### PR TITLE
fix(api): disable unscoped Surreal auth/content snapshots in org backups

### DIFF
--- a/apps/api/src/sibyl/jobs/backup.py
+++ b/apps/api/src/sibyl/jobs/backup.py
@@ -189,8 +189,11 @@ async def run_backup(  # noqa: PLR0915
     backup_id = backup_id or generate_backup_id(organization_id)
     job_id = _backup_job_id(backup_id)
     include_database_dump = _effective_include_database_dump(include_database_dump)
-    include_auth_snapshot = _include_surreal_auth_snapshot()
-    include_content_snapshot = _include_surreal_content_snapshot()
+    include_auth_snapshot = False
+    include_content_snapshot = False
+    if not organization_id:
+        include_auth_snapshot = _include_surreal_auth_snapshot()
+        include_content_snapshot = _include_surreal_content_snapshot()
 
     # Update DB to mark as in progress
     await _update_backup_db(backup_id, status="in_progress", started_at=started_at)

--- a/apps/api/tests/test_jobs_backup.py
+++ b/apps/api/tests/test_jobs_backup.py
@@ -179,7 +179,7 @@ async def test_run_scheduled_backups_removes_orphan_record_when_queue_fails() ->
 
 
 @pytest.mark.asyncio
-async def test_run_backup_in_fully_surreal_mode_includes_runtime_snapshots(
+async def test_run_backup_in_fully_surreal_mode_skips_runtime_snapshots_for_org_backups(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
@@ -234,8 +234,8 @@ async def test_run_backup_in_fully_surreal_mode_includes_runtime_snapshots(
     assert result["database_dump_size_bytes"] == 0
     assert "pg_size_bytes" not in result
     assert result["job_id"] == "backup:backup_fixed"
-    export_auth.assert_awaited_once_with()
-    export_content.assert_awaited_once_with()
+    export_auth.assert_not_awaited()
+    export_content.assert_not_awaited()
     create_graph_backup.assert_awaited_once_with(organization_id=org_id)
     assert update_backup_db.await_count == 2
     broadcast.assert_any_await(
@@ -257,7 +257,9 @@ async def test_run_backup_in_fully_surreal_mode_includes_runtime_snapshots(
         names = set(archive.getnames())
         metadata = json.load(archive.extractfile("metadata.json"))
 
-    assert {"metadata.json", "auth.json", "content.json", "graph.json"} <= names
+    assert {"metadata.json", "graph.json"} <= names
+    assert "auth.json" not in names
+    assert "content.json" not in names
     assert "postgres.sql" not in names
     assert metadata["database_dump_tables"] == 0
     assert "pg_entities" not in metadata


### PR DESCRIPTION
### Motivation

- Prevent cross-tenant data exposure where organization-scoped backup archives could include full Surreal `auth` and `content` namespaces because the exporters executed unscoped `SELECT *` queries.

### Description

- Changed `run_backup` in `apps/api/src/sibyl/jobs/backup.py` to disable Surreal `auth.json` and `content.json` snapshots for organization-scoped backups by default and only enable them for global/system-scoped backups (i.e., when `organization_id` is not provided).
- Kept graph runtime export behavior unchanged so org graph backups remain supported via `create_backup(organization_id=...)`.
- Updated unit test in `apps/api/tests/test_jobs_backup.py` to assert that `export_auth_archive_payload` and `export_content_archive_payload` are not called for org-scoped backups and that `auth.json`/`content.json` are absent from the generated archive.

### Testing

- Updated test `test_run_backup_in_fully_surreal_mode_skips_runtime_snapshots_for_org_backups` in `apps/api/tests/test_jobs_backup.py` to reflect new behavior; no tests were executed in this environment because the monorepo test runner `moon` is not available (`/bin/bash: moon: command not found`).
- No other automated test runs were performed here; change is intentionally minimal to block the vulnerable path until scoped exporters are implemented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092034e770832a8b35115d8cb0da5c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Organization backups no longer include auth or content snapshot files; archives now contain only metadata and graph data as expected.

* **Tests**
  * Updated test suite to reflect and validate the revised backup behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->