### PR TITLE
fix(api): reload global settings after embedded env configuration

### DIFF
--- a/apps/api/src/sibyl/cli/main.py
+++ b/apps/api/src/sibyl/cli/main.py
@@ -168,6 +168,7 @@ def serve(
 
 
 def _configure_embedded_environment(data_dir: Path | None = None) -> Path:
+    from sibyl.config import reload_settings_from_env
     from sibyl.embedded import default_embedded_data_dir
 
     resolved_data_dir = data_dir or Path(
@@ -179,6 +180,7 @@ def _configure_embedded_environment(data_dir: Path | None = None) -> Path:
     os.environ.setdefault("SIBYL_COORDINATION_BACKEND", "local")
     os.environ.setdefault("SIBYL_ALLOW_EMBEDDED_SINGLE_WRITER", "1")
     os.environ.setdefault("SIBYL_SURREAL_URL", f"surrealkv://{resolved_data_dir}")
+    reload_settings_from_env()
     return resolved_data_dir
 
 

--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -557,3 +557,10 @@ class Settings(BaseSettings):
 
 # Global settings instance
 settings = Settings()
+
+
+def reload_settings_from_env() -> Settings:
+    """Reload the global settings instance from current environment variables."""
+    refreshed = Settings()
+    settings.__dict__.update(refreshed.__dict__)
+    return settings

--- a/apps/api/tests/test_cli_main.py
+++ b/apps/api/tests/test_cli_main.py
@@ -97,6 +97,16 @@ def test_configure_embedded_environment(monkeypatch, tmp_path) -> None:
     assert os.environ["SIBYL_SURREAL_URL"] == f"surrealkv://{data_dir}"
 
 
+def test_configure_embedded_environment_refreshes_global_settings(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("SIBYL_SURREAL_URL", raising=False)
+    monkeypatch.setattr("sibyl.config.settings.surreal_url", "")
+
+    data_dir = cli_main._configure_embedded_environment(tmp_path / "surreal")
+
+    assert os.environ["SIBYL_SURREAL_URL"] == f"surrealkv://{data_dir}"
+    assert f"surrealkv://{data_dir}" == import_module("sibyl.config").settings.resolved_surreal_url
+
+
 def test_setup_surreal_services_skips_redis_for_local_coordination(monkeypatch) -> None:
     checked: list[tuple[str, int]] = []
 


### PR DESCRIPTION
### Motivation
- Embedded `sibyld --embedded` mutates `os.environ` at runtime but the global `settings = Settings()` singleton is created earlier, leaving `settings.resolved_surreal_url` stuck on `memory://` and making auth/content clients use volatile storage.
- This could cause an exposed instance to silently use in-memory auth storage and reopen setup/admin takeover after a restart.

### Description
- Add `reload_settings_from_env()` in `sibyl.config` which reconstructs `Settings()` from the current environment and updates the global `settings` object.
- Call `reload_settings_from_env()` at the end of `_configure_embedded_environment()` in `sibyl.cli.main` so the embedded `SIBYL_*` defaults take immediate effect for code that already imported `settings`.
- Add a focused regression test `test_configure_embedded_environment_refreshes_global_settings` in `apps/api/tests/test_cli_main.py` that asserts the global `settings.resolved_surreal_url` reflects the embedded data directory after configuration.

### Testing
- Added unit test `apps/api/tests/test_cli_main.py::test_configure_embedded_environment_refreshes_global_settings` that verifies the global settings URL is refreshed; the test is present in the test suite.
- Attempted to run `moon run api:test --filter test_cli_main.py` but `moon` is not available in this environment so it could not be executed here.
- Ran `python -m pytest apps/api/tests/test_cli_main.py -q` but the run failed due to the local pytest environment/config plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5e9ae2c0832aa9ce3842735e171f)