### PR TITLE
fix(api): escape OAuth client_name in MCP login UI

### DIFF
--- a/apps/api/src/sibyl/auth/mcp_oauth.py
+++ b/apps/api/src/sibyl/auth/mcp_oauth.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import secrets
 import time
+from html import escape
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Protocol, cast
@@ -511,7 +512,7 @@ class SibylMcpOAuthProvider(
             )
 
         client = await self.get_client(pending.client_id)
-        client_name = (client.client_name if client else None) or "MCP Client"
+        client_name = escape((client.client_name if client else None) or "MCP Client", quote=True)
 
         html = f"""
 <!doctype html>

--- a/apps/api/src/sibyl/auth/mcp_oauth.py
+++ b/apps/api/src/sibyl/auth/mcp_oauth.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 import secrets
 import time
-from html import escape
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from html import escape
 from typing import Protocol, cast
 from urllib.parse import urlencode, urlsplit, urlunsplit
 from uuid import UUID, uuid4
@@ -450,9 +450,7 @@ class SibylMcpOAuthProvider(
     async def _create_session_record(self, **kwargs: object) -> object:
         return await create_session_record(**kwargs)
 
-    async def _load_oauth_client_registration(
-        self, client_id: str
-    ) -> dict[str, object] | None:
+    async def _load_oauth_client_registration(self, client_id: str) -> dict[str, object] | None:
         return cast(
             "dict[str, object] | None",
             await load_oauth_client_registration(client_id),

--- a/apps/api/tests/test_mcp_oauth_multi_org_selection.py
+++ b/apps/api/tests/test_mcp_oauth_multi_org_selection.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 from mcp.server.auth.provider import AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull
 from pydantic.networks import AnyUrl
 from starlette.requests import Request
 
@@ -138,3 +139,27 @@ async def test_mcp_oauth_org_selection_issues_code(monkeypatch) -> None:
     assert qs["state"] == ["state123"]
     assert "req123" not in provider._pending
     assert "req123" not in provider._authed
+
+
+@pytest.mark.asyncio
+async def test_mcp_oauth_login_page_escapes_client_name() -> None:
+    provider = SibylMcpOAuthProvider()
+    provider._pending["req123"] = _PendingAuth(client_id="client1", expires_at=time.time() + 600, params=None)
+    await provider.register_client(
+        OAuthClientInformationFull(
+            client_id="client1",
+            client_secret="secret1",
+            redirect_uris=["http://127.0.0.1:9911/callback"],
+            token_endpoint_auth_method="client_secret_post",
+            scope="mcp",
+            client_name='</strong><script>alert("xss")</script><strong>',
+        )
+    )
+
+    req = _make_get_request(path="/_oauth/login", query={"req": "req123"})
+    resp = await provider.ui_login_get(req)
+
+    assert resp.status_code == 200
+    body = resp.body.decode("utf-8")
+    assert "<script>alert(\"xss\")</script>" not in body
+    assert "&lt;/strong&gt;&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;&lt;strong&gt;" in body


### PR DESCRIPTION
### Motivation
- Prevent a stored/persistent XSS where attacker-controlled OAuth `client_name` (now persisted in auth storage) can be interpolated into the MCP OAuth login HTML and execute script in the browser.

### Description
- HTML-escape the resolved `client_name` using `html.escape(..., quote=True)` in `SibylMcpOAuthProvider.ui_login_get` (`apps/api/src/sibyl/auth/mcp_oauth.py`) and add a regression test `test_mcp_oauth_login_page_escapes_client_name` in `apps/api/tests/test_mcp_oauth_multi_org_selection.py` that registers a malicious client name and asserts the page contains the escaped text instead of raw markup.

### Testing
- Attempted `moon run api:test` but `moon` is not available in this environment; ran `pytest -q apps/api/tests/test_mcp_oauth_multi_org_selection.py` which failed during collection due to a local pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f429f4d0832aa7a50ab11d2ae0db)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security on the OAuth login page by escaping client names to prevent injection via displayed client labels.

* **Tests**
  * Added automated test validating that client names with HTML/JS are rendered as escaped/encoded text on the login page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->