### PR TITLE
fix: resolve CI failures on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,8 +448,8 @@ jobs:
       SIBYL_AUTH_STORE: surreal
       SIBYL_COORDINATION_BACKEND: local
       SIBYL_SURREAL_URL: ws://localhost:8000/rpc
-      SIBYL_SURREAL_USERNAME: root
-      SIBYL_SURREAL_PASSWORD: root
+      SIBYL_SURREAL_USERNAME: sibyl_ci
+      SIBYL_SURREAL_PASSWORD: sibyl_ci_password
       SIBYL_OPENAI_API_KEY: sk-test-key
       SIBYL_ANTHROPIC_API_KEY: sk-ant-test-key
       SIBYL_MOCK_LLM: true

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -31,8 +31,8 @@ jobs:
       SIBYL_AUTH_STORE: surreal
       SIBYL_COORDINATION_BACKEND: local
       SIBYL_SURREAL_URL: ws://localhost:8000/rpc
-      SIBYL_SURREAL_USERNAME: root
-      SIBYL_SURREAL_PASSWORD: root
+      SIBYL_SURREAL_USERNAME: sibyl_ci
+      SIBYL_SURREAL_PASSWORD: sibyl_ci_password
       SIBYL_RETRIEVAL_MODE: compare
       SIBYL_OPENAI_API_KEY: sk-test-key
       SIBYL_ANTHROPIC_API_KEY: sk-ant-test-key
@@ -218,8 +218,8 @@ jobs:
       SIBYL_AUTH_STORE: surreal
       SIBYL_COORDINATION_BACKEND: local
       SIBYL_SURREAL_URL: ws://localhost:8000/rpc
-      SIBYL_SURREAL_USERNAME: root
-      SIBYL_SURREAL_PASSWORD: root
+      SIBYL_SURREAL_USERNAME: sibyl_ci
+      SIBYL_SURREAL_PASSWORD: sibyl_ci_password
       SIBYL_OPENAI_API_KEY: sk-test-key
       SIBYL_ANTHROPIC_API_KEY: sk-ant-test-key
       SIBYL_MOCK_LLM: true

--- a/docs/_archive/SIBYL_V09_RELEASE_NOTES_DRAFT.md
+++ b/docs/_archive/SIBYL_V09_RELEASE_NOTES_DRAFT.md
@@ -61,5 +61,6 @@ Status: released as `v0.9.0`.
 `v0.9.0` is published. Treat this document as the release receipt and claim boundary, not an active
 hold notice.
 
-Post-v0.9 planning moved to [`SIBYL_1_0_ROADMAP.md`](../architecture/SIBYL_1_0_ROADMAP.md), which promotes the
-manual review and workspace work into the larger 1.0 automatic memory operating-system plan.
+Post-v0.9 planning moved to [`SIBYL_1_0_ROADMAP.md`](../architecture/SIBYL_1_0_ROADMAP.md), which
+promotes the manual review and workspace work into the larger 1.0 automatic memory operating-system
+plan.

--- a/docs/api/auth-api-keys.md
+++ b/docs/api/auth-api-keys.md
@@ -22,9 +22,9 @@ API keys provide:
 | `api:write` | All operations on `/api/*` (implies read)        |
 
 Beyond these access scopes, a key can also be bound to specific projects and memory spaces. Those
-bindings further restrict which projects and memory scopes the key can read or write, independent
-of the access scope. A key with no project or memory-space binding inherits the creating user's
-full access within the organization.
+bindings further restrict which projects and memory scopes the key can read or write, independent of
+the access scope. A key with no project or memory-space binding inherits the creating user's full
+access within the organization.
 
 ## Creating API Keys
 

--- a/docs/api/auth-authorization.md
+++ b/docs/api/auth-authorization.md
@@ -17,19 +17,19 @@ Organization (org-level roles)
 - **Organization Roles**: `owner`, `admin`, `member`, `viewer` - inherited across all projects
 - **Project Roles**: `project_owner`, `project_maintainer`, `project_contributor`,
   `project_viewer` - scoped to specific projects
-- **Org Isolation**: each organization has its own SurrealDB namespace, so cross-org data access
-  is impossible at the storage layer
+- **Org Isolation**: each organization has its own SurrealDB namespace, so cross-org data access is
+  impossible at the storage layer
 
 ## Role Hierarchy
 
 ### Organization Roles
 
-| Role     | Description                                              |
-| -------- | -------------------------------------------------------- |
+| Role     | Description                                               |
+| -------- | --------------------------------------------------------- |
 | `owner`  | Super admin. Full org access, owner-only boundaries, logs |
-| `admin`  | Full organization access, can manage members             |
-| `member` | Standard member, project access based on assignments     |
-| `viewer` | Read-only member                                         |
+| `admin`  | Full organization access, can manage members              |
+| `member` | Standard member, project access based on assignments      |
+| `viewer` | Read-only member                                          |
 
 Organization owners and admins have full project access across the organization.
 
@@ -97,8 +97,8 @@ The resolved role is then compared against the role the route requires.
 ### Dependency Functions
 
 Organization-level access is gated with `require_org_role`. Project-level access uses
-`require_project_role` and its convenience shortcuts `require_project_read`, `require_project_write`,
-and `require_project_admin`.
+`require_project_role` and its convenience shortcuts `require_project_read`,
+`require_project_write`, and `require_project_admin`.
 
 ```python
 from sibyl.auth.dependencies import require_org_role
@@ -159,18 +159,18 @@ When authorization fails, a structured error is returned:
 
 ## Organization Isolation
 
-Sibyl's default runtime is SurrealDB-native. Organization isolation is enforced by the storage
-layer through a namespace per organization.
+Sibyl's default runtime is SurrealDB-native. Organization isolation is enforced by the storage layer
+through a namespace per organization.
 
 ### Namespace-Per-Org
 
-Each organization gets its own SurrealDB namespace, named `org_<uuid_hex>`. Graph, content, and
-auth records for an organization live entirely within that namespace.
+Each organization gets its own SurrealDB namespace, named `org_<uuid_hex>`. Graph, content, and auth
+records for an organization live entirely within that namespace.
 
 - Every authenticated request resolves an organization first, then operates inside that
   organization's namespace.
-- A query issued in one namespace cannot see another organization's data. Cross-org leakage is
-  not possible at the storage layer.
+- A query issued in one namespace cannot see another organization's data. Cross-org leakage is not
+  possible at the storage layer.
 - The SurrealDB driver is cloned per organization (`driver.clone(group_id)`) so a single client
   instance is never shared across namespaces.
 
@@ -190,9 +190,9 @@ than silently crossing tenants.
 
 ### PostgreSQL and Migration
 
-PostgreSQL is retained only for migration and archive rehearsal, not for the default runtime.
-Where PostgreSQL is used for rehearsal, row-level security policies provide org isolation within
-that database. Migration and archive operations use explicit `sibyld migrate` commands:
+PostgreSQL is retained only for migration and archive rehearsal, not for the default runtime. Where
+PostgreSQL is used for rehearsal, row-level security policies provide org isolation within that
+database. Migration and archive operations use explicit `sibyld migrate` commands:
 
 ```bash
 sibyld migrate import migration-archive.tar.gz \

--- a/docs/api/auth-jwt.md
+++ b/docs/api/auth-jwt.md
@@ -29,8 +29,8 @@ Short-lived token for API authentication.
 }
 ```
 
-Access tokens may also carry an `org_role` claim and a `scopes` claim when the issuer includes
-them. The MCP server uses `org_role` to gate owner-only tools.
+Access tokens may also carry an `org_role` claim and a `scopes` claim when the issuer includes them.
+The MCP server uses `org_role` to gate owner-only tools.
 
 **Default Expiry:** 60 minutes (configurable via `SIBYL_ACCESS_TOKEN_EXPIRE_MINUTES`)
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -31,19 +31,19 @@ multi-process or distributed worker deployments.
 The MCP interface exposes eleven tools that cover discovery, context, capture, synthesis, and
 administration. Tools are registered in `apps/api/src/sibyl/server.py`.
 
-| Tool               | Purpose                                                       | Documentation                          |
-| ------------------ | ------------------------------------------------------------- | --------------------------------------- |
-| `search`           | Semantic search across knowledge graph and documents          | [mcp-search.md](./mcp-search.md)        |
-| `context`          | Compile a structured context pack for an agent goal           | [mcp-context.md](./mcp-context.md)      |
-| `synthesis_plan`   | Plan a source-grounded synthesis outline                      | [mcp-synthesis.md](./mcp-synthesis.md)  |
-| `synthesis_draft`  | Draft, verify, and optionally remember a synthesis artifact   | [mcp-synthesis.md](./mcp-synthesis.md)  |
-| `synthesis_verify` | Verify citation, freshness, hidden-context, and gap coverage  | [mcp-synthesis.md](./mcp-synthesis.md)  |
-| `explore`          | Navigate and browse graph structure                          | [mcp-explore.md](./mcp-explore.md)      |
-| `add`              | Create new knowledge entities                                 | [mcp-add.md](./mcp-add.md)              |
-| `remember`         | Capture durable memory with verbatim raw provenance           | [mcp-remember.md](./mcp-remember.md)    |
-| `reflect`          | Reflect raw notes into reviewable memory candidates           | [mcp-reflect.md](./mcp-reflect.md)      |
-| `manage`           | Lifecycle operations and administration                       | [mcp-manage.md](./mcp-manage.md)        |
-| `logs`             | Recent server logs (OWNER role)                               | [mcp-logs.md](./mcp-logs.md)            |
+| Tool               | Purpose                                                      | Documentation                          |
+| ------------------ | ------------------------------------------------------------ | -------------------------------------- |
+| `search`           | Semantic search across knowledge graph and documents         | [mcp-search.md](./mcp-search.md)       |
+| `context`          | Compile a structured context pack for an agent goal          | [mcp-context.md](./mcp-context.md)     |
+| `synthesis_plan`   | Plan a source-grounded synthesis outline                     | [mcp-synthesis.md](./mcp-synthesis.md) |
+| `synthesis_draft`  | Draft, verify, and optionally remember a synthesis artifact  | [mcp-synthesis.md](./mcp-synthesis.md) |
+| `synthesis_verify` | Verify citation, freshness, hidden-context, and gap coverage | [mcp-synthesis.md](./mcp-synthesis.md) |
+| `explore`          | Navigate and browse graph structure                          | [mcp-explore.md](./mcp-explore.md)     |
+| `add`              | Create new knowledge entities                                | [mcp-add.md](./mcp-add.md)             |
+| `remember`         | Capture durable memory with verbatim raw provenance          | [mcp-remember.md](./mcp-remember.md)   |
+| `reflect`          | Reflect raw notes into reviewable memory candidates          | [mcp-reflect.md](./mcp-reflect.md)     |
+| `manage`           | Lifecycle operations and administration                      | [mcp-manage.md](./mcp-manage.md)       |
+| `logs`             | Recent server logs (OWNER role)                              | [mcp-logs.md](./mcp-logs.md)           |
 
 **MCP Endpoint:** `POST /mcp` (streamable-http transport)
 
@@ -55,14 +55,14 @@ The MCP server also exposes two resources: `sibyl://health` (connectivity and en
 The REST API spans 26 routers. The pages below cover the most commonly used surfaces; the full
 contract is in the OpenAPI schema.
 
-| Category  | Endpoints                           | Documentation                            |
-| --------- | ----------------------------------- | ----------------------------------------- |
-| Entities  | `/api/entities/*`                   | [rest-entities.md](./rest-entities.md)    |
-| Tasks     | `/api/tasks/*`                      | [rest-tasks.md](./rest-tasks.md)          |
-| Projects  | `/api/entities?entity_type=project` | [rest-projects.md](./rest-projects.md)    |
-| Search    | `/api/search`, `/api/search/explore`| [rest-search.md](./rest-search.md)        |
-| Memory    | `/api/memory/*`, `/api/context/*`   | [rest-memory.md](./rest-memory.md)        |
-| Synthesis | `/api/synthesis/*`                  | [rest-synthesis.md](./rest-synthesis.md)  |
+| Category  | Endpoints                            | Documentation                            |
+| --------- | ------------------------------------ | ---------------------------------------- |
+| Entities  | `/api/entities/*`                    | [rest-entities.md](./rest-entities.md)   |
+| Tasks     | `/api/tasks/*`                       | [rest-tasks.md](./rest-tasks.md)         |
+| Projects  | `/api/entities?entity_type=project`  | [rest-projects.md](./rest-projects.md)   |
+| Search    | `/api/search`, `/api/search/explore` | [rest-search.md](./rest-search.md)       |
+| Memory    | `/api/memory/*`, `/api/context/*`    | [rest-memory.md](./rest-memory.md)       |
+| Synthesis | `/api/synthesis/*`                   | [rest-synthesis.md](./rest-synthesis.md) |
 
 Additional routers not covered by dedicated pages include `auth`, `users`, `epics`, `graph`,
 `crawler`, `rag`, `resolve`, `jobs`, `backups`, `settings`, `metrics`, `admin`, `logs`, `orgs`,

--- a/docs/api/mcp-add.md
+++ b/docs/api/mcp-add.md
@@ -13,8 +13,8 @@ The `add` tool creates entities in the knowledge graph with:
 - Auto-tagging based on content analysis (for tasks)
 - Conflict detection against semantically similar existing knowledge
 
-The MCP `add` tool runs against the SurrealDB-native graph runtime. There is no Graphiti or
-FalkorDB processing stage in the default memory loop.
+The MCP `add` tool runs against the SurrealDB-native graph runtime. There is no Graphiti or FalkorDB
+processing stage in the default memory loop.
 
 ## Input Schema
 
@@ -283,17 +283,17 @@ operations), use the REST endpoint `POST /api/entities?sync=true` documented in
 
 ### From Request Parameters
 
-| Relationship | Target     | Condition                        |
-| ------------ | ---------- | -------------------------------- |
-| `RELATED_TO` | Any entity | For each ID in `related_to`      |
-| `DEPENDS_ON` | Task       | For each ID in `depends_on`      |
+| Relationship | Target     | Condition                   |
+| ------------ | ---------- | --------------------------- |
+| `RELATED_TO` | Any entity | For each ID in `related_to` |
+| `DEPENDS_ON` | Task       | For each ID in `depends_on` |
 
 Tasks and epics are bound to their project through the required `project` parameter.
 
 ### Auto-Discovered
 
-| Relationship | Source     | Target                                     |
-| ------------ | ---------- | ------------------------------------------ |
+| Relationship | Source     | Target                                        |
+| ------------ | ---------- | --------------------------------------------- |
 | `RELATED_TO` | New entity | Semantically similar patterns/rules/templates |
 
 ## Validation

--- a/docs/api/mcp-context.md
+++ b/docs/api/mcp-context.md
@@ -7,8 +7,8 @@ generic search browsing.
 
 The `context` tool retrieves the memory that matters for a specific goal and groups it into facets
 such as active work, decisions, plans, ideas, constraints, artifacts, procedures, gotchas, and
-recent sessions. Use it before dispatching or resuming an agent so the agent starts with the
-working set it needs.
+recent sessions. Use it before dispatching or resuming an agent so the agent starts with the working
+set it needs.
 
 The `context` tool is the retrieval companion to [`remember`](./mcp-remember.md): `remember` stores
 what future agents should not have to relearn, and `context` pulls that material back into a goal.
@@ -36,26 +36,26 @@ interface ContextInput {
 
 ### Intent Values
 
-| Intent     | Use For                                            |
-| ---------- | -------------------------------------------------- |
-| `build`    | Implementation work (default)                      |
-| `plan`     | Sequencing, milestones, roadmap work               |
-| `ideate`   | Brainstorming and option generation                |
-| `research` | Investigation and landscape analysis               |
-| `debug`    | Diagnosing failures                                |
-| `decide`   | Resolving a choice                                 |
-| `learn`    | Building understanding of a topic                  |
-| `general`  | Unscoped retrieval                                 |
+| Intent     | Use For                              |
+| ---------- | ------------------------------------ |
+| `build`    | Implementation work (default)        |
+| `plan`     | Sequencing, milestones, roadmap work |
+| `ideate`   | Brainstorming and option generation  |
+| `research` | Investigation and landscape analysis |
+| `debug`    | Diagnosing failures                  |
+| `decide`   | Resolving a choice                   |
+| `learn`    | Building understanding of a topic    |
+| `general`  | Unscoped retrieval                   |
 
 Intent shapes which facets are emphasized in the resulting pack.
 
 ### Retrieval Layers
 
-| Layer         | Behavior                                                  |
-| ------------- | --------------------------------------------------------- |
-| `wake`        | Compact retrieval for session start                       |
-| `recall`      | Working context for an active goal (default)              |
-| `deep_search` | Broad retrieval for research-grade context                |
+| Layer         | Behavior                                     |
+| ------------- | -------------------------------------------- |
+| `wake`        | Compact retrieval for session start          |
+| `recall`      | Working context for an active goal (default) |
+| `deep_search` | Broad retrieval for research-grade context   |
 
 ## Response Schema
 
@@ -208,10 +208,10 @@ project raw memory.
 
 ## Error Handling
 
-| Error                              | Cause                                  | Resolution                          |
-| ----------------------------------- | -------------------------------------- | ----------------------------------- |
-| `Organization context required`     | No org-scoped token                    | Authenticate with an org-scoped token |
-| `Project access denied: <id>`        | Caller cannot access the project       | Use an accessible project ID        |
+| Error                           | Cause                            | Resolution                            |
+| ------------------------------- | -------------------------------- | ------------------------------------- |
+| `Organization context required` | No org-scoped token              | Authenticate with an org-scoped token |
+| `Project access denied: <id>`   | Caller cannot access the project | Use an accessible project ID          |
 
 ## Related
 

--- a/docs/api/mcp-logs.md
+++ b/docs/api/mcp-logs.md
@@ -8,8 +8,8 @@ in-memory log ring buffer to authorized callers.
 `logs` returns recent entries from the server's ring buffer, letting an agent debug Sibyl behavior
 without direct access to the host. It is a developer-introspection tool.
 
-This tool requires the **OWNER** role (the super-admin equivalent). Callers without OWNER
-membership receive an authorization error.
+This tool requires the **OWNER** role (the super-admin equivalent). Callers without OWNER membership
+receive an authorization error.
 
 ## Input Schema
 
@@ -21,8 +21,8 @@ interface LogsInput {
 }
 ```
 
-The `limit` argument is clamped to the range 1-500 regardless of the value supplied. The ring
-buffer retains the most recent entries only; older entries are dropped as new ones arrive.
+The `limit` argument is clamped to the range 1-500 regardless of the value supplied. The ring buffer
+retains the most recent entries only; older entries are dropped as new ones arrive.
 
 ## Response Schema
 
@@ -100,10 +100,10 @@ Returns the last 50 entries.
 
 ## Error Handling
 
-| Error                              | Cause                          | Resolution                          |
-| ----------------------------------- | ------------------------------ | ----------------------------------- |
-| `Organization context required`     | No org-scoped token            | Authenticate with an org-scoped token |
-| `OWNER role required for log access` | Caller is not an org OWNER     | Use an OWNER credential             |
+| Error                                | Cause                      | Resolution                            |
+| ------------------------------------ | -------------------------- | ------------------------------------- |
+| `Organization context required`      | No org-scoped token        | Authenticate with an org-scoped token |
+| `OWNER role required for log access` | Caller is not an org OWNER | Use an OWNER credential               |
 
 ## Related
 

--- a/docs/api/mcp-manage.md
+++ b/docs/api/mcp-manage.md
@@ -7,13 +7,13 @@ operations, analysis, and admin actions through a single action-dispatched tool.
 
 The `manage` tool handles state-changing operations organized by category:
 
-| Category          | Actions                                                                                   |
-| ----------------- | ----------------------------------------------------------------------------------------- |
+| Category          | Actions                                                                                                                 |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Task Workflow     | `start_task`, `block_task`, `unblock_task`, `submit_review`, `complete_task`, `archive_task`, `update_task`, `add_note` |
-| Epic Workflow     | `start_epic`, `complete_epic`, `archive_epic`, `update_epic`                              |
-| Source Operations | `crawl`, `sync`, `refresh`, `link_graph`, `link_graph_status`                             |
-| Analysis          | `estimate`, `prioritize`, `detect_cycles`, `suggest`                                      |
-| Admin             | `health`, `stats`, `rebuild_index`                                                        |
+| Epic Workflow     | `start_epic`, `complete_epic`, `archive_epic`, `update_epic`                                                            |
+| Source Operations | `crawl`, `sync`, `refresh`, `link_graph`, `link_graph_status`                                                           |
+| Analysis          | `estimate`, `prioritize`, `detect_cycles`, `suggest`                                                                    |
+| Admin             | `health`, `stats`, `rebuild_index`                                                                                      |
 
 For web applications, the REST task endpoints (`/api/tasks/{id}/*`) offer the same task workflow
 with finer-grained routes and authorization. The `manage` tool is the agent-facing equivalent and

--- a/docs/api/mcp-reflect.md
+++ b/docs/api/mcp-reflect.md
@@ -1,13 +1,13 @@
 # MCP Tool: reflect
 
-Reflect raw notes into reviewable durable memory candidates. Use `reflect` after planning,
-ideation, debugging, or building sessions to extract structured memory from unstructured notes.
+Reflect raw notes into reviewable durable memory candidates. Use `reflect` after planning, ideation,
+debugging, or building sessions to extract structured memory from unstructured notes.
 
 ## Overview
 
-Where [`remember`](./mcp-remember.md) captures a single piece of memory you already know you want
-to keep, `reflect` takes a block of raw session notes and extracts multiple memory candidates from
-it: decisions, plans, ideas, claims, artifacts, procedures, and session checkpoints. Each candidate
+Where [`remember`](./mcp-remember.md) captures a single piece of memory you already know you want to
+keep, `reflect` takes a block of raw session notes and extracts multiple memory candidates from it:
+decisions, plans, ideas, claims, artifacts, procedures, and session checkpoints. Each candidate
 carries a confidence score and a reason.
 
 By default `reflect` only extracts and returns candidates. Use the persistence flags to write them
@@ -53,11 +53,11 @@ Intent guides which kinds of candidates the extractor emphasizes.
 
 The persistence flags control what happens to the extracted candidates:
 
-| `persist` | `persist_review` | Outcome                                                          |
-| --------- | ---------------- | ---------------------------------------------------------------- |
-| `false`   | any              | Extract and return candidates only, no writes                    |
-| `true`    | `false`          | Promote candidates into the knowledge graph                      |
-| `true`    | `true`           | Store candidates in the raw review queue for later review        |
+| `persist` | `persist_review` | Outcome                                                   |
+| --------- | ---------------- | --------------------------------------------------------- |
+| `false`   | any              | Extract and return candidates only, no writes             |
+| `true`    | `false`          | Promote candidates into the knowledge graph               |
+| `true`    | `true`           | Store candidates in the raw review queue for later review |
 
 `persist_source` (default `true`) controls whether the raw reflection source itself is stored as a
 provenance record. The review queue feeds the reflection dream-cycle, where candidates are reviewed
@@ -169,11 +169,11 @@ through the reflection dream-cycle.
 
 ## Error Handling
 
-| Error                                                | Cause                                | Resolution                            |
-| ----------------------------------------------------- | ------------------------------------ | ------------------------------------- |
-| `Organization context required`                        | No org-scoped token                  | Authenticate with an org-scoped token |
-| `Project is required when MCP credentials are project-scoped` | Project-scoped key, `persist=true`, no `project` | Supply a `project`        |
-| `api_key_memory_space_denied`                           | API key lacks the target memory scope | Grant the key the required memory scope |
+| Error                                                         | Cause                                            | Resolution                              |
+| ------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------- |
+| `Organization context required`                               | No org-scoped token                              | Authenticate with an org-scoped token   |
+| `Project is required when MCP credentials are project-scoped` | Project-scoped key, `persist=true`, no `project` | Supply a `project`                      |
+| `api_key_memory_space_denied`                                 | API key lacks the target memory scope            | Grant the key the required memory scope |
 
 ## Related
 

--- a/docs/api/mcp-remember.md
+++ b/docs/api/mcp-remember.md
@@ -1,7 +1,7 @@
 # MCP Tool: remember
 
-Capture durable context from planning, ideation, building, or any domain. `remember` stores
-verbatim raw memory as provenance and creates a graph entity in one call.
+Capture durable context from planning, ideation, building, or any domain. `remember` stores verbatim
+raw memory as provenance and creates a graph entity in one call.
 
 ## Overview
 
@@ -48,19 +48,19 @@ interface RememberInput {
 episode, decision, plan, idea, claim, artifact, procedure, domain, session, pattern, rule
 ```
 
-| Kind        | Capture For                                       |
-| ----------- | ------------------------------------------------- |
-| `episode`   | Temporal knowledge, learnings (default)           |
-| `decision`  | A chosen direction with rationale                 |
-| `plan`      | Strategy, sequencing, milestones                  |
-| `idea`      | A brainstormed concept or unresolved option       |
-| `claim`     | An atomic fact or assertion                       |
-| `artifact`  | A file, object, document, asset, or work product  |
-| `procedure` | A repeatable workflow or runbook                  |
-| `domain`    | A modeled problem space                           |
-| `session`   | A conversation or work-session checkpoint         |
-| `pattern`   | A reusable pattern or best practice               |
-| `rule`      | A rule or guideline                               |
+| Kind        | Capture For                                      |
+| ----------- | ------------------------------------------------ |
+| `episode`   | Temporal knowledge, learnings (default)          |
+| `decision`  | A chosen direction with rationale                |
+| `plan`      | Strategy, sequencing, milestones                 |
+| `idea`      | A brainstormed concept or unresolved option      |
+| `claim`     | An atomic fact or assertion                      |
+| `artifact`  | A file, object, document, asset, or work product |
+| `procedure` | A repeatable workflow or runbook                 |
+| `domain`    | A modeled problem space                          |
+| `session`   | A conversation or work-session checkpoint        |
+| `pattern`   | A reusable pattern or best practice              |
+| `rule`      | A rule or guideline                              |
 
 ## Memory Scope
 
@@ -69,14 +69,14 @@ The scope is derived from `project`:
 - With a `project`, the memory is scoped to that project (`project` scope).
 - Without a `project`, the memory is private to the calling user (`private` scope).
 
-Project-scoped writes require access to the project. Project-scoped credentials (an API key bound
-to specific projects) must supply a `project`.
+Project-scoped writes require access to the project. Project-scoped credentials (an API key bound to
+specific projects) must supply a `project`.
 
 ## Active Task Linking
 
 When `active_task` is `true` (default) and a `project` is supplied, `remember` looks up the single
-task in `doing` status for that project. If exactly one exists, the new memory is linked to it.
-This keeps captures attached to the work in progress without the caller tracking task IDs.
+task in `doing` status for that project. If exactly one exists, the new memory is linked to it. This
+keeps captures attached to the work in progress without the caller tracking task IDs.
 
 Supply `task_ids` for explicit task linkage regardless of the active-task lookup.
 
@@ -159,20 +159,20 @@ Without a `project`, the memory is private to the calling user.
 
 ## Notes
 
-- The raw memory record is stored verbatim before the graph entity is created. The
-  `raw_source_id` is the stable provenance key for that record.
-- `remember` requires a user context. API keys without a resolvable user cannot capture raw
-  source material.
+- The raw memory record is stored verbatim before the graph entity is created. The `raw_source_id`
+  is the stable provenance key for that record.
+- `remember` requires a user context. API keys without a resolvable user cannot capture raw source
+  material.
 - Every call is authorized against the memory policy and audited.
 
 ## Error Handling
 
-| Error                                                | Cause                                       | Resolution                            |
-| ----------------------------------------------------- | ------------------------------------------- | ------------------------------------- |
-| `Organization context required`                        | No org-scoped token                         | Authenticate with an org-scoped token |
-| `User context required to remember raw source material` | Credential has no resolvable user           | Use a user-bound token or API key     |
-| `Project is required when MCP credentials are project-scoped` | Project-scoped key with no `project`        | Supply a `project`                    |
-| `api_key_memory_space_denied`                           | API key lacks the memory scope being written | Grant the key the required memory scope |
+| Error                                                         | Cause                                        | Resolution                              |
+| ------------------------------------------------------------- | -------------------------------------------- | --------------------------------------- |
+| `Organization context required`                               | No org-scoped token                          | Authenticate with an org-scoped token   |
+| `User context required to remember raw source material`       | Credential has no resolvable user            | Use a user-bound token or API key       |
+| `Project is required when MCP credentials are project-scoped` | Project-scoped key with no `project`         | Supply a `project`                      |
+| `api_key_memory_space_denied`                                 | API key lacks the memory scope being written | Grant the key the required memory scope |
 
 ## Related
 

--- a/docs/api/mcp-synthesis.md
+++ b/docs/api/mcp-synthesis.md
@@ -9,11 +9,11 @@ Synthesis turns the knowledge graph into a structured artifact (documentation, r
 roadmap, release notes, audit packet) where every section is grounded in cited sources. The three
 tools share the same request shape and differ only in what they produce:
 
-| Tool               | Produces                                                          |
-| ------------------ | ----------------------------------------------------------------- |
-| `synthesis_plan`   | A deterministic outline with materialized source packs            |
-| `synthesis_draft`  | A drafted artifact plus verification, optionally remembered        |
-| `synthesis_verify` | The same run as `plan`, with verification applied, no artifact     |
+| Tool               | Produces                                                       |
+| ------------------ | -------------------------------------------------------------- |
+| `synthesis_plan`   | A deterministic outline with materialized source packs         |
+| `synthesis_draft`  | A drafted artifact plus verification, optionally remembered    |
+| `synthesis_verify` | The same run as `plan`, with verification applied, no artifact |
 
 A typical flow is `synthesis_plan` to inspect coverage, then `synthesis_draft` to produce the
 artifact. `synthesis_verify` is useful as a standalone coverage check.
@@ -66,11 +66,11 @@ documentation, report, briefing, roadmap, release_notes, audit_packet, custom
 
 ### Depth Values
 
-| Depth      | Behavior                                              |
-| ---------- | ----------------------------------------------------- |
-| `brief`    | Tight outline, fewer sources per section              |
-| `standard` | Balanced coverage (default)                           |
-| `deep`     | Broad retrieval, more sources per section             |
+| Depth      | Behavior                                  |
+| ---------- | ----------------------------------------- |
+| `brief`    | Tight outline, fewer sources per section  |
+| `standard` | Balanced coverage (default)               |
+| `deep`     | Broad retrieval, more sources per section |
 
 ## Tool: synthesis_plan
 
@@ -123,9 +123,9 @@ interface SynthesisDraftExtra {
 }
 ```
 
-When `remember` is `true` and `memory_scope` is `project`, `scope_key` defaults to `project` and
-the write is authorized against the memory policy. The remembered artifact's IDs appear on the
-returned artifact (`remembered_memory_id`, `remembered_source_id`).
+When `remember` is `true` and `memory_scope` is `project`, `scope_key` defaults to `project` and the
+write is authorized against the memory policy. The remembered artifact's IDs appear on the returned
+artifact (`remembered_memory_id`, `remembered_source_id`).
 
 ## Tool: synthesis_verify
 
@@ -233,11 +233,11 @@ interface SynthesisArtifact {
 
 ### Verification Status
 
-| Status    | Meaning                                                       |
-| --------- | ------------------------------------------------------------- |
-| `pending` | Verification has not been applied (raw `synthesis_plan` run)  |
-| `gaps`    | One or more sections lack sufficient grounding                |
-| `pass`    | All sections are adequately source-grounded                   |
+| Status    | Meaning                                                      |
+| --------- | ------------------------------------------------------------ |
+| `pending` | Verification has not been applied (raw `synthesis_plan` run) |
+| `gaps`    | One or more sections lack sufficient grounding               |
+| `pass`    | All sections are adequately source-grounded                  |
 
 `hidden_count` on a source pack reports sources that are relevant but withheld because the caller's
 memory policy does not grant access. A high `hidden_count` means the caller is synthesizing without
@@ -253,12 +253,12 @@ full visibility.
 
 ## Error Handling
 
-| Error                              | Cause                                  | Resolution                          |
-| ----------------------------------- | -------------------------------------- | ----------------------------------- |
-| `Organization context required`     | No org-scoped token                    | Authenticate with an org-scoped token |
-| `Project access denied: <id>`        | Caller cannot access the project       | Use an accessible project ID        |
-| `missing_scope_key`                  | `remember` with project scope, no key  | Supply `scope_key` or `project`     |
-| `principal_id is required`           | `remember=true` with no resolvable user | Use a user-bound credential         |
+| Error                           | Cause                                   | Resolution                            |
+| ------------------------------- | --------------------------------------- | ------------------------------------- |
+| `Organization context required` | No org-scoped token                     | Authenticate with an org-scoped token |
+| `Project access denied: <id>`   | Caller cannot access the project        | Use an accessible project ID          |
+| `missing_scope_key`             | `remember` with project scope, no key   | Supply `scope_key` or `project`       |
+| `principal_id is required`      | `remember=true` with no resolvable user | Use a user-bound credential           |
 
 ## Related
 

--- a/docs/api/rest-memory.md
+++ b/docs/api/rest-memory.md
@@ -26,11 +26,11 @@ All endpoints require authentication via:
 
 ## Role Requirements
 
-| Operation group                       | Required Roles               |
-| --------------------------------------- | ---------------------------- |
-| Read (recall, context pack, import status) | Owner, Admin, Member, Viewer |
+| Operation group                                     | Required Roles               |
+| --------------------------------------------------- | ---------------------------- |
+| Read (recall, context pack, import status)          | Owner, Admin, Member, Viewer |
 | Write (remember, reflect, share preview, promotion) | Owner, Admin, Member         |
-| Admin (memory spaces, audit, inspect, corrections) | Owner, Admin                 |
+| Admin (memory spaces, audit, inspect, corrections)  | Owner, Admin                 |
 
 ## Memory Scopes
 
@@ -74,20 +74,20 @@ Stores verbatim memory before extraction or graph reflection.
 
 **Request Schema:**
 
-| Field             | Type     | Required | Default   | Description                                  |
-| ----------------- | -------- | -------- | --------- | -------------------------------------------- |
-| `raw_content`     | string   | Yes      | -         | Verbatim memory (1-500,000 chars)            |
-| `title`           | string   | No       | ""        | Human title (max 300 chars)                  |
-| `source_id`       | string   | No       | -         | Stable provenance ID                         |
-| `memory_scope`    | string   | No       | `private` | Retrieval scope                              |
-| `scope_key`       | string   | No       | -         | Project/team/shared scope key                |
-| `diary`           | boolean  | No       | false     | Store as a private agent diary entry         |
-| `agent_id`        | string   | No       | -         | Agent identity for diary entries             |
-| `project_id`      | string   | No       | -         | Associated project                          |
-| `tags`            | string[] | No       | `[]`      | Searchable tags                              |
-| `metadata`        | object   | No       | `{}`      | Auxiliary metadata                           |
-| `provenance`      | object   | No       | `{}`      | Source provenance                           |
-| `capture_surface` | string   | No       | `api`     | Capture surface label                        |
+| Field             | Type     | Required | Default   | Description                          |
+| ----------------- | -------- | -------- | --------- | ------------------------------------ |
+| `raw_content`     | string   | Yes      | -         | Verbatim memory (1-500,000 chars)    |
+| `title`           | string   | No       | ""        | Human title (max 300 chars)          |
+| `source_id`       | string   | No       | -         | Stable provenance ID                 |
+| `memory_scope`    | string   | No       | `private` | Retrieval scope                      |
+| `scope_key`       | string   | No       | -         | Project/team/shared scope key        |
+| `diary`           | boolean  | No       | false     | Store as a private agent diary entry |
+| `agent_id`        | string   | No       | -         | Agent identity for diary entries     |
+| `project_id`      | string   | No       | -         | Associated project                   |
+| `tags`            | string[] | No       | `[]`      | Searchable tags                      |
+| `metadata`        | object   | No       | `{}`      | Auxiliary metadata                   |
+| `provenance`      | object   | No       | `{}`      | Source provenance                    |
+| `capture_surface` | string   | No       | `api`     | Capture surface label                |
 
 **Response:**
 
@@ -134,15 +134,15 @@ Recalls verbatim memories through scoped retrieval.
 }
 ```
 
-| Field          | Type    | Required | Default   | Description                  |
-| -------------- | ------- | -------- | --------- | ---------------------------- |
-| `query`        | string  | Yes      | -         | Full-text recall query       |
-| `memory_scope` | string  | No       | `private` | Retrieval scope              |
-| `scope_key`    | string  | No       | -         | Scope key                    |
-| `diary`        | boolean | No       | false     | Recall agent diary entries   |
-| `agent_id`     | string  | No       | -         | Agent identity to recall     |
-| `project_id`   | string  | No       | -         | Project diary filter         |
-| `limit`        | integer | No       | 10        | Maximum memories (1-50)      |
+| Field          | Type    | Required | Default   | Description                |
+| -------------- | ------- | -------- | --------- | -------------------------- |
+| `query`        | string  | Yes      | -         | Full-text recall query     |
+| `memory_scope` | string  | No       | `private` | Retrieval scope            |
+| `scope_key`    | string  | No       | -         | Scope key                  |
+| `diary`        | boolean | No       | false     | Recall agent diary entries |
+| `agent_id`     | string  | No       | -         | Agent identity to recall   |
+| `project_id`   | string  | No       | -         | Project diary filter       |
+| `limit`        | integer | No       | 10        | Maximum memories (1-50)    |
 
 **Response:**
 
@@ -150,9 +150,7 @@ Recalls verbatim memories through scoped retrieval.
 {
   "query": "surreal concurrency",
   "limit": 10,
-  "memories": [
-    { "id": "raw_abc123", "title": "SurrealDB write concurrency", "score": 0.88 }
-  ],
+  "memories": [{ "id": "raw_abc123", "title": "SurrealDB write concurrency", "score": 0.88 }],
   "policy_reason": "allowed"
 }
 ```
@@ -184,17 +182,17 @@ Compiles a structured context pack for an agent goal. This is the REST equivalen
 }
 ```
 
-| Field             | Type    | Required | Default  | Description                              |
-| ----------------- | ------- | -------- | -------- | ---------------------------------------- |
-| `goal`            | string  | Yes      | -        | Agent goal or user task                  |
-| `intent`          | string  | No       | `build`  | How the agent will act                   |
-| `layer`           | string  | No       | `recall` | `wake`, `recall`, or `deep_search`       |
-| `domain`          | string  | No       | -        | Domain to bias retrieval                 |
-| `project`         | string  | No       | -        | Project ID to scope context              |
-| `agent_id`        | string  | No       | -        | Agent diary identity to include          |
-| `limit`           | integer | No       | 24       | Maximum context items (1-50)             |
-| `include_related` | boolean | No       | true     | Include one-hop related graph context    |
-| `related_limit`   | integer | No       | 3        | Related items per context item (0-5)     |
+| Field             | Type    | Required | Default  | Description                           |
+| ----------------- | ------- | -------- | -------- | ------------------------------------- |
+| `goal`            | string  | Yes      | -        | Agent goal or user task               |
+| `intent`          | string  | No       | `build`  | How the agent will act                |
+| `layer`           | string  | No       | `recall` | `wake`, `recall`, or `deep_search`    |
+| `domain`          | string  | No       | -        | Domain to bias retrieval              |
+| `project`         | string  | No       | -        | Project ID to scope context           |
+| `agent_id`        | string  | No       | -        | Agent diary identity to include       |
+| `limit`           | integer | No       | 24       | Maximum context items (1-50)          |
+| `include_related` | boolean | No       | true     | Include one-hop related graph context |
+| `related_limit`   | integer | No       | 3        | Related items per context item (0-5)  |
 
 The response is a context pack with `sections`, `total_items`, `usage_hint`, and a rendered
 `markdown` field. See [mcp-context.md](./mcp-context.md) for the full pack schema.
@@ -227,32 +225,32 @@ Reflects raw notes into durable memory candidates. This is the REST equivalent o
 }
 ```
 
-| Field            | Type     | Required | Default              | Description                                       |
-| ---------------- | -------- | -------- | -------------------- | ------------------------------------------------- |
-| `content`        | string   | Yes      | -                    | Raw session notes                                 |
-| `source_title`   | string   | No       | `Session reflection` | Source/session title                              |
-| `intent`         | string   | No       | `general`            | Reflection intent                                 |
-| `domain`         | string   | No       | -                    | Domain for candidates                             |
-| `project`        | string   | No       | -                    | Project ID to scope candidates                    |
-| `related_to`     | string[] | No       | -                    | Entity IDs to link persisted candidates           |
-| `task_ids`       | string[] | No       | -                    | Task IDs to link persisted output                 |
-| `active_task`    | boolean  | No       | true                 | Link persisted output to the active doing task    |
-| `persist`        | boolean  | No       | false                | Persist candidates into the graph                 |
-| `persist_source` | boolean  | No       | true                 | Store the raw source notes                        |
-| `persist_review` | boolean  | No       | false                | Store output in the raw review queue              |
-| `limit`          | integer  | No       | 12                   | Maximum candidates (1-25)                          |
+| Field            | Type     | Required | Default              | Description                                    |
+| ---------------- | -------- | -------- | -------------------- | ---------------------------------------------- |
+| `content`        | string   | Yes      | -                    | Raw session notes                              |
+| `source_title`   | string   | No       | `Session reflection` | Source/session title                           |
+| `intent`         | string   | No       | `general`            | Reflection intent                              |
+| `domain`         | string   | No       | -                    | Domain for candidates                          |
+| `project`        | string   | No       | -                    | Project ID to scope candidates                 |
+| `related_to`     | string[] | No       | -                    | Entity IDs to link persisted candidates        |
+| `task_ids`       | string[] | No       | -                    | Task IDs to link persisted output              |
+| `active_task`    | boolean  | No       | true                 | Link persisted output to the active doing task |
+| `persist`        | boolean  | No       | false                | Persist candidates into the graph              |
+| `persist_source` | boolean  | No       | true                 | Store the raw source notes                     |
+| `persist_review` | boolean  | No       | false                | Store output in the raw review queue           |
+| `limit`          | integer  | No       | 12                   | Maximum candidates (1-25)                      |
 
 The response is a reflection pack with `candidates`, `total_candidates`, `persisted_count`, and a
 rendered `markdown` field. See [mcp-reflect.md](./mcp-reflect.md) for the candidate schema.
 
 ## Reflection Promotion Endpoints
 
-| Method | Path                                       | Purpose                                                    |
-| ------ | ------------------------------------------ | ---------------------------------------------------------- |
-| POST   | `/api/memory/reflection/promote`           | Promote a reviewed candidate into native Surreal memory    |
-| POST   | `/api/memory/reflection/promote/preview`   | Preview a promotion without writing                        |
-| POST   | `/api/memory/reflection/review/auto`       | Auto-review and promote a single safe candidate            |
-| POST   | `/api/memory/reflection/review/drain`      | Bulk auto-review pending candidates                        |
+| Method | Path                                     | Purpose                                                 |
+| ------ | ---------------------------------------- | ------------------------------------------------------- |
+| POST   | `/api/memory/reflection/promote`         | Promote a reviewed candidate into native Surreal memory |
+| POST   | `/api/memory/reflection/promote/preview` | Preview a promotion without writing                     |
+| POST   | `/api/memory/reflection/review/auto`     | Auto-review and promote a single safe candidate         |
+| POST   | `/api/memory/reflection/review/drain`    | Bulk auto-review pending candidates                     |
 
 These endpoints drive the reflection dream-cycle: candidates flow into the review queue, then are
 promoted automatically (when confident and within policy) or by an operator. Promotion endpoints
@@ -263,40 +261,39 @@ require Member-or-higher role.
 Memory spaces are persisted scope records for owner/admin inspection. All space endpoints require
 Owner or Admin role.
 
-| Method | Path                                            | Purpose                                  |
-| ------ | ----------------------------------------------- | ---------------------------------------- |
-| GET    | `/api/memory/spaces`                            | List persisted memory spaces             |
-| POST   | `/api/memory/spaces`                            | Create a memory-space record             |
-| GET    | `/api/memory/spaces/{space_id}`                 | Inspect a space and its memberships      |
-| PATCH  | `/api/memory/spaces/{space_id}`                 | Update space metadata or state           |
-| POST   | `/api/memory/spaces/{space_id}/members`         | Grant a principal membership             |
-| POST   | `/api/memory/spaces/{space_id}/members/preview` | Preview what a principal could recall    |
+| Method | Path                                            | Purpose                               |
+| ------ | ----------------------------------------------- | ------------------------------------- |
+| GET    | `/api/memory/spaces`                            | List persisted memory spaces          |
+| POST   | `/api/memory/spaces`                            | Create a memory-space record          |
+| GET    | `/api/memory/spaces/{space_id}`                 | Inspect a space and its memberships   |
+| PATCH  | `/api/memory/spaces/{space_id}`                 | Update space metadata or state        |
+| POST   | `/api/memory/spaces/{space_id}/members`         | Grant a principal membership          |
+| POST   | `/api/memory/spaces/{space_id}/members/preview` | Preview what a principal could recall |
 
 ## Inspection, Audit, and Sharing
 
-| Method | Path                                                   | Purpose                                          |
-| ------ | ------------------------------------------------------ | ------------------------------------------------ |
-| GET    | `/api/memory/audit`                                    | List memory audit events (filterable)            |
-| GET    | `/api/memory/inspect/{source_id}`                      | Inspect a raw memory source and derived records  |
-| POST   | `/api/memory/inspect/{source_id}/corrections/preview`  | Preview a correction or lifecycle action         |
-| POST   | `/api/memory/inspect/{source_id}/corrections`          | Apply a correction or lifecycle action           |
-| POST   | `/api/memory/share/preview`                            | Preview memory sharing without enabling a share  |
-| GET    | `/api/memory/source-imports/{import_id}`               | Get source-safe import progress                  |
+| Method | Path                                                  | Purpose                                         |
+| ------ | ----------------------------------------------------- | ----------------------------------------------- |
+| GET    | `/api/memory/audit`                                   | List memory audit events (filterable)           |
+| GET    | `/api/memory/inspect/{source_id}`                     | Inspect a raw memory source and derived records |
+| POST   | `/api/memory/inspect/{source_id}/corrections/preview` | Preview a correction or lifecycle action        |
+| POST   | `/api/memory/inspect/{source_id}/corrections`         | Apply a correction or lifecycle action          |
+| POST   | `/api/memory/share/preview`                           | Preview memory sharing without enabling a share |
+| GET    | `/api/memory/source-imports/{import_id}`              | Get source-safe import progress                 |
 
 Memory corrections support actions such as `delete` and `hide` for lifecycle management. Audit and
-inspection endpoints require Owner or Admin role; `source-imports` status is readable by any
-member.
+inspection endpoints require Owner or Admin role; `source-imports` status is readable by any member.
 
 ## Error Responses
 
-| Status | Cause                                                       |
-| ------ | ----------------------------------------------------------- |
-| 400    | Invalid request, or `invalid_memory_space_id`               |
-| 401    | Missing or invalid authentication (`Not authenticated`)     |
+| Status | Cause                                                             |
+| ------ | ----------------------------------------------------------------- |
+| 400    | Invalid request, or `invalid_memory_space_id`                     |
+| 401    | Missing or invalid authentication (`Not authenticated`)           |
 | 403    | Insufficient role, project access denied, or memory policy denial |
-| 404    | Source, import, or reflection candidate not found           |
-| 422    | Request body validation failed                             |
-| 500    | Memory operation failed                                     |
+| 404    | Source, import, or reflection candidate not found                 |
+| 422    | Request body validation failed                                    |
+| 500    | Memory operation failed                                           |
 
 ## Related
 

--- a/docs/api/rest-search.md
+++ b/docs/api/rest-search.md
@@ -281,21 +281,21 @@ conflict detection.
 
 **Request Schema:**
 
-| Field             | Type    | Required | Default   | Description                                  |
-| ----------------- | ------- | -------- | --------- | -------------------------------------------- |
-| `mode`            | string  | No       | `history` | `history`, `timeline`, or `conflicts`        |
-| `entity_id`       | string  | No       | -         | Entity to scope the temporal query           |
-| `as_of`           | string  | No       | -         | Point-in-time date for `history` mode        |
-| `include_expired` | boolean | No       | false     | Include expired edges                        |
-| `limit`           | integer | No       | 50        | Maximum edges to return                      |
+| Field             | Type    | Required | Default   | Description                           |
+| ----------------- | ------- | -------- | --------- | ------------------------------------- |
+| `mode`            | string  | No       | `history` | `history`, `timeline`, or `conflicts` |
+| `entity_id`       | string  | No       | -         | Entity to scope the temporal query    |
+| `as_of`           | string  | No       | -         | Point-in-time date for `history` mode |
+| `include_expired` | boolean | No       | false     | Include expired edges                 |
+| `limit`           | integer | No       | 50        | Maximum edges to return               |
 
 **Modes:**
 
-| Mode        | Answers                                                |
-| ----------- | ------------------------------------------------------ |
-| `history`   | Edges as they existed at `as_of`                       |
-| `timeline`  | All versions of edges over time (knowledge evolution)  |
-| `conflicts` | Invalidated or superseded facts                        |
+| Mode        | Answers                                               |
+| ----------- | ----------------------------------------------------- |
+| `history`   | Edges as they existed at `as_of`                      |
+| `timeline`  | All versions of edges over time (knowledge evolution) |
+| `conflicts` | Invalidated or superseded facts                       |
 
 **Response:**
 

--- a/docs/api/rest-synthesis.md
+++ b/docs/api/rest-synthesis.md
@@ -20,7 +20,7 @@ All endpoints require authentication via:
 
 ## Role Requirements
 
-| Operation                  | Required Roles               |
+| Operation                   | Required Roles               |
 | --------------------------- | ---------------------------- |
 | Plan and draft              | Owner, Admin, Member, Viewer |
 | Draft with `remember: true` | Owner, Admin, Member         |
@@ -60,23 +60,23 @@ section. No artifact text is generated.
 
 **Request Schema:**
 
-| Field                   | Type     | Required | Default         | Description                                  |
-| ----------------------- | -------- | -------- | --------------- | -------------------------------------------- |
-| `goal`                  | string   | Yes      | -               | Synthesis goal (1-1000 chars)                |
-| `output_type`           | string   | No       | `documentation` | Output type                                  |
-| `audience`              | string   | No       | -               | Intended reader (max 500 chars)              |
-| `depth`                 | string   | No       | `standard`      | `brief`, `standard`, or `deep`               |
-| `seed_query`            | string   | No       | -               | Explicit retrieval query                     |
-| `project`               | string   | No       | -               | Project ID to scope sources                  |
-| `domain`                | string   | No       | -               | Domain to scope sources                      |
-| `entity_ids`            | string[] | No       | `[]`            | Pinned entity sources (max 100)              |
-| `decision_ids`          | string[] | No       | `[]`            | Pinned decision sources (max 100)            |
-| `task_ids`              | string[] | No       | `[]`            | Pinned task sources (max 100)                |
-| `artifact_ids`          | string[] | No       | `[]`            | Pinned artifact sources (max 100)            |
-| `required_sections`     | object[] | No       | `[]`            | Forced outline sections (max 12)             |
-| `constraints`           | string[] | No       | `[]`            | Free-text output constraints (max 50)        |
-| `max_sections`          | integer  | No       | 6               | Outline section cap (1-12)                   |
-| `include_neighborhoods` | boolean  | No       | true            | Include one-hop related sources              |
+| Field                   | Type     | Required | Default         | Description                           |
+| ----------------------- | -------- | -------- | --------------- | ------------------------------------- |
+| `goal`                  | string   | Yes      | -               | Synthesis goal (1-1000 chars)         |
+| `output_type`           | string   | No       | `documentation` | Output type                           |
+| `audience`              | string   | No       | -               | Intended reader (max 500 chars)       |
+| `depth`                 | string   | No       | `standard`      | `brief`, `standard`, or `deep`        |
+| `seed_query`            | string   | No       | -               | Explicit retrieval query              |
+| `project`               | string   | No       | -               | Project ID to scope sources           |
+| `domain`                | string   | No       | -               | Domain to scope sources               |
+| `entity_ids`            | string[] | No       | `[]`            | Pinned entity sources (max 100)       |
+| `decision_ids`          | string[] | No       | `[]`            | Pinned decision sources (max 100)     |
+| `task_ids`              | string[] | No       | `[]`            | Pinned task sources (max 100)         |
+| `artifact_ids`          | string[] | No       | `[]`            | Pinned artifact sources (max 100)     |
+| `required_sections`     | object[] | No       | `[]`            | Forced outline sections (max 12)      |
+| `constraints`           | string[] | No       | `[]`            | Free-text output constraints (max 50) |
+| `max_sections`          | integer  | No       | 6               | Outline section cap (1-12)            |
+| `include_neighborhoods` | boolean  | No       | true            | Include one-hop related sources       |
 
 A `required_sections` entry has the shape:
 
@@ -150,8 +150,8 @@ documentation, report, briefing, roadmap, release_notes, audit_packet, custom
 }
 ```
 
-`hidden_count` on a source pack reports relevant sources withheld because the caller's memory
-policy does not grant access.
+`hidden_count` on a source pack reports relevant sources withheld because the caller's memory policy
+does not grant access.
 
 ### Draft Synthesis
 
@@ -181,13 +181,13 @@ artifact as a memory record.
 
 **Additional Request Schema:**
 
-| Field           | Type     | Required | Default    | Description                                      |
-| --------------- | -------- | -------- | ---------- | ------------------------------------------------ |
-| `output_format` | string   | No       | `markdown` | `markdown` or `json`                             |
-| `remember`      | boolean  | No       | false      | Persist the generated artifact as memory         |
+| Field           | Type     | Required | Default    | Description                                        |
+| --------------- | -------- | -------- | ---------- | -------------------------------------------------- |
+| `output_format` | string   | No       | `markdown` | `markdown` or `json`                               |
+| `remember`      | boolean  | No       | false      | Persist the generated artifact as memory           |
 | `memory_scope`  | string   | No       | `private`  | `private` or `project` for the remembered artifact |
-| `scope_key`     | string   | No       | -          | Project ID when `memory_scope` is `project`      |
-| `tags`          | string[] | No       | `[]`       | Tags for the remembered artifact (max 50)        |
+| `scope_key`     | string   | No       | -          | Project ID when `memory_scope` is `project`        |
+| `tags`          | string[] | No       | `[]`       | Tags for the remembered artifact (max 50)          |
 
 When `remember` is `true` with `memory_scope: "project"`, `scope_key` is required (it defaults to
 `project` when omitted) and the write requires Member-or-higher role plus project access.
@@ -239,24 +239,24 @@ When `remember` is `false`, `remembered_memory_id` and `remembered_source_id` ar
 Both endpoints attach a `verification` summary. The `/draft` endpoint applies verification before
 returning; `/plan` returns `verification.status: "pending"`.
 
-| Status    | Meaning                                                       |
-| --------- | ------------------------------------------------------------- |
-| `pending` | Verification not yet applied (raw `/plan` response)           |
-| `gaps`    | One or more sections lack sufficient grounding                |
-| `pass`    | All sections are adequately source-grounded                   |
+| Status    | Meaning                                             |
+| --------- | --------------------------------------------------- |
+| `pending` | Verification not yet applied (raw `/plan` response) |
+| `gaps`    | One or more sections lack sufficient grounding      |
+| `pass`    | All sections are adequately source-grounded         |
 
 Each `gap` identifies the under-grounded section, the reason, the retrieval query that came up
 short, and any missing source IDs.
 
 ## Error Responses
 
-| Status | Cause                                                          |
-| ------ | -------------------------------------------------------------- |
-| 400    | Invalid request, or `missing_scope_key` on a project-scoped draft |
-| 401    | Missing or invalid authentication                              |
+| Status | Cause                                                                |
+| ------ | -------------------------------------------------------------------- |
+| 400    | Invalid request, or `missing_scope_key` on a project-scoped draft    |
+| 401    | Missing or invalid authentication                                    |
 | 403    | Insufficient role, `insufficient_org_role`, or project access denied |
-| 422    | Request body validation failed                                |
-| 500    | Synthesis planning or drafting failed                          |
+| 422    | Request body validation failed                                       |
+| 500    | Synthesis planning or drafting failed                                |
 
 ## Related
 

--- a/docs/architecture/SIBYL_1_0_ROADMAP.md
+++ b/docs/architecture/SIBYL_1_0_ROADMAP.md
@@ -29,8 +29,8 @@ real work, and leave the graph smarter without Bliss babysitting a manual inbox.
 These living docs in `docs/architecture/` remain active planning inputs:
 
 - [`SIBYL_NORTHSTAR.md`](SIBYL_NORTHSTAR.md): product and architecture truth.
-- [`SIBYL_V012_REFLECTION_OS_PLAN.md`](SIBYL_V012_REFLECTION_OS_PLAN.md): current v0.12 Reflection OS
-  implementation plan.
+- [`SIBYL_V012_REFLECTION_OS_PLAN.md`](SIBYL_V012_REFLECTION_OS_PLAN.md): current v0.12 Reflection
+  OS implementation plan.
 - [`PERMISSION_SYSTEM_AUDIT.md`](PERMISSION_SYSTEM_AUDIT.md): current auth, policy, project RBAC,
   MCP, and trust-surface audit.
 - [`TASKIQ_MIGRATION_PLAN.md`](TASKIQ_MIGRATION_PLAN.md): coordination backend boundary and

--- a/docs/architecture/SIBYL_NORTHSTAR.md
+++ b/docs/architecture/SIBYL_NORTHSTAR.md
@@ -28,7 +28,8 @@ Shipped execution plans, kept in `docs/_archive/` as release receipts and design
   [`SIBYL_V08_PURE_SURREAL_CLOSURE_AND_MEMORY_TRUST_PLAN.md`](../_archive/SIBYL_V08_PURE_SURREAL_CLOSURE_AND_MEMORY_TRUST_PLAN.md)
 - v0.9 synthesis and memory workspace:
   [`SIBYL_POST_V08_SYNTHESIS_AND_MEMORY_WORKSPACE_PLAN.md`](../_archive/SIBYL_POST_V08_SYNTHESIS_AND_MEMORY_WORKSPACE_PLAN.md)
-- Native LLM provider substrate: [`SIBYL_LLM_SUBSTRATE_PLAN.md`](../_archive/SIBYL_LLM_SUBSTRATE_PLAN.md)
+- Native LLM provider substrate:
+  [`SIBYL_LLM_SUBSTRATE_PLAN.md`](../_archive/SIBYL_LLM_SUBSTRATE_PLAN.md)
 
 ## Northstar
 

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -12,8 +12,8 @@ For a single-blob quick capture, see [`capture`](./capture.md). For typed memory
 sibyl add [title] [content] [options]
 ```
 
-Title and content can be passed positionally or with the `--title` / `--content` flags. Content
-can also be read from a file with `--content-file`.
+Title and content can be passed positionally or with the `--title` / `--content` flags. Content can
+also be read from a file with `--content-file`.
 
 ## Arguments
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -1,18 +1,18 @@
 # auth
 
-Authentication and credentials. `auth` logs the CLI into a Sibyl server, manages stored tokens,
-and creates API keys for MCP clients and scripts.
+Authentication and credentials. `auth` logs the CLI into a Sibyl server, manages stored tokens, and
+creates API keys for MCP clients and scripts.
 
 ## Commands
 
-| Command                                       | Description                                  |
-| ---------------------------------------------- | -------------------------------------------- |
-| [`sibyl auth login`](#auth-login)             | Log in to a server and save credentials      |
-| [`sibyl auth status`](#auth-status)           | Show auth status for the current context     |
-| [`sibyl auth local-signup`](#auth-local-signup) | Create a local user and save its token     |
-| [`sibyl auth set-token`](#auth-set-token)     | Set an auth token for a server               |
-| [`sibyl auth clear-token`](#auth-clear-token) | Clear auth tokens for a server               |
-| [`sibyl auth api-key`](#auth-api-key)         | API key management                           |
+| Command                                         | Description                              |
+| ----------------------------------------------- | ---------------------------------------- |
+| [`sibyl auth login`](#auth-login)               | Log in to a server and save credentials  |
+| [`sibyl auth status`](#auth-status)             | Show auth status for the current context |
+| [`sibyl auth local-signup`](#auth-local-signup) | Create a local user and save its token   |
+| [`sibyl auth set-token`](#auth-set-token)       | Set an auth token for a server           |
+| [`sibyl auth clear-token`](#auth-clear-token)   | Clear auth tokens for a server           |
+| [`sibyl auth api-key`](#auth-api-key)           | API key management                       |
 
 ---
 
@@ -30,21 +30,21 @@ sibyl auth login [url] [options]
 
 ### Arguments
 
-| Argument | Required | Description                                              |
-| -------- | -------- | -------------------------------------------------------- |
+| Argument | Required | Description                                                |
+| -------- | -------- | ---------------------------------------------------------- |
 | `url`    | No       | Server URL. If omitted, uses the active context or default |
 
 ### Options
 
-| Option         | Short | Default | Description                                       |
-| -------------- | ----- | ------- | ------------------------------------------------- |
-| `--server`     | `-s`  | (none)  | Server base URL (alias for the positional URL)    |
-| `--context`    | `-c`  | (none)  | Create or update a named context for this server  |
-| `--no-browser` |       | false   | Print the URL instead of opening a browser        |
-| `--timeout`    |       | 180     | Seconds to wait for approval/auth                 |
-| `--email`      | `-e`  | (none)  | Email for local login                             |
-| `--password`   | `-p`  | (none)  | Password for local login                          |
-| `--insecure`   | `-k`  | false   | Disable SSL certificate verification              |
+| Option         | Short | Default | Description                                      |
+| -------------- | ----- | ------- | ------------------------------------------------ |
+| `--server`     | `-s`  | (none)  | Server base URL (alias for the positional URL)   |
+| `--context`    | `-c`  | (none)  | Create or update a named context for this server |
+| `--no-browser` |       | false   | Print the URL instead of opening a browser       |
+| `--timeout`    |       | 180     | Seconds to wait for approval/auth                |
+| `--email`      | `-e`  | (none)  | Email for local login                            |
+| `--password`   | `-p`  | (none)  | Password for local login                         |
+| `--insecure`   | `-k`  | false   | Disable SSL certificate verification             |
 
 ### Examples
 
@@ -89,11 +89,11 @@ sibyl auth local-signup --email <email> --password <password> --name <name>
 
 ### Options
 
-| Option       | Short | Required | Description               |
-| ------------ | ----- | -------- | ------------------------- |
-| `--email`    | `-e`  | Yes      | Email address             |
-| `--password` | `-p`  | Yes      | Password (min 8 chars)    |
-| `--name`     | `-n`  | Yes      | Display name              |
+| Option       | Short | Required | Description            |
+| ------------ | ----- | -------- | ---------------------- |
+| `--email`    | `-e`  | Yes      | Email address          |
+| `--password` | `-p`  | Yes      | Password (min 8 chars) |
+| `--name`     | `-n`  | Yes      | Display name           |
 
 ### Example
 
@@ -122,16 +122,16 @@ sibyl auth set-token <token> [options]
 
 ### Options
 
-| Option     | Short | Description                                  |
-| ---------- | ----- | -------------------------------------------- |
+| Option     | Short | Description                                                  |
+| ---------- | ----- | ------------------------------------------------------------ |
 | `--server` | `-s`  | Server URL to set the token for (defaults to active context) |
 
 ---
 
 ## auth clear-token
 
-Clear auth tokens for a server. Defaults to the active context server, or use `--all` to clear
-every stored token.
+Clear auth tokens for a server. Defaults to the active context server, or use `--all` to clear every
+stored token.
 
 ### Synopsis
 
@@ -141,10 +141,10 @@ sibyl auth clear-token [options]
 
 ### Options
 
-| Option     | Short | Description                                  |
-| ---------- | ----- | -------------------------------------------- |
+| Option     | Short | Description                                                 |
+| ---------- | ----- | ----------------------------------------------------------- |
 | `--server` | `-s`  | Server URL to clear tokens for (defaults to active context) |
-| `--all`    | `-a`  | Clear tokens for ALL servers                 |
+| `--all`    | `-a`  | Clear tokens for ALL servers                                |
 
 ### Example
 
@@ -159,11 +159,11 @@ sibyl auth clear-token --all
 API key management. API keys authenticate MCP clients and scripts without a browser session. Keys
 carry scopes and can be limited to specific projects and memory spaces.
 
-| Subcommand                            | Description       |
-| ------------------------------------- | ----------------- |
-| `sibyl auth api-key list`             | List API keys     |
-| `sibyl auth api-key create`           | Create an API key |
-| `sibyl auth api-key revoke`           | Revoke an API key |
+| Subcommand                  | Description       |
+| --------------------------- | ----------------- |
+| `sibyl auth api-key list`   | List API keys     |
+| `sibyl auth api-key create` | Create an API key |
+| `sibyl auth api-key revoke` | Revoke an API key |
 
 ### auth api-key list
 
@@ -177,14 +177,14 @@ sibyl auth api-key list
 sibyl auth api-key create --name <name> [options]
 ```
 
-| Option            | Short | Default | Description                                          |
-| ----------------- | ----- | ------- | ---------------------------------------------------- |
-| `--name`          | `-n`  | (req.)  | Display name for the key (required)                  |
-| `--live` / `--test` |     | `live`  | Use an `sk_live_` (default) or `sk_test_` key prefix |
-| `--scopes`        |       | `mcp`   | Comma-separated scopes                               |
-| `--projects`      |       | (none)  | Comma-separated graph project IDs the key may access |
-| `--memory-spaces` |       | (none)  | Comma-separated memory-space IDs the key may access  |
-| `--expires-days`  |       | (none)  | Optional expiry in days (1-365)                      |
+| Option              | Short | Default | Description                                          |
+| ------------------- | ----- | ------- | ---------------------------------------------------- |
+| `--name`            | `-n`  | (req.)  | Display name for the key (required)                  |
+| `--live` / `--test` |       | `live`  | Use an `sk_live_` (default) or `sk_test_` key prefix |
+| `--scopes`          |       | `mcp`   | Comma-separated scopes                               |
+| `--projects`        |       | (none)  | Comma-separated graph project IDs the key may access |
+| `--memory-spaces`   |       | (none)  | Comma-separated memory-space IDs the key may access  |
+| `--expires-days`    |       | (none)  | Optional expiry in days (1-365)                      |
 
 Available scopes include `mcp`, `api:read`, `api:write`, plus memory scopes. The full key value is
 shown only once at creation.
@@ -210,8 +210,8 @@ sibyl auth api-key create --name "agent-sandbox" --test \
 sibyl auth api-key revoke <api_key_id>
 ```
 
-| Argument     | Required | Description       |
-| ------------ | -------- | ----------------- |
+| Argument     | Required | Description          |
+| ------------ | -------- | -------------------- |
 | `api_key_id` | Yes      | API key ID to revoke |
 
 ## Related Commands

--- a/docs/cli/capture.md
+++ b/docs/cli/capture.md
@@ -1,7 +1,7 @@
 # capture
 
-Capture a quick memory without separate title and content fields. `capture` is the fastest way
-into the memory loop: pass a single blob of text (or pipe it in) and Sibyl derives a title for you.
+Capture a quick memory without separate title and content fields. `capture` is the fastest way into
+the memory loop: pass a single blob of text (or pipe it in) and Sibyl derives a title for you.
 
 ## Synopsis
 
@@ -13,9 +13,9 @@ Content is read from stdin when the positional argument is omitted.
 
 ## Arguments
 
-| Argument  | Required | Description                                |
-| --------- | -------- | ------------------------------------------ |
-| `content` | No       | What to capture. Reads stdin if omitted    |
+| Argument  | Required | Description                             |
+| --------- | -------- | --------------------------------------- |
+| `content` | No       | What to capture. Reads stdin if omitted |
 
 ## Options
 
@@ -37,9 +37,9 @@ Content is read from stdin when the positional argument is omitted.
 
 ## When to Use
 
-Reach for `capture` when you have a thought to record and do not want to stop to phrase a title.
-Use [`remember`](./remember.md) when the memory has a clear name or a specific kind (decision,
-plan, claim). Use [`add`](./add.md) when you want explicit title and content fields.
+Reach for `capture` when you have a thought to record and do not want to stop to phrase a title. Use
+[`remember`](./remember.md) when the memory has a clear name or a specific kind (decision, plan,
+claim). Use [`add`](./add.md) when you want explicit title and content fields.
 
 ## Examples
 

--- a/docs/cli/context.md
+++ b/docs/cli/context.md
@@ -38,10 +38,10 @@ sibyl context [options]
 
 ### Options
 
-| Option                 | Short | Description                                              |
-| ---------------------- | ----- | -------------------------------------------------------- |
-| `--json`               | `-j`  | JSON output                                              |
-| `--quick` / `--validate` |     | Show local server/org/project/auth status only          |
+| Option                   | Short | Description                                    |
+| ------------------------ | ----- | ---------------------------------------------- |
+| `--json`                 | `-j`  | JSON output                                    |
+| `--quick` / `--validate` |       | Show local server/org/project/auth status only |
 
 ### Example
 
@@ -60,8 +60,8 @@ Output:
   Project:  proj_abc123 (linked)
 ```
 
-If a directory is linked, it shows `(linked)` next to the project. Use `--quick` for a fast
-local status check that skips fetching full project detail.
+If a directory is linked, it shows `(linked)` next to the project. Use `--quick` for a fast local
+status check that skips fetching full project detail.
 
 ---
 
@@ -69,8 +69,8 @@ local status check that skips fetching full project detail.
 
 Compile a precise context pack for an agent. This is the lower-level command behind
 [`sibyl recall`](./recall.md): it builds a goal-scoped bundle of tasks, decisions, and graph
-neighbors. Use `recall` for everyday work and `context pack` when you need fine-grained control
-over the pack.
+neighbors. Use `recall` for everyday work and `context pack` when you need fine-grained control over
+the pack.
 
 ### Synopsis
 
@@ -86,19 +86,19 @@ sibyl context pack <goal> [options]
 
 ### Options
 
-| Option            | Short | Default  | Description                                       |
-| ----------------- | ----- | -------- | ------------------------------------------------- |
+| Option            | Short | Default  | Description                                                                        |
+| ----------------- | ----- | -------- | ---------------------------------------------------------------------------------- |
 | `--intent`        | `-i`  | `build`  | Agent intent: build, plan, ideate, research, review, debug, decide, learn, general |
-| `--layer`         |       | `recall` | Context depth: `wake`, `recall`, `deep_search`    |
-| `--domain`        | `-d`  | (none)   | Domain/category to bias retrieval                 |
-| `--project`       | `-p`  | (auto)   | Project ID to scope context                       |
-| `--agent`         |       | (none)   | Agent diary identity to include                   |
-| `--all`           | `-a`  | false    | Use all accessible projects                       |
-| `--limit`         | `-l`  | 24       | Maximum total context items (1-50)                |
-| `--related`       |       | on       | Include one-hop related graph context (`--no-related`) |
-| `--related-limit` |       | 3        | Related items per context item (0-5)              |
-| `--markdown`      | `-m`  | false    | Output compact Markdown for agent injection       |
-| `--json`          | `-j`  | false    | JSON output                                       |
+| `--layer`         |       | `recall` | Context depth: `wake`, `recall`, `deep_search`                                     |
+| `--domain`        | `-d`  | (none)   | Domain/category to bias retrieval                                                  |
+| `--project`       | `-p`  | (auto)   | Project ID to scope context                                                        |
+| `--agent`         |       | (none)   | Agent diary identity to include                                                    |
+| `--all`           | `-a`  | false    | Use all accessible projects                                                        |
+| `--limit`         | `-l`  | 24       | Maximum total context items (1-50)                                                 |
+| `--related`       |       | on       | Include one-hop related graph context (`--no-related`)                             |
+| `--related-limit` |       | 3        | Related items per context item (0-5)                                               |
+| `--markdown`      | `-m`  | false    | Output compact Markdown for agent injection                                        |
+| `--json`          | `-j`  | false    | JSON output                                                                        |
 
 ### Examples
 

--- a/docs/cli/crawl.md
+++ b/docs/cli/crawl.md
@@ -1,24 +1,24 @@
 # crawl
 
-Web crawling and documentation ingestion. `crawl` registers documentation sources, ingests them
-into the content store, and links the crawled chunks into the knowledge graph so they surface in
+Web crawling and documentation ingestion. `crawl` registers documentation sources, ingests them into
+the content store, and links the crawled chunks into the knowledge graph so they surface in
 [`sibyl search`](./search.md).
 
 ## Commands
 
-| Command                                          | Description                                |
-| ------------------------------------------------- | ------------------------------------------ |
-| [`sibyl crawl list`](#crawl-list)                 | List crawl sources                         |
-| [`sibyl crawl add`](#crawl-add)                   | Add a new documentation source             |
-| [`sibyl crawl ingest`](#crawl-ingest)             | Start crawling a source                    |
-| [`sibyl crawl status`](#crawl-status)             | Get crawl status for a source              |
-| [`sibyl crawl show`](#crawl-show)                 | Show crawl source details                  |
-| [`sibyl crawl stats`](#crawl-stats)               | Show crawling statistics                   |
-| [`sibyl crawl health`](#crawl-health)             | Check crawl system health                  |
-| [`sibyl crawl delete`](#crawl-delete)             | Delete a source and all its documents      |
-| [`sibyl crawl link-status`](#crawl-link-status)   | Show pending graph linking work per source |
-| [`sibyl crawl link-graph`](#crawl-link-graph)     | Link crawled chunks into the graph         |
-| [`sibyl crawl documents`](#crawl-documents)       | Browse crawled documents                   |
+| Command                                         | Description                                |
+| ----------------------------------------------- | ------------------------------------------ |
+| [`sibyl crawl list`](#crawl-list)               | List crawl sources                         |
+| [`sibyl crawl add`](#crawl-add)                 | Add a new documentation source             |
+| [`sibyl crawl ingest`](#crawl-ingest)           | Start crawling a source                    |
+| [`sibyl crawl status`](#crawl-status)           | Get crawl status for a source              |
+| [`sibyl crawl show`](#crawl-show)               | Show crawl source details                  |
+| [`sibyl crawl stats`](#crawl-stats)             | Show crawling statistics                   |
+| [`sibyl crawl health`](#crawl-health)           | Check crawl system health                  |
+| [`sibyl crawl delete`](#crawl-delete)           | Delete a source and all its documents      |
+| [`sibyl crawl link-status`](#crawl-link-status) | Show pending graph linking work per source |
+| [`sibyl crawl link-graph`](#crawl-link-graph)   | Link crawled chunks into the graph         |
+| [`sibyl crawl documents`](#crawl-documents)     | Browse crawled documents                   |
 
 ## Workflow
 
@@ -41,11 +41,11 @@ List crawl sources.
 sibyl crawl list [options]
 ```
 
-| Option     | Short | Default | Description                  |
-| ---------- | ----- | ------- | ---------------------------- |
-| `--status` | `-s`  | (all)   | Filter by status             |
-| `--limit`  | `-n`  | 20      | Max results                  |
-| `--json`   | `-j`  | false   | JSON output                  |
+| Option     | Short | Default | Description      |
+| ---------- | ----- | ------- | ---------------- |
+| `--status` | `-s`  | (all)   | Filter by status |
+| `--limit`  | `-n`  | 20      | Max results      |
+| `--json`   | `-j`  | false   | JSON output      |
 
 ---
 
@@ -57,17 +57,17 @@ Add a new documentation source.
 sibyl crawl add <url> [options]
 ```
 
-| Argument | Required | Description                  |
-| -------- | -------- | ---------------------------- |
-| `url`    | Yes      | Documentation URL to add     |
+| Argument | Required | Description              |
+| -------- | -------- | ------------------------ |
+| `url`    | Yes      | Documentation URL to add |
 
-| Option                  | Short | Default   | Description                            |
-| ----------------------- | ----- | --------- | -------------------------------------- |
-| `--name`                | `-n`  | (derived) | Source name                            |
-| `--type`                | `-T`  | `website` | Source type: `website`, `github`, `api_docs` |
-| `--depth`               | `-d`  | 2         | Crawl depth                            |
-| `--pattern` / `--include` | `-p` | (none)   | URL patterns to include                |
-| `--json`                | `-j`  | false     | JSON output                            |
+| Option                    | Short | Default   | Description                                  |
+| ------------------------- | ----- | --------- | -------------------------------------------- |
+| `--name`                  | `-n`  | (derived) | Source name                                  |
+| `--type`                  | `-T`  | `website` | Source type: `website`, `github`, `api_docs` |
+| `--depth`                 | `-d`  | 2         | Crawl depth                                  |
+| `--pattern` / `--include` | `-p`  | (none)    | URL patterns to include                      |
+| `--json`                  | `-j`  | false     | JSON output                                  |
 
 ### Example
 
@@ -87,16 +87,16 @@ Start crawling a documentation source.
 sibyl crawl ingest <source_id> [options]
 ```
 
-| Argument    | Required | Description           |
-| ----------- | -------- | --------------------- |
-| `source_id` | Yes      | Source ID to crawl    |
+| Argument    | Required | Description        |
+| ----------- | -------- | ------------------ |
+| `source_id` | Yes      | Source ID to crawl |
 
-| Option        | Short | Default | Description                  |
-| ------------- | ----- | ------- | ---------------------------- |
-| `--max-pages` | `-p`  | 50      | Maximum pages to crawl       |
-| `--depth`     | `-d`  | 3       | Maximum link depth           |
-| `--no-embed`  |       | false   | Skip embedding generation    |
-| `--json`      | `-j`  | false   | JSON output                  |
+| Option        | Short | Default | Description               |
+| ------------- | ----- | ------- | ------------------------- |
+| `--max-pages` | `-p`  | 50      | Maximum pages to crawl    |
+| `--depth`     | `-d`  | 3       | Maximum link depth        |
+| `--no-embed`  |       | false   | Skip embedding generation |
+| `--json`      | `-j`  | false   | JSON output               |
 
 ### Examples
 
@@ -171,8 +171,8 @@ sibyl crawl delete <source_id> [options]
 
 ## crawl link-status
 
-Show pending graph linking work per source. Use this to see how many crawled chunks still need to
-be linked into the graph.
+Show pending graph linking work per source. Use this to see how many crawled chunks still need to be
+linked into the graph.
 
 ```bash
 sibyl crawl link-status [--json]
@@ -188,16 +188,16 @@ Link crawled chunks into the graph. Pass a source ID, or `all` to process every 
 sibyl crawl link-graph [source_id] [options]
 ```
 
-| Argument    | Required | Description                          |
-| ----------- | -------- | ------------------------------------ |
-| `source_id` | No       | Source ID, or `all` for all sources  |
+| Argument    | Required | Description                         |
+| ----------- | -------- | ----------------------------------- |
+| `source_id` | No       | Source ID, or `all` for all sources |
 
-| Option         | Short | Default | Description                                  |
-| -------------- | ----- | ------- | -------------------------------------------- |
-| `--batch`      | `-b`  | 50      | Batch size                                   |
-| `--dry-run`    | `-n`  | false   | Show what would be processed                 |
+| Option         | Short | Default | Description                                    |
+| -------------- | ----- | ------- | ---------------------------------------------- |
+| `--batch`      | `-b`  | 50      | Batch size                                     |
+| `--dry-run`    | `-n`  | false   | Show what would be processed                   |
 | `--create-new` |       | false   | Create graph entities for unlinked extractions |
-| `--json`       | `-j`  | false   | JSON output                                  |
+| `--json`       | `-j`  | false   | JSON output                                    |
 
 ### Examples
 
@@ -223,11 +223,11 @@ List crawled documents.
 sibyl crawl documents list [options]
 ```
 
-| Option     | Short | Default | Description           |
-| ---------- | ----- | ------- | --------------------- |
-| `--source` | `-s`  | (all)   | Filter by source ID   |
-| `--limit`  | `-n`  | 20      | Max results           |
-| `--json`   | `-j`  | false   | JSON output           |
+| Option     | Short | Default | Description         |
+| ---------- | ----- | ------- | ------------------- |
+| `--source` | `-s`  | (all)   | Filter by source ID |
+| `--limit`  | `-n`  | 20      | Max results         |
+| `--json`   | `-j`  | false   | JSON output         |
 
 ### crawl documents show
 
@@ -237,14 +237,14 @@ Show full document content. Use the `document_id` from search result metadata.
 sibyl crawl documents show <document_id> [options]
 ```
 
-| Argument      | Required | Description                            |
-| ------------- | -------- | -------------------------------------- |
+| Argument      | Required | Description                             |
+| ------------- | -------- | --------------------------------------- |
 | `document_id` | Yes      | Document ID from search result metadata |
 
-| Option   | Short | Description                |
-| -------- | ----- | -------------------------- |
-| `--raw`  | `-r`  | Show raw markdown content  |
-| `--json` | `-j`  | JSON output                |
+| Option   | Short | Description               |
+| -------- | ----- | ------------------------- |
+| `--raw`  | `-r`  | Show raw markdown content |
+| `--json` | `-j`  | JSON output               |
 
 ### Example
 

--- a/docs/cli/explore.md
+++ b/docs/cli/explore.md
@@ -135,8 +135,8 @@ sibyl explore dependencies [entity_id] [options]
 
 ### Arguments
 
-| Argument    | Required | Description                       |
-| ----------- | -------- | --------------------------------- |
+| Argument    | Required | Description                             |
+| ----------- | -------- | --------------------------------------- |
 | `entity_id` | No       | Task or Project ID (or use `--project`) |
 
 ### Options

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -46,73 +46,73 @@ The CLI has roughly three dozen command groups. They fall into five families.
 
 Capture knowledge and recall it back into agent context.
 
-| Command                           | Description                                          |
-| ---------------------------------- | ---------------------------------------------------- |
-| [`sibyl recall`](./recall.md)     | Recall a compact working context pack for an agent   |
-| [`sibyl remember`](./remember.md) | Remember a decision, plan, idea, claim, or learning  |
-| [`sibyl reflect`](./reflect.md)   | Reflect raw notes into reviewable memory candidates  |
-| [`sibyl capture`](./capture.md)   | Quick capture with an auto-derived title             |
-| [`sibyl note`](./remember.md)     | Add a task note or capture a free note memory        |
-| [`sibyl add`](./add.md)           | Add knowledge with explicit title and content        |
-| [`sibyl search`](./search.md)     | Semantic search across graph and crawled docs        |
-| [`sibyl entity`](./entity.md)     | Generic entity CRUD operations                       |
-| [`sibyl explore`](./explore.md)   | Graph traversal and exploration                      |
-| [`sibyl archive`](./archive.md)   | Browse raw quick captures                            |
-| [`sibyl session`](./session.md)   | Package a wake-up context bundle                     |
-| [`sibyl context`](./context.md)   | Compile context packs and manage CLI contexts        |
+| Command                           | Description                                         |
+| --------------------------------- | --------------------------------------------------- |
+| [`sibyl recall`](./recall.md)     | Recall a compact working context pack for an agent  |
+| [`sibyl remember`](./remember.md) | Remember a decision, plan, idea, claim, or learning |
+| [`sibyl reflect`](./reflect.md)   | Reflect raw notes into reviewable memory candidates |
+| [`sibyl capture`](./capture.md)   | Quick capture with an auto-derived title            |
+| [`sibyl note`](./remember.md)     | Add a task note or capture a free note memory       |
+| [`sibyl add`](./add.md)           | Add knowledge with explicit title and content       |
+| [`sibyl search`](./search.md)     | Semantic search across graph and crawled docs       |
+| [`sibyl entity`](./entity.md)     | Generic entity CRUD operations                      |
+| [`sibyl explore`](./explore.md)   | Graph traversal and exploration                     |
+| [`sibyl archive`](./archive.md)   | Browse raw quick captures                           |
+| [`sibyl session`](./session.md)   | Package a wake-up context bundle                    |
+| [`sibyl context`](./context.md)   | Compile context packs and manage CLI contexts       |
 
 ### Work tracking
 
 Plan and run tasks, epics, and projects.
 
-| Command                           | Description                          |
-| ---------------------------------- | ------------------------------------ |
-| [`sibyl task`](./task-list.md)    | Task lifecycle management            |
-| [`sibyl epic`](./epic.md)         | Epic (feature group) management      |
-| [`sibyl project`](./project.md)   | Project management                   |
+| Command                         | Description                     |
+| ------------------------------- | ------------------------------- |
+| [`sibyl task`](./task-list.md)  | Task lifecycle management       |
+| [`sibyl epic`](./epic.md)       | Epic (feature group) management |
+| [`sibyl project`](./project.md) | Project management              |
 
 ### Sources and synthesis
 
 Ingest external docs and produce source-grounded artifacts.
 
-| Command                              | Description                                  |
-| ------------------------------------- | -------------------------------------------- |
-| [`sibyl crawl`](./crawl.md)          | Web crawling and documentation ingestion     |
-| [`sibyl synthesis`](./synthesis.md)  | Source-grounded synthesis (plan/draft/verify) |
+| Command                             | Description                                   |
+| ----------------------------------- | --------------------------------------------- |
+| [`sibyl crawl`](./crawl.md)         | Web crawling and documentation ingestion      |
+| [`sibyl synthesis`](./synthesis.md) | Source-grounded synthesis (plan/draft/verify) |
 
 ### Memory governance
 
 Review, promote, share, and audit memory.
 
-| Command                                       | Description                                  |
-| ---------------------------------------------- | -------------------------------------------- |
-| [`sibyl memory-audit`](./memory.md)           | Inspect memory audit receipts                |
-| [`sibyl memory-inspect`](./memory.md)         | Inspect a memory source and its audit trail  |
-| [`sibyl memory-promote`](./memory.md)         | Preview or auto-review candidate promotion   |
-| [`sibyl memory-share`](./memory.md)           | Preview memory sharing across scopes         |
-| [`sibyl memory-space`](./memory.md)           | Memory-space inspection and preview          |
-| [`sibyl memory-review`](./memory.md)          | Reflection review queue and dream-cycle      |
-| [`sibyl pending-writes`](./pending-writes.md) | Inspect and replay locally buffered writes   |
+| Command                                       | Description                                 |
+| --------------------------------------------- | ------------------------------------------- |
+| [`sibyl memory-audit`](./memory.md)           | Inspect memory audit receipts               |
+| [`sibyl memory-inspect`](./memory.md)         | Inspect a memory source and its audit trail |
+| [`sibyl memory-promote`](./memory.md)         | Preview or auto-review candidate promotion  |
+| [`sibyl memory-share`](./memory.md)           | Preview memory sharing across scopes        |
+| [`sibyl memory-space`](./memory.md)           | Memory-space inspection and preview         |
+| [`sibyl memory-review`](./memory.md)          | Reflection review queue and dream-cycle     |
+| [`sibyl pending-writes`](./pending-writes.md) | Inspect and replay locally buffered writes  |
 
 ### System
 
 Auth, organizations, configuration, and operations.
 
-| Command                       | Description                                       |
-| ------------------------------ | ------------------------------------------------- |
-| [`sibyl auth`](./auth.md)      | Authentication, tokens, and API keys              |
-| [`sibyl org`](./org.md)        | Organizations and member management               |
-| `sibyl context`                | Server/org/project context bundles (see above)    |
-| `sibyl config`                 | Manage CLI configuration                          |
-| `sibyl health`                 | Check Sibyl server health                         |
-| `sibyl stats`                  | Show knowledge graph statistics                   |
-| `sibyl version`                | Show version information                          |
-| `sibyl logs`                   | View server logs (requires OWNER role)            |
-| `sibyl debug`                  | Debug tools for development (requires OWNER role) |
-| `sibyl local`                  | Manage a local Docker-based Sibyl instance        |
-| `sibyl dev`                    | Devcontainer shell and lifecycle commands         |
-| `sibyl update`                 | Update Sibyl components                           |
-| `sibyl skill`                  | Print or install the canonical Sibyl skill        |
+| Command                   | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| [`sibyl auth`](./auth.md) | Authentication, tokens, and API keys              |
+| [`sibyl org`](./org.md)   | Organizations and member management               |
+| `sibyl context`           | Server/org/project context bundles (see above)    |
+| `sibyl config`            | Manage CLI configuration                          |
+| `sibyl health`            | Check Sibyl server health                         |
+| `sibyl stats`             | Show knowledge graph statistics                   |
+| `sibyl version`           | Show version information                          |
+| `sibyl logs`              | View server logs (requires OWNER role)            |
+| `sibyl debug`             | Debug tools for development (requires OWNER role) |
+| `sibyl local`             | Manage a local Docker-based Sibyl instance        |
+| `sibyl dev`               | Devcontainer shell and lifecycle commands         |
+| `sibyl update`            | Update Sibyl components                           |
+| `sibyl skill`             | Print or install the canonical Sibyl skill        |
 
 ## Global Options
 

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -4,14 +4,14 @@ Sibyl's memory loop is governed. Raw memories and reflection candidates are not 
 into the shared graph; they move through review, promotion, and audit. This page covers the
 governance command family:
 
-| Command                                          | Description                                      |
-| ------------------------------------------------- | ------------------------------------------------ |
-| [`sibyl memory-audit`](#memory-audit)             | Inspect memory audit receipts                    |
-| [`sibyl memory-inspect`](#memory-inspect)         | Inspect a memory source and its audit trail      |
-| [`sibyl memory-promote`](#memory-promote)         | Preview or auto-review candidate promotion       |
-| [`sibyl memory-share`](#memory-share)             | Preview memory sharing across scopes             |
-| [`sibyl memory-space`](#memory-space)             | Memory-space inspection and preview              |
-| [`sibyl memory-review`](#memory-review)           | Reflection review queue automation               |
+| Command                                   | Description                                 |
+| ----------------------------------------- | ------------------------------------------- |
+| [`sibyl memory-audit`](#memory-audit)     | Inspect memory audit receipts               |
+| [`sibyl memory-inspect`](#memory-inspect) | Inspect a memory source and its audit trail |
+| [`sibyl memory-promote`](#memory-promote) | Preview or auto-review candidate promotion  |
+| [`sibyl memory-share`](#memory-share)     | Preview memory sharing across scopes        |
+| [`sibyl memory-space`](#memory-space)     | Memory-space inspection and preview         |
+| [`sibyl memory-review`](#memory-review)   | Reflection review queue automation          |
 
 For the dream-cycle automation that drives much of this, see [`memory-review`](#memory-review).
 
@@ -19,12 +19,12 @@ For the dream-cycle automation that drives much of this, see [`memory-review`](#
 
 Raw memories and artifacts carry a scope that controls who can recall them:
 
-| Scope     | Visibility                                |
-| --------- | ----------------------------------------- |
-| `private` | The capturing principal only (default)    |
-| `project` | Members working in a project              |
-| `team`    | A named team                              |
-| `shared`  | Org-wide shared memory                    |
+| Scope     | Visibility                             |
+| --------- | -------------------------------------- |
+| `private` | The capturing principal only (default) |
+| `project` | Members working in a project           |
+| `team`    | A named team                           |
+| `shared`  | Org-wide shared memory                 |
 
 `--scope-key` pins a scope to a specific project, team, or shared bucket.
 
@@ -43,17 +43,17 @@ sibyl memory-audit [options]
 
 ### Options
 
-| Option         | Short | Default | Description                       |
-| -------------- | ----- | ------- | --------------------------------- |
-| `--action`     | `-a`  | (all)   | Filter by audit action            |
-| `--actor`      |       | (all)   | Filter by actor user ID           |
-| `--source-id`  |       | (all)   | Filter by source ID               |
-| `--derived-id` |       | (all)   | Filter by derived ID              |
-| `--scope`      |       | (all)   | Filter by memory scope            |
-| `--project`    | `-p`  | (all)   | Filter by project ID              |
-| `--policy`     |       | (all)   | Filter: `allowed` or `denied`     |
-| `--limit`      | `-l`  | 50      | Maximum events (1-200)            |
-| `--json`       | `-j`  | false   | Output as JSON                    |
+| Option         | Short | Default | Description                   |
+| -------------- | ----- | ------- | ----------------------------- |
+| `--action`     | `-a`  | (all)   | Filter by audit action        |
+| `--actor`      |       | (all)   | Filter by actor user ID       |
+| `--source-id`  |       | (all)   | Filter by source ID           |
+| `--derived-id` |       | (all)   | Filter by derived ID          |
+| `--scope`      |       | (all)   | Filter by memory scope        |
+| `--project`    | `-p`  | (all)   | Filter by project ID          |
+| `--policy`     |       | (all)   | Filter: `allowed` or `denied` |
+| `--limit`      | `-l`  | 50      | Maximum events (1-200)        |
+| `--json`       | `-j`  | false   | Output as JSON                |
 
 ### Examples
 
@@ -83,14 +83,14 @@ sibyl memory-inspect <source_id> [options]
 
 ### Arguments
 
-| Argument    | Required | Description           |
-| ----------- | -------- | --------------------- |
-| `source_id` | Yes      | Raw memory source ID  |
+| Argument    | Required | Description          |
+| ----------- | -------- | -------------------- |
+| `source_id` | Yes      | Raw memory source ID |
 
 ### Options
 
-| Option   | Short | Description |
-| -------- | ----- | ----------- |
+| Option   | Short | Description    |
+| -------- | ----- | -------------- |
 | `--json` | `-j`  | Output as JSON |
 
 ### Example
@@ -115,26 +115,26 @@ sibyl memory-promote <candidate_id> [options]
 
 ### Arguments
 
-| Argument       | Required | Description                  |
-| -------------- | -------- | ---------------------------- |
-| `candidate_id` | Yes      | Raw reflection candidate ID  |
+| Argument       | Required | Description                 |
+| -------------- | -------- | --------------------------- |
+| `candidate_id` | Yes      | Raw reflection candidate ID |
 
 ### Options
 
-| Option                    | Short | Description                                          |
-| ------------------------- | ----- | ---------------------------------------------------- |
-| `--preview`               |       | Preview without promoting                            |
-| `--auto`                  |       | Auto-review and promote when safe                    |
-| `--dry-run`               |       | Evaluate auto-review without applying                |
-| `--confidence-threshold`  |       | Override the auto-review confidence threshold (0.0-1.0) |
-| `--scope`                 |       | Target memory scope                                  |
-| `--scope-key`             |       | Target scope key                                     |
-| `--domain`                | `-d`  | Domain/category                                      |
-| `--project`               | `-p`  | Project ID                                           |
-| `--all-projects`          |       | Do not auto-scope to the linked project              |
-| `--related-to`            |       | Comma-separated graph IDs to relate after promotion  |
-| `--task`                  |       | Comma-separated task IDs to relate after promotion   |
-| `--json`                  | `-j`  | Output as JSON                                       |
+| Option                   | Short | Description                                             |
+| ------------------------ | ----- | ------------------------------------------------------- |
+| `--preview`              |       | Preview without promoting                               |
+| `--auto`                 |       | Auto-review and promote when safe                       |
+| `--dry-run`              |       | Evaluate auto-review without applying                   |
+| `--confidence-threshold` |       | Override the auto-review confidence threshold (0.0-1.0) |
+| `--scope`                |       | Target memory scope                                     |
+| `--scope-key`            |       | Target scope key                                        |
+| `--domain`               | `-d`  | Domain/category                                         |
+| `--project`              | `-p`  | Project ID                                              |
+| `--all-projects`         |       | Do not auto-scope to the linked project                 |
+| `--related-to`           |       | Comma-separated graph IDs to relate after promotion     |
+| `--task`                 |       | Comma-separated task IDs to relate after promotion      |
+| `--json`                 | `-j`  | Output as JSON                                          |
 
 ### Promotion Modes
 
@@ -172,21 +172,21 @@ sibyl memory-share <source_ids>... [options]
 
 ### Arguments
 
-| Argument     | Required | Description                    |
-| ------------ | -------- | ------------------------------ |
+| Argument     | Required | Description                     |
+| ------------ | -------- | ------------------------------- |
 | `source_ids` | Yes      | Raw memory IDs to share-preview |
 
 ### Options
 
-| Option            | Short | Description                       |
-| ----------------- | ----- | --------------------------------- |
-| `--preview`       |       | Preview without sharing           |
-| `--target-scope`  |       | Intended target scope             |
-| `--target-key`    |       | Target scope key                  |
-| `--recipient-org` |       | Future recipient organization ID  |
-| `--project`       | `-p`  | Project ID                        |
+| Option            | Short | Description                             |
+| ----------------- | ----- | --------------------------------------- |
+| `--preview`       |       | Preview without sharing                 |
+| `--target-scope`  |       | Intended target scope                   |
+| `--target-key`    |       | Target scope key                        |
+| `--recipient-org` |       | Future recipient organization ID        |
+| `--project`       | `-p`  | Project ID                              |
 | `--all-projects`  |       | Do not auto-scope to the linked project |
-| `--json`          | `-j`  | Output as JSON                    |
+| `--json`          | `-j`  | Output as JSON                          |
 
 ### Example
 
@@ -204,8 +204,8 @@ boundary an agent or API key can be scoped to.
 
 ### memory-space preview-agent
 
-Preview what an agent could recall from selected memory spaces. Use this to confirm an agent's
-reach before granting it.
+Preview what an agent could recall from selected memory spaces. Use this to confirm an agent's reach
+before granting it.
 
 #### Synopsis
 
@@ -215,18 +215,18 @@ sibyl memory-space preview-agent <agent_id> --space <space_id> [options]
 
 #### Arguments
 
-| Argument   | Required | Description          |
-| ---------- | -------- | -------------------- |
-| `agent_id` | Yes      | Agent principal ID   |
+| Argument   | Required | Description        |
+| ---------- | -------- | ------------------ |
+| `agent_id` | Yes      | Agent principal ID |
 
 #### Options
 
-| Option         | Short | Required | Description                                |
-| -------------- | ----- | -------- | ------------------------------------------ |
-| `--space`      |       | Yes      | Primary memory space ID                    |
+| Option         | Short | Required | Description                                 |
+| -------------- | ----- | -------- | ------------------------------------------- |
+| `--space`      |       | Yes      | Primary memory space ID                     |
 | `--also-space` |       | No       | Comma-separated additional memory space IDs |
-| `--limit`      | `-l`  | No       | Maximum sources (1-200, default 50)        |
-| `--json`       | `-j`  | No       | Output as JSON                             |
+| `--limit`      | `-l`  | No       | Maximum sources (1-200, default 50)         |
+| `--json`       | `-j`  | No       | Output as JSON                              |
 
 #### Example
 
@@ -245,11 +245,11 @@ Memory review queue automation commands. This is the reflection dream-cycle: the
 drains pending candidates, runs the org-scoped nightly maintenance job, and records decision
 receipts.
 
-| Subcommand                              | Description                                              |
-| --------------------------------------- | -------------------------------------------------------- |
+| Subcommand                                      | Description                                                  |
+| ----------------------------------------------- | ------------------------------------------------------------ |
 | [`memory-review drain`](#memory-review-drain)   | Drain pending reflection candidates through automatic review |
-| [`memory-review dream`](#memory-review-dream)   | Queue the automatic reflection dream-cycle job           |
-| [`memory-review status`](#memory-review-status) | Show dream-cycle runs and automatic decision receipts    |
+| [`memory-review dream`](#memory-review-dream)   | Queue the automatic reflection dream-cycle job               |
+| [`memory-review status`](#memory-review-status) | Show dream-cycle runs and automatic decision receipts        |
 
 ### memory-review drain
 
@@ -264,21 +264,21 @@ sibyl memory-review drain [options]
 
 #### Options
 
-| Option                   | Short | Description                                              |
-| ------------------------ | ----- | -------------------------------------------------------- |
-| `--apply`                |       | Apply safe promotions instead of only previewing         |
-| `--limit`                |       | Candidates to process (1-200, default 50)                |
-| `--confidence-threshold` |       | Override the auto-review confidence threshold (0.0-1.0)  |
-| `--scope`                |       | Target memory scope                                      |
-| `--scope-key`            |       | Target scope key                                         |
-| `--domain`               | `-d`  | Domain/category                                          |
-| `--project`              | `-p`  | Project ID                                               |
-| `--all-projects`         |       | Do not auto-scope to the linked project                  |
-| `--related-to`           |       | Comma-separated graph IDs to relate after promotion      |
-| `--task`                 |       | Comma-separated task IDs to relate after promotion       |
+| Option                   | Short | Description                                               |
+| ------------------------ | ----- | --------------------------------------------------------- |
+| `--apply`                |       | Apply safe promotions instead of only previewing          |
+| `--limit`                |       | Candidates to process (1-200, default 50)                 |
+| `--confidence-threshold` |       | Override the auto-review confidence threshold (0.0-1.0)   |
+| `--scope`                |       | Target memory scope                                       |
+| `--scope-key`            |       | Target scope key                                          |
+| `--domain`               | `-d`  | Domain/category                                           |
+| `--project`              | `-p`  | Project ID                                                |
+| `--all-projects`         |       | Do not auto-scope to the linked project                   |
+| `--related-to`           |       | Comma-separated graph IDs to relate after promotion       |
+| `--task`                 |       | Comma-separated task IDs to relate after promotion        |
 | `--archive-exceptions`   |       | Archive terminal duplicate/stale exceptions when applying |
-| `--archive-reasons`      |       | Comma-separated exception reasons eligible for archive   |
-| `--json`                 | `-j`  | Output as JSON                                           |
+| `--archive-reasons`      |       | Comma-separated exception reasons eligible for archive    |
+| `--json`                 | `-j`  | Output as JSON                                            |
 
 #### Examples
 
@@ -304,13 +304,13 @@ sibyl memory-review dream [options]
 
 #### Options
 
-| Option                | Description                                              |
-| --------------------- | -------------------------------------------------------- |
-| `--apply`             | Apply safe automatic promotions instead of a dry run      |
-| `--source-limit`      | Raw sources to process (0-100, default 20)               |
-| `--candidate-limit`   | Pending reflection candidates (0-200, default 50)        |
+| Option                 | Description                                                                                            |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `--apply`              | Apply safe automatic promotions instead of a dry run                                                   |
+| `--source-limit`       | Raw sources to process (0-100, default 20)                                                             |
+| `--candidate-limit`    | Pending reflection candidates (0-200, default 50)                                                      |
 | `--archive-exceptions` | Archive terminal duplicate/stale exceptions when applying (`--keep-exceptions` to disable, default on) |
-| `--json` / `-j`       | Output as JSON                                           |
+| `--json` / `-j`        | Output as JSON                                                                                         |
 
 #### Examples
 
@@ -334,10 +334,10 @@ sibyl memory-review status [options]
 
 #### Options
 
-| Option    | Short | Default | Description               |
-| --------- | ----- | ------- | ------------------------- |
+| Option    | Short | Default | Description                |
+| --------- | ----- | ------- | -------------------------- |
 | `--limit` | `-l`  | 10      | Maximum runs/events (1-50) |
-| `--json`  | `-j`  | false   | Output as JSON            |
+| `--json`  | `-j`  | false   | Output as JSON             |
 
 #### Example
 

--- a/docs/cli/org.md
+++ b/docs/cli/org.md
@@ -6,18 +6,18 @@ members.
 
 ## Commands
 
-| Command                                   | Description                          |
-| ------------------------------------------ | ------------------------------------ |
-| [`sibyl org list`](#org-list)             | List organizations                   |
-| [`sibyl org create`](#org-create)         | Create an organization               |
-| [`sibyl org switch`](#org-switch)         | Switch the active organization       |
-| [`sibyl org members`](#org-members)       | Manage organization members          |
+| Command                             | Description                    |
+| ----------------------------------- | ------------------------------ |
+| [`sibyl org list`](#org-list)       | List organizations             |
+| [`sibyl org create`](#org-create)   | Create an organization         |
+| [`sibyl org switch`](#org-switch)   | Switch the active organization |
+| [`sibyl org members`](#org-members) | Manage organization members    |
 
 ## Org Isolation
 
-Every graph and memory operation is scoped to an organization. Switching orgs changes the
-namespace the CLI reads and writes. Membership roles (`owner`, `admin`, `member`, `viewer`) govern
-what a user can do inside an org.
+Every graph and memory operation is scoped to an organization. Switching orgs changes the namespace
+the CLI reads and writes. Membership roles (`owner`, `admin`, `member`, `viewer`) govern what a user
+can do inside an org.
 
 ---
 
@@ -43,11 +43,11 @@ sibyl org create --name <name> [options]
 
 ### Options
 
-| Option     | Short | Default | Description                                          |
-| ---------- | ----- | ------- | ---------------------------------------------------- |
-| `--name`   | `-n`  | (req.)  | Organization name (required)                         |
-| `--slug`   |       | (derived) | Optional URL slug                                  |
-| `--switch` |       | on      | Switch into the org after creating it (`--no-switch`) |
+| Option     | Short | Default   | Description                                           |
+| ---------- | ----- | --------- | ----------------------------------------------------- |
+| `--name`   | `-n`  | (req.)    | Organization name (required)                          |
+| `--slug`   |       | (derived) | Optional URL slug                                     |
+| `--switch` |       | on        | Switch into the org after creating it (`--no-switch`) |
 
 ### Example
 
@@ -85,12 +85,12 @@ sibyl org switch acme-eng
 
 Manage organization members.
 
-| Subcommand                            | Description                  |
-| ------------------------------------- | ---------------------------- |
-| `sibyl org members list`              | List all members of an org   |
-| `sibyl org members add`               | Add a member to an org       |
-| `sibyl org members remove`            | Remove a member from an org  |
-| `sibyl org members role`              | Update a member's role       |
+| Subcommand                 | Description                 |
+| -------------------------- | --------------------------- |
+| `sibyl org members list`   | List all members of an org  |
+| `sibyl org members add`    | Add a member to an org      |
+| `sibyl org members remove` | Remove a member from an org |
+| `sibyl org members role`   | Update a member's role      |
 
 Roles: `owner`, `admin`, `member`, `viewer`.
 
@@ -115,9 +115,9 @@ sibyl org members add <slug> <user_id> [options]
 | `slug`    | Yes      | Organization slug |
 | `user_id` | Yes      | User ID to add    |
 
-| Option   | Short | Default  | Description     |
-| -------- | ----- | -------- | --------------- |
-| `--role` | `-r`  | `member` | Role to assign  |
+| Option   | Short | Default  | Description    |
+| -------- | ----- | -------- | -------------- |
+| `--role` | `-r`  | `member` | Role to assign |
 
 ### org members remove
 
@@ -125,10 +125,10 @@ sibyl org members add <slug> <user_id> [options]
 sibyl org members remove <slug> <user_id> [options]
 ```
 
-| Argument  | Required | Description        |
-| --------- | -------- | ------------------ |
-| `slug`    | Yes      | Organization slug  |
-| `user_id` | Yes      | User ID to remove  |
+| Argument  | Required | Description       |
+| --------- | -------- | ----------------- |
+| `slug`    | Yes      | Organization slug |
+| `user_id` | Yes      | User ID to remove |
 
 | Option    | Short | Description       |
 | --------- | ----- | ----------------- |
@@ -140,10 +140,10 @@ sibyl org members remove <slug> <user_id> [options]
 sibyl org members role <slug> <user_id> <role>
 ```
 
-| Argument  | Required | Description                                |
-| --------- | -------- | ------------------------------------------ |
-| `slug`    | Yes      | Organization slug                          |
-| `user_id` | Yes      | User ID                                    |
+| Argument  | Required | Description                                    |
+| --------- | -------- | ---------------------------------------------- |
+| `slug`    | Yes      | Organization slug                              |
+| `user_id` | Yes      | User ID                                        |
 | `role`    | Yes      | New role: `owner`, `admin`, `member`, `viewer` |
 
 ### Examples

--- a/docs/cli/pending-writes.md
+++ b/docs/cli/pending-writes.md
@@ -6,11 +6,11 @@ lists, replays, and discards that buffer.
 
 ## Commands
 
-| Command                                          | Description                                          |
-| ------------------------------------------------- | ---------------------------------------------------- |
-| [`sibyl pending-writes list`](#pending-writes-list)       | List buffered writes (no sensitive payload bodies)   |
-| [`sibyl pending-writes flush`](#pending-writes-flush)     | Replay buffered writes                               |
-| [`sibyl pending-writes discard`](#pending-writes-discard) | Discard buffered writes without replaying            |
+| Command                                                   | Description                                        |
+| --------------------------------------------------------- | -------------------------------------------------- |
+| [`sibyl pending-writes list`](#pending-writes-list)       | List buffered writes (no sensitive payload bodies) |
+| [`sibyl pending-writes flush`](#pending-writes-flush)     | Replay buffered writes                             |
+| [`sibyl pending-writes discard`](#pending-writes-discard) | Discard buffered writes without replaying          |
 
 ## How Buffering Works
 
@@ -49,8 +49,8 @@ sibyl pending-writes list
 
 ## pending-writes flush
 
-Replay buffered writes. With no arguments, flushes the entire buffer. Pass IDs or prefixes to
-replay a subset.
+Replay buffered writes. With no arguments, flushes the entire buffer. Pass IDs or prefixes to replay
+a subset.
 
 ### Synopsis
 
@@ -60,9 +60,9 @@ sibyl pending-writes flush [write_ids]...
 
 ### Arguments
 
-| Argument    | Required | Description                                          |
-| ----------- | -------- | ---------------------------------------------------- |
-| `write_ids` | No       | Pending write IDs or prefixes. Omit to flush all     |
+| Argument    | Required | Description                                      |
+| ----------- | -------- | ------------------------------------------------ |
+| `write_ids` | No       | Pending write IDs or prefixes. Omit to flush all |
 
 ### Examples
 
@@ -89,9 +89,9 @@ sibyl pending-writes discard <write_ids>...
 
 ### Arguments
 
-| Argument    | Required | Description                          |
-| ----------- | -------- | ------------------------------------ |
-| `write_ids` | Yes      | Pending write IDs or prefixes        |
+| Argument    | Required | Description                   |
+| ----------- | -------- | ----------------------------- |
+| `write_ids` | Yes      | Pending write IDs or prefixes |
 
 ### Example
 

--- a/docs/cli/project.md
+++ b/docs/cli/project.md
@@ -294,8 +294,8 @@ The link is stored in `~/.sibyl/config.toml`:
 
 ## project relink
 
-Repair the project link for the current directory. Use this when a link points at a stale or
-renamed project and you want to retarget it without unlinking first.
+Repair the project link for the current directory. Use this when a link points at a stale or renamed
+project and you want to retarget it without unlinking first.
 
 ### Synopsis
 
@@ -305,10 +305,10 @@ sibyl project relink [options]
 
 ### Options
 
-| Option   | Short | Default | Description                                       |
-| -------- | ----- | ------- | ------------------------------------------------- |
-| `--id`   |       | (none)  | Project ID, UUID, name, or slug to relink to      |
-| `--path` | `-p`  | cwd     | Directory path                                    |
+| Option   | Short | Default | Description                                  |
+| -------- | ----- | ------- | -------------------------------------------- |
+| `--id`   |       | (none)  | Project ID, UUID, name, or slug to relink to |
+| `--path` | `-p`  | cwd     | Directory path                               |
 
 ### Example
 

--- a/docs/cli/recall.md
+++ b/docs/cli/recall.md
@@ -12,43 +12,43 @@ sibyl recall <goal> [options]
 
 ## Arguments
 
-| Argument | Required | Description              |
-| -------- | -------- | ------------------------ |
-| `goal`   | Yes      | Agent goal or user task  |
+| Argument | Required | Description             |
+| -------- | -------- | ----------------------- |
+| `goal`   | Yes      | Agent goal or user task |
 
 ## Options
 
-| Option          | Short | Default   | Description                                          |
-| --------------- | ----- | --------- | ---------------------------------------------------- |
-| `--intent`      | `-i`  | `build`   | Agent intent (see below)                             |
-| `--layer`       |       | `recall`  | Context depth: `wake`, `recall`, `deep_search`       |
-| `--domain`      | `-d`  | (none)    | Domain/category to bias retrieval                    |
-| `--project`     | `-p`  | (auto)    | Project ID                                           |
-| `--agent`       |       | (none)    | Agent diary identity to include                      |
-| `--all`         | `-a`  | false     | Use all accessible projects                          |
-| `--limit`       | `-l`  | 12        | Maximum context items (1-50)                         |
-| `--related`     |       | on        | Include one-hop related graph context (`--no-related`) |
-| `--json`        | `-j`  | false     | Output full JSON                                     |
-| `--raw`         |       | false     | Recall verbatim raw memories                         |
-| `--diary`       |       | false     | Recall a private agent diary                         |
-| `--scope`       |       | `private` | Raw memory scope                                     |
-| `--scope-key`   |       | (none)    | Project/team/shared scope key                        |
+| Option        | Short | Default   | Description                                            |
+| ------------- | ----- | --------- | ------------------------------------------------------ |
+| `--intent`    | `-i`  | `build`   | Agent intent (see below)                               |
+| `--layer`     |       | `recall`  | Context depth: `wake`, `recall`, `deep_search`         |
+| `--domain`    | `-d`  | (none)    | Domain/category to bias retrieval                      |
+| `--project`   | `-p`  | (auto)    | Project ID                                             |
+| `--agent`     |       | (none)    | Agent diary identity to include                        |
+| `--all`       | `-a`  | false     | Use all accessible projects                            |
+| `--limit`     | `-l`  | 12        | Maximum context items (1-50)                           |
+| `--related`   |       | on        | Include one-hop related graph context (`--no-related`) |
+| `--json`      | `-j`  | false     | Output full JSON                                       |
+| `--raw`       |       | false     | Recall verbatim raw memories                           |
+| `--diary`     |       | false     | Recall a private agent diary                           |
+| `--scope`     |       | `private` | Raw memory scope                                       |
+| `--scope-key` |       | (none)    | Project/team/shared scope key                          |
 
 ## Intent
 
 The `--intent` flag biases what kind of memory the pack favors:
 
-| Intent     | Bias                                       |
-| ---------- | ------------------------------------------ |
-| `build`    | Implementation patterns and active tasks   |
-| `plan`     | Decisions, plans, roadmap context          |
-| `ideate`   | Ideas, open questions, prior exploration   |
-| `research` | Claims, sources, documents                 |
-| `review`   | Recent changes, prior review notes         |
-| `debug`    | Error patterns, gotchas, related failures  |
-| `decide`   | Decisions, constraints, tradeoffs          |
-| `learn`    | Guides, procedures, durable knowledge      |
-| `general`  | Balanced mix                               |
+| Intent     | Bias                                      |
+| ---------- | ----------------------------------------- |
+| `build`    | Implementation patterns and active tasks  |
+| `plan`     | Decisions, plans, roadmap context         |
+| `ideate`   | Ideas, open questions, prior exploration  |
+| `research` | Claims, sources, documents                |
+| `review`   | Recent changes, prior review notes        |
+| `debug`    | Error patterns, gotchas, related failures |
+| `decide`   | Decisions, constraints, tradeoffs         |
+| `learn`    | Guides, procedures, durable knowledge     |
+| `general`  | Balanced mix                              |
 
 ## Layers
 

--- a/docs/cli/reflect.md
+++ b/docs/cli/reflect.md
@@ -1,8 +1,8 @@
 # reflect
 
 Reflect raw notes into memory candidates, optionally persisting them. `reflect` takes unstructured
-session notes and runs them through Sibyl's extractor to produce typed memory candidates
-(decisions, plans, ideas, claims, and learnings) you can review or commit.
+session notes and runs them through Sibyl's extractor to produce typed memory candidates (decisions,
+plans, ideas, claims, and learnings) you can review or commit.
 
 ## Synopsis
 
@@ -14,27 +14,27 @@ Content is read from stdin when the positional argument is omitted.
 
 ## Arguments
 
-| Argument  | Required | Description                              |
-| --------- | -------- | ---------------------------------------- |
+| Argument  | Required | Description                                  |
+| --------- | -------- | -------------------------------------------- |
 | `content` | No       | Raw notes to reflect. Reads stdin if omitted |
 
 ## Options
 
-| Option           | Short | Default              | Description                                            |
-| ---------------- | ----- | -------------------- | ------------------------------------------------------ |
-| `--title`        | `-t`  | `Session reflection` | Source/session title                                   |
-| `--intent`       | `-i`  | `general`            | Intent: build, plan, ideate, research, review, debug, decide, learn, general |
-| `--domain`       | `-d`  | (none)               | Domain/category                                        |
-| `--project`      | `-p`  | (auto)               | Project ID                                             |
-| `--all-projects` |       | false                | Do not auto-scope to the linked project                |
-| `--related-to`   |       | (none)               | Comma-separated entity IDs to link persisted candidates to |
-| `--task`         |       | (none)               | Comma-separated task IDs to link persisted output to   |
-| `--active-task`  |       | on                   | When persisting, auto-link to the active task (`--no-active-task`) |
-| `--persist`      |       | false                | Persist candidates into the graph                      |
+| Option           | Short | Default              | Description                                                                   |
+| ---------------- | ----- | -------------------- | ----------------------------------------------------------------------------- |
+| `--title`        | `-t`  | `Session reflection` | Source/session title                                                          |
+| `--intent`       | `-i`  | `general`            | Intent: build, plan, ideate, research, review, debug, decide, learn, general  |
+| `--domain`       | `-d`  | (none)               | Domain/category                                                               |
+| `--project`      | `-p`  | (auto)               | Project ID                                                                    |
+| `--all-projects` |       | false                | Do not auto-scope to the linked project                                       |
+| `--related-to`   |       | (none)               | Comma-separated entity IDs to link persisted candidates to                    |
+| `--task`         |       | (none)               | Comma-separated task IDs to link persisted output to                          |
+| `--active-task`  |       | on                   | When persisting, auto-link to the active task (`--no-active-task`)            |
+| `--persist`      |       | false                | Persist candidates into the graph                                             |
 | `--source`       |       | on                   | When persisting, also store the raw notes as a session memory (`--no-source`) |
-| `--review`       |       | false                | Store persisted output in the raw review queue instead of graph promotion |
-| `--limit`        | `-l`  | 12                   | Maximum candidates (1-25)                              |
-| `--json`         | `-j`  | false                | Output as JSON                                         |
+| `--review`       |       | false                | Store persisted output in the raw review queue instead of graph promotion     |
+| `--limit`        | `-l`  | 12                   | Maximum candidates (1-25)                                                     |
+| `--json`         | `-j`  | false                | Output as JSON                                                                |
 
 ## How It Works
 
@@ -70,8 +70,8 @@ sibyl reflect --persist --project proj_abc123 < notes.txt
 
 ### Route Candidates to the Review Queue
 
-Use `--review` when candidates should be governed before they land in the graph. They become
-pending reflection candidates that `memory-promote` or `memory-review` can act on.
+Use `--review` when candidates should be governed before they land in the graph. They become pending
+reflection candidates that `memory-promote` or `memory-review` can act on.
 
 ```bash
 sibyl reflect --persist --review --domain synthesis < notes.txt

--- a/docs/cli/remember.md
+++ b/docs/cli/remember.md
@@ -1,8 +1,8 @@
 # remember
 
-Remember a decision, plan, idea, claim, artifact, session, or learning. `remember` is the write
-side of the Sibyl memory loop. It captures a titled memory and routes it into the graph, or stores
-it verbatim as a raw memory or private agent diary entry.
+Remember a decision, plan, idea, claim, artifact, session, or learning. `remember` is the write side
+of the Sibyl memory loop. It captures a titled memory and routes it into the graph, or stores it
+verbatim as a raw memory or private agent diary entry.
 
 ## Synopsis
 
@@ -14,10 +14,10 @@ Content is read from stdin when the positional argument is omitted.
 
 ## Arguments
 
-| Argument  | Required | Description                                  |
-| --------- | -------- | -------------------------------------------- |
-| `title`   | Yes      | Title/name of the memory                     |
-| `content` | No       | Memory body. Reads stdin if omitted          |
+| Argument  | Required | Description                         |
+| --------- | -------- | ----------------------------------- |
+| `title`   | Yes      | Title/name of the memory            |
+| `content` | No       | Memory body. Reads stdin if omitted |
 
 ## Options
 
@@ -47,18 +47,18 @@ Content is read from stdin when the positional argument is omitted.
 
 ## Memory Kinds
 
-`remember` defaults to `episode`, but the memory loop adds first-class kinds for durable
-reasoning artifacts:
+`remember` defaults to `episode`, but the memory loop adds first-class kinds for durable reasoning
+artifacts:
 
-| Kind       | Use Case                                          |
-| ---------- | ------------------------------------------------- |
-| `decision` | A choice that was made, with rationale            |
-| `plan`     | An intended sequence of work                      |
-| `idea`     | An exploration or proposal not yet acted on       |
-| `claim`    | An assertion to be verified or cited later        |
-| `artifact` | A produced output (synthesis, doc, summary)       |
-| `session`  | A session-level memory or summary                 |
-| `episode`  | General learning or knowledge (default)           |
+| Kind       | Use Case                                    |
+| ---------- | ------------------------------------------- |
+| `decision` | A choice that was made, with rationale      |
+| `plan`     | An intended sequence of work                |
+| `idea`     | An exploration or proposal not yet acted on |
+| `claim`    | An assertion to be verified or cited later  |
+| `artifact` | A produced output (synthesis, doc, summary) |
+| `session`  | A session-level memory or summary           |
+| `episode`  | General learning or knowledge (default)     |
 
 See [`sibyl entity`](./entity.md) for the full entity type list.
 
@@ -88,8 +88,8 @@ sibyl remember "Incident 2026-05 postmortem" --content-file ./postmortem.md --ki
 
 ### Store a Raw Memory
 
-`--raw` skips graph extraction and stores the payload verbatim in the raw memory store. Raw
-memories are read back with `recall --raw` and reviewed before promotion.
+`--raw` skips graph extraction and stores the payload verbatim in the raw memory store. Raw memories
+are read back with `recall --raw` and reviewed before promotion.
 
 ```bash
 sibyl remember "Deploy runbook" --raw --scope project --scope-key proj_abc123

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -26,8 +26,8 @@ sibyl search <query> [options]
 | `--docs-only`  |       | false   | Search crawled docs only             |
 | `--json`       | `-j`  | false   | Output as JSON                       |
 
-Search spans both graph memory and crawled documents by default. Use `--graph-only` or
-`--docs-only` to restrict the surface.
+Search spans both graph memory and crawled documents by default. Use `--graph-only` or `--docs-only`
+to restrict the surface.
 
 ## Entity Types
 

--- a/docs/cli/synthesis.md
+++ b/docs/cli/synthesis.md
@@ -6,12 +6,12 @@ plan, draft, verify, and remember.
 
 ## Commands
 
-| Command                              | Description                                          |
-| ------------------------------------- | ---------------------------------------------------- |
+| Command                                           | Description                                           |
+| ------------------------------------------------- | ----------------------------------------------------- |
 | [`sibyl synthesis plan`](#synthesis-plan)         | Plan source-grounded synthesis from authorized memory |
-| [`sibyl synthesis draft`](#synthesis-draft)       | Draft a verified synthesis artifact                  |
-| [`sibyl synthesis verify`](#synthesis-verify)     | Verify citation, freshness, redaction, gap coverage  |
-| [`sibyl synthesis remember`](#synthesis-remember) | Draft, verify, and remember an artifact              |
+| [`sibyl synthesis draft`](#synthesis-draft)       | Draft a verified synthesis artifact                   |
+| [`sibyl synthesis verify`](#synthesis-verify)     | Verify citation, freshness, redaction, gap coverage   |
+| [`sibyl synthesis remember`](#synthesis-remember) | Draft, verify, and remember an artifact               |
 
 ## The Synthesis Pipeline
 
@@ -39,30 +39,30 @@ sibyl synthesis plan <goal> [options]
 
 ### Arguments
 
-| Argument | Required | Description     |
-| -------- | -------- | --------------- |
-| `goal`   | Yes      | Synthesis goal  |
+| Argument | Required | Description    |
+| -------- | -------- | -------------- |
+| `goal`   | Yes      | Synthesis goal |
 
 ### Options
 
-| Option            | Short | Default         | Description                                       |
-| ----------------- | ----- | --------------- | ------------------------------------------------- |
-| `--type`          |       | `documentation` | Output type                                       |
-| `--audience`      |       | (none)          | Intended audience                                 |
-| `--depth`         |       | `standard`      | `brief`, `standard`, or `deep`                    |
-| `--seed`          |       | (none)          | Search seed query                                 |
-| `--project`       | `-p`  | (auto)          | Project ID                                        |
-| `--all-projects`  |       | false           | Skip cwd project scope                            |
-| `--domain`        | `-d`  | (none)          | Domain/category                                   |
-| `--entity`        |       | (none)          | Comma-separated entity IDs                        |
-| `--decision`      |       | (none)          | Comma-separated decision IDs                      |
-| `--task`          |       | (none)          | Comma-separated task IDs                          |
-| `--artifact`      |       | (none)          | Comma-separated artifact IDs                      |
-| `--section`       |       | (none)          | Pipe-separated `Title::Prompt::sources` specs     |
-| `--constraint`    |       | (none)          | Comma-separated constraints                       |
-| `--max-sections`  |       | 6               | Maximum sections (1-12)                           |
+| Option            | Short | Default         | Description                                                |
+| ----------------- | ----- | --------------- | ---------------------------------------------------------- |
+| `--type`          |       | `documentation` | Output type                                                |
+| `--audience`      |       | (none)          | Intended audience                                          |
+| `--depth`         |       | `standard`      | `brief`, `standard`, or `deep`                             |
+| `--seed`          |       | (none)          | Search seed query                                          |
+| `--project`       | `-p`  | (auto)          | Project ID                                                 |
+| `--all-projects`  |       | false           | Skip cwd project scope                                     |
+| `--domain`        | `-d`  | (none)          | Domain/category                                            |
+| `--entity`        |       | (none)          | Comma-separated entity IDs                                 |
+| `--decision`      |       | (none)          | Comma-separated decision IDs                               |
+| `--task`          |       | (none)          | Comma-separated task IDs                                   |
+| `--artifact`      |       | (none)          | Comma-separated artifact IDs                               |
+| `--section`       |       | (none)          | Pipe-separated `Title::Prompt::sources` specs              |
+| `--constraint`    |       | (none)          | Comma-separated constraints                                |
+| `--max-sections`  |       | 6               | Maximum sections (1-12)                                    |
 | `--neighborhoods` |       | on              | Include one-hop graph neighborhoods (`--no-neighborhoods`) |
-| `--json`          | `-j`  | false           | Output full JSON                                  |
+| `--json`          | `-j`  | false           | Output full JSON                                           |
 
 ### Examples
 
@@ -96,8 +96,8 @@ sibyl synthesis draft <goal> [options]
 
 `draft` accepts every [`synthesis plan`](#synthesis-plan) option plus:
 
-| Option     | Default    | Description         |
-| ---------- | ---------- | ------------------- |
+| Option     | Default    | Description          |
+| ---------- | ---------- | -------------------- |
 | `--format` | `markdown` | `markdown` or `json` |
 
 ### Examples
@@ -129,12 +129,12 @@ sibyl synthesis verify <goal> [options]
 
 ### Verification Checks
 
-| Check      | What it confirms                                          |
-| ---------- | --------------------------------------------------------- |
-| Citation   | Every claim is backed by a cited source                   |
-| Freshness  | Cited sources are recent enough for the goal              |
-| Redaction  | No hidden-context or out-of-scope memory leaked in        |
-| Gap        | Planned sections are actually covered by the draft        |
+| Check     | What it confirms                                   |
+| --------- | -------------------------------------------------- |
+| Citation  | Every claim is backed by a cited source            |
+| Freshness | Cited sources are recent enough for the goal       |
+| Redaction | No hidden-context or out-of-scope memory leaked in |
+| Gap       | Planned sections are actually covered by the draft |
 
 ### Example
 
@@ -159,10 +159,10 @@ sibyl synthesis remember <goal> [options]
 
 `remember` accepts every [`synthesis draft`](#synthesis-draft) option plus:
 
-| Option        | Default   | Description                  |
-| ------------- | --------- | ---------------------------- |
-| `--scope`     | `private` | Artifact memory scope        |
-| `--scope-key` | (none)    | Artifact scope key           |
+| Option        | Default   | Description                   |
+| ------------- | --------- | ----------------------------- |
+| `--scope`     | `private` | Artifact memory scope         |
+| `--scope-key` | (none)    | Artifact scope key            |
 | `--tags`      | (none)    | Comma-separated artifact tags |
 
 ### Example

--- a/docs/cli/task-lifecycle.md
+++ b/docs/cli/task-lifecycle.md
@@ -28,9 +28,9 @@ sibyl task show <task_id> [options]
 
 ### Arguments
 
-| Argument  | Required | Description                       |
-| --------- | -------- | --------------------------------- |
-| `task_id` | Yes      | Task ID or unambiguous prefix     |
+| Argument  | Required | Description                   |
+| --------- | -------- | ----------------------------- |
+| `task_id` | Yes      | Task ID or unambiguous prefix |
 
 ### Options
 
@@ -38,8 +38,8 @@ sibyl task show <task_id> [options]
 | -------- | ----- | ----------- |
 | `--json` | `-j`  | JSON output |
 
-Task ID arguments accept an unambiguous prefix, so `sibyl task show task_abc1` resolves as long
-as only one task matches.
+Task ID arguments accept an unambiguous prefix, so `sibyl task show task_abc1` resolves as long as
+only one task matches.
 
 ### Example
 
@@ -242,14 +242,14 @@ sibyl task complete <task_id> [options]
 
 ### Options
 
-| Option                  | Short | Default | Description                                     |
-| ----------------------- | ----- | ------- | ----------------------------------------------- |
-| `--hours`               | `-h`  | (none)  | Actual hours spent                              |
-| `--learnings` / `--note` | `-l` | (none)  | Key learnings (creates an episode)              |
-| `--learnings-file`      |       | (none)  | Read learnings from a file                      |
-| `--max-size`            |       | 1048576 | Maximum learnings file size in bytes            |
-| `--follow-symlinks`     |       | false   | Allow `--learnings-file` to read through symlinks |
-| `--json`                | `-j`  | false   | JSON output                                     |
+| Option                   | Short | Default | Description                                       |
+| ------------------------ | ----- | ------- | ------------------------------------------------- |
+| `--hours`                | `-h`  | (none)  | Actual hours spent                                |
+| `--learnings` / `--note` | `-l`  | (none)  | Key learnings (creates an episode)                |
+| `--learnings-file`       |       | (none)  | Read learnings from a file                        |
+| `--max-size`             |       | 1048576 | Maximum learnings file size in bytes              |
+| `--follow-symlinks`      |       | false   | Allow `--learnings-file` to read through symlinks |
+| `--json`                 | `-j`  | false   | JSON output                                       |
 
 ### Basic Completion
 
@@ -362,21 +362,21 @@ sibyl task update <task_id> [options]
 
 ### Options
 
-| Option          | Short | Description                                                   |
-| --------------- | ----- | ------------------------------------------------------------- |
-| `--status`      | `-s`  | Status: todo, doing, blocked, review, done                    |
-| `--priority`    | `-p`  | Priority: critical, high, medium, low, someday                |
-| `--complexity`  |       | Complexity: trivial, simple, medium, complex, epic            |
-| `--title`       |       | Task title                                                    |
-| `--description` | `-d`  | Task description/content                                      |
-| `--assignee`    | `-a`  | Assignee                                                      |
-| `--epic`        | `-e`  | Epic ID to group under                                        |
-| `--feature`     | `-f`  | Feature area                                                  |
-| `--tags`        |       | Comma-separated tags (replaces existing)                      |
-| `--tech`        |       | Comma-separated technologies (replaces existing)              |
-| `--add-dep`     |       | Comma-separated task IDs to add as dependencies               |
-| `--remove-dep`  |       | Comma-separated task IDs to remove as dependencies            |
-| `--json`        | `-j`  | JSON output                                                   |
+| Option          | Short | Description                                        |
+| --------------- | ----- | -------------------------------------------------- |
+| `--status`      | `-s`  | Status: todo, doing, blocked, review, done         |
+| `--priority`    | `-p`  | Priority: critical, high, medium, low, someday     |
+| `--complexity`  |       | Complexity: trivial, simple, medium, complex, epic |
+| `--title`       |       | Task title                                         |
+| `--description` | `-d`  | Task description/content                           |
+| `--assignee`    | `-a`  | Assignee                                           |
+| `--epic`        | `-e`  | Epic ID to group under                             |
+| `--feature`     | `-f`  | Feature area                                       |
+| `--tags`        |       | Comma-separated tags (replaces existing)           |
+| `--tech`        |       | Comma-separated technologies (replaces existing)   |
+| `--add-dep`     |       | Comma-separated task IDs to add as dependencies    |
+| `--remove-dep`  |       | Comma-separated task IDs to remove as dependencies |
+| `--json`        | `-j`  | JSON output                                        |
 
 To archive a task, use [`task archive`](#task-archive) rather than `task update --status`.
 
@@ -416,21 +416,21 @@ sibyl task note <task_id> [content] [options]
 
 ### Arguments
 
-| Argument  | Required | Description                       |
-| --------- | -------- | --------------------------------- |
-| `task_id` | Yes      | Task ID or unambiguous prefix     |
-| `content` | No       | Note content or `-` for stdin     |
+| Argument  | Required | Description                   |
+| --------- | -------- | ----------------------------- |
+| `task_id` | Yes      | Task ID or unambiguous prefix |
+| `content` | No       | Note content or `-` for stdin |
 
 ### Options
 
-| Option                   | Short | Default | Description                                     |
-| ------------------------ | ----- | ------- | ----------------------------------------------- |
-| `--content-file`         |       | (none)  | Read note content from a file                   |
-| `--max-size`             |       | 1048576 | Maximum content file size in bytes              |
-| `--follow-symlinks`      |       | false   | Allow `--content-file` to read through symlinks |
-| `--assistant` / `--agent` |      | false   | Mark as assistant-authored (default: user)      |
-| `--author`               | `-a`  | (none)  | Author name/identifier                          |
-| `--json`                 | `-j`  | false   | JSON output                                     |
+| Option                    | Short | Default | Description                                     |
+| ------------------------- | ----- | ------- | ----------------------------------------------- |
+| `--content-file`          |       | (none)  | Read note content from a file                   |
+| `--max-size`              |       | 1048576 | Maximum content file size in bytes              |
+| `--follow-symlinks`       |       | false   | Allow `--content-file` to read through symlinks |
+| `--assistant` / `--agent` |       | false   | Mark as assistant-authored (default: user)      |
+| `--author`                | `-a`  | (none)  | Author name/identifier                          |
+| `--json`                  | `-j`  | false   | JSON output                                     |
 
 ### Examples
 

--- a/docs/cli/task-list.md
+++ b/docs/cli/task-list.md
@@ -36,10 +36,10 @@ sibyl task list [options]
 
 ### Output
 
-| Option   | Short | Description                                  |
-| -------- | ----- | -------------------------------------------- |
-| `--json` | `-j`  | JSON output                                  |
-| `--csv`  |       | CSV output                                   |
+| Option   | Short | Description                                     |
+| -------- | ----- | ----------------------------------------------- |
+| `--json` | `-j`  | JSON output                                     |
+| `--csv`  |       | CSV output                                      |
 | `--wide` |       | Render a wide task table without title wrapping |
 
 ## Status Values

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -55,8 +55,8 @@ SIBYL_COORDINATION_BACKEND=redis moon run dev
 
 ## Service Definitions
 
-The root `docker-compose.yml` defines a Surreal-first local stack plus an opt-in `redis` profile.
-It runs only the data services; the API and web apps run natively for hot reload.
+The root `docker-compose.yml` defines a Surreal-first local stack plus an opt-in `redis` profile. It
+runs only the data services; the API and web apps run natively for hot reload.
 
 ```yaml
 services:
@@ -65,9 +65,13 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-sibyl}-surrealdb
     command:
       [
-        "start", "--log", "info",
-        "--user", "${SIBYL_SURREAL_USERNAME:-root}",
-        "--pass", "${SIBYL_SURREAL_PASSWORD:-root}",
+        "start",
+        "--log",
+        "info",
+        "--user",
+        "${SIBYL_SURREAL_USERNAME:-root}",
+        "--pass",
+        "${SIBYL_SURREAL_PASSWORD:-root}",
         "${SIBYL_SURREAL_PATH:-rocksdb:///data/sibyl.db}",
       ]
     ports:

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -38,15 +38,15 @@ multi-pod deployments. See [storage-modes.md](../guide/storage-modes.md) for the
 
 SurrealDB is the default and only runtime store. These settings apply to every Sibyl process.
 
-| Variable                         | Default | Description                                                          |
-| -------------------------------- | ------- | -------------------------------------------------------------------- |
-| `SIBYL_SURREAL_URL`              | (empty) | Connection URL (`ws://`, `http://`, `surrealkv://`, `memory://`)     |
-| `SIBYL_SURREAL_DATA_DIR`         | (empty) | Local SurrealKV path used when `SIBYL_SURREAL_URL` is unset          |
-| `SIBYL_SURREAL_USERNAME`         | (empty) | Root username for remote runtimes                                    |
-| `SIBYL_SURREAL_PASSWORD`         | (empty) | Root password for remote runtimes                                    |
-| `SIBYL_SURREAL_TOKEN`            | (empty) | Bearer token for remote runtimes (alternative to username/password)  |
-| `SIBYL_SURREAL_NAMESPACE_PREFIX` | `org_`  | Namespace prefix for per-org isolation (`org_<uuid_hex>`)            |
-| `SIBYL_SURREAL_DATABASE`         | `graph` | Database name inside each org namespace                              |
+| Variable                         | Default | Description                                                           |
+| -------------------------------- | ------- | --------------------------------------------------------------------- |
+| `SIBYL_SURREAL_URL`              | (empty) | Connection URL (`ws://`, `http://`, `surrealkv://`, `memory://`)      |
+| `SIBYL_SURREAL_DATA_DIR`         | (empty) | Local SurrealKV path used when `SIBYL_SURREAL_URL` is unset           |
+| `SIBYL_SURREAL_USERNAME`         | (empty) | Root username for remote runtimes                                     |
+| `SIBYL_SURREAL_PASSWORD`         | (empty) | Root password for remote runtimes                                     |
+| `SIBYL_SURREAL_TOKEN`            | (empty) | Bearer token for remote runtimes (alternative to username/password)   |
+| `SIBYL_SURREAL_NAMESPACE_PREFIX` | `org_`  | Namespace prefix for per-org isolation (`org_<uuid_hex>`)             |
+| `SIBYL_SURREAL_DATABASE`         | `graph` | Database name inside each org namespace                               |
 | `SIBYL_SURREAL_SLOW_QUERY_MS`    | `500`   | Log SurrealDB queries at warning level when elapsed time exceeds this |
 
 `SIBYL_SURREAL_URL` and `SIBYL_SURREAL_DATA_DIR` are mutually exclusive; set only one. When neither
@@ -168,14 +168,14 @@ Redis/Valkey is optional. The default Surreal runtime uses local in-process coor
 Document chunk embeddings and graph node/relationship embeddings are configured separately. The
 graph embedding dimensions also size the native Surreal vector indexes.
 
-| Variable                           | Default                  | Description                                  |
-| ----------------------------------- | ------------------------ | -------------------------------------------- |
-| `SIBYL_EMBEDDING_PROVIDER`          | `openai`                 | Document chunk embedding provider: openai or gemini |
-| `SIBYL_EMBEDDING_MODEL`             | `text-embedding-3-small` | Document chunk embedding model               |
-| `SIBYL_EMBEDDING_DIMENSIONS`        | `1536`                   | Document chunk embedding vector dimensions   |
-| `SIBYL_GRAPH_EMBEDDING_PROVIDER`    | `openai`                 | Graph node/relationship embedding provider   |
-| `SIBYL_GRAPH_EMBEDDING_MODEL`       | `text-embedding-3-small` | Graph node/relationship embedding model      |
-| `SIBYL_GRAPH_EMBEDDING_DIMENSIONS`  | `1024`                   | Graph embedding dimensions (sizes vector indexes) |
+| Variable                           | Default                  | Description                                         |
+| ---------------------------------- | ------------------------ | --------------------------------------------------- |
+| `SIBYL_EMBEDDING_PROVIDER`         | `openai`                 | Document chunk embedding provider: openai or gemini |
+| `SIBYL_EMBEDDING_MODEL`            | `text-embedding-3-small` | Document chunk embedding model                      |
+| `SIBYL_EMBEDDING_DIMENSIONS`       | `1536`                   | Document chunk embedding vector dimensions          |
+| `SIBYL_GRAPH_EMBEDDING_PROVIDER`   | `openai`                 | Graph node/relationship embedding provider          |
+| `SIBYL_GRAPH_EMBEDDING_MODEL`      | `text-embedding-3-small` | Graph node/relationship embedding model             |
+| `SIBYL_GRAPH_EMBEDDING_DIMENSIONS` | `1024`                   | Graph embedding dimensions (sizes vector indexes)   |
 
 ## API Keys
 
@@ -190,8 +190,10 @@ graph embedding dimensions also size the native Surreal vector indexes.
 API keys are resolved in this order:
 
 1. **Database** - Keys stored via web UI (Settings, AI Services)
-2. **Environment variables** - `SIBYL_OPENAI_API_KEY`, `SIBYL_ANTHROPIC_API_KEY`, `SIBYL_GEMINI_API_KEY`
-3. **Unprefixed fallbacks** - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` / `GOOGLE_API_KEY`
+2. **Environment variables** - `SIBYL_OPENAI_API_KEY`, `SIBYL_ANTHROPIC_API_KEY`,
+   `SIBYL_GEMINI_API_KEY`
+3. **Unprefixed fallbacks** - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` /
+   `GOOGLE_API_KEY`
 
 This allows zero-config deployments where API keys are entered through the onboarding wizard and
 stored encrypted in the database (using `SIBYL_SETTINGS_KEY`).
@@ -223,24 +225,24 @@ fallback for migration or investigation.
 
 ## Runtime Telemetry
 
-| Variable                       | Default | Description                                            |
-| ------------------------------ | ------- | ------------------------------------------------------ |
-| `SIBYL_METRICS_SCRAPE_TOKEN`   | (empty) | Bearer/header token for non-local `/metrics` scraping |
+| Variable                     | Default | Description                                           |
+| ---------------------------- | ------- | ----------------------------------------------------- |
+| `SIBYL_METRICS_SCRAPE_TOKEN` | (empty) | Bearer/header token for non-local `/metrics` scraping |
 
 ## Email (Resend)
 
-| Variable                  | Default                     | Description                                            |
-| ------------------------- | --------------------------- | ------------------------------------------------------ |
-| `SIBYL_RESEND_API_KEY`    | (empty)                     | Resend API key for transactional email                 |
-| `SIBYL_EMAIL_FROM`        | `Sibyl <noreply@sibyl.dev>` | Default from address                                   |
-| `SIBYL_EMAIL_OUTBOX_PATH` | (empty)                     | Optional JSONL outbox path for local/staging capture   |
+| Variable                  | Default                     | Description                                          |
+| ------------------------- | --------------------------- | ---------------------------------------------------- |
+| `SIBYL_RESEND_API_KEY`    | (empty)                     | Resend API key for transactional email               |
+| `SIBYL_EMAIL_FROM`        | `Sibyl <noreply@sibyl.dev>` | Default from address                                 |
+| `SIBYL_EMAIL_OUTBOX_PATH` | (empty)                     | Optional JSONL outbox path for local/staging capture |
 
 ## Content Ingestion
 
-| Variable                     | Default            | Description                                              |
-| ---------------------------- | ------------------ | -------------------------------------------------------- |
-| `SIBYL_CHUNK_MAX_TOKENS`     | `1000`             | Maximum tokens per chunk                                 |
-| `SIBYL_CHUNK_OVERLAP_TOKENS` | `100`              | Token overlap between chunks                             |
+| Variable                     | Default            | Description                                             |
+| ---------------------------- | ------------------ | ------------------------------------------------------- |
+| `SIBYL_CHUNK_MAX_TOKENS`     | `1000`             | Maximum tokens per chunk                                |
+| `SIBYL_CHUNK_OVERLAP_TOKENS` | `100`              | Token overlap between chunks                            |
 | `SIBYL_SOURCE_IMPORT_DIR`    | `./source-imports` | Directory of local source archives API imports may read |
 
 ## Backups
@@ -248,12 +250,12 @@ fallback for migration or investigation.
 Scheduled archive backups run from the worker. See [Monitoring](monitoring.md) for operational
 detail.
 
-| Variable                      | Default       | Description                                       |
-| ----------------------------- | ------------- | ------------------------------------------------- |
-| `SIBYL_BACKUP_ENABLED`        | `true`        | Enable scheduled automatic backups                |
-| `SIBYL_BACKUP_DIR`            | `./backups`   | Directory to store backup archives                |
-| `SIBYL_BACKUP_RETENTION_DAYS` | `30`          | Days to retain backups before auto-cleanup        |
-| `SIBYL_BACKUP_SCHEDULE`       | `0 2 * * *`   | Cron schedule for automatic backups (2 AM daily)  |
+| Variable                      | Default     | Description                                      |
+| ----------------------------- | ----------- | ------------------------------------------------ |
+| `SIBYL_BACKUP_ENABLED`        | `true`      | Enable scheduled automatic backups               |
+| `SIBYL_BACKUP_DIR`            | `./backups` | Directory to store backup archives               |
+| `SIBYL_BACKUP_RETENTION_DAYS` | `30`        | Days to retain backups before auto-cleanup       |
+| `SIBYL_BACKUP_SCHEDULE`       | `0 2 * * *` | Cron schedule for automatic backups (2 AM daily) |
 
 ## Worker Configuration
 
@@ -454,5 +456,5 @@ settings.requires_relational_support  # True only for relational store/auth_stor
 settings.resolved_coordination_backend  # resolves "auto" to "local" or "redis"
 ```
 
-With the default `SIBYL_STORE=surreal` and `SIBYL_AUTH_STORE=surreal`, `fully_surreal` is `True`
-and both `uses_relational_auth` and `requires_relational_support` are `False`.
+With the default `SIBYL_STORE=surreal` and `SIBYL_AUTH_STORE=surreal`, `fully_surreal` is `True` and
+both `uses_relational_auth` and `requires_relational_support` are `False`.

--- a/docs/deployment/monitoring.md
+++ b/docs/deployment/monitoring.md
@@ -239,11 +239,10 @@ GET /api/telemetry/prometheus
 GET /metrics
 ```
 
-Sibyl records its own runtime telemetry in-process and persists bounded minute rollups in
-SurrealDB. The JSON summary powers the web overview page, while `/metrics` exposes
-Prometheus-compatible counters, gauges, and latency summaries for scrapers. Set
-`SIBYL_METRICS_SCRAPE_TOKEN` for non-local scraping and pass it as a bearer token or
-`X-Sibyl-Metrics-Token` header.
+Sibyl records its own runtime telemetry in-process and persists bounded minute rollups in SurrealDB.
+The JSON summary powers the web overview page, while `/metrics` exposes Prometheus-compatible
+counters, gauges, and latency summaries for scrapers. Set `SIBYL_METRICS_SCRAPE_TOKEN` for non-local
+scraping and pass it as a bearer token or `X-Sibyl-Metrics-Token` header.
 
 Captured surfaces:
 

--- a/docs/guide/agent-collaboration.md
+++ b/docs/guide/agent-collaboration.md
@@ -8,9 +8,9 @@ description: Multi-agent patterns with shared knowledge
 Sibyl enables multiple AI agents to share knowledge and coordinate work. This guide covers patterns
 for multi-agent collaboration.
 
-Every agent runs the same [memory loop](./memory-loop.md): recall before acting,
-remember what it learns, reflect on its session. Because the graph is shared, one
-agent's remember is the next agent's recall.
+Every agent runs the same [memory loop](./memory-loop.md): recall before acting, remember what it
+learns, reflect on its session. Because the graph is shared, one agent's remember is the next
+agent's recall.
 
 ## Shared Knowledge Graph
 

--- a/docs/guide/capturing-knowledge.md
+++ b/docs/guide/capturing-knowledge.md
@@ -35,8 +35,8 @@ sibyl remember "Chose SurrealDB" "One engine replaces three backends" --kind dec
 sibyl add "Descriptive title" "What, why, how, caveats" --type pattern
 ```
 
-`capture` and `remember` are the memory-loop verbs. `add` is the lower-level command
-with the widest set of flags.
+`capture` and `remember` are the memory-loop verbs. `add` is the lower-level command with the widest
+set of flags.
 
 ### Complete With Learnings
 

--- a/docs/guide/claude-code.md
+++ b/docs/guide/claude-code.md
@@ -27,9 +27,9 @@ and data sources. Sibyl exposes 11 MCP tools:
 | `manage`           | State changes: task workflow, crawl, sync, analysis, admin     |
 | `logs`             | Recent server logs (OWNER role)                                |
 
-The four memory-loop tools (`context`, `remember`, `reflect`, and the `synthesis_*`
-family) implement the [memory loop](./memory-loop.md) for agents. `search`, `explore`,
-`add`, and `manage` cover retrieval and workflow.
+The four memory-loop tools (`context`, `remember`, `reflect`, and the `synthesis_*` family)
+implement the [memory loop](./memory-loop.md) for agents. `search`, `explore`, `add`, and `manage`
+cover retrieval and workflow.
 
 ## Configuration
 

--- a/docs/guide/entity-types.md
+++ b/docs/guide/entity-types.md
@@ -10,10 +10,10 @@ each type helps keep your knowledge graph organized and searchable.
 
 The full set, as accepted by `--type` on `sibyl add` and `--kind` on `sibyl remember`:
 
-`pattern`, `rule`, `template`, `guide`, `tool`, `language`, `topic`, `episode`,
-`knowledge_source`, `config_file`, `slash_command`, `project`, `epic`, `task`, `team`,
-`error_pattern`, `milestone`, `source`, `document`, `procedure`, `community`, `note`, `domain`,
-`artifact`, `decision`, `plan`, `idea`, `claim`, `session`.
+`pattern`, `rule`, `template`, `guide`, `tool`, `language`, `topic`, `episode`, `knowledge_source`,
+`config_file`, `slash_command`, `project`, `epic`, `task`, `team`, `error_pattern`, `milestone`,
+`source`, `document`, `procedure`, `community`, `note`, `domain`, `artifact`, `decision`, `plan`,
+`idea`, `claim`, `session`.
 
 You rarely touch most of them directly. The sections below cover the types you choose by hand;
 crawler, analysis, and reflection paths create the rest.
@@ -151,8 +151,8 @@ High-level concepts and knowledge areas.
 
 ## Memory Loop Types
 
-These types are the vocabulary of the [memory loop](./memory-loop.md). They are the natural
-`--kind` values for `sibyl remember` and capture the durable thinking behind your work.
+These types are the vocabulary of the [memory loop](./memory-loop.md). They are the natural `--kind`
+values for `sibyl remember` and capture the durable thinking behind your work.
 
 ### Decision
 
@@ -498,33 +498,33 @@ Entity clusters from graph analysis.
 A handful of types exist for completeness and are created by specific paths rather than chosen by
 hand:
 
-| Type               | Created by                                                        |
-| ------------------ | ----------------------------------------------------------------- |
-| `knowledge_source` | Knowledge ingestion paths that register an origin for memory      |
-| `config_file`      | Capturing a configuration file as referenceable knowledge         |
-| `slash_command`    | Capturing a slash command definition                              |
-| `language`         | Programming-language nodes used for tagging and traversal         |
+| Type               | Created by                                                   |
+| ------------------ | ------------------------------------------------------------ |
+| `knowledge_source` | Knowledge ingestion paths that register an origin for memory |
+| `config_file`      | Capturing a configuration file as referenceable knowledge    |
+| `slash_command`    | Capturing a slash command definition                         |
+| `language`         | Programming-language nodes used for tagging and traversal    |
 
 They accept the same `--type` flag if you ever need them, but most workflows never do.
 
 ## Type Selection Guide
 
-| Scenario                       | Recommended Type |
-| ------------------------------ | ---------------- |
-| "I just figured something out" | `episode`        |
-| "This is how we always do X"   | `pattern`        |
-| "This must never happen"       | `rule`           |
-| "We chose A over B, here's why"| `decision`       |
-| "Here's the approach I'll take"| `plan`           |
-| "Worth trying later"           | `idea`           |
-| "X behaves like this"          | `claim`          |
-| "I need to implement X"        | `task`           |
-| "X is a major feature area"    | `epic`           |
-| "X is a big initiative"        | `project`        |
-| "Here's useful external docs"  | `source`         |
-| "This error keeps happening"   | `error_pattern`  |
-| "A repeatable runbook"         | `procedure`      |
-| "Template for new services"    | `template`       |
+| Scenario                        | Recommended Type |
+| ------------------------------- | ---------------- |
+| "I just figured something out"  | `episode`        |
+| "This is how we always do X"    | `pattern`        |
+| "This must never happen"        | `rule`           |
+| "We chose A over B, here's why" | `decision`       |
+| "Here's the approach I'll take" | `plan`           |
+| "Worth trying later"            | `idea`           |
+| "X behaves like this"           | `claim`          |
+| "I need to implement X"         | `task`           |
+| "X is a major feature area"     | `epic`           |
+| "X is a big initiative"         | `project`        |
+| "Here's useful external docs"   | `source`         |
+| "This error keeps happening"    | `error_pattern`  |
+| "A repeatable runbook"          | `procedure`      |
+| "Template for new services"     | `template`       |
 
 ## Creating Entities
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -85,8 +85,8 @@ filter to find what you need.
 
 ## The Memory Loop
 
-Every effective Sibyl workflow follows the same cycle: **recall, act, remember,
-reflect.** Learn it once and the rest of Sibyl falls into place.
+Every effective Sibyl workflow follows the same cycle: **recall, act, remember, reflect.** Learn it
+once and the rest of Sibyl falls into place.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -116,8 +116,8 @@ reflect.** Learn it once and the rest of Sibyl falls into place.
 └─────────────────────────────────────────────────────────┘
 ```
 
-The loop runs on the CLI, through MCP tools, and from hooks. See
-[The Memory Loop](./memory-loop) for the full cycle.
+The loop runs on the CLI, through MCP tools, and from hooks. See [The Memory Loop](./memory-loop)
+for the full cycle.
 
 ## What to Capture
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -129,18 +129,18 @@ SIBYL_ANTHROPIC_API_KEY=...        # For LLM operations
 
 ### Optional Environment Variables
 
-| Variable                     | Default                  | Description                                 |
-| ---------------------------- | ------------------------ | ------------------------------------------- |
-| `SIBYL_STORE`                | `surreal`                | Active persistence runtime                  |
-| `SIBYL_COORDINATION_BACKEND` | `auto`                   | `local` or `redis` coordination backend     |
-| `SIBYL_SURREAL_URL`          | -                        | SurrealDB server URL                        |
-| `SIBYL_LOG_LEVEL`            | `INFO`                   | Logging level                               |
-| `SIBYL_EMBEDDING_MODEL`      | `text-embedding-3-small` | OpenAI embedding model                      |
-| `SIBYL_PUBLIC_URL`           | `http://localhost:3337`  | Public base URL (OAuth callbacks, redirects)|
-| `SIBYL_SERVER_URL`           | derived                  | Override API base URL (defaults to public)  |
-| `SIBYL_FRONTEND_URL`         | derived                  | Override frontend URL (defaults to public)  |
-| `SIBYL_REDIS_HOST`           | `127.0.0.1`              | Redis/Valkey host when `coordination=redis` |
-| `SIBYL_POSTGRES_HOST`        | `localhost`              | Migration-only PostgreSQL host              |
+| Variable                     | Default                  | Description                                  |
+| ---------------------------- | ------------------------ | -------------------------------------------- |
+| `SIBYL_STORE`                | `surreal`                | Active persistence runtime                   |
+| `SIBYL_COORDINATION_BACKEND` | `auto`                   | `local` or `redis` coordination backend      |
+| `SIBYL_SURREAL_URL`          | -                        | SurrealDB server URL                         |
+| `SIBYL_LOG_LEVEL`            | `INFO`                   | Logging level                                |
+| `SIBYL_EMBEDDING_MODEL`      | `text-embedding-3-small` | OpenAI embedding model                       |
+| `SIBYL_PUBLIC_URL`           | `http://localhost:3337`  | Public base URL (OAuth callbacks, redirects) |
+| `SIBYL_SERVER_URL`           | derived                  | Override API base URL (defaults to public)   |
+| `SIBYL_FRONTEND_URL`         | derived                  | Override frontend URL (defaults to public)   |
+| `SIBYL_REDIS_HOST`           | `127.0.0.1`              | Redis/Valkey host when `coordination=redis`  |
+| `SIBYL_POSTGRES_HOST`        | `localhost`              | Migration-only PostgreSQL host               |
 
 ## Running Sibyl
 

--- a/docs/guide/mcp-configuration.md
+++ b/docs/guide/mcp-configuration.md
@@ -170,14 +170,14 @@ sibyl auth api-key create --name "MCP Client" --scopes mcp
 
 ### Database Settings
 
-| Variable             | Default     | Description                                |
-| -------------------- | ----------- | ------------------------------------------ |
+| Variable             | Default     | Description                                    |
+| -------------------- | ----------- | ---------------------------------------------- |
 | `SIBYL_SURREAL_URL`  | -           | SurrealDB connection URL (`ws://` / `http://`) |
-| `SIBYL_REDIS_HOST`   | `127.0.0.1` | Optional Redis/Valkey host                 |
-| `SIBYL_POSTGRES_URL` | -           | Migration/rehearsal-only PostgreSQL        |
+| `SIBYL_REDIS_HOST`   | `127.0.0.1` | Optional Redis/Valkey host                     |
+| `SIBYL_POSTGRES_URL` | -           | Migration/rehearsal-only PostgreSQL            |
 
-`moon run dev` provisions a local SurrealDB automatically. The `memory://` URL is a
-test-only mode and is rejected by the production config validator.
+`moon run dev` provisions a local SurrealDB automatically. The `memory://` URL is a test-only mode
+and is rejected by the production config validator.
 
 ### Embedding Settings
 
@@ -190,10 +190,9 @@ test-only mode and is rejected by the production config validator.
 
 ### Tool Registration
 
-The MCP server is constructed in `server.py` and registers 11 tools: `search`,
-`context`, `synthesis_plan`, `synthesis_draft`, `synthesis_verify`, `explore`, `add`,
-`remember`, `reflect`, `manage`, and `logs`. See
-[Claude Code Integration](./claude-code.md) for what each one does.
+The MCP server is constructed in `server.py` and registers 11 tools: `search`, `context`,
+`synthesis_plan`, `synthesis_draft`, `synthesis_verify`, `explore`, `add`, `remember`, `reflect`,
+`manage`, and `logs`. See [Claude Code Integration](./claude-code.md) for what each one does.
 
 ```python
 mcp = FastMCP(

--- a/docs/guide/memory-loop.md
+++ b/docs/guide/memory-loop.md
@@ -5,10 +5,9 @@ description: Recall, act, remember, reflect - the cycle Sibyl is built around
 
 # The Memory Loop 🔮
 
-Sibyl is built around a durable cycle that both humans and AI agents follow:
-**recall, act, remember, reflect.** Every interface (CLI, MCP tools, hooks, and the
-web workspace) exists to support this loop. Learn it once and the rest of Sibyl falls
-into place.
+Sibyl is built around a durable cycle that both humans and AI agents follow: **recall, act,
+remember, reflect.** Every interface (CLI, MCP tools, hooks, and the web workspace) exists to
+support this loop. Learn it once and the rest of Sibyl falls into place.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -36,14 +35,13 @@ into place.
 └─────────────────────────────────────────────────────────────┘
 ```
 
-Every completed loop makes the graph smarter. The next recall is sharper because the
-last remember and reflect fed it.
+Every completed loop makes the graph smarter. The next recall is sharper because the last remember
+and reflect fed it.
 
 ## Recall
 
-`sibyl recall` compiles a compact working context pack for a goal. It fuses semantic
-search, raw memory, and one-hop graph context into a result sized for an agent's
-prompt budget.
+`sibyl recall` compiles a compact working context pack for a goal. It fuses semantic search, raw
+memory, and one-hop graph context into a result sized for an agent's prompt budget.
 
 ```bash
 # Recall context for a goal
@@ -58,24 +56,23 @@ sibyl recall "why is login flaky" --intent debug --layer deep_search
 
 Key flags:
 
-| Flag        | Purpose                                                            |
-| ----------- | ------------------------------------------------------------------ |
+| Flag        | Purpose                                                                                |
+| ----------- | -------------------------------------------------------------------------------------- |
 | `--intent`  | `build`, `plan`, `ideate`, `research`, `review`, `debug`, `decide`, `learn`, `general` |
-| `--layer`   | Context depth: `wake`, `recall`, `deep_search`                     |
-| `--project` | Scope recall to a project                                          |
-| `--limit`   | Maximum context items (1-50, default 12)                           |
-| `--raw`     | Recall verbatim raw memories instead of synthesized context        |
-| `--diary`   | Recall a private agent diary                                       |
-| `--json`    | Full structured output                                             |
+| `--layer`   | Context depth: `wake`, `recall`, `deep_search`                                         |
+| `--project` | Scope recall to a project                                                              |
+| `--limit`   | Maximum context items (1-50, default 12)                                               |
+| `--raw`     | Recall verbatim raw memories instead of synthesized context                            |
+| `--diary`   | Recall a private agent diary                                                           |
+| `--json`    | Full structured output                                                                 |
 
-The `--layer` flag trades latency for depth. `wake` is a fast session-start pull,
-`recall` is the everyday default, and `deep_search` runs a wider, slower scan for
-hard questions.
+The `--layer` flag trades latency for depth. `wake` is a fast session-start pull, `recall` is the
+everyday default, and `deep_search` runs a wider, slower scan for hard questions.
 
 ## Act
 
-The middle of the loop is the work itself. Sibyl tracks it through tasks so progress
-survives the session:
+The middle of the loop is the work itself. Sibyl tracks it through tasks so progress survives the
+session:
 
 ```bash
 sibyl task start <task_id>
@@ -86,8 +83,8 @@ See [Task Management](./task-management.md) for the full lifecycle.
 
 ## Remember
 
-`sibyl remember` captures durable memory. Unlike a quick note, a remembered entry is
-typed and source-grounded, so later recall and synthesis can cite it.
+`sibyl remember` captures durable memory. Unlike a quick note, a remembered entry is typed and
+source-grounded, so later recall and synthesis can cite it.
 
 ```bash
 # Remember a learning (default kind: episode)
@@ -100,8 +97,8 @@ sibyl remember "Chose SurrealDB" "One engine replaces three backends" --kind dec
 sibyl remember "Q3 reflection rollout" "Phased per-org enablement" --kind plan
 ```
 
-Useful kinds for the loop are `decision`, `plan`, `idea`, `claim`, `episode`, and
-`session`. See [Entity Types](./entity-types.md) for the full set.
+Useful kinds for the loop are `decision`, `plan`, `idea`, `claim`, `episode`, and `session`. See
+[Entity Types](./entity-types.md) for the full set.
 
 For a fast capture without separate title and content, use `sibyl capture`:
 
@@ -109,14 +106,13 @@ For a fast capture without separate title and content, use `sibyl capture`:
 sibyl capture "Surreal embedded mode is single-writer, fine for local dev"
 ```
 
-`capture` derives a title from the content and stores the entry as raw memory. It is
-the lowest-friction way to get a thought into the graph mid-task.
+`capture` derives a title from the content and stores the entry as raw memory. It is the
+lowest-friction way to get a thought into the graph mid-task.
 
 ## Reflect
 
-`sibyl reflect` turns a pile of raw notes into structured memory candidates. Instead
-of remembering one thing at a time, you hand Sibyl a session's worth of notes and it
-extracts the durable pieces.
+`sibyl reflect` turns a pile of raw notes into structured memory candidates. Instead of remembering
+one thing at a time, you hand Sibyl a session's worth of notes and it extracts the durable pieces.
 
 ```bash
 # Reflect notes piped from a file or scratchpad
@@ -129,14 +125,14 @@ sibyl reflect --persist < session-notes.md
 sibyl reflect --persist --review < session-notes.md
 ```
 
-`--review` routes the extracted candidates to a queue for inspection before they land
-as graph entities. Without `--review`, `--persist` promotes them directly.
+`--review` routes the extracted candidates to a queue for inspection before they land as graph
+entities. Without `--review`, `--persist` promotes them directly.
 
 ## The Reflection Dream-Cycle 🌙
 
-Reflection also runs on its own. The dream-cycle is an org-scoped maintenance job
-that drains pending reflection candidates through automatic review, applies lifecycle
-findings, and records inspectable run receipts.
+Reflection also runs on its own. The dream-cycle is an org-scoped maintenance job that drains
+pending reflection candidates through automatic review, applies lifecycle findings, and records
+inspectable run receipts.
 
 ```bash
 # Drain pending candidates through automatic review now
@@ -149,14 +145,14 @@ sibyl memory-review dream
 sibyl memory-review status
 ```
 
-The dream-cycle keeps the graph from accumulating unreviewed noise. Candidates that
-pass review become durable memory; the rest are surfaced for a human or owner agent
-to triage. Run receipts make every automatic decision auditable.
+The dream-cycle keeps the graph from accumulating unreviewed noise. Candidates that pass review
+become durable memory; the rest are surfaced for a human or owner agent to triage. Run receipts make
+every automatic decision auditable.
 
 ## Inspecting Memory
 
-Memory is auditable end to end. These commands trace where a memory came from and
-how it was reviewed:
+Memory is auditable end to end. These commands trace where a memory came from and how it was
+reviewed:
 
 ```bash
 sibyl memory-audit              # Inspect memory audit receipts
@@ -167,8 +163,8 @@ sibyl archive                   # Browse archived raw quick captures
 
 ## Offline Writes
 
-When the server is unreachable, loop writes are buffered locally instead of lost. The
-buffer is encrypted and keyed for idempotent replay:
+When the server is unreachable, loop writes are buffered locally instead of lost. The buffer is
+encrypted and keyed for idempotent replay:
 
 ```bash
 sibyl pending-writes list       # List buffered writes (payload bodies hidden)
@@ -184,8 +180,8 @@ The same loop runs everywhere:
   [Claude Code Integration](./claude-code.md).
 - **Hooks:** the SessionStart hook performs a wake-layer recall automatically. See
   [Skills & Hooks](./skills.md).
-- **Web UI:** the [memory workspace](./memory-workspace.md) shows captures, imports,
-  and synthesis for human oversight.
+- **Web UI:** the [memory workspace](./memory-workspace.md) shows captures, imports, and synthesis
+  for human oversight.
 
 ## Next Steps
 

--- a/docs/guide/memory-workspace.md
+++ b/docs/guide/memory-workspace.md
@@ -5,62 +5,59 @@ description: The web surface for captures, imports, and synthesis
 
 # Memory Workspace 🎭
 
-The memory workspace is the web UI's home for the [memory loop](./memory-loop.md). It
-is where a human reviews what agents captured, watches source imports land, and runs
-synthesis interactively. The CLI drives the loop from the terminal; the workspace
-gives it oversight.
+The memory workspace is the web UI's home for the [memory loop](./memory-loop.md). It is where a
+human reviews what agents captured, watches source imports land, and runs synthesis interactively.
+The CLI drives the loop from the terminal; the workspace gives it oversight.
 
-It lives at the protected `/memory` route. Earlier releases called this surface the
-cockpit; it is now the workspace.
+It lives at the protected `/memory` route. Earlier releases called this surface the cockpit; it is
+now the workspace.
 
 ## What's in the Workspace
 
-| Surface       | Route                  | Purpose                                          |
-| ------------- | ---------------------- | ------------------------------------------------ |
-| **Overview**  | `/memory`              | Activity feed of recent memory writes            |
-| **Captures**  | `/memory/captures`     | Raw quick captures awaiting review or promotion  |
-| **Imports**   | `/memory/imports`      | Source import jobs and their progress            |
-| **Sources**   | `/memory/sources/[id]` | A single import source and its records           |
-| **Synthesize**| `/memory/synthesize`   | Interactive plan, draft, and verify              |
+| Surface        | Route                  | Purpose                                         |
+| -------------- | ---------------------- | ----------------------------------------------- |
+| **Overview**   | `/memory`              | Activity feed of recent memory writes           |
+| **Captures**   | `/memory/captures`     | Raw quick captures awaiting review or promotion |
+| **Imports**    | `/memory/imports`      | Source import jobs and their progress           |
+| **Sources**    | `/memory/sources/[id]` | A single import source and its records          |
+| **Synthesize** | `/memory/synthesize`   | Interactive plan, draft, and verify             |
 
 ## Activity Feed
 
-The overview shows a unified feed of memory activity across the org: what was
-remembered, what was reflected, what was imported, and what synthesis ran. It is the
-fastest way to answer "what has the team's memory been doing".
+The overview shows a unified feed of memory activity across the org: what was remembered, what was
+reflected, what was imported, and what synthesis ran. It is the fastest way to answer "what has the
+team's memory been doing".
 
 ## Captures
 
-Captures are raw, low-friction memories created with `sibyl capture` or the `remember`
-flow. The captures surface lists them so a human can:
+Captures are raw, low-friction memories created with `sibyl capture` or the `remember` flow. The
+captures surface lists them so a human can:
 
 - See what agents captured without leaving the browser
 - Promote a capture into durable typed memory
 - Discard noise before it clutters the graph
 
 This is the human half of the reflection workflow. The
-[dream-cycle](./memory-loop.md#the-reflection-dream-cycle) handles automatic review;
-the captures surface handles the judgment calls.
+[dream-cycle](./memory-loop.md#the-reflection-dream-cycle) handles automatic review; the captures
+surface handles the judgment calls.
 
 ## Imports
 
-The imports surface tracks [source import](./sources.md#source-import) jobs. Source
-import ingests structured external records, such as a mailbox archive, into raw
-memory. Because imports are resumable, the surface shows checkpoint progress and lets
-you see exactly which records landed.
+The imports surface tracks [source import](./sources.md#source-import) jobs. Source import ingests
+structured external records, such as a mailbox archive, into raw memory. Because imports are
+resumable, the surface shows checkpoint progress and lets you see exactly which records landed.
 
 ## Synthesize
 
-The synthesize surface runs [source-grounded synthesis](./synthesis.md) interactively.
-Set a goal, pick scope, and run plan, draft, and verify with the verification report
-rendered inline. It is the same engine as `sibyl synthesis`, surfaced for review
-instead of scripting.
+The synthesize surface runs [source-grounded synthesis](./synthesis.md) interactively. Set a goal,
+pick scope, and run plan, draft, and verify with the verification report rendered inline. It is the
+same engine as `sibyl synthesis`, surfaced for review instead of scripting.
 
 ## Memory Spaces
 
-Memory is scoped. A memory has a scope (`private`, `team`, `shared`, and similar) and
-the workspace respects it, so you see the memory you are authorized to see. Preview
-what an agent could recall from a given set of spaces with:
+Memory is scoped. A memory has a scope (`private`, `team`, `shared`, and similar) and the workspace
+respects it, so you see the memory you are authorized to see. Preview what an agent could recall
+from a given set of spaces with:
 
 ```bash
 sibyl memory-space preview-agent
@@ -70,9 +67,9 @@ This makes sharing boundaries explicit before you widen a scope.
 
 ## Access
 
-The `/memory` route is protected. Reaching it requires an authenticated session with
-access to the organization. Memory is org-isolated like every other Sibyl surface;
-see [Multi-Tenancy](./multi-tenancy.md).
+The `/memory` route is protected. Reaching it requires an authenticated session with access to the
+organization. Memory is org-isolated like every other Sibyl surface; see
+[Multi-Tenancy](./multi-tenancy.md).
 
 ## Next Steps
 

--- a/docs/guide/multi-tenancy.md
+++ b/docs/guide/multi-tenancy.md
@@ -201,8 +201,8 @@ sibyl task list  # Lists tasks in my-org
 
 ### Per-Command Project Override
 
-The `--context` flag and `SIBYL_CONTEXT` override the active **project** for a single
-command, not the organization. Switch organizations with `sibyl org switch`.
+The `--context` flag and `SIBYL_CONTEXT` override the active **project** for a single command, not
+the organization. Switch organizations with `sibyl org switch`.
 
 ```bash
 # Override project context for a single command

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -210,8 +210,10 @@ sibyl task list --csv
 
 Now that you have Sibyl running:
 
-1. **Learn the Memory Loop** - [The Memory Loop](./memory-loop.md) explains recall, act, remember, reflect
-2. **Read the Philosophy** - [Introduction](./index.md) explains why context should survive the session
+1. **Learn the Memory Loop** - [The Memory Loop](./memory-loop.md) explains recall, act, remember,
+   reflect
+2. **Read the Philosophy** - [Introduction](./index.md) explains why context should survive the
+   session
 3. **Understand the Graph** - [Knowledge Graph](./knowledge-graph.md) explains how entities connect
 4. **Set Up Claude** - [Claude Code Integration](./claude-code.md) for full AI agent support
 

--- a/docs/guide/semantic-search.md
+++ b/docs/guide/semantic-search.md
@@ -79,14 +79,14 @@ sibyl search "database" --type pattern,episode
 
 The `search` command keeps a small, focused flag set:
 
-| Flag           | Purpose                                  |
-| -------------- | ---------------------------------------- |
-| `--type`       | Filter by entity type (comma-separated)  |
-| `--limit`      | Maximum results (default 10)             |
+| Flag           | Purpose                                             |
+| -------------- | --------------------------------------------------- |
+| `--type`       | Filter by entity type (comma-separated)             |
+| `--limit`      | Maximum results (default 10)                        |
 | `--all`        | Search across all projects, not just the linked one |
-| `--graph-only` | Search graph memory only                 |
-| `--docs-only`  | Search crawled docs only                 |
-| `--json`       | Structured output                        |
+| `--graph-only` | Search graph memory only                            |
+| `--docs-only`  | Search crawled docs only                            |
+| `--json`       | Structured output                                   |
 
 ```bash
 # Search every project, not just the linked one
@@ -96,8 +96,8 @@ sibyl search "rate limiting" --all
 sibyl search "OAuth callback" --graph-only
 ```
 
-`search` takes a required query. To list entities by structured filters such as
-status, project, or assignee, use `sibyl task list` or `sibyl entity list` instead.
+`search` takes a required query. To list entities by structured filters such as status, project, or
+assignee, use `sibyl task list` or `sibyl entity list` instead.
 
 ```bash
 # Listing, not searching: structured filters live on task/entity list
@@ -260,8 +260,8 @@ sibyl search "authentication" --type pattern
 
 ### 4. Use the Right Tool for Listing
 
-`search` always takes a query. To enumerate entities by structured filters, use
-`task list` or `entity list`:
+`search` always takes a query. To enumerate entities by structured filters, use `task list` or
+`entity list`:
 
 ```bash
 # List all patterns
@@ -273,8 +273,8 @@ sibyl task list --status todo --project proj_abc
 
 ## Document Search
 
-Sibyl can also search crawled documentation. By default a search covers both graph
-memory and crawled docs; narrow it with `--docs-only` or `--graph-only`:
+Sibyl can also search crawled documentation. By default a search covers both graph memory and
+crawled docs; narrow it with `--docs-only` or `--graph-only`:
 
 ```bash
 # Docs only
@@ -284,9 +284,8 @@ sibyl search "Next.js middleware" --docs-only
 sibyl search "OAuth callback" --graph-only
 ```
 
-Document search uses the same hybrid approach over Surreal-backed document chunks. The
-MCP `search` tool exposes finer filters such as `source_name` for narrowing to a
-single crawled source.
+Document search uses the same hybrid approach over Surreal-backed document chunks. The MCP `search`
+tool exposes finer filters such as `source_name` for narrowing to a single crawled source.
 
 ## Understanding Results
 

--- a/docs/guide/setting-up-prompts.md
+++ b/docs/guide/setting-up-prompts.md
@@ -165,8 +165,7 @@ Use consistent response format from `src/lib/responses.ts`.
 
 ### A Real Project CLAUDE.md
 
-Here's how a project that uses Sibyl as its own knowledge repository sets up its
-`CLAUDE.md`:
+Here's how a project that uses Sibyl as its own knowledge repository sets up its `CLAUDE.md`:
 
 ```markdown
 # Sibyl Development Guide

--- a/docs/guide/sources.md
+++ b/docs/guide/sources.md
@@ -153,8 +153,7 @@ sibyl search "useState" --docs-only
 sibyl search "useState" --graph-only
 ```
 
-To narrow a search to one crawled source by name, use the MCP `search` tool's
-`source_name` filter.
+To narrow a search to one crawled source by name, use the MCP `search` tool's `source_name` filter.
 
 ### Search Result Types
 
@@ -246,23 +245,21 @@ sibyl crawl link-status
 
 ## Source Import
 
-Crawling pulls documentation from the web. **Source import** is the other ingestion
-path: it brings structured external records into raw memory through an adapter.
+Crawling pulls documentation from the web. **Source import** is the other ingestion path: it brings
+structured external records into raw memory through an adapter.
 
-The first shipped adapter is the **mailbox adapter**, which ingests an mbox archive.
-Each message becomes a source record with its headers, body, and attachments captured
-and privacy-classified. Other adapters follow the same contract.
+The first shipped adapter is the **mailbox adapter**, which ingests an mbox archive. Each message
+becomes a source record with its headers, body, and attachments captured and privacy-classified.
+Other adapters follow the same contract.
 
-Source import jobs are **resumable**. Each job checkpoints its progress, so a large
-archive can be ingested across multiple runs without re-processing records that
-already landed.
+Source import jobs are **resumable**. Each job checkpoints its progress, so a large archive can be
+ingested across multiple runs without re-processing records that already landed.
 
-The [memory workspace](./memory-workspace.md) tracks import jobs at `/memory/imports`,
-showing checkpoint progress and the records each source produced. Imported records are
-raw memory, scoped like every other memory and ready for reflection and recall.
+The [memory workspace](./memory-workspace.md) tracks import jobs at `/memory/imports`, showing
+checkpoint progress and the records each source produced. Imported records are raw memory, scoped
+like every other memory and ready for reflection and recall.
 
-Configure where importable archives live with the `SIBYL_SOURCE_IMPORT_DIR`
-environment variable.
+Configure where importable archives live with the `SIBYL_SOURCE_IMPORT_DIR` environment variable.
 
 ## Best Practices
 

--- a/docs/guide/synthesis.md
+++ b/docs/guide/synthesis.md
@@ -5,31 +5,31 @@ description: Draft verified documents from your own remembered memory
 
 # Source-Grounded Synthesis 🧪
 
-Synthesis turns the memory you have already captured into a finished artifact:
-documentation, a decision record, a runbook, a summary. Unlike asking a model to
-write from nothing, every synthesis artifact is grounded in your authorized memory
-and carries citations, freshness checks, and gap coverage.
+Synthesis turns the memory you have already captured into a finished artifact: documentation, a
+decision record, a runbook, a summary. Unlike asking a model to write from nothing, every synthesis
+artifact is grounded in your authorized memory and carries citations, freshness checks, and gap
+coverage.
 
-The point is trust. A synthesized document is only as good as the memory behind it,
-so Sibyl makes that link explicit and checkable.
+The point is trust. A synthesized document is only as good as the memory behind it, so Sibyl makes
+that link explicit and checkable.
 
 ## The Three Stages
 
 Synthesis runs in three stages, each available as a CLI command and an MCP tool.
 
-| Stage      | CLI                     | MCP tool           | What it produces                          |
-| ---------- | ----------------------- | ------------------ | ------------------------------------------ |
-| **Plan**   | `sibyl synthesis plan`  | `synthesis_plan`   | A section outline grounded in memory       |
-| **Draft**  | `sibyl synthesis draft` | `synthesis_draft`  | A drafted, verified artifact               |
-| **Verify** | `sibyl synthesis verify`| `synthesis_verify` | Citation, freshness, redaction, gap report |
+| Stage      | CLI                      | MCP tool           | What it produces                           |
+| ---------- | ------------------------ | ------------------ | ------------------------------------------ |
+| **Plan**   | `sibyl synthesis plan`   | `synthesis_plan`   | A section outline grounded in memory       |
+| **Draft**  | `sibyl synthesis draft`  | `synthesis_draft`  | A drafted, verified artifact               |
+| **Verify** | `sibyl synthesis verify` | `synthesis_verify` | Citation, freshness, redaction, gap report |
 
-`sibyl synthesis remember` runs draft, verify, and remember in one step, persisting
-the verified artifact back into memory.
+`sibyl synthesis remember` runs draft, verify, and remember in one step, persisting the verified
+artifact back into memory.
 
 ## Plan
 
-Planning compiles the relevant memory and proposes a section outline before any prose
-is written. It is the cheap, fast way to see what the synthesis will be built from.
+Planning compiles the relevant memory and proposes a section outline before any prose is written. It
+is the cheap, fast way to see what the synthesis will be built from.
 
 ```bash
 sibyl synthesis plan "How our auth system handles token refresh"
@@ -40,8 +40,8 @@ sibyl synthesis plan "Onboarding guide for the payments service" \
   --depth deep
 ```
 
-The plan shows which entities, decisions, tasks, and artifacts were pulled in. If the
-plan looks thin, capture more memory before drafting.
+The plan shows which entities, decisions, tasks, and artifacts were pulled in. If the plan looks
+thin, capture more memory before drafting.
 
 ## Draft
 
@@ -56,22 +56,22 @@ sibyl synthesis draft "Release runbook for sibyld" --format json
 
 Useful flags across the synthesis commands:
 
-| Flag             | Purpose                                                     |
-| ---------------- | ----------------------------------------------------------- |
-| `--type`         | Output type (default `documentation`)                       |
-| `--audience`     | Intended reader                                             |
-| `--depth`        | `brief`, `standard`, or `deep`                              |
-| `--seed`         | Search seed query to focus memory retrieval                 |
-| `--project`      | Scope source memory to a project                            |
-| `--entity`       | Comma-separated entity IDs to ground on explicitly          |
-| `--decision`     | Comma-separated decision IDs to ground on                   |
-| `--section`      | Pipe-separated `Title::Prompt::spec` section overrides      |
-| `--max-sections` | Section cap (1-12, default 6)                               |
+| Flag             | Purpose                                                |
+| ---------------- | ------------------------------------------------------ |
+| `--type`         | Output type (default `documentation`)                  |
+| `--audience`     | Intended reader                                        |
+| `--depth`        | `brief`, `standard`, or `deep`                         |
+| `--seed`         | Search seed query to focus memory retrieval            |
+| `--project`      | Scope source memory to a project                       |
+| `--entity`       | Comma-separated entity IDs to ground on explicitly     |
+| `--decision`     | Comma-separated decision IDs to ground on              |
+| `--section`      | Pipe-separated `Title::Prompt::spec` section overrides |
+| `--max-sections` | Section cap (1-12, default 6)                          |
 
 ## Verify
 
-Verification is the trust gate. It checks the drafted artifact against the memory it
-claims to be built from.
+Verification is the trust gate. It checks the drafted artifact against the memory it claims to be
+built from.
 
 ```bash
 sibyl synthesis verify "How our auth system handles token refresh"
@@ -84,13 +84,13 @@ Verification covers four things:
 - **Redaction:** hidden-context and private material did not leak into the artifact.
 - **Gap coverage:** the artifact does not silently skip parts of the goal.
 
-A failing verification means the draft is not safe to ship as-is. Capture missing
-memory or narrow the goal, then re-run.
+A failing verification means the draft is not safe to ship as-is. Capture missing memory or narrow
+the goal, then re-run.
 
 ## Remember
 
-When a verified artifact is worth keeping, `synthesis remember` drafts, verifies, and
-persists it as a memory in one command.
+When a verified artifact is worth keeping, `synthesis remember` drafts, verifies, and persists it as
+a memory in one command.
 
 ```bash
 sibyl synthesis remember "Auth token refresh design" \
@@ -98,14 +98,14 @@ sibyl synthesis remember "Auth token refresh design" \
   --scope team --scope-key proj_auth
 ```
 
-The artifact becomes a first-class memory. Later recall and further synthesis can
-cite it, so synthesis output compounds like any other captured knowledge.
+The artifact becomes a first-class memory. Later recall and further synthesis can cite it, so
+synthesis output compounds like any other captured knowledge.
 
 ## Synthesis in the Web UI
 
-The [memory workspace](./memory-workspace.md) includes a synthesize surface at
-`/memory/synthesize` for running the same plan, draft, and verify stages
-interactively, with the verification report rendered for review.
+The [memory workspace](./memory-workspace.md) includes a synthesize surface at `/memory/synthesize`
+for running the same plan, draft, and verify stages interactively, with the verification report
+rendered for review.
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ hero:
   name: Sibyl
   text: Durable Project Memory
   tagline:
-    Stop rediscovering the same solutions every session. Sibyl gives your projects a
-    knowledge graph, an agent memory loop, semantic search, and durable task context.
+    Stop rediscovering the same solutions every session. Sibyl gives your projects a knowledge
+    graph, an agent memory loop, semantic search, and durable task context.
   actions:
     - theme: brand
       text: Get Started
@@ -19,46 +19,44 @@ features:
   - icon: 🔮
     title: Memory That Sticks
     details:
-      Knowledge survives across sessions. Patterns, decisions, gotchas, and hard-won
-      lessons stay searchable in a SurrealDB-native knowledge graph.
+      Knowledge survives across sessions. Patterns, decisions, gotchas, and hard-won lessons stay
+      searchable in a SurrealDB-native knowledge graph.
   - icon: 🪄
     title: The Memory Loop
     details:
-      Recall context before you act, remember what you learn, and reflect raw notes
-      into durable memory. Built into the CLI, MCP, and hooks.
+      Recall context before you act, remember what you learn, and reflect raw notes into durable
+      memory. Built into the CLI, MCP, and hooks.
   - icon: 🎯
     title: Project-Centric Tasks
     details:
-      Track work across sessions. Full lifecycle from backlog to completion, with
-      learnings captured along the way.
+      Track work across sessions. Full lifecycle from backlog to completion, with learnings captured
+      along the way.
   - icon: ⚡
     title: Find by Meaning
     details:
-      Semantic search finds knowledge by intent, not keywords. Ask "how do I handle
-      auth?" and surface the relevant patterns instantly.
+      Semantic search finds knowledge by intent, not keywords. Ask "how do I handle auth?" and
+      surface the relevant patterns instantly.
   - icon: 🧪
     title: Source-Grounded Synthesis
     details:
-      Draft verified documents from your own memory, with citation, freshness, and
-      gap checks built in.
+      Draft verified documents from your own memory, with citation, freshness, and gap checks built
+      in.
   - icon: 🌊
     title: Ingest External Sources
     details:
-      Crawl documentation sites and import sources into the same graph as your own
-      project knowledge.
+      Crawl documentation sites and import sources into the same graph as your own project
+      knowledge.
 ---
 
 ## The Problem
 
-Every time you start a new coding session, critical context slips away. That OAuth
-gotcha you debugged for two hours? Gone. The pattern that finally made your tests
-pass? Vanished. The configuration quirk that took forever to figure out? Lost to the
-void.
+Every time you start a new coding session, critical context slips away. That OAuth gotcha you
+debugged for two hours? Gone. The pattern that finally made your tests pass? Vanished. The
+configuration quirk that took forever to figure out? Lost to the void.
 
 ## The Solution
 
-Sibyl is a **knowledge graph, agent memory loop, and task workflow** that gives your
-team:
+Sibyl is a **knowledge graph, agent memory loop, and task workflow** that gives your team:
 
 - **Memory:** Store patterns, decisions, and solutions that persist across sessions
 - **The Memory Loop:** `recall → act → remember → reflect`, built into every surface
@@ -114,8 +112,8 @@ sibyl task start task_xyz
 sibyl task complete task_xyz --learnings "OAuth tokens need refresh..."
 ```
 
-**Hooks** automatically inject relevant knowledge into every prompt so useful context
-shows up before you have to go looking for it.
+**Hooks** automatically inject relevant knowledge into every prompt so useful context shows up
+before you have to go looking for it.
 
 ### For Humans: Web UI + CLI
 
@@ -175,18 +173,18 @@ Sibyl is built around a durable cycle that both humans and agents follow:
 └─────────────────────────────────────────────────────┘
 ```
 
-Every completed task makes your knowledge graph smarter. Every pattern discovered
-helps future sessions move faster. **The system learns as you work.**
+Every completed task makes your knowledge graph smarter. Every pattern discovered helps future
+sessions move faster. **The system learns as you work.**
 
 ## Why Sibyl?
 
-| Without Sibyl                    | With Sibyl                              |
-| -------------------------------- | --------------------------------------- |
+| Without Sibyl                    | With Sibyl                                |
+| -------------------------------- | ----------------------------------------- |
 | Agent rediscovers same solutions | Agent recalls existing patterns instantly |
-| Context lost between sessions    | Knowledge persists in a graph           |
-| Manual prompting required        | Hooks inject context automatically      |
-| No task tracking                 | Full lifecycle with learnings capture   |
-| Scattered documentation          | Searchable, connected knowledge graph   |
+| Context lost between sessions    | Knowledge persists in a graph             |
+| Manual prompting required        | Hooks inject context automatically        |
+| No task tracking                 | Full lifecycle with learnings capture     |
+| Scattered documentation          | Searchable, connected knowledge graph     |
 
 ## Get Started
 

--- a/docs/testing/PERMISSION_TEST_STRATEGY.md
+++ b/docs/testing/PERMISSION_TEST_STRATEGY.md
@@ -4,8 +4,8 @@ Testing strategy for Sibyl's multi-tier permission system.
 
 ## Permission Tiers Overview
 
-Sibyl scopes access at three levels: organization, project, and memory. Org and project each have
-an ordered role enum; project visibility controls who can see a project at all.
+Sibyl scopes access at three levels: organization, project, and memory. Org and project each have an
+ordered role enum; project visibility controls who can see a project at all.
 
 ```
 Organization role (sibyl_core.auth.OrganizationRole)
@@ -40,23 +40,23 @@ filter:
 moon run api:test -- -k auth
 ```
 
-| File                                  | Focus                                              |
-| ------------------------------------- | -------------------------------------------------- |
-| `test_auth_authorization.py`          | Project-role hierarchy and `require_project_*`      |
-| `test_auth_context.py`                | `AuthContext` construction and role resolution      |
-| `test_auth_dependencies.py`           | FastAPI auth dependencies and guards                |
-| `test_auth_tenancy.py`                | Org isolation and namespace-per-org scoping         |
-| `test_auth_rls.py`                    | Row-level access enforcement                        |
-| `test_auth_api_keys.py`               | API key issue/verify lifecycle                      |
-| `test_auth_api_key_scopes_rest.py`    | API-key scope enforcement on REST endpoints         |
-| `test_auth_jwt.py`                    | JWT issue, verify, and expiry                       |
-| `test_auth_mcp_token_verifier.py`     | MCP bearer-token verification                       |
-| `test_auth_invitation_token.py`       | Org invitation token boundaries                     |
-| `test_auth_signup_locks.py`           | Signup race and lock handling                       |
-| `test_auth_session_cache.py`          | Session cache behavior and invalidation             |
-| `test_auth_errors.py`                 | Auth error mapping and safe responses               |
-| `test_auth_http.py`                   | End-to-end auth over the HTTP app                   |
-| `test_auth_flow_replay.py`            | Recorded auth-flow replay checks                    |
+| File                               | Focus                                          |
+| ---------------------------------- | ---------------------------------------------- |
+| `test_auth_authorization.py`       | Project-role hierarchy and `require_project_*` |
+| `test_auth_context.py`             | `AuthContext` construction and role resolution |
+| `test_auth_dependencies.py`        | FastAPI auth dependencies and guards           |
+| `test_auth_tenancy.py`             | Org isolation and namespace-per-org scoping    |
+| `test_auth_rls.py`                 | Row-level access enforcement                   |
+| `test_auth_api_keys.py`            | API key issue/verify lifecycle                 |
+| `test_auth_api_key_scopes_rest.py` | API-key scope enforcement on REST endpoints    |
+| `test_auth_jwt.py`                 | JWT issue, verify, and expiry                  |
+| `test_auth_mcp_token_verifier.py`  | MCP bearer-token verification                  |
+| `test_auth_invitation_token.py`    | Org invitation token boundaries                |
+| `test_auth_signup_locks.py`        | Signup race and lock handling                  |
+| `test_auth_session_cache.py`       | Session cache behavior and invalidation        |
+| `test_auth_errors.py`              | Auth error mapping and safe responses          |
+| `test_auth_http.py`                | End-to-end auth over the HTTP app              |
+| `test_auth_flow_replay.py`         | Recorded auth-flow replay checks               |
 
 ## Test Categories
 
@@ -66,8 +66,7 @@ moon run api:test -- -k auth
 
 - `PROJECT_ROLE_LEVELS` ordering (`viewer < contributor < maintainer < owner`)
 - `_max_role` resolution across multiple grants
-- `require_project_read`, `require_project_write`, `require_project_admin`,
-  `require_project_role`
+- `require_project_read`, `require_project_write`, `require_project_admin`, `require_project_role`
 - `list_accessible_project_graph_ids` for visibility-filtered listing
 
 Example:
@@ -86,19 +85,19 @@ moon run api:test -- tests/test_auth_authorization.py
 
 ### 2. Organization Role Enforcement
 
-Org-role checks run through `AuthContext`. `test_auth_context.py` exercises context construction
-and role resolution; `test_auth_dependencies.py` covers the FastAPI guards that gate endpoints.
+Org-role checks run through `AuthContext`. `test_auth_context.py` exercises context construction and
+role resolution; `test_auth_dependencies.py` covers the FastAPI guards that gate endpoints.
 
 Owner-only operations include deleting the org, transferring ownership, and managing invitations.
 Admins manage members and roles but cannot delete the org.
 
-| Operation               | Owner | Admin | Member | Viewer |
-| ----------------------- | ----- | ----- | ------ | ------ |
-| Delete organization     | yes   | no    | no     | no     |
-| Transfer ownership      | yes   | no    | no     | no     |
-| Add/remove members      | yes   | yes   | no     | no     |
-| Create tasks/knowledge  | yes   | yes   | yes    | no     |
-| Read tasks/knowledge    | yes   | yes   | yes    | yes    |
+| Operation              | Owner | Admin | Member | Viewer |
+| ---------------------- | ----- | ----- | ------ | ------ |
+| Delete organization    | yes   | no    | no     | no     |
+| Transfer ownership     | yes   | no    | no     | no     |
+| Add/remove members     | yes   | yes   | no     | no     |
+| Create tasks/knowledge | yes   | yes   | yes    | no     |
+| Read tasks/knowledge   | yes   | yes   | yes    | yes    |
 
 Run:
 
@@ -127,8 +126,8 @@ moon run api:test -- tests/test_auth_tenancy.py tests/test_auth_rls.py
 ### 4. API Key Scopes
 
 `test_auth_api_keys.py` covers the key lifecycle; `test_auth_api_key_scopes_rest.py` asserts scope
-enforcement on REST endpoints. Scopes include `mcp`, `api:read`, `api:write`, and the memory
-scopes. A read-scoped key must be rejected on write endpoints.
+enforcement on REST endpoints. Scopes include `mcp`, `api:read`, `api:write`, and the memory scopes.
+A read-scoped key must be rejected on write endpoints.
 
 Run:
 

--- a/docs/testing/benchmark-methodology.md
+++ b/docs/testing/benchmark-methodology.md
@@ -220,8 +220,8 @@ Required record fields:
 `moon run bench-gate -- <artifact>.json --profile ai-memory` for a single uncommitted artifact.
 
 The canonical ledger for which rows are citable is
-`docs/_archive/SURREALDB_GRAPHITI_EXIT_BENCHMARK_EVIDENCE.md`. If a benchmark suite is missing
-from that ledger, add it there before citing the result anywhere else.
+`docs/_archive/SURREALDB_GRAPHITI_EXIT_BENCHMARK_EVIDENCE.md`. If a benchmark suite is missing from
+that ledger, add it there before citing the result anywhere else.
 
 ## Suggested PR Notes
 

--- a/packages/python/sibyl-core/tests/test_graph_entities.py
+++ b/packages/python/sibyl-core/tests/test_graph_entities.py
@@ -1,7 +1,7 @@
 """Tests for sibyl-core graph/entities.py EntityManager."""
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1175,117 +1175,6 @@ class TestEntityListByType:
         second_query = surreal_entity_manager._driver.execute_query.await_args_list[1].args[0]
         assert "project_id = $project_id" in first_query
         assert "project_id = $project_id" not in second_query
-
-    @pytest.mark.asyncio
-    async def test_list_by_type_episode_reads_surreal_episode_table(
-        self,
-        surreal_entity_manager: EntityManager,
-    ) -> None:
-        created_at = datetime.now(UTC)
-        surreal_entity_manager._driver.execute_query = AsyncMock(
-            side_effect=[
-                [
-                    {
-                        "uuid": "episode-001",
-                        "name": "Baseline Corpus Episode",
-                        "group_id": "test-org-123",
-                        "content": "Runtime baseline seed.",
-                        "source_description": "Baseline",
-                        "created_at": created_at,
-                    }
-                ],
-                [],
-            ]
-        )
-
-        results = await surreal_entity_manager.list_by_type(EntityType.EPISODE)
-
-        assert len(results) == 1
-        assert results[0].id == "episode-001"
-        assert results[0].name == "Baseline Corpus Episode"
-        assert results[0].entity_type == EntityType.EPISODE
-        episode_query = surreal_entity_manager._driver.execute_query.await_args_list[0].args[0]
-        legacy_query = surreal_entity_manager._driver.execute_query.await_args_list[1].args[0]
-        assert "FROM episode" in episode_query
-        assert "FROM entity" in legacy_query
-        assert "entity_type = $entity_type" in legacy_query
-
-    @pytest.mark.asyncio
-    async def test_list_by_type_episode_includes_legacy_entity_table_rows(
-        self,
-        surreal_entity_manager: EntityManager,
-    ) -> None:
-        created_at = datetime.now(UTC)
-        surreal_entity_manager._driver.execute_query = AsyncMock(
-            side_effect=[
-                [],
-                [
-                    {
-                        "uuid": "episode-legacy",
-                        "name": "Baseline Corpus Episode",
-                        "entity_type": "episode",
-                        "group_id": "test-org-123",
-                        "summary": "Baseline",
-                        "description": "Baseline",
-                        "content": "Runtime baseline seed.",
-                        "metadata": json.dumps({"tags": ["baseline-corpus"]}),
-                        "created_at": created_at,
-                        "updated_at": created_at,
-                    }
-                ],
-            ]
-        )
-
-        results = await surreal_entity_manager.list_by_type(EntityType.EPISODE)
-
-        assert len(results) == 1
-        assert results[0].id == "episode-legacy"
-        assert results[0].name == "Baseline Corpus Episode"
-        assert results[0].entity_type == EntityType.EPISODE
-
-    @pytest.mark.asyncio
-    async def test_list_by_type_episode_paginates_native_rows_before_slice(
-        self,
-        surreal_entity_manager: EntityManager,
-    ) -> None:
-        base_time = datetime.now(UTC)
-        first_page = [
-            {
-                "uuid": f"episode-{index:04d}",
-                "name": f"Episode {index}",
-                "group_id": "test-org-123",
-                "content": f"Episode {index}",
-                "source_description": "Baseline",
-                "created_at": base_time - timedelta(seconds=index),
-            }
-            for index in range(1000)
-        ]
-        second_page = [
-            {
-                "uuid": "episode-1000",
-                "name": "Episode 1000",
-                "group_id": "test-org-123",
-                "content": "Episode 1000",
-                "source_description": "Baseline",
-                "created_at": base_time - timedelta(seconds=1000),
-            }
-        ]
-        surreal_entity_manager._driver.execute_query = AsyncMock(
-            side_effect=[first_page, second_page, []]
-        )
-
-        results = await surreal_entity_manager.list_by_type(
-            EntityType.EPISODE,
-            limit=1,
-            offset=1000,
-            include_archived=True,
-        )
-
-        assert [entity.id for entity in results] == ["episode-1000"]
-        calls = surreal_entity_manager._driver.execute_query.await_args_list
-        assert calls[0].kwargs["query_offset"] == 0
-        assert calls[1].kwargs["query_offset"] == 1000
-        assert calls[2].kwargs["query_offset"] == 0
 
     @pytest.mark.asyncio
     async def test_list_by_type_refuses_surreal_legacy_fallback(


### PR DESCRIPTION
## Summary
Three failures were breaking CI on `main`, in a masking cascade:

1. **E2E** — backend ran with `SIBYL_ENVIRONMENT=production` + `root/root` Surreal credentials, which PR #28's validator now rejects, so the backend never started. Switched the E2E and nightly-regression jobs to non-default credentials.
2. **Package Tests** — three `TestEntityListByType` tests still asserted the episode-table listing path that PR #35 removed. Deleted them (`list_by_type(EPISODE)` now uses the shared select path; episodes are retrieved via scoped native recall).
3. **Static Checks** — `docs:lint` (`prettier --check`) failed on 56 docs files. This was masked behind `infra:lint` until #44 fixed that. Applied `prettier --write`.

E2E already verified green on the credential fix in an earlier run of this PR.

## Test plan
- [x] `moon run core:test` → 1013 passed
- [x] `moon run core:lint`, `moon run docs:lint`, `moon run infra:lint` pass
- [ ] Full CI run green (E2E, Package Tests, Static Checks, Build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity and readability across API reference, CLI command documentation, and deployment guides through consistent formatting and restructuring.
  * Enhanced descriptions of authentication mechanisms, authorization controls, and role-based access restrictions.
  * Clarified memory scope behavior, API key binding restrictions, and MCP tool registration details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->