### PR TITLE
fix(auth): disable production local auth by default

### DIFF
--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -167,7 +167,7 @@ class Settings(BaseSettings):
         description="Allow self-serve local account creation after initial setup",
     )
     local_auth_enabled: bool = Field(
-        default=True,
+        default=False,
         description="Enable local username/password login outside setup and break-glass flows",
     )
     break_glass_enabled: bool = Field(
@@ -209,6 +209,8 @@ class Settings(BaseSettings):
         """Prevent insecure settings in production."""
         if "auth_store" not in self.model_fields_set:
             object.__setattr__(self, "auth_store", default_auth_store(store=self.store))
+        if "local_auth_enabled" not in self.model_fields_set and self.environment == "development":
+            object.__setattr__(self, "local_auth_enabled", True)
         if self.environment == "production":
             if self.disable_auth:
                 raise ValueError(
@@ -474,6 +476,8 @@ class Settings(BaseSettings):
         """Fall back to non-prefixed env vars for API keys."""
         if "auth_store" not in self.model_fields_set:
             object.__setattr__(self, "auth_store", default_auth_store(store=self.store))
+        if "local_auth_enabled" not in self.model_fields_set and self.environment == "development":
+            object.__setattr__(self, "local_auth_enabled", True)
 
         # Anthropic: check ANTHROPIC_API_KEY if SIBYL_ANTHROPIC_API_KEY not set
         if not self.anthropic_api_key.get_secret_value():

--- a/apps/api/tests/test_auth_settings.py
+++ b/apps/api/tests/test_auth_settings.py
@@ -144,7 +144,7 @@ def test_settings_auth_defaults_keep_development_login_available() -> None:
     assert s.oidc.providers == []
 
 
-def test_settings_auth_defaults_keep_production_local_login_available() -> None:
+def test_settings_auth_defaults_disable_production_local_login() -> None:
     s = Settings(
         _env_file=None,
         environment="production",
@@ -155,7 +155,7 @@ def test_settings_auth_defaults_keep_production_local_login_available() -> None:
         surreal_password="really_secure_password",
     )
 
-    assert s.local_auth_enabled is True
+    assert s.local_auth_enabled is False
     assert s.public_signups_enabled is False
     assert s.break_glass_enabled is False
     assert s.oidc.providers == []
@@ -193,7 +193,7 @@ def test_settings_enterprise_auth_features_are_opt_in() -> None:
         surreal_password="really_secure_password",
     )
 
-    assert s.local_auth_enabled is True
+    assert s.local_auth_enabled is False
     assert s.public_signups_enabled is False
     assert s.break_glass_enabled is False
     assert s.break_glass_allowed_ips == []


### PR DESCRIPTION
### Motivation

- A previous change made `local_auth_enabled` default to `True`, which reintroduced a remote-accessible local username/password path in production and weakened SSO-only deployments' security guarantees. 
- The intent of this change is to restore a secure default (no local password login in production) while preserving developer ergonomics for local development.

### Description

- Set `local_auth_enabled` default to `False` in `apps/api/src/sibyl/config.py` so production deployments do not enable local password login unless explicitly configured. 
- Added a post-construction validator that auto-enables `local_auth_enabled` only when the setting is unset and `environment == "development"`, preserving development convenience without exposing production. 
- Applied the same development-default logic in the secondary validator path to cover alternate initialization flows. 
- Updated `apps/api/tests/test_auth_settings.py` to assert that production now defaults to `local_auth_enabled is False` and renamed the affected test to reflect the new behavior, while keeping explicit override tests intact.

### Testing

- Attempted `moon run api:test -- apps/api/tests/test_auth_settings.py` but `moon` is not available in this environment, so the monorepo test harness could not be run. 
- Ran `pytest apps/api/tests/test_auth_settings.py` directly which failed with a pytest configuration error (`Unknown config option: asyncio_default_fixture_loop_scope`), so automated tests could not be executed here. 
- The change is intentionally minimal and limited to settings/defaulting logic so it does not alter runtime auth flow except to require an explicit opt-in for production local auth via `SIBYL_LOCAL_AUTH_ENABLED=true`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1088795b80832a9fbba9d2fd3ca0f1)