### PR TITLE
fix(reflect): avoid deterministic direct writes for source checkpoints

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
@@ -176,17 +176,20 @@ async def reflect_memory(
                 source_metadata["domain"] = domain
             if project:
                 source_metadata["project_id"] = project
-            source = await add_fn(
-                title=source_title,
-                content=content,
-                entity_type="session",
-                category=domain,
-                tags=_tags_for("session", domain),
-                related_to=related_to,
-                metadata=source_metadata,
-                sync=True,
-                check_conflicts=False,
-            )
+        source = await add_fn(
+            title=source_title,
+            content=content,
+            entity_type="session",
+            category=domain,
+            tags=_tags_for("session", domain),
+            related_to=related_to,
+            metadata=source_metadata,
+            # Keep reflection source checkpoints as episodic memories so they are
+            # tenant-scoped writes and avoid deterministic direct-entity UUID
+            # collisions across organizations/projects.
+            sync=False,
+            check_conflicts=False,
+        )
         if source.success:
             source_id = source.id
 

--- a/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
@@ -176,20 +176,20 @@ async def reflect_memory(
                 source_metadata["domain"] = domain
             if project:
                 source_metadata["project_id"] = project
-        source = await add_fn(
-            title=source_title,
-            content=content,
-            entity_type="session",
-            category=domain,
-            tags=_tags_for("session", domain),
-            related_to=related_to,
-            metadata=source_metadata,
-            # Keep reflection source checkpoints as episodic memories so they are
-            # tenant-scoped writes and avoid deterministic direct-entity UUID
-            # collisions across organizations/projects.
-            sync=False,
-            check_conflicts=False,
-        )
+            source = await add_fn(
+                title=source_title,
+                content=content,
+                entity_type="session",
+                category=domain,
+                tags=_tags_for("session", domain),
+                related_to=related_to,
+                metadata=source_metadata,
+                # Keep reflection source checkpoints as episodic memories so they
+                # are tenant-scoped writes and avoid deterministic direct-entity
+                # UUID collisions across organizations/projects.
+                sync=False,
+                check_conflicts=False,
+            )
         if source.success:
             source_id = source.id
 


### PR DESCRIPTION
### Motivation
- The reflection endpoint could persist raw session sources via a deterministic direct-entity upsert, allowing identical default titles to collide and overwrite entities across organizations/projects when written from a read-scoped route, so the goal is to avoid cross-tenant UUID collisions while preserving source checkpoint persistence.

### Description
- Changed the raw source write in `reflect_memory` to call `add_fn(..., sync=False)` so reflection source checkpoints are stored via the episodic/indirect path instead of the deterministic direct `session` upsert, and added a short security-focused comment explaining the rationale (file: `packages/python/sibyl-core/src/sibyl_core/tools/reflect.py`).

### Testing
- Attempted the monorepo test command `moon run core:test` but `moon` is not available in this environment so it could not run.  
- Attempted targeted tests with `python -m pytest packages/python/sibyl-core/tests/test_reflect.py` but the runtime lacked the installed package dependencies and failed with `ModuleNotFoundError: No module named 'sibyl_core'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091bdd5c1c832aafa4e86fa468d8f9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how reflection checkpoints are persisted: storage is now non-blocking and treats reflection sources as episodic entries to reduce identifier collisions and improve reliability of memory checkpointing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->