### PR TITLE
fix(retrieval): scope edge fulltext match stage by project filters

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
@@ -972,14 +972,10 @@ def _edge_filter_clause(
 def _edge_match_filter_clause(
     search_filter: NativeSearchFilter,
 ) -> tuple[list[str], dict[str, Any]]:
-    clauses: list[str] = []
-    params: dict[str, Any] = {}
+    clauses, params = _edge_filter_clause(search_filter)
     if search_filter.edge_uuids:
         clauses.append("uuid IN $edge_uuids")
         params["edge_uuids"] = list(search_filter.edge_uuids)
-    if search_filter.edge_types:
-        clauses.append("name IN $edge_types")
-        params["edge_types"] = list(search_filter.edge_types)
     return clauses, params
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
@@ -972,11 +972,7 @@ def _edge_filter_clause(
 def _edge_match_filter_clause(
     search_filter: NativeSearchFilter,
 ) -> tuple[list[str], dict[str, Any]]:
-    clauses, params = _edge_filter_clause(search_filter)
-    if search_filter.edge_uuids:
-        clauses.append("uuid IN $edge_uuids")
-        params["edge_uuids"] = list(search_filter.edge_uuids)
-    return clauses, params
+    return _edge_filter_clause(search_filter)
 
 
 def _edge_select(extra: str | None = None) -> str:

--- a/packages/python/sibyl-core/tests/test_native_retrieval.py
+++ b/packages/python/sibyl-core/tests/test_native_retrieval.py
@@ -943,11 +943,12 @@ async def test_edge_fulltext_splits_matches_from_relation_hydration() -> None:
     match_query = client.calls[0][0]
     hydrate_query = client.calls[1][0]
     assert "fact @0@" in match_query
-    assert "in." not in match_query
-    assert "out." not in match_query
-    assert "attributes." not in match_query
+    assert "attributes.project_id IN $project_ids" in match_query
+    assert "in.project_id IN $project_ids" in match_query
+    assert "out.project_id IN $project_ids" in match_query
     assert "uuid IN $edge_uuids" in match_query
     assert "name IN $edge_types" in match_query
     assert client.calls[0][1]["match_limit"] == 32
+    assert client.calls[0][1]["project_ids"] == ["project_123"]
     assert "fact @0@" not in hydrate_query
     assert "uuid IN $match_uuids" in hydrate_query


### PR DESCRIPTION
### Motivation
- Prevent cross-project crowd-out in two-stage edge fulltext retrieval by ensuring project and node filters are enforced before ranking and limiting results. 
- Restore retrieval integrity so authorized in-project edges cannot be displaced by out-of-project matches during the initial MATCHES selection.

### Description
- Change `_edge_match_filter_clause` to call `_edge_filter_clause(search_filter)` so the full set of edge filters (including `project_ids` and `node_labels`) are applied during the first-stage match query. 
- Preserve explicit `edge_uuids` narrowing inside `_edge_match_filter_clause` after incorporating the broader filter set. 
- Update the existing edge fulltext test `test_edge_fulltext_splits_matches_from_relation_hydration` to assert that project filters appear in the first-stage match query and that `project_ids` are bound in the match query params.

### Testing
- Attempted `moon run core:test -- --run-in-band packages/python/sibyl-core/tests/test_native_retrieval.py`, but `moon` is not present in the execution environment so the run could not be performed. 
- Attempted `python -m pytest packages/python/sibyl-core/tests/test_native_retrieval.py -k edge_fulltext_splits_matches_from_relation_hydration`, which failed with `ModuleNotFoundError: No module named 'sibyl_core'` due to missing local package/dependencies in this environment. 
- The change is small and covered by the adjusted unit test which asserts the presence of project filters in the initial match query; running the repository test suite in a properly provisioned dev environment (with `moon`/project deps installed) should validate the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c270c8832a8058292ba17b389f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate filtering conditions in edge retrieval queries that could impact search result accuracy and query performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->