### PR TITLE
fix(raw-promotion): respect raw memory scope

### DIFF
--- a/apps/api/src/sibyl/jobs/raw_promotion.py
+++ b/apps/api/src/sibyl/jobs/raw_promotion.py
@@ -28,6 +28,7 @@ from sibyl.persistence.graph_runtime import get_entity_graph_runtime
 from sibyl_core.models.entities import Entity, EntityType
 from sibyl_core.observability import elapsed_ms
 from sibyl_core.services.surreal_content import (
+    MemoryScope,
     RawMemory,
     list_raw_memories_for_promotion,
     raw_memory_recallable,
@@ -59,6 +60,7 @@ async def promote_raw_captures(
         "skipped_superseded_count": 0,
         "skipped_existing_count": 0,
         "skipped_review_count": 0,
+        "skipped_scoped_count": 0,
         "failed_count": 0,
         "chunk_count": 0,
         "raw_memory_ids": [],
@@ -98,6 +100,8 @@ async def promote_raw_captures(
             result["skipped_superseded_count"] += 1
         elif outcome["status"] == "skipped_existing":
             result["skipped_existing_count"] += 1
+        elif outcome["status"] == "skipped_scoped":
+            result["skipped_scoped_count"] += 1
         else:
             result["skipped_review_count"] += 1
 
@@ -114,7 +118,7 @@ async def _promote_one(
 ) -> dict[str, Any]:
     skip_status = _promotion_skip_status(memory, force=force)
     if skip_status is not None:
-        if skip_status in {"skipped_deleted", "skipped_superseded"}:
+        if skip_status in {"skipped_deleted", "skipped_superseded", "skipped_scoped"}:
             await _mark_skipped(memory, skip_status)
         return {"status": skip_status, "chunk_count": 0}
 
@@ -184,6 +188,22 @@ async def _promote_one(
         "chunk_count": len(saved_chunks),
         "entity_id": entity_id,
     }
+
+
+def _organization_visible_for_promotion(memory: RawMemory) -> bool:
+    return memory.memory_scope in {MemoryScope.ORGANIZATION, MemoryScope.PUBLIC}
+
+
+def _scope_metadata(memory: RawMemory) -> dict[str, str]:
+    metadata = {
+        "memory_scope": memory.memory_scope.value,
+        "principal_id": memory.principal_id,
+    }
+    if memory.scope_key is not None:
+        metadata["scope_key"] = memory.scope_key
+    if memory.project_id is not None:
+        metadata["project_id"] = memory.project_id
+    return metadata
 
 
 def _document_from_raw_memory(memory: RawMemory) -> CrawledDocumentRecord:
@@ -259,6 +279,8 @@ def _promotion_skip_status(memory: RawMemory, *, force: bool) -> str | None:
         return "skipped_existing"
     if not raw_memory_recallable(memory):
         return "skipped_review"
+    if not _organization_visible_for_promotion(memory):
+        return "skipped_scoped"
     return None
 
 
@@ -291,6 +313,7 @@ async def _upsert_document_entity(
             created_by=memory.created_by_user_id or memory.principal_id,
             metadata={
                 "created_by": "raw_promotion",
+                **_scope_metadata(memory),
                 "raw_memory_id": memory.id,
                 "source_id": memory.source_id,
                 "document_id": str(document.id),

--- a/apps/api/tests/test_jobs_raw_promotion.py
+++ b/apps/api/tests/test_jobs_raw_promotion.py
@@ -21,13 +21,18 @@ def _raw_memory(
     metadata: dict[str, object] | None = None,
     deleted_at: datetime | None = None,
     entity_id: str | None = None,
+    memory_scope: MemoryScope = MemoryScope.ORGANIZATION,
+    scope_key: str | None = None,
+    project_id: str | None = None,
 ) -> RawMemory:
     return RawMemory(
         id=raw_id or str(uuid4()),
         organization_id=organization_id or str(uuid4()),
         source_id=source_id,
         principal_id="user-1",
-        memory_scope=MemoryScope.PRIVATE,
+        memory_scope=memory_scope,
+        scope_key=scope_key,
+        project_id=project_id,
         review_state=review_state,
         entity_id=entity_id,
         title="Imported note",
@@ -128,11 +133,45 @@ async def test_promote_raw_captures_writes_chunks_and_graph_entity(
     assert all(chunk.embedding is not None for chunk in saved_chunks)
     assert created_entities[0][0].id == memory.id
     assert created_entities[0][0].entity_type.value == "document"
+    assert created_entities[0][0].metadata["memory_scope"] == "organization"
+    assert created_entities[0][0].metadata["principal_id"] == memory.principal_id
     assert created_entities[0][1] is False
     assert saved_memories[-1].entity_id == memory.id
     assert saved_memories[-1].metadata["raw_promotion_state"] == "promoted"
     assert saved_memories[-1].metadata["raw_promotion_chunk_count"] == len(saved_chunks)
     assert saved_memories[-1].metadata["source_extraction_state"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_promote_raw_captures_skips_non_org_visible_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memory = _raw_memory(
+        memory_scope=MemoryScope.PRIVATE,
+        scope_key="user-1",
+        project_id="secret-project",
+    )
+    saved_memories = []
+
+    async def fake_save_memory(updated: RawMemory) -> RawMemory:
+        saved_memories.append(updated)
+        return updated
+
+    monkeypatch.setattr(
+        raw_promotion,
+        "list_raw_memories_for_promotion",
+        _list_memories([memory]),
+    )
+    monkeypatch.setattr(raw_promotion, "EmbeddingService", _fake_embedder)
+    monkeypatch.setattr(raw_promotion, "save_raw_memory", fake_save_memory)
+
+    result = await raw_promotion.promote_raw_captures({}, memory.organization_id)
+
+    assert result["promoted_count"] == 0
+    assert result["skipped_scoped_count"] == 1
+    assert result["failed_count"] == 0
+    assert saved_memories[-1].metadata["raw_promotion_state"] == "skipped_scoped"
+    assert saved_memories[-1].entity_id is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- The raw-promotion path was materializing imported raw captures into org-scoped documents and chunks while dropping the original `memory_scope`/`scope_key`/`principal_id`/`project_id`, which allowed private or project-scoped captures to be discovered by org members. 
- Promotion was being enqueued automatically for all imported batches without ensuring the capture was organization-visible, creating a metadata/authorization bypass. 
- The intent of the change is to prevent promoting non-organization-visible raw captures and to preserve scope metadata on promoted graph entities so search/linking respects original memory scopes.

### Description

- Add an `_organization_visible_for_promotion` helper that only allows promotion for memories whose `memory_scope` is `organization` or `public` and skip promotion otherwise by returning `skipped_scoped`. 
- Record `skipped_scoped` in the promotion job results and mark skipped memories' metadata with `raw_promotion_state = "skipped_scoped"` so the state is persisted. 
- Preserve raw memory scope attributes on promoted graph entities by introducing `_scope_metadata(memory)` and merging its keys into the created entity `metadata` payload. 
- Add unit regression coverage in `apps/api/tests/test_jobs_raw_promotion.py` to assert that non-org-visible captures are skipped and that promoted entities include `memory_scope`/`principal_id` metadata.

### Testing

- Ran `uv run pytest apps/api/tests/test_jobs_raw_promotion.py` and all tests passed (`4 passed`).
- Ran `uv run ruff check apps/api/src/sibyl/jobs/raw_promotion.py apps/api/tests/test_jobs_raw_promotion.py` and lint checks passed.
- The change is minimal and limited to `apps/api/src/sibyl/jobs/raw_promotion.py` and its tests in `apps/api/tests/test_jobs_raw_promotion.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bc4763500832a977033165e1701bb)