### PR TITLE
fix(ingestion): block private network URL import option

### DIFF
--- a/apps/api/src/sibyl/api/routes/ingestion.py
+++ b/apps/api/src/sibyl/api/routes/ingestion.py
@@ -192,8 +192,6 @@ def _document_import_options(request: DocumentImportRequest) -> dict[str, object
         options["text"] = request.text or ""
     if title := _optional_str(request.title):
         options["title"] = title
-    if request.allow_private_network:
-        options["allow_private_network"] = True
     return options
 
 

--- a/apps/api/src/sibyl/api/schemas/ingestion.py
+++ b/apps/api/src/sibyl/api/schemas/ingestion.py
@@ -44,7 +44,6 @@ class DocumentImportRequest(BaseModel):
     target_scope_key: str = Field(..., min_length=1, max_length=500)
     batch_size: int = Field(default=100, ge=1, le=1000)
     promotion_preview_approved: bool = False
-    allow_private_network: bool = False
 
     @model_validator(mode="after")
     def validate_source(self) -> DocumentImportRequest:

--- a/apps/api/tests/test_routes_ingestion.py
+++ b/apps/api/tests/test_routes_ingestion.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 
 from sibyl.api.routes.ingestion import (
     _document_collections_from_captures,
+    _document_import_options,
     _resolve_route_import_source_uri,
     _resolve_route_import_source_uri_for_adapter,
     list_document_collections_route,
@@ -279,7 +280,6 @@ async def test_start_document_import_route_enqueues_url_import() -> None:
         target_scope_key="project_123",
         collection="docs",
         batch_size=25,
-        allow_private_network=True,
     )
     org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
     ctx = SimpleNamespace(user_id="user-1")
@@ -317,7 +317,6 @@ async def test_start_document_import_route_enqueues_url_import() -> None:
             "target_memory_scope": "project",
             "target_scope_key": "project_123",
             "collection": "docs",
-            "allow_private_network": True,
         },
         batch_size=25,
         promotion_preview_approved=False,
@@ -330,6 +329,21 @@ async def test_start_document_import_route_enqueues_url_import() -> None:
         batch_size=25,
         promotion_preview_approved=False,
     )
+
+
+def test_document_import_request_ignores_private_network_bypass_option() -> None:
+    request = DocumentImportRequest(
+        kind="url",
+        source_uri="https://docs.example.com/page",
+        target_scope_key="project_123",
+        allow_private_network=True,
+    )
+
+    assert not hasattr(request, "allow_private_network")
+    assert _document_import_options(request) == {
+        "target_memory_scope": "project",
+        "target_scope_key": "project_123",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- A client-controlled `allow_private_network` flag could be passed from the document import API into the URL adapter and worker, allowing project members to bypass private-host checks and enqueue SSRF-style fetches of internal services.
- The intent is to remove any user-controlled bypass so document URL imports always enforce private-host rejection by default unless an elevated, audited path is introduced later.

### Description
- Removed the `allow_private_network` field from `DocumentImportRequest` so the route no longer accepts a client-controlled private-network toggle (`apps/api/src/sibyl/api/schemas/ingestion.py`).
- Stopped forwarding a private-network option from `_document_import_options`, preserving existing `target_scope_key`, `collection`, `text`, and `title` behavior but not propagating any bypass flag to adapters (`apps/api/src/sibyl/api/routes/ingestion.py`).
- Updated ingestion route tests to remove the bypass flag from expected adapter options and added a regression test asserting a supplied `allow_private_network` attribute is ignored (`apps/api/tests/test_routes_ingestion.py`).
- No changes were made to adapter-side host-rejection logic; adapters continue to reject private hosts unless explicitly invoked via an authorized/elevated path in the future (`apps/api/src/sibyl/services/document_adapters.py` remains unchanged).

### Testing
- Ran the targeted test subset with `uv run pytest apps/api/tests/test_routes_ingestion.py apps/api/tests/test_document_adapters.py apps/api/tests/test_jobs_source_imports.py`, and all tests passed: 38 passed.
- Verified test adjustments that ensure URL imports no longer propagate a private-network bypass option and existing document-adapter tests still enforce default private-host rejection.
- Ran `git diff --check` to ensure no whitespace/index errors remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c071d8dec832a9fb411072b2e12d4)