### PR TITLE
fix(api): redact reflection metadata in denied memory inspect

### DIFF
--- a/apps/api/src/sibyl/api/routes/memory.py
+++ b/apps/api/src/sibyl/api/routes/memory.py
@@ -1131,6 +1131,11 @@ def _memory_source_inspect_response(
     audit_events: list[MemoryAuditEventResponse],
 ) -> MemorySourceInspectResponse:
     content_redacted = not policy_decision.allowed or _memory_lifecycle_redacts_content(memory)
+    metadata = dict(memory.metadata)
+    if content_redacted:
+        metadata.pop("memory_lifecycle", None)
+        metadata.pop("reflection_findings", None)
+        metadata.pop("claim_records", None)
     visible_audit_events = _audit_events_for_visibility(
         audit_events,
         content_visible=policy_decision.allowed,
@@ -1139,15 +1144,25 @@ def _memory_source_inspect_response(
     derived_ids = [record.id for record in derived_records]
     derived_types = list(dict.fromkeys(record.record_type for record in derived_records))
     project_id = _memory_project_id(memory)
-    lifecycle = memory_lifecycle_from_metadata(
-        memory.metadata,
-        source_id=memory.id,
-        review_state=memory.review_state,
-    ).to_dict()
-    reflection_findings = [
-        finding.to_dict() for finding in reflection_findings_from_metadata(memory.metadata)
-    ]
-    claim_records = [claim.to_dict() for claim in claim_records_from_metadata(memory.metadata)]
+    lifecycle = (
+        {}
+        if content_redacted
+        else memory_lifecycle_from_metadata(
+            memory.metadata,
+            source_id=memory.id,
+            review_state=memory.review_state,
+        ).to_dict()
+    )
+    reflection_findings = (
+        []
+        if content_redacted
+        else [finding.to_dict() for finding in reflection_findings_from_metadata(memory.metadata)]
+    )
+    claim_records = (
+        []
+        if content_redacted
+        else [claim.to_dict() for claim in claim_records_from_metadata(memory.metadata)]
+    )
     return MemorySourceInspectResponse(
         id=memory.id,
         organization_id=memory.organization_id,
@@ -1187,7 +1202,7 @@ def _memory_source_inspect_response(
         content_redacted=content_redacted,
         raw_content_length=len(memory.raw_content),
         tags=memory.tags,
-        metadata=memory.metadata,
+        metadata=metadata,
         provenance=memory.provenance,
         capture_surface=memory.capture_surface,
         captured_at=memory.captured_at,

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -1262,6 +1262,12 @@ async def test_inspect_memory_source_redacts_project_content_without_access() ->
         scope_key="project_hidden",
         project_id="project_hidden",
         raw_content="Private project detail.",
+        metadata={
+            "domain": "sibyl",
+            "memory_lifecycle": {"state": "promoted"},
+            "reflection_findings": [{"kind": "promotion"}],
+            "claim_records": [{"content": "Private project detail."}],
+        },
     )
     event = {
         "uuid": "audit-1",
@@ -1306,6 +1312,9 @@ async def test_inspect_memory_source_redacts_project_content_without_access() ->
     assert response.visibility["content_visible"] is False
     assert response.available_actions[1]["available"] is False
     assert response.metadata == {"domain": "sibyl"}
+    assert response.lifecycle == {}
+    assert response.reflection_findings == []
+    assert response.claim_records == []
     assert response.recent_audit_events[0].details == {}
     audit.assert_awaited_once()
     assert audit.await_args.kwargs["policy_allowed"] is False
@@ -1320,6 +1329,12 @@ async def test_inspect_memory_source_redacts_other_private_principal() -> None:
         organization_id=str(org.id),
         principal_id="other-user",
         raw_content="Another user's private note.",
+        metadata={
+            "domain": "sibyl",
+            "memory_lifecycle": {"state": "active"},
+            "reflection_findings": [{"kind": "correction"}],
+            "claim_records": [{"content": "Another user's private note."}],
+        },
     )
 
     with (
@@ -1341,6 +1356,10 @@ async def test_inspect_memory_source_redacts_other_private_principal() -> None:
     assert response.content_redacted is True
     assert response.policy_allowed is False
     assert response.policy_reason == "principal_mismatch"
+    assert response.metadata == {"domain": "sibyl"}
+    assert response.lifecycle == {}
+    assert response.reflection_findings == []
+    assert response.claim_records == []
     audit.assert_awaited_once()
     assert audit.await_args.kwargs["policy_reason"] == "principal_mismatch"
 


### PR DESCRIPTION
### Motivation
- Prevent information disclosure where structured reflection data (`memory_lifecycle`, `reflection_findings`, `claim_records`) could be returned by the `/memory/inspect/{source_id}` response even when `raw_content` is redacted by the memory read policy.

### Description
- In `_memory_source_inspect_response` copy `memory.metadata` to a local `metadata` dict and remove sensitive structured keys when `content_redacted` is true (`memory_lifecycle`, `reflection_findings`, `claim_records`).
- When `content_redacted` is true return empty values for `lifecycle`, `reflection_findings`, and `claim_records` instead of parsing them from `memory.metadata`.
- Use the scrubbed `metadata` in the returned `MemorySourceInspectResponse` so redacted responses do not leak structured reflection/claim contents.
- Updated tests in `apps/api/tests/test_routes_memory.py` to include structured reflection metadata in denied-read scenarios and to assert those fields are scrubbed or empty in the redacted response.

### Testing
- Attempted to run API tests with `moon run api:test -- --filter inspect_memory_source`, but `moon` is not available in this environment so the command could not run.
- Ran `python -m pytest apps/api/tests/test_routes_memory.py -k inspect_memory_source` which could not complete due to the local pytest configuration/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).
- Tests were updated to cover the redaction behavior, but automated test execution could not be fully validated in this environment due to the above tooling constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0967ddc7a0832a970d35944adebcf9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed memory inspection response to properly redact sensitive metadata fields (lifecycle state, reflection findings, and claim records) when content is not accessible to the user. Users without appropriate permissions will now see a cleaner response with sensitive information appropriately hidden.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->