### PR TITLE
fix(auth): block API keys from account deletion endpoint

### DIFF
--- a/apps/api/src/sibyl/api/routes/users.py
+++ b/apps/api/src/sibyl/api/routes/users.py
@@ -385,6 +385,12 @@ async def delete_current_user(
     auth: AuthContext = Depends(get_auth_context),
 ) -> UserDeletionResponse:
     """Schedule current user deletion and personal-memory purge."""
+    if auth.api_key_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Account deletion requires a user session",
+        )
+
     try:
         result = await request_user_deletion(
             user_id=auth.user.id,

--- a/apps/api/tests/test_users_routes.py
+++ b/apps/api/tests/test_users_routes.py
@@ -24,6 +24,7 @@ def _auth() -> SimpleNamespace:
             preferences={},
         ),
         organization=None,
+        api_key_id=None,
     )
 
 
@@ -268,3 +269,21 @@ async def test_delete_current_user_schedules_deletion(
     assert response.private_memories_scheduled == 3
     assert response.api_keys_revoked == 1
     assert response.sessions_revoked == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_current_user_rejects_api_key_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = _auth()
+    auth.api_key_id = str(uuid4())
+    request_deletion = AsyncMock()
+    request = SimpleNamespace(headers={}, cookies={})
+    monkeypatch.setattr(user_routes, "request_user_deletion", request_deletion)
+
+    with pytest.raises(user_routes.HTTPException) as exc_info:
+        await user_routes.delete_current_user(request=request, auth=auth)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Account deletion requires a user session"
+    request_deletion.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Prevent bearer API keys (including project- or memory-scoped `api:write` keys) from invoking a high-impact user lifecycle operation that revokes keys/sessions and schedules personal-memory purge.

### Description
- Add a guard in the `DELETE /users/me` route (`apps/api/src/sibyl/api/routes/users.py`) that returns HTTP 403 when `auth.api_key_id` is present, and add a regression test `test_delete_current_user_rejects_api_key_auth` in `apps/api/tests/test_users_routes.py` to assert the route rejects API-key-authenticated contexts and does not call `request_user_deletion`.

### Testing
- Attempted `moon run api:test -- --maxfail=1 apps/api/tests/test_users_routes.py` but `moon` is not available in this environment so the command could not be run (`/bin/bash: line 1: moon: command not found`).
- Ran `pytest -q apps/api/tests/test_users_routes.py` which failed during pytest config parsing with `PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope`, so the local test run could not complete; the new test was added but could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1080eba598832ab7ae19ffca1e42a7)