### PR TITLE
fix(retrieval): prevent cross-project edge leakage in native mode

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
@@ -945,7 +945,9 @@ def _edge_select(extra: str | None = None) -> str:
         SELECT uuid, name, fact, fact_embedding, group_id, episodes, attributes,
                created_at, expired_at, valid_at, invalid_at,
                in.uuid AS source_node_uuid,
-               out.uuid AS target_node_uuid{extra_select}
+               out.uuid AS target_node_uuid,
+               in.project_id AS source_node_project_id,
+               out.project_id AS target_node_project_id{extra_select}
         FROM relates_to
     """
 
@@ -1406,6 +1408,12 @@ def _candidate_from_edge(
 ) -> NativeRetrievalCandidate:
     attributes = _attributes(edge)
     source = _string_value(attributes.get("source_id") or getattr(edge, "uuid", None))
+    source_project_id = _string_value(
+        getattr(edge, "source_node_project_id", None) or attributes.get("source_node_project_id")
+    )
+    target_project_id = _string_value(
+        getattr(edge, "target_node_project_id", None) or attributes.get("target_node_project_id")
+    )
     return NativeRetrievalCandidate(
         id=str(getattr(edge, "uuid", "")),
         type="claim",
@@ -1420,6 +1428,8 @@ def _candidate_from_edge(
             "source_id": source,
             "source_node_uuid": _string_value(getattr(edge, "source_node_uuid", None)),
             "target_node_uuid": _string_value(getattr(edge, "target_node_uuid", None)),
+            "source_node_project_id": source_project_id,
+            "target_node_project_id": target_project_id,
             "retrieval_signals": [signal.value],
         },
         project_id=_string_value(attributes.get("project_id")),
@@ -1506,6 +1516,14 @@ def _candidate_allowed(
         return False
     if plan.project and candidate.project_id and candidate.project_id != plan.project:
         return False
+    if candidate.type == "claim" and plan.accessible_projects is not None:
+        endpoint_project_ids = {
+            _string_value(candidate.metadata.get("source_node_project_id")),
+            _string_value(candidate.metadata.get("target_node_project_id")),
+        }
+        endpoint_project_ids.discard(None)
+        if endpoint_project_ids and not endpoint_project_ids.issubset(plan.accessible_projects):
+            return False
     return not (
         plan.accessible_projects is not None
         and candidate.project_id is not None

--- a/packages/python/sibyl-core/tests/test_native_retrieval.py
+++ b/packages/python/sibyl-core/tests/test_native_retrieval.py
@@ -190,6 +190,70 @@ def test_build_native_context_retrieval_plan_requires_principal() -> None:
     ]
 
 
+def test_candidate_allowed_rejects_cross_project_claim_edge() -> None:
+    plan = build_native_context_retrieval_plan(
+        query="edge permissions",
+        organization_id="org-123",
+        facets=[ContextFacet.ACTIVE_WORK],
+        facet_types={ContextFacet.ACTIVE_WORK: ["claim"]},
+        principal_id="user-123",
+        project="project_A",
+        accessible_projects={"project_A"},
+    )
+    candidate = NativeRetrievalCandidate(
+        id="edge-1",
+        type="claim",
+        name="Cross-project relationship",
+        content="Sensitive relationship",
+        score=1.0,
+        source=None,
+        metadata={
+            "source_node_project_id": "project_A",
+            "target_node_project_id": "project_B",
+        },
+        project_id=None,
+    )
+
+    assert not native_module._candidate_allowed(
+        candidate,
+        plan=plan,
+        requested_types=set(),
+        facet=None,
+    )
+
+
+def test_candidate_allowed_accepts_claim_edge_when_both_endpoints_accessible() -> None:
+    plan = build_native_context_retrieval_plan(
+        query="edge permissions",
+        organization_id="org-123",
+        facets=[ContextFacet.ACTIVE_WORK],
+        facet_types={ContextFacet.ACTIVE_WORK: ["claim"]},
+        principal_id="user-123",
+        project="project_A",
+        accessible_projects={"project_A"},
+    )
+    candidate = NativeRetrievalCandidate(
+        id="edge-1",
+        type="claim",
+        name="In-project relationship",
+        content="Safe relationship",
+        score=1.0,
+        source=None,
+        metadata={
+            "source_node_project_id": "project_A",
+            "target_node_project_id": "project_A",
+        },
+        project_id=None,
+    )
+
+    assert native_module._candidate_allowed(
+        candidate,
+        plan=plan,
+        requested_types=set(),
+        facet=None,
+    )
+
+
 def test_native_plan_estimates_project_filter_selectivity() -> None:
     accessible_projects = {f"project_{index}" for index in range(20)}
     plan = build_native_context_retrieval_plan(


### PR DESCRIPTION
### Motivation
- Close a native retrieval authorization gap where claim/edge candidates could leak relationship facts and endpoint UUIDs when an edge lacked `attributes.project_id` but one endpoint belonged to an accessible project.
- Ensure final authorization can verify both edge endpoints' project scope rather than relying only on an edge-level `project_id` set by attributes or DB projection.

### Description
- Add endpoint project IDs to the Surreal DB edge projection by selecting `in.project_id AS source_node_project_id` and `out.project_id AS target_node_project_id` in `_edge_select` so the query returns endpoint scope context for edges.
- Populate candidate metadata with `source_node_project_id` and `target_node_project_id` in `_candidate_from_edge` so endpoint scopes travel with the `NativeRetrievalCandidate`.
- Harden `_candidate_allowed` to reject `claim`-type candidates when either endpoint project is present and not contained in `plan.accessible_projects`, preventing cross-project disclosure even if `candidate.project_id` is absent.
- Add two regression tests in `test_native_retrieval.py`: one asserting cross-project claim edges are rejected, and one asserting claim edges are allowed when both endpoints are in an accessible project.

### Testing
- Attempted to run monorepo tests via `moon run core:test`, but `moon` is not available in this environment so the monorepo test harness could not be executed (failed: `moon: command not found`).
- Attempted targeted test run with `pytest -q packages/python/sibyl-core/tests/test_native_retrieval.py`, but the environment is missing local package path/dependencies causing `ModuleNotFoundError: No module named 'sibyl_core'` so tests could not be executed here.
- Added targeted unit tests that exercise the new authorization behavior and committed them; they should run successfully in CI or a properly bootstrapped development environment where `moon`/dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0903e55c48832a92843e86dffe96ca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter project-level authorization for claim retrieval: claim candidates are now validated against endpoint project IDs and rejected if they reference projects outside allowed projects (empty/absent endpoint IDs do not cause rejection).

* **Tests**
  * Added unit tests covering claim authorization—both cross-project rejection and same-project acceptance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->