### PR TITLE
fix(source-import): scope source-import dedupe lookups to principal + memory scope

### DIFF
--- a/apps/api/src/sibyl/jobs/source_imports.py
+++ b/apps/api/src/sibyl/jobs/source_imports.py
@@ -403,6 +403,9 @@ def _default_duplicate_checker(
         existing = await get_raw_memory_by_source_id(
             organization_id=organization_id,
             source_id=payload.source_id,
+            principal_id=payload.principal_id,
+            memory_scope=payload.memory_scope,
+            scope_key=payload.scope_key,
         )
         if existing is not None:
             return existing.id

--- a/apps/api/tests/test_jobs_source_imports.py
+++ b/apps/api/tests/test_jobs_source_imports.py
@@ -176,6 +176,35 @@ async def test_import_source_archive_resumes_from_checkpoint(tmp_path: Path) -> 
     assert first_result["dedupe_keys"] != second_result["dedupe_keys"]
 
 
+
+
+@pytest.mark.asyncio
+async def test_import_source_archive_duplicate_lookup_is_policy_scoped(tmp_path: Path) -> None:
+    mbox_path = _write_mbox(tmp_path / "scoped-dedupe.mbox")
+    lookup_calls: list[dict[str, object]] = []
+
+    async def capture_lookup(**kwargs: object) -> RawMemory | None:
+        lookup_calls.append(dict(kwargs))
+        return None
+
+    with patch(
+        "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
+        AsyncMock(side_effect=capture_lookup),
+    ):
+        await source_imports.import_source_archive(
+            {},
+            str(mbox_path),
+            organization_id="org-1",
+            principal_id="user-1",
+            policy_context=_policy_context(),
+        )
+
+    assert len(lookup_calls) == 1
+    assert lookup_calls[0]["organization_id"] == "org-1"
+    assert lookup_calls[0]["principal_id"] == "user-1"
+    assert lookup_calls[0]["memory_scope"] is MemoryScope.PRIVATE
+    assert lookup_calls[0]["scope_key"] is None
+
 @pytest.mark.asyncio
 async def test_import_source_archive_fails_closed_without_policy_context(tmp_path: Path) -> None:
     mbox_path = _write_mbox(tmp_path / "job.mbox")

--- a/apps/api/tests/test_jobs_source_imports.py
+++ b/apps/api/tests/test_jobs_source_imports.py
@@ -11,7 +11,8 @@ import pytest
 
 from sibyl.jobs import source_imports
 from sibyl.jobs.worker import WorkerSettings
-from sibyl_core.services.source_adapters import clear_source_adapters
+from sibyl_core.models.sources import SourceRecord
+from sibyl_core.services.source_adapters import SourceRawMemoryWrite, clear_source_adapters
 from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 
 
@@ -176,34 +177,86 @@ async def test_import_source_archive_resumes_from_checkpoint(tmp_path: Path) -> 
     assert first_result["dedupe_keys"] != second_result["dedupe_keys"]
 
 
+def _source_record(source_id: str = "msg-1") -> SourceRecord:
+    return SourceRecord(
+        adapter_record_id=source_id,
+        source_id=source_id,
+        source_type="mbox",
+        content_hash=f"hash-{source_id}",
+        dedupe_key=f"dedupe-{source_id}",
+    )
+
+
+def _raw_memory_write(
+    *,
+    source_id: str = "msg-1",
+    principal_id: str = "user-1",
+    memory_scope: MemoryScope = MemoryScope.PRIVATE,
+    scope_key: str | None = None,
+) -> SourceRawMemoryWrite:
+    return SourceRawMemoryWrite(
+        organization_id="org-1",
+        principal_id=principal_id,
+        source_id=source_id,
+        raw_content="body",
+        title="subject",
+        memory_scope=memory_scope,
+        scope_key=scope_key,
+        tags=[],
+        metadata={},
+        provenance={},
+    )
 
 
 @pytest.mark.asyncio
-async def test_import_source_archive_duplicate_lookup_is_policy_scoped(tmp_path: Path) -> None:
-    mbox_path = _write_mbox(tmp_path / "scoped-dedupe.mbox")
+async def test_duplicate_checker_scopes_db_lookup_to_principal_and_scope() -> None:
     lookup_calls: list[dict[str, object]] = []
 
     async def capture_lookup(**kwargs: object) -> RawMemory | None:
         lookup_calls.append(dict(kwargs))
         return None
 
+    checker = source_imports._default_duplicate_checker(
+        organization_id="org-1",
+        record_source_ids={},
+    )
     with patch(
         "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
         AsyncMock(side_effect=capture_lookup),
     ):
-        await source_imports.import_source_archive(
-            {},
-            str(mbox_path),
-            organization_id="org-1",
-            principal_id="user-1",
-            policy_context=_policy_context(),
+        result = await checker(
+            record=_source_record(),
+            payload=_raw_memory_write(
+                memory_scope=MemoryScope.PROJECT,
+                scope_key="project-7",
+            ),
         )
 
+    assert result is None
     assert len(lookup_calls) == 1
     assert lookup_calls[0]["organization_id"] == "org-1"
     assert lookup_calls[0]["principal_id"] == "user-1"
-    assert lookup_calls[0]["memory_scope"] is MemoryScope.PRIVATE
-    assert lookup_calls[0]["scope_key"] is None
+    assert lookup_calls[0]["memory_scope"] is MemoryScope.PROJECT
+    assert lookup_calls[0]["scope_key"] == "project-7"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_checker_prefers_in_run_source_ids_over_db() -> None:
+    async def fail_lookup(**kwargs: object) -> RawMemory | None:
+        raise AssertionError("db lookup should be skipped for in-run duplicates")
+
+    checker = source_imports._default_duplicate_checker(
+        organization_id="org-1",
+        record_source_ids={"msg-1": "raw-existing"},
+    )
+    with patch(
+        "sibyl.jobs.source_imports.get_raw_memory_by_source_id",
+        AsyncMock(side_effect=fail_lookup),
+    ):
+        result = await checker(record=_source_record(), payload=_raw_memory_write())
+
+    assert result == "raw-existing"
+
 
 @pytest.mark.asyncio
 async def test_import_source_archive_fails_closed_without_policy_context(tmp_path: Path) -> None:

--- a/packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
@@ -885,15 +885,37 @@ async def get_raw_memory_by_source_id(
     *,
     organization_id: str,
     source_id: str,
+    principal_id: str | None = None,
+    memory_scope: MemoryScope | str | None = None,
+    scope_key: str | None = None,
 ) -> RawMemory | None:
+    filters = [
+        "source_id = $source_id",
+        "organization_id = $organization_id",
+    ]
+    params: dict[str, object] = {
+        "source_id": source_id,
+        "organization_id": organization_id,
+    }
+    if principal_id is not None:
+        filters.append("principal_id = $principal_id")
+        params["principal_id"] = principal_id
+    if memory_scope is not None:
+        filters.append("memory_scope = $memory_scope")
+        params["memory_scope"] = _coerce_memory_scope(memory_scope).value
+    if scope_key is None:
+        filters.append("scope_key IS NONE")
+    else:
+        filters.append("scope_key = $scope_key")
+        params["scope_key"] = scope_key
+
     async with surreal_content_client() as client:
         record = await _select_one(
             client,
             "SELECT * FROM raw_captures "
-            "WHERE source_id = $source_id AND organization_id = $organization_id "
+            f"WHERE {' AND '.join(filters)} "
             "ORDER BY captured_at DESC LIMIT 1;",
-            source_id=source_id,
-            organization_id=organization_id,
+            **params,
         )
     return _raw_memory_from_record(record) if record is not None else None
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
@@ -903,11 +903,11 @@ async def get_raw_memory_by_source_id(
     if memory_scope is not None:
         filters.append("memory_scope = $memory_scope")
         params["memory_scope"] = _coerce_memory_scope(memory_scope).value
-    if scope_key is None:
-        filters.append("scope_key IS NONE")
-    else:
-        filters.append("scope_key = $scope_key")
-        params["scope_key"] = scope_key
+        if scope_key is None:
+            filters.append("scope_key IS NONE")
+        else:
+            filters.append("scope_key = $scope_key")
+            params["scope_key"] = scope_key
 
     async with surreal_content_client() as client:
         record = await _select_one(

--- a/packages/python/sibyl-core/tests/test_services_surreal_content.py
+++ b/packages/python/sibyl-core/tests/test_services_surreal_content.py
@@ -12,6 +12,7 @@ from sibyl_core.services.surreal_content import (
     MemoryScope,
     _replace_record,
     get_or_create_source,
+    get_raw_memory_by_source_id,
     list_unlinked_document_chunks,
     load_search_scope,
     recall_raw_memory,
@@ -1090,3 +1091,89 @@ class TestSurrealContentHelpers:
                 raw_content="context",
                 memory_scope=memory_scope,
             )
+
+
+class TestGetRawMemoryBySourceId:
+    @pytest.mark.asyncio
+    async def test_unscoped_lookup_does_not_filter_by_scope(self) -> None:
+        fake_client = FakeClient([_query_result([])])
+
+        from sibyl_core.services import surreal_content as content_service
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                content_service,
+                "surreal_content_client",
+                lambda: _yield_client(fake_client),
+            )
+            await get_raw_memory_by_source_id(
+                organization_id="org-1",
+                source_id="source-1",
+            )
+
+        query, params = fake_client.calls[0]
+        assert "scope_key" not in query
+        assert "principal_id" not in query
+        assert "memory_scope" not in query
+        assert params == {"organization_id": "org-1", "source_id": "source-1"}
+
+    @pytest.mark.asyncio
+    async def test_private_scope_lookup_filters_principal_and_null_scope_key(self) -> None:
+        fake_client = FakeClient([_query_result([])])
+
+        from sibyl_core.services import surreal_content as content_service
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                content_service,
+                "surreal_content_client",
+                lambda: _yield_client(fake_client),
+            )
+            await get_raw_memory_by_source_id(
+                organization_id="org-1",
+                source_id="source-1",
+                principal_id="user-a",
+                memory_scope=MemoryScope.PRIVATE,
+                scope_key=None,
+            )
+
+        query, params = fake_client.calls[0]
+        assert "principal_id = $principal_id" in query
+        assert "memory_scope = $memory_scope" in query
+        assert "scope_key IS NONE" in query
+        assert params == {
+            "organization_id": "org-1",
+            "source_id": "source-1",
+            "principal_id": "user-a",
+            "memory_scope": MemoryScope.PRIVATE.value,
+        }
+
+    @pytest.mark.asyncio
+    async def test_keyed_scope_lookup_filters_scope_key_value(self) -> None:
+        fake_client = FakeClient([_query_result([])])
+
+        from sibyl_core.services import surreal_content as content_service
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                content_service,
+                "surreal_content_client",
+                lambda: _yield_client(fake_client),
+            )
+            await get_raw_memory_by_source_id(
+                organization_id="org-1",
+                source_id="source-1",
+                principal_id="user-a",
+                memory_scope=MemoryScope.PROJECT,
+                scope_key="project-7",
+            )
+
+        query, params = fake_client.calls[0]
+        assert "scope_key = $scope_key" in query
+        assert "scope_key IS NONE" not in query
+        assert params["scope_key"] == "project-7"
+
+
+@asynccontextmanager
+async def _yield_client(fake_client: FakeClient):
+    yield fake_client


### PR DESCRIPTION
### Motivation
- Prevent org-wide duplicate detection from treating another principal's private/project memory as a duplicate and leaking its `raw_memory_id` via source-import status metadata.
- Ensure dedupe checks respect the importer's memory policy context so duplicates are scoped to the requesting principal and memory scope.

### Description
- Update the default duplicate checker in `apps/api/src/sibyl/jobs/source_imports.py` to pass the import payload's `principal_id`, `memory_scope`, and `scope_key` into the duplicate lookup call to enforce policy-scoped deduplication.
- Extend `packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py::get_raw_memory_by_source_id` to accept optional `principal_id`, `memory_scope`, and `scope_key` parameters and build a dynamic SurrealDB `WHERE` clause that filters by those fields, including `scope_key IS NONE` handling.
- Add a regression test in `apps/api/tests/test_jobs_source_imports.py` asserting that duplicate lookup calls include `organization_id`, `principal_id`, `memory_scope`, and `scope_key` to prevent future regressions.

### Testing
- Compiled modified files with `python -m compileall` for `apps/api/src/sibyl/jobs/source_imports.py`, `packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py`, and `apps/api/tests/test_jobs_source_imports.py`, which completed successfully.
- Ran `python -m pytest apps/api/tests/test_jobs_source_imports.py -q` but the container environment raised a pytest config mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests could not be executed in this environment.
- Attempted repository test orchestration (`moon`) was not available in the container, so full test suite execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbca60c8c832aa0ca3d112b9e7993)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Source import duplicate detection now respects policy boundaries by considering the importing principal, memory scope, and scope key for more accurate deduplication.

* **Tests**
  * Added test to verify duplicate lookup respects policy scoping during source imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->