### PR TITLE
style(infra): fix Prettier formatting to unblock Static Checks CI

### DIFF
--- a/infra/ansible/roles/sibyl/files/docker-compose.yml
+++ b/infra/ansible/roles/sibyl/files/docker-compose.yml
@@ -53,7 +53,8 @@ services:
       SIBYL_SERVER_HOST: 0.0.0.0
       SIBYL_SERVER_PORT: "3334"
     healthcheck:
-      test: ["CMD-SHELL", 'python -c "import httpx; httpx.get(''http://localhost:3334/api/health'')"']
+      test:
+        ["CMD-SHELL", 'python -c "import httpx; httpx.get(''http://localhost:3334/api/health'')"']
       interval: 30s
       timeout: 10s
       retries: 3

--- a/infra/local/README.md
+++ b/infra/local/README.md
@@ -62,8 +62,8 @@ Docker and skips an explicit image load. Override with `SIBYL_CONTAINER_BUILDER=
 
 ## Manual Render Checks
 
-The Tiltfile registers these chart repos as `surrealdb-helm` and `valkey-helm`. The
-render checks below use the same aliases.
+The Tiltfile registers these chart repos as `surrealdb-helm` and `valkey-helm`. The render checks
+below use the same aliases.
 
 ```bash
 helm template surrealdb surrealdb-helm/surrealdb \


### PR DESCRIPTION
## Summary
- `infra:lint` (`prettier --check`) was failing the **Static Checks** CI job on `main`
- Two files had formatting nits: a long healthcheck line in the ansible `docker-compose.yml` and a prose line in `infra/local/README.md`
- Applied `moon run infra:format` (`prettier --write`); no semantic change

## Test plan
- [x] `moon run infra:lint` → "All matched files use Prettier code style!"

Note: the E2E and Package Tests jobs on the same run failed separately on a transient `ghcr.io` 502 while `proto install` fetched a plugin — an infra flake, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local development setup documentation with clarification about Helm chart repository registration and aliases used in configuration.

* **Chores**
  * Updated Docker Compose healthcheck configuration structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->