### PR TITLE
fix(core): authorize supersedes targets during reflection promotion

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/native_memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/native_memory.py
@@ -303,12 +303,18 @@ async def persist_reflection_candidate_native(
         }
     )
     created_id = await runtime.entity_manager.create_direct(entity)
+    superseded_ids = await _authorized_superseded_entity_ids(
+        runtime=runtime,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        candidate=candidate,
+    )
     relationships = _relationships_for_promotion(
         created_id,
         project=project,
         source_id=source_id if link_source_entity else None,
         related_to=related_to,
-        supersedes=_superseded_entity_ids(candidate.metadata),
+        supersedes=superseded_ids,
         raw_source_ids=source_ids,
     )
     if relationships:
@@ -1598,6 +1604,40 @@ def _superseded_entity_ids(metadata: Mapping[str, object]) -> list[str]:
         "superseded_ids",
         "supersedes_entity_ids",
     )
+
+
+async def _authorized_superseded_entity_ids(
+    *,
+    runtime: Any,
+    principal_id: str | None,
+    accessible_projects: Iterable[str] | None,
+    candidate: ReflectionCandidate,
+) -> list[str]:
+    authorized_ids: list[str] = []
+    for entity_id in _superseded_entity_ids(candidate.metadata):
+        try:
+            target_entity = await runtime.entity_manager.get(entity_id)
+        except Exception:
+            continue
+        metadata = target_entity.metadata if isinstance(target_entity.metadata, Mapping) else {}
+        target_scope = _resolve_memory_scope(
+            _metadata_str(metadata, "memory_scope"),
+            _metadata_str(metadata, "project_id"),
+        )
+        target_scope_key = _resolve_scope_key(
+            target_scope,
+            _metadata_str(metadata, "scope_key"),
+            _metadata_str(metadata, "project_id"),
+        )
+        decision = authorize_memory_write(
+            principal_id=principal_id,
+            memory_scope=target_scope,
+            scope_key=target_scope_key,
+            accessible_projects=accessible_projects,
+        )
+        if decision.allowed:
+            authorized_ids.append(entity_id)
+    return authorized_ids
 
 
 def _is_reflection_candidate(memory: RawMemory) -> bool:

--- a/packages/python/sibyl-core/src/sibyl_core/services/native_memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/native_memory.py
@@ -279,6 +279,12 @@ async def persist_reflection_candidate_native(
 
     runtime = await get_native_graph_runtime(organization_id)
     source_ids = _candidate_source_ids(candidate, source_id)
+    superseded_ids = await _authorized_superseded_entity_ids(
+        runtime=runtime,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        candidate=candidate,
+    )
     entity = _entity_from_candidate(
         candidate,
         organization_id=organization_id,
@@ -292,23 +298,20 @@ async def persist_reflection_candidate_native(
     )
     entity = entity.model_copy(
         update={
-            "metadata": _promotion_lifecycle_metadata(
-                metadata=entity.metadata,
-                promoted_entity_id=entity.id,
-                source_ids=source_ids,
-                source_id=source_ids[0] if source_ids else None,
-                reason=candidate.reason,
-                policy_metadata=policy_metadata,
+            "metadata": _with_authorized_supersedes(
+                _promotion_lifecycle_metadata(
+                    metadata=entity.metadata,
+                    promoted_entity_id=entity.id,
+                    source_ids=source_ids,
+                    source_id=source_ids[0] if source_ids else None,
+                    reason=candidate.reason,
+                    policy_metadata=policy_metadata,
+                ),
+                superseded_ids,
             )
         }
     )
     created_id = await runtime.entity_manager.create_direct(entity)
-    superseded_ids = await _authorized_superseded_entity_ids(
-        runtime=runtime,
-        principal_id=principal_id,
-        accessible_projects=accessible_projects,
-        candidate=candidate,
-    )
     relationships = _relationships_for_promotion(
         created_id,
         project=project,
@@ -736,13 +739,7 @@ async def preview_memory_access(
     policy_reasons = [decision.reason for decision in decisions]
     denied_reasons = [decision.reason for decision in decisions if not decision.allowed]
     allowed = not denied_reasons and not lifecycle_hidden_source_ids
-    access_state = (
-        "allowed"
-        if allowed
-        else "partial"
-        if visible_source_ids
-        else "denied"
-    )
+    access_state = "allowed" if allowed else "partial" if visible_source_ids else "denied"
     metadata: dict[str, Any] = {
         "access_state": access_state,
         "denied_memory_space_ids": [space_id for space_id in denied_space_ids if space_id],
@@ -764,9 +761,7 @@ async def preview_memory_access(
         target_principal_type=normalized_target_type,
         target_principal_id=target_principal_id,
         memory_space_ids=[
-            str(_space_field(space, "id"))
-            for space in memory_spaces
-            if _space_field(space, "id")
+            str(_space_field(space, "id")) for space in memory_spaces if _space_field(space, "id")
         ],
         visible_source_ids=visible_source_ids,
         denied_source_ids=denied_source_ids,
@@ -1114,9 +1109,7 @@ def _correction_metadata(
             lifecycle_state=lifecycle.state,
             source_ids=[memory.id],
             related_source_ids=[
-                item
-                for item in (replacement_source_id, duplicate_of_source_id)
-                if item is not None
+                item for item in (replacement_source_id, duplicate_of_source_id) if item is not None
             ],
             policy_reasons=_metadata_str_values(preview.metadata or {}, "policy_reasons"),
             reversible=preview.reversible,
@@ -1596,14 +1589,27 @@ def _candidate_source_ids(
     )
 
 
+_SUPERSEDES_METADATA_KEYS = (
+    "supersedes",
+    "supersedes_ids",
+    "superseded_ids",
+    "supersedes_entity_ids",
+)
+
+
 def _superseded_entity_ids(metadata: Mapping[str, object]) -> list[str]:
-    return _metadata_str_values(
-        metadata,
-        "supersedes",
-        "supersedes_ids",
-        "superseded_ids",
-        "supersedes_entity_ids",
-    )
+    return _metadata_str_values(metadata, *_SUPERSEDES_METADATA_KEYS)
+
+
+def _with_authorized_supersedes(
+    metadata: Mapping[str, object], authorized_ids: Sequence[str]
+) -> dict[str, object]:
+    """Replace any supersedes id list in metadata with the authorized targets."""
+    sanitized = dict(metadata)
+    for key in _SUPERSEDES_METADATA_KEYS:
+        if key in sanitized:
+            sanitized[key] = list(authorized_ids)
+    return sanitized
 
 
 async def _authorized_superseded_entity_ids(
@@ -1618,6 +1624,8 @@ async def _authorized_superseded_entity_ids(
         try:
             target_entity = await runtime.entity_manager.get(entity_id)
         except Exception:
+            continue
+        if target_entity is None:
             continue
         metadata = target_entity.metadata if isinstance(target_entity.metadata, Mapping) else {}
         target_scope = _resolve_memory_scope(

--- a/packages/python/sibyl-core/tests/graph/surreal/test_native_memory_contract.py
+++ b/packages/python/sibyl-core/tests/graph/surreal/test_native_memory_contract.py
@@ -331,6 +331,18 @@ async def test_post_reflection_recall_promotes_review_candidate_into_native_cont
             ),
             generate_embedding=False,
         )
+        await runtime.entity_manager.create_direct(
+            Entity(
+                id="decision_other_project",
+                entity_type=EntityType.DECISION,
+                name="Decision: Other project should stay isolated",
+                description="Cross-project metadata must not create supersedes edges.",
+                content="Cross-project metadata must not create supersedes edges.",
+                organization_id=group_id,
+                metadata={"project_id": "project_other"},
+            ),
+            generate_embedding=False,
+        )
 
         compatibility_add = AsyncMock(
             side_effect=AssertionError("compatibility add path should not run")
@@ -370,7 +382,7 @@ async def test_post_reflection_recall_promotes_review_candidate_into_native_cont
                 candidate_memory,
                 metadata={
                     **candidate_memory.metadata,
-                    "supersedes_ids": ["decision_legacy_recall"],
+                    "supersedes_ids": ["decision_legacy_recall", "decision_other_project"],
                 },
             )
         )
@@ -424,6 +436,7 @@ async def test_post_reflection_recall_promotes_review_candidate_into_native_cont
         assert (promotion.promoted_id, "BELONGS_TO", "project_native") in relationship_keys
         assert (promotion.promoted_id, "RELATED_TO", "task_native") in relationship_keys
         assert (promotion.promoted_id, "SUPERSEDES", "decision_legacy_recall") in relationship_keys
+        assert (promotion.promoted_id, "SUPERSEDES", "decision_other_project") not in relationship_keys
         supersedes_row = next(row for row in relationship_rows if row["name"] == "SUPERSEDES")
         assert supersedes_row["attributes"]["source_id"] == reflection.source_id
         assert supersedes_row["attributes"]["raw_source_ids"] == [reflection.source_id]


### PR DESCRIPTION
### Motivation

- Prevent metadata-sourced `supersedes` IDs from allowing an authenticated caller to inject unauthorized cross-project `SUPERSEDES` graph edges during reflection promotion.
- Ensure promotion only creates relationships to targets the caller is authorized to write, preserving project/memory isolation and recall integrity.

### Description

- Introduced `async def _authorized_superseded_entity_ids(...)` which loads each candidate target entity, derives its target `memory_scope`/`scope_key` from target metadata, and applies `authorize_memory_write(...)` to filter allowed IDs.
- Switched promotion to call `_authorized_superseded_entity_ids(...)` and pass the filtered `supersedes` IDs into `_relationships_for_promotion(...)` instead of trusting `candidate.metadata` directly.
- Added test coverage in `tests/graph/surreal/test_native_memory_contract.py` that creates an in-project and an other-project decision and asserts the promotion only creates a `SUPERSEDES` edge for the authorized same-project target.

### Testing

- Attempted `moon run core:test -- tests/graph/surreal/test_native_memory_contract.py` but it failed because `moon` is not available in the execution environment (command not found). 
- Attempted `python -m pytest packages/python/sibyl-core/tests/graph/surreal/test_native_memory_contract.py -k reflection -q` but the run failed with `ModuleNotFoundError: No module named 'sibyl_core'` due to missing local test/runtime dependencies, so the updated test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0900b8f97c832aa8ccc102cf540375)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced write-authorization when promoting entities so superseding actions only include authorized, in-scope targets, preventing cross-project or unauthorized supersedes.

* **Tests**
  * Added/updated tests to confirm promotions respect project boundaries and only create supersede relationships for authorized, in-scope entities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->