### PR TITLE
fix(api): skip Gemini key validation in public /setup/status to avoid quota burn

### DIFF
--- a/apps/api/src/sibyl/api/routes/setup.py
+++ b/apps/api/src/sibyl/api/routes/setup.py
@@ -145,8 +145,8 @@ async def get_setup_status(
     - Optionally validates API keys work (validate_keys=true)
 
     This endpoint requires no authentication since it must work
-    before setup completes. Key validation only runs before setup completes;
-    initialized instances should use owner/admin validation routes.
+    before setup completes. Public validation skips Gemini to avoid unauthenticated
+    quota burn; use /setup/validate-keys for Gemini checks.
     """
     setup_status = await get_runtime_setup_status()
 
@@ -169,8 +169,6 @@ async def get_setup_status(
             openai_valid, _ = await _check_openai_key(openai_key)
         if anthropic_configured:
             anthropic_valid, _ = await _check_anthropic_key(anthropic_key)
-        if gemini_configured:
-            gemini_valid, _ = await _check_gemini_key(gemini_key)
 
     return SetupStatus(
         needs_setup=not setup_status.setup_complete,

--- a/apps/api/src/sibyl/api/routes/setup.py
+++ b/apps/api/src/sibyl/api/routes/setup.py
@@ -135,18 +135,21 @@ def _validation_error(result: KeyValidationResult) -> str | None:
 
 @router.get("/status", response_model=SetupStatus)
 async def get_setup_status(
-    validate_keys: bool = False,
+    validate_keys: bool = False,  # noqa: ARG001 - retained for API compatibility
 ) -> SetupStatus:
     """Check if this Sibyl instance needs initial setup.
 
     Returns the current setup state including:
     - Whether setup is complete
     - Whether API keys are configured
-    - Optionally validates API keys work (validate_keys=true)
 
-    This endpoint requires no authentication since it must work
-    before setup completes. Public validation skips Gemini to avoid unauthenticated
-    quota burn; use /setup/validate-keys for Gemini checks.
+    This endpoint requires no authentication since it must work before
+    setup completes, so it never performs provider key validation: doing
+    so would let unauthenticated callers burn provider quota and incur
+    cost using the server-stored OpenAI, Anthropic, and Gemini keys. Use
+    the authenticated /setup/validate-keys route for full key validation.
+    The validate_keys parameter is retained only for backward
+    compatibility and is ignored.
     """
     setup_status = await get_runtime_setup_status()
 
@@ -159,17 +162,6 @@ async def get_setup_status(
     anthropic_configured = bool(anthropic_key)
     gemini_configured = bool(gemini_key)
 
-    # Optionally validate keys work
-    openai_valid: bool | None = None
-    anthropic_valid: bool | None = None
-    gemini_valid: bool | None = None
-
-    if validate_keys and not setup_status.setup_complete:
-        if openai_configured:
-            openai_valid, _ = await _check_openai_key(openai_key)
-        if anthropic_configured:
-            anthropic_valid, _ = await _check_anthropic_key(anthropic_key)
-
     return SetupStatus(
         needs_setup=not setup_status.setup_complete,
         has_users=setup_status.has_users,
@@ -178,9 +170,9 @@ async def get_setup_status(
         openai_configured=openai_configured,
         anthropic_configured=anthropic_configured,
         gemini_configured=gemini_configured,
-        openai_valid=openai_valid,
-        anthropic_valid=anthropic_valid,
-        gemini_valid=gemini_valid,
+        openai_valid=None,
+        anthropic_valid=None,
+        gemini_valid=None,
     )
 
 

--- a/apps/api/tests/test_setup_routes.py
+++ b/apps/api/tests/test_setup_routes.py
@@ -9,7 +9,7 @@ from sibyl.persistence.surreal import setup as surreal_setup
 
 
 @pytest.mark.asyncio
-async def test_get_setup_status_uses_runtime_status_and_validates_keys(
+async def test_get_setup_status_skips_provider_validation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = AsyncMock()
@@ -23,9 +23,11 @@ async def test_get_setup_status_uses_runtime_status_and_validates_keys(
         AsyncMock(return_value=SetupStatus(has_users=False, has_orgs=False)),
     )
     monkeypatch.setattr(setup_routes, "get_settings_service", lambda: service)
-    monkeypatch.setattr(setup_routes, "_check_openai_key", AsyncMock(return_value=(True, None)))
-    monkeypatch.setattr(setup_routes, "_check_anthropic_key", AsyncMock(return_value=(False, None)))
+    openai_check = AsyncMock(return_value=(True, None))
+    anthropic_check = AsyncMock(return_value=(False, None))
     gemini_check = AsyncMock(return_value=(True, None))
+    monkeypatch.setattr(setup_routes, "_check_openai_key", openai_check)
+    monkeypatch.setattr(setup_routes, "_check_anthropic_key", anthropic_check)
     monkeypatch.setattr(setup_routes, "_check_gemini_key", gemini_check)
 
     response = await setup_routes.get_setup_status(validate_keys=True)
@@ -37,9 +39,13 @@ async def test_get_setup_status_uses_runtime_status_and_validates_keys(
     assert response.openai_configured is True
     assert response.anthropic_configured is False
     assert response.gemini_configured is True
-    assert response.openai_valid is True
+    # The public endpoint never validates keys: no provider probe runs,
+    # so every *_valid stays None regardless of validate_keys.
+    assert response.openai_valid is None
     assert response.anthropic_valid is None
     assert response.gemini_valid is None
+    openai_check.assert_not_awaited()
+    anthropic_check.assert_not_awaited()
     gemini_check.assert_not_awaited()
 
 

--- a/apps/api/tests/test_setup_routes.py
+++ b/apps/api/tests/test_setup_routes.py
@@ -25,7 +25,8 @@ async def test_get_setup_status_uses_runtime_status_and_validates_keys(
     monkeypatch.setattr(setup_routes, "get_settings_service", lambda: service)
     monkeypatch.setattr(setup_routes, "_check_openai_key", AsyncMock(return_value=(True, None)))
     monkeypatch.setattr(setup_routes, "_check_anthropic_key", AsyncMock(return_value=(False, None)))
-    monkeypatch.setattr(setup_routes, "_check_gemini_key", AsyncMock(return_value=(True, None)))
+    gemini_check = AsyncMock(return_value=(True, None))
+    monkeypatch.setattr(setup_routes, "_check_gemini_key", gemini_check)
 
     response = await setup_routes.get_setup_status(validate_keys=True)
 
@@ -38,7 +39,8 @@ async def test_get_setup_status_uses_runtime_status_and_validates_keys(
     assert response.gemini_configured is True
     assert response.openai_valid is True
     assert response.anthropic_valid is None
-    assert response.gemini_valid is True
+    assert response.gemini_valid is None
+    gemini_check.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- The unauthenticated `GET /setup/status` endpoint could be invoked with `validate_keys=true` and would call the Gemini embeddings API with the server-stored key, enabling unauthenticated callers to consume Gemini quota or incur cost.
- The change prevents a public endpoint from performing provider-consuming operations while preserving other pre-setup checks and a separate authenticated path for full validation.

### Description
- Removed the call to `_check_gemini_key()` from the public `get_setup_status` flow so Gemini validation is no longer performed during unauthenticated status checks.
- Updated the `get_setup_status` docstring to document that public validation skips Gemini and direct full checks to `/setup/validate-keys`.
- Adjusted unit tests in `apps/api/tests/test_setup_routes.py` to assert that Gemini validation is skipped and that `_check_gemini_key` is not awaited in the public pre-setup path.

### Testing
- Ran `pytest` on the modified test file but collection failed in this environment due to a local pytest configuration/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).
- Attempted the repository's `moon` test task but the `moon` tool is not available in this environment, so automated test execution could not be completed here.
- Updated tests reflect the intended behavior (Gemini is not validated by `GET /setup/status`) but full CI/test execution should be run in the project CI or a development environment with `moon` configured to validate all changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c2d544832ab36fad7aaf30c21b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Setup status endpoint now skips Gemini key validation during setup completion checks. Use the dedicated `/setup/validate-keys` endpoint for complete validation including Gemini checks.

* **Tests**
  * Updated setup status tests to reflect endpoint validation behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->