### PR TITLE
fix(core): prevent Maildir symlink traversal during imports

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/mailbox_adapter.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/mailbox_adapter.py
@@ -339,6 +339,10 @@ def _resolve_maildir_path(source_uri: str) -> Path:
     if missing:
         msg = f"Maildir source is missing required directories: {', '.join(missing)}"
         raise ValueError(msg)
+    symlinked_dirs = [name for name in ("cur", "new", "tmp") if (path / name).is_symlink()]
+    if symlinked_dirs:
+        msg = f"Maildir source has symlinked directories: {', '.join(symlinked_dirs)}"
+        raise ValueError(msg)
     return path
 
 
@@ -600,7 +604,11 @@ def _part_payload_bytes(part: Message) -> bytes:
 def _maildir_entries(path: Path) -> list[Path]:
     entries: list[Path] = []
     for folder in ("cur", "new"):
-        entries.extend(child for child in (path / folder).iterdir() if child.is_file())
+        entries.extend(
+            child
+            for child in (path / folder).iterdir()
+            if child.is_file() and not child.is_symlink()
+        )
     return entries
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/mailbox_adapter.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/mailbox_adapter.py
@@ -253,7 +253,13 @@ class MaildirSourceAdapter:
 
         maildir = mailbox.Maildir(path, create=False)
         try:
-            keys = sorted(maildir.keys())
+            symlinked_keys = _maildir_symlinked_keys(path, maildir.colon)
+            # iterating the mailbox yields messages, not keys, so .keys() is required
+            keys = sorted(
+                key
+                for key in maildir.keys()  # noqa: SIM118
+                if key not in symlinked_keys
+            )
             message_count = len(keys)
             for index, key in enumerate(keys):
                 if index < start:
@@ -610,6 +616,22 @@ def _maildir_entries(path: Path) -> list[Path]:
             if child.is_file() and not child.is_symlink()
         )
     return entries
+
+
+def _maildir_symlinked_keys(path: Path, colon: str) -> set[str]:
+    """Maildir keys whose backing file is a symlink and must not be ingested.
+
+    `mailbox.Maildir` happily reads through symlinked message files, so an
+    attacker who stages a Maildir with a symlinked entry could exfiltrate
+    arbitrary host files. The Maildir key is the unique-name prefix of the
+    filename (everything before the ``colon`` info separator).
+    """
+    symlinked: set[str] = set()
+    for folder in ("cur", "new"):
+        for child in (path / folder).iterdir():
+            if child.is_symlink():
+                symlinked.add(child.name.split(colon)[0])
+    return symlinked
 
 
 def _maildir_source_version(entries: list[Path]) -> str:

--- a/packages/python/sibyl-core/tests/test_mailbox_adapter.py
+++ b/packages/python/sibyl-core/tests/test_mailbox_adapter.py
@@ -334,6 +334,29 @@ async def test_maildir_manifest_ignores_symlinked_entries(tmp_path: Path) -> Non
     assert manifest.source_version.startswith("entries:1:mtime:")
 
 
+@pytest.mark.asyncio
+async def test_maildir_iter_records_skips_symlinked_entries(tmp_path: Path) -> None:
+    source = _write_maildir(
+        tmp_path / "maildir",
+        [_message(message_id="maildir-1@example.com", attachment=None)],
+    )
+    outside_message = tmp_path / "outside.eml"
+    outside_message.write_text(
+        "From: attacker@example.com\nSubject: outside\n\nsecret host data\n",
+        encoding="utf-8",
+    )
+    (source / "cur" / "leak:2,").symlink_to(outside_message)
+    adapter = MaildirSourceAdapter()
+    manifest = await adapter.prepare_manifest(source_uri=str(source))
+
+    batches = [batch async for batch in adapter.iter_records(manifest, batch_size=10)]
+
+    ingested = [record for batch in batches for record in batch.records]
+    assert len(ingested) == 1
+    assert ingested[0].adapter_record_id == "maildir-1@example.com"
+    assert all("secret host data" not in record.body for record in ingested)
+
+
 def test_ensure_mailbox_adapter_registers_once() -> None:
     ensure_mailbox_adapter_registered()
     ensure_mailbox_adapter_registered()

--- a/packages/python/sibyl-core/tests/test_mailbox_adapter.py
+++ b/packages/python/sibyl-core/tests/test_mailbox_adapter.py
@@ -298,6 +298,42 @@ async def test_maildir_adapter_preserves_metadata_and_resumes(tmp_path: Path) ->
     } == {"maildir-1@example.com", "maildir-2@example.com"}
 
 
+@pytest.mark.asyncio
+async def test_maildir_manifest_rejects_symlinked_maildir_subdirectories(
+    tmp_path: Path,
+) -> None:
+    source = _write_maildir(tmp_path / "maildir", [_message()])
+    cur_dir = source / "cur"
+    shadow = tmp_path / "outside-cur"
+    shadow.mkdir()
+    cur_dir.rename(source / "cur.real")
+    cur_dir.symlink_to(shadow, target_is_directory=True)
+    adapter = MaildirSourceAdapter()
+
+    with pytest.raises(ValueError, match="symlinked directories"):
+        await adapter.prepare_manifest(source_uri=str(source))
+
+
+@pytest.mark.asyncio
+async def test_maildir_manifest_ignores_symlinked_entries(tmp_path: Path) -> None:
+    source = _write_maildir(
+        tmp_path / "maildir",
+        [_message(message_id="maildir-1@example.com", attachment=None)],
+    )
+    outside_message = tmp_path / "outside.eml"
+    outside_message.write_text(
+        "From: attacker@example.com\nSubject: outside\n\nsecret\n",
+        encoding="utf-8",
+    )
+    (source / "cur" / "leak:2,").symlink_to(outside_message)
+    adapter = MaildirSourceAdapter()
+
+    manifest = await adapter.prepare_manifest(source_uri=str(source))
+
+    assert manifest.metadata["message_count"] == 1
+    assert manifest.source_version.startswith("entries:1:mtime:")
+
+
 def test_ensure_mailbox_adapter_registers_once() -> None:
     ensure_mailbox_adapter_registered()
     ensure_mailbox_adapter_registered()


### PR DESCRIPTION
### Motivation

- The Maildir source adapter could follow symlinks in `cur/new/tmp` and in listed message entries, allowing staged Maildir imports to read files outside the intended `source_import_dir` and leak sensitive host data.
- Route-level top-level path checks are insufficient because symlinked subdirectories and file entries can point outside the resolved root and still be opened by `mailbox.Maildir`.

### Description

- Harden `_resolve_maildir_path` to reject Maildirs that contain symlinked `cur`, `new`, or `tmp` subdirectories by raising a `ValueError` when any of those entries are symlinks.
- Update `_maildir_entries` to ignore symlinked files when enumerating entries in `cur` and `new`, so symlink targets are not counted, fingerprinted, or ingested as messages.
- Add two targeted unit tests: `test_maildir_manifest_rejects_symlinked_maildir_subdirectories` which asserts symlinked maildir subdirs are rejected, and `test_maildir_manifest_ignores_symlinked_entries` which asserts symlinked message entries are ignored in the manifest message count and source versioning.

### Testing

- Attempted to run the test suite with `moon run core:test -- packages/python/sibyl-core/tests/test_mailbox_adapter.py`, but the `moon` binary is not available in this environment so it could not be executed.
- Attempted `python -m pytest packages/python/sibyl-core/tests/test_mailbox_adapter.py`, but the environment is not bootstrapped and pytest failed with `ModuleNotFoundError: No module named 'sibyl_core'` so tests could not be fully executed here.
- The changes are unit-test driven and include new tests that exercise the symlink rejection and filtering behavior; they should pass in the repository CI or a properly bootstrapped developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b285b67d4832aa6463f7eb0936c0f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maildir path resolution now validates that required subdirectories are not symlinks and raises an error if detected.
  * Symlinked files are excluded when collecting messages from mailbox folders.

* **Tests**
  * Added tests to verify rejection of Maildir with symlinked subdirectories.
  * Added tests to verify symlinked entries are ignored during import.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->