### PR TITLE
fix: restrict source import worker job to configured import directory

### DIFF
--- a/apps/api/src/sibyl/jobs/source_imports.py
+++ b/apps/api/src/sibyl/jobs/source_imports.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 import structlog
 
 from sibyl.api.event_types import WSEvent
+from sibyl.config import settings
 from sibyl_core.auth import MemoryPolicyContext, authorize_memory_write
 from sibyl_core.models.sources import SourceImportCheckpoint, SourceRecord
 from sibyl_core.services.mailbox_adapter import ensure_mailbox_adapter_registered
@@ -411,6 +413,17 @@ def _default_duplicate_checker(
     return check_duplicate
 
 
+def _resolve_import_source_uri(source_uri: str) -> str:
+    raw_path = source_uri[7:] if source_uri.startswith("file://") else source_uri
+    source_path = Path(raw_path).expanduser().resolve()
+    import_root = settings.source_import_dir.expanduser().resolve()
+    try:
+        source_path.relative_to(import_root)
+    except ValueError as exc:
+        raise PermissionError("source_import_path_denied") from exc
+    return str(source_path)
+
+
 async def import_source_archive(
     ctx: dict[str, Any],
     source_uri: str,
@@ -427,6 +440,7 @@ async def import_source_archive(
     duplicate_checker: SourceRecordDuplicateChecker | None = None,
 ) -> dict[str, Any]:
     """Import a bounded source archive batch into raw memory."""
+    source_uri = _resolve_import_source_uri(source_uri)
     ensure_mailbox_adapter_registered()
     adapter = get_source_adapter(adapter_name)
     manifest = await adapter.prepare_manifest(

--- a/apps/api/src/sibyl/jobs/source_imports.py
+++ b/apps/api/src/sibyl/jobs/source_imports.py
@@ -414,7 +414,7 @@ def _default_duplicate_checker(
 
 
 def _resolve_import_source_uri(source_uri: str) -> str:
-    raw_path = source_uri[7:] if source_uri.startswith("file://") else source_uri
+    raw_path = source_uri.removeprefix("file://")
     source_path = Path(raw_path).expanduser().resolve()
     import_root = settings.source_import_dir.expanduser().resolve()
     try:

--- a/apps/api/tests/test_jobs_source_imports.py
+++ b/apps/api/tests/test_jobs_source_imports.py
@@ -115,14 +115,15 @@ async def test_import_source_archive_imports_mbox_with_private_scope(tmp_path: P
         writes.append(dict(kwargs))
         return _raw_memory_from_kwargs(dict(kwargs), raw_id=f"raw-{len(writes)}")
 
-    result = await source_imports.import_source_archive(
-        {},
-        str(mbox_path),
-        organization_id="org-1",
-        principal_id="user-1",
-        policy_context=_policy_context(),
-        remember=fake_remember,
-    )
+    with patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path):
+        result = await source_imports.import_source_archive(
+            {},
+            str(mbox_path),
+            organization_id="org-1",
+            principal_id="user-1",
+            policy_context=_policy_context(),
+            remember=fake_remember,
+        )
 
     assert result["adapter_name"] == "mbox"
     assert result["imported_count"] == 1
@@ -149,25 +150,26 @@ async def test_import_source_archive_resumes_from_checkpoint(tmp_path: Path) -> 
     async def fake_remember(**kwargs: object) -> RawMemory:
         return _raw_memory_from_kwargs(dict(kwargs), raw_id=str(kwargs["source_id"]))
 
-    first_result = await source_imports.import_source_archive(
-        {},
-        str(tmp_path / "resume.mbox"),
-        organization_id="org-1",
-        principal_id="user-1",
-        policy_context=_policy_context(),
-        batch_size=1,
-        remember=fake_remember,
-    )
-    second_result = await source_imports.import_source_archive(
-        {},
-        str(tmp_path / "resume.mbox"),
-        organization_id="org-1",
-        principal_id="user-1",
-        policy_context=_policy_context(),
-        checkpoint=first_result["checkpoint"],
-        batch_size=1,
-        remember=fake_remember,
-    )
+    with patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path):
+        first_result = await source_imports.import_source_archive(
+            {},
+            str(tmp_path / "resume.mbox"),
+            organization_id="org-1",
+            principal_id="user-1",
+            policy_context=_policy_context(),
+            batch_size=1,
+            remember=fake_remember,
+        )
+        second_result = await source_imports.import_source_archive(
+            {},
+            str(tmp_path / "resume.mbox"),
+            organization_id="org-1",
+            principal_id="user-1",
+            policy_context=_policy_context(),
+            checkpoint=first_result["checkpoint"],
+            batch_size=1,
+            remember=fake_remember,
+        )
 
     assert first_result["checkpoint"]["cursor"] == "1"
     assert first_result["checkpoint"]["done"] is False
@@ -180,13 +182,31 @@ async def test_import_source_archive_resumes_from_checkpoint(tmp_path: Path) -> 
 async def test_import_source_archive_fails_closed_without_policy_context(tmp_path: Path) -> None:
     mbox_path = _write_mbox(tmp_path / "job.mbox")
 
-    with pytest.raises(ValueError, match="job_policy_context_missing"):
-        await source_imports.import_source_archive(
-            {},
-            str(mbox_path),
-            organization_id="org-1",
-            principal_id="user-1",
-        )
+    with patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path):
+        with pytest.raises(ValueError, match="job_policy_context_missing"):
+            await source_imports.import_source_archive(
+                {},
+                str(mbox_path),
+                organization_id="org-1",
+                principal_id="user-1",
+            )
+
+
+@pytest.mark.asyncio
+async def test_import_source_archive_denies_paths_outside_import_root(tmp_path: Path) -> None:
+    staged_dir = tmp_path / "staged"
+    staged_dir.mkdir()
+    outside_mbox = _write_mbox(tmp_path / "outside.mbox")
+
+    with patch("sibyl.jobs.source_imports.settings.source_import_dir", staged_dir):
+        with pytest.raises(PermissionError, match="source_import_path_denied"):
+            await source_imports.import_source_archive(
+                {},
+                str(outside_mbox),
+                organization_id="org-1",
+                principal_id="user-1",
+                policy_context=_policy_context(),
+            )
 
 
 @pytest.mark.asyncio
@@ -203,7 +223,7 @@ async def test_source_import_run_resumes_from_persisted_checkpoint(
     with patch(
         "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
         AsyncMock(return_value=None),
-    ):
+    ), patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path):
         first = await source_imports.start_source_import(
             source_uri=str(mbox_path),
             organization_id="org-1",
@@ -250,6 +270,7 @@ async def test_source_import_run_broadcasts_status_changes(tmp_path: Path) -> No
             "sibyl.jobs.source_imports._safe_broadcast_source_import",
             AsyncMock(side_effect=capture_status),
         ),
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path),
     ):
         first = await source_imports.start_source_import(
             source_uri=str(mbox_path),

--- a/apps/api/tests/test_jobs_source_imports.py
+++ b/apps/api/tests/test_jobs_source_imports.py
@@ -182,14 +182,16 @@ async def test_import_source_archive_resumes_from_checkpoint(tmp_path: Path) -> 
 async def test_import_source_archive_fails_closed_without_policy_context(tmp_path: Path) -> None:
     mbox_path = _write_mbox(tmp_path / "job.mbox")
 
-    with patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path):
-        with pytest.raises(ValueError, match="job_policy_context_missing"):
-            await source_imports.import_source_archive(
-                {},
-                str(mbox_path),
-                organization_id="org-1",
-                principal_id="user-1",
-            )
+    with (
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path),
+        pytest.raises(ValueError, match="job_policy_context_missing"),
+    ):
+        await source_imports.import_source_archive(
+            {},
+            str(mbox_path),
+            organization_id="org-1",
+            principal_id="user-1",
+        )
 
 
 @pytest.mark.asyncio
@@ -198,15 +200,17 @@ async def test_import_source_archive_denies_paths_outside_import_root(tmp_path: 
     staged_dir.mkdir()
     outside_mbox = _write_mbox(tmp_path / "outside.mbox")
 
-    with patch("sibyl.jobs.source_imports.settings.source_import_dir", staged_dir):
-        with pytest.raises(PermissionError, match="source_import_path_denied"):
-            await source_imports.import_source_archive(
-                {},
-                str(outside_mbox),
-                organization_id="org-1",
-                principal_id="user-1",
-                policy_context=_policy_context(),
-            )
+    with (
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", staged_dir),
+        pytest.raises(PermissionError, match="source_import_path_denied"),
+    ):
+        await source_imports.import_source_archive(
+            {},
+            str(outside_mbox),
+            organization_id="org-1",
+            principal_id="user-1",
+            policy_context=_policy_context(),
+        )
 
 
 @pytest.mark.asyncio
@@ -220,10 +224,13 @@ async def test_source_import_run_resumes_from_persisted_checkpoint(
         writes.append(dict(kwargs))
         return _raw_memory_from_kwargs(dict(kwargs), raw_id=f"raw-{len(writes)}")
 
-    with patch(
-        "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
-        AsyncMock(return_value=None),
-    ), patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path):
+    with (
+        patch(
+            "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
+            AsyncMock(return_value=None),
+        ),
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path),
+    ):
         first = await source_imports.start_source_import(
             source_uri=str(mbox_path),
             organization_id="org-1",
@@ -316,9 +323,12 @@ async def test_source_import_run_records_dedupe_without_duplicate_write(
         writes.append(dict(kwargs))
         return _raw_memory_from_kwargs(dict(kwargs), raw_id="raw-existing")
 
-    with patch(
-        "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
-        AsyncMock(return_value=None),
+    with (
+        patch(
+            "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
+            AsyncMock(return_value=None),
+        ),
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path),
     ):
         first = await source_imports.start_source_import(
             source_uri=str(mbox_path),
@@ -333,9 +343,12 @@ async def test_source_import_run_records_dedupe_without_duplicate_write(
     run.status = source_imports.SourceImportStatus.PAUSED
     run.completed_at = None
 
-    with patch(
-        "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
-        AsyncMock(return_value=None),
+    with (
+        patch(
+            "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
+            AsyncMock(return_value=None),
+        ),
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path),
     ):
         second = await source_imports.resume_source_import(
             first["import_id"],
@@ -358,9 +371,12 @@ async def test_cancel_source_import_blocks_resume(tmp_path: Path) -> None:
     async def fake_remember(**kwargs: object) -> RawMemory:
         return _raw_memory_from_kwargs(dict(kwargs), raw_id=str(kwargs["source_id"]))
 
-    with patch(
-        "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
-        AsyncMock(return_value=None),
+    with (
+        patch(
+            "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
+            AsyncMock(return_value=None),
+        ),
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path),
     ):
         first = await source_imports.start_source_import(
             source_uri=str(mbox_path),
@@ -395,9 +411,12 @@ async def test_source_import_controls_are_principal_bound(tmp_path: Path) -> Non
     async def fake_remember(**kwargs: object) -> RawMemory:
         return _raw_memory_from_kwargs(dict(kwargs), raw_id=str(kwargs["source_id"]))
 
-    with patch(
-        "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
-        AsyncMock(return_value=None),
+    with (
+        patch(
+            "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
+            AsyncMock(return_value=None),
+        ),
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path),
     ):
         first = await source_imports.start_source_import(
             source_uri=str(mbox_path),
@@ -431,9 +450,12 @@ async def test_resume_source_import_rechecks_current_policy_context(tmp_path: Pa
     async def fake_remember(**kwargs: object) -> RawMemory:
         return _raw_memory_from_kwargs(dict(kwargs), raw_id=str(kwargs["source_id"]))
 
-    with patch(
-        "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
-        AsyncMock(return_value=None),
+    with (
+        patch(
+            "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
+            AsyncMock(return_value=None),
+        ),
+        patch("sibyl.jobs.source_imports.settings.source_import_dir", tmp_path),
     ):
         first = await source_imports.start_source_import(
             source_uri=str(mbox_path),
@@ -449,17 +471,17 @@ async def test_resume_source_import_rechecks_current_policy_context(tmp_path: Pa
             remember=fake_remember,
         )
 
-    stale_context = _policy_context(memory_space="project", scope_key="project-1")
-    stale_context["accessible_projects"] = []
-    with pytest.raises(ValueError, match="unverified_membership"):
-        await source_imports.resume_source_import(
-            first["import_id"],
-            organization_id="org-1",
-            principal_id="user-1",
-            policy_context=stale_context,
-            promotion_preview_approved=True,
-            remember=fake_remember,
-        )
+        stale_context = _policy_context(memory_space="project", scope_key="project-1")
+        stale_context["accessible_projects"] = []
+        with pytest.raises(ValueError, match="unverified_membership"):
+            await source_imports.resume_source_import(
+                first["import_id"],
+                organization_id="org-1",
+                principal_id="user-1",
+                policy_context=stale_context,
+                promotion_preview_approved=True,
+                remember=fake_remember,
+            )
 
 
 def test_worker_settings_registers_source_import_job() -> None:


### PR DESCRIPTION
### Motivation
- Close a worker-level local-file read vector where `import_source_archive` accepted arbitrary `source_uri` values and allowed imports of any readable MBOX file on the server filesystem.
- Ensure the worker enforces the same staged-import boundary the API route layer already expects so queued/enqueued jobs cannot escape the staged import root.

### Description
- Added `from sibyl.config import settings` and a `_resolve_import_source_uri` helper that resolves and enforces `source_path.relative_to(settings.source_import_dir)` and raises `PermissionError("source_import_path_denied")` for outside-root paths in `apps/api/src/sibyl/jobs/source_imports.py`.
- Call `_resolve_import_source_uri` at the start of `import_source_archive` so the adapter never receives an allowed path outside the configured import root.
- Updated `apps/api/tests/test_jobs_source_imports.py` to patch `settings.source_import_dir` for existing tests and added `test_import_source_archive_denies_paths_outside_import_root` to assert outside-root imports are rejected.

### Testing
- Attempted to run the monorepo test target `moon run api:test -- tests/test_jobs_source_imports.py` but `moon` is not available in this environment so the monorepo test runner could not be executed.
- Ran `pytest -q apps/api/tests/test_jobs_source_imports.py` directly, but test collection failed due to an environment/config mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests were not executed to completion.
- Local test adjustments were limited to patching `settings.source_import_dir` in tests and adding a regression test to validate the new path guard; these tests will run in CI or a developer environment with `moon`/pytest configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0967de89f8832ab7a6caca9f03cd3c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for source import paths to ensure they remain within the configured import directory. Paths attempting to escape the import root are now properly rejected.

* **Tests**
  * Improved test isolation for source import tests using isolated test directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->