### PR TITLE
fix(api): preserve RBAC project filter for explore traversal

### DIFF
--- a/apps/api/src/sibyl/api/routes/search.py
+++ b/apps/api/src/sibyl/api/routes/search.py
@@ -164,7 +164,9 @@ async def explore(
                     project_id,
                     required_role=ProjectRole.VIEWER,
                 )
-            accessible_filter = None
+            accessible_filter = (
+                set(request.project_ids) if request.mode in {"related", "traverse"} else None
+            )
         elif request.project:
             await verify_entity_project_access(
                 None,
@@ -172,7 +174,9 @@ async def explore(
                 request.project,
                 required_role=ProjectRole.VIEWER,
             )
-            accessible_filter = None
+            accessible_filter = (
+                {request.project} if request.mode in {"related", "traverse"} else None
+            )
         else:
             accessible_filter = await list_accessible_project_graph_ids(ctx)
 

--- a/apps/api/tests/test_routes_search.py
+++ b/apps/api/tests/test_routes_search.py
@@ -186,6 +186,38 @@ class TestExploreRoute:
         assert core_explore.await_args.kwargs["project_ids"] == ["proj_1"]
         assert core_explore.await_args.kwargs["accessible_projects"] is None
 
+
+    @pytest.mark.asyncio
+    async def test_explore_related_with_project_ids_preserves_accessible_filter(self) -> None:
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        ctx = SimpleNamespace()
+        result = SimpleNamespace(
+            mode="related",
+            entities=[{"id": "task_1", "name": "Ship it"}],
+            total=1,
+            filters={"project_ids": ["proj_1"]},
+            limit=10,
+            offset=0,
+            has_more=False,
+            actual_total=1,
+        )
+
+        with (
+            patch(
+                "sibyl.api.routes.search.verify_entity_project_access",
+                AsyncMock(return_value=ProjectRole.VIEWER),
+            ),
+            patch("sibyl_core.tools.core.explore", AsyncMock(return_value=result)) as core_explore,
+        ):
+            await explore(
+                request=ExploreRequest(mode="related", entity_id="entity_1", project_ids=["proj_1"]),
+                org=org,
+                ctx=ctx,
+            )
+
+        assert core_explore.await_args.kwargs["project_ids"] == ["proj_1"]
+        assert core_explore.await_args.kwargs["accessible_projects"] == {"proj_1"}
+
     @pytest.mark.asyncio
     async def test_explore_without_project_passes_default_accessible_scope(self) -> None:
         org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))


### PR DESCRIPTION
### Motivation

- Fix a high-severity RBAC bypass where supplying `project`/`project_ids` to the `/search/explore` route could null out `accessible_projects` and allow `related`/`traverse` exploration to return entities from projects the caller should not see. 
- Preserve existing behavior for `list` and `dependencies` modes while ensuring `related` and `traverse` modes are constrained by project RBAC when request-scoped projects are provided.

### Description

- Change the `/search/explore` handler (`apps/api/src/sibyl/api/routes/search.py`) to compute `accessible_filter` as `set(request.project_ids)` or `{request.project}` when `mode` is `related` or `traverse`, instead of always setting it to `None` when explicit projects are supplied. 
- Continue to reject `project_ids` for `dependencies` mode and keep the prior `list`/`dependencies` semantics unchanged. 
- Ensure the handler passes the computed `accessible_filter` into `core_explore` via the `accessible_projects` parameter. 
- Add a regression test `test_explore_related_with_project_ids_preserves_accessible_filter` in `apps/api/tests/test_routes_search.py` verifying that `related` mode forwards both `project_ids` and a non-`None` `accessible_projects` set to the core explore call.

### Testing

- Attempted to run the repository-standard test runner with `moon run api:test` but `moon` is not available in this environment, so that invocation could not be executed. 
- Ran a targeted `pytest apps/api/tests/test_routes_search.py` which failed to execute in this environment during pytest config bootstrap due to an unknown config option (`asyncio_default_fixture_loop_scope`), so the new test could not be run here; the test was added to the test suite for CI/maintainers to run in the project's environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a093714e004832aa47483cc596656cd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project access filters now correctly apply when exploring in related or traverse modes with specified project IDs or a single project, preventing unintended access in other modes.

* **Tests**
  * Added coverage to verify explore behavior when project IDs are provided alongside related-mode exploration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->