### PR TITLE
fix(api): enforce archived exclusion in typed entity pagination

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -267,7 +267,7 @@ async def _list_entities_by_type_paginated(
         list_kwargs: dict[str, Any] = {
             "limit": batch_size,
             "offset": offset,
-            "include_archived": True,
+            "include_archived": False,
             **_lightweight_entity_list_kwargs(entity_manager),
         }
         if project_id:

--- a/apps/api/tests/test_routes_entities.py
+++ b/apps/api/tests/test_routes_entities.py
@@ -102,7 +102,7 @@ class TestListEntitiesRoute:
                 EntityType.TASK,
                 limit=1000,
                 offset=0,
-                include_archived=True,
+                include_archived=False,
                 project_id="proj-1",
             ),
         ]
@@ -157,7 +157,7 @@ class TestListEntitiesRoute:
                 EntityType.TASK,
                 limit=1000,
                 offset=0,
-                include_archived=True,
+                include_archived=False,
             ),
         ]
         manager.list_all.assert_not_awaited()
@@ -281,9 +281,9 @@ class TestListEntitiesRoute:
             )
 
         assert manager.list_by_type.await_args_list == [
-            call(EntityType.TASK, limit=2, offset=0, include_archived=True),
-            call(EntityType.TASK, limit=2, offset=2, include_archived=True),
-            call(EntityType.TASK, limit=2, offset=4, include_archived=True),
+            call(EntityType.TASK, limit=2, offset=0, include_archived=False),
+            call(EntityType.TASK, limit=2, offset=2, include_archived=False),
+            call(EntityType.TASK, limit=2, offset=4, include_archived=False),
         ]
         manager.list_all.assert_not_awaited()
         assert [entity.id for entity in response.entities] == ["ent-1", "ent-2", "ent-3"]


### PR DESCRIPTION
### Motivation
- A recent change requested archived records from the graph for typed entity listings and then applied a caller-side filter that only inspected `entity.metadata['status']`, which missed archive state stored in the normalized top-level `n.status` field and allowed archived entities to leak in list responses.
- The goal is to ensure the storage-layer archived exclusion (`n.status != 'archived'`) is applied for typed listings so archived content cannot be disclosed via the listing endpoint.

### Description
- Reverted the typed-entity pagination call to request `include_archived=False` from the `EntityManager` so the graph query predicate that checks normalized `n.status` runs in storage.
- Kept the existing Python-side ` _entity_is_archived` check in place for defense-in-depth and to handle metadata-based archive markers.
- Updated affected unit tests in `apps/api/tests/test_routes_entities.py` to assert the `list_by_type(..., include_archived=False)` call contract.

### Testing
- Attempted to run the repository test target with `moon` but `moon` is not available in this environment so that step was skipped.
- Ran `pytest` against the changed test file but test collection failed due to a local pytest configuration/plugin mismatch (`asyncio_default_fixture_loop_scope` unknown), which is unrelated to this code change.
- Verified the change was committed with message `fix(api): enforce storage archived filter for typed entity paging`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c280fc832a8fe7521a0d3d7052)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Archived entities are now correctly excluded from paginated entity type listings in API responses, ensuring only active entities are returned when querying entities by type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->