### PR TITLE
fix(api): enforce raw capture scope visibility

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -201,6 +201,29 @@ def _serialize_raw_capture(capture: RawCaptureRecord) -> RawCaptureResponse:
     )
 
 
+def _raw_capture_visible_to_reader(
+    capture: RawCaptureRecord,
+    *,
+    reader_user_id: str | None,
+    accessible_projects: set[str],
+) -> bool:
+    metadata = capture.metadata or {}
+    memory_scope = str(metadata.get("memory_scope") or "private")
+
+    if memory_scope == "project":
+        project_id = str(metadata.get("scope_key") or metadata.get("project_id") or "").strip()
+        return bool(project_id and project_id in accessible_projects)
+
+    if memory_scope == "private":
+        owner = str(
+            metadata.get("principal_id")
+            or (str(capture.created_by_user_id) if capture.created_by_user_id else "")
+        ).strip()
+        return bool(owner and reader_user_id and owner == reader_user_id)
+
+    return True
+
+
 async def _list_all_entities_paginated(
     entity_manager: Any,
     *,
@@ -656,6 +679,7 @@ async def _fetch_related_entity_summaries(
 @router.get("/captures", response_model=RawCaptureListResponse)
 async def list_raw_captures(
     org: AuthOrganization = Depends(get_current_organization),
+    ctx: AuthContext = Depends(get_auth_context),
     session: Any = Depends(get_content_read_session_dependency),
     entity_type: str | None = Query(default=None, description="Filter by entity type"),
     capture_surface: str | None = Query(default=None, description="Filter by capture surface"),
@@ -665,6 +689,7 @@ async def list_raw_captures(
 ) -> RawCaptureListResponse:
     """List archived raw quick captures for the current organization."""
     try:
+        accessible_projects = await _accessible_project_ids_for_read(ctx)
         captures, has_more = await content_runtime.list_raw_captures(
             session,
             organization_id=org.id,
@@ -674,6 +699,15 @@ async def list_raw_captures(
             limit=limit,
             offset=offset,
         )
+        captures = [
+            capture
+            for capture in captures
+            if _raw_capture_visible_to_reader(
+                capture,
+                reader_user_id=getattr(ctx, "user_id", None),
+                accessible_projects=accessible_projects,
+            )
+        ]
 
         return RawCaptureListResponse(
             captures=[_serialize_raw_capture_summary(capture) for capture in captures],
@@ -692,16 +726,22 @@ async def list_raw_captures(
 async def get_raw_capture(
     capture_id: UUID,
     org: AuthOrganization = Depends(get_current_organization),
+    ctx: AuthContext = Depends(get_auth_context),
     session: Any = Depends(get_content_read_session_dependency),
 ) -> RawCaptureResponse:
     """Get a single archived raw quick capture."""
     try:
+        accessible_projects = await _accessible_project_ids_for_read(ctx)
         capture = await content_runtime.get_raw_capture(
             session,
             organization_id=org.id,
             capture_id=capture_id,
         )
-        if not capture:
+        if not capture or not _raw_capture_visible_to_reader(
+            capture,
+            reader_user_id=getattr(ctx, "user_id", None),
+            accessible_projects=accessible_projects,
+        ):
             raise HTTPException(status_code=404, detail=f"Raw capture not found: {capture_id}")
 
         return _serialize_raw_capture(capture)

--- a/apps/api/tests/test_api_raw_captures.py
+++ b/apps/api/tests/test_api_raw_captures.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from fastapi import HTTPException
@@ -36,8 +36,9 @@ def _capture(
     surface: str,
     entity_type: str = "episode",
     review_state: str | None = None,
+    owner_id: UUID | None = None,
 ) -> RawCaptureRecord:
-    owner_id = uuid4()
+    owner_id = owner_id or uuid4()
     metadata = {
         "capture_mode": "quick",
         "capture_surface": surface,
@@ -66,9 +67,10 @@ def _capture(
 async def test_list_raw_captures_returns_paginated_summaries() -> None:
     org = _org()
     session = MagicMock()
+    reader_id = uuid4()
     captures = [
-        _capture(org_id=org.id, title="Newest", surface="dashboard"),
-        _capture(org_id=org.id, title="Older", surface="cli"),
+        _capture(org_id=org.id, title="Newest", surface="dashboard", owner_id=reader_id),
+        _capture(org_id=org.id, title="Older", surface="cli", owner_id=reader_id),
     ]
 
     with patch(
@@ -77,7 +79,7 @@ async def test_list_raw_captures_returns_paginated_summaries() -> None:
     ) as list_captures:
         response = await list_raw_captures(
             org=org,
-            ctx=_ctx(user_id=str(captures[0].created_by_user_id)),
+            ctx=_ctx(user_id=str(reader_id)),
             session=session,
             entity_type=None,
             capture_surface=None,
@@ -170,6 +172,29 @@ async def test_get_raw_capture_raises_not_found_for_other_org() -> None:
         await get_raw_capture(
             uuid4(),
             org=_org(),
+            ctx=_ctx(user_id=str(uuid4())),
+            session=session,
+        )
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_raw_capture_hides_other_users_private_capture() -> None:
+    org = _org()
+    capture = _capture(org_id=org.id, title="Someone else's note", surface="dashboard")
+    session = MagicMock()
+
+    with (
+        patch(
+            "sibyl.api.routes.entities.content_runtime.get_raw_capture",
+            AsyncMock(return_value=capture),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await get_raw_capture(
+            capture.id,
+            org=org,
             ctx=_ctx(user_id=str(uuid4())),
             session=session,
         )

--- a/apps/api/tests/test_api_raw_captures.py
+++ b/apps/api/tests/test_api_raw_captures.py
@@ -23,6 +23,12 @@ def _org() -> MagicMock:
     return org
 
 
+def _ctx(*, user_id: str) -> MagicMock:
+    ctx = MagicMock()
+    ctx.user_id = user_id
+    return ctx
+
+
 def _capture(
     *,
     org_id,
@@ -31,7 +37,13 @@ def _capture(
     entity_type: str = "episode",
     review_state: str | None = None,
 ) -> RawCaptureRecord:
-    metadata = {"capture_mode": "quick", "capture_surface": surface}
+    owner_id = uuid4()
+    metadata = {
+        "capture_mode": "quick",
+        "capture_surface": surface,
+        "memory_scope": "private",
+        "principal_id": str(owner_id),
+    }
     if review_state is not None:
         metadata["review_state"] = review_state
 
@@ -45,7 +57,7 @@ def _capture(
         tags=["alpha"],
         metadata=metadata,
         capture_surface=surface,
-        created_by_user_id=uuid4(),
+        created_by_user_id=owner_id,
         created_at=datetime(2026, 4, 14, 16, 0, tzinfo=UTC),
     )
 
@@ -65,6 +77,7 @@ async def test_list_raw_captures_returns_paginated_summaries() -> None:
     ) as list_captures:
         response = await list_raw_captures(
             org=org,
+            ctx=_ctx(user_id=str(captures[0].created_by_user_id)),
             session=session,
             entity_type=None,
             capture_surface=None,
@@ -104,6 +117,7 @@ async def test_list_raw_captures_supports_review_state_filter() -> None:
     ) as list_captures:
         response = await list_raw_captures(
             org=org,
+            ctx=_ctx(user_id=str(captures[0].created_by_user_id)),
             session=session,
             entity_type=None,
             capture_surface=None,
@@ -126,7 +140,12 @@ async def test_get_raw_capture_returns_verbatim_content() -> None:
         "sibyl.api.routes.entities.content_runtime.get_raw_capture",
         AsyncMock(return_value=capture),
     ) as load_capture:
-        response = await get_raw_capture(capture.id, org=org, session=session)
+        response = await get_raw_capture(
+            capture.id,
+            org=org,
+            ctx=_ctx(user_id=str(capture.created_by_user_id)),
+            session=session,
+        )
 
     assert response.id == str(capture.id)
     assert response.title == "Quick memory"
@@ -148,7 +167,12 @@ async def test_get_raw_capture_raises_not_found_for_other_org() -> None:
     session.execute = AsyncMock(return_value=result)
 
     with pytest.raises(HTTPException) as exc:
-        await get_raw_capture(uuid4(), org=_org(), session=session)
+        await get_raw_capture(
+            uuid4(),
+            org=_org(),
+            ctx=_ctx(user_id=str(uuid4())),
+            session=session,
+        )
 
     assert exc.value.status_code == 404
 


### PR DESCRIPTION
### Motivation
- Reflection callers can persist private/project-scoped raw reflection notes into the `raw_captures` review queue when `persist_review` is used, but the read endpoints exposed those captures to any org viewer because listing/detail queries only filtered by `organization_id`.
- This change prevents org-level viewers from enumerating or reading private or project-scoped captures they do not have access to by enforcing the stored `memory_scope` at the API read boundary.

### Description
- Add a visibility gate function `
_raw_capture_visible_to_reader(capture, *, reader_user_id, accessible_projects)
` that enforces `private` captures are readable only by the owning principal and `project` captures are readable only by callers with access to the project; other scopes remain unchanged. (modified `apps/api/src/sibyl/api/routes/entities.py`)
- Wire auth context into the raw-capture read endpoints and filter list results and detail responses through the new visibility gate. (modified `apps/api/src/sibyl/api/routes/entities.py`)
- Update unit tests for raw capture routes to include an auth context and owner metadata so the new visibility rules are exercised. (modified `apps/api/tests/test_api_raw_captures.py`)

### Testing
- Updated tests: `apps/api/tests/test_api_raw_captures.py` was extended to pass an auth context and owner metadata and still expects previous surface/review_state behavior; the updated tests are included in the change set.
- Attempted the monorepo test command `moon run api:test -- apps/api/tests/test_api_raw_captures.py` but `moon` is not available in this environment, so it was not run here.
- Ran `pytest -q apps/api/tests/test_api_raw_captures.py` locally but collection failed due to the environment's pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests could not be executed to completion in this sandbox.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09005ed7c4832abc5389fbbec49bcf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raw-capture visibility controls enforced: listing and viewing now only return captures visible to the requester based on capture scope (project, private, or default/public).
* **Tests**
  * Updated and added tests to validate visibility rules, including private-capture access and cross-project access scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->