### PR TITLE
fix(api): authorize related_to targets on entity create

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -381,7 +381,11 @@ async def _validate_related_to_targets_for_write(
         try:
             related_entity = await entity_manager.get(related_id)
         except Exception as exc:
-            raise HTTPException(status_code=404, detail=f"Related entity not found: {related_id}") from exc
+            raise HTTPException(
+                status_code=404, detail=f"Related entity not found: {related_id}"
+            ) from exc
+        if related_entity is None:
+            raise HTTPException(status_code=404, detail=f"Related entity not found: {related_id}")
 
         related_project_id = _entity_read_project_id(related_entity)
         if related_project_id is not None:

--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -363,6 +363,36 @@ async def _require_entity_read_access(ctx: AuthContext, entity: Any) -> set[str]
     return accessible_projects
 
 
+async def _validate_related_to_targets_for_write(
+    *,
+    ctx: AuthContext,
+    entity_manager: Any,
+    related_to: list[str] | None,
+) -> None:
+    if not related_to:
+        return
+
+    checked_ids: set[str] = set()
+    for related_id in related_to:
+        if related_id in checked_ids:
+            continue
+        checked_ids.add(related_id)
+
+        try:
+            related_entity = await entity_manager.get(related_id)
+        except Exception as exc:
+            raise HTTPException(status_code=404, detail=f"Related entity not found: {related_id}") from exc
+
+        related_project_id = _entity_read_project_id(related_entity)
+        if related_project_id is not None:
+            await verify_entity_project_access(
+                None,
+                ctx,
+                related_project_id,
+                required_role=ProjectRole.CONTRIBUTOR,
+            )
+
+
 def _entity_matches_project_filter(
     entity: Any,
     *,
@@ -1188,6 +1218,12 @@ async def create_entity(
                 required_role=ProjectRole.CONTRIBUTOR,
                 require_existing_project=True,
             )
+        runtime = await get_entity_graph_runtime(group_id)
+        await _validate_related_to_targets_for_write(
+            ctx=ctx,
+            entity_manager=runtime.entity_manager,
+            related_to=entity.related_to,
+        )
 
         # Use description as content fallback (frontend sends description, add() needs content)
         content = entity.content or entity.description or entity.name

--- a/apps/api/tests/test_api_entities_create_task_fields.py
+++ b/apps/api/tests/test_api_entities_create_task_fields.py
@@ -43,9 +43,21 @@ async def test_entities_create_passes_task_fields_to_add() -> None:
     add_result.id = "task_new"
     add_result.message = "ok"
 
+    related_target = MagicMock()
+    related_target.entity_type = EntityType.DECISION
+    related_target.project_id = None
+    related_target.metadata = {}
+    runtime = MagicMock()
+    runtime.entity_manager = MagicMock()
+    runtime.entity_manager.get = AsyncMock(return_value=related_target)
+
     with (
         patch("sibyl_core.tools.core.add", AsyncMock(return_value=add_result)) as add,
         patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),
+        patch(
+            "sibyl.api.routes.entities.get_entity_graph_runtime",
+            AsyncMock(return_value=runtime),
+        ),
         patch(
             "sibyl.api.routes.entities.verify_entity_project_access", AsyncMock()
         ) as verify_access,
@@ -98,22 +110,25 @@ async def test_entities_create_rejects_missing_related_to_target() -> None:
 
     runtime = MagicMock()
     runtime.entity_manager = MagicMock()
-    runtime.entity_manager.get = AsyncMock(side_effect=Exception("not found"))
+    runtime.entity_manager.get = AsyncMock(side_effect=KeyError("not found"))
 
     with (
-        patch("sibyl.api.routes.entities.get_entity_graph_runtime", AsyncMock(return_value=runtime)),
+        patch(
+            "sibyl.api.routes.entities.get_entity_graph_runtime",
+            AsyncMock(return_value=runtime),
+        ),
         patch("sibyl_core.tools.core.add", AsyncMock()) as add,
         patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),
+        pytest.raises(HTTPException) as exc,
     ):
-        with pytest.raises(HTTPException) as exc:
-            await create_entity(
-                request=request,
-                entity=entity,
-                org=org,
-                ctx=ctx,
-                content_session=content_session,
-                sync=False,
-            )
+        await create_entity(
+            request=request,
+            entity=entity,
+            org=org,
+            ctx=ctx,
+            content_session=content_session,
+            sync=False,
+        )
 
     assert exc.value.status_code == 404
     assert exc.value.detail == "Related entity not found: decision_missing"

--- a/apps/api/tests/test_api_entities_create_task_fields.py
+++ b/apps/api/tests/test_api_entities_create_task_fields.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 
 from sibyl.api.routes.entities import create_entity
 from sibyl.api.schemas import EntityCreate
@@ -73,3 +74,47 @@ async def test_entities_create_passes_task_fields_to_add() -> None:
     assert kwargs["technologies"] == ["python"]
     assert kwargs["depends_on"] == ["task_a", "task_b"]
     assert kwargs["related_to"] == ["decision_123"]
+
+
+@pytest.mark.asyncio
+async def test_entities_create_rejects_missing_related_to_target() -> None:
+    org = MagicMock()
+    org.id = uuid4()
+
+    request = MagicMock()
+    request.headers = {}
+    request.cookies = {}
+
+    content_session = AsyncMock()
+    ctx = MagicMock()
+
+    entity = EntityCreate(
+        name="Test task",
+        description="",
+        content="do it",
+        entity_type=EntityType.TASK,
+        related_to=["decision_missing"],
+    )
+
+    runtime = MagicMock()
+    runtime.entity_manager = MagicMock()
+    runtime.entity_manager.get = AsyncMock(side_effect=Exception("not found"))
+
+    with (
+        patch("sibyl.api.routes.entities.get_entity_graph_runtime", AsyncMock(return_value=runtime)),
+        patch("sibyl_core.tools.core.add", AsyncMock()) as add,
+        patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await create_entity(
+                request=request,
+                entity=entity,
+                org=org,
+                ctx=ctx,
+                content_session=content_session,
+                sync=False,
+            )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Related entity not found: decision_missing"
+    add.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- The REST `EntityCreate.related_to` field allowed callers to create `RELATED_TO` edges to arbitrary entity IDs without per-target authorization, enabling low-privilege org members to mutate the graph and leak related-entity metadata.

### Description
- Add `_validate_related_to_targets_for_write` which deduplicates `related_to` IDs, verifies each target exists, and enforces `ProjectRole.CONTRIBUTOR` access on the target entity's project before allowing creation.
- Invoke the validator from `create_entity` (after existing project checks and before calling `add()`), preventing unauthorized edges from reaching the core write path.
- Add a regression test in `apps/api/tests/test_api_entities_create_task_fields.py` that ensures a missing `related_to` target yields `404 Related entity not found` and that `add()` is not called.
- Changes touch `apps/api/src/sibyl/api/routes/entities.py` and the test file `apps/api/tests/test_api_entities_create_task_fields.py`.

### Testing
- Added unit test `test_entities_create_rejects_missing_related_to_target` to cover missing related target blocking behavior and preventing `add()` invocation; the test was committed.
- Attempted to run package tests with `moon run api:test -- apps/api/tests/test_api_entities_create_task_fields.py`, but `moon` is not available in this environment so it could not be executed.
- Attempted `python -m pytest apps/api/tests/test_api_entities_create_task_fields.py`, but test collection failed in this environment due to a pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c2ecd0832aa248dd08a21c2fbb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity creation now validates that all related entities exist and user has required access permissions, providing clear error messages for missing references.

* **Tests**
  * Added test coverage for missing related entity validation scenarios during entity creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->