### PR TITLE
fix(cli): bind docker init ports to localhost by default

### DIFF
--- a/apps/cli/src/sibyl_cli/docker.py
+++ b/apps/cli/src/sibyl_cli/docker.py
@@ -45,7 +45,7 @@ def compose_config(
         "api": {
             "image": api_image,
             "container_name": "sibyl-api",
-            "ports": [f"{api_port}:3334"],
+            "ports": [f"127.0.0.1:{api_port}:3334"],
             "depends_on": {"surrealdb": {"condition": "service_healthy"}},
             "environment": {
                 "SIBYL_STORE": "surreal",
@@ -65,7 +65,7 @@ def compose_config(
         "web": {
             "image": f"ghcr.io/hyperb1iss/sibyl-web:{image_tag}",
             "container_name": "sibyl-web",
-            "ports": [f"{web_port}:3337"],
+            "ports": [f"127.0.0.1:{web_port}:3337"],
             "depends_on": {"api": {"condition": "service_started"}},
             "environment": {
                 "SIBYL_API_URL": "http://api:3334/api",
@@ -87,7 +87,7 @@ def compose_config(
                 "${SIBYL_SURREAL_PASSWORD}",
                 "rocksdb:///data/sibyl.db",
             ],
-            "ports": [f"{surreal_port}:8000"],
+            "ports": [f"127.0.0.1:{surreal_port}:8000"],
             "volumes": ["sibyl_surreal:/data"],
             "healthcheck": {
                 "test": ["CMD", "/surreal", "is-ready", "--conn", "http://localhost:8000"],

--- a/apps/cli/tests/test_docker_runtime.py
+++ b/apps/cli/tests/test_docker_runtime.py
@@ -31,6 +31,9 @@ def test_docker_compose_defaults_to_single_host_runtime() -> None:
     assert services["api"]["environment"]["SIBYL_COORDINATION_BACKEND"] == "local"
     assert services["api"]["image"] == "ghcr.io/hyperb1iss/sibyl-api:1.0.0-rc.1"
     assert services["web"]["image"] == "ghcr.io/hyperb1iss/sibyl-web:1.0.0-rc.1"
+    assert services["api"]["ports"] == ["127.0.0.1:3334:3334"]
+    assert services["web"]["ports"] == ["127.0.0.1:3337:3337"]
+    assert services["surrealdb"]["ports"] == ["127.0.0.1:8000:8000"]
 
 
 def test_docker_compose_can_opt_into_worker_runtime() -> None:


### PR DESCRIPTION
### Motivation
- The `sibyl docker init` generator published API, web, and SurrealDB ports using Docker short syntax (e.g. `3334:3334`), which binds to all host interfaces and can expose unauthenticated first-run setup to the network. 
- The change restricts the default host bindings to `127.0.0.1` to avoid accidental LAN/WAN exposure while preserving local developer workflows. 

### Description
- Updated the compose generator in `apps/cli/src/sibyl_cli/docker.py` so published ports explicitly bind to `127.0.0.1` (e.g. `127.0.0.1:{api_port}:3334`) for the `api`, `web`, and `surrealdb` services. 
- Kept container-side ports and runtime environment values intact so internal container networking and behavior are unchanged. 
- Added assertions to `apps/cli/tests/test_docker_runtime.py` to lock in the localhost-only default port mappings for the compose output. 

### Testing
- Added/updated unit test assertions in `apps/cli/tests/test_docker_runtime.py` to validate `127.0.0.1` bindings. 
- Attempted `moon run cli:test -- test_docker_runtime.py` but `moon` is not available in this environment, so the monorepo task runner could not be executed. 
- Attempted `pytest apps/cli/tests/test_docker_runtime.py -q` but the local pytest run failed due to an environment/config warning (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5e83c4ac832a898515ee1cb9ecee)