### PR TITLE
fix(migrate): prevent archive user takeover via email coalescing

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/migrate/merge.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/merge.py
@@ -272,9 +272,6 @@ def _normalized_email(row: dict[str, Any]) -> str:
 
 
 def _user_identity_key(row: dict[str, Any]) -> tuple[str, str]:
-    email = _normalized_email(row)
-    if email:
-        return ("email", email)
     github_id = str(row.get("github_id") or "").strip()
     if github_id:
         return ("github_id", github_id)

--- a/packages/python/sibyl-core/tests/test_migrate_merge.py
+++ b/packages/python/sibyl-core/tests/test_migrate_merge.py
@@ -305,7 +305,7 @@ def test_merge_archives_can_override_canonical_org_name_and_slug() -> None:
     assert auth["tables"]["organizations"][0]["slug"] == "merged-organization"
 
 
-def test_merge_archives_coalesces_users_by_email_and_rewrites_references() -> None:
+def test_merge_archives_does_not_coalesce_users_by_email() -> None:
     result = merge_archives(
         [
             _archive(
@@ -424,24 +424,16 @@ def test_merge_archives_coalesces_users_by_email_and_rewrites_references() -> No
         options=ArchiveMergeOptions(canonical_org_id=CANONICAL_ORG_ID),
     )
 
-    assert result.user_alias_count == 1
+    assert result.user_alias_count == 0
 
     auth = json.loads(result.archive.files[AUTH_FILENAME].decode("utf-8"))
     assert auth["tables"]["users"] == [
-        {
-            "uuid": "user-a",
-            "email": "stef@hyperbliss.tech",
-            "name": "Stef A",
-            "is_admin": True,
-        }
+        {"uuid": "user-a", "email": "stef@hyperbliss.tech", "name": "Stef A", "is_admin": False},
+        {"uuid": "user-b", "email": "stef@hyperbliss.tech", "name": "Stef B", "is_admin": True},
     ]
     assert auth["tables"]["organization_members"] == [
-        {
-            "uuid": "member-a",
-            "organization_id": CANONICAL_ORG_ID,
-            "user_id": "user-a",
-            "role": "owner",
-        }
+        {"uuid": "member-a", "organization_id": CANONICAL_ORG_ID, "user_id": "user-a", "role": "member"},
+        {"uuid": "member-b", "organization_id": CANONICAL_ORG_ID, "user_id": "user-b", "role": "owner"},
     ]
     assert auth["tables"]["memory_spaces"] == [
         {
@@ -458,5 +450,5 @@ def test_merge_archives_coalesces_users_by_email_and_rewrites_references() -> No
     assert content["tables"]["raw_captures"][0]["principal_id"] == "user-a"
     assert content["tables"]["raw_captures"][0]["scope_key"] == "user-a"
     assert content["tables"]["raw_captures"][0]["created_by_user_id"] == "user-a"
-    assert content["tables"]["source_imports"][0]["principal_id"] == "user-a"
-    assert content["tables"]["source_imports"][0]["target_scope_key"] == "user-a"
+    assert content["tables"]["source_imports"][0]["principal_id"] == "user-b"
+    assert content["tables"]["source_imports"][0]["target_scope_key"] == "user-b"

--- a/packages/python/sibyl-core/tests/test_migrate_merge.py
+++ b/packages/python/sibyl-core/tests/test_migrate_merge.py
@@ -432,8 +432,18 @@ def test_merge_archives_does_not_coalesce_users_by_email() -> None:
         {"uuid": "user-b", "email": "stef@hyperbliss.tech", "name": "Stef B", "is_admin": True},
     ]
     assert auth["tables"]["organization_members"] == [
-        {"uuid": "member-a", "organization_id": CANONICAL_ORG_ID, "user_id": "user-a", "role": "member"},
-        {"uuid": "member-b", "organization_id": CANONICAL_ORG_ID, "user_id": "user-b", "role": "owner"},
+        {
+            "uuid": "member-a",
+            "organization_id": CANONICAL_ORG_ID,
+            "user_id": "user-a",
+            "role": "member",
+        },
+        {
+            "uuid": "member-b",
+            "organization_id": CANONICAL_ORG_ID,
+            "user_id": "user-b",
+            "role": "owner",
+        },
     ]
     assert auth["tables"]["memory_spaces"] == [
         {
@@ -442,7 +452,14 @@ def test_merge_archives_does_not_coalesce_users_by_email() -> None:
             "memory_scope": "private",
             "scope_key": "user-a",
             "created_by_user_id": "user-a",
-        }
+        },
+        {
+            "uuid": "space-b",
+            "organization_id": CANONICAL_ORG_ID,
+            "memory_scope": "private",
+            "scope_key": "user-b",
+            "created_by_user_id": "user-b",
+        },
     ]
     assert "user_sessions" not in auth["tables"]
 


### PR DESCRIPTION
### Motivation
- The archive merge previously treated any non-empty email as a primary identity key and rewrote auth/content references to the first-seen account, enabling an attacker-supplied archive to claim a victim email and inherit credentials/privileges. 
- The change prevents unverified-email collisions during consolidation and reduces the attack surface by requiring more stable identity keys for automatic coalescing.

### Description
- Remove email-based identity keying from `_user_identity_key()` so automatic coalescing no longer uses `email` as the primary merge key; coalescing remains keyed by `github_id`, `uuid`, or stable per-row fallback. (`packages/python/sibyl-core/src/sibyl_core/migrate/merge.py`)
- Update the merge unit test to assert that same-email users are not merged, that `user_alias_count` stays `0`, and that organization membership and content references remain attached to their original users. (`packages/python/sibyl-core/tests/test_migrate_merge.py`)
- This is a minimal remediation that preserves existing merge behavior for provider-backed identifiers while avoiding insecure email-based ownership rewrites.

### Testing
- Attempted to run the package test runner via `moon run core:test -- packages/python/sibyl-core/tests/test_migrate_merge.py` but the `moon` binary was not available in this environment, so it could not be executed here.
- Ran `python -m pytest packages/python/sibyl-core/tests/test_migrate_merge.py` which failed to load the local package due to missing import wiring (error: `ModuleNotFoundError: No module named 'sibyl_core'`).
- Ran `PYTHONPATH=packages/python/sibyl-core/src python -m pytest packages/python/sibyl-core/tests/test_migrate_merge.py` which failed due to missing runtime dependency `pydantic`; the test file was updated but could not be executed to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f2de6cf8832ab6cd27ad6b65e043)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User deduplication during archive merges no longer coalesces accounts by email; accounts are preserved as distinct using external ID/UUID logic so separate users sharing an email remain separate.
* **Tests**
  * Tests updated to assert that merged archives keep distinct user records and do not rewrite content or membership references based on email.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->