### PR TITLE
fix(mcp): enforce API-key memory-space checks on context and reflect

### DIFF
--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -808,6 +808,8 @@ async def _add_mcp_entity(
         project,
         require_project_when_restricted=True,
     )
+    memory_scope = "project" if project else "private"
+    scope_key = project
     write_decision = _authorize_mcp_memory_write(
         ctx=ctx,
         memory_scope=memory_scope,
@@ -927,9 +929,6 @@ async def _manage_mcp_action(
         entity_id=entity_id,
         data=full_data,
         organization_id=ctx.org_id,
-        allowed_memory_scope_keys=set(ctx.api_key_memory_scope_keys)
-        if ctx.api_key_memory_scope_keys is not None
-        else None,
     )
     payload = _to_dict(result)
     if policy_decision is not None:

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -272,6 +272,16 @@ async def _compile_mcp_context_pack(
 
     ctx = await _require_mcp_context()
     accessible_projects = await _resolve_mcp_project_scope(ctx, project)
+    memory_scope = "project" if project else "private"
+    scope_key = project
+    if not _mcp_memory_scope_allowed(ctx, memory_scope=memory_scope, scope_key=scope_key):
+        _deny_mcp_api_key_memory_scope(
+            ctx=ctx,
+            action=MemoryPolicyAction.READ,
+            memory_scope=memory_scope,
+            scope_key=scope_key,
+            surface="mcp_context",
+        )
     pack = await _compile_context(
         goal=goal,
         intent=intent,
@@ -285,6 +295,9 @@ async def _compile_mcp_context_pack(
         include_related=include_related,
         related_limit=related_limit,
         organization_id=ctx.org_id,
+        allowed_memory_scope_keys=set(ctx.api_key_memory_scope_keys)
+        if ctx.api_key_memory_scope_keys is not None
+        else None,
     )
     payload = context_pack_to_dict(pack)
     payload["markdown"] = context_pack_to_markdown(pack)
@@ -554,6 +567,16 @@ async def _reflect_mcp_memory(
         task_ids=task_ids,
         active_task=active_task and persist,
     )
+    memory_scope = "project" if project else "private"
+    scope_key = project
+    if persist:
+        _authorize_mcp_memory_write(
+            ctx=ctx,
+            memory_scope=memory_scope,
+            scope_key=scope_key,
+            accessible_projects=accessible_projects,
+            surface="mcp_reflect",
+        )
     pack = await reflect_memory(
         content=content,
         source_title=source_title,
@@ -564,8 +587,8 @@ async def _reflect_mcp_memory(
         organization_id=ctx.org_id,
         principal_id=ctx.user_id,
         accessible_projects=accessible_projects,
-        memory_scope="project" if project else "private",
-        scope_key=project,
+        memory_scope=memory_scope,
+        scope_key=scope_key,
         persist=persist,
         persist_source=persist_source,
         persist_review=persist_review,
@@ -787,8 +810,8 @@ async def _add_mcp_entity(
     )
     write_decision = _authorize_mcp_memory_write(
         ctx=ctx,
-        memory_scope="project" if project else "private",
-        scope_key=project,
+        memory_scope=memory_scope,
+        scope_key=scope_key,
         accessible_projects=accessible_projects,
         surface="mcp_add",
     )
@@ -904,6 +927,9 @@ async def _manage_mcp_action(
         entity_id=entity_id,
         data=full_data,
         organization_id=ctx.org_id,
+        allowed_memory_scope_keys=set(ctx.api_key_memory_scope_keys)
+        if ctx.api_key_memory_scope_keys is not None
+        else None,
     )
     payload = _to_dict(result)
     if policy_decision is not None:

--- a/apps/api/tests/test_server_accessible_projects.py
+++ b/apps/api/tests/test_server_accessible_projects.py
@@ -189,6 +189,7 @@ async def test_compile_mcp_context_pack_audits_render_receipt() -> None:
     resolve_scope.assert_awaited_once_with(ctx, "project-a")
     compile_context.assert_awaited_once()
     assert compile_context.await_args.kwargs["accessible_projects"] == {"project-a"}
+    assert compile_context.await_args.kwargs["allowed_memory_scope_keys"] is None
     audit.assert_awaited_once()
     kwargs = audit.await_args.kwargs
     assert kwargs["action"] == "memory.context_pack"
@@ -204,6 +205,33 @@ async def test_compile_mcp_context_pack_audits_render_receipt() -> None:
     assert kwargs["details"]["domain"] == "sibyl"
     assert kwargs["details"]["layer"] == "wake"
     assert kwargs["details"]["accessible_project_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_compile_mcp_context_pack_denies_api_key_memory_scope_mismatch() -> None:
+    ctx = McpContext(
+        org_id=str(uuid4()),
+        user_id="user-1",
+        scopes=["mcp"],
+        api_key_memory_scope_keys=[api_key_memory_scope_key("project", "project-a")],
+    )
+
+    with (
+        patch("sibyl.server._require_mcp_context", AsyncMock(return_value=ctx)),
+        patch("sibyl.server._resolve_mcp_project_scope", AsyncMock(return_value={"project-b"})),
+        pytest.raises(ValueError, match="api_key_memory_space_denied"),
+    ):
+        await _compile_mcp_context_pack(
+            goal="ship faster",
+            intent="build",
+            layer="wake",
+            domain="sibyl",
+            project="project-b",
+            agent_id="nova",
+            limit=8,
+            include_related=False,
+            related_limit=0,
+        )
 
 
 @pytest.mark.asyncio
@@ -932,6 +960,30 @@ async def test_reflect_mcp_memory_links_single_active_task_when_persisting() -> 
     assert audit.await_args.kwargs["derived_ids"] == []
     assert audit.await_args.kwargs["details"]["related_to_count"] == 3
     explore.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reflect_mcp_memory_persist_enforces_api_key_memory_scope() -> None:
+    ctx = McpContext(
+        org_id=str(uuid4()),
+        user_id=str(uuid4()),
+        scopes=["mcp"],
+        api_key_memory_scope_keys=[api_key_memory_scope_key("project", "project-a")],
+    )
+
+    with (
+        patch("sibyl.server._require_mcp_context", AsyncMock(return_value=ctx)),
+        patch("sibyl.server._get_accessible_projects", AsyncMock(return_value={"project-b"})),
+        patch("sibyl_core.tools.core.reflect_memory", AsyncMock()) as reflect_memory,
+        pytest.raises(ValueError, match="api_key_memory_space_denied"),
+    ):
+        await _reflect_mcp_memory(
+            content="Denied",
+            project="project-b",
+            persist=True,
+        )
+
+    reflect_memory.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -414,6 +414,7 @@ async def _compile_raw_memory_section(
     agent_id: str | None,
     project: str | None,
     accessible_projects: set[str] | None,
+    allowed_memory_scope_keys: set[str] | None,
     limit: int,
     recall_fn: RawMemoryRecallFn,
 ) -> ContextSection | None:
@@ -429,6 +430,11 @@ async def _compile_raw_memory_section(
     if agent_id:
         recall_specs.append(("private", None, agent_id, project))
     for memory_scope, scope_key, spec_agent_id, spec_project_id in recall_specs:
+        if allowed_memory_scope_keys is not None:
+            effective_scope_key = principal_id if memory_scope == "private" else scope_key
+            policy_key = f"{memory_scope}\x1f{'' if effective_scope_key is None else str(effective_scope_key).strip()}"
+            if policy_key not in allowed_memory_scope_keys:
+                continue
         if memory_scope == "project" and not scope_key:
             continue
         decision = authorize_memory_read(
@@ -832,6 +838,7 @@ async def compile_context(
     related_fn: RelatedFn = _default_related_items,
     raw_memory_recall_fn: RawMemoryRecallFn = recall_raw_memory,
     retrieval_mode: str | NativeRetrievalMode | None = None,
+    allowed_memory_scope_keys: set[str] | None = None,
 ) -> ContextPack:
     """Build a small, structured context pack for an agent goal."""
 
@@ -904,6 +911,7 @@ async def compile_context(
             agent_id=agent_id,
             project=project,
             accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
             limit=min(LAYER_RAW_LIMITS[normalized_layer], limit),
             recall_fn=raw_memory_recall_fn,
         )


### PR DESCRIPTION
### Motivation
- MCP API-key memory-space restrictions were only enforced for some write helpers, allowing context compilation and reflect persistence to read or write out-of-scope memories and bypass the intended least-privilege boundary.
- The change closes an authorization gap so MCP tokens scoped to specific memory spaces cannot access or persist memory outside those spaces.

### Description
- Deny out-of-scope context requests early in `_compile_mcp_context_pack` by checking `_mcp_memory_scope_allowed` and raising the API-key memory-space denial when mismatched.
- Forward the API-key allow-list into core retrieval by adding an `allowed_memory_scope_keys` parameter to `compile_context` and passing `set(ctx.api_key_memory_scope_keys)` from the MCP server when present.
- Filter raw-memory recalls inside `_compile_raw_memory_section` to skip `private`/`project` recall specs not included in the `allowed_memory_scope_keys` allow-list while preserving existing policy checks.
- Enforce `_authorize_mcp_memory_write(...)` in `_reflect_mcp_memory` when `persist=True` so reflect persistence cannot bypass the API-key memory-space check, and pass consistent `memory_scope`/`scope_key` values to `reflect_memory`.
- Add focused server tests that assert context compilation returns `allowed_memory_scope_keys` is `None` for unrestricted keys, that context compilation denies mismatched API-key memory scopes, and that reflect persistence is denied and `reflect_memory` is not invoked for mismatched API-key scopes.

### Testing
- Attempted `moon run api:test ...` but `moon` is not installed in this environment so it was not executed here.
- Ran `pytest` targeting the modified server tests, but the test run failed due to a local pytest configuration/plugin mismatch reporting an unknown `asyncio_default_fixture_loop_scope` option, so the added tests could not be executed in this environment.
- New tests have been added under `apps/api/tests/test_server_accessible_projects.py` and were committed with the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f2fe7e84832ab01226ca6841c4f8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory scope enforcement tightened: operations that compile or persist memory now respect API key–allowed memory scopes and correctly reject unauthorized requests.

* **Tests**
  * Added tests verifying that memory compilation and persistence fail when requested scopes are outside an API key’s permitted memory scopes, and that unauthorized calls are not performed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->