### PR TITLE
fix(api): require global admin for setup config writes

### DIFF
--- a/apps/api/src/sibyl/persistence/surreal/setup.py
+++ b/apps/api/src/sibyl/persistence/surreal/setup.py
@@ -114,7 +114,7 @@ async def require_setup_mode_or_auth(request: Request) -> None:
 
 
 async def require_setup_mode_or_admin(request: Request) -> AuthUser | None:
-    """Allow setup mode access, otherwise require an authenticated org owner/admin."""
+    """Allow setup mode access, otherwise require an authenticated global admin."""
     if await is_setup_mode():
         return None
 
@@ -130,10 +130,10 @@ async def require_setup_mode_or_admin(request: Request) -> AuthUser | None:
         ) from exc
 
     ctx = await build_auth_context(request, None)
-    if ctx.organization is None or ctx.org_role not in _ADMIN_ROLES:
+    if ctx.user.is_admin is not True:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin or owner role required",
+            detail="Global admin required",
         )
     return ctx.user
 

--- a/apps/api/tests/test_surreal_setup.py
+++ b/apps/api/tests/test_surreal_setup.py
@@ -119,10 +119,10 @@ async def test_require_setup_mode_or_admin_reports_initialized_without_token(
 
 
 @pytest.mark.asyncio
-async def test_require_setup_mode_or_admin_accepts_org_owner(
+async def test_require_setup_mode_or_admin_accepts_global_admin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    user = object()
+    user = SimpleNamespace(is_admin=True)
     monkeypatch.setattr(surreal_setup, "is_setup_mode", AsyncMock(return_value=False))
     monkeypatch.setattr(
         surreal_setup,
@@ -149,12 +149,12 @@ async def test_require_setup_mode_or_admin_accepts_org_owner(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("role", [OrganizationRole.OWNER, OrganizationRole.ADMIN])
-async def test_require_setup_mode_or_admin_accepts_org_admin_roles(
+@pytest.mark.parametrize("role", [OrganizationRole.OWNER, OrganizationRole.ADMIN, OrganizationRole.MEMBER])
+async def test_require_setup_mode_or_admin_accepts_global_admin_in_any_org_role(
     monkeypatch: pytest.MonkeyPatch,
     role: OrganizationRole,
 ) -> None:
-    user = object()
+    user = SimpleNamespace(is_admin=True)
     monkeypatch.setattr(surreal_setup, "is_setup_mode", AsyncMock(return_value=False))
     monkeypatch.setattr(
         surreal_setup,
@@ -182,13 +182,19 @@ async def test_require_setup_mode_or_admin_accepts_org_admin_roles(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("organization", "role"),
-    [(object(), OrganizationRole.MEMBER), (None, OrganizationRole.OWNER)],
+    ("organization", "role", "is_admin"),
+    [
+        (object(), OrganizationRole.OWNER, False),
+        (object(), OrganizationRole.ADMIN, False),
+        (object(), OrganizationRole.MEMBER, False),
+        (None, OrganizationRole.OWNER, False),
+    ],
 )
 async def test_require_setup_mode_or_admin_rejects_non_admin_context(
     monkeypatch: pytest.MonkeyPatch,
     organization: object | None,
     role: OrganizationRole,
+    is_admin: bool,
 ) -> None:
     monkeypatch.setattr(surreal_setup, "is_setup_mode", AsyncMock(return_value=False))
     monkeypatch.setattr(
@@ -203,7 +209,7 @@ async def test_require_setup_mode_or_admin_rejects_non_admin_context(
             return_value=SimpleNamespace(
                 organization=organization,
                 org_role=role,
-                user=object(),
+                user=SimpleNamespace(is_admin=is_admin),
             )
         ),
     )
@@ -214,7 +220,7 @@ async def test_require_setup_mode_or_admin_rejects_non_admin_context(
         )
 
     assert exc_info.value.status_code == 403
-    assert exc_info.value.detail == "Admin or owner role required"
+    assert exc_info.value.detail == "Global admin required"
 
 
 def test_surreal_setup_exports_neutral_runtime_surface() -> None:


### PR DESCRIPTION
### Motivation
- The post-setup guard for `/api/setup/config` previously authorized any organization `OWNER`/`ADMIN`, which allowed ordinary users (who are owner of their personal org) to update server-wide provider secrets.
- The intent is to protect global runtime secrets after bootstrap by requiring a global administrator, not per-organization owners.

### Description
- Tighten `require_setup_mode_or_admin` in `apps/api/src/sibyl/persistence/surreal/setup.py` to require `ctx.user.is_admin is True` after setup completes and update the docstring and error detail to reflect a global-admin requirement.
- Update `apps/api/tests/test_surreal_setup.py` to reflect the new authorization boundary by asserting global admins are allowed regardless of org role and non-global-admin contexts are rejected with a `403` and message `"Global admin required"`.
- Leave the `require_settings_admin` org-admin guard unchanged so org-scoped settings still require org owner/admin as intended.

### Testing
- Attempted monorepo test runner: `moon run api:test -- apps/api/tests/test_surreal_setup.py` (failed because `moon` is not available in this environment).
- Ran `pytest -q apps/api/tests/test_surreal_setup.py`, which failed during collection due to environment/plugin mismatch (unknown pytest config option `asyncio_default_fixture_loop_scope`).
- Updated unit tests locally in the branch to reflect the new behavior, but full automated test execution could not be completed in this environment due to missing test runtime configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fa9f8394832aac00acdf6476f591)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated setup operation authorization to require global admin status instead of organization-scoped roles, improving access control consistency across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->