### PR TITLE
fix(ci): prevent tag injection in Homebrew publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,40 +142,52 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: "△ Extract and validate version from tag"
+        id: version
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          version="${TAG#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "Invalid tag format: $TAG"
+            echo "Expected: vX.Y.Z or vX.Y.Z-suffix"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: "◆ Checkout Homebrew tap"
         uses: actions/checkout@v4
         with:
           repository: hyperb1iss/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
-
-      - name: "△ Extract version from tag"
-        id: version
-        run: echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-        env:
-          TAG: ${{ inputs.tag }}
+          persist-credentials: false
 
       - name: "△ Generate formula"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           python tools/release/homebrew_formula.py \
-            --version "${{ steps.version.outputs.version }}" \
+            --version "$VERSION" \
             --output homebrew-tap/Formula/sibyl.rb
 
       - name: "► Commit tap update"
         working-directory: homebrew-tap
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if git diff --quiet -- Formula/sibyl.rb; then
-            echo "Formula/sibyl.rb already matches v${{ steps.version.outputs.version }}"
+            echo "Formula/sibyl.rb already matches v$VERSION"
             exit 0
           fi
 
           git add Formula/sibyl.rb
           git commit \
-            -m "feat: update sibyl to v${{ steps.version.outputs.version }}" \
+            -m "feat: update sibyl to v$VERSION" \
             -m "Generate the formula from the published PyPI artifacts." \
             -m "The tap now installs both the sibyl CLI and sibyld daemon."
           git push


### PR DESCRIPTION
### Motivation
- The Homebrew publish job accepted an arbitrary `workflow_dispatch` tag and embedded the derived value directly into shell run blocks while a secret-bearing tap checkout existed, creating a command-injection/supply-chain risk. 

### Description
- Add an early `Extract and validate version from tag` step that strips a leading `v` and enforces a strict `X.Y.Z` (with optional suffix) regex, failing fast on invalid input. 
- Move the Homebrew tap checkout to occur after validation and set `persist-credentials: false` to reduce credential exposure. 
- Stop embedding the step output directly into shell scripts by exporting the version via `env` as `VERSION` and referencing `"$VERSION"` in the generate/commit steps and commit message. 

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors and returned success. 
- Verified repository status with `git status --short` showing the intended change staged. 
- Created a commit with the change, which succeeded (`fix(ci): validate publish tag before homebrew tap update`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6b0bdc24832a8bb8bd6eb8682d5f)