### PR TITLE
fix(core): bound batch relationship edge reads

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/graph/relationships.py
+++ b/packages/python/sibyl-core/src/sibyl_core/graph/relationships.py
@@ -937,10 +937,12 @@ class RelationshipManager:
                     )
                 return results
 
+            batch_limit = max(limit_per_entity, 1) * len(seed_ids)
             edges = await surreal_edge_ops.get_by_node_uuids(
                 self._driver,
                 seed_ids,
                 group_ids=[self._group_id],
+                limit=batch_limit,
             )
 
             type_values = {t.value for t in relationship_types} if relationship_types else None

--- a/packages/python/sibyl-core/tests/test_graph_relationships.py
+++ b/packages/python/sibyl-core/tests/test_graph_relationships.py
@@ -1596,6 +1596,7 @@ class TestGetRelatedEntities:
             surreal_relationship_manager._driver,
             ["entity-001", "entity-003"],
             group_ids=["test-org-123"],
+            limit=10,
         )
         node_ops.get_by_uuids.assert_awaited_once_with(
             surreal_relationship_manager._driver,


### PR DESCRIPTION
### Motivation
- Prevent unbounded SurrealDB edge scans during batched graph traversal by ensuring a database-side limit is applied when fetching edges for a frontier.

### Description
- In `RelationshipManager.get_related_entities_batch()` compute `batch_limit = max(limit_per_entity, 1) * len(seed_ids)` and pass it as `limit` to `surreal_edge_ops.get_by_node_uuids(...)`, capping the number of edges returned by the DB for the whole frontier and avoiding large unbounded reads (file: `packages/python/sibyl-core/src/sibyl_core/graph/relationships.py`).
- Update the unit test expectation in `packages/python/sibyl-core/tests/test_graph_relationships.py` to assert that `get_by_node_uuids` is invoked with the forwarded `limit` argument for the batched case.
- Preserve existing in-memory per-seed enforcement of `limit_per_entity` so behavior for result shaping remains unchanged.

### Testing
- Attempted to run the package tests via the monorepo runner `moon` for the targeted test (failed because `moon` is not available in this environment).  
- Attempted to run the targeted pytest for `test_get_related_entities_batch_uses_surreal_batch_ops` (failed due to import environment: `ModuleNotFoundError: No module named 'sibyl_core'`).  
- The change is covered by the updated unit test which now asserts that the DB-level `limit` is forwarded; running the test suite in a properly provisioned developer environment (with `moon` and Python deps installed) should validate the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c2d4d8832a8e7242c96276361e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch relationship queries now enforce explicit result limits that scale with the number of entities being queried, ensuring more consistent and predictable response sizing. This improves query reliability and replaces reliance on backend defaults for result limiting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->