### PR TITLE
fix(api): escape OAuth org chooser fields to prevent stored XSS

### DIFF
--- a/apps/api/src/sibyl/auth/mcp_oauth.py
+++ b/apps/api/src/sibyl/auth/mcp_oauth.py
@@ -537,7 +537,7 @@ class SibylMcpOAuthProvider(
     <h1>Login to Sibyl</h1>
     <div class="sub">Authorize <strong>{client_name}</strong> to access your MCP tools.</div>
     <form method="post" action="/_oauth/login">
-      <input type="hidden" name="req" value="{request_id}" />
+      <input type="hidden" name="req" value="{escape(request_id, quote=True)}" />
       <label>Email</label>
       <input name="email" type="email" autocomplete="username" required />
       <label>Password</label>

--- a/apps/api/src/sibyl/auth/mcp_oauth.py
+++ b/apps/api/src/sibyl/auth/mcp_oauth.py
@@ -636,8 +636,8 @@ class SibylMcpOAuthProvider(
         options = "\n".join(
             (
                 '<label style="display:block;margin:10px 0;padding:10px;border:1px solid #2a2a3a;border-radius:10px;">'
-                f'<input type="radio" name="org_id" value="{org.id}" required style="margin-right:10px;" />'
-                f"<strong>{org.name}</strong>"
+                f'<input type="radio" name="org_id" value="{escape(str(org.id), quote=True)}" required style="margin-right:10px;" />'
+                f"<strong>{escape(org.name)}</strong>"
                 + (' <span style="color:#a7a7c7">(personal)</span>' if org.is_personal else "")
                 + "</label>"
             )
@@ -666,12 +666,12 @@ class SibylMcpOAuthProvider(
     <h1>Select an organization</h1>
     <div class="sub">Choose which org to use for this MCP session.</div>
     <form method="post" action="/_oauth/org">
-      <input type="hidden" name="req" value="{request_id}" />
+      <input type="hidden" name="req" value="{escape(request_id, quote=True)}" />
       {options}
       <button type="submit">Continue</button>
     </form>
     <form method="post" action="/_oauth/org">
-      <input type="hidden" name="req" value="{request_id}" />
+      <input type="hidden" name="req" value="{escape(request_id, quote=True)}" />
       <input type="hidden" name="create_personal" value="1" />
       <button class="secondary" type="submit">Create / use personal org</button>
     </form>

--- a/apps/api/tests/test_mcp_oauth_multi_org_selection.py
+++ b/apps/api/tests/test_mcp_oauth_multi_org_selection.py
@@ -142,9 +142,43 @@ async def test_mcp_oauth_org_selection_issues_code(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_oauth_org_page_escapes_org_name(monkeypatch) -> None:
+    provider = SibylMcpOAuthProvider()
+
+    user = SimpleNamespace(id=uuid4(), name="Test User")
+    hostile_org = SimpleNamespace(
+        id=uuid4(),
+        name='</strong><script>alert("xss")</script><strong>',
+        slug="evil",
+        is_personal=False,
+    )
+
+    provider._pending["req123"] = _PendingAuth(
+        client_id="client1", expires_at=time.time() + 600, params=None
+    )
+    provider._authed["req123"] = _AuthedUser(user_id=user.id, expires_at=time.time() + 300)
+
+    monkeypatch.setattr(
+        provider,
+        "_list_user_orgs",
+        AsyncMock(return_value=[hostile_org]),
+    )
+
+    req = _make_get_request(path="/_oauth/org", query={"req": "req123"})
+    resp = await provider.ui_org_get(req)
+
+    assert resp.status_code == 200
+    body = resp.body.decode("utf-8")
+    assert '<script>alert("xss")</script>' not in body
+    assert "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;" in body
+
+
+@pytest.mark.asyncio
 async def test_mcp_oauth_login_page_escapes_client_name() -> None:
     provider = SibylMcpOAuthProvider()
-    provider._pending["req123"] = _PendingAuth(client_id="client1", expires_at=time.time() + 600, params=None)
+    provider._pending["req123"] = _PendingAuth(
+        client_id="client1", expires_at=time.time() + 600, params=None
+    )
     await provider.register_client(
         OAuthClientInformationFull(
             client_id="client1",
@@ -161,5 +195,7 @@ async def test_mcp_oauth_login_page_escapes_client_name() -> None:
 
     assert resp.status_code == 200
     body = resp.body.decode("utf-8")
-    assert "<script>alert(\"xss\")</script>" not in body
-    assert "&lt;/strong&gt;&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;&lt;strong&gt;" in body
+    assert '<script>alert("xss")</script>' not in body
+    assert (
+        "&lt;/strong&gt;&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;&lt;strong&gt;" in body
+    )


### PR DESCRIPTION
### Motivation
- The OAuth organization chooser returned HTML that interpolated `org.name` and other user-controlled values directly, creating a stored same-origin XSS sink once `/_oauth/*` routes were proxied to the backend.
- Fixing the output encoding at the HTML sink prevents attackers from injecting executable markup while preserving the existing OAuth flow.

### Description
- Escape user-controlled values in the org picker by applying `html.escape` (via the existing `escape` import) to `org.name`, `org.id`, and `request_id` in `ui_org_get`.
- Changes are limited to `apps/api/src/sibyl/auth/mcp_oauth.py` and only alter rendered output encoding; no routing or higher-level logic was modified.
- The form `value` attributes and hidden `req` inputs are escaped with `quote=True` to prevent attribute-context injection.

### Testing
- Attempted the monorepo test command `moon run api:test`, but `moon` is not available in this environment so it could not be executed.
- Attempted a targeted pytest run with `python -m pytest apps/api/tests/auth/test_mcp_oauth.py -k org -q`, which failed during collection because the requested test path was not found and the local pytest config produced `Unknown config option: asyncio_default_fixture_loop_scope`.
- No automated tests could be run successfully in this execution environment, but the patch is a minimal, surface-level encoding change that is safe to review and run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a01b51ac4832abd0e5a9a6d2325f5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in the organization selection interface by properly escaping dynamic values in HTML attributes. Fixed potential injection vulnerabilities in form fields to ensure safe rendering of user data during organization selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->