### PR TITLE
fix(reflection): require authorized prior IDs before supersession metadata

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/reflection.py
@@ -749,8 +749,9 @@ def _explicit_superseded_ids(
 ) -> list[str]:
     matched = _ids_from_pattern(_SUPERSESSION_PATTERN, candidate.content)
     known_ids = {source_id.lower() for source_id in prior_source_ids}
-    if known_ids:
-        matched = [source_id for source_id in matched if source_id.lower() in known_ids]
+    if not known_ids:
+        return []
+    matched = [source_id for source_id in matched if source_id.lower() in known_ids]
     return list(dict.fromkeys(matched))
 
 

--- a/packages/python/sibyl-core/tests/test_reflection_extractor.py
+++ b/packages/python/sibyl-core/tests/test_reflection_extractor.py
@@ -312,6 +312,19 @@ def test_reflection_lifecycle_decisions_prefer_explicit_supersession() -> None:
     assert result.reflection_findings[-1].kind == "supersession"
 
 
+def test_reflection_lifecycle_decisions_ignore_supersession_without_authorized_prior() -> None:
+    candidate = _grounded_candidate("Sibyl review is disabled and supersedes memory-1.")
+
+    [result] = apply_reflection_lifecycle_decisions(
+        [candidate],
+        prior_memories=[],
+    )
+
+    assert "supersedes_source_ids" not in result.metadata
+    assert "supersedes" not in result.metadata
+    assert all(finding.kind != "supersession" for finding in result.reflection_findings)
+
+
 def test_reflection_lifecycle_decisions_emit_stale_findings() -> None:
     candidate = _grounded_candidate("memory-1 is outdated.")
 


### PR DESCRIPTION
### Motivation
- Prevent user-controlled `supersedes <id>` phrases from injecting arbitrary supersession targets into candidate metadata when no authorized prior memories are available, which could otherwise be promoted into `SUPERSEDES` graph relationships crossing project/tenant boundaries.

### Description
- Hardened `_explicit_superseded_ids` to return an empty list when `prior_source_ids` contains no authorized IDs by checking `known_ids` and returning `[]` early; when `known_ids` exist, matches are still filtered against that allowlist (`_explicit_superseded_ids`).
- Added a regression test `test_reflection_lifecycle_decisions_ignore_supersession_without_authorized_prior` that asserts no `supersedes` metadata or `supersession` finding is emitted when `prior_memories` is empty even if candidate text contains `supersedes memory-1`.
- The change preserves existing behavior when authorized prior IDs are present (explicit supersession still preferred and recorded).

### Testing
- Attempted the monorepo test runner with `moon run core:test -- packages/python/sibyl-core/tests/test_reflection_extractor.py` but `moon` is not available in the execution environment, so the run could not be performed.
- Attempted a focused run with `python -m pytest packages/python/sibyl-core/tests/test_reflection_extractor.py -k supersession` but it failed due to local import setup (`ModuleNotFoundError: No module named 'sibyl_core'`), so tests could not be executed here.
- A unit regression test was added to the test suite to cover the fix; the test should be executable in CI or a developer environment where `moon` or proper Python package setup is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f3796b48832a9a8291a9efe0b59a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected supersession filtering logic to properly validate identifiers only against authorized prior references. When no prior references exist, supersession candidates are now correctly excluded from results.

* **Tests**
  * Added test coverage for reflection lifecycle decisions to verify proper handling when prior references are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->