### PR TITLE
fix(core): scope active work lookup to API key grants

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import structlog
 
+from sibyl_core.auth.memory_policy import memory_scope_policy_key
 from sibyl_core.embeddings.providers import configured_embedding_provider
 from sibyl_core.models.context import (
     ContextFacet,
@@ -25,6 +26,7 @@ from sibyl_core.retrieval.search import (
 )
 from sibyl_core.services.graph import get_surreal_graph_runtime
 from sibyl_core.services.surreal_content import (
+    MemoryScope,
     RawMemory,
     recall_raw_memory,
 )
@@ -1002,6 +1004,22 @@ def _item_from_active_entity(entity: Any) -> ContextItem:
     )
 
 
+def _active_work_project_allowed(
+    *,
+    project: str,
+    accessible_projects: set[str] | None,
+    scoped_accessible_projects: frozenset[str] | None,
+    allowed_memory_scope_keys: set[str] | None,
+) -> bool:
+    if scoped_accessible_projects is not None:
+        return project in scoped_accessible_projects
+    if accessible_projects is not None and project not in accessible_projects:
+        return False
+    if allowed_memory_scope_keys is not None:
+        return memory_scope_policy_key(MemoryScope.PROJECT, project) in allowed_memory_scope_keys
+    return True
+
+
 async def _default_active_work(
     *,
     organization_id: str,
@@ -1153,7 +1171,12 @@ async def compile_context(
     if (
         ContextFacet.ACTIVE_WORK in facets
         and project
-        and (accessible_projects is None or project in accessible_projects)
+        and _active_work_project_allowed(
+            project=project,
+            accessible_projects=accessible_projects,
+            scoped_accessible_projects=plan.accessible_projects,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
+        )
     ):
         lookup = active_work_fn if active_work_fn is not None else _default_active_work
         try:

--- a/packages/python/sibyl-core/tests/test_context_pack.py
+++ b/packages/python/sibyl-core/tests/test_context_pack.py
@@ -1078,6 +1078,52 @@ async def test_compile_context_direct_active_lookup_leads_active_work(
 
 
 @pytest.mark.asyncio
+async def test_compile_context_direct_active_lookup_respects_api_key_project_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sibyl_core.auth.memory_policy import memory_scope_policy_key
+    from sibyl_core.services.surreal_content import MemoryScope
+
+    active_calls: list[dict[str, Any]] = []
+
+    async def fake_native_context_search(**kwargs: Any) -> SearchResponse:
+        assert kwargs["plan"].accessible_projects == frozenset()
+        return SearchResponse(results=[], total=0, query=kwargs["plan"].query, filters={})
+
+    async def fake_active_work(**kwargs: Any) -> list[ContextItem]:
+        active_calls.append(kwargs)
+        return [
+            ContextItem(
+                id="task-denied",
+                type="task",
+                name="Denied active task",
+                content="Sensitive denied project work",
+                score=0.0,
+                facet=ContextFacet.ACTIVE_WORK,
+                reason="task is currently in progress for this project",
+            )
+        ]
+
+    monkeypatch.setattr(context_module, "context_search", fake_native_context_search)
+
+    pack = await compile_context(
+        "ship retrieval",
+        intent="build",
+        project="project-denied",
+        accessible_projects={"project-denied"},
+        principal_id="user-123",
+        organization_id="org-123",
+        active_work_fn=fake_active_work,
+        allowed_memory_scope_keys={
+            memory_scope_policy_key(MemoryScope.PRIVATE, "user-123"),
+        },
+    )
+
+    assert active_calls == []
+    assert pack.items == []
+
+
+@pytest.mark.asyncio
 async def test_compile_context_active_lookup_failure_degrades_gracefully(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- The direct Active Work lookup could bypass the retrieval plan's API-key memory-scope filtering and leak project task data for projects a key was not granted to, so the lookup must honor the scoped plan and API-key grants.

### Description
- Add `_active_work_project_allowed(...)` in `packages/python/sibyl-core/src/sibyl_core/tools/context.py` to check `plan.accessible_projects`, `accessible_projects`, and `allowed_memory_scope_keys` (via `memory_scope_policy_key`) before permitting a direct Active Work lookup.
- Import `memory_scope_policy_key` and `MemoryScope` and use the helper to gate the Active Work branch in `compile_context()` so the direct lookup cannot run for projects excluded by the retrieval plan or API-key scopes.
- Add a regression test `test_compile_context_direct_active_lookup_respects_api_key_project_scope` in `packages/python/sibyl-core/tests/test_context_pack.py` that asserts a key with only a private memory scope does not trigger the direct Active Work lookup for a denied project.

### Testing
- Ran `uv run pytest packages/python/sibyl-core/tests/test_context_pack.py -q`, all tests passed (`44 passed`).
- Ran `uv run ruff check packages/python/sibyl-core/src/sibyl_core/tools/context.py packages/python/sibyl-core/tests/test_context_pack.py`, and lint checks passed.
- Local environment note: `moon` is not available in this container, so targeted `uv`/`pytest` checks were used for validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bc0e3e2ec832aaa54901d9d3e8664)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced project scope validation to properly restrict access to work items based on API key authorization and memory scope policies.

* **Tests**
  * Added test coverage for project scope authorization enforcement in context compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->