### PR TITLE
fix(api): enforce API-key scopes on raw memory promotion

### DIFF
--- a/apps/api/src/sibyl/api/routes/memory.py
+++ b/apps/api/src/sibyl/api/routes/memory.py
@@ -1315,6 +1315,97 @@ async def _accessible_projects_for_promotion(
     return {str(project_id) for project_id in accessible_projects or set()}
 
 
+def _promotion_target_scope(
+    request: ReflectionPromotionRequest,
+) -> tuple[str, str | None] | None:
+    if request.promote_to_scope is None:
+        return None
+    try:
+        target_scope = MemoryScope(request.promote_to_scope)
+    except ValueError:
+        return None
+    target_scope_key = request.promote_to_scope_key
+    if target_scope is MemoryScope.PROJECT:
+        target_scope_key = target_scope_key or request.project
+    return target_scope.value, target_scope_key
+
+
+async def _authorize_raw_promotion_api_key_scopes(
+    *,
+    ctx: AuthContext,
+    request: ReflectionPromotionRequest,
+    organization_id: str,
+    accessible_projects: set[str],
+    http_request: Request | None,
+    surface: str,
+) -> None:
+    allowed_scope_keys = getattr(ctx, "api_key_memory_scope_keys", None)
+    if allowed_scope_keys is None or not isinstance(
+        allowed_scope_keys, list | tuple | set | frozenset
+    ):
+        return
+
+    memory = await get_raw_memory(
+        organization_id=organization_id,
+        memory_id=request.candidate_id,
+    )
+    if memory is None:
+        return
+
+    checks: tuple[tuple[MemoryPolicyAction, str, str | None, str | None], ...] = (
+        (
+            MemoryPolicyAction.READ,
+            memory.memory_scope.value,
+            memory.scope_key,
+            _memory_project_id(memory),
+        ),
+    )
+    target_scope = _promotion_target_scope(request)
+    if target_scope is not None:
+        checks = (
+            *checks,
+            (MemoryPolicyAction.WRITE, target_scope[0], target_scope[1], request.project),
+        )
+
+    for action, memory_scope, scope_key, project_id in checks:
+        if _api_key_memory_scope_allowed(ctx, memory_scope=memory_scope, scope_key=scope_key):
+            continue
+        policy_context = MemoryPolicyContext(
+            actor_user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            organization_role=ctx.org_role,
+            memory_space=memory_scope,
+            scope_key=scope_key,
+            project_id=project_id,
+            accessible_projects=accessible_projects,
+            source_surface=surface,
+        )
+        deny_decision = _api_key_memory_scope_denial(
+            action=action,
+            memory_scope=memory_scope,
+            scope_key=scope_key,
+            policy_context=policy_context,
+        )
+        _log_policy_decision(ctx=ctx, decision=deny_decision, surface=surface)
+        await _log_memory_audit(
+            action="memory.policy_deny",
+            ctx=ctx,
+            request=http_request,
+            memory_scope=memory_scope,
+            scope_key=scope_key,
+            project_id=project_id,
+            source_surface=surface,
+            source_ids=[request.candidate_id],
+            policy_allowed=False,
+            policy_reason=deny_decision.reason,
+            details={"policy_action": deny_decision.action.value},
+        )
+        raise HTTPException(
+            status_code=_policy_http_status(deny_decision.reason),
+            detail=deny_decision.reason,
+        )
+
+
 async def _accessible_projects_for_share_preview(
     *,
     ctx: AuthContext,
@@ -2168,6 +2259,14 @@ async def preview_memory_promotion(
         accessible_projects=accessible_projects,
     )
     if result.reason == "not_reflection_candidate":
+        await _authorize_raw_promotion_api_key_scopes(
+            ctx=ctx,
+            request=request,
+            organization_id=str(org.id),
+            accessible_projects=accessible_projects,
+            http_request=http_request,
+            surface="memory_promote_preview",
+        )
         result = await preview_raw_memory_promotion(
             raw_memory_id=request.candidate_id,
             organization_id=str(org.id),
@@ -2588,6 +2687,14 @@ async def promote_memory(
             accessible_projects=accessible_projects,
         )
         if result.reason == "not_reflection_candidate":
+            await _authorize_raw_promotion_api_key_scopes(
+                ctx=ctx,
+                request=request,
+                organization_id=str(org.id),
+                accessible_projects=accessible_projects,
+                http_request=http_request,
+                surface="memory_promote",
+            )
             result = await promote_raw_memory(
                 raw_memory_id=request.candidate_id,
                 organization_id=str(org.id),

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -1933,6 +1933,121 @@ async def test_preview_memory_promotion_routes_imported_raw_memory() -> None:
 
 
 @pytest.mark.asyncio
+async def test_preview_memory_promotion_denies_raw_source_outside_api_key_memory_space() -> None:
+    org = _org()
+    ctx = _ctx()
+    ctx.api_key_memory_scope_keys = [api_key_memory_scope_key("project", "project_allowed")]
+    reflection_result = ReflectionPromotionPreview(
+        allowed=False,
+        candidate_id="raw-1",
+        reason="not_reflection_candidate",
+        review_state="pending",
+        memory_scope=MemoryScope.PRIVATE,
+        scope_key=None,
+        raw_source_ids=[],
+    )
+
+    with (
+        patch("sibyl.api.routes.memory.verify_entity_project_access", AsyncMock()),
+        patch(
+            "sibyl.api.routes.memory.preview_reflection_candidate_promotion",
+            AsyncMock(return_value=reflection_result),
+        ),
+        patch(
+            "sibyl.api.routes.memory.get_raw_memory",
+            AsyncMock(
+                return_value=_memory(
+                    id="raw-1",
+                    memory_scope=MemoryScope.PROJECT,
+                    scope_key="project_secret",
+                    metadata={"project_id": "project_secret"},
+                )
+            ),
+        ),
+        patch("sibyl.api.routes.memory.preview_raw_memory_promotion", AsyncMock()) as raw_preview,
+        patch("sibyl.api.routes.memory.log_memory_audit_event", AsyncMock()) as audit,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await preview_memory_promotion(
+            ReflectionPromotionRequest(
+                candidate_id="raw-1",
+                promote_to_scope="project",
+                promote_to_scope_key="project_allowed",
+                project="project_allowed",
+            ),
+            http_request=_http_request(),
+            org=org,
+            ctx=ctx,
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "api_key_memory_space_denied"
+    raw_preview.assert_not_awaited()
+    audit.assert_awaited_once()
+    assert audit.await_args.kwargs["memory_scope"] == "project"
+    assert audit.await_args.kwargs["scope_key"] == "project_secret"
+    assert audit.await_args.kwargs["policy_reason"] == "api_key_memory_space_denied"
+
+
+@pytest.mark.asyncio
+async def test_promote_memory_denies_raw_target_outside_api_key_memory_space() -> None:
+    org = _org()
+    ctx = _ctx()
+    ctx.api_key_memory_scope_keys = [api_key_memory_scope_key("project", "project_allowed")]
+    reflection_result = ReflectionPromotionResult(
+        success=False,
+        candidate_id="raw-1",
+        promoted_id=None,
+        reason="not_reflection_candidate",
+        review_state="pending",
+        memory_scope=MemoryScope.PRIVATE,
+        scope_key=None,
+        raw_source_ids=[],
+    )
+
+    with (
+        patch("sibyl.api.routes.memory.verify_entity_project_access", AsyncMock()),
+        patch(
+            "sibyl.api.routes.memory.promote_reflection_candidate_review",
+            AsyncMock(return_value=reflection_result),
+        ),
+        patch(
+            "sibyl.api.routes.memory.get_raw_memory",
+            AsyncMock(
+                return_value=_memory(
+                    id="raw-1",
+                    memory_scope=MemoryScope.PROJECT,
+                    scope_key="project_allowed",
+                    metadata={"project_id": "project_allowed"},
+                )
+            ),
+        ),
+        patch("sibyl.api.routes.memory.promote_raw_memory", AsyncMock()) as raw_promote,
+        patch("sibyl.api.routes.memory.log_memory_audit_event", AsyncMock()) as audit,
+        pytest.raises(HTTPException) as exc,
+    ):
+        await promote_memory(
+            ReflectionPromotionRequest(
+                candidate_id="raw-1",
+                promote_to_scope="project",
+                promote_to_scope_key="project_secret",
+                project="project_secret",
+            ),
+            http_request=_http_request(),
+            org=org,
+            ctx=ctx,
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "api_key_memory_space_denied"
+    raw_promote.assert_not_awaited()
+    audit.assert_awaited_once()
+    assert audit.await_args.kwargs["memory_scope"] == "project"
+    assert audit.await_args.kwargs["scope_key"] == "project_secret"
+    assert audit.await_args.kwargs["policy_reason"] == "api_key_memory_space_denied"
+
+
+@pytest.mark.asyncio
 async def test_auto_review_reflection_candidate_promotes_safe_candidate() -> None:
     org = _org()
     ctx = _ctx()


### PR DESCRIPTION
### Motivation
- The generic `/memory/promote` and `/memory/promote/preview` fallback path for imported raw memories omitted the API-key memory-space gate, allowing scoped API keys to preview or promote raw captures outside their granted memory spaces.  
- Enforce the same API-key memory-space restrictions applied to other raw memory routes to preserve least-privilege for scoped API keys.

### Description
- Add `_promotion_target_scope` and `_authorize_raw_promotion_api_key_scopes` helpers in `apps/api/src/sibyl/api/routes/memory.py` to compute the promotion target and validate API-key memory-space grants for both source read and target write scopes.  
- Invoke the new `_authorize_raw_promotion_api_key_scopes` from the generic preview and promote routes before falling back to `preview_raw_memory_promotion` / `promote_raw_memory`.  
- Add regression tests in `apps/api/tests/test_routes_memory.py` to verify that previewing a raw source outside an API key's granted scope is denied and that promoting into an out-of-scope target is denied.  
- Run `ruff` formatting/checks on the modified files.

### Testing
- Ran the focused pytest selection `uv run pytest apps/api/tests/test_routes_memory.py -k 'preview_memory_promotion_denies_raw_source_outside_api_key_memory_space or promote_memory_denies_raw_target_outside_api_key_memory_space or preview_memory_promotion_routes_imported_raw_memory or promote_memory_routes_imported_raw_memory'` and the four selected tests passed (`4 passed, 48 deselected`).  
- Ran lint/format checks with `uv run ruff check apps/api/src/sibyl/api/routes/memory.py apps/api/tests/test_routes_memory.py` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c07b4fc2c832abc87aa589f016c36)