### PR TITLE
fix(api): bound untyped entity listing to single batch

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -230,26 +230,14 @@ async def _list_all_entities_paginated(
     batch_size: int | None = None,
 ) -> list[Any]:
     batch_size = LIST_ALL_PAGE_SIZE if batch_size is None else batch_size
-    entities: list[Any] = []
-    offset = 0
-
-    while True:
-        list_kwargs: dict[str, Any] = {
-            "limit": batch_size,
-            "offset": offset,
-            "include_archived": True,
-            **_lightweight_entity_list_kwargs(entity_manager),
-        }
-        batch = await entity_manager.list_all(
-            **list_kwargs,
-        )
-        if not batch:
-            break
-
-        entities.extend(entity for entity in batch if not _entity_is_archived(entity))
-        offset += batch_size
-
-    return entities
+    list_kwargs: dict[str, Any] = {
+        "limit": batch_size,
+        "offset": 0,
+        "include_archived": True,
+        **_lightweight_entity_list_kwargs(entity_manager),
+    }
+    batch = await entity_manager.list_all(**list_kwargs)
+    return [entity for entity in batch if not _entity_is_archived(entity)]
 
 
 async def _list_entities_by_type_paginated(

--- a/apps/api/tests/test_routes_entities.py
+++ b/apps/api/tests/test_routes_entities.py
@@ -444,7 +444,7 @@ class TestListEntitiesRoute:
         assert response.has_more is True
 
     @pytest.mark.asyncio
-    async def test_untyped_project_filters_skip_archived_only_pages(self) -> None:
+    async def test_untyped_project_filters_apply_to_bounded_batch(self) -> None:
         org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
         manager = MagicMock()
         archived_page = [
@@ -456,7 +456,7 @@ class TestListEntitiesRoute:
             _entity("ent-unassigned", project_id=None, name="Unassigned"),
         ]
         manager.list_by_type = AsyncMock()
-        manager.list_all = AsyncMock(side_effect=[archived_page, live_page, []])
+        manager.list_all = AsyncMock(return_value=archived_page + live_page)
         runtime = SimpleNamespace(entity_manager=manager)
 
         with (
@@ -485,11 +485,7 @@ class TestListEntitiesRoute:
             )
 
         manager.list_by_type.assert_not_awaited()
-        assert manager.list_all.await_args_list == [
-            call(limit=2, offset=0, include_archived=True),
-            call(limit=2, offset=2, include_archived=True),
-            call(limit=2, offset=4, include_archived=True),
-        ]
+        manager.list_all.assert_awaited_once_with(limit=2, offset=0, include_archived=True)
         assert [entity.id for entity in response.entities] == ["ent-match", "ent-unassigned"]
         assert response.total == 2
         assert response.has_more is False

--- a/apps/api/tests/test_routes_entities.py
+++ b/apps/api/tests/test_routes_entities.py
@@ -447,6 +447,7 @@ class TestListEntitiesRoute:
     async def test_untyped_project_filters_apply_to_bounded_batch(self) -> None:
         org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
         manager = MagicMock()
+        manager._surreal_entity_node_ops.return_value = None
         archived_page = [
             _entity("ent-archived-1", project_id="proj-1", name="Archived 1", archived=True),
             _entity("ent-archived-2", project_id="proj-1", name="Archived 2", archived=True),


### PR DESCRIPTION
### Motivation
- A recent change made `GET /entities` without `entity_type` iterate through all graph pages and accumulate every entity in memory, creating an authenticated availability/DoS risk for low-privileged users. 
- The intent of this change is to restore a hard upper bound on backend work and memory for untyped listings while preserving existing behavior for typed queries.

### Description
- Replace the unbounded paginator `_list_all_entities_paginated` with a single bounded `list_all` call using `limit=LIST_ALL_PAGE_SIZE` and `offset=0` so untyped listings perform one capped graph query only. 
- Keep archived filtering and `supports_lightweight_entity_list` behavior by passing the same `include_archived` and `include_content` kwargs to the single call. 
- Update the affected unit test to assert the bounded single-call behavior for untyped requests and to reflect the new single-batch return shape. 
- Changes made in `apps/api/src/sibyl/api/routes/entities.py` and `apps/api/tests/test_routes_entities.py`.

### Testing
- Attempted to run the package test harness with `moon run api:test -- apps/api/tests/test_routes_entities.py`, but `moon` is not available in this environment so it could not be executed. 
- Ran `python -m pytest apps/api/tests/test_routes_entities.py` as a local fallback and the run failed due to a local pytest configuration/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`). 
- Unit test updates were applied to align expectations with the bounded behavior; tests were not fully executed here due to the environment limitations described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c2cdd0832ab3700e4d2665cd38)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated entity listing to return first-page results with filtering applied, instead of accumulating results across multiple pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->