### PR TITLE
[codex] harden 0.8.1 inventory guard

### DIFF
--- a/docs/architecture/SIBYL_POST_V08_SYNTHESIS_AND_MEMORY_COCKPIT_PLAN.md
+++ b/docs/architecture/SIBYL_POST_V08_SYNTHESIS_AND_MEMORY_COCKPIT_PLAN.md
@@ -1,6 +1,6 @@
 # Sibyl Post-v0.8 Synthesis and Memory Cockpit Plan
 
-- Status: full execution plan draft
+- Status: full execution plan draft, anchored to the v0.8 evidence baseline at `4855ba8a`
 - Target release: v0.9 candidate
 - Depends on:
   - `docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_AND_MEMORY_TRUST_PLAN.md`
@@ -796,6 +796,16 @@ Verify:
 Exit criteria:
 
 - This plan starts from current evidence, not assumptions.
+
+Receipt, 2026-05-14:
+
+- Starting evidence baseline: pushed `main` commit `4855ba8a`.
+- Main CI run `25870913035`, docs deploy run `25877971558`, and nightly regression run `25877971585`
+  completed successfully on `4855ba8a`.
+- v0.8 claim boundary: Surreal-only default runtime, optional Graphiti compatibility, policy-backed
+  inspectable memory, promotion preview, share preview, and the `memory-trust-gate`.
+- Post-v0.8 owns persisted MemorySpace CRUD, source lifecycle and correction, source adapters,
+  `synthesize`, mailbox import, and the memory cockpit.
 
 ### Packet A1: Memory Space Records
 

--- a/docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_AND_MEMORY_TRUST_PLAN.md
+++ b/docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_AND_MEMORY_TRUST_PLAN.md
@@ -1,7 +1,7 @@
 # Sibyl v0.8 Pure Surreal Closure and Memory Trust Plan
 
-- Status: local implementation packets closed; release hold pending pushed-main CI and nightly
-  receipts
+- Status: v0.8 release evidence complete for pushed `main` commit `4855ba8a`; tag and release
+  publication remain manual
 - Target release: v0.8
 - Planning source: `plan_e464fd1e7b11`
 - Plan-authoring task: `c64a358e-aef4-4b32-8735-28f03047a13e`
@@ -34,7 +34,16 @@ without leaking the wrong context.
 
 ## 1. Current State
 
-Verified on 2026-05-13 during the A0 baseline lock:
+Release evidence verified on 2026-05-14:
+
+- Pushed `main` release baseline: `4855ba8a`.
+- Main CI run `25870913035` completed successfully on `4855ba8a`.
+- Docs deploy run `25877971558` completed successfully on `4855ba8a`.
+- Nightly regression run `25877971585` completed successfully on `4855ba8a`.
+- The local 0.8.1 docs and inventory hardening after this baseline needs separate CI evidence if it
+  becomes patch-release evidence.
+
+Earlier A0 baseline lock, 2026-05-13:
 
 - Local baseline commit: `1de0b408`.
 - Last pushed `origin/main` receipt commit: `d2d3d926`.
@@ -101,6 +110,7 @@ Required release gates:
 - `moon run bench-gate`
 - `moon run core:bench-context -- --cases benchmarks/context_pack_cases.json --auth-manifest .moon/cache/baseline-runtime-manifest.json --label retrieval-compare --repeat 20 --metadata retrieval_mode=compare`
 - CI green on `main`
+- docs deploy green on `main`
 - Nightly regression green on `main`
 
 The baseline seed and replay gates predate v0.8 and remain required because release benchmark and
@@ -2565,9 +2575,8 @@ Receipt, 2026-05-14:
   docs now appear in the retained legacy-term inventory whenever they mention retired or optional
   legacy services. Every retained reference must render with an owner and reason on the same
   generated inventory row, and unowned references fail `inventory-check`.
-- Remaining risk: extensionless or non-scanned formats such as Dockerfiles, Helm `_helpers.tpl`,
-  JSON, or TOML can still acquire future legacy terms without this guard noticing. Add those formats
-  when one becomes an active legacy-reference carrier.
+- Remaining risk closed by the 0.8.1 inventory hardening pass: the retained legacy-term scanner now
+  covers tracked Dockerfiles, JSON, TOML, Helm `.tpl`, and root package config files.
 
 ### Packet A6.1: Pure Surreal Release Audit
 
@@ -2624,8 +2633,13 @@ Receipt, 2026-05-14:
 - Local tree under audit: this release-audit refresh packet after `e0bb7ac3`
   (`fix(cli): clarify queued task learning`). The final commit for this packet records the exact
   tree hash.
-- Branch state: local `main` is ahead of `origin/main`; this receipt is local-only and still does
-  not claim CI, docs deploy, or nightly coverage for the local commits.
+- Pushed release evidence baseline: `main` commit `4855ba8a`.
+- CI, docs, and nightly coverage for the release baseline:
+  - Main CI run `25870913035` completed successfully on `4855ba8a`.
+  - Docs deploy run `25877971558` completed successfully on `4855ba8a`.
+  - Nightly regression run `25877971585` completed successfully on `4855ba8a`.
+- The follow-up 0.8.1 docs and inventory hardening work is intentionally outside those pushed-main
+  receipts until it gets its own CI run.
 - Dependency boundary:
   - `graphiti-core[anthropic,google-genai]>=0.28.2` appears only in `sibyl-core[compatibility]` and
     the `sibyl-core` dev dependency group.
@@ -2663,10 +2677,25 @@ Receipt, 2026-05-14:
 - Policy or compatibility decision: the local tree is Surreal-only by default and memory-trust gates
   now include task-learning jobs. Persisted MemorySpace CRUD is explicitly post-v0.8 and is not part
   of the release claim.
-- Binary recommendation: hold the release until CI, docs deploy, and scheduled nightly receipts are
-  recorded for the pushed commit. After those are green, ship.
-- Remaining risk: CI and nightly receipts are intentionally pending because local project policy
-  forbids pushing `main` from this agent session.
+- Binary recommendation: ship v0.8 from `4855ba8a` when Bliss is ready to cut the tag and release.
+- Remaining risk: the next patch-release baseline should re-run CI, docs deploy, nightly, and the
+  inventory guard after the 0.8.1 hardening commit lands.
+
+### Packet A6.2: 0.8.1 Inventory Guard Hardening
+
+Purpose: close the post-audit scanner blind spot for active config formats that can carry retained
+legacy-service references.
+
+Receipt, 2026-05-14:
+
+- The retained legacy-term scanner now scans tracked Dockerfiles, JSON, TOML, Helm `.tpl`, root
+  package config files, and `.devcontainer` files.
+- The scanner filters to `git ls-files --cached` paths so untracked audit drafts and ignored
+  research dumps do not become release blockers.
+- The allowlist now stays scoped to files that actually retain legacy terms; scan-only files are
+  covered by a separate regression assertion.
+- Verification: `moon run inventory` wrote the generated inventory snapshot, and
+  `moon run inventory-test` reported 27 passed in 14.06s.
 
 ## 14. Evidence Ledger
 

--- a/docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_EXECUTION_PLAN.md
+++ b/docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_EXECUTION_PLAN.md
@@ -1,16 +1,16 @@
 # Sibyl v0.8 Pure Surreal Closure Execution Plan
 
-- Status: active focused execution plan
+- Status: closed; superseded by the parent A6/B6 release receipts
 - Parent plan: `docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_AND_MEMORY_TRUST_PLAN.md`
 - Tracking epic: Pure Surreal Closure, `epic_416f955f7f39`
 - Source inventory: `docs/architecture/SURREALDB_GRAPHITI_EXIT_INVENTORY.md`
 - Source burndown: `docs/architecture/SURREALDB_PHASE3_BURNDOWN.md`
-- Current baseline commit: `543963f3`
+- Current release evidence baseline: `4855ba8a`
 
-This document is the working plan for the remaining v0.8 pure Surreal closure work. The parent v0.8
-plan still owns the combined release definition and the Memory Trust Foundation track. This child
-plan goes deeper on Track A: native graph managers, native embeddings, Graphiti compatibility
-disposition, archive policy, stale docs, and the final Surreal-only release audit.
+This document was the working plan for the v0.8 pure Surreal closure work. The parent v0.8 plan now
+owns the release evidence and the Memory Trust Foundation receipts. This child plan remains as the
+historical Track A execution record for native graph managers, native embeddings, Graphiti
+compatibility disposition, archive policy, stale docs, and the final Surreal-only release audit.
 
 The release goal is simple: the default Sibyl runtime should be SurrealDB-only, with Graphiti,
 FalkorDB, PostgreSQL, and Redis/Valkey absent from the default data plane. Any retained legacy
@@ -18,6 +18,14 @@ behavior must be opt-in, named honestly, separately tested, and documented as co
 migration, admin, benchmark, or historical archive support.
 
 ## 1. Current State
+
+Closed as of the 2026-05-14 release evidence refresh:
+
+- Pushed `main` release baseline: `4855ba8a`.
+- Main CI run `25870913035` completed successfully on `4855ba8a`.
+- Docs deploy run `25877971558` completed successfully on `4855ba8a`.
+- Nightly regression run `25877971585` completed successfully on `4855ba8a`.
+- The parent v0.8 plan is authoritative for the final release recommendation and residual risks.
 
 Completed as of `543963f3`:
 
@@ -552,8 +560,7 @@ is more than documentation.
 
 ## 14. Recommendation
 
-Proceed with A2 first, starting with native entity hydration. It is the right next move because A1
-already made Graphiti compatibility opt-in, and A2 removes the remaining Graphiti-shaped graph model
-pressure from default runtime code. Do not start A4 deletion until A2 and A3 prove native graph and
-embedding ownership. Do not cut v0.8 until A6 records fresh receipts from the final tree and the
-retained compatibility surface is named, opt-in, and separately tested.
+Historical execution recommendation: proceed with A2 first, then A3, A4, A5, and A6. That sequence
+has now closed. Current recommendation lives in the parent plan: v0.8 can ship from `4855ba8a`, and
+the next roadmap starts with post-v0.8 memory productization plus the 0.8.1 inventory guard
+hardening.

--- a/docs/research/rust-port/INVENTORY.md
+++ b/docs/research/rust-port/INVENTORY.md
@@ -12,7 +12,7 @@ Generated from code by `tools/inventory/runtime_surface.py`. Do not hand-edit.
 - Raw SQL query usage files: 0
 - Session-backed storage access files: 0
 - Graphiti import files: 21
-- Retained legacy term files: 87
+- Retained legacy term files: 90
 - Dependency records: 4
 
 ## API Surface
@@ -114,6 +114,7 @@ must carry an owner and reason here.
 | `Tiltfile` | `redis`, `valkey` | 14 | local Kubernetes/Tilt dev | Local Tilt and Helm dev keep Redis/Valkey as explicit coordination while Surreal owns data. |
 | `apps/api/README.md` | `postgres`, `redis` | 12 | v0.8 packaged docs | Packaged README and skill docs retain migration and optional coordination language. |
 | `apps/api/moon.yml` | `graphiti` | 7 | v0.8 packaged docs | Packaged README and skill docs retain migration and optional coordination language. |
+| `apps/api/pyproject.toml` | `graphiti`, `redis` | 4 | v0.8 deployment config | Compose and chart files retain Redis as an explicit coordination profile or chart option. |
 | `apps/cli/README.md` | `redis` | 1 | v0.8 packaged docs | Packaged README and skill docs retain migration and optional coordination language. |
 | `apps/cli/src/sibyl_cli/data/skills/sibyl/EXAMPLES.md` | `redis` | 3 | v0.8 packaged docs | Packaged README and skill docs retain migration and optional coordination language. |
 | `apps/cli/src/sibyl_cli/data/skills/sibyl/SKILL.md` | `redis` | 4 | v0.8 packaged docs | Packaged README and skill docs retain migration and optional coordination language. |
@@ -134,9 +135,9 @@ must carry an owner and reason here.
 | `docs/architecture/PERMISSION_SYSTEM_AUDIT.md` | `falkor`, `postgres` | 23 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/architecture/PERMISSION_SYSTEM_PLAN.md` | `falkor`, `postgres`, `redis` | 13 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/architecture/SIBYL_NORTHSTAR.md` | `falkor`, `graphiti`, `postgres`, `redis` | 38 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
-| `docs/architecture/SIBYL_POST_V08_SYNTHESIS_AND_MEMORY_COCKPIT_PLAN.md` | `graphiti` | 1 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
+| `docs/architecture/SIBYL_POST_V08_SYNTHESIS_AND_MEMORY_COCKPIT_PLAN.md` | `graphiti` | 2 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_AND_MEMORY_TRUST_PLAN.md` | `falkor`, `graphiti`, `postgres`, `redis`, `valkey` | 163 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
-| `docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_EXECUTION_PLAN.md` | `falkor`, `graphiti`, `postgres`, `redis`, `valkey` | 90 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
+| `docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_EXECUTION_PLAN.md` | `falkor`, `graphiti`, `postgres`, `redis`, `valkey` | 88 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/architecture/SURREALDB_GRAPHITI_EXIT_BENCHMARK_EVIDENCE.md` | `graphiti` | 23 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/architecture/SURREALDB_GRAPHITI_EXIT_INVENTORY.md` | `graphiti` | 101 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/architecture/SURREALDB_NATIVE_MEMORY_CORE_SPEC.md` | `falkor`, `graphiti`, `postgres` | 48 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
@@ -187,6 +188,8 @@ must carry an owner and reason here.
 | `packages/python/sibyl-core/COVERAGE_PLAN.md` | `falkor` | 3 | v0.7 Graphiti exit | Core package docs and tasks preserve compatibility coverage and historical Graphiti context. |
 | `packages/python/sibyl-core/README.md` | `graphiti` | 1 | v0.7 Graphiti exit | Core package docs and tasks preserve compatibility coverage and historical Graphiti context. |
 | `packages/python/sibyl-core/moon.yml` | `graphiti` | 9 | v0.7 Graphiti exit | Core package docs and tasks preserve compatibility coverage and historical Graphiti context. |
+| `packages/python/sibyl-core/pyproject.toml` | `graphiti` | 2 | v0.7 Graphiti exit | Core package docs and tasks preserve compatibility coverage and historical Graphiti context. |
+| `pyproject.toml` | `graphiti` | 4 | repo package config | Root package configs retain compatibility extras and dev dependency boundaries. |
 | `setup-dev.sh` | `falkor`, `postgres` | 3 | dev bootstrap | Dev scripts mention legacy migration checks and optional Redis coordination. |
 | `skills/sibyl/EXAMPLES.md` | `redis` | 3 | v0.8 skill docs | Source skill docs retain examples that mention Redis as historical troubleshooting context. |
 | `skills/sibyl/SKILL.md` | `redis` | 4 | v0.8 skill docs | Source skill docs retain examples that mention Redis as historical troubleshooting context. |

--- a/tools/inventory/runtime_surface.py
+++ b/tools/inventory/runtime_surface.py
@@ -4,6 +4,8 @@ import argparse
 import ast
 import difflib
 import re
+import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -94,11 +96,23 @@ LEGACY_TERM_CANONICAL_NAMES = {
     "valkey": "valkey",
     "graphiti": "graphiti",
 }
-LEGACY_TERM_SCAN_EXTENSIONS = {".example", ".md", ".mdx", ".yml", ".yaml", ".sh"}
+LEGACY_TERM_SCAN_EXTENSIONS = {
+    ".example",
+    ".json",
+    ".md",
+    ".mdx",
+    ".sh",
+    ".toml",
+    ".tpl",
+    ".yml",
+    ".yaml",
+}
+LEGACY_TERM_SCAN_FILENAMES = {"Dockerfile"}
 LEGACY_TERM_SCAN_ROOTS = (
     REPO_ROOT / "apps",
     REPO_ROOT / "charts",
     REPO_ROOT / "docs",
+    REPO_ROOT / ".devcontainer",
     REPO_ROOT / ".github",
     REPO_ROOT / "infra",
     REPO_ROOT / "packages",
@@ -117,6 +131,9 @@ LEGACY_TERM_SCAN_FILES = tuple(
             REPO_ROOT / ".env.quickstart.example",
             REPO_ROOT / ".env.quickstart.test",
             REPO_ROOT / ".env.test.example",
+            REPO_ROOT / "package.json",
+            REPO_ROOT / "pnpm-workspace.yaml",
+            REPO_ROOT / "pyproject.toml",
             REPO_ROOT / "moon.yml",
             REPO_ROOT / "setup-dev.sh",
             *REPO_ROOT.glob("docker-compose*.yml"),
@@ -134,8 +151,12 @@ LEGACY_TERM_EXCLUDED_PARTS = {
     ".tox",
     ".venv",
     ".vitepress",
+    ".next",
     "__pycache__",
     "_archive",
+    "coverage",
+    "coverage-core",
+    "storybook-static",
     "build",
     "dist",
     "node_modules",
@@ -375,6 +396,7 @@ SKILL_SOURCE_LEGACY_TERM_FILES = (
     "skills/sibyl/SKILL.md",
 )
 DEPLOYMENT_CONFIG_LEGACY_TERM_FILES = (
+    "apps/api/pyproject.toml",
     "charts/sibyl/Chart.yaml",
     "charts/sibyl/templates/backend-deployment.yaml",
     "charts/sibyl/templates/configmap.yaml",
@@ -390,6 +412,7 @@ PROJECT_INSTRUCTION_LEGACY_TERM_FILES = (
     "CLAUDE.md",
 )
 ROOT_TASK_LEGACY_TERM_FILES = ("moon.yml",)
+ROOT_CONFIG_LEGACY_TERM_FILES = ("pyproject.toml",)
 ENV_TEMPLATE_LEGACY_TERM_FILES = (
     ".env.example",
     ".env.quickstart.example",
@@ -407,11 +430,30 @@ PACKAGE_LEGACY_TERM_FILES = (
     "packages/python/sibyl-core/COVERAGE_PLAN.md",
     "packages/python/sibyl-core/README.md",
     "packages/python/sibyl-core/moon.yml",
+    "packages/python/sibyl-core/pyproject.toml",
 )
 DEV_SCRIPT_LEGACY_TERM_FILES = (
     "setup-dev.sh",
     "tools/dev/run-surreal-dev.sh",
 )
+
+
+def git_index_paths() -> frozenset[str]:
+    git = shutil.which("git")
+    if git is None:
+        msg = "git executable is required to collect tracked inventory paths"
+        raise RuntimeError(msg)
+    result = subprocess.run(  # noqa: S603
+        [git, "ls-files", "--cached"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return frozenset(line for line in result.stdout.splitlines() if line)
+
+
+GIT_INDEX_PATHS = git_index_paths()
 LEGACY_TERM_ALLOWLIST = (
     LegacyTermAllowlistRecord(
         path="README.md",
@@ -437,6 +479,11 @@ LEGACY_TERM_ALLOWLIST = (
         ROOT_TASK_LEGACY_TERM_FILES,
         owner="v0.7 Graphiti exit",
         reason="Root moon tasks retain the explicit Graphiti compatibility test island.",
+    ),
+    *legacy_term_allowlist_records(
+        ROOT_CONFIG_LEGACY_TERM_FILES,
+        owner="repo package config",
+        reason="Root package configs retain compatibility extras and dev dependency boundaries.",
     ),
     *legacy_term_allowlist_records(
         ENV_TEMPLATE_LEGACY_TERM_FILES,
@@ -865,9 +912,15 @@ def collect_dependencies() -> tuple[DependencyRecord, ...]:
 def _legacy_term_scan_path(path: Path) -> bool:
     if path == SNAPSHOT_PATH:
         return False
-    if path.suffix not in LEGACY_TERM_SCAN_EXTENSIONS:
+    relative_path = relpath(path)
+    if relative_path not in GIT_INDEX_PATHS:
         return False
-    relative_parts = path.relative_to(REPO_ROOT).parts
+    if (
+        path.suffix not in LEGACY_TERM_SCAN_EXTENSIONS
+        and path.name not in LEGACY_TERM_SCAN_FILENAMES
+    ):
+        return False
+    relative_parts = Path(relative_path).parts
     return not any(part in LEGACY_TERM_EXCLUDED_PARTS for part in relative_parts)
 
 

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -19,6 +19,7 @@ from tools.inventory.runtime_surface import (
     collect_runtime_surface,
     default_runtime_graphiti_imports,
     graphiti_allowlist_record,
+    iter_legacy_term_files,
     legacy_term_allowlist_record,
     parse_dependency_name,
     render_markdown,
@@ -33,6 +34,8 @@ EXPECTED_MCP_TOOL_COUNT = 8
 EXPECTED_MCP_RESOURCE_COUNT = 2
 EXPECTED_SQLMODEL_TABLE_COUNT = 0
 EXPECTED_LEGACY_TERM_SCAN_PATHS = {
+    ".devcontainer/Dockerfile",
+    ".devcontainer/devcontainer.json",
     ".env.example",
     ".env.quickstart.example",
     ".env.quickstart.test",
@@ -40,17 +43,35 @@ EXPECTED_LEGACY_TERM_SCAN_PATHS = {
     "AGENTS.md",
     "CLAUDE.md",
     "Tiltfile",
+    "apps/api/Dockerfile",
+    "apps/api/pyproject.toml",
+    "apps/web/Dockerfile",
+    "apps/web/package.json",
+    "charts/sibyl/templates/_helpers.tpl",
     "infra/local/README.md",
     "infra/local/secrets.yaml.example",
     "infra/local/sibyl-values.yaml",
     "infra/local/valkey-values.yaml",
     "moon.yml",
+    "package.json",
     "packages/python/sibyl-core/README.md",
     "packages/python/sibyl-core/moon.yml",
+    "pnpm-workspace.yaml",
+    "pyproject.toml",
     "skills/sibyl/EXAMPLES.md",
     "skills/sibyl/SKILL.md",
     "setup-dev.sh",
     "tools/dev/run-surreal-dev.sh",
+}
+EXPECTED_LEGACY_TERM_RECORD_PATHS = EXPECTED_LEGACY_TERM_SCAN_PATHS - {
+    ".devcontainer/Dockerfile",
+    ".devcontainer/devcontainer.json",
+    "apps/api/Dockerfile",
+    "apps/web/Dockerfile",
+    "apps/web/package.json",
+    "charts/sibyl/templates/_helpers.tpl",
+    "package.json",
+    "pnpm-workspace.yaml",
 }
 CORE_GRAPHITI_COMPATIBILITY_TESTS = (
     "tests/graph/surreal",
@@ -303,6 +324,10 @@ def test_graphiti_exit_inventory_tracks_no_graphiti_smoke_plan() -> None:
 def test_legacy_term_inventory_covers_active_docs_and_configs() -> None:
     surface = collect_runtime_surface()
     inventory = SNAPSHOT_PATH.read_text(encoding="utf-8")
+    legacy_inventory = inventory.split("## Retained Legacy Term Inventory", maxsplit=1)[1].split(
+        "\n## Dependency Inventory",
+        maxsplit=1,
+    )[0]
     record_paths = {record.path for record in surface.legacy_term_records}
     literal_allowlist_paths = {
         allowed.path for allowed in LEGACY_TERM_ALLOWLIST if not allowed.path.endswith("*")
@@ -310,18 +335,26 @@ def test_legacy_term_inventory_covers_active_docs_and_configs() -> None:
 
     assert "## Retained Legacy Term Inventory" in inventory
     assert unclassified_legacy_term_records(surface) == ()
-    assert record_paths >= EXPECTED_LEGACY_TERM_SCAN_PATHS
+    assert record_paths >= EXPECTED_LEGACY_TERM_RECORD_PATHS
     assert record_paths >= literal_allowlist_paths
     for record in surface.legacy_term_records:
         allowed = legacy_term_allowlist_record(record.path)
         assert allowed is not None
         matching_rows = [
-            line for line in inventory.splitlines() if line.startswith(f"| `{record.path}` |")
+            line
+            for line in legacy_inventory.splitlines()
+            if line.startswith(f"| `{record.path}` |")
         ]
         assert len(matching_rows) == 1
         row = matching_rows[0]
         assert f"| {allowed.owner} |" in row
         assert f"| {allowed.reason} |" in row
+
+
+def test_legacy_term_scanner_covers_active_docs_and_configs() -> None:
+    scanned_paths = {path.relative_to(REPO_ROOT).as_posix() for path in iter_legacy_term_files()}
+
+    assert scanned_paths >= EXPECTED_LEGACY_TERM_SCAN_PATHS
 
 
 def test_legacy_term_inventory_rejects_unowned_active_doc() -> None:


### PR DESCRIPTION
## Summary

- hardens the retained legacy-term scanner for tracked config formats that can carry legacy-service references
- records the pushed v0.8 release evidence baseline at `4855ba8a`
- anchors the post-v0.8 roadmap to the v0.8 evidence boundary and closes stale child-plan language

## Why

The v0.8 release evidence is green on pushed `main`, but the post-audit inventory review found that Dockerfiles, TOML, JSON, Helm helper templates, root package config, and devcontainer files could acquire legacy-service references without the release inventory noticing. This patch makes that guard explicit while keeping untracked audit drafts and ignored research dumps out of release gates.

## Verification

- `moon run inventory-check inventory-typecheck inventory-test inventory-lint` -> inventory current, typecheck and lint clean, 27 passed in 14.06s
- `npx prettier --check docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_AND_MEMORY_TRUST_PLAN.md docs/architecture/SIBYL_POST_V08_SYNTHESIS_AND_MEMORY_COCKPIT_PLAN.md docs/architecture/SIBYL_V08_PURE_SURREAL_CLOSURE_EXECUTION_PLAN.md` -> all matched files use Prettier code style
- `git diff --check` -> clean
- Claude cross-model review -> PASS

## Notes

Broad `moon run docs:lint` is currently blocked by unrelated untracked/research docs outside this PR scope.
