### PR TITLE
fix(api): enforce contributor RBAC on project raw memory writes

### DIFF
--- a/apps/api/src/sibyl/api/routes/memory.py
+++ b/apps/api/src/sibyl/api/routes/memory.py
@@ -205,6 +205,23 @@ async def _project_accessible_for_policy(
     return {str(project_id) for project_id in accessible_projects or set()}
 
 
+
+async def _authorize_project_scope_write(
+    *,
+    ctx: AuthContext,
+    memory_scope: str,
+    scope_key: str | None,
+) -> None:
+    if memory_scope != "project" or not scope_key:
+        return
+    await verify_entity_project_access(
+        None,
+        ctx,
+        scope_key,
+        required_role=ProjectRole.CONTRIBUTOR,
+        require_existing_project=True,
+    )
+
 def _api_key_memory_scope_allowed(
     ctx: AuthContext,
     *,
@@ -1493,6 +1510,11 @@ async def remember_raw(
             scope_key=request.scope_key,
             policy_action="write",
             request=http_request,
+        )
+        await _authorize_project_scope_write(
+            ctx=ctx,
+            memory_scope=request.memory_scope,
+            scope_key=request.scope_key,
         )
         write_decision = await _authorize_memory_policy(
             ctx=ctx,

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -422,6 +422,10 @@ async def test_remember_raw_uses_shared_policy_for_project_scope_write() -> None
     ctx = _ctx()
     with (
         patch(
+            "sibyl.api.routes.memory.verify_entity_project_access",
+            AsyncMock(),
+        ) as verify_access,
+        patch(
             "sibyl.api.routes.memory.list_accessible_project_graph_ids",
             AsyncMock(return_value={"project_123"}),
         ) as accessible_projects,
@@ -441,6 +445,13 @@ async def test_remember_raw_uses_shared_policy_for_project_scope_write() -> None
             ctx=ctx,
         )
 
+    verify_access.assert_awaited_once_with(
+        None,
+        ctx,
+        "project_123",
+        required_role=ProjectRole.CONTRIBUTOR,
+        require_existing_project=True,
+    )
     accessible_projects.assert_awaited_once_with(ctx)
     route_log.info.assert_any_call(
         "memory_policy_decision",
@@ -539,6 +550,31 @@ async def test_remember_raw_denies_project_scope_without_policy_membership() -> 
         scope_key="project_123",
         surface="raw_remember",
     )
+    remember.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remember_raw_denies_project_scope_without_contributor_role() -> None:
+    with (
+        patch(
+            "sibyl.api.routes.memory.verify_entity_project_access",
+            AsyncMock(side_effect=HTTPException(status_code=403, detail="project_access_denied")),
+        ),
+        patch("sibyl.api.routes.memory.remember_raw_memory", AsyncMock()) as remember,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await remember_raw(
+            RawMemoryRememberRequest(
+                raw_content="project note",
+                memory_scope="project",
+                scope_key="project_123",
+            ),
+            org=_org(),
+            ctx=_ctx(),
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "project_access_denied"
     remember.assert_not_awaited()
 
 

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -472,6 +472,7 @@ async def test_remember_raw_denies_disallowed_api_key_memory_space() -> None:
     ctx = _ctx()
     ctx.api_key_memory_scope_keys = [api_key_memory_scope_key("project", "project_allowed")]
     with (
+        patch("sibyl.api.routes.memory.verify_entity_project_access", AsyncMock()),
         patch(
             "sibyl.api.routes.memory.list_accessible_project_graph_ids",
             AsyncMock(return_value={"project_123"}),


### PR DESCRIPTION
### Motivation
- A regression allowed project-scoped raw writes to rely on the read-oriented `accessible_projects` set, which includes viewer-only projects, enabling low-privilege users to write project memory without `ProjectRole.CONTRIBUTOR`.
- The goal is to restore explicit, role-aware verification for the actual project `scope_key` while keeping centralized policy evaluation and logging intact.

### Description
- Added an `_authorize_project_scope_write` helper that calls `verify_entity_project_access(..., required_role=ProjectRole.CONTRIBUTOR, require_existing_project=True)` for `memory_scope == "project"` and a present `scope_key` in `apps/api/src/sibyl/api/routes/memory.py`.
- Invoked the helper in the `remember_raw` route before calling the shared `_authorize_memory_policy` so writes to a project scope require contributor rights for the target `scope_key`.
- Updated tests in `apps/api/tests/test_routes_memory.py` to assert the contributor check is invoked for project writes and added `test_remember_raw_denies_project_scope_without_contributor_role` to guard the regression.

### Testing
- Attempted to run the package test runner with `moon run api:test -- --match 'remember_raw'`, but the `moon` binary is not available in this environment so the command could not be executed (failed).
- Ran a targeted pytest invocation `pytest apps/api/tests/test_routes_memory.py -k remember_raw`, but collection failed due to the environment pytest configuration (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests could not be executed here.
- Added/updated unit tests locally in the repository to validate the behavior; these tests are expected to pass in the project CI or a developer environment where `moon` and the repo pytest config are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ffa6a2cc832a914d65dd58226b18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project-scoped memory writes now require and verify contributor-level access to the referenced project before allowing the write.

* **Tests**
  * Added tests covering project-scoped memory write authorization, including verification of contributor access and expected rejection (HTTP 403) when access is not granted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->