### PR TITLE
fix(core): restore per-context Surreal content clients

### DIFF
--- a/apps/api/src/sibyl/api/app.py
+++ b/apps/api/src/sibyl/api/app.py
@@ -216,13 +216,9 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # noqa: PLR0915
     try:
         from sibyl.persistence.surreal.auth import close_shared_surreal_auth_client
         from sibyl.persistence.surreal.content import close_shared_surreal_content_client
-        from sibyl_core.services.surreal_content import (
-            close_shared_surreal_content_client as close_core_surreal_content_client,
-        )
 
         await close_shared_surreal_auth_client()
         await close_shared_surreal_content_client()
-        await close_core_surreal_content_client()
     except Exception as e:
         log.debug("Shared Surreal client shutdown error", error=str(e))
 

--- a/apps/api/src/sibyl/main.py
+++ b/apps/api/src/sibyl/main.py
@@ -244,13 +244,9 @@ def create_combined_app(  # noqa: PLR0915
         try:
             from sibyl.persistence.surreal.auth import close_shared_surreal_auth_client
             from sibyl.persistence.surreal.content import close_shared_surreal_content_client
-            from sibyl_core.services.surreal_content import (
-                close_shared_surreal_content_client as close_core_surreal_content_client,
-            )
 
             await close_shared_surreal_auth_client()
             await close_shared_surreal_content_client()
-            await close_core_surreal_content_client()
         except Exception as e:
             log.warning("Error shutting down shared Surreal client", error=str(e))
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import re
 from collections.abc import AsyncIterator, Iterable, Mapping
 from contextlib import asynccontextmanager
@@ -61,15 +60,6 @@ _SCOPES_REQUIRING_SCOPE_KEY = {
     MemoryScope.TEAM,
     MemoryScope.SHARED,
 }
-
-
-@dataclass(slots=True)
-class _SharedContentClientState:
-    client: SurrealContentClient | None = None
-
-
-_shared_content_client_state = _SharedContentClientState()
-_shared_content_client_lock = asyncio.Lock()
 
 
 @dataclass(slots=True)
@@ -195,27 +185,13 @@ def build_surreal_content_client() -> SurrealContentClient:
     )
 
 
-async def get_shared_surreal_content_client() -> SurrealContentClient:
-    if _shared_content_client_state.client is not None:
-        return _shared_content_client_state.client
-
-    async with _shared_content_client_lock:
-        if _shared_content_client_state.client is None:
-            _shared_content_client_state.client = build_surreal_content_client()
-        return _shared_content_client_state.client
-
-
-async def close_shared_surreal_content_client() -> None:
-    async with _shared_content_client_lock:
-        client = _shared_content_client_state.client
-        _shared_content_client_state.client = None
-        if client is not None:
-            await client.close()
-
-
 @asynccontextmanager
 async def surreal_content_client() -> AsyncIterator[SurrealContentClient]:
-    yield await get_shared_surreal_content_client()
+    client = build_surreal_content_client()
+    try:
+        yield client
+    finally:
+        await client.close()
 
 
 def _normalize_record(record: object) -> SurrealRecord | None:
@@ -1484,11 +1460,9 @@ __all__ = [
     "MemoryScope",
     "RawMemory",
     "build_surreal_content_client",
-    "close_shared_surreal_content_client",
     "get_or_create_source",
     "get_raw_memory",
     "get_raw_memory_by_source_id",
-    "get_shared_surreal_content_client",
     "lexical_score",
     "lexical_score_from_tokens",
     "list_raw_memories_for_scope",

--- a/packages/python/sibyl-core/tests/test_services_surreal_content.py
+++ b/packages/python/sibyl-core/tests/test_services_surreal_content.py
@@ -73,29 +73,25 @@ class FakeClient:
 
 class TestSurrealContentHelpers:
     @pytest.mark.asyncio
-    async def test_surreal_content_client_reuses_shared_client(self) -> None:
-        fake_client = FakeClient([])
+    async def test_surreal_content_client_creates_per_context_client(self) -> None:
+        first_client = FakeClient([])
+        second_client = FakeClient([])
 
         from sibyl_core.services import surreal_content as content_service
 
-        await content_service.close_shared_surreal_content_client()
-        try:
-            with pytest.MonkeyPatch.context() as monkeypatch:
-                monkeypatch.setattr(
-                    content_service,
-                    "build_surreal_content_client",
-                    lambda: fake_client,
-                )
-                async with (
-                    content_service.surreal_content_client() as first,
-                    content_service.surreal_content_client() as second,
-                ):
-                    assert first is fake_client
-                    assert second is fake_client
-        finally:
-            await content_service.close_shared_surreal_content_client()
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                content_service,
+                "build_surreal_content_client",
+                lambda: first_client if first_client.closed == 0 else second_client,
+            )
+            async with content_service.surreal_content_client() as first:
+                assert first is first_client
+            async with content_service.surreal_content_client() as second:
+                assert second is second_client
 
-        assert fake_client.closed == 1
+        assert first_client.closed == 1
+        assert second_client.closed == 1
 
     @pytest.mark.asyncio
     async def test_replace_record_uses_single_upsert_statement(self) -> None:


### PR DESCRIPTION
### Motivation
- A previous change switched the core Surreal content access to a process-wide shared `SurrealContentClient`, which caused all content queries to serialize on a single `_query_lock` and created a cross-tenant head-of-line blocking availability risk.
- Revert to the per-context client lifecycle to avoid one slow or blocked query from impacting unrelated requests and organizations in the same worker.

### Description
- Removed the module-level `_SharedContentClientState` and `_shared_content_client_lock` and the shared-client getters/closers from `packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py`.
- Restored `surreal_content_client()` to create a fresh client with `build_surreal_content_client()` on enter and `await client.close()` on exit so each caller gets an independent connection.
- Updated `__all__` to remove the shared-client API surface that no longer exists.
- Adjusted the unit test `test_surreal_content_client_*` in `packages/python/sibyl-core/tests/test_services_surreal_content.py` to assert that separate context managers produce distinct clients and that each is closed.

### Testing
- Attempted monorepo test run with `moon run ...` but `moon` is not available in this environment so it could not be executed (failed: `moon` not found).
- Ran `python -m pytest packages/python/sibyl-core/tests/test_services_surreal_content.py` but test invocation failed due to missing project imports (`ModuleNotFoundError: No module named 'sibyl_core'`).
- Ran `PYTHONPATH=packages/python/sibyl-core/src python -m pytest packages/python/sibyl-core/tests/test_services_surreal_content.py` but pytest failed due to missing runtime dependency `pydantic` in the environment; no tests could be executed to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c259f8832a92ccf4541fce6f44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modified Surreal content service to create independent client instances for each operation instead of reusing a shared client.

* **Tests**
  * Updated tests to verify the new independent client instance behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->