### PR TITLE
ci: pre-sync uv workspace before parallel moon check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,9 @@ jobs:
       - name: "◇ Install Node dependencies"
         run: cd apps/web && pnpm install --frozen-lockfile
 
+      - name: "◇ Sync Python workspace"
+        run: uv sync --locked --all-packages
+
       - name: "◆ Run RC gate bundle"
         run: moon run :check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,9 @@ jobs:
       - name: "◇ Install Node dependencies"
         run: cd apps/web && pnpm install --frozen-lockfile
 
+      - name: "◇ Sync Python workspace"
+        run: uv sync --locked --all-packages
+
       - name: "△ Determine version"
         id: version
         run: |


### PR DESCRIPTION
## Summary

The v1.0.0-rc.2 release just failed at the RC gate with `ModuleNotFoundError: No module named 'pydantic_ai'` / `surrealdb` / `numpy`. Code is fine — CI on the same SHA was green.

Root cause: `moon run :check` fans out lint/typecheck/test across ~4 projects in parallel (~12 concurrent tasks). Each `uv run pytest` does an implicit workspace sync on first call. With a cold uv cache (which is the norm after a dependency batch lands), the first task starts downloading numpy/surrealdb/scipy while other tasks race ahead and invoke pytest against a half-populated venv → collection fails.

CI hides this because its cache is warmer (frequent commits keep `~/.cache/uv` and `.moon/cache` hot). The release and publish caches only thaw on release day, which is exactly when freshly-landed dep bumps need to download.

Fix: one explicit `uv sync --locked --all-packages` step right before `moon run :check`. Now the venv is fully populated before the parallel fan-out, and the per-task `uv run` calls just verify the env and proceed.

## Files

- `.github/workflows/release.yml` — adds sync before RC gate
- `.github/workflows/publish.yml` — same, for the rc-gate job

`--locked` enforces lockfile reproducibility; `--all-packages` ensures every workspace member's deps land in the shared venv.

## Test plan

- [ ] Merge, then dispatch `release.yml` with `version: 1.0.0-rc.2`
- [ ] Confirm RC gate bundle now passes
- [ ] Confirm subsequent tag/release/publish chain fires