### PR TITLE
fix(api): cap metrics task pagination to prevent memory exhaustion

### DIFF
--- a/apps/api/src/sibyl/api/routes/metrics.py
+++ b/apps/api/src/sibyl/api/routes/metrics.py
@@ -49,7 +49,6 @@ async def execute_surreal_graph_query(
     return await execute_surreal_graph_query(group_id, query, **params)
 
 
-
 METRICS_MAX_TASKS = 10_000
 
 
@@ -566,7 +565,9 @@ async def get_project_summaries(
         )
 
     except MetricsEntityLimitExceededError as e:
-        log.warning("get_project_summaries_entity_limit_exceeded", error=str(e), group_id=str(org.id))
+        log.warning(
+            "get_project_summaries_entity_limit_exceeded", error=str(e), group_id=str(org.id)
+        )
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail="Too many tasks to compute project summaries. Please narrow scope.",

--- a/apps/api/src/sibyl/api/routes/metrics.py
+++ b/apps/api/src/sibyl/api/routes/metrics.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from sibyl.api.schemas import (
     AssigneeStats,
@@ -47,6 +47,14 @@ async def execute_surreal_graph_query(
     from sibyl.persistence.graph_runtime import execute_surreal_graph_query
 
     return await execute_surreal_graph_query(group_id, query, **params)
+
+
+
+METRICS_MAX_TASKS = 10_000
+
+
+class MetricsEntityLimitExceededError(RuntimeError):
+    """Raised when metrics endpoint pagination exceeds the allowed entity cap."""
 
 
 router = APIRouter(
@@ -212,6 +220,7 @@ async def _list_entities_by_type_paginated_via_service(
     entity_type: EntityType,
     *,
     batch_size: int = 1000,
+    max_entities: int | None = None,
 ) -> list[Any]:
     """List all entities of a type by following service cursors."""
     entities: list[Any] = []
@@ -227,6 +236,10 @@ async def _list_entities_by_type_paginated_via_service(
             break
 
         entities.extend(page.items)
+        if max_entities is not None and len(entities) > max_entities:
+            raise MetricsEntityLimitExceededError(
+                f"metrics entity limit exceeded for {entity_type.value}: {max_entities}"
+            )
         if page.next_cursor is None:
             break
         cursor = page.next_cursor
@@ -451,6 +464,7 @@ async def _list_summary_metric_tasks(
             service,
             EntityType.TASK,
             batch_size=1000,
+            max_entities=METRICS_MAX_TASKS,
         )
     ]
 
@@ -551,6 +565,12 @@ async def get_project_summaries(
             projects_summary=_build_project_summaries(projects, counts_by_project)
         )
 
+    except MetricsEntityLimitExceededError as e:
+        log.warning("get_project_summaries_entity_limit_exceeded", error=str(e), group_id=str(org.id))
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Too many tasks to compute project summaries. Please narrow scope.",
+        ) from e
     except Exception as e:
         log.exception("get_project_summaries_failed", error=str(e))
         raise HTTPException(
@@ -608,6 +628,12 @@ async def get_org_metrics(
             projects_summary=projects_summary,
         )
 
+    except MetricsEntityLimitExceededError as e:
+        log.warning("get_org_metrics_entity_limit_exceeded", error=str(e), group_id=str(org.id))
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Too many tasks to compute organization metrics. Please narrow scope.",
+        ) from e
     except Exception as e:
         log.exception("get_org_metrics_failed", error=str(e))
         raise HTTPException(

--- a/apps/api/tests/test_metrics.py
+++ b/apps/api/tests/test_metrics.py
@@ -811,7 +811,6 @@ class TestGetOrgMetrics:
         assert result.top_assignees[0].name == "alice"
         assert result.projects_summary[0].id in {"proj_a", "proj_b"}
 
-
     @pytest.mark.asyncio
     async def test_org_metrics_rejects_unbounded_service_task_enumeration(self) -> None:
         """Returns 413 when paged task enumeration exceeds metrics safety cap."""
@@ -858,9 +857,9 @@ class TestGetOrgMetrics:
                 "sibyl.api.routes.metrics._list_surreal_metric_task_rows",
                 AsyncMock(return_value=None),
             ),
+            pytest.raises(HTTPException) as exc_info,
         ):
-            with pytest.raises(HTTPException) as exc_info:
-                await get_org_metrics(org=mock_org)
+            await get_org_metrics(org=mock_org)
 
         assert exc_info.value.status_code == 413
 

--- a/apps/api/tests/test_metrics.py
+++ b/apps/api/tests/test_metrics.py
@@ -811,6 +811,59 @@ class TestGetOrgMetrics:
         assert result.top_assignees[0].name == "alice"
         assert result.projects_summary[0].id in {"proj_a", "proj_b"}
 
+
+    @pytest.mark.asyncio
+    async def test_org_metrics_rejects_unbounded_service_task_enumeration(self) -> None:
+        """Returns 413 when paged task enumeration exceeds metrics safety cap."""
+        from sibyl.api.routes.metrics import METRICS_MAX_TASKS, get_org_metrics
+
+        mock_org = create_mock_org()
+        mock_service = AsyncMock()
+
+        mock_projects = [
+            create_mock_entity(entity_type="project", name="Project A", entity_id="proj_a"),
+        ]
+        first_page = [
+            create_mock_entity(
+                entity_type="task",
+                name=f"Task {index}",
+                entity_id=f"task_{index}",
+                metadata={"project_id": "proj_a", "status": "todo"},
+            )
+            for index in range(METRICS_MAX_TASKS)
+        ]
+        overflow_page = [
+            create_mock_entity(
+                entity_type="task",
+                name="Overflow Task",
+                entity_id="task_overflow",
+                metadata={"project_id": "proj_a", "status": "todo"},
+            )
+        ]
+
+        mock_service.list_entities = AsyncMock(
+            side_effect=[
+                Page(items=mock_projects, next_cursor=None),
+                Page(items=first_page, next_cursor="cursor-2"),
+                Page(items=overflow_page, next_cursor=None),
+            ]
+        )
+
+        with (
+            patch(
+                "sibyl.api.routes.metrics.get_knowledge_read_adapter",
+                AsyncMock(return_value=mock_service),
+            ),
+            patch(
+                "sibyl.api.routes.metrics._list_surreal_metric_task_rows",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_org_metrics(org=mock_org)
+
+        assert exc_info.value.status_code == 413
+
     @pytest.mark.asyncio
     async def test_org_metrics_empty(self) -> None:
         """Returns metrics with no projects or tasks."""


### PR DESCRIPTION
### Motivation
- The metrics endpoints previously enumerated and `model_dump()`-ed every `TASK` entity via a cursored service path with no upper bound, allowing authenticated org members to trigger unbounded memory/CPU use on large or attacker-inflated tenants. 
- The change restores a safety gate so metrics aggregation cannot OOM the API process while preserving the lean SurrealDB fast-path when available.

### Description
- Add a per-endpoint safety cap `METRICS_MAX_TASKS` and a dedicated `MetricsEntityLimitExceededError` in `apps/api/src/sibyl/api/routes/metrics.py` to represent the limit. 
- Extend `_list_entities_by_type_paginated_via_service` with an optional `max_entities` parameter and fail fast by raising the new exception when the accumulated entity count exceeds the cap. 
- Apply the cap to the task fallback path used by `GET /metrics` and `GET /metrics/projects-summary` so the service-based fallback no longer materializes unlimited full `Entity` payloads. 
- Convert a cap breach into HTTP 413 responses from both endpoints and add regression coverage in `apps/api/tests/test_metrics.py` (`test_org_metrics_rejects_unbounded_service_task_enumeration`).

### Testing
- Ran the package test file with the project runner: `uv run pytest apps/api/tests/test_metrics.py -q`, which completed successfully with `48 passed`.
- Attempted `moon run api:test` in this environment but the `moon` binary was not available so it could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c33d28832aa92b7ba540f1fbd8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Metrics API now returns HTTP 413 with a descriptive error when task enumeration exceeds capacity, rather than a generic server error.

* **Tests**
  * Added tests for metrics API task enumeration limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->