### PR TITLE
fix(core): scope projected entity hnsw dedup

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
@@ -631,7 +631,17 @@ async def _resolve_projected_entities(
     deduplicator = EntityDeduplicator(
         client=client,
         entity_manager=entity_manager,
-        config=DedupConfig(similarity_threshold=0.95, same_type_only=True),
+        config=DedupConfig(
+            similarity_threshold=0.95,
+            same_type_only=True,
+            scope_metadata_keys=(
+                "memory_scope",
+                "scope_key",
+                "project_id",
+                "principal_id",
+                "agent_id",
+            ),
+        ),
     )
     matches = await deduplicator.resolve_existing_entities(entities)
     return {entity_id: pair.entity2_id for entity_id, pair in matches.items()}

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/dedup.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/dedup.py
@@ -34,12 +34,15 @@ class DedupConfig:
         batch_size: Number of entities to process per batch.
         same_type_only: Only compare entities of the same type.
         min_name_overlap: Minimum Jaccard similarity of names (extra filter).
+        scope_metadata_keys: Metadata fields that must match exactly when resolving
+            incoming entities against existing graph rows.
     """
 
     similarity_threshold: float = 0.95
     batch_size: int = 100
     same_type_only: bool = True
     min_name_overlap: float = 0.3
+    scope_metadata_keys: tuple[str, ...] = ()
 
 
 @dataclass
@@ -166,6 +169,25 @@ def _dedup_candidate_with_seed_from_row(
         return None
     entity_id, name, entity_type, score = candidate
     return seed_id, entity_id, name, entity_type, score
+
+
+def _append_scope_constraint_clauses(
+    clauses: list[str],
+    params: dict[str, Any],
+    scope_constraints: dict[str, object | None] | None,
+    *,
+    param_prefix: str,
+) -> None:
+    if not scope_constraints:
+        return
+    for key, value in scope_constraints.items():
+        field = f"attributes.{key}"
+        if value is None:
+            clauses.append(f"{field} = NONE")
+            continue
+        param_name = f"{param_prefix}_{key}"
+        clauses.append(f"{field} = ${param_name}")
+        params[param_name] = value
 
 
 @dataclass
@@ -334,10 +356,16 @@ class EntityDeduplicator:
             execute_query_raw = None
 
         seeds: list[tuple[str, str, str, list[float]]] = []
+        scope_constraints: dict[str, dict[str, object | None]] = {}
         for entity in entities:
             embedding = _float_list(entity.embedding)
             if entity.id and embedding:
                 seeds.append((entity.id, entity.name, entity.entity_type.value, embedding))
+                if self.config.scope_metadata_keys:
+                    metadata = entity.metadata if isinstance(entity.metadata, dict) else {}
+                    scope_constraints[entity.id] = {
+                        key: metadata.get(key) for key in self.config.scope_metadata_keys
+                    }
         if not seeds:
             return {}
 
@@ -350,6 +378,7 @@ class EntityDeduplicator:
                 seen_pairs=set(),
                 execute_query=execute_query,
                 execute_query_raw=execute_query_raw,
+                scope_constraints=scope_constraints,
             )
         except Exception as exc:
             log.warning(
@@ -373,6 +402,7 @@ class EntityDeduplicator:
         seen_pairs: set[tuple[str, str]],
         execute_query: Any,
         execute_query_raw: Any | None = None,
+        scope_constraints: dict[str, dict[str, object | None]] | None = None,
     ) -> list[DuplicatePair]:
         if not seeds:
             return []
@@ -390,6 +420,7 @@ class EntityDeduplicator:
                         candidate_limit=candidate_limit,
                         seen_pairs=seen_pairs,
                         execute_query=execute_query,
+                        scope_constraints=(scope_constraints or {}).get(seed[0]),
                     )
                 )
             return pairs
@@ -406,6 +437,7 @@ class EntityDeduplicator:
             seed_type_param = f"seed_type_{index}"
             seed_embedding_param = f"seed_embedding_{index}"
             limit_param = f"limit_{index}"
+            scope = (scope_constraints or {}).get(seed_id)
             clauses = [
                 "group_id = $group_id",
                 f"uuid != ${seed_id_param}",
@@ -415,6 +447,12 @@ class EntityDeduplicator:
                 clauses.append(f"entity_type = ${seed_type_param}")
             elif entity_types:
                 clauses.append("entity_type IN $entity_types")
+            _append_scope_constraint_clauses(
+                clauses,
+                params,
+                scope,
+                param_prefix=f"scope_{index}",
+            )
 
             params[seed_id_param] = seed_id
             params[seed_type_param] = seed_type
@@ -484,6 +522,7 @@ class EntityDeduplicator:
         candidate_limit: int,
         seen_pairs: set[tuple[str, str]],
         execute_query: Any,
+        scope_constraints: dict[str, object | None] | None = None,
     ) -> list[DuplicatePair]:
         seed_id, seed_name, seed_type, seed_embedding = seed
         clauses = [
@@ -504,6 +543,12 @@ class EntityDeduplicator:
             params["seed_type"] = seed_type
         elif entity_types:
             clauses.append("entity_type IN $entity_types")
+        _append_scope_constraint_clauses(
+            clauses,
+            params,
+            scope_constraints,
+            param_prefix="scope",
+        )
 
         knn_effort = max(1, int(settings.graph_knn_ef))
         rows = normalize_records(

--- a/packages/python/sibyl-core/tests/test_memory_projection.py
+++ b/packages/python/sibyl-core/tests/test_memory_projection.py
@@ -366,10 +366,93 @@ async def test_project_extracted_memory_entities_resolves_hnsw_duplicate_target(
     assert client.calls
     query, params = client.calls[0]
     assert query.count("name_embedding <|") == 1
+    assert "attributes.memory_scope = NONE" in query
+    assert "attributes.project_id = NONE" in query
     assert params["seed_embedding_0"] == [1.0, 0.0]
 
     relationships = relationship_manager.create_bulk.await_args.args[0]
     assert relationships[0].target_id == "topic_existing_samsung"
+
+
+@pytest.mark.asyncio
+async def test_project_extracted_memory_entities_does_not_resolve_across_private_scopes() -> None:
+    source = _document(
+        "The Apollo dossier mentions Samsung TV preferences.",
+        metadata={"memory_scope": "private", "principal_id": "attacker-user"},
+    )
+
+    class ScopedHnswClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+            self.calls.append((query, params))
+            if params.get("scope_0_principal_id") == "attacker-user":
+                return [{"status": "OK", "result": []}]
+            return [
+                {
+                    "status": "OK",
+                    "result": [
+                        {
+                            "seed_id": params["seed_id_0"],
+                            "uuid": "victim_private_projected",
+                            "name": "Samsung TV",
+                            "entity_type": "topic",
+                            "score": 0.99,
+                        }
+                    ],
+                }
+            ]
+
+    client = ScopedHnswClient()
+
+    async def prepare_entities(
+        entities: list[Entity],
+        *,
+        generate_embeddings: bool,
+    ) -> list[Entity]:
+        assert generate_embeddings is True
+        return [entity.model_copy(update={"embedding": [1.0, 0.0]}) for entity in entities]
+
+    entity_manager = SimpleNamespace(
+        _client=client,
+        _group_id="org-123",
+        prepare_entities_for_write=prepare_entities,
+        create_direct_bulk=AsyncMock(
+            side_effect=lambda entities, **_: [entity.id for entity in entities]
+        ),
+    )
+    relationship_manager = SimpleNamespace(create_bulk=AsyncMock(return_value=(1, 0)))
+
+    result = await project_extracted_memory_entities(
+        entity_manager=entity_manager,
+        relationship_manager=relationship_manager,
+        sources=[source],
+        group_id="org-123",
+        extractions_by_source_id={
+            source.id: [
+                ExtractedMemoryEntity(
+                    name="Samsung TV",
+                    entity_type="topic",
+                    summary="A television in a private dossier",
+                    evidence="The Apollo dossier mentions Samsung TV preferences.",
+                    confidence=0.92,
+                )
+            ]
+        },
+        generate_embeddings=True,
+    )
+
+    assert result.projected_entities == 1
+    entity_manager.create_direct_bulk.assert_awaited_once()
+    query, params = client.calls[0]
+    assert "attributes.memory_scope = $scope_0_memory_scope" in query
+    assert "attributes.principal_id = $scope_0_principal_id" in query
+    assert params["scope_0_memory_scope"] == "private"
+    assert params["scope_0_principal_id"] == "attacker-user"
+
+    relationships = relationship_manager.create_bulk.await_args.args[0]
+    assert relationships[0].target_id != "victim_private_projected"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Prevent cross-scope semantic deduplication that could remap a newly projected entity from one memory/project/private scope onto an existing entity from another scope, which can leak private/project-scoped data. 
- Ensure write-time HNSW resolution respects per-memory/project isolation metadata so projected entities remain isolated by their intended scope.

### Description
- Add an optional `scope_metadata_keys` field to `DedupConfig` and collect per-seed scope values for resolution in `EntityDeduplicator` (`packages/python/sibyl-core/src/sibyl_core/retrieval/dedup.py`).
- Implement `_append_scope_constraint_clauses` and propagate scope constraints into both batched and single-seed HNSW candidate queries so generated SurrealDB WHERE clauses require matching scope metadata (or explicit `NONE`) when configured.
- Configure memory projection resolution to pass exact-match keys `memory_scope`, `scope_key`, `project_id`, `principal_id`, and `agent_id` to the deduplicator so extracted/projected entities only reuse existing targets when scope metadata aligns (`packages/python/sibyl-core/src/sibyl_core/projection/memory.py`).
- Add regression tests to assert queries include scope clauses and that private/project scoped extracted projections do not resolve across isolation boundaries (`packages/python/sibyl-core/tests/test_memory_projection.py`).

### Testing
- Ran targeted unit tests with `uv run pytest` for `packages/python/sibyl-core/tests/test_memory_projection.py` and selected `packages/python/sibyl-core/tests/test_retrieval_advanced.py` cases, and all tests passed (`15 passed`).
- Ran linters with `uv run ruff check` against the modified files and the checks passed.
- Note: `moon` is not available in the container, so `uv run` was used for test and lint runs instead of `moon`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c65a328c0832a8a90dc6d0ed08a01)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity deduplication to enforce scope constraints, preventing memory entities from resolving across different private scopes based on scope metadata fields.

* **Tests**
  * Added test coverage for cross-scope entity resolution behavior to ensure proper scope isolation is maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->