### PR TITLE
fix(helm): fail closed when deprecated store/authStore values are provided

### DIFF
--- a/charts/sibyl/templates/configmap.yaml
+++ b/charts/sibyl/templates/configmap.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
+{{- if hasKey .Values "store" }}
+{{- fail "Deprecated value 'store' is no longer supported. Remove it and complete legacy-to-Surreal migration before upgrading." }}
+{{- end }}
+{{- if hasKey .Values "authStore" }}
+{{- fail "Deprecated value 'authStore' is no longer supported. Remove it and complete legacy auth migration before upgrading." }}
+{{- end }}
 metadata:
   name: {{ include "sibyl.fullname" . }}-config
   labels:


### PR DESCRIPTION
### Motivation
- Prevent silent ignore of legacy top-level `store`/`authStore` Helm values which can cause a fail-open upgrade path where an empty Surreal auth store allows an unauthenticated first-signup to become admin.

### Description
- Add template-time guards in `charts/sibyl/templates/configmap.yaml` that check `hasKey .Values "store"` and `hasKey .Values "authStore"` and call `fail` to abort rendering when present.
- This is a minimal fail-closed change that preserves the current Surreal-only runtime rendering while forcing operators to perform a deliberate legacy-to-Surreal migration before upgrading.

### Testing
- Attempted to run `helm template test charts/sibyl` and `helm template test charts/sibyl --set store=legacy` to validate rendering behavior, but `helm` is not installed in the execution environment so the checks could not be executed.
- No other automated test suites were run as part of this change and no runtime code was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0903e628a4832abd7d7ce0d5d0ca48)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Helm chart validation now enforces completion of legacy data and auth migrations before upgrades. Deprecated configuration options are rejected at render time, causing chart rendering to fail with guidance to migrate settings prior to upgrading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->