### PR TITLE
fix(api): prevent MCP callers from lowering conflict threshold

### DIFF
--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -801,6 +801,7 @@ async def _add_mcp_entity(
     conflict_threshold: float = 0.85,
 ) -> dict[str, Any]:
     from sibyl_core.tools.core import add
+    from sibyl_core.tools.conflicts import CONFLICT_THRESHOLD
 
     ctx = await _require_mcp_context()
     accessible_projects = await _resolve_mcp_project_scope(
@@ -841,7 +842,9 @@ async def _add_mcp_entity(
         repository_url=repository_url,
         check_conflicts=check_conflicts,
         skip_conflicts=skip_conflicts,
-        conflict_threshold=conflict_threshold,
+        # Remote callers can request stricter detection, but cannot weaken
+        # the baseline threshold for organization-wide conflict probes.
+        conflict_threshold=max(conflict_threshold, CONFLICT_THRESHOLD),
     )
     payload = _to_dict(result)
     payload["policy_reason"] = write_decision.reason

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -801,7 +801,6 @@ async def _add_mcp_entity(
     conflict_threshold: float = 0.85,
 ) -> dict[str, Any]:
     from sibyl_core.tools.core import add
-    from sibyl_core.tools.conflicts import CONFLICT_THRESHOLD
 
     ctx = await _require_mcp_context()
     accessible_projects = await _resolve_mcp_project_scope(
@@ -842,9 +841,10 @@ async def _add_mcp_entity(
         repository_url=repository_url,
         check_conflicts=check_conflicts,
         skip_conflicts=skip_conflicts,
-        # Remote callers can request stricter detection, but cannot weaken
-        # the baseline threshold for organization-wide conflict probes.
-        conflict_threshold=max(conflict_threshold, CONFLICT_THRESHOLD),
+        # Remote MCP callers may relax conflict detection but must not drop
+        # below the baseline: a near-zero threshold turns every add into a
+        # low-similarity probe of organization entities.
+        conflict_threshold=max(conflict_threshold, 0.85),
     )
     payload = _to_dict(result)
     payload["policy_reason"] = write_decision.reason

--- a/apps/api/tests/test_server_accessible_projects.py
+++ b/apps/api/tests/test_server_accessible_projects.py
@@ -613,6 +613,38 @@ async def test_add_mcp_entity_requires_project_for_restricted_credentials() -> N
 
 
 @pytest.mark.asyncio
+async def test_add_mcp_entity_clamps_conflict_threshold_floor_for_mcp_callers() -> None:
+    ctx = McpContext(org_id=str(uuid4()), user_id=str(uuid4()), scopes=["mcp"])
+    add = AsyncMock(return_value=AddResponse(success=True, id="task_123", message="ok"))
+
+    with (
+        patch("sibyl.server._require_mcp_context", AsyncMock(return_value=ctx)),
+        patch("sibyl.server._get_accessible_projects", AsyncMock(return_value={"project-a"})),
+        patch("sibyl_core.tools.core.add", add),
+    ):
+        await _add_mcp_entity(
+            title="Probe threshold floor",
+            content="Threshold should not be weakenable by remote callers.",
+            entity_type="task",
+            category=None,
+            languages=None,
+            tags=None,
+            related_to=None,
+            metadata=None,
+            project="project-a",
+            priority=None,
+            assignees=None,
+            due_date=None,
+            technologies=None,
+            depends_on=None,
+            repository_url=None,
+            conflict_threshold=-1.0,
+        )
+
+    assert add.await_args.kwargs["conflict_threshold"] == 0.85
+
+
+@pytest.mark.asyncio
 async def test_add_mcp_entity_denies_missing_actor_with_policy_reason() -> None:
     ctx = McpContext(
         org_id=str(uuid4()),

--- a/apps/api/tests/test_server_accessible_projects.py
+++ b/apps/api/tests/test_server_accessible_projects.py
@@ -615,7 +615,7 @@ async def test_add_mcp_entity_requires_project_for_restricted_credentials() -> N
 @pytest.mark.asyncio
 async def test_add_mcp_entity_clamps_conflict_threshold_floor_for_mcp_callers() -> None:
     ctx = McpContext(org_id=str(uuid4()), user_id=str(uuid4()), scopes=["mcp"])
-    add = AsyncMock(return_value=AddResponse(success=True, id="task_123", message="ok"))
+    add = AsyncMock(return_value={"success": True, "id": "task_123"})
 
     with (
         patch("sibyl.server._require_mcp_context", AsyncMock(return_value=ctx)),


### PR DESCRIPTION
### Motivation
- Prevent remote MCP callers from weakening organization-wide conflict detection by passing an arbitrarily low `conflict_threshold` that could broaden conflict warnings and leak cross-project entity metadata.

### Description
- Clamp remote `conflict_threshold` to the system baseline by importing `CONFLICT_THRESHOLD` and forwarding `conflict_threshold=max(conflict_threshold, CONFLICT_THRESHOLD)` when calling `sibyl_core.tools.core.add` in `apps/api/src/sibyl/server.py`.
- Add a regression unit test `test_add_mcp_entity_clamps_conflict_threshold_floor_for_mcp_callers` in `apps/api/tests/test_server_accessible_projects.py` that calls `_add_mcp_entity` with `conflict_threshold=-1.0` and asserts the forwarded value is clamped to `0.85`.

### Testing
- Added unit test `test_add_mcp_entity_clamps_conflict_threshold_floor_for_mcp_callers` which verifies the clamping behavior via mocks; the test is included in `apps/api/tests/test_server_accessible_projects.py`.
- Attempted to run the package test suite via `moon run api:test ...`, but `moon` is not available in this environment so that invocation could not run.
- Attempted `pytest` directly for the modified test file, but the local test run failed due to a pytest configuration/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ef97d448832abadfb19ebd3e83b3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The system now enforces a minimum conflict-detection threshold for certain add operations, preventing lowering of baseline conflict detection.

* **Tests**
  * Added a test to verify the minimum conflict-detection threshold is enforced for those calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->