### PR TITLE
fix(imap): reject mailbox control characters

### DIFF
--- a/apps/api/src/sibyl/jobs/source_imports.py
+++ b/apps/api/src/sibyl/jobs/source_imports.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 from uuid import uuid4
 
 import structlog
@@ -564,9 +564,15 @@ def _is_imap_secret_option(option: object) -> bool:
     return any(marker in normalized for marker in _IMAP_SECRET_OPTION_MARKERS)
 
 
+def _has_control_char(value: str) -> bool:
+    return any(ord(char) < 0x20 or ord(char) == 0x7F for char in value)
+
+
 def _validate_source_import_uri(adapter_name: str, source_uri: str) -> None:
     if adapter_name != IMAP_ADAPTER_NAME:
         return
+    if _has_control_char(source_uri):
+        raise ValueError("imap_source_uri_must_not_include_control_characters")
     parsed = urlparse(source_uri)
     if parsed.scheme != "imaps":
         raise ValueError("imap_source_uri_must_use_tls")
@@ -576,6 +582,8 @@ def _validate_source_import_uri(adapter_name: str, source_uri: str) -> None:
         raise ValueError("imap_source_uri_must_not_include_query_or_fragment")
     if not parsed.hostname:
         raise ValueError("imap_source_uri_must_include_host")
+    if _has_control_char(unquote(parsed.path)):
+        raise ValueError("imap_source_uri_must_not_include_control_characters")
 
 
 def _ensure_builtin_source_adapters() -> None:

--- a/apps/api/tests/test_jobs_source_imports.py
+++ b/apps/api/tests/test_jobs_source_imports.py
@@ -636,6 +636,21 @@ async def test_start_source_import_rejects_imap_query_before_persist(source_uri:
 
 
 @pytest.mark.asyncio
+async def test_start_source_import_rejects_encoded_imap_control_path_before_persist() -> None:
+    with pytest.raises(ValueError, match="imap_source_uri_must_not_include_control_characters"):
+        await source_imports.start_source_import(
+            source_uri="imaps://mail.example.com/INBOX%0D%0AA999%20SELECT%20Archive",
+            organization_id="org-1",
+            principal_id="user-1",
+            policy_context=_policy_context(),
+            adapter_name=IMAP_ADAPTER_NAME,
+            options={"username": "bliss"},
+        )
+
+    assert source_imports._SOURCE_IMPORT_RUNS == {}
+
+
+@pytest.mark.asyncio
 async def test_start_source_import_rejects_non_url_imap_source_before_persist() -> None:
     with pytest.raises(ValueError, match="imap_source_uri_must_use_tls"):
         await source_imports.start_source_import(

--- a/packages/python/sibyl-core/src/sibyl_core/services/mailbox_adapter.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/mailbox_adapter.py
@@ -50,6 +50,17 @@ IMAP_ADAPTER_VERSION = "1.0"
 _EMAIL_DEDUPE_IDENTITY = "email_message"
 _IMAP_SECRET_OPTION_KEYS = frozenset({"access_token", "oauth2_token", "password"})
 _IMAP_PASSWORD_ENV_PREFIX = "SIBYL_SOURCE_IMPORT_IMAP_"
+_IMAP_MAILBOX_CONTROL_ERROR = "IMAP mailbox must not contain control characters"
+
+
+def _has_control_char(value: str) -> bool:
+    return any(ord(char) < 0x20 or ord(char) == 0x7F for char in value)
+
+
+def _validate_imap_mailbox(mailbox: str) -> str:
+    if _has_control_char(mailbox):
+        raise ValueError(_IMAP_MAILBOX_CONTROL_ERROR)
+    return mailbox
 
 
 class ImapClient(Protocol):
@@ -1065,7 +1076,9 @@ def _imap_config(
         port = int(parsed_port)
     else:
         port = 993 if ssl else 143
-    mailbox = _optional_str(options.get("mailbox")) or unquote(parsed.path.lstrip("/")) or "INBOX"
+    mailbox = _validate_imap_mailbox(
+        _optional_str(options.get("mailbox")) or unquote(parsed.path.lstrip("/")) or "INBOX"
+    )
     username = _optional_str(options.get("username"))
     if username is None and parsed.username:
         username = unquote(parsed.username)

--- a/packages/python/sibyl-core/tests/test_mailbox_adapter.py
+++ b/packages/python/sibyl-core/tests/test_mailbox_adapter.py
@@ -16,6 +16,7 @@ from sibyl_core.services.mailbox_adapter import (
     ImapSourceAdapter,
     MaildirSourceAdapter,
     MboxSourceAdapter,
+    _imap_config,
     ensure_mailbox_adapter_registered,
 )
 from sibyl_core.services.source_adapters import (
@@ -440,6 +441,22 @@ async def test_maildir_iter_records_skips_symlinked_entries(tmp_path: Path) -> N
     assert len(ingested) == 1
     assert ingested[0].adapter_record_id == "maildir-1@example.com"
     assert all("secret host data" not in record.body for record in ingested)
+
+
+def test_imap_config_rejects_encoded_mailbox_control_characters() -> None:
+    with pytest.raises(ValueError, match="control characters"):
+        _imap_config(
+            "imaps://127.0.0.1/INBOX%0D%0AA999%20SELECT%20Archive",
+            {"allow_private_network": True},
+        )
+
+
+def test_imap_config_rejects_option_mailbox_control_characters() -> None:
+    with pytest.raises(ValueError, match="control characters"):
+        _imap_config(
+            "imaps://127.0.0.1/INBOX",
+            {"allow_private_network": True, "mailbox": "INBOX\r\nA999 SELECT Archive"},
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Close a CRLF/command-injection vector where percent-encoded or option-provided mailbox names could decode to IMAP control characters and be sent directly to the IMAP server. 
- Ensure the read-only guarantee cannot be bypassed by supplying encoded CR/LF in the IMAP URI path or in adapter options.

### Description
- Add a `_has_control_char` helper and reject raw control characters at the job validation layer (`apps/api/src/sibyl/jobs/source_imports.py`) for IMAP URIs, including a percent-decoded path check. 
- Add `_validate_imap_mailbox` in the core adapter (`packages/python/sibyl-core/src/sibyl_core/services/mailbox_adapter.py`) and validate mailbox names coming from either the decoded URI path or the adapter `mailbox` option before returning adapter config. 
- Import `unquote` where needed to inspect decoded paths and ensure both encoded and option-provided mailbox values are checked. 
- Add regression tests that assert encoded/immediate mailbox control characters are rejected at both the job layer and adapter layer (`apps/api/tests/test_jobs_source_imports.py` and `packages/python/sibyl-core/tests/test_mailbox_adapter.py`).

### Testing
- Ran targeted pytest for adapter-level tests: `uv run pytest packages/python/sibyl-core/tests/test_mailbox_adapter.py::test_imap_config_rejects_encoded_mailbox_control_characters packages/python/sibyl-core/tests/test_mailbox_adapter.py::test_imap_config_rejects_option_mailbox_control_characters -q`, and both tests passed. 
- Ran the API-level test: `uv run pytest apps/api/tests/test_jobs_source_imports.py::test_start_source_import_rejects_encoded_imap_control_path_before_persist -q`, and the test passed. 
- Ran static checks: `uv run ruff check ...` for the modified files and all checks passed. 
- Note: a single combined pytest invocation that mixed test roots in one call produced an import-path mismatch in this environment, so tests were executed in separate, focused invocations which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c63dbab74832aa7c14c2c2e45a6b0)