### PR TITLE
fix(retrieval): constrain agent diary raw retrieval to project scope

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/native.py
@@ -413,19 +413,36 @@ def _scope_decisions(
             )
         )
     if agent_id:
-        decisions.append(
-            (
-                authorize_memory_read(
-                    principal_id=principal_id,
-                    memory_scope=MemoryScope.PRIVATE,
-                    project_id=project,
-                    agent_id=agent_id,
-                    accessible_projects=accessible_projects,
-                ),
-                project,
-                agent_id,
+        diary_projects = (project,) if project else tuple(accessible_projects or ())
+        if diary_projects:
+            for diary_project in diary_projects:
+                decisions.append(
+                    (
+                        authorize_memory_read(
+                            principal_id=principal_id,
+                            memory_scope=MemoryScope.PRIVATE,
+                            project_id=diary_project,
+                            agent_id=agent_id,
+                            accessible_projects=accessible_projects,
+                        ),
+                        diary_project,
+                        agent_id,
+                    )
+                )
+        else:
+            decisions.append(
+                (
+                    authorize_memory_read(
+                        principal_id=principal_id,
+                        memory_scope=MemoryScope.PRIVATE,
+                        project_id=None,
+                        agent_id=agent_id,
+                        accessible_projects=accessible_projects,
+                    ),
+                    None,
+                    agent_id,
+                )
             )
-        )
     return decisions
 
 
@@ -1344,7 +1361,7 @@ def _candidate_from_raw_memory(
     scope: NativeScopeSpec,
 ) -> NativeRetrievalCandidate:
     source = memory.source_id or memory.capture_surface
-    project_id = memory.metadata.get("project_id") or (
+    project_id = memory.metadata.get("project_id") or memory.project_id or (
         memory.scope_key if memory.memory_scope is MemoryScope.PROJECT else None
     )
     metadata = {

--- a/packages/python/sibyl-core/tests/test_native_retrieval.py
+++ b/packages/python/sibyl-core/tests/test_native_retrieval.py
@@ -231,6 +231,50 @@ def test_build_native_context_retrieval_plan_keeps_all_accessible_projects_when_
     assert plan.accessible_projects == frozenset({"project_123", "project_456"})
 
 
+def test_build_native_context_retrieval_plan_scopes_agent_diary_to_accessible_projects() -> None:
+    plan = build_native_context_retrieval_plan(
+        query="unscoped agent diary",
+        organization_id="org-123",
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["session", "episode", "note"]},
+        principal_id="user-123",
+        project=None,
+        accessible_projects={"project_123", "project_456"},
+        agent_id="nova",
+    )
+
+    diary_scopes = [
+        scope
+        for scope in plan.scopes
+        if scope.memory_scope is MemoryScope.PRIVATE and scope.agent_id == "nova"
+    ]
+    assert {scope.project_id for scope in diary_scopes} == {"project_123", "project_456"}
+
+
+def test_candidate_from_raw_memory_uses_top_level_project_id_when_metadata_missing() -> None:
+    candidate = native_module._candidate_from_raw_memory(
+        RawMemory(
+            id="raw-1",
+            organization_id="org-123",
+            source_id="agent-diary",
+            principal_id="user-123",
+            project_id="project_999",
+            title="Diary memory",
+            raw_content="secret",
+            memory_scope=MemoryScope.PRIVATE,
+            metadata={"agent_id": "nova"},
+        ),
+        scope=native_module.NativeScopeSpec(
+            memory_scope=MemoryScope.PRIVATE,
+            principal_id="user-123",
+            scope_key=None,
+            policy_reason="agent_diary_private_read_allowed",
+        ),
+    )
+
+    assert candidate.project_id == "project_999"
+
+
 def test_candidate_allowed_denies_private_candidate_without_private_grant() -> None:
     plan = build_native_context_retrieval_plan(
         query="private memory",


### PR DESCRIPTION
### Motivation
- A recent refactor removed the legacy graphiti raw-memory path and caused native retrieval to produce an unprojected agent-diary scope when `project` is omitted, allowing an authenticated request with `agent_id` to recall diary rows across the organization when `accessible_projects` was set.
- Raw-memory candidates also derived `project_id` only from `metadata` or `scope_key`, which let rows whose project was stored in top-level `RawMemory.project_id` bypass `accessible_projects` filtering.

### Description
- Update `_scope_decisions` to expand agent-diary private scopes per-accessible-project when `project` is not provided, generating one per `accessible_projects` entry instead of a single unprojected scope, while preserving the explicit-`project` behavior when given.
- Change `_candidate_from_raw_memory` to include the top-level `RawMemory.project_id` as a fallback when `metadata['project_id']` is absent so candidate `project_id` is accurate for filtering.
- Add focused regression tests: `test_build_native_context_retrieval_plan_scopes_agent_diary_to_accessible_projects` and `test_candidate_from_raw_memory_uses_top_level_project_id_when_metadata_missing` in `packages/python/sibyl-core/tests/test_native_retrieval.py`.

### Testing
- Ran the targeted pytest selection with `uv run pytest packages/python/sibyl-core/tests/test_native_retrieval.py -k "scopes_agent_diary or top_level_project_id"` and both new tests passed (`2 passed, 29 deselected`).
- `moon` was not available in the environment so broader monorepo test orchestration via `moon` was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c25a04204832ab764c3447e5cdb13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed project scoping for private agent diary retrieval to correctly associate memory items with their respective projects.
* Improved project ID resolution in memory candidate creation to use available metadata before deriving from scope information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->