### PR TITLE
style(skills): format agent activity audit docs

### DIFF
--- a/skills/agent-activity-audit/EXAMPLES.md
+++ b/skills/agent-activity-audit/EXAMPLES.md
@@ -1,7 +1,7 @@
 # Agent Activity Audit — Worked Example
 
-This is the actual run that produced the skill: a 30-day audit of how Codex and Claude Code
-agents used Sibyl in real coding sessions, executed 2026-05-14. The full output is preserved at
+This is the actual run that produced the skill: a 30-day audit of how Codex and Claude Code agents
+used Sibyl in real coding sessions, executed 2026-05-14. The full output is preserved at
 `/home/bliss/dev/sibyl/contexts/sibyl-analysis-2026-05-14/`.
 
 Reading this file should let you reproduce the audit pattern for any other tool/skill/system.
@@ -10,26 +10,26 @@ Reading this file should let you reproduce the audit pattern for any other tool/
 
 ## Goal of the example run
 
-> "Find how Sibyl was used by the agent, when and how, and if at all Sibyl was helping it or
-> hurting it. Other issues? Successes? What can we learn? We need to be thorough, multiple passes
-> and multiple swarms, going through ALL the data, to figure out how to improve Sibyl even more."
+> "Find how Sibyl was used by the agent, when and how, and if at all Sibyl was helping it or hurting
+> it. Other issues? Successes? What can we learn? We need to be thorough, multiple passes and
+> multiple swarms, going through ALL the data, to figure out how to improve Sibyl even more."
 
 Scope: last 30 days of conversation transcripts from `~/.claude/projects/` (Claude Code) and
 `~/.codex/sessions/` (Codex).
 
 ## Numbers at a glance
 
-| Phase | Count | Notes |
-|---|---|---|
-| Files in window | 529 | 296 Claude · 233 Codex |
-| Total transcript size | ~1 GB | mostly Codex |
-| Files mentioning sibyl | 472 | includes CLAUDE.md/AGENTS.md boilerplate |
-| Files *actually using* sibyl tools | 179 | 7 Claude · 172 Codex |
-| Real Sibyl CLI calls | ~3000 | scanner-validated |
-| Episode markdown files written | 179 | total ~13 MB |
-| Subagents dispatched | 6 (Wave 1) | partitioned by date |
-| Cross-cutting data builds | 5 | error catalog, workflow stats, retry loops, capture stats, source grounding |
-| Final synthesis report | 1 | `SYNTHESIS.md` |
+| Phase                              | Count      | Notes                                                                       |
+| ---------------------------------- | ---------- | --------------------------------------------------------------------------- |
+| Files in window                    | 529        | 296 Claude · 233 Codex                                                      |
+| Total transcript size              | ~1 GB      | mostly Codex                                                                |
+| Files mentioning sibyl             | 472        | includes CLAUDE.md/AGENTS.md boilerplate                                    |
+| Files _actually using_ sibyl tools | 179        | 7 Claude · 172 Codex                                                        |
+| Real Sibyl CLI calls               | ~3000      | scanner-validated                                                           |
+| Episode markdown files written     | 179        | total ~13 MB                                                                |
+| Subagents dispatched               | 6 (Wave 1) | partitioned by date                                                         |
+| Cross-cutting data builds          | 5          | error catalog, workflow stats, retry loops, capture stats, source grounding |
+| Final synthesis report             | 1          | `SYNTHESIS.md`                                                              |
 
 End-to-end wall time, including subagent runs: roughly 25-30 minutes.
 
@@ -127,8 +127,8 @@ out to be one Codex rollout that absorbed multiple consecutive missions). Always
 
 ### 5. Dispatch the swarm in parallel
 
-Send one message with all Agent tool calls, `run_in_background: true`. Each prompt is
-self-contained — agents won't see your conversation history. Example prompt for Group B:
+Send one message with all Agent tool calls, `run_in_background: true`. Each prompt is self-contained
+— agents won't see your conversation history. Example prompt for Group B:
 
 ```
 You're analyzing how agents used Sibyl in real coding sessions over the past month. Sibyl is a
@@ -151,7 +151,7 @@ strong vs weak signal count.
 
 ### 6. Build cross-cutting data while agents run
 
-```bash
+````bash
 # Error catalog
 python3 -c '
 import re
@@ -181,13 +181,12 @@ print(f'learnings: {sum(1 for f in sessions if re.search(r\"--learnings\", f.rea
 "
 
 # Retry loops: same sibyl command run 3+ times in a row in any single session
-```
+````
 
 ### 7. Synthesize from agent reports
 
-After all agents complete, read every `findings/group_*.md`, the error catalog, the workflow
-stats, and the relevant source. Write `SYNTHESIS.md` using the structure documented in `SKILL.md`
-§7.
+After all agents complete, read every `findings/group_*.md`, the error catalog, the workflow stats,
+and the relevant source. Write `SYNTHESIS.md` using the structure documented in `SKILL.md` §7.
 
 For this run the synthesis revealed:
 
@@ -230,14 +229,13 @@ A few non-obvious calls worth flagging for replays:
   emerged from short user messages with reaction words AND target mentions — about 26 unique
   signals. Most weren't even about Sibyl (most were "ugh hypercolor faces are fucked").
 
-- **Skipped a planned Wave 2.** The initial design included a second cross-cutting swarm to
-  re-read Wave 1 findings by theme. After reading 5/6 Wave 1 reports, the convergence on the same
-  themes was so strong that Wave 2 would have been a re-litigation. Saved an estimated 5-10
-  minutes and ~80 KB of context.
+- **Skipped a planned Wave 2.** The initial design included a second cross-cutting swarm to re-read
+  Wave 1 findings by theme. After reading 5/6 Wave 1 reports, the convergence on the same themes was
+  so strong that Wave 2 would have been a re-litigation. Saved an estimated 5-10 minutes and ~80 KB
+  of context.
 
-- **Read current Sibyl source** to ground every recommendation in code paths. The CLAUDE.md
-  rule "Before recommending from memory: verify the file/symbol/flag still exists" applies
-  doubly here.
+- **Read current Sibyl source** to ground every recommendation in code paths. The CLAUDE.md rule
+  "Before recommending from memory: verify the file/symbol/flag still exists" applies doubly here.
 
 ---
 
@@ -245,23 +243,22 @@ A few non-obvious calls worth flagging for replays:
 
 Documented so future runs avoid the mistakes:
 
-1. **Initial regex `\bsibyl\b` triggered on every CLAUDE.md mention.** Had to filter on actual
-   tool invocations (Bash command containing `sibyl `, function_call name matching `mcp__sibyl__`,
-   etc.) before scoping the swarm. The scanner now does this by default.
+1. **Initial regex `\bsibyl\b` triggered on every CLAUDE.md mention.** Had to filter on actual tool
+   invocations (Bash command containing `sibyl `, function_call name matching `mcp__sibyl__`, etc.)
+   before scoping the swarm. The scanner now does this by default.
 
-2. **Codex schema wasn't initially handled.** First scan returned 0 Sibyl uses for Codex even
-   though the visible greps showed 886 sibyl mentions in one file. Codex wraps tool calls in
-   `payload`; the scanner now unwraps that.
+2. **Codex schema wasn't initially handled.** First scan returned 0 Sibyl uses for Codex even though
+   the visible greps showed 886 sibyl mentions in one file. Codex wraps tool calls in `payload`; the
+   scanner now unwraps that.
 
 3. **`exec_command` wasn't in the Bash-equivalent list.** Codex's name for shell calls. Added.
 
-4. **The "OUTPUT (ERROR)" extractor was over-aggressive.** Search results with the word "error"
-   in their content got flagged as errors. The catalog now post-filters on exit-code markers and
-   `✗`.
+4. **The "OUTPUT (ERROR)" extractor was over-aggressive.** Search results with the word "error" in
+   their content got flagged as errors. The catalog now post-filters on exit-code markers and `✗`.
 
-5. **One session had 4409 episodes (8.4 MB)** which would have crushed the partition-by-date
-   agent's context. Pulled it out as its own dedicated subagent and instructed it to sample
-   strategically (start/middle/end + all error blocks) rather than read top-to-bottom.
+5. **One session had 4409 episodes (8.4 MB)** which would have crushed the partition-by-date agent's
+   context. Pulled it out as its own dedicated subagent and instructed it to sample strategically
+   (start/middle/end + all error blocks) rather than read top-to-bottom.
 
 ---
 

--- a/skills/agent-activity-audit/SKILL.md
+++ b/skills/agent-activity-audit/SKILL.md
@@ -3,16 +3,16 @@ name: agent-activity-audit
 description:
   Audit recent agent transcripts (Claude Code and Codex) to learn how a tool, system, or skill is
   actually being used in the wild. Surfaces failure modes, friction, success patterns, and concrete
-  improvement candidates from real session data. Use this when you want to improve a developer-facing
-  system that agents interact with regularly.
+  improvement candidates from real session data. Use this when you want to improve a
+  developer-facing system that agents interact with regularly.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Agent
 ---
 
 # Agent Activity Audit
 
 This skill executes a structured pass over recent agent transcripts to learn what's working and
-what's hurting. The original audit (May 2026) examined ~30 days of Claude Code and Codex sessions
-to improve Sibyl itself — see `EXAMPLES.md` for the full reproducible run.
+what's hurting. The original audit (May 2026) examined ~30 days of Claude Code and Codex sessions to
+improve Sibyl itself — see `EXAMPLES.md` for the full reproducible run.
 
 The output is a synthesis report grounded in real session evidence, plus per-group findings files
 you can act on directly.
@@ -39,23 +39,23 @@ session transcripts; it doesn't analyze code.
    extracts, and findings in one tree so the analysis is reproducible and the user can replay or
    extend it.
 
-2. **Filter early, filter hard.** Most transcripts are noise. Triage with cheap grep before
-   spinning up parallel subagents — the goal is to give each subagent ~50-100 KB of focused episode
-   data, not raw multi-MB JSONLs.
+2. **Filter early, filter hard.** Most transcripts are noise. Triage with cheap grep before spinning
+   up parallel subagents — the goal is to give each subagent ~50-100 KB of focused episode data, not
+   raw multi-MB JSONLs.
 
-3. **Partition by date for the swarm.** Date-based partitions are mutually exclusive, cover the
-   full window, and make convergence across groups easy to spot (same theme in 4+ date ranges =
-   durable issue).
+3. **Partition by date for the swarm.** Date-based partitions are mutually exclusive, cover the full
+   window, and make convergence across groups easy to spot (same theme in 4+ date ranges = durable
+   issue).
 
-4. **Each subagent writes findings to a file.** Don't let agents return giant prose back to the
-   main thread. Their job: produce `findings/group_<X>.md`, return a ≤250-word summary.
+4. **Each subagent writes findings to a file.** Don't let agents return giant prose back to the main
+   thread. Their job: produce `findings/group_<X>.md`, return a ≤250-word summary.
 
 5. **Convergence-first synthesis.** A pain point in 4+ groups is durable. Single-group findings
    warrant a sanity check before they're elevated. Count evidence; don't trust impressions.
 
 6. **Verify before recommending fixes.** Inspect current source for the surfaces the audit
-   implicates. A finding like "the CLI rejects `--kind gotcha`" should point at the enum's
-   actual location.
+   implicates. A finding like "the CLI rejects `--kind gotcha`" should point at the enum's actual
+   location.
 
 7. **Capture durable learnings to Sibyl after synthesis.** The point is to feed back into the
    product graph; use `sibyl remember --kind pattern` (or `--kind decision`) on the substantive
@@ -101,6 +101,7 @@ cat triage/all_files.txt | xargs -P 12 -n 5 python3 "$SKILL_DIR/scripts/scan.py"
 ```
 
 The scanner detects three shapes of usage:
+
 - **CLI**: Bash/exec_command calls whose command line matches the target's CLI name
 - **MCP**: tool names matching `mcp__<target>__*` or `<target>_*`
 - **Skill**: Skill invocations whose name matches the target
@@ -109,9 +110,9 @@ Look at the output to confirm signal quality before proceeding.
 
 ### Step 3: Extract focused episodes
 
-Each "episode" is a target-tool call plus its preceding user message, assistant text, and
-tool result. Use `scripts/extract_episodes.py` to write per-session markdown files
-(~10-30 KB each, vs the 50-500 KB raw transcripts).
+Each "episode" is a target-tool call plus its preceding user message, assistant text, and tool
+result. Use `scripts/extract_episodes.py` to write per-session markdown files (~10-30 KB each, vs
+the 50-500 KB raw transcripts).
 
 ```bash
 # Filter to files with actual usage
@@ -130,8 +131,8 @@ cat triage/using_files.txt | xargs -P 12 -n 3 python3 \
 
 ### Step 4: Partition for the swarm
 
-Partition episodes by date (or by file count if the window is shorter). Aim for groups of
-20-60 files each, ~500-1500 KB total payload per group. One agent per partition.
+Partition episodes by date (or by file count if the window is shorter). Aim for groups of 20-60
+files each, ~500-1500 KB total payload per group. One agent per partition.
 
 ```bash
 # Date-based partitions (adjust ranges to your window)
@@ -158,6 +159,7 @@ agent's prompt should include:
 # Group <id> — <description>
 
 ## At-a-glance
+
 - Sessions analyzed: N
 - Total target tool calls: N (with CLI / MCP / skill breakdown)
 - Errored calls: N
@@ -166,21 +168,27 @@ agent's prompt should include:
 - Net assessment: Helping / Hurting / Mixed (one sentence)
 
 ## Usage patterns (ranked by frequency)
+
 What did agents reach for the target to do? How often? How well?
 
 ## Top failure modes (with evidence)
+
 Verbatim error message, frequency, blast radius, session refs.
 
 ## What genuinely helped
+
 Concrete wins with citations.
 
 ## UX friction
+
 Confusing CLI/output, subcommand naming, output formatting, etc.
 
 ## User reactions
+
 Direct user messages about the target — corrections, complaints, praise.
 
 ## Improvement ideas (ranked by impact)
+
 1. [Issue] → [Specific fix]
    - Evidence (session refs)
    - Why it matters
@@ -193,13 +201,13 @@ Direct user messages about the target — corrections, complaints, praise.
 
 While agents work, do the prep that needs the full corpus, not partitions:
 
-- **Error catalog**: classify all error outputs by pattern. Most-common categories should match
-  what subagents independently find.
-- **Workflow stats**: did sessions follow the full lifecycle? `sessions_using_target /
-  sessions_capturing_knowledge / sessions_completing_lifecycle`.
+- **Error catalog**: classify all error outputs by pattern. Most-common categories should match what
+  subagents independently find.
+- **Workflow stats**: did sessions follow the full lifecycle?
+  `sessions_using_target / sessions_capturing_knowledge / sessions_completing_lifecycle`.
 - **Retry loops**: same command run 3+ times in a row in any session → signals stuck behavior.
-- **User corrections**: short user messages mentioning the target tool + reaction words
-  ("ugh", "broken", "wrong", "stop") → real feedback.
+- **User corrections**: short user messages mentioning the target tool + reaction words ("ugh",
+  "broken", "wrong", "stop") → real feedback.
 
 ### Step 7: Synthesize
 
@@ -232,8 +240,8 @@ vs main.py remember --help. Audit: contexts/sibyl-analysis-2026-05-14/SYNTHESIS.
   --kind error_pattern --tags audit,cli,enum
 ```
 
-Keep these scoped to the project being audited; future sessions on that project should find them
-via `sibyl recall`.
+Keep these scoped to the project being audited; future sessions on that project should find them via
+`sibyl recall`.
 
 ---
 
@@ -242,11 +250,11 @@ via `sibyl recall`.
 A good audit:
 
 - Has at least 3 convergent findings (same theme in 4+ partitions).
-- Quantifies impact (calls/month, sessions affected, minutes wasted) rather than naming severity
-  in the abstract.
+- Quantifies impact (calls/month, sessions affected, minutes wasted) rather than naming severity in
+  the abstract.
 - Names current code locations for every recommended fix.
 - Distinguishes design issues from operational issues from documentation issues.
-- Identifies what's working so the team knows what *not* to change.
+- Identifies what's working so the team knows what _not_ to change.
 - Captures surprises — the patterns that contradict the team's prior model.
 
 A bad audit:
@@ -264,23 +272,23 @@ A bad audit:
 - **Big sessions**: any single transcript > 5 MB of episodes deserves its own subagent. The May 10
   monster session (8.4 MB, 4409 episodes spanning 4 days) needed strategic sampling — read
   start/middle/end + all error blocks, not top-to-bottom.
-- **Cold sessions**: transcripts where the target tool was barely used are still data. They tell
-  you the agent *didn't reach* for the tool. That's its own finding.
-- **Cross-project bleed**: if the target lives in one repo but is called from many, partition by
-  cwd as well as date.
-- **Multi-client**: Claude and Codex have different transcript schemas. The scanner handles both
-  but findings should note any client-specific patterns (e.g., Codex agents read SKILL.md every
-  session; Claude agents launch the skill differently).
+- **Cold sessions**: transcripts where the target tool was barely used are still data. They tell you
+  the agent _didn't reach_ for the tool. That's its own finding.
+- **Cross-project bleed**: if the target lives in one repo but is called from many, partition by cwd
+  as well as date.
+- **Multi-client**: Claude and Codex have different transcript schemas. The scanner handles both but
+  findings should note any client-specific patterns (e.g., Codex agents read SKILL.md every session;
+  Claude agents launch the skill differently).
 
 ---
 
 ## Caveats
 
-- **Survivorship bias**: agents who got stuck and gave up early produce shorter transcripts.
-  Don't conclude the system is fine from a sample of finished work.
-- **User-message false positives**: filter out boilerplate (`# AGENTS.md`, `<INSTRUCTIONS>`,
-  long task prompts) before flagging "user reactions." Real reactions are short, in lowercase,
-  and often profane.
+- **Survivorship bias**: agents who got stuck and gave up early produce shorter transcripts. Don't
+  conclude the system is fine from a sample of finished work.
+- **User-message false positives**: filter out boilerplate (`# AGENTS.md`, `<INSTRUCTIONS>`, long
+  task prompts) before flagging "user reactions." Real reactions are short, in lowercase, and often
+  profane.
 - **"OUTPUT (ERROR)" over-inclusion**: the episode extractor flags errors heuristically. Filter
   again on `Process exited with code 1` or `✗` markers before counting real failures.
 - **Don't fix surfaces the team is already redesigning.** Check `sibyl recall <topic>` before


### PR DESCRIPTION
## Summary

- Run Prettier over the newly added `agent-activity-audit` skill docs.

## Why

Latest `main` CI failed in Static Checks on `ca8b675b` because `skills:lint`
reported formatting issues in `agent-activity-audit/EXAMPLES.md` and
`agent-activity-audit/SKILL.md`. This is the release blocker for cutting
`v0.9.0` from current `main`.

## Validation

- `moon run skills:lint` → All matched files use Prettier code style


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation formatting, text wrapping, and layout across skill examples and guidance materials for enhanced readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/10)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->