### PR TITLE
fix(cli): use surreal is-ready --endpoint for local healthcheck (v3 renamed --conn)

### DIFF
--- a/apps/cli/src/sibyl_cli/local.py
+++ b/apps/cli/src/sibyl_cli/local.py
@@ -168,7 +168,7 @@ COMPOSE_CONFIG = {
             "ports": ["127.0.0.1:8000:8000"],
             "volumes": ["sibyl_surreal:/data"],
             "healthcheck": {
-                "test": ["CMD", "/surreal", "is-ready", "--conn", "http://localhost:8000"],
+                "test": ["CMD", "/surreal", "is-ready", "--endpoint", "http://localhost:8000"],
                 "interval": "5s",
                 "timeout": "3s",
                 "retries": 5,


### PR DESCRIPTION
## Problem

On a fresh setup `sibyl local start` fails — the `surrealdb` container never
becomes healthy, so every dependent (`api`, `worker`, `web`) is gated off by
`depends_on: { condition: service_healthy }`:

```
Container sibyl-surrealdb  Error
dependency failed to start: container sibyl-surrealdb is unhealthy
✗ Failed to start services
```

SurrealDB itself starts fine (`Started web server on 0.0.0.0:8000`) — it's the
**healthcheck command** that's wrong.

## Root cause

SurrealDB v3 renamed the `is-ready` connection flag from `--conn` to
`--endpoint`. The compose generated in `apps/cli/src/sibyl_cli/local.py` still
probes with `--conn`, which v3 rejects:

```
$ surreal is-ready --help        # v3.0.5 and v3.1.0
Options:
  -e, --endpoint <ENDPOINT>  Remote database server url ... [default: ws://localhost:8000]
```

So the probe exits non-zero every interval → the container is marked unhealthy
forever.

## Fix

One line — `--conn` → `--endpoint`.

## Validation

Against the running container (reproduced on v3.0.5 and the v3.1.0 image now
pinned on `main`):

```
$ docker exec sibyl-surrealdb /surreal is-ready --conn http://localhost:8000
error: unexpected argument '--conn' found        # exit 2

$ docker exec sibyl-surrealdb /surreal is-ready --endpoint http://localhost:8000
OK                                               # exit 0
```

With the fix applied, `docker compose up --wait` brings the stack up cleanly:

```
Container sibyl-surrealdb  Healthy
Container sibyl-api        Healthy
✓ sibyl is healthy
```

## Scope

Only the `surrealdb` healthcheck flag — no behavior, schema, or image changes.
(The separate `web`/`worker` healthchecks are out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Docker Compose healthcheck configuration for the database service to use the correct endpoint parameter, improving service reliability during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->