### PR TITLE
fix(backups): redact org auth archive secrets

### DIFF
--- a/apps/api/src/sibyl/persistence/auth_archive.py
+++ b/apps/api/src/sibyl/persistence/auth_archive.py
@@ -209,6 +209,12 @@ _ORG_EXCLUDED_GLOBAL_USER_TABLES = frozenset(
         "oauth_connections",
     }
 )
+_ORG_SCOPED_REDACTED_FIELDS = {
+    "api_keys": frozenset({"key_salt", "key_hash"}),
+    "device_authorization_requests": frozenset({"device_code_hash", "user_code"}),
+    "organization_invitations": frozenset({"token", "token_hash"}),
+    "user_sessions": frozenset({"token_hash", "refresh_token_hash"}),
+}
 
 _AUTH_ORG_CLEAN_TABLES = (
     "organization_members",
@@ -311,10 +317,12 @@ async def _select_auth_rows(
     )
 
 
-def _redact_org_user_rows(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+def _redact_auth_rows(
+    rows: list[dict[str, object]],
+    redacted_fields: frozenset[str],
+) -> list[dict[str, object]]:
     return [
-        {key: value for key, value in row.items() if key not in _ORG_USER_REDACTED_FIELDS}
-        for row in rows
+        {key: value for key, value in row.items() if key not in redacted_fields} for row in rows
     ]
 
 
@@ -404,6 +412,8 @@ async def _export_org_auth_tables(
             f"SELECT * FROM {table} WHERE organization_id = $organization_id ORDER BY id ASC;",  # noqa: S608
             organization_id=organization_id,
         )
+        if redacted_fields := _ORG_SCOPED_REDACTED_FIELDS.get(table):
+            tables[table] = _redact_auth_rows(tables[table], redacted_fields)
 
     team_ids = _row_ids(tables["teams"])
     tables["team_members"] = await _select_auth_rows_by_ids(
@@ -433,8 +443,9 @@ async def _export_org_auth_tables(
     # credentials and identity records are account-wide. Keep the member profile
     # rows needed to preserve org membership references, but never include global
     # credential or identity material in a scoped organization archive.
-    tables["users"] = _redact_org_user_rows(
-        await _select_auth_rows_by_ids(client, "users", "uuid", user_ids)
+    tables["users"] = _redact_auth_rows(
+        await _select_auth_rows_by_ids(client, "users", "uuid", user_ids),
+        _ORG_USER_REDACTED_FIELDS,
     )
     for table in _ORG_EXCLUDED_GLOBAL_USER_TABLES:
         tables[table] = []

--- a/apps/api/src/sibyl/persistence/auth_archive.py
+++ b/apps/api/src/sibyl/persistence/auth_archive.py
@@ -193,6 +193,23 @@ _AUTH_ORG_SCOPED_TABLES = frozenset(
         "llm_usage_buckets",
     }
 )
+
+_ORG_USER_REDACTED_FIELDS = frozenset(
+    {
+        "password_salt",
+        "password_hash",
+        "password_iterations",
+    }
+)
+_ORG_EXCLUDED_GLOBAL_USER_TABLES = frozenset(
+    {
+        "user_identity",
+        "password_reset_tokens",
+        "login_history",
+        "oauth_connections",
+    }
+)
+
 _AUTH_ORG_CLEAN_TABLES = (
     "organization_members",
     "user_sessions",
@@ -292,6 +309,13 @@ async def _select_auth_rows(
             for row in _normalize_records(result)
         ]
     )
+
+
+def _redact_org_user_rows(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        {key: value for key, value in row.items() if key not in _ORG_USER_REDACTED_FIELDS}
+        for row in rows
+    ]
 
 
 async def _select_auth_rows_by_ids(
@@ -405,31 +429,15 @@ async def _export_org_auth_tables(
             *_row_values(tables["memory_space_members"], "created_by_user_id"),
         }
     )
-    tables["users"] = await _select_auth_rows_by_ids(client, "users", "uuid", user_ids)
-    tables["user_identity"] = await _select_auth_rows_by_ids(
-        client,
-        "user_identity",
-        "user_id",
-        user_ids,
+    # Organization archives are downloadable by organization admins, while user
+    # credentials and identity records are account-wide. Keep the member profile
+    # rows needed to preserve org membership references, but never include global
+    # credential or identity material in a scoped organization archive.
+    tables["users"] = _redact_org_user_rows(
+        await _select_auth_rows_by_ids(client, "users", "uuid", user_ids)
     )
-    tables["password_reset_tokens"] = await _select_auth_rows_by_ids(
-        client,
-        "password_reset_tokens",
-        "user_id",
-        user_ids,
-    )
-    tables["login_history"] = await _select_auth_rows_by_ids(
-        client,
-        "login_history",
-        "user_id",
-        user_ids,
-    )
-    tables["oauth_connections"] = await _select_auth_rows_by_ids(
-        client,
-        "oauth_connections",
-        "user_id",
-        user_ids,
-    )
+    for table in _ORG_EXCLUDED_GLOBAL_USER_TABLES:
+        tables[table] = []
 
     api_key_ids = _row_ids(tables["api_keys"])
     tables["api_key_project_scopes"] = await _select_auth_rows_by_ids(

--- a/apps/api/tests/test_surreal_auth_persistence.py
+++ b/apps/api/tests/test_surreal_auth_persistence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -295,7 +296,57 @@ async def test_auth_archive_export_can_scope_to_one_organization(
     for user_id, email in ((user_a, "a@example.com"), (user_b, "b@example.com")):
         await surreal_auth_client.execute_query(
             "CREATE users CONTENT $record;",
-            record={"uuid": str(user_id), "email": email, "name": email},
+            record={
+                "uuid": str(user_id),
+                "email": email,
+                "name": email,
+                "password_salt": f"{email}-salt",
+                "password_hash": f"{email}-hash",
+                "password_iterations": 310000,
+            },
+        )
+    for user_id, email in ((user_a, "a@example.com"), (user_b, "b@example.com")):
+        await surreal_auth_client.execute_query(
+            "CREATE user_identity CONTENT $record;",
+            record={
+                "uuid": str(uuid4()),
+                "provider_name": "oidc",
+                "issuer": "https://idp.example.com",
+                "subject": str(user_id),
+                "subject_key": f"oidc:{user_id}",
+                "user_id": str(user_id),
+                "email": email,
+            },
+        )
+        await surreal_auth_client.execute_query(
+            "CREATE password_reset_tokens CONTENT $record;",
+            record={
+                "uuid": str(uuid4()),
+                "user_id": str(user_id),
+                "token_hash": f"{email}-reset-token-hash",
+                "expires_at": datetime(2026, 4, 20, 1, 2, 3, tzinfo=UTC),
+            },
+        )
+        await surreal_auth_client.execute_query(
+            "CREATE login_history CONTENT $record;",
+            record={
+                "uuid": str(uuid4()),
+                "user_id": str(user_id),
+                "event_type": "login",
+                "success": True,
+                "ip_address": "192.0.2.10",
+            },
+        )
+        await surreal_auth_client.execute_query(
+            "CREATE oauth_connections CONTENT $record;",
+            record={
+                "uuid": str(uuid4()),
+                "user_id": str(user_id),
+                "provider": "github",
+                "provider_user_id": str(user_id),
+                "access_token_encrypted": f"{email}-access-token",
+                "refresh_token_encrypted": f"{email}-refresh-token",
+            },
         )
     for org_id, slug in ((org_a, "org-a"), (org_b, "org-b")):
         await surreal_auth_client.execute_query(
@@ -362,6 +413,14 @@ async def test_auth_archive_export_can_scope_to_one_organization(
     assert payload["organization_id"] == str(org_a)
     assert [row["uuid"] for row in payload["tables"]["organizations"]] == [str(org_a)]
     assert [row["uuid"] for row in payload["tables"]["users"]] == [str(user_a)]
+    assert payload["tables"]["users"][0]["email"] == "a@example.com"
+    assert "password_salt" not in payload["tables"]["users"][0]
+    assert "password_hash" not in payload["tables"]["users"][0]
+    assert "password_iterations" not in payload["tables"]["users"][0]
+    assert payload["tables"]["user_identity"] == []
+    assert payload["tables"]["password_reset_tokens"] == []
+    assert payload["tables"]["login_history"] == []
+    assert payload["tables"]["oauth_connections"] == []
     assert [row["uuid"] for row in payload["tables"]["api_keys"]] == [str(api_key_a)]
     assert [row["api_key_id"] for row in payload["tables"]["api_key_project_scopes"]] == [
         str(api_key_a)

--- a/apps/api/tests/test_surreal_auth_persistence.py
+++ b/apps/api/tests/test_surreal_auth_persistence.py
@@ -290,6 +290,12 @@ async def test_auth_archive_export_can_scope_to_one_organization(
     user_b = uuid4()
     api_key_a = uuid4()
     api_key_b = uuid4()
+    session_a = uuid4()
+    session_b = uuid4()
+    invitation_a = uuid4()
+    invitation_b = uuid4()
+    device_request_a = uuid4()
+    device_request_b = uuid4()
     project_a = uuid4()
     project_b = uuid4()
 
@@ -363,6 +369,51 @@ async def test_auth_archive_export_can_scope_to_one_organization(
                 "role": "owner",
             },
         )
+    for org_id, user_id, session_id, suffix in (
+        (org_a, user_a, session_a, "a"),
+        (org_b, user_b, session_b, "b"),
+    ):
+        await surreal_auth_client.execute_query(
+            "CREATE user_sessions CONTENT $record;",
+            record={
+                "uuid": str(session_id),
+                "organization_id": str(org_id),
+                "user_id": str(user_id),
+                "token_hash": f"{suffix}-session-token-hash",
+                "refresh_token_hash": f"{suffix}-refresh-token-hash",
+                "expires_at": datetime(2026, 4, 20, 1, 2, 3, tzinfo=UTC),
+            },
+        )
+    for org_id, creator_id, invitation_id, suffix in (
+        (org_a, user_a, invitation_a, "a"),
+        (org_b, user_b, invitation_b, "b"),
+    ):
+        await surreal_auth_client.execute_query(
+            "CREATE organization_invitations CONTENT $record;",
+            record={
+                "uuid": str(invitation_id),
+                "organization_id": str(org_id),
+                "invited_email": f"{suffix}@example.com",
+                "created_by_user_id": str(creator_id),
+                "token": f"{suffix}-invite-token",
+                "token_hash": f"{suffix}-invite-token-hash",
+            },
+        )
+    for org_id, user_id, request_id, suffix in (
+        (org_a, user_a, device_request_a, "a"),
+        (org_b, user_b, device_request_b, "b"),
+    ):
+        await surreal_auth_client.execute_query(
+            "CREATE device_authorization_requests CONTENT $record;",
+            record={
+                "uuid": str(request_id),
+                "organization_id": str(org_id),
+                "user_id": str(user_id),
+                "device_code_hash": f"{suffix}-device-code-hash",
+                "user_code": f"{suffix}-user-code",
+                "expires_at": datetime(2026, 4, 20, 1, 2, 3, tzinfo=UTC),
+            },
+        )
     for org_id, project_id, owner_id, slug in (
         (org_a, project_a, user_a, "project-a"),
         (org_b, project_b, user_b, "project-b"),
@@ -422,6 +473,22 @@ async def test_auth_archive_export_can_scope_to_one_organization(
     assert payload["tables"]["login_history"] == []
     assert payload["tables"]["oauth_connections"] == []
     assert [row["uuid"] for row in payload["tables"]["api_keys"]] == [str(api_key_a)]
+    assert payload["tables"]["api_keys"][0]["key_prefix"] == "ak_a"
+    assert "key_salt" not in payload["tables"]["api_keys"][0]
+    assert "key_hash" not in payload["tables"]["api_keys"][0]
+    assert [row["uuid"] for row in payload["tables"]["user_sessions"]] == [str(session_a)]
+    assert "token_hash" not in payload["tables"]["user_sessions"][0]
+    assert "refresh_token_hash" not in payload["tables"]["user_sessions"][0]
+    assert [row["uuid"] for row in payload["tables"]["organization_invitations"]] == [
+        str(invitation_a)
+    ]
+    assert "token" not in payload["tables"]["organization_invitations"][0]
+    assert "token_hash" not in payload["tables"]["organization_invitations"][0]
+    assert [row["uuid"] for row in payload["tables"]["device_authorization_requests"]] == [
+        str(device_request_a)
+    ]
+    assert "device_code_hash" not in payload["tables"]["device_authorization_requests"][0]
+    assert "user_code" not in payload["tables"]["device_authorization_requests"][0]
     assert [row["api_key_id"] for row in payload["tables"]["api_key_project_scopes"]] == [
         str(api_key_a)
     ]


### PR DESCRIPTION
### Motivation
- Organization-scoped Surreal auth exports previously expanded org member `user_id`s into global user-scoped tables and therefore included account-wide sensitive material like `password_hash`, `password_salt`, password iteration counts, password reset tokens, login history, and encrypted OAuth tokens, enabling data disclosure to org admins.
- The change aims to prevent sensitive, account-wide auth material from being packaged into archives that are downloadable by organization administrators while preserving the organization-scoped data needed for restore and membership semantics.

### Description
- Add a small, explicit redaction policy by introducing `_ORG_USER_REDACTED_FIELDS` and `_ORG_EXCLUDED_GLOBAL_USER_TABLES` and apply them during organization-scoped exports in `_export_org_auth_tables` so user credential fields are removed and global user tables are omitted from org archives (file: `apps/api/src/sibyl/persistence/auth_archive.py`).
- Implement `_redact_org_user_rows` to strip `password_salt`, `password_hash`, and `password_iterations` from exported `users` rows while keeping non-secret profile fields required for membership references (file: `apps/api/src/sibyl/persistence/auth_archive.py`).
- Add regression coverage by seeding sensitive fields and global user-scoped records in the org-scoped export test and asserting the export preserves org-scoped tables but omits credential and global identity material (file: `apps/api/tests/test_surreal_auth_persistence.py`).

### Testing
- Ran `uv run ruff format` and `uv run ruff check` on the modified files and the formatter/linter checks passed.
- Executed the targeted unit test `apps/api/tests/test_surreal_auth_persistence.py::test_auth_archive_export_can_scope_to_one_organization` and the full `apps/api/tests/test_surreal_auth_persistence.py` test suite, and all tests passed (targeted test passed; full file: 13 passed).
- `moon run api:format` was not run because `moon` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ef9a378c832aafeedf1a946abbb6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Organization-scoped authentication archive exports now omit globally scoped credential/identity tables entirely.
  * Organization exports now redact sensitive credential-related fields from user and other scoped auth tables (e.g., password fields, secrets/hashes, session and invitation token data).
* **Tests**
  * Expanded auth archive scoping tests to seed more per-user and per-organization auth data and verify correct field omission/redaction and empty auxiliary sensitive tables in scoped exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->