### PR TITLE
fix(api): force Redis-backed job execution to avoid local event-loop blocking

### DIFF
--- a/apps/api/src/sibyl/coordination/broker.py
+++ b/apps/api/src/sibyl/coordination/broker.py
@@ -176,7 +176,7 @@ _broker_backend: QueueBackend | None = None
 
 def get_queue_backend() -> QueueBackend:
     """Return the queue backend used for job execution."""
-    return get_coordination_backend()
+    return "redis"
 
 
 def get_broker() -> QueueBroker:


### PR DESCRIPTION
### Motivation
- Prevent background jobs from running in-process on the API event loop (which can block the ASGI loop for minutes for jobs that perform synchronous `subprocess.run` or tarfile work) by restoring Redis/arq as the job execution backend.

### Description
- Change `get_queue_backend()` in `apps/api/src/sibyl/coordination/broker.py` to return `"redis"` instead of `get_coordination_backend()`, ensuring jobs use the Redis/arq worker path rather than the local in-process broker.

### Testing
- Attempted to run the monorepo test target with `moon run api:test -- --maxfail=1 -k coordination`, but `moon` is not installed in this environment so the command failed; attempted targeted `pytest apps/api/tests/test_coordination_local.py -q` but collection aborted due to environment pytest config/plugin incompatibility (`Unknown config option: asyncio_default_fixture_loop_scope`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c274b8832aa58232ed1083341c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed job coordination to consistently use a single queue backend, improving system stability and eliminating variable backend selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->