### PR TITLE
fix(api): restrict telemetry endpoints to OWNER and ADMIN

### DIFF
--- a/apps/api/src/sibyl/api/routes/telemetry.py
+++ b/apps/api/src/sibyl/api/routes/telemetry.py
@@ -21,7 +21,6 @@ from sibyl_core.observability import telemetry_registry
 _READ_ROLES = (
     OrganizationRole.OWNER,
     OrganizationRole.ADMIN,
-    OrganizationRole.MEMBER,
 )
 
 router = APIRouter(


### PR DESCRIPTION
### Motivation
- Telemetry summary and Prometheus endpoints exposed process-wide telemetry to ordinary organization members, risking cross-tenant information disclosure in multi-tenant deployments.

### Description
- Remove `OrganizationRole.MEMBER` from the telemetry router read roles so `/telemetry/summary` and `/telemetry/prometheus` are accessible only to `OWNER` and `ADMIN` (change in `apps/api/src/sibyl/api/routes/telemetry.py`).

### Testing
- Ran targeted pytest for telemetry routes (`pytest apps/api/tests/test_telemetry_routes.py`), but collection failed due to a local pytest config/plugin mismatch (`asyncio_default_fixture_loop_scope` unknown), so tests could not be executed successfully.
- Attempted monorepo test invocation (`moon run api:test`) but `moon` is not available in this environment, so full suite could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c22178832a8c262ac7d6509ec8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted access to telemetry endpoints to organization owners and administrators only. Member-level access has been removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->