### PR TITLE
fix(core): avoid unbounded adjacency scan in relationship bulk idempotency

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/graph/relationships.py
+++ b/packages/python/sibyl-core/src/sibyl_core/graph/relationships.py
@@ -561,35 +561,22 @@ class RelationshipManager:
         surreal_edge_ops = self._surreal_entity_edge_ops()
         if surreal_edge_ops is not None:
             try:
-                node_ids = sorted(
-                    {
-                        node_id
-                        for relationship in relationships
-                        for node_id in (relationship.source_id, relationship.target_id)
-                    }
-                )
-                existing_edges = await surreal_edge_ops.get_by_node_uuids(
-                    self._driver,
-                    node_ids,
-                    group_ids=[self._group_id],
-                )
-                existing_keys = {
-                    (edge.source_node_uuid, edge.name, edge.target_node_uuid)
-                    for edge in existing_edges
-                    if edge.group_id == self._group_id
-                }
                 edges = []
                 skipped = 0
                 for relationship in relationships:
-                    key = (
+                    existing = await surreal_edge_ops.get_between_nodes(
+                        self._driver,
                         relationship.source_id,
-                        relationship.relationship_type.value,
                         relationship.target_id,
+                        group_ids=[self._group_id],
+                        limit=1000,
                     )
-                    if key in existing_keys:
+                    if any(
+                        edge.name == relationship.relationship_type.value and edge.group_id == self._group_id
+                        for edge in existing
+                    ):
                         skipped += 1
                         continue
-                    existing_keys.add(key)
                     edges.append(self._to_graphiti_edge(relationship))
                 if edges:
                     await surreal_edge_ops.save_bulk(self._driver, edges)

--- a/packages/python/sibyl-core/tests/test_graph_relationships.py
+++ b/packages/python/sibyl-core/tests/test_graph_relationships.py
@@ -438,7 +438,7 @@ class TestRelationshipBulkCreate:
         surreal_relationship_manager: RelationshipManager,
     ) -> None:
         ops = surreal_relationship_manager._driver.entity_edge_ops
-        ops.get_by_node_uuids = AsyncMock(return_value=[])
+        ops.get_between_nodes = AsyncMock(return_value=[])
         ops.save_bulk = AsyncMock()
         relationships = [
             Relationship(
@@ -477,6 +477,7 @@ class TestRelationshipBulkCreate:
             ("entity-1", "RELATED_TO", "entity-2"),
             ("entity-2", "DEPENDS_ON", "entity-3"),
         }
+        assert ops.get_between_nodes.await_count == 2
 
     @pytest.mark.asyncio
     async def test_bulk_create_is_idempotent_against_existing_surreal_edges(
@@ -485,7 +486,7 @@ class TestRelationshipBulkCreate:
         sample_entity_edge: EntityEdge,
     ) -> None:
         ops = surreal_relationship_manager._driver.entity_edge_ops
-        ops.get_by_node_uuids = AsyncMock(return_value=[sample_entity_edge])
+        ops.get_between_nodes = AsyncMock(side_effect=[[sample_entity_edge], []])
         ops.save_bulk = AsyncMock()
         relationships = [
             Relationship(
@@ -508,11 +509,16 @@ class TestRelationshipBulkCreate:
 
         assert created == 2
         assert failed == 0
-        ops.get_by_node_uuids.assert_awaited_once_with(
+        first_call = ops.get_between_nodes.await_args_list[0]
+        assert first_call.args == (
             surreal_relationship_manager._driver,
-            ["entity-001", "entity-002", "entity-003", "entity-004"],
-            group_ids=[surreal_relationship_manager._group_id],
+            "entity-001",
+            "entity-002",
         )
+        assert first_call.kwargs == {
+            "group_ids": [surreal_relationship_manager._group_id],
+            "limit": 1000,
+        }
         ops.save_bulk.assert_awaited_once()
         saved_edges = ops.save_bulk.await_args.args[1]
         assert [


### PR DESCRIPTION
### Motivation
- Prevent an unbounded adjacency preflight that materialized edges for any endpoint in a bulk relationship request, which could exhaust worker/API/DB resources when user-controlled IDs include high-degree nodes.
- Preserve bulk idempotency checks while constraining read scope to exact source/target pairs to remove the availability risk.

### Description
- Replace the preflight call to `get_by_node_uuids(...)` with per-relationship `get_between_nodes(..., limit=1000)` checks scoped to each source/target pair and filtered by relationship type. (file: `packages/python/sibyl-core/src/sibyl_core/graph/relationships.py`)
- Maintain the existing bulk `save_bulk(...)` path and fallback-to-per-relationship `create()` behavior when the bulk save fails. (file: `packages/python/sibyl-core/src/sibyl_core/graph/relationships.py`)
- Update unit tests to mock and assert `get_between_nodes` usage and ensure idempotency behavior is preserved. (file: `packages/python/sibyl-core/tests/test_graph_relationships.py`)

### Testing
- Attempted to run `moon run core:test -- packages/python/sibyl-core/tests/test_graph_relationships.py`, but `moon` is not available in the execution environment so the suite could not be invoked there. (failed)
- Ran targeted `pytest` invocations; they failed to load due to missing project dependencies (`ModuleNotFoundError: No module named 'sibyl_core'` and missing `pydantic`) so tests could not execute end-to-end in this environment. (failed)
- Updated tests locally in the repo to reflect the new preflight behavior; these tests should pass in CI or a developer environment with project dependencies and `moon` available. (not executed here)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c21fb8832a974734983c228510)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced duplicate relationship detection in bulk creation operations through improved group-scoped edge checking methodology.

* **Tests**
  * Expanded test coverage for bulk relationship creation scenarios, including verification of deduplication behavior and idempotency across different relationship triplets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->