### PR TITLE
fix(cli): harden local runtime network and DB secret defaults

### DIFF
--- a/apps/cli/src/sibyl_cli/local.py
+++ b/apps/cli/src/sibyl_cli/local.py
@@ -76,7 +76,7 @@ COMPOSE_CONFIG = {
         "api": {
             "image": f"ghcr.io/hyperb1iss/sibyl-api:{DEFAULT_IMAGE_TAG}",
             "container_name": "sibyl-api",
-            "ports": ["3334:3334"],
+            "ports": ["127.0.0.1:3334:3334"],
             "depends_on": {
                 "surrealdb": {"condition": "service_healthy"},
             },
@@ -135,7 +135,7 @@ COMPOSE_CONFIG = {
         "web": {
             "image": f"ghcr.io/hyperb1iss/sibyl-web:{DEFAULT_IMAGE_TAG}",
             "container_name": "sibyl-web",
-            "ports": ["3337:3337"],
+            "ports": ["127.0.0.1:3337:3337"],
             "depends_on": {
                 "api": {"condition": "service_healthy"},
             },
@@ -165,7 +165,7 @@ COMPOSE_CONFIG = {
                 "${SIBYL_SURREAL_PASSWORD:-sibyl_local}",
                 "rocksdb:///data/sibyl.db",
             ],
-            "ports": ["8000:8000"],
+            "ports": ["127.0.0.1:8000:8000"],
             "volumes": ["sibyl_surreal:/data"],
             "healthcheck": {
                 "test": ["CMD", "/surreal", "is-ready", "--conn", "http://localhost:8000"],
@@ -270,7 +270,7 @@ SIBYL_JWT_SECRET={jwt_secret}
 
 # SurrealDB
 SIBYL_SURREAL_USERNAME=root
-SIBYL_SURREAL_PASSWORD=sibyl_local
+SIBYL_SURREAL_PASSWORD={secrets.token_urlsafe(24)}
 """
     with open(SIBYL_LOCAL_ENV, "w") as f:
         f.write(env_content)

--- a/apps/cli/tests/test_local_surreal.py
+++ b/apps/cli/tests/test_local_surreal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -61,6 +62,10 @@ def test_local_env_file_contains_surreal_credentials(
 
     env = env_path.read_text()
     assert "SIBYL_SURREAL_USERNAME=root" in env
-    assert "SIBYL_SURREAL_PASSWORD=sibyl_local" in env
+    password_match = re.search(r"^SIBYL_SURREAL_PASSWORD=(\S+)$", env, re.MULTILINE)
+    assert password_match is not None
+    password = password_match.group(1)
+    assert password != "sibyl_local", "must not regress to the static default"
+    assert len(password) >= 24, "token_urlsafe(24) yields ~32 chars of entropy"
     assert "SIBYL_POSTGRES_PASSWORD" not in env
     assert "SIBYL_FALKORDB_PASSWORD" not in env


### PR DESCRIPTION
### Motivation

- The installer and `sibyl up` previously started a Docker compose stack that published API, web, and SurrealDB ports to all host interfaces and wrote a predictable SurrealDB root password, allowing unintended network access and trivial credential-based takeover.
- The change aims to prevent accidental LAN/Internet exposure from the default local runtime while preserving the existing developer UX of a one-command local runtime.

### Description

- Bound published Docker ports to loopback by changing port mappings to `127.0.0.1:3334:3334`, `127.0.0.1:3337:3337`, and `127.0.0.1:8000:8000` in the embedded compose config (`apps/cli/src/sibyl_cli/local.py`).
- Replaced the static generated SurrealDB password `sibyl_local` with a per-install random secret generated via `secrets.token_urlsafe(24)` in the `.env` writer (`write_env_file`).
- Kept the compose generation and `sibyl up` behavior unchanged so the local runtime still starts by default when invoked, but is now safer by default.

### Testing

- Ran `python -m py_compile apps/cli/src/sibyl_cli/local.py`, which succeeded.
- Attempted `pytest -q apps/cli/tests/test_docker_runtime.py`, but the run failed in this environment due to a pytest config/plugin mismatch (`Unknown config option: asyncio_default_fixture_loop_scope`).
- Attempted `moon run cli:test ...` but `moon` is not available in this execution environment, so those CI-oriented test runs could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fcb2b2ae0832aa656da424b9ca726)