### PR TITLE
fix(api): enforce source-scope read checks in reflection drain

### DIFF
--- a/apps/api/src/sibyl/api/routes/memory.py
+++ b/apps/api/src/sibyl/api/routes/memory.py
@@ -2189,8 +2189,39 @@ async def drain_reflection_review(
             ),
             http_request=http_request,
         )
+        source_accessible_projects = await list_accessible_project_graph_ids(ctx)
+        readable_projects = {
+            str(project_id) for project_id in source_accessible_projects or set()
+        }
         results: list[ReflectionReviewDrainItem] = []
         for candidate in candidates:
+            policy_context = MemoryPolicyContext(
+                action=MemoryPolicyAction.READ,
+                actor_user_id=ctx.user_id,
+                organization_id=ctx.organization_id,
+                organization_role=ctx.org_role,
+                memory_space=candidate.memory_scope.value,
+                scope_key=candidate.scope_key,
+                project_id=_memory_project_id(candidate),
+                accessible_projects=readable_projects,
+                agent_id=candidate.agent_id,
+                source_surface="reflection_review_drain",
+            )
+            decision = authorize_memory_read(policy_context=policy_context)
+            if not decision.allowed:
+                results.append(
+                    ReflectionReviewDrainItem(
+                        candidate_id=candidate.id,
+                        outcome="skip",
+                        recommended_action="route_to_review",
+                        dry_run=request.dry_run,
+                        reason="policy_denied",
+                        review_state=candidate.review_state,
+                        raw_source_ids=[],
+                        policy_reasons=[decision.reason],
+                    )
+                )
+                continue
             candidate_request = ReflectionAutonomyRequest(
                 candidate_id=candidate.id,
                 promote_to_scope=request.promote_to_scope,

--- a/apps/api/src/sibyl/api/routes/memory.py
+++ b/apps/api/src/sibyl/api/routes/memory.py
@@ -1019,7 +1019,8 @@ def _correction_history(
     for event in audit_events:
         if not (
             event.action.startswith("memory.correction")
-            or event.action in {
+            or event.action
+            in {
                 "memory.hide",
                 "memory.redact",
                 "memory.restore",
@@ -2190,13 +2191,10 @@ async def drain_reflection_review(
             http_request=http_request,
         )
         source_accessible_projects = await list_accessible_project_graph_ids(ctx)
-        readable_projects = {
-            str(project_id) for project_id in source_accessible_projects or set()
-        }
+        readable_projects = {str(project_id) for project_id in source_accessible_projects or set()}
         results: list[ReflectionReviewDrainItem] = []
         for candidate in candidates:
             policy_context = MemoryPolicyContext(
-                action=MemoryPolicyAction.READ,
                 actor_user_id=ctx.user_id,
                 organization_id=ctx.organization_id,
                 organization_role=ctx.org_role,

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -459,9 +459,7 @@ async def test_remember_raw_uses_shared_policy_for_project_scope_write() -> None
 @pytest.mark.asyncio
 async def test_remember_raw_denies_disallowed_api_key_memory_space() -> None:
     ctx = _ctx()
-    ctx.api_key_memory_scope_keys = [
-        api_key_memory_scope_key("project", "project_allowed")
-    ]
+    ctx.api_key_memory_scope_keys = [api_key_memory_scope_key("project", "project_allowed")]
     with (
         patch(
             "sibyl.api.routes.memory.list_accessible_project_graph_ids",
@@ -2028,7 +2026,7 @@ async def test_drain_reflection_review_dry_run_summarizes_pending_candidates() -
         review_state="pending",
         limit=2,
     )
-    access.assert_awaited_once()
+    access.assert_awaited()
     promote.assert_not_awaited()
     assert response.scanned_count == 2
     assert response.auto_promote_count == 1
@@ -2038,8 +2036,6 @@ async def test_drain_reflection_review_dry_run_summarizes_pending_candidates() -
     assert response.results[0].outcome == "auto_promote"
     assert response.results[1].candidate_id == "candidate-exception"
     assert response.results[1].reason == "policy_denied"
-
-
 
 
 @pytest.mark.asyncio
@@ -2061,6 +2057,10 @@ async def test_drain_reflection_review_skips_inaccessible_candidate_scope() -> N
         ),
         patch(
             "sibyl.api.routes.memory.list_accessible_project_graph_ids",
+            AsyncMock(return_value={"open-project"}),
+        ),
+        patch(
+            "sibyl.api.routes.memory._accessible_projects_for_promotion",
             AsyncMock(return_value={"open-project"}),
         ),
         patch(
@@ -2086,6 +2086,7 @@ async def test_drain_reflection_review_skips_inaccessible_candidate_scope() -> N
     assert response.results[0].candidate_id == "candidate-secret"
     assert response.results[0].reason == "policy_denied"
     assert response.results[0].policy_reasons == ["unverified_membership"]
+
 
 @pytest.mark.asyncio
 async def test_drain_reflection_review_archives_terminal_exceptions() -> None:

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -2040,6 +2040,53 @@ async def test_drain_reflection_review_dry_run_summarizes_pending_candidates() -
     assert response.results[1].reason == "policy_denied"
 
 
+
+
+@pytest.mark.asyncio
+async def test_drain_reflection_review_skips_inaccessible_candidate_scope() -> None:
+    inaccessible_candidate = RawMemory(
+        id="candidate-secret",
+        organization_id="org-1",
+        source_id="source-secret",
+        principal_id="owner-user",
+        memory_scope=MemoryScope.PROJECT,
+        scope_key="secret-project",
+        metadata={"project_id": "secret-project"},
+        capture_surface="reflection_candidate",
+    )
+    with (
+        patch(
+            "sibyl.api.routes.memory.list_reflection_candidate_reviews",
+            AsyncMock(return_value=[inaccessible_candidate]),
+        ),
+        patch(
+            "sibyl.api.routes.memory.list_accessible_project_graph_ids",
+            AsyncMock(return_value={"open-project"}),
+        ),
+        patch(
+            "sibyl.api.routes.memory.preview_reflection_candidate_promotion",
+            AsyncMock(),
+        ) as preview,
+        patch("sibyl.api.routes.memory.log_memory_audit_event", AsyncMock()),
+    ):
+        response = await drain_reflection_review(
+            ReflectionReviewDrainRequest(
+                dry_run=False,
+                limit=1,
+                promote_to_scope="project",
+                promote_to_scope_key="open-project",
+            ),
+            org=_org(),
+            ctx=_ctx(),
+        )
+
+    preview.assert_not_awaited()
+    assert response.scanned_count == 1
+    assert response.skip_count == 1
+    assert response.results[0].candidate_id == "candidate-secret"
+    assert response.results[0].reason == "policy_denied"
+    assert response.results[0].policy_reasons == ["unverified_membership"]
+
 @pytest.mark.asyncio
 async def test_drain_reflection_review_archives_terminal_exceptions() -> None:
     preview = NativeReflectionPromotionPreview(


### PR DESCRIPTION
### Motivation
- Prevent an IDOR and data-leak where the `/memory/reflection/review/drain` bulk path could promote candidates from projects the caller cannot read into a target project the caller controls.
- Ensure the drain only processes candidates whose source-scope content the caller is authorized to read to preserve confidentiality and integrity across project boundaries.

### Description
- Added a per-candidate read policy check in `drain_reflection_review` that builds a `MemoryPolicyContext` and calls `authorize_memory_read` before preview/promotion, and skips candidates that are not allowed. (`apps/api/src/sibyl/api/routes/memory.py`).
- Collected source-readable project IDs via `list_accessible_project_graph_ids` and passed them into the read policy decision to ensure project-scoped candidates are validated against caller visibility. (`apps/api/src/sibyl/api/routes/memory.py`).
- When a candidate is denied by the read policy the drain now appends a `ReflectionReviewDrainItem` with `outcome="skip"` and `reason="policy_denied"` instead of attempting preview/promotion or archive. (`apps/api/src/sibyl/api/routes/memory.py`).
- Added a regression test `test_drain_reflection_review_skips_inaccessible_candidate_scope` that verifies project-scoped candidates from inaccessible projects are skipped and never sent to promotion preview. (`apps/api/tests/test_routes_memory.py`).

### Testing
- Attempted the repository test runner with `moon run api:test -- apps/api/tests/test_routes_memory.py -k drain_reflection_review`, but `moon` is not available in the current environment so the command could not be executed.
- Ran `python -m pytest apps/api/tests/test_routes_memory.py -k drain_reflection_review`, but pytest collection failed due to a local pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests could not be fully executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f51efa60832ab2917077216c5c56)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reflection review now enforces authorization per candidate; inaccessible items are skipped and flagged with clear policy-denied outcomes.
* **Tests**
  * Added a test validating that inaccessible reflection candidates are not auto-reviewed and are reported as skipped.
  * Adjusted an existing dry-run test’s assertion to reflect relaxed mock invocation expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->