### PR TITLE
fix(auth): require existing project for search/explore project filters

### DIFF
--- a/apps/api/src/sibyl/api/routes/search.py
+++ b/apps/api/src/sibyl/api/routes/search.py
@@ -75,6 +75,7 @@ async def search(
                 ctx,
                 project_filter,
                 required_role=ProjectRole.VIEWER,
+                require_existing_project=True,
             )
             accessible_projects = None
         else:
@@ -163,6 +164,7 @@ async def explore(
                     ctx,
                     project_id,
                     required_role=ProjectRole.VIEWER,
+                    require_existing_project=True,
                 )
             accessible_filter = (
                 set(request.project_ids) if request.mode in {"related", "traverse"} else None
@@ -173,6 +175,7 @@ async def explore(
                 ctx,
                 request.project,
                 required_role=ProjectRole.VIEWER,
+                require_existing_project=True,
             )
             accessible_filter = (
                 {request.project} if request.mode in {"related", "traverse"} else None

--- a/apps/api/tests/test_routes_search.py
+++ b/apps/api/tests/test_routes_search.py
@@ -114,6 +114,7 @@ class TestSearchRoute:
             ctx,
             "proj_1",
             required_role=ProjectRole.VIEWER,
+            require_existing_project=True,
         )
         assert response.total == 1
         assert response.results[0].id == "pattern_1"
@@ -180,6 +181,7 @@ class TestExploreRoute:
             ctx,
             "proj_1",
             required_role=ProjectRole.VIEWER,
+            require_existing_project=True,
         )
         assert response.total == 1
         assert response.entities[0]["id"] == "task_1"
@@ -288,6 +290,7 @@ class TestExploreRoute:
             ctx,
             "proj_1",
             required_role=ProjectRole.VIEWER,
+            require_existing_project=True,
         )
         assert response.total == 1
         assert core_explore.await_args.kwargs["project"] == "proj_1"


### PR DESCRIPTION
### Motivation
- Single-project search/explore filters were being validated with a non-strict helper that treats missing project records as viewable for `VIEWER` role, which can allow attacker-supplied orphan/unknown project IDs to bypass the accessible-projects RBAC filter and expose project-scoped graph data.

### Description
- Enforce strict existence checks by adding `require_existing_project=True` to `verify_entity_project_access` for single-project validation in the `search` route.
- Enforce strict existence checks by adding `require_existing_project=True` to `verify_entity_project_access` for each `project_id` in `explore`'s `project_ids` handling.
- Enforce strict existence checks by adding `require_existing_project=True` to `verify_entity_project_access` for single `project` in `explore`'s `dependencies` mode handling.
- Updated `apps/api/tests/test_routes_search.py` to assert the verifier is called with `require_existing_project=True` for the affected cases.

### Testing
- Attempted to run package tests with `moon run api:test -- apps/api/tests/test_routes_search.py`, but `moon` is not available in this environment so the command could not be executed.
- Ran `pytest -q apps/api/tests/test_routes_search.py` directly and test collection failed due to a local pytest configuration/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).
- The route unit tests were updated to reflect the new strict verifier usage but could not be fully executed in this environment due to the above test runner limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c23a24832a8dc1ff0de19f8f5a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for project access verification to ensure only existing projects are processed in search and explore operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->