### PR TITLE
fix(crawler): restore extraction output token budget

### DIFF
--- a/apps/api/src/sibyl/crawler/graph_integration.py
+++ b/apps/api/src/sibyl/crawler/graph_integration.py
@@ -912,4 +912,3 @@ async def integrate_document_with_graph(
         return IntegrationStats()
 
     return await service.process_chunks(chunks, source_name)
-    DEFAULT_MAX_TOKENS = 1000

--- a/apps/api/src/sibyl/crawler/graph_integration.py
+++ b/apps/api/src/sibyl/crawler/graph_integration.py
@@ -217,6 +217,7 @@ Entity types to extract:
 
 Only extract entities that are clearly mentioned or demonstrated.
 Do not infer entities that aren't explicitly present."""
+    DEFAULT_MAX_TOKENS = 1000
 
     def __init__(
         self,
@@ -235,6 +236,7 @@ Do not infer entities that aren't explicitly present."""
             surface=LLMSurface.CRAWLER,
             model_override=model,
             output_retries=2,
+            max_tokens=self.DEFAULT_MAX_TOKENS,
         )
         log.debug("Entity extractor initialized", model=model or "surface default")
 
@@ -910,3 +912,4 @@ async def integrate_document_with_graph(
         return IntegrationStats()
 
     return await service.process_chunks(chunks, source_name)
+    DEFAULT_MAX_TOKENS = 1000

--- a/apps/api/tests/test_crawler_graph_integration.py
+++ b/apps/api/tests/test_crawler_graph_integration.py
@@ -119,6 +119,14 @@ class TestEntityExtractor:
     """Tests for LLM-based entity extraction."""
 
     @pytest.mark.asyncio
+    async def test_default_extractor_uses_token_cap(self):
+        """Test default extractor keeps crawler token cap."""
+        with patch("sibyl.crawler.graph_integration.Extractor") as extractor_cls:
+            EntityExtractor()
+            _, kwargs = extractor_cls.call_args
+            assert kwargs["max_tokens"] == EntityExtractor.DEFAULT_MAX_TOKENS
+
+    @pytest.mark.asyncio
     async def test_extract_from_chunk_success(self, sample_chunk_content):
         """Test successful entity extraction from chunk."""
         structured = FakeStructuredExtractor(

--- a/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from pydantic_ai import Agent
+from pydantic_ai.models import ModelSettings
 
 from sibyl_core.ai.clients import get_agent
 from sibyl_core.ai.errors import LLMError, classify_llm_exception
@@ -24,6 +25,7 @@ class Extractor[T]:
         system_prompt: str | Sequence[str] | None = None,
         model_override: str | None = None,
         output_retries: int | None = 2,
+        max_tokens: int | None = None,
         agent: Agent[Any, Any] | None = None,
     ) -> None:
         self.output_type = output_type
@@ -31,13 +33,17 @@ class Extractor[T]:
         self.system_prompt = system_prompt
         self.model_override = model_override
         self.output_retries = output_retries
+        self.max_tokens = max_tokens
         self._agent = agent
 
     async def extract(self, prompt: str) -> T:
         started_at = time.perf_counter()
         try:
             agent = await self._get_agent()
-            result = await agent.run(prompt)
+            result = await agent.run(
+                prompt,
+                model_settings=_model_settings(self.max_tokens),
+            )
             telemetry_registry().record_llm_call(
                 surface=self.surface.value,
                 provider="runtime",
@@ -90,3 +96,9 @@ class Extractor[T]:
             model=self.model_override,
             surface=self.surface.value,
         )
+
+
+def _model_settings(max_tokens: int | None) -> ModelSettings | None:
+    if max_tokens is None:
+        return None
+    return ModelSettings(max_tokens=max_tokens)

--- a/packages/python/sibyl-core/tests/ai/llm/test_extractor.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_extractor.py
@@ -7,6 +7,7 @@ from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.settings import ModelSettings
 
 from sibyl_core.ai.errors import LLMProviderError, LLMRateLimitError, LLMValidationError
 from sibyl_core.ai.llm import Extractor
@@ -55,6 +56,32 @@ async def test_extract_many_returns_partial_errors() -> None:
 
     assert results[0] == Payload(name="good", score=1.0)
     assert isinstance(results[1], LLMProviderError)
+
+
+@pytest.mark.asyncio
+async def test_extractor_applies_max_tokens_model_settings() -> None:
+    captured_settings: list[ModelSettings | None] = []
+
+    async def record_settings(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        captured_settings.append(info.model_settings)
+        output_tool = info.output_tools[0]
+        return ModelResponse(
+            parts=[ToolCallPart(output_tool.name, {"name": "Sibyl", "score": 0.9})],
+            model_name="function",
+        )
+
+    extractor = Extractor(
+        Payload,
+        agent=Agent(FunctionModel(record_settings), output_type=Payload),
+        max_tokens=123,
+    )
+
+    result = await extractor.extract("extract")
+
+    assert result == Payload(name="Sibyl", score=0.9)
+    assert len(captured_settings) == 1
+    assert captured_settings[0] is not None
+    assert captured_settings[0].get("max_tokens") == 123
 
 
 async def _invalid_json_response(_: list[ModelMessage], __: AgentInfo) -> ModelResponse:


### PR DESCRIPTION
### Motivation
- A migration to the shared LLM substrate removed the crawler's hard `max_tokens=1000` cap, allowing unbounded LLM outputs and creating a resource-exhaustion/cost risk when processing attacker-controlled crawl content.

### Description
- Restore a default crawler output budget by adding `EntityExtractor.DEFAULT_MAX_TOKENS = 1000` and passing it into the shared `Extractor` via `max_tokens` in `apps/api/src/sibyl/crawler/graph_integration.py`.
- Extend `packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py` to accept an optional `max_tokens` constructor parameter and forward it as `ModelSettings(max_tokens=...)` into `agent.run(...)` so per-call caps are enforced at provider call time.
- Add regression tests: `apps/api/tests/test_crawler_graph_integration.py` verifies the default crawler wiring uses the token cap, and `packages/python/sibyl-core/tests/ai/llm/test_extractor.py` verifies `max_tokens` is propagated into model settings.

### Testing
- Attempted to run the new tests with `moon` (monorepo runner) but `moon` is not installed in the execution environment, so that command could not be executed. (failed)
- Ran targeted `pytest` invocations for the modified tests but execution was blocked by missing runtime dependencies and import resolution: `ModuleNotFoundError: No module named 'sibyl_core'` and missing `pydantic` when using `PYTHONPATH`, preventing tests from running to completion. (failed)
- Local unit test additions are `packages/python/sibyl-core/tests/ai/llm/test_extractor.py` and `apps/api/tests/test_crawler_graph_integration.py`; they exercise the new `max_tokens` plumbing and the crawler default wiring and should pass in a properly provisioned development environment. (not executed here)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0967de9970832a9415bd5fc2bf3263)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity extraction now supports configurable maximum token limits for LLM operations.

* **Tests**
  * Added test coverage verifying that token limit settings are correctly applied during extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->