### PR TITLE
fix(infra): bind Caddy published ports to loopback in single-host stack

### DIFF
--- a/infra/ansible/roles/sibyl/files/docker-compose.yml
+++ b/infra/ansible/roles/sibyl/files/docker-compose.yml
@@ -80,8 +80,8 @@ services:
       - backend
       - frontend
     ports:
-      - "80:80"
-      - "443:443"
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:443:443"
     environment:
       SIBYL_DOMAIN: ${SIBYL_DOMAIN:?set SIBYL_DOMAIN in .env}
       CF_API_TOKEN: ${CF_API_TOKEN:?set CF_API_TOKEN in .env}


### PR DESCRIPTION
### Motivation
- Align the single-host Docker stack with the documented DNS-01 / tailnet-only intent by preventing Caddy from publishing HTTP/HTTPS ports on all host interfaces, which could expose first-run signup/admin bootstrap to the public internet.

### Description
- Updated `infra/ansible/roles/sibyl/files/docker-compose.yml` to change the Caddy published ports from `"80:80"` and `"443:443"` to `"127.0.0.1:80:80"` and `"127.0.0.1:443:443"` to bind them to loopback only.

### Testing
- No automated tests were run for this configuration-only change; the patch was validated by reviewing the compose diff and verifying the updated file lines in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090ba8506c832aa4d8fe329a89d365)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Caddy service network access configuration to restrict connectivity patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->