### PR TITLE
fix(memory): enforce source-scope auth for reflection promotion

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/native_memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/native_memory.py
@@ -361,6 +361,7 @@ async def promote_reflection_candidate_review(
         promote_to_scope_key=promote_to_scope_key,
         domain=domain,
         project=project,
+        accessible_projects=accessible_projects,
     )
     if isinstance(plan, NativeReflectionPromotionResult):
         return plan
@@ -450,6 +451,7 @@ async def preview_reflection_candidate_promotion(
         promote_to_scope_key=promote_to_scope_key,
         domain=domain,
         project=project,
+        accessible_projects=accessible_projects,
     )
     if isinstance(plan, NativeReflectionPromotionResult):
         return _promotion_preview_from_denial(plan)
@@ -1187,6 +1189,7 @@ async def _resolve_reflection_promotion_plan(
     promote_to_scope_key: str | None = None,
     domain: str | None = None,
     project: str | None = None,
+    accessible_projects: Iterable[str] | None = None,
 ) -> _NativeReflectionPromotionPlan | NativeReflectionPromotionResult:
     candidate_memory = await get_raw_memory(
         organization_id=organization_id,
@@ -1247,6 +1250,15 @@ async def _resolve_reflection_promotion_plan(
     )
     if ownership_denial is not None:
         return ownership_denial
+    source_scope_denial = _source_scope_denial(
+        input_memories,
+        candidate_id=candidate_memory.id,
+        principal_id=principal_id,
+        raw_source_ids=raw_source_ids,
+        accessible_projects=accessible_projects,
+    )
+    if source_scope_denial is not None:
+        return source_scope_denial
 
     target_scope = _coerce_promotion_scope(promote_to_scope)
     if target_scope is None:
@@ -1696,6 +1708,35 @@ def _principal_denial(
                 memory_scope=memory.memory_scope,
                 scope_key=memory.scope_key,
                 raw_source_ids=raw_source_ids,
+            )
+    return None
+
+
+def _source_scope_denial(
+    memories: Sequence[RawMemory],
+    *,
+    candidate_id: str,
+    principal_id: str | None,
+    raw_source_ids: list[str],
+    accessible_projects: Iterable[str] | None,
+) -> NativeReflectionPromotionResult | None:
+    for memory in memories:
+        read_decision = authorize_memory_read(
+            principal_id=principal_id,
+            memory_scope=memory.memory_scope,
+            scope_key=memory.scope_key,
+            accessible_projects=accessible_projects,
+        )
+        if not read_decision.allowed:
+            return _promotion_denied(
+                candidate_id=candidate_id,
+                reason=read_decision.reason,
+                review_state=memories[0].review_state,
+                memory_scope=memory.memory_scope,
+                scope_key=memory.scope_key,
+                raw_source_ids=raw_source_ids,
+                policy_decisions=(read_decision,),
+                metadata={"input_scopes": _scope_metadata(memories)},
             )
     return None
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/native_memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/native_memory.py
@@ -1430,6 +1430,7 @@ def _promotion_denied(
     scope_key: str | None,
     raw_source_ids: list[str],
     metadata: dict[str, Any] | None = None,
+    policy_decisions: Sequence[MemoryPolicyDecision] = (),
 ) -> NativeReflectionPromotionResult:
     payload = {"policy_reasons": [reason], "policy_allowed": False}
     if metadata:
@@ -1444,6 +1445,7 @@ def _promotion_denied(
         scope_key=scope_key,
         raw_source_ids=raw_source_ids,
         metadata=payload,
+        policy_decisions=tuple(policy_decisions),
     )
 
 

--- a/packages/python/sibyl-core/tests/test_native_memory.py
+++ b/packages/python/sibyl-core/tests/test_native_memory.py
@@ -462,9 +462,7 @@ async def test_apply_memory_correction_marks_hidden_and_preserves_history(
     assert lifecycle.action == "hide"
     assert findings[-1].kind == "correction"
     assert findings[-1].target_source_id == "source-1"
-    assert result.updated_memory.metadata["correction_history"][0] == {
-        "action": "mark_stale"
-    }
+    assert result.updated_memory.metadata["correction_history"][0] == {"action": "mark_stale"}
     assert result.updated_memory.metadata["correction_history"][1]["action"] == "hide"
     save_raw_memory.assert_awaited_once()
 
@@ -723,6 +721,7 @@ async def test_promote_review_candidate_denies_mixed_scope_without_target(
         organization_id="org-1",
         principal_id="user-1",
         promote_to_scope=None,
+        accessible_projects={"project_123"},
     )
 
     assert not result.success
@@ -753,6 +752,7 @@ async def test_promote_review_candidate_requires_broadest_mixed_scope_target(
         organization_id="org-1",
         principal_id="user-1",
         promote_to_scope="private",
+        accessible_projects={"project_123"},
     )
 
     assert not result.success
@@ -769,7 +769,7 @@ async def test_promote_review_candidate_denies_inaccessible_source_scope(
         scope_key="project_secret",
         principal_id="victim-user",
     )
-    source = _raw_review_candidate(id="source-1")
+    source = _raw_review_candidate(id="source-1", principal_id="attacker-user")
     monkeypatch.setattr(
         native_memory,
         "get_raw_memory",

--- a/packages/python/sibyl-core/tests/test_native_memory.py
+++ b/packages/python/sibyl-core/tests/test_native_memory.py
@@ -761,6 +761,39 @@ async def test_promote_review_candidate_requires_broadest_mixed_scope_target(
 
 
 @pytest.mark.asyncio
+async def test_promote_review_candidate_denies_inaccessible_source_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candidate = _raw_review_candidate(
+        memory_scope=MemoryScope.PROJECT,
+        scope_key="project_secret",
+        principal_id="victim-user",
+    )
+    source = _raw_review_candidate(id="source-1")
+    monkeypatch.setattr(
+        native_memory,
+        "get_raw_memory",
+        AsyncMock(side_effect=[candidate, source]),
+    )
+    persist = AsyncMock()
+    monkeypatch.setattr(native_memory, "persist_reflection_candidate_native", persist)
+
+    result = await promote_reflection_candidate_review(
+        candidate_id="candidate-1",
+        organization_id="org-1",
+        principal_id="attacker-user",
+        promote_to_scope="private",
+        accessible_projects=set(),
+    )
+
+    assert not result.success
+    assert result.reason == "unverified_membership"
+    assert result.memory_scope is MemoryScope.PROJECT
+    assert result.scope_key == "project_secret"
+    persist.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_promote_review_candidate_persists_native_record_and_marks_promoted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- The reflection promotion flow authorized only the destination scope and did not verify read access to the source candidate or its raw sources, allowing an IDOR where an authenticated org member could copy restricted candidate content into their own scope.

### Description
- Add a `_source_scope_denial` helper that calls `authorize_memory_read` for each candidate/source memory and returns a promotion denial when any source is unreadable.
- Invoke `_source_scope_denial` in `_resolve_reflection_promotion_plan(...)` immediately after `_principal_denial(...)` so promotion planning fails if the caller cannot read any input scope.
- Thread `accessible_projects` through `promote_reflection_candidate_review(...)`, `preview_reflection_candidate_promotion(...)`, and `_resolve_reflection_promotion_plan(...)` so source read checks use the same project context as destination checks.
- Add a regression test `test_promote_review_candidate_denies_inaccessible_source_scope` in `packages/python/sibyl-core/tests/test_native_memory.py` that asserts a project-scoped candidate cannot be promoted by a caller lacking project membership.

### Testing
- Added unit test `test_promote_review_candidate_denies_inaccessible_source_scope` in `packages/python/sibyl-core/tests/test_native_memory.py` (test asserts the promotion is denied and `persist_reflection_candidate_native` is not called).
- Attempted `moon run core:test` but `moon` is not available in this environment so the full test suite could not be run (environment limitation).
- Attempted `pytest packages/python/sibyl-core/tests/test_native_memory.py -k "promote_review_candidate"` but the test run failed in this environment due to import path configuration (`ModuleNotFoundError: No module named 'sibyl_core'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0900136b54832aa2ea52494c61f00d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Promotion now enforces per-source read authorization and project access; denials provide the specific failing policy decision and include input-scope metadata in the result.

* **Tests**
  * Added test coverage for unauthorized promotion attempts from inaccessible projects and updated related tests to include accessible-project context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->