### PR TITLE
fix(api): guard source-import supersession by scope

### DIFF
--- a/apps/api/src/sibyl/jobs/source_imports.py
+++ b/apps/api/src/sibyl/jobs/source_imports.py
@@ -501,6 +501,13 @@ def _default_supersession_handler(*, organization_id: str) -> SourceRecordSupers
         )
         if superseded is None:
             return False
+        if (
+            superseded.principal_id != memory.principal_id
+            or superseded.memory_scope != memory.memory_scope
+            or superseded.scope_key != memory.scope_key
+            or superseded.source_id != memory.source_id
+        ):
+            return False
 
         superseded_metadata = dict(superseded.metadata)
         superseded_metadata["superseded_by_raw_memory_id"] = memory.id

--- a/apps/api/tests/test_jobs_source_imports.py
+++ b/apps/api/tests/test_jobs_source_imports.py
@@ -1095,3 +1095,47 @@ def test_worker_settings_registers_source_import_job() -> None:
     assert promote_raw_captures in WorkerSettings.functions
     assert poll_raw_capture_changefeed in WorkerSettings.functions
     assert poll_all_raw_capture_changefeeds in WorkerSettings.functions
+
+
+@pytest.mark.asyncio
+async def test_supersession_handler_refuses_cross_principal_or_scope_targets() -> None:
+    saved: list[RawMemory] = []
+    victim = RawMemory(
+        id="raw-victim",
+        organization_id="org-1",
+        source_id="msg-1",
+        principal_id="victim-user",
+        memory_scope=MemoryScope.PRIVATE,
+        metadata={"content_hash": "hash-old"},
+        review_state="accepted",
+    )
+    attacker = RawMemory(
+        id="raw-attacker",
+        organization_id="org-1",
+        source_id="msg-1",
+        principal_id="attacker-user",
+        memory_scope=MemoryScope.PRIVATE,
+        metadata={"content_hash": "hash-new"},
+    )
+
+    async def capture_save(memory: RawMemory) -> RawMemory:
+        saved.append(memory)
+        return memory
+
+    handler = source_imports._default_supersession_handler(organization_id="org-1")
+    with (
+        patch("sibyl.jobs.source_imports.get_raw_memory", AsyncMock(return_value=victim)),
+        patch("sibyl.jobs.source_imports.save_raw_memory", AsyncMock(side_effect=capture_save)),
+    ):
+        superseded = await handler(
+            record=_source_record(),
+            payload=_raw_memory_write(principal_id="attacker-user"),
+            memory=attacker,
+            superseded_raw_memory_id="raw-victim",
+        )
+
+    assert superseded is False
+    assert saved == []
+    assert victim.review_state == "accepted"
+    assert "superseded_by_raw_memory_id" not in victim.metadata
+    assert "supersedes_raw_memory_id" not in attacker.metadata


### PR DESCRIPTION
Salvaged and reworked from the original scanner PR.

The load-bearing half of the original fix (scoping the source-import duplicate lookup by principal and memory scope) already landed on main independently, so this PR now carries only the remaining net-new piece: a defense-in-depth guard in the supersession handler.

## What was wrong

`_default_supersession_handler` looked up the target raw memory by id and overwrote it (marking it superseded, rewriting metadata and review state) without verifying the target belonged to the same principal and memory scope as the incoming record. Two imports sharing a `source_id` but owned by different principals could therefore let one principal supersede another's raw memory.

## The fix

Refuse to supersede when the target's `principal_id`, `memory_scope`, `scope_key`, or `source_id` differs from the incoming memory. The legitimate same-principal, same-scope supersession path is unchanged (covered by the existing happy-path test).

Rebased fresh onto current main; the redundant duplicate-lookup hunk and its now-incorrect test expectations were dropped. New test: `test_supersession_handler_refuses_cross_principal_or_scope_targets`.