### PR TITLE
fix(api): prevent forged raw-memory scope in entity capture metadata

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -103,6 +103,26 @@ GRAPH_ENTITY_ID_PREFIXES = frozenset(
 )
 LIST_RESPONSE_CONTENT = ""
 
+_RAW_CAPTURE_METADATA_DENYLIST = frozenset(
+    {
+        "principal_id",
+        "memory_scope",
+        "scope_key",
+        "agent_id",
+        "project_id",
+        "review_state",
+        "source_id",
+        "raw_source_id",
+    }
+)
+
+
+def _sanitize_raw_capture_metadata(metadata: dict[str, object]) -> dict[str, object]:
+    """Drop caller-controlled fields that map to authoritative capture columns."""
+    return {
+        key: value for key, value in metadata.items() if key not in _RAW_CAPTURE_METADATA_DENYLIST
+    }
+
 
 # =============================================================================
 # Helpers
@@ -1178,6 +1198,7 @@ async def create_entity(
             raise HTTPException(status_code=400, detail=message)
 
         if request_metadata.get("capture_mode") in {"quick", "remember"}:
+            raw_capture_metadata = _sanitize_raw_capture_metadata(request_metadata)
             await _archive_raw_capture(
                 content_session,
                 organization_id=org.id,
@@ -1187,7 +1208,7 @@ async def create_entity(
                 entity_content=content,
                 entity_type=entity.entity_type.value,
                 tags=list(entity.tags or []),
-                metadata=request_metadata,
+                metadata=raw_capture_metadata,
             )
 
         # For async creation, return immediately with pending response.

--- a/apps/api/tests/test_routes_entities_write.py
+++ b/apps/api/tests/test_routes_entities_write.py
@@ -236,3 +236,55 @@ async def test_delete_project_routes_through_runtime_project_record() -> None:
         graph_project_id="project_new",
     )
     audit_log.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_entity_sanitizes_raw_capture_scope_metadata() -> None:
+    org = _org()
+    ctx = _ctx()
+    entity = EntityCreate(
+        name="Scoped capture",
+        content="Capture this.",
+        entity_type=EntityType.DECISION,
+        metadata={
+            "capture_mode": "remember",
+            "capture_surface": "dashboard",
+            "memory_scope": "project",
+            "scope_key": "project_forged",
+            "principal_id": "victim",
+            "project_id": "project_forged",
+            "review_state": "accepted",
+            "source_id": "source-forged",
+            "raw_source_id": "raw-source-forged",
+            "safe": "kept",
+        },
+    )
+    add_result = SimpleNamespace(success=True, id="decision_1", message="ok")
+
+    with (
+        patch("sibyl_core.tools.core.add", AsyncMock(return_value=add_result)),
+        patch("sibyl.api.routes.entities.get_entity_graph_runtime", AsyncMock()),
+        patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),
+        patch("sibyl.api.routes.entities.log_audit_event", AsyncMock()),
+        patch("sibyl.api.routes.entities._archive_raw_capture", AsyncMock()) as archive_capture,
+    ):
+        await create_entity(
+            request=_request(),
+            entity=entity,
+            org=org,
+            ctx=ctx,
+            content_session=None,
+            sync=False,
+        )
+
+    sent_metadata = archive_capture.await_args.kwargs["metadata"]
+    assert sent_metadata["capture_mode"] == "remember"
+    assert sent_metadata["capture_surface"] == "dashboard"
+    assert sent_metadata["safe"] == "kept"
+    assert "memory_scope" not in sent_metadata
+    assert "scope_key" not in sent_metadata
+    assert "principal_id" not in sent_metadata
+    assert "project_id" not in sent_metadata
+    assert "review_state" not in sent_metadata
+    assert "source_id" not in sent_metadata
+    assert "raw_source_id" not in sent_metadata

--- a/apps/api/tests/test_routes_entities_write.py
+++ b/apps/api/tests/test_routes_entities_write.py
@@ -262,6 +262,7 @@ async def test_create_entity_sanitizes_raw_capture_scope_metadata() -> None:
     add_result = SimpleNamespace(success=True, id="decision_1", message="ok")
 
     with (
+        patch("sibyl.api.routes.entities.verify_entity_project_access", AsyncMock()),
         patch("sibyl_core.tools.core.add", AsyncMock(return_value=add_result)),
         patch("sibyl.api.routes.entities.get_entity_graph_runtime", AsyncMock()),
         patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),


### PR DESCRIPTION
### Motivation

- The entity creation path forwarded untrusted `entity.metadata` into the raw-capture persistence path, allowing callers to set fields like `memory_scope`, `scope_key`, and `principal_id` that are later used by raw-memory recall selectors and can forge memory scope/identity for other users or projects. 
- This is an integrity/authorization bypass because the entity route only validated `project_id` and did not perform the same authorization checks as the dedicated raw-memory API.

### Description

- Added an allowlist/denylist sanitizer that drops caller-controlled keys mapping to authoritative raw-capture columns by introducing `_RAW_CAPTURE_METADATA_DENYLIST` and `_sanitize_raw_capture_metadata` in `apps/api/src/sibyl/api/routes/entities.py`.
- Updated the `create_entity` flow to call `_sanitize_raw_capture_metadata` and pass the sanitized metadata to `_archive_raw_capture` for `capture_mode` values `quick` and `remember`, preserving informational fields like `capture_mode` and `capture_surface` while removing sensitive scope/selector fields.
- Added a focused regression test `test_create_entity_sanitizes_raw_capture_scope_metadata` in `apps/api/tests/test_routes_entities_write.py` that asserts sensitive keys are removed before `_archive_raw_capture` is invoked and that benign metadata remains.

### Testing

- Attempted to run the repository test driver via `moon` but `moon` is not available in the execution environment, so a monorepo-level test run could not be performed.
- Ran a focused `pytest` invocation for the added route test, however collection failed due to a local pytest configuration/plugin mismatch (`asyncio_default_fixture_loop_scope` unknown), so the new test could not be executed in this environment.
- No automated tests in this environment failed due to the changes; the modifications are minimal and limited to sanitizing metadata before archival and adding a unit test that will validate the behavior when the test environment matches repository configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f128e59c832a9bfed3cbcd5bcecc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized caller-controlled metadata during entity creation in quick and remember capture modes so disallowed fields are removed before being archived or persisted.

* **Tests**
  * Added tests to confirm metadata sanitization and ensure only allowed metadata fields are forwarded during entity creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->