### PR TITLE
fix(api): forbid in-memory Surreal auth in prod legacy runtime

### DIFF
--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -123,7 +123,9 @@ class Settings(BaseSettings):
                     "CRITICAL: Default PostgreSQL password 'sibyl_dev' is forbidden in production. "
                     "Set SIBYL_POSTGRES_PASSWORD to a secure value."
                 )
-            if self.store == "surreal" and self.resolved_surreal_url.startswith("memory://"):
+            if requires_surreal_support(
+                store=self.store, auth_store=self.auth_store
+            ) and self.resolved_surreal_url.startswith("memory://"):
                 raise ValueError(
                     "CRITICAL: In-memory SurrealDB is forbidden in production. "
                     "Set SIBYL_SURREAL_URL or SIBYL_SURREAL_DATA_DIR."

--- a/apps/api/tests/test_config_security.py
+++ b/apps/api/tests/test_config_security.py
@@ -93,15 +93,14 @@ class TestEnvironmentValidation:
 class TestProductionPasswordSecurity:
     """Tests for production password validation."""
 
-    def test_default_postgres_password_allowed_after_sidecar_removal(self) -> None:
-        settings = Settings(
-            environment="production",
-            store="legacy",
-            auth_store="surreal",
-            postgres_password="sibyl_dev",
-        )
-
-        assert settings.requires_relational_support is False
+    def test_legacy_runtime_rejects_memory_surreal_in_production(self) -> None:
+        with pytest.raises(ValueError, match="In-memory SurrealDB is forbidden in production"):
+            Settings(
+                environment="production",
+                store="legacy",
+                auth_store="surreal",
+                postgres_password="sibyl_dev",
+            )
 
     def test_legacy_password_defaults_do_not_block_fully_surreal_production(self) -> None:
         settings = Settings(


### PR DESCRIPTION
### Motivation
- Prevent legacy production deployments from silently using a non-persistent `memory://` SurrealDB for auth (which could allow an attacker to become the first admin), now that auth dispatch is Surreal-only.

### Description
- Tighten production validation in `Settings.validate_security_settings` so the in-memory Surreal guard runs whenever Surreal support is required by the runtime (`requires_surreal_support`) instead of only when `store == "surreal"` (changed in `apps/api/src/sibyl/config.py`).
- Update the security test to assert that a production `store="legacy"` with `auth_store="surreal"` fails when Surreal resolves to `memory://` (changed `apps/api/tests/test_config_security.py`).

### Testing
- Attempted monorepo test command with `moon` but `moon` is not available in this environment so the command could not run.
- Ran targeted `pytest apps/api/tests/test_config_security.py` but collection failed due to a local pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090594caa4832a8e87ab4bd297f71d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened production security validation to prevent in-memory SurrealDB usage across a wider range of runtime configurations.

* **Tests**
  * Updated security validation tests to verify production environment constraints are properly enforced for all supported configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->