### PR TITLE
fix(auth): enforce REST API key scopes in Surreal request claims

### DIFF
--- a/apps/api/src/sibyl/persistence/surreal/auth_runtime.py
+++ b/apps/api/src/sibyl/persistence/surreal/auth_runtime.py
@@ -69,6 +69,20 @@ _PROJECT_ROLE_LEVELS: dict[ProjectRole, int] = {
 }
 _USER_UUID_FIELDS = {"id", "github_id", "created_by_user_id", "accepted_by_user_id"}
 _USER_DATETIME_FIELDS = {"created_at", "updated_at", "email_verified_at", "last_login_at"}
+_SAFE_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+_REST_READ_SCOPES = frozenset({"api:read", "api:write"})
+_REST_WRITE_SCOPE = "api:write"
+
+
+def _is_rest_request(request: Request) -> bool:
+    return request.url.path.startswith("/api/")
+
+
+def _api_key_allows_rest(*, scopes: list[str], method: str) -> bool:
+    normalized = {s.strip() for s in scopes if str(s).strip()}
+    if method.upper() in _SAFE_HTTP_METHODS:
+        return bool(normalized & _REST_READ_SCOPES)
+    return _REST_WRITE_SCOPE in normalized
 
 
 def _project_not_found_detail(project_id: object) -> str:
@@ -1794,6 +1808,11 @@ async def resolve_request_claims(request) -> SurrealRecord | None:
         auth = await authenticate_api_key(token)
         if auth is None:
             return None
+        scopes = list(auth.scopes or [])
+        if _is_rest_request(request) and not _api_key_allows_rest(
+            scopes=scopes, method=request.method
+        ):
+            raise HTTPException(status_code=403, detail="Insufficient API key scope")
         return _api_key_claim_payload(auth)
     return None
 

--- a/apps/api/tests/test_surreal_auth_runtime.py
+++ b/apps/api/tests/test_surreal_auth_runtime.py
@@ -2618,3 +2618,59 @@ async def test_exchange_device_code_handles_missing_last_polled_at(
     assert "UPSERT device_authorization_requests" not in query
     assert params["uuid"] == str(device_request_id)
     assert params["last_polled_at"] == params["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_request_claims_rejects_rest_write_with_mcp_only_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = SimpleNamespace(
+        user_id=uuid4(),
+        organization_id=uuid4(),
+        api_key_id=uuid4(),
+        scopes=["mcp"],
+        project_ids=[],
+        memory_space_ids=[],
+        memory_spaces=[],
+    )
+    request = SimpleNamespace(
+        state=SimpleNamespace(jwt_claims=None),
+        headers={"authorization": "Bearer sk_live_test"},
+        cookies={},
+        method="POST",
+        url=SimpleNamespace(path="/api/auth/device/verify"),
+    )
+    monkeypatch.setattr(surreal_auth_runtime, "authenticate_api_key", AsyncMock(return_value=auth))
+
+    with pytest.raises(HTTPException, match="Insufficient API key scope") as exc_info:
+        await surreal_auth_runtime.resolve_request_claims(request)
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_resolve_request_claims_allows_rest_write_with_api_write_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = SimpleNamespace(
+        user_id=uuid4(),
+        organization_id=uuid4(),
+        api_key_id=uuid4(),
+        scopes=["api:write"],
+        project_ids=[],
+        memory_space_ids=[],
+        memory_spaces=[],
+    )
+    request = SimpleNamespace(
+        state=SimpleNamespace(jwt_claims=None),
+        headers={"authorization": "Bearer sk_live_test"},
+        cookies={},
+        method="POST",
+        url=SimpleNamespace(path="/api/auth/device/verify"),
+    )
+    monkeypatch.setattr(surreal_auth_runtime, "authenticate_api_key", AsyncMock(return_value=auth))
+
+    claims = await surreal_auth_runtime.resolve_request_claims(request)
+
+    assert claims is not None
+    assert claims["typ"] == "api_key"


### PR DESCRIPTION
### Motivation

- The Surreal-backed resolver used by device-approval flows returned claims for `sk_*` API keys without enforcing REST method/path scope checks, enabling MCP-only keys to approve device flows and obtain session tokens.  
- Device approval delegates to runtime claim resolution (`resolve_request_claims`) and must respect REST API-key scope rules to prevent privilege escalation.  
- The change restores the same REST-scoping semantics present in the other resolver so mutating `/api/*` endpoints require `api:write` where appropriate.  

### Description

- Added REST-scoping helpers and constants (`_SAFE_HTTP_METHODS`, `_REST_READ_SCOPES`, `_REST_WRITE_SCOPE`, `_is_rest_request`, `_api_key_allows_rest`) to `apps/api/src/sibyl/persistence/surreal/auth_runtime.py`.  
- Enforced API-key REST scope checks in `resolve_request_claims`: API-key authentication now raises `HTTPException(status_code=403, detail="Insufficient API key scope")` for `/api/*` mutating requests when the key lacks the required scopes.  
- Added focused regression tests in `apps/api/tests/test_surreal_auth_runtime.py` that assert rejection for an MCP-only `sk_*` key on a `POST /api/auth/device/verify` and acceptance when the key has `api:write`.  

### Testing

- Attempted to run the package test target with `moon run api:test`, but `moon` is not available in this execution environment so that command could not run.  
- Executed a targeted `pytest` invocation for the new tests, but collection failed due to a local pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so the new tests could not be executed here.  
- The change is minimal and unit-tests were added; please run the full test suite in the normal development environment with `moon run api:test` (or `pytest` from the repo root per project guidance) to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09296e6a68832a99c4935b79064fe3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced API-key scope checks for REST endpoints so requests lacking required permissions are now rejected (method-sensitive: read vs write access enforced).

* **Tests**
  * Added tests covering API-key scope validation for REST requests to ensure correct allow/deny behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->