### PR TITLE
fix(core): cap runtime document scan chunk budget

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/document_search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/document_search.py
@@ -437,7 +437,10 @@ async def _search_documents_runtime_scan(
 
     org_uuid = UUID(organization_id)
     requested_source_id = UUID(source_id) if source_id else None
-    chunk_budget = min(max(limit, 1) * RUNTIME_SCAN_CHUNK_LIMIT_MULTIPLIER, RUNTIME_SCAN_CHUNK_LIMIT_MAX)
+    chunk_budget = min(
+        max(limit, 1) * RUNTIME_SCAN_CHUNK_LIMIT_MULTIPLIER,
+        RUNTIME_SCAN_CHUNK_LIMIT_MAX,
+    )
 
     async with get_content_read_session() as session:
         sources = await list_sources_for_graph_linking(
@@ -462,8 +465,7 @@ async def _search_documents_runtime_scan(
             if remaining_budget <= 0:
                 break
             chunks.extend(
-                cast(DocumentSearchChunk, chunk)
-                for chunk in source_chunks[:remaining_budget]
+                cast(DocumentSearchChunk, chunk) for chunk in source_chunks[:remaining_budget]
             )
             if len(chunks) >= chunk_budget:
                 break

--- a/packages/python/sibyl-core/src/sibyl_core/services/document_search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/document_search.py
@@ -32,6 +32,8 @@ DOCUMENT_VECTOR_WEIGHT = 0.7
 DOCUMENT_LEXICAL_WEIGHT = 0.3
 DOCUMENT_EMBEDDING_TIMEOUT_SECONDS = 2.0
 DOCUMENT_EMBEDDING_CACHE_SIZE = 1000
+RUNTIME_SCAN_CHUNK_LIMIT_MULTIPLIER = 25
+RUNTIME_SCAN_CHUNK_LIMIT_MAX = 2000
 
 _document_embedding_provider: NativeEmbeddingProvider | None = None
 _document_embedding_fingerprint: tuple[NativeEmbeddingProviderName, str, int, str] | None = None
@@ -435,6 +437,7 @@ async def _search_documents_runtime_scan(
 
     org_uuid = UUID(organization_id)
     requested_source_id = UUID(source_id) if source_id else None
+    chunk_budget = min(max(limit, 1) * RUNTIME_SCAN_CHUNK_LIMIT_MULTIPLIER, RUNTIME_SCAN_CHUNK_LIMIT_MAX)
 
     async with get_content_read_session() as session:
         sources = await list_sources_for_graph_linking(
@@ -454,10 +457,24 @@ async def _search_documents_runtime_scan(
             documents = await list_source_documents(session, source_id=source.id)
             for document in documents:
                 documents_by_id[str(document.id)] = cast(DocumentSearchDocument, document)
+            source_chunks = await list_source_chunks(session, source_id=source.id)
+            remaining_budget = chunk_budget - len(chunks)
+            if remaining_budget <= 0:
+                break
             chunks.extend(
                 cast(DocumentSearchChunk, chunk)
-                for chunk in await list_source_chunks(session, source_id=source.id)
+                for chunk in source_chunks[:remaining_budget]
             )
+            if len(chunks) >= chunk_budget:
+                break
+
+    if len(chunks) >= chunk_budget:
+        log.warning(
+            "document_runtime_scan_chunk_budget_exhausted",
+            organization_id=organization_id,
+            limit=limit,
+            chunk_budget=chunk_budget,
+        )
 
     return _search_documents_from_scope(
         query=query,

--- a/packages/python/sibyl-core/tests/test_services_document_search.py
+++ b/packages/python/sibyl-core/tests/test_services_document_search.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from uuid import uuid4
 from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
 import pytest
 
@@ -333,19 +333,84 @@ class TestDocumentSearch:
         monkeypatch.setattr(document_search_service, "RUNTIME_SCAN_CHUNK_LIMIT_MAX", 3)
 
         source_ids = [uuid4(), uuid4()]
-        sources = [SimpleNamespace(id=source_ids[0], name="Source 1"), SimpleNamespace(id=source_ids[1], name="Source 2")]
+        sources = [
+            SimpleNamespace(id=source_ids[0], name="Source 1"),
+            SimpleNamespace(id=source_ids[1], name="Source 2"),
+        ]
         documents = {
-            source_ids[0]: [SimpleNamespace(id=uuid4(), source_id=source_ids[0], title="Doc 1", content="alpha", url="https://example.com/1", has_code=False)],
-            source_ids[1]: [SimpleNamespace(id=uuid4(), source_id=source_ids[1], title="Doc 2", content="alpha", url="https://example.com/2", has_code=False)],
+            source_ids[0]: [
+                SimpleNamespace(
+                    id=uuid4(),
+                    source_id=source_ids[0],
+                    title="Doc 1",
+                    content="alpha",
+                    url="https://example.com/1",
+                    has_code=False,
+                )
+            ],
+            source_ids[1]: [
+                SimpleNamespace(
+                    id=uuid4(),
+                    source_id=source_ids[1],
+                    title="Doc 2",
+                    content="alpha",
+                    url="https://example.com/2",
+                    has_code=False,
+                )
+            ],
         }
         chunks = {
             source_ids[0]: [
-                SimpleNamespace(id=uuid4(), document_id=documents[source_ids[0]][0].id, content="alpha one", context="", heading_path=[], chunk_type="text", chunk_index=0, language=None, has_entities=False, embedding=[1.0, 0.0]),
-                SimpleNamespace(id=uuid4(), document_id=documents[source_ids[0]][0].id, content="alpha two", context="", heading_path=[], chunk_type="text", chunk_index=1, language=None, has_entities=False, embedding=[1.0, 0.0]),
+                SimpleNamespace(
+                    id=uuid4(),
+                    document_id=documents[source_ids[0]][0].id,
+                    content="alpha one",
+                    context="",
+                    heading_path=[],
+                    chunk_type="text",
+                    chunk_index=0,
+                    language=None,
+                    has_entities=False,
+                    embedding=[1.0, 0.0],
+                ),
+                SimpleNamespace(
+                    id=uuid4(),
+                    document_id=documents[source_ids[0]][0].id,
+                    content="alpha two",
+                    context="",
+                    heading_path=[],
+                    chunk_type="text",
+                    chunk_index=1,
+                    language=None,
+                    has_entities=False,
+                    embedding=[1.0, 0.0],
+                ),
             ],
             source_ids[1]: [
-                SimpleNamespace(id=uuid4(), document_id=documents[source_ids[1]][0].id, content="alpha three", context="", heading_path=[], chunk_type="text", chunk_index=0, language=None, has_entities=False, embedding=[1.0, 0.0]),
-                SimpleNamespace(id=uuid4(), document_id=documents[source_ids[1]][0].id, content="alpha four", context="", heading_path=[], chunk_type="text", chunk_index=1, language=None, has_entities=False, embedding=[1.0, 0.0]),
+                SimpleNamespace(
+                    id=uuid4(),
+                    document_id=documents[source_ids[1]][0].id,
+                    content="alpha three",
+                    context="",
+                    heading_path=[],
+                    chunk_type="text",
+                    chunk_index=0,
+                    language=None,
+                    has_entities=False,
+                    embedding=[1.0, 0.0],
+                ),
+                SimpleNamespace(
+                    id=uuid4(),
+                    document_id=documents[source_ids[1]][0].id,
+                    content="alpha four",
+                    context="",
+                    heading_path=[],
+                    chunk_type="text",
+                    chunk_index=1,
+                    language=None,
+                    has_entities=False,
+                    embedding=[1.0, 0.0],
+                ),
             ],
         }
 
@@ -366,10 +431,19 @@ class TestDocumentSearch:
             return chunks[source_id]
 
         with (
-            patch("sibyl_core.services.document_search._embed_text", AsyncMock(return_value=[1.0, 0.0])),
+            patch(
+                "sibyl_core.services.document_search._embed_text",
+                AsyncMock(return_value=[1.0, 0.0]),
+            ),
             patch("sibyl.persistence.content_runtime.get_content_read_session", fake_session),
-            patch("sibyl.persistence.content_runtime.list_sources_for_graph_linking", fake_list_sources_for_graph_linking),
-            patch("sibyl.persistence.content_runtime.list_source_documents", fake_list_source_documents),
+            patch(
+                "sibyl.persistence.content_runtime.list_sources_for_graph_linking",
+                fake_list_sources_for_graph_linking,
+            ),
+            patch(
+                "sibyl.persistence.content_runtime.list_source_documents",
+                fake_list_source_documents,
+            ),
             patch("sibyl.persistence.content_runtime.list_source_chunks", fake_list_source_chunks),
         ):
             results = await search_documents("alpha", organization_id=str(uuid4()), limit=3)

--- a/packages/python/sibyl-core/tests/test_services_document_search.py
+++ b/packages/python/sibyl-core/tests/test_services_document_search.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import uuid4
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -316,3 +319,60 @@ class TestDocumentSearch:
 
         assert len(results) == 1
         assert document_content_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_search_documents_runtime_scan_stops_at_chunk_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(document_search_service.settings, "store", "legacy")
+        monkeypatch.setattr(
+            document_search_service,
+            "RUNTIME_SCAN_CHUNK_LIMIT_MULTIPLIER",
+            1,
+        )
+        monkeypatch.setattr(document_search_service, "RUNTIME_SCAN_CHUNK_LIMIT_MAX", 3)
+
+        source_ids = [uuid4(), uuid4()]
+        sources = [SimpleNamespace(id=source_ids[0], name="Source 1"), SimpleNamespace(id=source_ids[1], name="Source 2")]
+        documents = {
+            source_ids[0]: [SimpleNamespace(id=uuid4(), source_id=source_ids[0], title="Doc 1", content="alpha", url="https://example.com/1", has_code=False)],
+            source_ids[1]: [SimpleNamespace(id=uuid4(), source_id=source_ids[1], title="Doc 2", content="alpha", url="https://example.com/2", has_code=False)],
+        }
+        chunks = {
+            source_ids[0]: [
+                SimpleNamespace(id=uuid4(), document_id=documents[source_ids[0]][0].id, content="alpha one", context="", heading_path=[], chunk_type="text", chunk_index=0, language=None, has_entities=False, embedding=[1.0, 0.0]),
+                SimpleNamespace(id=uuid4(), document_id=documents[source_ids[0]][0].id, content="alpha two", context="", heading_path=[], chunk_type="text", chunk_index=1, language=None, has_entities=False, embedding=[1.0, 0.0]),
+            ],
+            source_ids[1]: [
+                SimpleNamespace(id=uuid4(), document_id=documents[source_ids[1]][0].id, content="alpha three", context="", heading_path=[], chunk_type="text", chunk_index=0, language=None, has_entities=False, embedding=[1.0, 0.0]),
+                SimpleNamespace(id=uuid4(), document_id=documents[source_ids[1]][0].id, content="alpha four", context="", heading_path=[], chunk_type="text", chunk_index=1, language=None, has_entities=False, embedding=[1.0, 0.0]),
+            ],
+        }
+
+        chunk_calls: list = []
+
+        @asynccontextmanager
+        async def fake_session():
+            yield object()
+
+        async def fake_list_sources_for_graph_linking(*args, **kwargs):
+            return sources
+
+        async def fake_list_source_documents(*args, source_id, **kwargs):
+            return documents[source_id]
+
+        async def fake_list_source_chunks(*args, source_id, **kwargs):
+            chunk_calls.append(source_id)
+            return chunks[source_id]
+
+        with (
+            patch("sibyl_core.services.document_search._embed_text", AsyncMock(return_value=[1.0, 0.0])),
+            patch("sibyl.persistence.content_runtime.get_content_read_session", fake_session),
+            patch("sibyl.persistence.content_runtime.list_sources_for_graph_linking", fake_list_sources_for_graph_linking),
+            patch("sibyl.persistence.content_runtime.list_source_documents", fake_list_source_documents),
+            patch("sibyl.persistence.content_runtime.list_source_chunks", fake_list_source_chunks),
+        ):
+            results = await search_documents("alpha", organization_id=str(uuid4()), limit=3)
+
+        assert results
+        assert len(chunk_calls) == 2


### PR DESCRIPTION
### Motivation
- Non-Surreal document searches performed an unbounded runtime scan that loaded and scored every source document/chunk before applying `limit`, enabling CPU/memory amplification by low-privilege authenticated users.  

### Description
- Add `RUNTIME_SCAN_CHUNK_LIMIT_MULTIPLIER` and `RUNTIME_SCAN_CHUNK_LIMIT_MAX` and compute a per-request `chunk_budget` derived from the user `limit` to bound work performed by `_search_documents_runtime_scan`.  
- Limit `list_source_chunks` results per-source to the remaining chunk budget and stop iterating sources once the budget is exhausted.  
- Emit a structured warning log `document_runtime_scan_chunk_budget_exhausted` when truncation occurs for observability.  
- Add `test_search_documents_runtime_scan_stops_at_chunk_budget` to validate that the runtime scan honors the configured budget and stops requesting further source chunks.

### Testing
- Added a focused unit test `test_search_documents_runtime_scan_stops_at_chunk_budget` in `packages/python/sibyl-core/tests/test_services_document_search.py` which simulates multiple sources and verifies scanning stops when the chunk budget is reached.  
- Attempted to run package tests with `moon run core:test -- packages/python/sibyl-core/tests/test_services_document_search.py` but `moon` is not available in the environment.  
- Attempted `python -m pytest packages/python/sibyl-core/tests/test_services_document_search.py` and `PYTHONPATH=packages/python/sibyl-core/src python -m pytest ...` but runs were blocked by missing project Python dependencies (e.g. `pydantic`) in the execution environment, so full test execution could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c2cf50832a9e22c2555a651a2a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document search runtime scanning now enforces chunk budget limits to optimize resource usage. Chunk retrieval stops once the configured limit is reached across sources, with warning logs when the budget is exhausted.

* **Tests**
  * Added test coverage validating that document search halts chunk retrieval appropriately when chunk budget limits are reached during runtime scanning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->