### PR TITLE
fix(security): stop exposing Valkey/Redis port in compose profiles

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -125,8 +125,6 @@ services:
     image: valkey/valkey:8-alpine
     container_name: sibyl-redis
     command: ["valkey-server", "--save", "", "--appendonly", "no"]
-    ports:
-      - "${SIBYL_REDIS_PORT:-6381}:6379"
     restart: unless-stopped
 
   # ==========================================================================

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -115,8 +115,6 @@ services:
     image: valkey/valkey:8-alpine
     container_name: sibyl-redis
     command: ["valkey-server", "--save", "", "--appendonly", "no"]
-    ports:
-      - "${SIBYL_REDIS_PORT:-6381}:6379"
     restart: unless-stopped
 
   # ==========================================================================


### PR DESCRIPTION
### Motivation
- The optional Valkey/Redis service in `docker-compose.prod.yml` and `docker-compose.quickstart.yml` published the Redis port to the host without password/ACL, creating an unauthenticated network-exposed queue that the worker trusts for mutating background jobs.

### Description
- Remove host port publishing for the `redis` service in `docker-compose.prod.yml` so Valkey/Redis remains internal to the Compose network.
- Remove host port publishing for the `redis` service in `docker-compose.quickstart.yml` so Valkey/Redis remains internal to the Compose network.
- The change is configuration-only and does not modify application code, worker job registration, or runtime behavior when the `redis` profile is enabled.

### Testing
- Confirmed the published port lines were removed by searching the compose files with `rg --line-number "redis:|SIBYL_REDIS_PORT|valkey-server|ports:"` and verifying the `ports:` mapping is no longer present for the `redis` service.
- Inspected the updated file regions with `nl -ba <file> | sed -n '<start>,<end>p'` to validate the `redis` service block no longer contains host port mappings.
- Verified repository working tree reflected the two modified compose files and that the diffs contained only the intended deletions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fd078a04832aab4c6e779930c15e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Redis/Valkey persistence disabled in production, so data will not be persisted across restarts.
  * Redis/Valkey no longer maps a host port; the service is reachable only via the internal Docker network, not directly from the host.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->