### PR TITLE
ci: fix RC release workflow plumbing (prerelease flag + trivy pin)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -371,7 +371,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "◆ Generate Trivy SBOM"
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: >-
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/sibyl-${{
@@ -389,7 +389,7 @@ jobs:
           retention-days: 90
 
       - name: "◆ Trivy CVE gate"
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: >-
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/sibyl-${{

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,7 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
           body: ${{ steps.release_notes.outputs.content }}
+          prerelease: ${{ steps.version.outputs.is_prerelease == 'true' }}
 
       - name: "◇ Trigger publish"
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary

Two CI fixes surfaced while cutting v1.0.0-rc.1:

- **release.yml** now passes `is_prerelease` to `softprops/action-gh-release`. Without it, the RC was published as Latest on the releases page and had to be edited by hand.
- **publish.yml** uses `aquasecurity/trivy-action@v0.36.0` (the actual tag — the v prefix matters). The previous `@0.36.0` pin was unresolvable, so Docker: Security api/web failed and Docker: Sign + Release: Update were skipped. Images shipped unsigned for rc.1.

Both are tiny, surgical patches. No behavior change beyond what the workflow already intended.

## Test plan

- [ ] Re-cut a prerelease or dispatch dry_run after merge and confirm:
  - GitHub release page shows the Pre-release badge
  - Docker: Security api/web complete successfully
  - Docker: Sign matrix executes
- [ ] Spot-check SBOM artifact uploads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Releases are now correctly marked as prerelease versions when applicable.

* **Chores**
  * Updated CI/CD workflow tooling versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->