### PR TITLE
fix(native-retrieval): enforce memory-scope policy on graph candidates

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
@@ -1513,7 +1513,9 @@ def _candidate_allowed(
     )
 
 
-def _candidate_scope_allowed(candidate: NativeRetrievalCandidate, plan: NativeRetrievalPlan) -> bool:
+def _candidate_scope_allowed(
+    candidate: NativeRetrievalCandidate, plan: NativeRetrievalPlan
+) -> bool:
     metadata = candidate.metadata if isinstance(candidate.metadata, Mapping) else {}
     raw_scope = metadata.get("memory_scope")
     if raw_scope is None:
@@ -1522,16 +1524,17 @@ def _candidate_scope_allowed(candidate: NativeRetrievalCandidate, plan: NativeRe
     if memory_scope is None:
         return False
     scope_key = _string_value(metadata.get("scope_key"))
-    if memory_scope is MemoryScope.PRIVATE and scope_key:
-        allowed_private_scope_keys = {scope.scope_key for scope in plan.scopes if scope.scope_key}
-        if scope_key not in allowed_private_scope_keys:
-            return False
+    plan_principal = plan.scopes[0].principal_id if plan.scopes else None
+    if memory_scope is MemoryScope.PRIVATE:
+        owner = _string_value(metadata.get("principal_id")) or scope_key
+        return bool(plan_principal) and owner == plan_principal
+    agent_id = next((scope.agent_id for scope in plan.scopes if scope.agent_id), None)
     decision = authorize_memory_read(
-        principal_id=plan.principal_id,
+        principal_id=plan_principal,
         memory_scope=memory_scope,
         scope_key=scope_key,
         project_id=plan.project,
-        agent_id=plan.agent_id,
+        agent_id=agent_id,
         accessible_projects=plan.accessible_projects,
     )
     return decision.allowed

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
@@ -1498,6 +1498,8 @@ def _candidate_allowed(
 ) -> bool:
     if requested_types and not _candidate_matches_types(candidate, requested_types, facet):
         return False
+    if not _candidate_scope_allowed(candidate, plan):
+        return False
     if _explicit_project_denied(plan) and candidate.type != "raw_memory":
         return False
     if candidate.type == "episode" and (plan.project or plan.accessible_projects is not None):
@@ -1509,6 +1511,39 @@ def _candidate_allowed(
         and candidate.project_id is not None
         and candidate.project_id not in plan.accessible_projects
     )
+
+
+def _candidate_scope_allowed(candidate: NativeRetrievalCandidate, plan: NativeRetrievalPlan) -> bool:
+    metadata = candidate.metadata if isinstance(candidate.metadata, Mapping) else {}
+    raw_scope = metadata.get("memory_scope")
+    if raw_scope is None:
+        return True
+    memory_scope = _coerce_memory_scope(raw_scope)
+    if memory_scope is None:
+        return False
+    scope_key = _string_value(metadata.get("scope_key"))
+    if memory_scope is MemoryScope.PRIVATE and scope_key:
+        allowed_private_scope_keys = {scope.scope_key for scope in plan.scopes if scope.scope_key}
+        if scope_key not in allowed_private_scope_keys:
+            return False
+    decision = authorize_memory_read(
+        principal_id=plan.principal_id,
+        memory_scope=memory_scope,
+        scope_key=scope_key,
+        project_id=plan.project,
+        agent_id=plan.agent_id,
+        accessible_projects=plan.accessible_projects,
+    )
+    return decision.allowed
+
+
+def _coerce_memory_scope(value: object) -> MemoryScope | None:
+    if isinstance(value, MemoryScope):
+        return value
+    try:
+        return MemoryScope(str(value))
+    except ValueError:
+        return None
 
 
 def _candidate_matches_types(

--- a/packages/python/sibyl-core/tests/test_native_retrieval.py
+++ b/packages/python/sibyl-core/tests/test_native_retrieval.py
@@ -112,6 +112,64 @@ def test_build_native_context_retrieval_plan_denies_unverified_project_scope() -
     )
 
 
+def test_candidate_allowed_denies_private_scope_key_mismatch() -> None:
+    plan = build_native_context_retrieval_plan(
+        query="private memory",
+        organization_id="org-123",
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["episode", "note"]},
+        principal_id="bob",
+        project=None,
+        accessible_projects=None,
+        agent_id=None,
+    )
+
+    assert not native_module._candidate_allowed(
+        NativeRetrievalCandidate(
+            id="entity-1",
+            type="note",
+            name="Alice private reflection",
+            content="secret",
+            score=1.0,
+            source=None,
+            metadata={"memory_scope": "private", "scope_key": "alice"},
+            project_id=None,
+        ),
+        plan=plan,
+        requested_types=set(),
+        facet=None,
+    )
+
+
+def test_candidate_allowed_allows_private_scope_key_match() -> None:
+    plan = build_native_context_retrieval_plan(
+        query="private memory",
+        organization_id="org-123",
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["episode", "note"]},
+        principal_id="bob",
+        project=None,
+        accessible_projects=None,
+        agent_id=None,
+    )
+
+    assert native_module._candidate_allowed(
+        NativeRetrievalCandidate(
+            id="entity-2",
+            type="note",
+            name="Bob private reflection",
+            content="mine",
+            score=1.0,
+            source=None,
+            metadata={"memory_scope": "private", "scope_key": "bob"},
+            project_id=None,
+        ),
+        plan=plan,
+        requested_types=set(),
+        facet=None,
+    )
+
+
 def test_build_native_context_retrieval_plan_requires_principal() -> None:
     plan = build_native_context_retrieval_plan(
         query="no principal",


### PR DESCRIPTION
### Motivation
- A change made native retrieval the default path and exposed an authorization gap where graph-projected entities carrying `memory_scope`/`scope_key` metadata could be returned without calling `authorize_memory_read`, allowing private reflected memories to leak across principals in the same organization.

### Description
- Add a pre-filter `_candidate_scope_allowed` that reads candidate `metadata.memory_scope`/`metadata.scope_key`, coerces the scope, and calls `authorize_memory_read` to enforce memory policy before existing type/project checks.
- Deny private-scoped graph projections whose `scope_key` is not present in the retrieval plan's authorized private scopes, while preserving existing behavior for candidates without scope metadata or with valid project scoping.
- Add helper `_coerce_memory_scope` to normalize candidate-provided scope values into `MemoryScope` and return `None` for invalid values.
- Add two regression tests asserting that a private graph candidate with a mismatched `scope_key` is denied and that a matching owner `scope_key` is allowed (`test_candidate_allowed_denies_private_scope_key_mismatch` and `test_candidate_allowed_allows_private_scope_key_match`).

### Testing
- Attempted to run package tests with `moon run core:test -- packages/python/sibyl-core/tests/test_native_retrieval.py`, but the `moon` tool is not available in this environment so the command could not be executed (failure).
- Attempted `python -m pytest packages/python/sibyl-core/tests/test_native_retrieval.py`, which failed in this environment due to missing import path setup (`ModuleNotFoundError: No module named 'sibyl_core'`).
- The change includes focused unit tests added to `packages/python/sibyl-core/tests/test_native_retrieval.py` which should be run in the normal development CI or a properly bootstrapped developer environment and are intended to prevent regressions for the scope-policy enforcement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08feda407c832abfa79b9c978bd328)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an extra scope-based authorization gate for memory candidates: private candidates now require matching scope keys to be accessible, and non-private candidates undergo an authorization check against the plan’s scope and project context.
* **Tests**
  * Added unit tests covering private-scope allow/deny behavior for memory candidates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->