### PR TITLE
fix(security): preserve episode project scoping for native Surreal episode writes

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -109,6 +109,7 @@ DEFINE FIELD IF NOT EXISTS group_id ON episode TYPE string;
 DEFINE FIELD IF NOT EXISTS created_at ON episode TYPE datetime DEFAULT time::now();
 DEFINE FIELD IF NOT EXISTS valid_at ON episode TYPE option<datetime>;
 DEFINE FIELD IF NOT EXISTS entity_edges ON episode TYPE array<string> DEFAULT [];
+DEFINE FIELD IF NOT EXISTS project_id ON episode TYPE option<string>;
 
 DEFINE INDEX IF NOT EXISTS idx_episode_uuid ON episode FIELDS uuid UNIQUE;
 DEFINE INDEX IF NOT EXISTS idx_episode_group ON episode FIELDS group_id;

--- a/packages/python/sibyl-core/src/sibyl_core/graph/entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/graph/entities.py
@@ -575,6 +575,7 @@ class EntityManager:
                 SELECT uuid,
                        name,
                        group_id,
+                       project_id,
                        content,
                        source_description,
                        created_at,
@@ -603,6 +604,7 @@ class EntityManager:
             SELECT uuid,
                    name,
                    group_id,
+                   project_id,
                    content,
                    source_description,
                    created_at,
@@ -666,6 +668,7 @@ class EntityManager:
             SELECT uuid,
                    name,
                    group_id,
+                   project_id,
                    content,
                    source_description,
                    created_at,
@@ -1148,6 +1151,8 @@ class EntityManager:
             raise RuntimeError(msg)
 
         episode_id = entity.id or str(uuid4())
+        metadata = entity.metadata or {}
+        project_id = metadata.get("project_id")
         node = EpisodicNode(
             uuid=episode_id,
             name=f"{entity.entity_type.value}:{entity.name}",
@@ -1160,6 +1165,17 @@ class EntityManager:
             entity_edges=[],
         )
         await episode_ops.save(self._driver, node)
+        if project_id is not None:
+            await self._driver.execute_query(
+                """
+                UPDATE episode
+                SET project_id = $project_id
+                WHERE uuid = $episode_id AND group_id = $group_id;
+                """,
+                project_id=str(project_id),
+                episode_id=episode_id,
+                group_id=self._group_id,
+            )
         return episode_id
 
     async def create(self, entity: Entity) -> str:
@@ -3245,7 +3261,11 @@ class EntityManager:
             "description": node_data.get("source_description") or "",
             "content": node_data.get("content") or "",
             "organization_id": node_data.get("group_id"),
-            "metadata": {},
+            "metadata": (
+                {"project_id": node_data.get("project_id")}
+                if node_data.get("project_id") is not None
+                else {}
+            ),
         }
         if created_at := self._parse_datetime(node_data.get("created_at")):
             entity_kwargs["created_at"] = created_at

--- a/packages/python/sibyl-core/tests/test_graph_entities.py
+++ b/packages/python/sibyl-core/tests/test_graph_entities.py
@@ -248,9 +248,11 @@ class TestEntityCreate:
             name="Surreal lesson",
             description="Captured from a session",
             content="Graphiti should write the raw episode.",
+            metadata={"project_id": "project-123"},
         )
         episode_ops = surreal_entity_manager._driver.episode_node_ops
         episode_ops.save = AsyncMock()
+        surreal_entity_manager._driver.execute_query = AsyncMock()
 
         with patch.object(
             surreal_entity_manager,
@@ -268,6 +270,7 @@ class TestEntityCreate:
         assert saved_episode.name == "episode:Surreal lesson"
         assert saved_episode.content == "Graphiti should write the raw episode."
         assert saved_episode.source.value == "text"
+        surreal_entity_manager._driver.execute_query.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_create_refuses_surreal_legacy_fallback(


### PR DESCRIPTION
### Motivation

- Close an authorization regression where task-learning `Episode` entities written via the native Surreal path lost `project_id` metadata and became discoverable by users without access to the originating project. 

### Description

- Add `project_id` as an optional field to the Surreal `episode` schema via `packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py`. 
- Persist an episode's `project_id` when `create_direct` uses the native Surreal writer by writing `project_id` after the `EpisodicNode` save in `EntityManager._create_surreal_episode_direct`. 
- Include `project_id` in Surreal episode read queries and hydrate it back into `Entity.metadata` in `_record_to_episode_entity` so downstream authorization and search filters see the original scope. 
- Extend the episode creation unit test to provide `metadata={"project_id": ...}` and assert the additional persistence call is invoked.

### Testing

- Attempted to run the package test target with `moon run core:test -- test_graph_entities.py -k surreal_episode_uses_episode_ops` but `moon` is not available in this environment so the monorepo test runner could not be executed. 
- Ran `pytest` for the same test file, which failed to load due to missing project test environment/dependency setup (`ModuleNotFoundError: No module named 'sibyl_core'`), so no automated tests were completed here. 
- Added/updated a unit test that will assert the `project_id` persistence behavior and should pass in a properly configured development environment or CI that runs the repo tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fee85db4832ab36de6d131e7ed3f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Episodes now support project association; project identifiers are included in episode creation, searches, and record hydration.

* **Tests**
  * Updated tests to cover episode creation with project metadata and validate the persistence call during creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->