### PR TITLE
fix(core): cap task filter expansion in legacy metadata matching

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/graph/entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/graph/entities.py
@@ -69,6 +69,7 @@ _SEARCH_STOP_WORDS = {
     "to",
     "with",
 }
+_MAX_TASK_FILTER_VALUES = 25
 
 
 class EpisodeType(StrEnum):
@@ -248,6 +249,24 @@ def _metadata_json_contains_any_params(
     if not clauses:
         return {}, "FALSE"
     return params, " OR ".join(clauses)
+
+
+def _normalized_filter_values(value: str | None) -> list[str]:
+    """Parse comma-separated filter values with normalization and caps."""
+    if not value:
+        return []
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for raw_value in value.split(","):
+        normalized = raw_value.strip().lower()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+        if len(deduped) >= _MAX_TASK_FILTER_VALUES:
+            break
+    return deduped
 
 
 class EntityManager:
@@ -2095,9 +2114,9 @@ class EntityManager:
             "n.group_id = $group_id",
         ]
 
-        status_list = [s.strip().lower() for s in status.split(",")] if status else []
-        priority_list = [p.strip().lower() for p in priority.split(",")] if priority else []
-        complexity_list = [c.strip().lower() for c in complexity.split(",")] if complexity else []
+        status_list = _normalized_filter_values(status)
+        priority_list = _normalized_filter_values(priority)
+        complexity_list = _normalized_filter_values(complexity)
 
         if self._surreal_entity_node_ops() is not None:
             try:

--- a/packages/python/sibyl-core/tests/test_graph_entities.py
+++ b/packages/python/sibyl-core/tests/test_graph_entities.py
@@ -1303,6 +1303,25 @@ class TestEntityListByType:
         assert ids == {"task-001", "task-002"}
 
     @pytest.mark.asyncio
+    async def test_list_by_type_caps_status_filter_value_expansion(
+        self,
+        entity_manager: EntityManager,
+        mock_driver: MagicMock,
+    ) -> None:
+        """list_by_type() caps comma-separated filter expansion to prevent query blowups."""
+        mock_driver.execute_query.return_value = ([], None, None)
+        status_filter = ",".join(f"value{i}" for i in range(60))
+
+        await entity_manager.list_by_type(EntityType.TASK, status=status_filter)
+
+        kwargs = mock_driver.execute_query.await_args.kwargs
+        assert len(kwargs["status_values"]) == 25
+        assert kwargs["status_values"][0] == "value0"
+        assert kwargs["status_values"][-1] == "value24"
+        legacy_keys = [k for k in kwargs if k.startswith("legacy_status_")]
+        assert len(legacy_keys) == 50
+
+    @pytest.mark.asyncio
     async def test_list_by_type_with_priority_filter(
         self,
         entity_manager: EntityManager,


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated or low-privileged attackers from forcing unbounded query/parameter growth by passing very large comma-separated `status`, `priority`, or `complexity` filter strings, which previously expanded into an OR clause and two parameters per value.
- Restore a bounded, predictable expansion behavior that preserves existing filtering semantics for normal inputs while mitigating resource-exhaustion (DoS) risk.

### Description
- Add a constant ` _MAX_TASK_FILTER_VALUES = 25` to cap how many comma-separated values are expanded for task filters.
- Introduce `_normalized_filter_values(value: str | None) -> list[str]` which parses, lowercases, deduplicates, and limits comma-separated filter input.
- Replace inline `split(",")` parsing for `status`, `priority`, and `complexity` with calls to `_normalized_filter_values` before building query parameters and legacy-match fallbacks.
- Add a regression test `test_list_by_type_caps_status_filter_value_expansion` asserting that a 60-value input is trimmed to 25 values and that legacy parameter keys are bounded.

### Testing
- Added a targeted unit test `test_list_by_type_caps_status_filter_value_expansion` in `packages/python/sibyl-core/tests/test_graph_entities.py` to validate bounded expansion behavior (test content present in the branch).
- Attempted to run the monorepo test task with `moon run core:test ...` but `moon` is not available in this environment, so that run did not execute.
- Attempted to run the relevant tests with `pytest -q packages/python/sibyl-core/tests/test_graph_entities.py -k "multiple_statuses or caps_status_filter_value_expansion or with_status_filter"` and the run failed due to import setup in this container (`ModuleNotFoundError: No module named 'sibyl_core'`), so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c28860832abef962c7c1ff06e1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task filtering performance by capping and normalizing filter values to prevent query blowups when listing tasks with multiple filter criteria.

* **Tests**
  * Added test coverage for task filter value normalization and capping behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->