### PR TITLE
fix(security): harden production compose auth defaults

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,6 +35,9 @@ services:
     ports:
       - "3334:3334"
     environment:
+      # Runtime environment and auth hardening
+      SIBYL_ENVIRONMENT: ${SIBYL_ENVIRONMENT:-production}
+      SIBYL_LOCAL_AUTH_ENABLED: ${SIBYL_LOCAL_AUTH_ENABLED:-false}
       # Store selection — fully Surreal by default
       SIBYL_STORE: ${SIBYL_STORE:-surreal}
       SIBYL_AUTH_STORE: ${SIBYL_AUTH_STORE:-surreal}
@@ -103,6 +106,8 @@ services:
       redis:
         condition: service_started
     environment:
+      SIBYL_ENVIRONMENT: ${SIBYL_ENVIRONMENT:-production}
+      SIBYL_LOCAL_AUTH_ENABLED: ${SIBYL_LOCAL_AUTH_ENABLED:-false}
       SIBYL_STORE: ${SIBYL_STORE:-surreal}
       SIBYL_AUTH_STORE: ${SIBYL_AUTH_STORE:-surreal}
       SIBYL_COORDINATION_BACKEND: ${SIBYL_COORDINATION_BACKEND:-redis}


### PR DESCRIPTION
### Motivation
- Prevent production Docker Compose deployments from inheriting `development` auth behavior and accidentally enabling local username/password login when `SIBYL_ENVIRONMENT` or `SIBYL_LOCAL_AUTH_ENABLED` are omitted.

### Description
- Add `SIBYL_ENVIRONMENT: ${SIBYL_ENVIRONMENT:-production}` and `SIBYL_LOCAL_AUTH_ENABLED: ${SIBYL_LOCAL_AUTH_ENABLED:-false}` to the `backend` and `worker` services in `docker-compose.prod.yml` so production compose files default to hardened auth settings.

### Testing
- Attempted to run the monorepo test task (`moon run api:test`) but `moon` is not available in this environment, so it was not executed.
- Ran the targeted pytest invocation `python -m pytest apps/api/tests/test_auth_settings.py -q`, which failed to run due to a local pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107ffe9318832a8a1aea12b54651ca)