### PR TITLE
fix(cli): harden content-file symlink protections

### DIFF
--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -72,8 +72,14 @@ def read_content_file(
     follow_symlinks: bool = False,
 ) -> str:
     file_path = Path(path).expanduser()
-    if file_path.is_symlink() and not follow_symlinks:
-        raise ValueError("Refusing to read symlink without --follow-symlinks.")
+    if not file_path.is_absolute():
+        file_path = Path.cwd() / file_path
+
+    if not follow_symlinks:
+        for component in (file_path, *file_path.parents):
+            if component.exists() and component.is_symlink():
+                raise ValueError("Refusing to read symlink without --follow-symlinks.")
+
     if not file_path.exists():
         raise ValueError(f"Content file not found: {file_path}")
     if not file_path.is_file():
@@ -84,10 +90,15 @@ def read_content_file(
         raise ValueError(f"Content file is not readable: {file_path}") from exc
     if size > max_size:
         raise ValueError(f"Content file is too large: {size} bytes exceeds {max_size}.")
-    if not os.access(file_path, os.R_OK):
-        raise ValueError(f"Content file is not readable: {file_path}")
     try:
-        data = file_path.read_bytes()
+        flags = os.O_RDONLY
+        if not follow_symlinks and hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(file_path, flags)
+        with os.fdopen(fd, "rb") as stream:
+            data = stream.read(max_size + 1)
+        if len(data) > max_size:
+            raise ValueError(f"Content file is too large: more than {max_size} bytes.")
         data[:CONTENT_FILE_BINARY_CHECK_BYTES].decode("utf-8")
         return data.decode("utf-8")
     except UnicodeDecodeError as exc:

--- a/apps/cli/tests/test_common.py
+++ b/apps/cli/tests/test_common.py
@@ -21,3 +21,28 @@ def test_read_content_file_rejects_binary_file(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="binary or non-UTF-8"):
         read_content_file(str(content_file))
+
+
+def test_read_content_file_rejects_parent_symlink(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("secret", encoding="utf-8")
+
+    linked_dir = tmp_path / "linked"
+    linked_dir.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="Refusing to read symlink"):
+        read_content_file(str(linked_dir / "secret.txt"))
+
+
+def test_read_content_file_allows_parent_symlink_when_enabled(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("secret", encoding="utf-8")
+
+    linked_dir = tmp_path / "linked"
+    linked_dir.symlink_to(outside, target_is_directory=True)
+
+    assert read_content_file(str(linked_dir / "secret.txt"), follow_symlinks=True) == "secret"


### PR DESCRIPTION
### Motivation

- The `read_content_file` helper only rejected a leaf symlink and performed validation and reading as separate operations, which allowed parent-directory symlinks and a TOCTOU to disclose local files when `--content-file` was used.
- The change tightens guards so the CLI honors the documented `--follow-symlinks` semantics and avoids accidental disclosure of sensitive local files.

### Description

- Normalize relative inputs to an absolute path by resolving against `cwd` so checks are performed on a consistent path (`read_content_file`).
- When `follow_symlinks=False`, reject any symlinked path component (leaf or parent) instead of only the final component.
- Open the file with `os.open()` and use `O_NOFOLLOW` when available, read via the returned file descriptor, and enforce a post-open size cap to reduce the TOCTOU window between validation and read.
- Preserve the previous UTF-8 detection and size limits while adding tests for parent-directory symlink rejection and opt-in acceptance via `follow_symlinks=True` (`apps/cli/src/sibyl_cli/common.py` and `apps/cli/tests/test_common.py`).

### Testing

- Added unit tests covering parent-directory symlink rejection and acceptance when `follow_symlinks=True`, but automated test runs could not be completed in this environment.
- `moon run cli:test -- --filter test_common.py` failed here because `moon` is not installed in the environment.
- `pytest apps/cli/tests/test_common.py` could not complete due to an environment/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests were not executed successfully here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbca29868832aaba014c14c41cbad)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file reading reliability with enhanced path normalization and validation
  * Implemented stricter symbolic link detection and handling in file access operations
  * Added file size validation enforcement for safer file operations

* **Tests**
  * Added comprehensive test coverage verifying symbolic link handling behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->