### PR TITLE
fix(core): preserve Surreal episode metadata for project RBAC

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/graph/entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/graph/entities.py
@@ -576,6 +576,7 @@ class EntityManager:
                        name,
                        group_id,
                        project_id,
+                       metadata,
                        content,
                        source_description,
                        created_at,
@@ -605,6 +606,7 @@ class EntityManager:
                    name,
                    group_id,
                    project_id,
+                   metadata,
                    content,
                    source_description,
                    created_at,
@@ -669,6 +671,7 @@ class EntityManager:
                    name,
                    group_id,
                    project_id,
+                   metadata,
                    content,
                    source_description,
                    created_at,
@@ -1097,6 +1100,16 @@ class EntityManager:
                         created_uuid=created_uuid,
                         desired_id=desired_id,
                     )
+                metadata = self._entity_to_metadata(entity)
+                await self._driver.execute_query(
+                    """
+                    UPDATE episode
+                    SET metadata = $metadata
+                    WHERE uuid = $desired_id;
+                    """,
+                    desired_id=desired_id,
+                    metadata=metadata,
+                )
             else:
                 # Force deterministic UUID when caller provides one
                 await self._driver.execute_query(
@@ -3112,6 +3125,13 @@ class EntityManager:
                 entity_type = EntityType(prefix.strip().lower())
                 name = suffix.strip()
 
+        metadata = node_data.get("metadata", {})
+        if isinstance(metadata, str):
+            with contextlib.suppress(json.JSONDecodeError):
+                metadata = json.loads(metadata)
+        if not isinstance(metadata, dict):
+            metadata = {}
+
         entity_kwargs: dict[str, Any] = {
             "id": node_data.get("uuid") or "",
             "name": name,
@@ -3120,9 +3140,9 @@ class EntityManager:
             "content": node_data.get("content") or "",
             "organization_id": node_data.get("group_id"),
             "metadata": (
-                {"project_id": node_data.get("project_id")}
+                {**metadata, "project_id": node_data["project_id"]}
                 if node_data.get("project_id") is not None
-                else {}
+                else metadata
             ),
         }
         if created_at := self._parse_datetime(node_data.get("created_at")):

--- a/packages/python/sibyl-core/tests/test_graph_entities.py
+++ b/packages/python/sibyl-core/tests/test_graph_entities.py
@@ -776,6 +776,24 @@ class TestTypedHydration:
         assert result.priority == TaskPriority.HIGH
         assert result.project_id == "project-typed-001"
 
+    def test_record_to_episode_entity_preserves_metadata_dict(
+        self,
+        entity_manager: EntityManager,
+    ) -> None:
+        entity = entity_manager._record_to_episode_entity(
+            {
+                "uuid": "episode-typed-001",
+                "name": "episode:Scoped episode",
+                "group_id": "test-org-123",
+                "metadata": {"project_id": "project-secret", "category": "notes"},
+                "content": "secret content",
+                "source_description": "MCP Entity: episode",
+            }
+        )
+
+        assert entity.metadata.get("project_id") == "project-secret"
+        assert entity.metadata.get("category") == "notes"
+
 
 # =============================================================================
 # Entity Update Tests


### PR DESCRIPTION
### Motivation

- Surreal-backed episode creation and search dropped `metadata` (including `project_id`), causing project-scoped episodes to be hydrated as unscoped and bypassing project RBAC checks.

### Description

- Persist episode metadata during Surreal-backed creation by writing normalized metadata to the `episode` row after `add_episode` completes (`UPDATE episode SET metadata = $metadata`).
- Include `metadata` in Surreal episode select/search queries so returned records carry project-scoping fields. 
- Change episode hydration in `_record_to_episode_entity` to parse `metadata` safely (handle JSON string or dict) and assign it to the returned `Entity` instead of forcing an empty dict. 
- Add a regression test `test_record_to_episode_entity_preserves_metadata_dict` to ensure `_record_to_episode_entity` preserves `metadata.project_id` and other metadata fields.

Files changed: `packages/python/sibyl-core/src/sibyl_core/graph/entities.py`, `packages/python/sibyl-core/tests/test_graph_entities.py`.

### Testing

- Attempted `moon run core:test -- tests/test_graph_entities.py`, but `moon` is not available in the execution environment so the full test harness could not be run. 
- Ran `python -m pytest packages/python/sibyl-core/tests/test_graph_entities.py -q`, which failed due to local package import setup (`ModuleNotFoundError: No module named 'sibyl_core'`) in this environment and prevented executing the test suite here. 
- Added a unit regression test that can be run in the project CI or a properly configured developer environment with `moon`/project PYTHONPATH set; the test asserts episode metadata (including `project_id`) is preserved during hydration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091a088028832a9b98932890b083e1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Episodes now include and persist metadata across exact-name search, fulltext search, and recent-episode scanning. Metadata is parsed (including JSON strings) and merged into episode entities, ensuring project_id and other fields are preserved.

* **Tests**
  * Added unit test to verify metadata is preserved when converting episode records into entities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->