### PR TITLE
fix(api): avoid archived episode scans in priority decay

### DIFF
--- a/apps/api/src/sibyl/jobs/consolidation.py
+++ b/apps/api/src/sibyl/jobs/consolidation.py
@@ -165,7 +165,7 @@ async def priority_decay(
                 EntityType.EPISODE,
                 limit=page_size,
                 offset=offset,
-                include_archived=True,
+                include_archived=False,
             )
             if not batch:
                 break

--- a/apps/api/tests/test_jobs_consolidation.py
+++ b/apps/api/tests/test_jobs_consolidation.py
@@ -244,8 +244,8 @@ async def test_priority_decay_archives_only_old_unarchived_episodes(
         "min_age_days": 180,
     }
     assert entity_manager.list_by_type.await_args_list == [
-        call(EntityType.EPISODE, limit=200, offset=0, include_archived=True),
-        call(EntityType.EPISODE, limit=200, offset=3, include_archived=True),
+        call(EntityType.EPISODE, limit=200, offset=0, include_archived=False),
+        call(EntityType.EPISODE, limit=200, offset=3, include_archived=False),
     ]
     entity_manager.update.assert_awaited_once()
     assert entity_manager.update.await_args.args[0] == "episode-old"
@@ -295,8 +295,8 @@ async def test_priority_decay_respects_archive_cap_across_pages(
     assert result["candidates_found"] == 3
     assert result["archived"] == 3
     assert entity_manager.list_by_type.await_args_list == [
-        call(EntityType.EPISODE, limit=200, offset=0, include_archived=True),
-        call(EntityType.EPISODE, limit=200, offset=2, include_archived=True),
+        call(EntityType.EPISODE, limit=200, offset=0, include_archived=False),
+        call(EntityType.EPISODE, limit=200, offset=2, include_archived=False),
     ]
     assert [await_call.args[0] for await_call in entity_manager.update.await_args_list] == [
         "episode-1",


### PR DESCRIPTION
### Motivation
- A recent refactor caused `priority_decay` to page episodes with `include_archived=True` and do cutoff/status checks in Python, which can force large scans of fresh or already-archived episodes and create an availability/performance regression for busy orgs.

### Description
- Fetch unarchived episodes during candidate paging by calling `entity_manager.list_by_type(..., include_archived=False)` and update the tests to assert the new call contract in `apps/api/src/sibyl/jobs/consolidation.py` and `apps/api/tests/test_jobs_consolidation.py`.

### Testing
- Attempted `moon run api:test -- test_jobs_consolidation.py` but `moon` is not available in this container so the monorepo test runner could not be executed, and running `pytest apps/api/tests/test_jobs_consolidation.py` produced a collection failure due to a local pytest config/plugin mismatch (`asyncio_default_fixture_loop_scope` unknown).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c23258832aa9738dd39c7274a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Modified entity selection logic to exclude archived entities from consolidation decay runs.

* **Tests**
  * Updated test assertions to reflect the new entity selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->