### PR TITLE
fix(api): reject comments in content debug queries

### DIFF
--- a/apps/api/src/sibyl/persistence/surreal/content.py
+++ b/apps/api/src/sibyl/persistence/surreal/content.py
@@ -84,6 +84,43 @@ _CONTENT_DEBUG_BOUNDARY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _CONTENT_DEBUG_WHERE_PATTERN = re.compile(r"\bWHERE\b", re.IGNORECASE)
+
+
+def _content_debug_query_has_comment(query: str) -> bool:
+    index = 0
+    length = len(query)
+
+    while index < length:
+        char = query[index]
+        next_char = query[index + 1] if index + 1 < length else ""
+
+        if char in {"'", '"', "`"}:
+            quote = char
+            index += 1
+            while index < length:
+                current = query[index]
+                if current == "\\":
+                    index += 2
+                    continue
+                index += 1
+                if current == quote:
+                    break
+            continue
+
+        if char == "/" and next_char == "*":
+            return True
+
+        if (char == "-" and next_char == "-") or (char == "/" and next_char == "/"):
+            return True
+
+        if char == "#":
+            return True
+
+        index += 1
+
+    return False
+
+
 type SurrealRecord = dict[str, object]
 
 
@@ -712,6 +749,9 @@ def _scope_content_debug_query(query: str) -> str:
         stripped = stripped[:-1].rstrip()
     if ";" in stripped:
         msg = "Content debug queries must use a single statement"
+        raise ValueError(msg)
+    if _content_debug_query_has_comment(stripped):
+        msg = "Content debug queries cannot contain comments"
         raise ValueError(msg)
 
     tokens = [token.upper() for token in query_tokens(stripped)]

--- a/apps/api/tests/test_surreal_content_debug.py
+++ b/apps/api/tests/test_surreal_content_debug.py
@@ -32,3 +32,28 @@ def test_scope_content_debug_query_rejects_content_table_subqueries() -> None:
 
     with pytest.raises(ValueError, match="one content table"):
         content_persistence._scope_content_debug_query(query)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM raw_captures WHERE true) -- hides organization filter",
+        "SELECT * FROM raw_captures WHERE true) // hides organization filter",
+        "SELECT * FROM raw_captures WHERE true) /* hides organization filter */",
+        "SELECT * FROM raw_captures WHERE true) # hides organization filter",
+    ],
+)
+def test_scope_content_debug_query_rejects_comments(query: str) -> None:
+    with pytest.raises(ValueError, match="cannot contain comments"):
+        content_persistence._scope_content_debug_query(query)
+
+
+def test_scope_content_debug_query_allows_comment_markers_inside_strings() -> None:
+    query = "SELECT * FROM raw_captures WHERE text = '-- not a comment' LIMIT 5"
+
+    scoped = content_persistence._scope_content_debug_query(query)
+
+    assert (
+        scoped == "SELECT * FROM raw_captures WHERE (text = '-- not a comment') "
+        "AND organization_id = $organization_id LIMIT 5"
+    )


### PR DESCRIPTION
### Motivation
- Prevent a SurrealQL comment-based tenant-escape where an attacker could close a parenthesis and start a comment (e.g. `true) -- ...`) to neutralize the appended `organization_id` predicate and read other orgs' content. 

### Description
- Add `_content_debug_query_has_comment(query: str)` in `apps/api/src/sibyl/persistence/surreal/content.py` to detect line and block comments while skipping quoted strings. 
- Enforce comment-free content debug queries by calling `_content_debug_query_has_comment` from `_scope_content_debug_query` before rewriting the WHERE clause. 
- Add regression tests in `apps/api/tests/test_surreal_content_debug.py` that assert comment-bearing queries are rejected and that comment-like markers inside string literals are allowed. 

### Testing
- Ran `uv run pytest apps/api/tests/test_surreal_content_debug.py apps/api/tests/test_routes_admin.py` and all tests passed (`37 passed`).
- Ran `uv run ruff check apps/api/src/sibyl/persistence/surreal/content.py apps/api/tests/test_surreal_content_debug.py` and lint checks passed.
- Ran `git diff --check` and there were no diff/check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0620cbc8832aa3497c50a4d9ca0e)