### PR TITLE
fix(api): enforce project RBAC in metrics endpoints

### DIFF
--- a/apps/api/src/sibyl/api/routes/metrics.py
+++ b/apps/api/src/sibyl/api/routes/metrics.py
@@ -19,8 +19,10 @@ from sibyl.api.schemas import (
     TaskStatusDistribution,
     TimeSeriesPoint,
 )
-from sibyl.auth.dependencies import get_current_organization, require_org_role
+from sibyl.auth.context import AuthContext
+from sibyl.auth.dependencies import get_auth_context, get_current_organization, require_org_role
 from sibyl_core.auth import AuthOrganization, OrganizationRole
+from sibyl.persistence.auth_runtime import list_accessible_project_graph_ids
 from sibyl_core.models.entities import EntityType
 from sibyl_core.services import KnowledgeReadService
 
@@ -367,6 +369,29 @@ def _prefer_valid_datetime_value(
     return metadata_value or row_value
 
 
+
+
+def _filter_projects_by_access(projects: list[Any], accessible_project_ids: set[str] | None) -> list[Any]:
+    """Filter projects to the caller's accessible set when provided."""
+    if accessible_project_ids is None:
+        return projects
+    return [project for project in projects if str(project.id) in accessible_project_ids]
+
+
+def _filter_tasks_by_access(
+    tasks: list[dict[str, Any]], accessible_project_ids: set[str] | None
+) -> list[dict[str, Any]]:
+    """Filter tasks to accessible projects when project RBAC set is available."""
+    if accessible_project_ids is None:
+        return tasks
+
+    filtered: list[dict[str, Any]] = []
+    for task in tasks:
+        project_id = str(task.get("metadata", {}).get("project_id") or "")
+        if project_id and project_id in accessible_project_ids:
+            filtered.append(task)
+    return filtered
+
 def _normalize_metric_task_row(row: dict[str, Any]) -> dict[str, Any]:
     """Normalize raw task rows into the legacy task-shaped metrics format."""
     metadata = _parse_metadata_dict(row.get("metadata"))
@@ -531,6 +556,7 @@ async def get_project_metrics(
 @router.get("/projects-summary", response_model=ProjectSummariesResponse)
 async def get_project_summaries(
     org: AuthOrganization = Depends(get_current_organization),
+    ctx: AuthContext | Any = Depends(get_auth_context),
 ) -> ProjectSummariesResponse:
     """Get the lean project-summary payload for the projects page."""
     try:
@@ -541,7 +567,13 @@ async def get_project_summaries(
             EntityType.PROJECT,
             batch_size=500,
         )
+        accessible_project_ids = (
+            await list_accessible_project_graph_ids(ctx) if isinstance(ctx, AuthContext) else None
+        )
+        projects = _filter_projects_by_access(projects, accessible_project_ids)
+
         tasks = await _list_summary_metric_tasks(group_id, service)
+        tasks = _filter_tasks_by_access(tasks, accessible_project_ids)
         counts_by_project = _compute_project_task_counts(
             tasks,
             now=datetime.now(UTC),
@@ -561,6 +593,7 @@ async def get_project_summaries(
 @router.get("", response_model=OrgMetricsResponse)
 async def get_org_metrics(
     org: AuthOrganization = Depends(get_current_organization),
+    ctx: AuthContext | Any = Depends(get_auth_context),
 ) -> OrgMetricsResponse:
     """Get organization-wide metrics aggregating all projects."""
     try:
@@ -573,7 +606,13 @@ async def get_org_metrics(
             EntityType.PROJECT,
             batch_size=500,
         )
+        accessible_project_ids = (
+            await list_accessible_project_graph_ids(ctx) if isinstance(ctx, AuthContext) else None
+        )
+        projects = _filter_projects_by_access(projects, accessible_project_ids)
+
         tasks = await _list_summary_metric_tasks(group_id, service)
+        tasks = _filter_tasks_by_access(tasks, accessible_project_ids)
 
         status_dist = _compute_status_distribution(tasks)
         priority_dist = _compute_priority_distribution(tasks)

--- a/apps/api/src/sibyl/api/routes/metrics.py
+++ b/apps/api/src/sibyl/api/routes/metrics.py
@@ -21,8 +21,8 @@ from sibyl.api.schemas import (
 )
 from sibyl.auth.context import AuthContext
 from sibyl.auth.dependencies import get_auth_context, get_current_organization, require_org_role
-from sibyl_core.auth import AuthOrganization, OrganizationRole
 from sibyl.persistence.auth_runtime import list_accessible_project_graph_ids
+from sibyl_core.auth import AuthOrganization, OrganizationRole
 from sibyl_core.models.entities import EntityType
 from sibyl_core.services import KnowledgeReadService
 
@@ -369,9 +369,9 @@ def _prefer_valid_datetime_value(
     return metadata_value or row_value
 
 
-
-
-def _filter_projects_by_access(projects: list[Any], accessible_project_ids: set[str] | None) -> list[Any]:
+def _filter_projects_by_access(
+    projects: list[Any], accessible_project_ids: set[str] | None
+) -> list[Any]:
     """Filter projects to the caller's accessible set when provided."""
     if accessible_project_ids is None:
         return projects
@@ -391,6 +391,7 @@ def _filter_tasks_by_access(
         if project_id and project_id in accessible_project_ids:
             filtered.append(task)
     return filtered
+
 
 def _normalize_metric_task_row(row: dict[str, Any]) -> dict[str, Any]:
     """Normalize raw task rows into the legacy task-shaped metrics format."""

--- a/apps/api/tests/test_metrics.py
+++ b/apps/api/tests/test_metrics.py
@@ -17,6 +17,7 @@ from sibyl.api.routes.metrics import (
     _parse_iso_date,
 )
 from sibyl_core.models.entities import Entity, EntityType
+from sibyl.auth.context import AuthContext
 from sibyl_core.storage import Page
 
 # =============================================================================
@@ -1173,6 +1174,64 @@ class TestGetOrgMetrics:
             ),
         ]
 
+
+
+    @pytest.mark.asyncio
+    async def test_org_metrics_filters_to_accessible_projects(self) -> None:
+        """Org metrics includes only projects/tasks in the caller access set."""
+        from sibyl.api.routes.metrics import get_org_metrics
+
+        mock_org = create_mock_org()
+        mock_service = AsyncMock()
+
+        mock_projects = [
+            create_mock_entity(entity_type="project", name="Public", entity_id="proj_public"),
+            create_mock_entity(entity_type="project", name="Secret", entity_id="proj_secret"),
+        ]
+        mock_tasks = [
+            create_mock_entity(
+                entity_type="task",
+                name="Public Task",
+                entity_id="task_public",
+                metadata={"project_id": "proj_public", "status": "doing", "priority": "high"},
+            ),
+            create_mock_entity(
+                entity_type="task",
+                name="Secret Task",
+                entity_id="task_secret",
+                metadata={"project_id": "proj_secret", "status": "done", "priority": "critical"},
+            ),
+        ]
+
+        mock_service.list_entities = AsyncMock(
+            side_effect=[
+                Page(items=mock_projects, next_cursor=None),
+                Page(items=mock_tasks, next_cursor=None),
+            ]
+        )
+        mock_ctx = MagicMock(spec=AuthContext)
+
+        with (
+            patch(
+                "sibyl.api.routes.metrics.get_knowledge_read_adapter",
+                AsyncMock(return_value=mock_service),
+            ),
+            patch(
+                "sibyl.api.routes.metrics._list_surreal_metric_task_rows",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "sibyl.api.routes.metrics.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_public"}),
+            ),
+        ):
+            result = await get_org_metrics(org=mock_org, ctx=mock_ctx)
+
+        assert result.total_projects == 1
+        assert result.total_tasks == 1
+        assert [summary.id for summary in result.projects_summary] == ["proj_public"]
+        assert result.status_distribution.doing == 1
+        assert result.status_distribution.done == 0
 
 class TestGetProjectSummaries:
     """Tests for get_project_summaries endpoint."""

--- a/apps/api/tests/test_metrics.py
+++ b/apps/api/tests/test_metrics.py
@@ -16,8 +16,8 @@ from sibyl.api.routes.metrics import (
     _normalize_metric_task_row,
     _parse_iso_date,
 )
-from sibyl_core.models.entities import Entity, EntityType
 from sibyl.auth.context import AuthContext
+from sibyl_core.models.entities import Entity, EntityType
 from sibyl_core.storage import Page
 
 # =============================================================================
@@ -1174,8 +1174,6 @@ class TestGetOrgMetrics:
             ),
         ]
 
-
-
     @pytest.mark.asyncio
     async def test_org_metrics_filters_to_accessible_projects(self) -> None:
         """Org metrics includes only projects/tasks in the caller access set."""
@@ -1232,6 +1230,7 @@ class TestGetOrgMetrics:
         assert [summary.id for summary in result.projects_summary] == ["proj_public"]
         assert result.status_distribution.doing == 1
         assert result.status_distribution.done == 0
+
 
 class TestGetProjectSummaries:
     """Tests for get_project_summaries endpoint."""


### PR DESCRIPTION
### Motivation

- The org-level metrics endpoints were returning per-project summaries and task rollups for every project in the org regardless of caller project access, exposing private project IDs/names and activity to non-admin org members.

### Description

- Add lightweight access filters `
_filter_projects_by_access` and `
_filter_tasks_by_access` to constrain collections to the caller's accessible project IDs.
- Use the caller auth context via `Depends(get_auth_context)` and compute the accessible project set with `list_accessible_project_graph_ids` when present, and apply those filters in `get_org_metrics` and `get_project_summaries` before any aggregation or summary computation.
- Import and wire `AuthContext`, `get_auth_context`, and `list_accessible_project_graph_ids` into `apps/api/src/sibyl/api/routes/metrics.py` and keep behavior compatible with direct unit-test invocation by only applying filtering when an `AuthContext` instance is available.
- Add a regression test `test_org_metrics_filters_to_accessible_projects` to `apps/api/tests/test_metrics.py` that asserts private projects/tasks are excluded from the `GET /metrics` response for a restricted caller.

### Testing

- Added a unit test covering the new RBAC filtering: `test_org_metrics_filters_to_accessible_projects` (present in `apps/api/tests/test_metrics.py`).
- Attempted monorepo test run `moon run api:test -- test_metrics.py -k accessible_projects` but `moon` is not available in the execution environment.
- Attempted direct `pytest apps/api/tests/test_metrics.py -k accessible_projects` but test collection failed due to a local pytest configuration/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).
- The change is minimal and local: it filters the project and task lists prior to existing metric computations so existing metrics logic is preserved for callers that have full org/project access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0964c2e890832a8ff303635e92679f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed metrics endpoints to enforce access control, ensuring users only see data for projects and organizations they have permission to access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->