### PR TITLE
fix(ci): harden AUR publish workflow action usage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,11 +131,14 @@ jobs:
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: "◆ Checkout Sibyl"
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
+          persist-credentials: false
 
       - name: "◇ Setup Python"
         uses: actions/setup-python@v5
@@ -189,11 +192,14 @@ jobs:
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - name: "◆ Checkout Sibyl"
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
+          persist-credentials: false
 
       - name: "◇ Setup Python"
         uses: actions/setup-python@v5
@@ -213,7 +219,7 @@ jobs:
             --output PKGBUILD
 
       - name: "► Publish to AUR"
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
+        uses: KSXGitHub/github-actions-deploy-aur@abe8ac26b51011c88be58c8809fd2ac674068ea5 # v4.1.2
         with:
           pkgname: sibyl
           pkgbuild: ./PKGBUILD


### PR DESCRIPTION
### Motivation
- Close a release-time supply-chain gap where a third-party AUR deploy action was referenced by a mutable tag while receiving the `AUR_SSH_KEY` secret. 
- Reduce blast radius by limiting GitHub token scope and preventing the checkout step from persisting credentials into jobs that don't need them.

### Description
- Pin `KSXGitHub/github-actions-deploy-aur` to an immutable commit SHA (`abe8ac26b51011c88be58c8809fd2ac674068ea5`) while keeping the human-friendly tag comment for traceability. 
- Add `permissions: contents: read` at the job level for the `aur` AUR publish job to enforce least privilege. 
- Set `persist-credentials: false` on the `actions/checkout@v4` step used by the AUR job to avoid leaking the workflow token into subsequent steps. 
- Apply the same `permissions: contents: read` and `persist-credentials: false` hardening to the Homebrew update job for consistency in release paths. 

### Testing
- Verified the workflow file changes by inspecting the diff of `.github/workflows/publish.yml` to confirm the action is pinned to the full SHA and the `permissions` and `persist-credentials` settings are present. 
- Resolved the action commit SHA via `git ls-remote` to obtain the immutable reference used in the pinning step. 
- Attempted to run repository tests with `moon run :test`, but the command failed because `moon` is not available in this environment (`/bin/bash: moon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a101c8a95ec832aad9e140392de6af3)