### PR TITLE
fix(api): forbid ephemeral Surreal auth in production

### DIFF
--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -123,7 +123,7 @@ class Settings(BaseSettings):
                     "CRITICAL: Default PostgreSQL password 'sibyl_dev' is forbidden in production. "
                     "Set SIBYL_POSTGRES_PASSWORD to a secure value."
                 )
-            if self.store == "surreal" and self.resolved_surreal_url.startswith("memory://"):
+            if self.auth_store == "surreal" and self.resolved_surreal_url.startswith("memory://"):
                 raise ValueError(
                     "CRITICAL: In-memory SurrealDB is forbidden in production. "
                     "Set SIBYL_SURREAL_URL or SIBYL_SURREAL_DATA_DIR."

--- a/apps/api/tests/test_config_security.py
+++ b/apps/api/tests/test_config_security.py
@@ -44,6 +44,7 @@ class TestDisableAuthSecurity:
             }
             if env == "production":
                 kwargs["postgres_password"] = "secure_postgres_pw"
+                kwargs["surreal_url"] = "ws://surrealdb:8000/rpc"
             settings = Settings(**kwargs)  # type: ignore[arg-type]
             assert settings.disable_auth is False
 
@@ -75,6 +76,7 @@ class TestEnvironmentValidation:
             }
             if env == "production":
                 kwargs["postgres_password"] = "secure_postgres_pw"
+                kwargs["surreal_url"] = "ws://surrealdb:8000/rpc"
             settings = Settings(**kwargs)  # type: ignore[arg-type]
             assert settings.environment == env
 
@@ -93,15 +95,14 @@ class TestEnvironmentValidation:
 class TestProductionPasswordSecurity:
     """Tests for production password validation."""
 
-    def test_default_postgres_password_allowed_after_sidecar_removal(self) -> None:
-        settings = Settings(
-            environment="production",
-            store="legacy",
-            auth_store="surreal",
-            postgres_password="sibyl_dev",
-        )
-
-        assert settings.requires_relational_support is False
+    def test_in_memory_surreal_forbidden_when_auth_uses_surreal_in_production(self) -> None:
+        with pytest.raises(ValueError, match="In-memory SurrealDB is forbidden in production"):
+            Settings(
+                environment="production",
+                store="legacy",
+                auth_store="surreal",
+                postgres_password="sibyl_dev",
+            )
 
     def test_legacy_password_defaults_do_not_block_fully_surreal_production(self) -> None:
         settings = Settings(
@@ -129,5 +130,6 @@ class TestProductionPasswordSecurity:
             store="legacy",
             auth_store="surreal",
             postgres_password="my_secure_postgres",
+            surreal_url="ws://surrealdb:8000/rpc",
         )
         assert settings.environment == "production"


### PR DESCRIPTION
### Motivation

- Prevent a production configuration where auth is Surreal-backed but uses the default ephemeral `memory://` backend, which reopens setup mode after restart and allows unauthenticated first-user admin takeover.

### Description

- Tighten production validation in `Settings.validate_security_settings` to reject `memory://` whenever `auth_store == "surreal"` instead of only when `store == "surreal"` by changing the conditional to check `self.auth_store`.
- Update `apps/api/tests/test_config_security.py` to add a regression test that production `store="legacy"` + `auth_store="surreal"` with default Surreal settings is rejected, and to pass a persistent `surreal_url` for production-success cases.
- Keep the intended secure production behavior for fully-Surreal deployments while closing the legacy-store bypass to ephemeral auth state.

### Testing

- Ran the focused test suite with `uv run pytest apps/api/tests/test_config_security.py` and observed all tests in that file passing (`12 passed`).
- The changes were validated by the updated tests which assert the forbidden in-memory SurrealDB behavior in production when `auth_store` is Surreal-backed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0904f24eb0832ab1c7ee97c2f451b5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed production configuration validation to correctly forbid in-memory SurrealDB when Surreal is used for authentication, preventing insecure deployments.
* **Tests**
  * Updated security tests to cover Surreal authentication scenarios and ensure production validation includes the Surreal URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->