### PR TITLE
fix(synthesis): avoid leaking redacted source metadata

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py
@@ -536,12 +536,16 @@ async def materialize_synthesis_section_packs(
             freshness[source_id] = item_freshness
             unresolved_claims.extend(_metadata_unresolved_claims(metadata))
             source_metadata = {
-                **metadata,
                 "facet": item.facet.value,
                 "freshness": item_freshness,
                 "project_id": project_id,
                 "reason": item.reason,
             }
+            if not redacted:
+                source_metadata = {
+                    **metadata,
+                    **source_metadata,
+                }
             sources.append(
                 SynthesisSourceReference(
                     id=source_id,

--- a/packages/python/sibyl-core/tests/test_synthesis.py
+++ b/packages/python/sibyl-core/tests/test_synthesis.py
@@ -398,6 +398,12 @@ async def test_materialize_synthesis_section_packs_redacts_visible_text() -> Non
     assert pack.redaction_count == 1
     assert pack.sources[0].content_preview == ""
     assert pack.unresolved_claims == ["needs citation"]
+    assert pack.sources[0].metadata == {
+        "facet": ContextFacet.RECENT_MEMORY.value,
+        "freshness": None,
+        "project_id": None,
+        "reason": "redacted source",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Prevent an information disclosure where redacted context items were returned in synthesis `source_packs` with `content_preview` blanked but still containing arbitrary `metadata`, which could leak sensitive fields.

### Description
- Change `materialize_synthesis_section_packs` in `packages/python/sibyl-core/src/sibyl_core/services/synthesis.py` to return only a small safe metadata subset (`facet`, `freshness`, `project_id`, `reason`) for redacted items and preserve full metadata only for non-redacted items, and add an assertion in `packages/python/sibyl-core/tests/test_synthesis.py` to verify redacted sources expose only the safe subset.

### Testing
- Updated test `test_materialize_synthesis_section_packs_redacts_visible_text` now asserts the redacted source `metadata` equals the safe subset, but automated runs in this environment could not be completed: `moon run` is not available and `PYTHONPATH=packages/python/sibyl-core/src python -m pytest packages/python/sibyl-core/tests/test_synthesis.py -k redacts_visible_text` failed due to missing dependency `pydantic`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbca2b6dc832aa04e64fe6d9be4a0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata handling for redacted synthesis sources. When source content is redacted, the associated metadata is now normalized to exclude original fields while preserving tracking information such as facet, freshness, project ID, and reason.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->