### PR TITLE
fix(auth): require contributor role for persisted context reflections

### DIFF
--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -55,13 +55,14 @@ async def _resolve_accessible_context_projects(
     *,
     ctx: AuthContext,
     project: str | None,
+    required_project_role: ProjectRole = ProjectRole.VIEWER,
 ) -> set[str] | None:
     if project:
         await verify_entity_project_access(
             None,
             ctx,
             project,
-            required_role=ProjectRole.VIEWER,
+            required_role=required_project_role,
         )
         return {str(project)}
     accessible_projects = await list_accessible_project_graph_ids(ctx)
@@ -231,6 +232,9 @@ async def reflect_context(
         accessible_projects = await _resolve_accessible_context_projects(
             ctx=ctx,
             project=request.project,
+            required_project_role=(
+                ProjectRole.CONTRIBUTOR if request.persist else ProjectRole.VIEWER
+            ),
         )
         related_to = await _resolve_reflection_links(
             org_id=str(org.id),

--- a/apps/api/tests/test_routes_context.py
+++ b/apps/api/tests/test_routes_context.py
@@ -713,7 +713,7 @@ class TestReflectRoute:
             None,
             ctx,
             "proj_1",
-            required_role=ProjectRole.VIEWER,
+            required_role=ProjectRole.CONTRIBUTOR,
         )
         assert reflect_memory.await_args.kwargs["related_to"] == ["plan_1", "task_1", "task_2"]
         assert reflect_memory.await_args.kwargs["principal_id"] == "user-123"

--- a/apps/api/tests/test_routes_context.py
+++ b/apps/api/tests/test_routes_context.py
@@ -565,7 +565,7 @@ class TestReflectRoute:
             None,
             ctx,
             "proj_1",
-            required_role=ProjectRole.VIEWER,
+            required_role=ProjectRole.CONTRIBUTOR,
         )
         assert response.source_title == "Planning"
         assert response.source_id == "session_1"


### PR DESCRIPTION
### Motivation
- Persisted reflections were being authorized using a `ProjectRole.VIEWER` check and then passing that accessible-project set into the native writer, which allowed viewer-only users to persist project-scoped memory when native writes were enabled.
- The goal is to ensure persisted reflection writes enforce the same write-level project bar used by other memory write paths (i.e., `ProjectRole.CONTRIBUTOR`).

### Description
- Parameterize `_resolve_accessible_context_projects` with a `required_project_role` argument so callers can request different project-role checks (`apps/api/src/sibyl/api/routes/context.py`).
- Require `ProjectRole.CONTRIBUTOR` for persisted `/context/reflect` calls while keeping non-persisting reflect operations at `ProjectRole.VIEWER` (so read-only reflection behavior is unchanged) (`apps/api/src/sibyl/api/routes/context.py`).
- Update tests to assert the contributor-level project verification for persisted reflect requests (`apps/api/tests/test_routes_context.py`).

### Testing
- Updated unit tests in `apps/api/tests/test_routes_context.py` to reflect the tightened authorization and committed the change; these test edits pass locally in the sense that the code and assertions were adjusted, but full test execution was not run here.
- Attempted to run the API test suite via the repository's runner with `moon run api:test -- apps/api/tests/test_routes_context.py apps/api/tests/test_server_accessible_projects.py`, but the `moon` tool is not installed in this environment so automated tests could not be executed (`moon: command not found`).
- No other automated test runners were available in this execution environment, so CI execution should be used to validate the change end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c310dc832aad9a2ea91a2b8042)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced access control for context operations: the reflect endpoint now requires contributor-level permissions when persisting data, and viewer-level permissions otherwise.

* **Tests**
  * Updated test expectations to validate new authorization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->