### PR TITLE
fix(core): bound hierarchical graph fetches by endpoint limits

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/graph/communities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/graph/communities.py
@@ -44,6 +44,8 @@ _COMMUNITY_PAGE_SIZE = 500
 _GRAPH_DIVERSITY_THRESHOLD = 100
 _GRAPH_PRIMARY_SAMPLE_SHARE = 0.8
 _GRAPH_MISSING_TYPE_MIN_RESERVE = 5
+_GRAPH_FETCH_NODE_MULTIPLIER = 3
+_GRAPH_FETCH_EDGE_MULTIPLIER = 3
 GRAPH_RESOLUTION_OVERVIEW = "overview"
 GRAPH_RESOLUTION_DETAIL = "detail"
 
@@ -1349,8 +1351,18 @@ async def _fetch_graph_nodes(
 ) -> tuple[list[dict[str, Any]], set[str]]:
     """Fetch nodes with cluster assignments, optionally filtered by project/type."""
     try:
-        entities = await _list_all_entities(client, organization_id)
-        relationships = await _list_all_relationships(client, organization_id)
+        max_entities = max(max_nodes * _GRAPH_FETCH_NODE_MULTIPLIER, max_nodes)
+        estimated_max_edges = max_nodes * 5
+        max_relationships = max(
+            estimated_max_edges * _GRAPH_FETCH_EDGE_MULTIPLIER,
+            estimated_max_edges,
+        )
+        entities = await _list_all_entities(client, organization_id, max_items=max_entities)
+        relationships = await _list_all_relationships(
+            client,
+            organization_id,
+            max_items=max_relationships,
+        )
         return _build_graph_nodes_from_snapshot(
             entities,
             relationships,
@@ -1375,7 +1387,12 @@ async def _fetch_graph_edges(
         return []
 
     try:
-        relationships = await _list_all_relationships(client, organization_id)
+        max_relationships = max(max_edges * _GRAPH_FETCH_EDGE_MULTIPLIER, max_edges)
+        relationships = await _list_all_relationships(
+            client,
+            organization_id,
+            max_items=max_relationships,
+        )
         return _build_graph_edges_from_snapshot(
             relationships,
             node_ids,


### PR DESCRIPTION
### Motivation
- The hierarchical graph and NetworkX export paths could materialize the entire org graph in Python before applying `max_nodes`/`max_edges`, enabling low-privileged authenticated users to force large in-memory and CPU work. This change restores request-level bounding at the data-access layer to mitigate availability impact. 

### Description
- Add `_GRAPH_FETCH_NODE_MULTIPLIER` and `_GRAPH_FETCH_EDGE_MULTIPLIER` fetch heuristics to control pre-filtering page limits. 
- Update `_fetch_graph_nodes()` to compute `max_entities` and `max_relationships` and call `_list_all_entities(..., max_items=...)` and `_list_all_relationships(..., max_items=...)` so pagination is bounded by request-derived limits. 
- Update `_fetch_graph_edges()` to compute `max_relationships` and call `_list_all_relationships(..., max_items=...)` before applying in-memory edge filtering. 
- Use an estimated edge budget derived from `max_nodes` to avoid underfetching while still enforcing an upper bound; preserve existing snapshot-based filtering and LOD caches. 

### Testing
- `python -m py_compile packages/python/sibyl-core/src/sibyl_core/graph/communities.py` succeeded. 
- Attempted to run package tests with `moon` but `moon` is not available in the environment so those scripts could not be executed. 
- Attempted `python -m pytest apps/api/tests/test_communities.py -q` but the local pytest run failed due to a test environment configuration/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c2ea40832a93ff5c0c6a4cb10b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced graph visualization by improving how entities and relationships are sampled before displaying subgraphs, resulting in more accurate and complete graph representations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->