### PR TITLE
style(ci): format deployment docs and Ansible task

### DIFF
--- a/docs/deployment/ansible.md
+++ b/docs/deployment/ansible.md
@@ -1,36 +1,34 @@
 # Single-Host Deployment (Ansible)
 
-Deploy the full Sibyl stack to one Linux host with the bundled Ansible
-role. Suited to a personal instance on a small cloud VM: one box, no
-Kubernetes, modest cost.
+Deploy the full Sibyl stack to one Linux host with the bundled Ansible role. Suited to a personal
+instance on a small cloud VM: one box, no Kubernetes, modest cost.
 
 ## Architecture
 
 Four containers, managed by a `sibyl.service` systemd unit:
 
-| Container   | Source                                            | Purpose                        |
-| ----------- | ------------------------------------------------- | ------------------------------ |
-| `surrealdb` | `surrealdb/surrealdb:v3.0.5`                      | Graph, content, and auth store |
-| `backend`   | `ghcr.io/hyperb1iss/sibyl-api`                    | FastAPI + MCP server           |
-| `frontend`  | `ghcr.io/hyperb1iss/sibyl-web`                    | Next.js web UI                 |
-| `caddy`     | built from `caddy:2` with the Cloudflare DNS module | TLS + path routing           |
+| Container   | Source                                              | Purpose                        |
+| ----------- | --------------------------------------------------- | ------------------------------ |
+| `surrealdb` | `surrealdb/surrealdb:v3.0.5`                        | Graph, content, and auth store |
+| `backend`   | `ghcr.io/hyperb1iss/sibyl-api`                      | FastAPI + MCP server           |
+| `frontend`  | `ghcr.io/hyperb1iss/sibyl-web`                      | Next.js web UI                 |
+| `caddy`     | built from `caddy:2` with the Cloudflare DNS module | TLS + path routing             |
 
-Caddy obtains a Let's Encrypt certificate over the Cloudflare DNS-01
-challenge, so the host needs no inbound HTTP or HTTPS from the public
-internet. Pair it with a private network (Tailscale, WireGuard) and the
-instance stays unreachable except to you, while still serving a
-browser-trusted certificate on a real domain.
+Caddy obtains a Let's Encrypt certificate over the Cloudflare DNS-01 challenge, so the host needs no
+inbound HTTP or HTTPS from the public internet. Pair it with a private network (Tailscale,
+WireGuard) and the instance stays unreachable except to you, while still serving a browser-trusted
+certificate on a real domain.
 
-The `backend` and `frontend` images are pulled pre-built from the
-registry, so nothing heavy compiles on the host.
+The `backend` and `frontend` images are pulled pre-built from the registry, so nothing heavy
+compiles on the host.
 
 ## The `sibyl` role
 
 `infra/ansible/roles/sibyl/` provisions a host end to end:
 
 - installs Docker Engine and the Compose plugin
-- installs `ufw`: default-deny inbound, SSH allowed, HTTP and HTTPS
-  reachable only on the proxy interface
+- installs `ufw`: default-deny inbound, SSH allowed, HTTP and HTTPS reachable only on the proxy
+  interface
 - deploys the compose stack and a rendered `.env`
 - runs the stack through a `sibyl.service` systemd unit
 
@@ -44,32 +42,29 @@ registry, so nothing heavy compiles on the host.
 | `sibyl_proxy_interface` | `tailscale0`            | Interface HTTP/HTTPS is exposed on |
 | `sibyl_mcp_auth_mode`   | `on`                    | MCP bearer-token enforcement       |
 
-Secrets have no defaults and must be supplied, ideally through
-ansible-vault: `sibyl_jwt_secret`, `sibyl_surreal_password`,
-`sibyl_openai_api_key`, `sibyl_anthropic_api_key`, `sibyl_cf_api_token`.
+Secrets have no defaults and must be supplied, ideally through ansible-vault: `sibyl_jwt_secret`,
+`sibyl_surreal_password`, `sibyl_openai_api_key`, `sibyl_anthropic_api_key`, `sibyl_cf_api_token`.
 The role asserts each one is set before doing any work.
 
 ## Deploying
 
-The role is provider-agnostic: any Ubuntu host reachable over SSH
-works.
+The role is provider-agnostic: any Ubuntu host reachable over SSH works.
 
 ### Prerequisites
 
-The role is not published to Ansible Galaxy, so two things must be in
-place before the playbook runs end to end:
+The role is not published to Ansible Galaxy, so two things must be in place before the playbook runs
+end to end:
 
-- **`roles_path`** — your playbook has to resolve the `sibyl` role from
-  a checkout of this repository. Point `ansible.cfg` at it:
+- **`roles_path`** — your playbook has to resolve the `sibyl` role from a checkout of this
+  repository. Point `ansible.cfg` at it:
 
   ```ini
   [defaults]
   roles_path = roles:/path/to/sibyl/infra/ansible/roles
   ```
 
-- **Secrets** — the five vault variables listed under
-  [Variables](#variables) have no defaults. The role asserts each one
-  before it touches the host, so an unset secret aborts the run cleanly
+- **Secrets** — the five vault variables listed under [Variables](#variables) have no defaults. The
+  role asserts each one before it touches the host, so an unset secret aborts the run cleanly
   instead of leaving a half-built stack.
 
 ### 1. Inventory
@@ -86,14 +81,12 @@ cloud:
 
 ### 2. Bootstrap (once)
 
-A fresh cloud host usually permits only `root`. Run a one-time play
-that creates your admin user and authorizes its SSH key, so later runs
-connect as that user and host hardening can disable root SSH.
+A fresh cloud host usually permits only `root`. Run a one-time play that creates your admin user and
+authorizes its SSH key, so later runs connect as that user and host hardening can disable root SSH.
 
 ### 3. Provision
 
-Apply the role, alongside a base-hardening role and optionally a
-Tailscale role, from your playbook:
+Apply the role, alongside a base-hardening role and optionally a Tailscale role, from your playbook:
 
 ```bash
 ansible-playbook site.yml --limit my-host
@@ -114,11 +107,11 @@ curl -sf https://<sibyl_domain>/api/health
 
 - **Logs:** `docker compose -f /opt/sibyl/docker-compose.yml logs -f`
 - **Update:** bump `sibyl_version` and re-run the role
-- **Backups:** schedule `surreal export` against the running stack and
-  copy the dump off-host. The graph is your memory; back it up.
+- **Backups:** schedule `surreal export` against the running stack and copy the dump off-host. The
+  graph is your memory; back it up.
 
 ## Reference
 
-This project is deployed from a separate homelab Ansible repository
-that supplies the inventory, the bootstrap play, ansible-vault secrets,
-and a Tailscale role. It is a worked example of the layout above.
+This project is deployed from a separate homelab Ansible repository that supplies the inventory, the
+bootstrap play, ansible-vault secrets, and a Tailscale role. It is a worked example of the layout
+above.

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -100,16 +100,16 @@ by the default runtime. See [storage-modes.md](../guide/storage-modes.md) and
 
 ## Quick Comparison
 
-| Feature               | Docker Compose | Tilt/Minikube | Production K8s | Single Host  |
-| --------------------- | -------------- | ------------- | -------------- | ------------ |
-| Setup time            | 1 minute       | 5-10 minutes  | Varies         | ~10 minutes  |
-| Hot reload            | Yes            | Yes           | No             | No           |
-| Kong Gateway          | No             | Yes           | Yes            | No           |
-| TLS                   | No             | Yes (Caddy)   | Yes            | Yes (Caddy)  |
-| Autoscaling           | No             | No            | Yes (HPA)      | No           |
-| Multi-replica         | No             | Yes           | Yes            | No           |
-| Resource requirements | Low            | Medium        | High           | Low          |
-| Production-like       | No             | Mostly        | Yes            | Mostly       |
+| Feature               | Docker Compose | Tilt/Minikube | Production K8s | Single Host |
+| --------------------- | -------------- | ------------- | -------------- | ----------- |
+| Setup time            | 1 minute       | 5-10 minutes  | Varies         | ~10 minutes |
+| Hot reload            | Yes            | Yes           | No             | No          |
+| Kong Gateway          | No             | Yes           | Yes            | No          |
+| TLS                   | No             | Yes (Caddy)   | Yes            | Yes (Caddy) |
+| Autoscaling           | No             | No            | Yes (HPA)      | No          |
+| Multi-replica         | No             | Yes           | Yes            | No          |
+| Resource requirements | Low            | Medium        | High           | Low         |
+| Production-like       | No             | Mostly        | Yes            | Mostly      |
 
 ## Port Mappings by Environment
 

--- a/infra/ansible/roles/sibyl/tasks/main.yml
+++ b/infra/ansible/roles/sibyl/tasks/main.yml
@@ -9,9 +9,8 @@
       - sibyl_cf_api_token | default('') | length > 0
     quiet: true
     fail_msg: >-
-      The sibyl role needs sibyl_surreal_password, sibyl_jwt_secret,
-      sibyl_openai_api_key, sibyl_anthropic_api_key and sibyl_cf_api_token.
-      Supply them through vault-backed variables.
+      The sibyl role needs sibyl_surreal_password, sibyl_jwt_secret, sibyl_openai_api_key,
+      sibyl_anthropic_api_key and sibyl_cf_api_token. Supply them through vault-backed variables.
 
 # ─── Docker engine ─────────────────────────────────────────────────────────────
 - name: Create the apt keyring directory


### PR DESCRIPTION
## Summary
- format the Ansible role task file flagged by Static Checks
- format the two deployment docs that the broader lint gate also flagged

## Verification
- CI=true moon run infra:lint -> All matched files use Prettier code style!
- CI=true moon run :lint -> Tasks: 12 completed (10 cached)
- independent Claude review -> PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting consistency across deployment documentation for better readability.

* **Style**
  * Enhanced error messaging in deployment configuration to explicitly list required secrets for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->