### PR TITLE
fix(security): constrain manage crawl to website and cap max_pages

### DIFF
--- a/apps/api/tests/test_tools_manage.py
+++ b/apps/api/tests/test_tools_manage.py
@@ -540,6 +540,55 @@ class TestSourceActions:
             create_or_get.assert_awaited_once()
             enqueue.assert_awaited_once()
 
+
+    @pytest.mark.asyncio
+    async def test_crawl_forces_website_source_type(self) -> None:
+        """crawl action should force website source type for manage surface."""
+        with (
+            patch(
+                "sibyl_core.tools.manage._create_or_get_crawl_source",
+                new=AsyncMock(return_value=("source_abc123", True)),
+            ) as create_or_get,
+            patch(
+                "sibyl_core.tools.manage._enqueue_source_crawl",
+                new=AsyncMock(return_value="crawl:source_abc123"),
+            ),
+        ):
+            result = await manage(
+                action="crawl",
+                data={
+                    "url": "https://docs.example.com",
+                    "source_type": "local",
+                },
+                organization_id=TEST_ORG_ID,
+            )
+
+            assert result.success is True
+            payload = create_or_get.await_args.args[2]
+            assert payload["source_type"] == "website"
+
+    @pytest.mark.asyncio
+    async def test_crawl_clamps_max_pages(self) -> None:
+        """crawl action should cap max_pages to API-safe bounds."""
+        with (
+            patch(
+                "sibyl_core.tools.manage._create_or_get_crawl_source",
+                new=AsyncMock(return_value=("source_abc123", True)),
+            ),
+            patch(
+                "sibyl_core.tools.manage._enqueue_source_crawl",
+                new=AsyncMock(return_value="crawl:source_abc123"),
+            ) as enqueue,
+        ):
+            result = await manage(
+                action="crawl",
+                data={"url": "https://docs.example.com", "max_pages": 999999999},
+                organization_id=TEST_ORG_ID,
+            )
+
+            assert result.success is True
+            assert enqueue.await_args.kwargs["max_pages"] == 500
+
     @pytest.mark.asyncio
     async def test_sync_source_not_found(self) -> None:
         """sync action should fail gracefully if source not found."""

--- a/packages/python/sibyl-core/src/sibyl_core/tools/manage.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/manage.py
@@ -32,6 +32,8 @@ from sibyl_core.tools.helpers import _project_id_for_policy
 
 log = structlog.get_logger()
 MEMORY_POLICY_CONTEXT_DATA_KEY = "_memory_policy_context"
+DEFAULT_CRAWL_MAX_PAGES = 50
+MAX_CRAWL_MAX_PAGES = 500
 
 
 @dataclass(frozen=True, slots=True)
@@ -1031,13 +1033,22 @@ async def _crawl_source(
     organization_id: str,
 ) -> ManageResponse:
     """Trigger crawl of a URL."""
+    sanitized_data = dict(data)
+    # Manage crawl only supports website ingestion.
+    sanitized_data["source_type"] = "website"
+
     source_id, created = await _create_or_get_crawl_source(
         url,
         depth,
-        data,
+        sanitized_data,
         organization_id=organization_id,
     )
-    max_pages = int(data.get("max_pages", 50))
+    raw_max_pages = data.get("max_pages", DEFAULT_CRAWL_MAX_PAGES)
+    try:
+        max_pages = int(raw_max_pages)
+    except (TypeError, ValueError):
+        max_pages = DEFAULT_CRAWL_MAX_PAGES
+    max_pages = max(1, min(max_pages, MAX_CRAWL_MAX_PAGES))
     generate_embeddings = bool(data.get("generate_embeddings", True))
     job_id = await _enqueue_source_crawl(
         source_id,


### PR DESCRIPTION
### Motivation
- The `manage` crawl handler accepted attacker-controlled `source_type` and unbounded `max_pages`, allowing escalation to local filesystem ingestion and unbounded crawl workloads. 
- The change aims to ensure the manage surface cannot create `local` crawl sources or request excessively large crawls without REST-level validation/sandboxing.

### Description
- Force-manage crawl requests now sanitize the payload and set `source_type = "website"` before persisting or enqueueing a crawl. (changes in `packages/python/sibyl-core/src/sibyl_core/tools/manage.py`).
- Introduce bounded `max_pages` parsing with a default of `50` and a hard cap to `500`, with safe fallback when parsing fails. (constants `DEFAULT_CRAWL_MAX_PAGES` and `MAX_CRAWL_MAX_PAGES` and clamping logic in `manage.py`).
- Pass the sanitized payload into `_create_or_get_crawl_source` so persisted `CrawlSource` records cannot be created with `local` type from the manage tool. (`_create_or_get_crawl_source(url, depth, sanitized_data, ...)`).
- Add two unit tests to `apps/api/tests/test_tools_manage.py` to validate that manage `crawl` forces `website` `source_type` and clamps very large `max_pages` values.

### Testing
- Added tests: `test_crawl_forces_website_source_type` and `test_crawl_clamps_max_pages` in `apps/api/tests/test_tools_manage.py` (not executed successfully here due to environment limitations). 
- Attempted `moon run api:test -- --maxfail=1 apps/api/tests/test_tools_manage.py`, which could not run because the `moon` binary is not available in this environment. 
- Attempted running pytest directly with `pytest -q apps/api/tests/test_tools_manage.py -k 'crawl_forces_website_source_type or crawl_clamps_max_pages'`, but collection failed with a local pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0935e7a094832abfe7c02c318e3258)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Crawl operations now sanitize input: source type is forced to "website" for crawls.
  * Crawl page limits are enforced and clamped—defaults applied and values capped at 500 pages to prevent out-of-range requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->