### PR TITLE
fix(api): enforce API-key memory scopes for raw-memory ID resolve

### DIFF
--- a/apps/api/src/sibyl/api/routes/resolve.py
+++ b/apps/api/src/sibyl/api/routes/resolve.py
@@ -8,7 +8,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
-from sibyl.api.routes.memory import _inspect_content_policy
+from sibyl.api.routes.memory import _api_key_memory_scope_allowed, _inspect_content_policy
 from sibyl.auth.context import AuthContext
 from sibyl.auth.dependencies import (
     get_auth_context,
@@ -132,6 +132,12 @@ async def _filter_visible_raw_memories(
 ) -> list[RawMemory]:
     visible: list[RawMemory] = []
     for memory in memories:
+        if not _api_key_memory_scope_allowed(
+            ctx,
+            memory_scope=memory.memory_scope.value,
+            scope_key=memory.scope_key,
+        ):
+            continue
         decision = await _inspect_content_policy(ctx=ctx, memory=memory)
         if decision.allowed:
             visible.append(memory)

--- a/apps/api/tests/test_routes_resolve.py
+++ b/apps/api/tests/test_routes_resolve.py
@@ -131,3 +131,63 @@ async def test_resolve_raw_memory_prefix_filters_policy_denied_matches(
     assert response.count == 1
     assert response.matches[0].id == "memory-visible"
     assert response.matches[0].entity_type == "raw_memory"
+
+
+@pytest.mark.asyncio
+async def test_resolve_raw_memory_prefix_filters_api_key_memory_scope_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org = AuthOrganization(id=uuid4(), name="Sibyl", slug="sibyl")
+    ctx = _auth_context(org)
+    ctx.api_key_memory_scope_keys = {"project\x1fproject-visible"}
+    memories = [
+        RawMemory(
+            id="memory-visible",
+            organization_id=str(org.id),
+            source_id="source-visible",
+            principal_id=ctx.user_id or "",
+            memory_scope=MemoryScope.PROJECT,
+            scope_key="project-visible",
+            project_id="project-visible",
+            title="Visible memory",
+        ),
+        RawMemory(
+            id="memory-hidden",
+            organization_id=str(org.id),
+            source_id="source-hidden",
+            principal_id="other-user",
+            memory_scope=MemoryScope.PROJECT,
+            scope_key="project-hidden",
+            project_id="project-hidden",
+            title="Hidden memory",
+        ),
+    ]
+
+    async def fake_resolve_raw(
+        *,
+        organization_id: str,
+        prefix: str,
+        limit: int,
+    ) -> list[RawMemory]:
+        assert organization_id == str(org.id)
+        assert prefix == "memory"
+        assert limit == 20
+        return memories
+
+    async def fake_policy(*, ctx: AuthContext, memory: RawMemory) -> SimpleNamespace:
+        return SimpleNamespace(allowed=True)
+
+    monkeypatch.setattr(resolve_route, "resolve_raw_memory_prefix", fake_resolve_raw)
+    monkeypatch.setattr(resolve_route, "_inspect_content_policy", fake_policy)
+
+    response = await resolve_route.resolve_id_prefix(
+        "memory",
+        org=org,
+        ctx=ctx,
+        entity_type="raw_memory",
+        limit=20,
+    )
+
+    assert response.count == 1
+    assert response.matches[0].id == "memory-visible"
+    assert response.matches[0].entity_type == "raw_memory"

--- a/apps/api/tests/test_routes_resolve.py
+++ b/apps/api/tests/test_routes_resolve.py
@@ -11,11 +11,16 @@ from sibyl_core.auth import AuthOrganization, AuthUser, OrganizationRole
 from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 
 
-def _auth_context(org: AuthOrganization) -> AuthContext:
+def _auth_context(
+    org: AuthOrganization,
+    *,
+    api_key_memory_scope_keys: set[str] | None = None,
+) -> AuthContext:
     return AuthContext(
         user=AuthUser(id=uuid4(), email="nova@example.test"),
         organization=org,
         org_role=OrganizationRole.MEMBER,
+        api_key_memory_scope_keys=api_key_memory_scope_keys,
     )
 
 
@@ -138,8 +143,7 @@ async def test_resolve_raw_memory_prefix_filters_api_key_memory_scope_matches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     org = AuthOrganization(id=uuid4(), name="Sibyl", slug="sibyl")
-    ctx = _auth_context(org)
-    ctx.api_key_memory_scope_keys = {"project\x1fproject-visible"}
+    ctx = _auth_context(org, api_key_memory_scope_keys={"project\x1fproject-visible"})
     memories = [
         RawMemory(
             id="memory-visible",


### PR DESCRIPTION
### Motivation
- The raw-memory ID resolver could enumerate out-of-scope raw-memory metadata for API keys that are restricted to specific memory spaces, so API-key memory-space restrictions must be applied in the resolve path. 
- The change aims to prevent metadata leakage while preserving existing content-policy and organization-level visibility semantics.

### Description
- Import ` _api_key_memory_scope_allowed` and apply it in the raw-memory filtering path to enforce API-key memory-space restrictions before policy checks. 
- Update `_filter_visible_raw_memories` to skip any `RawMemory` where ` _api_key_memory_scope_allowed(ctx, memory_scope=memory.memory_scope.value, scope_key=memory.scope_key)` returns false, then continue with the existing `_inspect_content_policy` check. 
- Add `test_resolve_raw_memory_prefix_filters_api_key_memory_scope_matches` to `apps/api/tests/test_routes_resolve.py` to assert that `entity_type=raw_memory` only returns in-scope memories when `ctx.api_key_memory_scope_keys` is set. 

### Testing
- Attempted `moon run api:test -- test_routes_resolve.py`, but `moon` is not available in this environment so the workspace-level test runner could not be used. 
- Ran `pytest apps/api/tests/test_routes_resolve.py`, which failed in this environment due to pytest configuration/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`). 
- A focused regression test was added to the test suite and is expected to pass in the project CI where `moon`/pytest are configured correctly, but it could not be executed successfully in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbca291e4832ab32e73da75f03ba1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key memory scope filtering now applied during memory resolution.

* **Tests**
  * Added test coverage for API key memory scope filtering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->