### PR TITLE
fix(context): scope agent diary recall to accessible projects

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -428,7 +428,15 @@ async def _compile_raw_memory_section(
         ("project", project, None, None),
     ]
     if agent_id:
-        recall_specs.append(("private", None, agent_id, project))
+        if project:
+            recall_specs.append(("private", None, agent_id, project))
+        elif accessible_projects:
+            recall_specs.extend(
+                ("private", None, agent_id, scoped_project)
+                for scoped_project in sorted(accessible_projects)
+            )
+        else:
+            recall_specs.append(("private", None, agent_id, None))
     for memory_scope, scope_key, spec_agent_id, spec_project_id in recall_specs:
         if allowed_memory_scope_keys is not None:
             effective_scope_key = principal_id if memory_scope == "private" else scope_key

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -430,7 +430,7 @@ async def _compile_raw_memory_section(
     if agent_id:
         if project:
             recall_specs.append(("private", None, agent_id, project))
-        elif accessible_projects:
+        elif accessible_projects is not None:
             recall_specs.extend(
                 ("private", None, agent_id, scoped_project)
                 for scoped_project in sorted(accessible_projects)

--- a/packages/python/sibyl-core/tests/test_context_pack.py
+++ b/packages/python/sibyl-core/tests/test_context_pack.py
@@ -491,6 +491,31 @@ async def test_compile_context_can_include_agent_diary_with_raw_memory() -> None
 
 
 @pytest.mark.asyncio
+async def test_compile_context_scopes_agent_diary_to_accessible_projects() -> None:
+    raw_calls: list[dict[str, Any]] = []
+
+    async def fake_raw_recall(**kwargs: Any) -> list[RawMemory]:
+        raw_calls.append(kwargs)
+        return []
+
+    await _compile_context_compat(
+        "implementation stance",
+        intent="build",
+        project=None,
+        accessible_projects={"project_123", "project_456"},
+        principal_id="user-123",
+        agent_id="nova",
+        organization_id="org-123",
+        search_fn=_empty_search_response,
+        raw_memory_recall_fn=fake_raw_recall,
+    )
+
+    diary_calls = [call for call in raw_calls if call.get("agent_id") == "nova"]
+    assert {call["project_id"] for call in diary_calls} == {"project_123", "project_456"}
+    assert all(call["project_id"] is not None for call in diary_calls)
+
+
+@pytest.mark.asyncio
 async def test_compile_context_native_ranks_agent_diary_by_relevance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/python/sibyl-core/tests/test_context_pack.py
+++ b/packages/python/sibyl-core/tests/test_context_pack.py
@@ -516,6 +516,30 @@ async def test_compile_context_scopes_agent_diary_to_accessible_projects() -> No
 
 
 @pytest.mark.asyncio
+async def test_compile_context_skips_agent_diary_without_accessible_projects() -> None:
+    raw_calls: list[dict[str, Any]] = []
+
+    async def fake_raw_recall(**kwargs: Any) -> list[RawMemory]:
+        raw_calls.append(kwargs)
+        return []
+
+    await _compile_context_compat(
+        "implementation stance",
+        intent="build",
+        project=None,
+        accessible_projects=set(),
+        principal_id="user-123",
+        agent_id="nova",
+        organization_id="org-123",
+        search_fn=_empty_search_response,
+        raw_memory_recall_fn=fake_raw_recall,
+    )
+
+    diary_calls = [call for call in raw_calls if call.get("agent_id") == "nova"]
+    assert diary_calls == []
+
+
+@pytest.mark.asyncio
 async def test_compile_context_native_ranks_agent_diary_by_relevance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Agent diary recalls added a path that used `project_id=None` when callers supplied `agent_id` but omitted `project`, allowing project-scoped credentials to receive private diary entries across projects. 
- The compile-context flow already accepts an `accessible_projects` set for project-scoped credentials and that constraint should apply to raw agent-diary recalls as well.

### Description
- Update `_compile_raw_memory_section` in `packages/python/sibyl-core/src/sibyl_core/tools/context.py` to constrain agent-diary recalls: when `project` is provided keep existing behavior, when `project` is omitted but `accessible_projects` is present fan out diary recall specs per accessible project, and otherwise fall back to the previous `project_id=None` behavior. 
- Add a regression test `test_compile_context_scopes_agent_diary_to_accessible_projects` in `packages/python/sibyl-core/tests/test_context_pack.py` that asserts diary recall calls for `agent_id` are issued with `project_id` values limited to the provided `accessible_projects` and never left `None` in the restricted case. 
- Preserve existing behavior for explicit `project` requests and for unrestricted callers (no `accessible_projects`).

### Testing
- Attempted `moon run core:test -- packages/python/sibyl-core/tests/test_context_pack.py` but `moon` is not available in this environment so the monorepo test runner could not be executed. 
- Attempted `python -m pytest packages/python/sibyl-core/tests/test_context_pack.py -k "agent_diary or scopes_agent_diary"` and it failed with `ModuleNotFoundError: No module named 'sibyl_core'`. 
- Attempted `PYTHONPATH=packages/python/sibyl-core/src python -m pytest packages/python/sibyl-core/tests/test_context_pack.py -k "agent_diary or scopes_agent_diary"` and it failed due to a missing dependency (`pydantic`) in the execution environment, so the added test could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091d340d08832ab6bf6a5bce0a1f49)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined private-memory retrieval so agent-specific diary recalls respect explicit accessible project scopes and fall back appropriately when none are provided.

* **Tests**
  * Added tests verifying agent diary recall only queries authorized projects and that no diary-specific recalls occur when no accessible projects are available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->