### PR TITLE
fix(ci): clear API Docker release blocker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,8 +23,6 @@
 !apps/api/pyproject.toml
 !apps/api/README.md
 !apps/api/src/
-!apps/api/alembic/
-!apps/api/alembic.ini
 
 # -----------------------------------------------------------------------------
 # Web Image (apps/web/Dockerfile)

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -19,8 +19,6 @@ COPY packages/python/sibyl-core/src packages/python/sibyl-core/src
 # Copy API package
 COPY apps/api/pyproject.toml apps/api/README.md apps/api/
 COPY apps/api/src apps/api/src
-COPY apps/api/alembic apps/api/alembic
-COPY apps/api/alembic.ini apps/api/
 COPY README.md ./
 
 # Install from workspace (--no-editable for proper wheel builds in Docker)
@@ -39,8 +37,6 @@ WORKDIR /app
 
 # Copy virtual environment from builder
 COPY --from=builder --chown=sibyl:sibyl /app/.venv /app/.venv
-COPY --from=builder --chown=sibyl:sibyl /app/apps/api/alembic /app/alembic
-COPY --from=builder --chown=sibyl:sibyl /app/apps/api/alembic.ini /app/alembic.ini
 
 # Install Playwright for crawl4ai (chromium headless)
 # Manual minimal deps instead of --with-deps (which pulls ~600MB of X11/GUI stuff)


### PR DESCRIPTION
## Summary

- Remove retired Alembic copies from the API Docker image.
- Drop stale Alembic whitelist entries from the Docker build context.

## Why

The v0.8.1 publish workflow failed while building the API image because
`apps/api/alembic.ini` was removed during the Surreal-only runtime cutover,
but `apps/api/Dockerfile` still tried to copy it. The runtime no longer uses
Alembic, so the image should not ship those files.

## Validation

- `docker build -f apps/api/Dockerfile -t sibyl-api:release-blocker-check .` → image built successfully
- `moon run api:lint api:typecheck` → exit 0; lint passed, typecheck reported existing warning diagnostics
- `gh issue view 8 --json state,stateReason` → closed as `NOT_PLANNED` after audit triage
- Cross-model review of `b900200f` → PASS
