### PR TITLE
fix(ingestion): gate private-network document imports

### DIFF
--- a/apps/api/src/sibyl/api/routes/ingestion.py
+++ b/apps/api/src/sibyl/api/routes/ingestion.py
@@ -174,7 +174,11 @@ def _document_source_uri(request: DocumentImportRequest) -> str:
     return request.source_uri.strip()
 
 
-def _document_import_options(request: DocumentImportRequest) -> dict[str, object]:
+def _document_import_options(
+    request: DocumentImportRequest,
+    *,
+    allow_private_network: bool = False,
+) -> dict[str, object]:
     options: dict[str, object] = {
         "target_memory_scope": "project",
         "target_scope_key": request.target_scope_key,
@@ -185,9 +189,20 @@ def _document_import_options(request: DocumentImportRequest) -> dict[str, object
         options["text"] = request.text or ""
     if title := _optional_str(request.title):
         options["title"] = title
-    if request.allow_private_network:
+    if allow_private_network:
         options["allow_private_network"] = True
     return options
+
+
+def _authorized_private_network_import(
+    request: DocumentImportRequest,
+    ctx: AuthContext,
+) -> bool:
+    if not request.allow_private_network:
+        return False
+    if getattr(ctx, "org_role", None) in {OrganizationRole.OWNER, OrganizationRole.ADMIN}:
+        return True
+    raise HTTPException(status_code=403, detail="private_network_import_forbidden")
 
 
 def _capture_visible_to_projects(
@@ -325,7 +340,11 @@ async def start_document_import_route(
         memory_scope="project",
         scope_key=request.target_scope_key,
     )
-    options = _document_import_options(request)
+    allow_private_network = _authorized_private_network_import(request, ctx)
+    options = _document_import_options(
+        request,
+        allow_private_network=allow_private_network,
+    )
     try:
         principal_id = _current_principal_id(ctx)
         payload = await start_source_import(

--- a/apps/api/tests/test_routes_ingestion.py
+++ b/apps/api/tests/test_routes_ingestion.py
@@ -25,6 +25,7 @@ from sibyl.api.schemas import (
 )
 from sibyl.config import settings
 from sibyl.persistence.content_common import RawCaptureRecord
+from sibyl_core.auth import OrganizationRole
 from sibyl_core.models.sources import (
     SourceAdapterCapability,
     SourceAdapterDescriptor,
@@ -232,7 +233,7 @@ async def test_start_document_import_route_enqueues_url_import() -> None:
         allow_private_network=True,
     )
     org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
-    ctx = SimpleNamespace(user_id="user-1")
+    ctx = SimpleNamespace(user_id="user-1", org_role=OrganizationRole.ADMIN)
 
     with (
         patch(
@@ -280,6 +281,40 @@ async def test_start_document_import_route_enqueues_url_import() -> None:
         batch_size=25,
         promotion_preview_approved=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_start_document_import_route_rejects_member_private_network_import() -> None:
+    policy_context = {
+        "actor_user_id": "user-1",
+        "organization_id": "00000000-0000-0000-0000-000000000111",
+        "memory_space": "project",
+        "scope_key": "project_123",
+    }
+    request = DocumentImportRequest(
+        kind="url",
+        source_uri="http://127.0.0.1/internal/metadata",
+        target_scope_key="project_123",
+        allow_private_network=True,
+    )
+    org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+    ctx = SimpleNamespace(user_id="user-1", org_role=OrganizationRole.MEMBER)
+
+    with (
+        patch(
+            "sibyl.api.routes.ingestion._source_import_policy_context",
+            AsyncMock(return_value=policy_context),
+        ),
+        patch("sibyl.api.routes.ingestion.start_source_import", AsyncMock()) as start,
+        patch("sibyl.jobs.queue.enqueue_source_import_drain", AsyncMock()) as enqueue,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await start_document_import_route(request, org=org, ctx=ctx)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "private_network_import_forbidden"
+    start.assert_not_awaited()
+    enqueue.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/apps/cli/src/sibyl_cli/document.py
+++ b/apps/cli/src/sibyl_cli/document.py
@@ -215,7 +215,10 @@ def add_document_source(
     ] = None,
     allow_private_network: Annotated[
         bool,
-        typer.Option("--allow-private-network", help="Allow URL imports from private hosts"),
+        typer.Option(
+            "--allow-private-network",
+            help="Allow URL imports from private hosts (owners/admins only)",
+        ),
     ] = False,
     json_out: Annotated[
         bool, typer.Option("--json", "-j", help="JSON output for scripting")


### PR DESCRIPTION
### Motivation
- A CLI flag and API path allowed ordinary org members to request server-side fetches of private/internal URLs via `allow_private_network`, creating an authenticated SSRF risk. 
- The change prevents low-privilege principals from bypassing host restrictions by forwarding a user-controlled flag to the document URL adapter. 

### Description
- Add `_authorized_private_network_import(request, ctx)` and require it to succeed before honoring `allow_private_network` when building adapter `options`, so the option is only forwarded after authorization. 
- Change `_document_import_options` signature to accept an explicit `allow_private_network` argument and only include the field when authorized. 
- Update `start_document_import_route` to call the new authorization helper and pass the authorized value into `_document_import_options`. 
- Update CLI help text for `--allow-private-network` to note that the capability is restricted to owners/admins, and add a route test that validates members are rejected while admins/owners are allowed. 

### Testing
- Ran API unit tests `uv run pytest tests/test_routes_ingestion.py -q` and they passed. 
- Ran CLI unit tests `uv run pytest tests/test_docs.py -q` and they passed. 
- Ran lint/format checks `uv run ruff check ...` and `uv run ruff format --check ...` on the modified files and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0811c418832aa664f2f91ae736ca)