### PR TITLE
fix(ai): scope agent cache by event loop object, not id

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/ai/clients.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/clients.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 from collections.abc import Sequence
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from pydantic_ai import Agent
 from pydantic_ai.output import PromptedOutput
@@ -14,9 +15,15 @@ from sibyl_core.ai.llm.config import LLMConfig, LLMSurface, resolve_llm_config
 from sibyl_core.ai.providers import build_model
 
 AgentOutputType = Any
-AgentCacheKey = tuple[int, str, str, str, tuple[str, ...], int | None]
+AgentCacheKey = tuple[str, str, str, tuple[str, ...], int | None]
 
-_agent_cache: dict[AgentCacheKey, Agent[Any, Any]] = {}
+# Per-loop cache. The outer WeakKeyDictionary drops a loop's bucket when the
+# loop is garbage-collected, which matters because CPython will happily reuse
+# a closed loop's id() for the next event loop and we'd otherwise return the
+# stale Agent bound to the dead loop's resources.
+_agent_cache: WeakKeyDictionary[
+    asyncio.AbstractEventLoop, dict[AgentCacheKey, Agent[Any, Any]]
+] = WeakKeyDictionary()
 
 
 async def get_agent(
@@ -34,8 +41,7 @@ async def get_agent(
 
     loop = asyncio.get_running_loop()
     normalized_prompt = _normalize_system_prompt(system_prompt)
-    key = (
-        id(loop),
+    key: AgentCacheKey = (
         surface.value,
         _config_fingerprint(config),
         _output_type_key(output_type),
@@ -43,14 +49,15 @@ async def get_agent(
         output_retries,
     )
 
-    if key not in _agent_cache:
-        _agent_cache[key] = Agent(
+    loop_bucket = _agent_cache.setdefault(loop, {})
+    if key not in loop_bucket:
+        loop_bucket[key] = Agent(
             model=build_model(config),
             output_type=_provider_output_type(config, output_type),
             instructions=normalized_prompt,
             output_retries=output_retries,
         )
-    return _agent_cache[key]
+    return loop_bucket[key]
 
 
 def invalidate_agent_cache(surface: LLMSurface | None = None) -> None:
@@ -58,13 +65,14 @@ def invalidate_agent_cache(surface: LLMSurface | None = None) -> None:
         _agent_cache.clear()
         return
 
-    for key in list(_agent_cache):
-        if key[1] == surface.value:
-            del _agent_cache[key]
+    for loop_bucket in _agent_cache.values():
+        for key in list(loop_bucket):
+            if key[0] == surface.value:
+                del loop_bucket[key]
 
 
 def agent_cache_size() -> int:
-    return len(_agent_cache)
+    return sum(len(bucket) for bucket in _agent_cache.values())
 
 
 def _normalize_system_prompt(system_prompt: str | Sequence[str] | None) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary

`test_agent_cache_is_scoped_per_event_loop` in `packages/python/sibyl-core/tests/ai/test_clients.py` was flaking in CI — it hit unrelated PRs #117 and #100 in this session and almost certainly other runs over the past week. The cause turned out to be in the production code, not the test: the cache was keyed by `id(loop)`, and CPython reuses a closed loop's memory address for the next `asyncio.new_event_loop()` call, which made the second `_run_in_new_loop(...)` collide with the first loop's cache entry and return the same `Agent`.

The fix moves the cache from `dict[(id(loop), ...), Agent]` to `WeakKeyDictionary[loop, dict[inner_key, Agent]]`. When a loop is garbage-collected its whole bucket drops, so the next loop (even at the same memory address) starts with an empty bucket. Inner keys lose the `id(loop)` component since the outer dict already partitions by loop.

The other test in the file — `test_get_agent_reuses_cache_for_same_loop_and_fingerprint` — keeps passing because within a single loop the bucket is shared and re-fetches hit the cache. `invalidate_agent_cache` and `agent_cache_size` walk the nested structure.

## Test plan

- [x] `pytest packages/python/sibyl-core/tests/ai/test_clients.py` — all 8 tests pass
- [x] `pytest packages/python/sibyl-core/tests/ai/test_clients.py::test_agent_cache_is_scoped_per_event_loop` x5 in a row — no flakes
- [ ] CI matches local

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent caching to prevent stale agents from being reused after event loop closure, enhancing reliability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hyperb1iss/sibyl/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->