### PR TITLE
fix(api): redact source import websocket status payload

### DIFF
--- a/apps/api/src/sibyl/jobs/source_imports.py
+++ b/apps/api/src/sibyl/jobs/source_imports.py
@@ -117,7 +117,15 @@ def _store_run(run: SourceImportRun) -> None:
 
 
 def _source_import_event_payload(run: SourceImportRun) -> dict[str, Any]:
-    payload = run.status_payload()
+    status_payload = run.status_payload()
+    payload = {
+        "import_id": status_payload["import_id"],
+        "status": status_payload["status"],
+        "progress": status_payload["progress"],
+        "created_at": status_payload["created_at"],
+        "updated_at": status_payload["updated_at"],
+        "completed_at": status_payload["completed_at"],
+    }
     for field_name in ("created_at", "updated_at", "completed_at"):
         value = payload.get(field_name)
         if isinstance(value, datetime):

--- a/apps/api/tests/test_jobs_source_imports.py
+++ b/apps/api/tests/test_jobs_source_imports.py
@@ -282,6 +282,14 @@ def test_source_import_event_payload_is_json_ready(tmp_path: Path) -> None:
     assert payload["import_id"] == "source_import:test"
     assert isinstance(payload["created_at"], str)
     assert isinstance(payload["updated_at"], str)
+    assert set(payload) == {
+        "import_id",
+        "status",
+        "progress",
+        "created_at",
+        "updated_at",
+        "completed_at",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Prevent leaking private per-principal source import metadata over organization-scoped WebSocket broadcasts by avoiding publishing the full `SourceImportRun.status_payload()` to every connection in the same org.

### Description
- Replace the event payload producer with a minimal progress envelope in `_source_import_event_payload()` that only includes `import_id`, `status`, `progress`, and the `created_at`/`updated_at`/`completed_at` timestamps (ISO-serialized) instead of the full `status_payload()` in `apps/api/src/sibyl/jobs/source_imports.py`.
- Keep the existing `_safe_broadcast_source_import()` behavior and event type (`WSEvent.SOURCE_IMPORT_UPDATED`) and org-scoping while removing sensitive fields such as `source_identity`, `raw_memory_ids`, `skipped_records`, `dedupe_keys`, and `errors` from the broadcast.
- Extend the unit test `test_source_import_event_payload_is_json_ready` in `apps/api/tests/test_jobs_source_imports.py` to assert the reduced payload shape and JSON-ready timestamps.

### Testing
- Attempted to run the repository test target via `moon run api:test -- test_jobs_source_imports.py` but `moon` is not available in the execution environment so it could not be executed here.
- Ran `pytest apps/api/tests/test_jobs_source_imports.py -q`, which failed during collection due to the environment missing pytest async configuration (unknown `asyncio_default_fixture_loop_scope`), so tests could not be run to completion in this environment.
- Added a deterministic unit assertion verifying the event payload keys and ISO-serialized timestamps to catch regressions in CI where the repo's full test harness can be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09636c1fc0832a873d975fb680d0fa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * WebSocket `SOURCE_IMPORT_UPDATED` events now include only essential fields (`import_id`, `status`, `progress`, `created_at`, `updated_at`, `completed_at`) instead of the full status payload, making events more focused and streamlined.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->