### PR TITLE
fix(api): enforce memory-scope visibility for graph entity list/read

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -368,6 +368,28 @@ def _entity_visible_to_projects(entity: Any, accessible_projects: set[str]) -> b
     return project_id is None or project_id in accessible_projects
 
 
+def _entity_visible_to_reader(
+    entity: Any,
+    *,
+    reader_user_id: str | None,
+    accessible_projects: set[str],
+) -> bool:
+    metadata = getattr(entity, "metadata", None) or {}
+    memory_scope = str(metadata.get("memory_scope") or "").strip().lower()
+
+    if memory_scope == "project":
+        project_id = str(metadata.get("scope_key") or metadata.get("project_id") or "").strip()
+        return bool(project_id and project_id in accessible_projects)
+
+    if memory_scope == "private":
+        owner = str(metadata.get("principal_id") or "").strip()
+        if not owner:
+            owner = str(getattr(entity, "created_by_user_id", None) or "").strip()
+        return bool(owner and reader_user_id and owner == reader_user_id)
+
+    return True
+
+
 async def _accessible_project_ids_for_read(ctx: AuthContext) -> set[str]:
     accessible_projects = await list_accessible_project_graph_ids(ctx)
     return {str(project_id) for project_id in accessible_projects or set()}
@@ -415,6 +437,13 @@ async def _require_entity_read_access(ctx: AuthContext, entity: Any) -> set[str]
     accessible_projects = await _accessible_project_ids_for_read(ctx)
     if project_id is not None:
         accessible_projects.add(project_id)
+    reader_user_id = str(getattr(getattr(ctx, "user", None), "id", None) or "") or None
+    if not _entity_visible_to_reader(
+        entity,
+        reader_user_id=reader_user_id,
+        accessible_projects=accessible_projects,
+    ):
+        raise HTTPException(status_code=404, detail="Entity not found")
     return accessible_projects
 
 
@@ -476,6 +505,8 @@ def _entity_matches_list_filters(
     project_ids: list[str] | None,
     real_project_ids: list[str],
     has_unassigned: bool,
+    reader_user_id: str | None,
+    accessible_projects: set[str],
     language: str | None,
     category: str | None,
     search: str | None,
@@ -488,6 +519,13 @@ def _entity_matches_list_filters(
         project_ids=project_ids,
         real_project_ids=real_project_ids,
         has_unassigned=has_unassigned,
+    ):
+        return False
+
+    if not _entity_visible_to_reader(
+        entity,
+        reader_user_id=reader_user_id,
+        accessible_projects=accessible_projects,
     ):
         return False
 
@@ -544,6 +582,8 @@ async def _list_entities_bounded(
     real_project_ids: list[str],
     has_unassigned: bool,
     single_project_id: str | None,
+    reader_user_id: str | None,
+    accessible_projects: set[str],
 ) -> tuple[list[Any], int, bool]:
     start = (page - 1) * page_size
     target = start + page_size + 1
@@ -580,6 +620,8 @@ async def _list_entities_bounded(
                 project_ids=project_ids,
                 real_project_ids=real_project_ids,
                 has_unassigned=has_unassigned,
+                reader_user_id=reader_user_id,
+                accessible_projects=accessible_projects,
                 language=None,
                 category=None,
                 search=None,
@@ -917,10 +959,16 @@ async def list_entities(
             page=page,
         )
 
+        reader_user_id = str(getattr(getattr(ctx, "user", None), "id", None) or "") or None
         project_ids, real_project_ids, has_unassigned = await _resolve_entity_list_project_filter(
             ctx=ctx,
             project_ids=project_ids,
         )
+        # Visibility check only consults accessible_projects for project-scoped
+        # entities. real_project_ids is either the user-verified filter set or
+        # the user's full accessible set, both of which are the correct frame
+        # for "can this user see this project-scoped projection."
+        accessible_projects = set(real_project_ids)
         runtime = await get_entity_graph_runtime(group_id)
         entity_manager = runtime.entity_manager
 
@@ -952,6 +1000,8 @@ async def list_entities(
                 real_project_ids=real_project_ids,
                 has_unassigned=bool(has_unassigned),
                 single_project_id=single_project_id,
+                reader_user_id=reader_user_id,
+                accessible_projects=accessible_projects,
             )
         else:
             if entity_type:
@@ -971,6 +1021,8 @@ async def list_entities(
                     project_ids=project_ids,
                     real_project_ids=real_project_ids,
                     has_unassigned=bool(has_unassigned),
+                    reader_user_id=reader_user_id,
+                    accessible_projects=accessible_projects,
                     language=language,
                     category=category,
                     search=search,

--- a/apps/api/tests/test_routes_entities.py
+++ b/apps/api/tests/test_routes_entities.py
@@ -656,6 +656,56 @@ class TestListEntitiesRoute:
         ]
         assert response.total == 3
 
+
+    @pytest.mark.asyncio
+    async def test_untyped_entity_list_hides_private_memory_projection_from_other_user(self) -> None:
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        manager = MagicMock()
+        manager._surreal_entity_node_ops.return_value = object()
+        manager.list_by_type = AsyncMock()
+        manager.list_all = AsyncMock(
+            return_value=[
+                _entity("task-visible", project_id="project-visible", name="Visible"),
+                SimpleNamespace(
+                    id="private-projection",
+                    entity_type=EntityType.PERSON,
+                    name="Private Projection",
+                    description="sensitive",
+                    content="",
+                    metadata={"memory_scope": "private", "scope_key": "someone-else"},
+                    languages=[],
+                    tags=[],
+                ),
+            ]
+        )
+        runtime = SimpleNamespace(entity_manager=manager)
+
+        with (
+            patch(
+                "sibyl.api.routes.entities.get_entity_graph_runtime",
+                AsyncMock(return_value=runtime),
+            ),
+            patch(
+                "sibyl.api.routes.entities.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"project-visible"}),
+            ),
+        ):
+            response = await list_entities(
+                org=org,
+                ctx=_ctx(),
+                entity_type=None,
+                language=None,
+                category=None,
+                search=None,
+                project_ids=None,
+                page=1,
+                page_size=50,
+                sort_by=SortField.UPDATED_AT,
+                sort_order=SortOrder.DESC,
+            )
+
+        assert [entity.id for entity in response.entities] == ["task-visible"]
+
     @pytest.mark.asyncio
     async def test_entity_list_rejects_inaccessible_project_filter(self) -> None:
         org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))

--- a/apps/api/tests/test_routes_entities_read.py
+++ b/apps/api/tests/test_routes_entities_read.py
@@ -122,6 +122,35 @@ async def test_get_entity_uses_knowledge_service_for_graph_entities() -> None:
     get_entity_graph_runtime.assert_not_awaited()
 
 
+
+
+@pytest.mark.asyncio
+async def test_get_entity_denies_private_memory_projection_for_non_owner() -> None:
+    org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+    entity = Entity(
+        id="person-1",
+        entity_type=EntityType.PERSON,
+        name="Private Person",
+        description="secret",
+        metadata={"memory_scope": "private", "scope_key": "different-user"},
+    )
+    service = AsyncMock()
+    service.get_entity_bundle.return_value = EntityBundle(entity=entity)
+
+    with (
+        patch(
+            "sibyl.api.routes.entities.get_entity_graph_runtime",
+            AsyncMock(),
+        ),
+        patch(
+            "sibyl.api.routes.entities.list_accessible_project_graph_ids",
+            AsyncMock(return_value={"project-1"}),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await get_entity("person-1", org=org, ctx=_ctx(), service=service)
+
+    assert exc.value.status_code == 404
 @pytest.mark.asyncio
 async def test_get_entity_keeps_project_summary_enrichment() -> None:
     org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))


### PR DESCRIPTION
### Motivation
- Persisted LLM extraction results were being written as normal graph `Entity` nodes that copied `memory_scope` metadata but could be listed/read as unassigned entities when `project_id` was unset, allowing exposure of private-scoped extracted content.
- The change enforces memory-scope visibility at the API read/filtering layer so `private` and `project` scoped projections are only visible to the proper principals without changing the projection writer.

### Description
- Add a helper `_entity_visible_to_reader(...)` that enforces `memory_scope` semantics: `project` requires the `scope_key/project_id` to be in caller `accessible_projects`, and `private` requires owner match with the requesting user. (file: `apps/api/src/sibyl/api/routes/entities.py`)
- Apply the new guard in the direct-read authorization path by extending `_require_entity_read_access` to raise `HTTPException(404)` for invisible entities. (file: `apps/api/src/sibyl/api/routes/entities.py`)
- Thread `reader_user_id` and `accessible_projects` into both bounded and unbounded list flows and call the visibility guard from `_entity_matches_list_filters` so list endpoints hide private projections from non-owners. (file: `apps/api/src/sibyl/api/routes/entities.py`)
- Add regression tests for the fix: `test_untyped_entity_list_hides_private_memory_projection_from_other_user` and `test_get_entity_denies_private_memory_projection_for_non_owner`. (files: `apps/api/tests/test_routes_entities.py`, `apps/api/tests/test_routes_entities_read.py`)

### Testing
- Attempted `moon run api:test -- apps/api/tests/test_routes_entities.py apps/api/tests/test_routes_entities_read.py` but `moon` is not available in the environment so the monorepo test task could not be executed.
- Attempted `python -m pytest apps/api/tests/test_routes_entities.py apps/api/tests/test_routes_entities_read.py` but test collection failed due to the local pytest environment config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`), so tests could not be run here.
- The new regression tests were added to the test suite and should pass in CI or a developer environment where `moon` and the project's pytest plugins/config are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6e5916c4832abeb7134c49aff77d)