### PR TITLE
fix(cli): remove worker and fix web healthcheck from local compose

### DIFF
--- a/apps/cli/src/sibyl_cli/docker.py
+++ b/apps/cli/src/sibyl_cli/docker.py
@@ -95,7 +95,7 @@ def compose_config(
             "ports": [f"127.0.0.1:{surreal_port}:8000"],
             "volumes": ["sibyl_surreal:/data"],
             "healthcheck": {
-                "test": ["CMD", "/surreal", "is-ready", "--conn", "http://localhost:8000"],
+                "test": ["CMD", "/surreal", "is-ready", "--endpoint", "http://localhost:8000"],
                 "interval": "5s",
                 "timeout": "3s",
                 "retries": 5,

--- a/apps/cli/src/sibyl_cli/local.py
+++ b/apps/cli/src/sibyl_cli/local.py
@@ -83,7 +83,7 @@ COMPOSE_CONFIG = {
             "environment": {
                 "SIBYL_STORE": "surreal",
                 "SIBYL_AUTH_STORE": "surreal",
-                "SIBYL_COORDINATION_BACKEND": "auto",
+                "SIBYL_COORDINATION_BACKEND": "local",
                 "SIBYL_SURREAL_URL": "ws://surrealdb:8000/rpc",
                 "SIBYL_SURREAL_USERNAME": "${SIBYL_SURREAL_USERNAME:-root}",
                 "SIBYL_SURREAL_PASSWORD": "${SIBYL_SURREAL_PASSWORD:-sibyl_local}",
@@ -111,27 +111,6 @@ COMPOSE_CONFIG = {
             },
             "restart": "unless-stopped",
         },
-        "worker": {
-            "image": f"ghcr.io/hyperb1iss/sibyl-api:{DEFAULT_IMAGE_TAG}",
-            "container_name": "sibyl-worker",
-            "command": ["sibyld", "worker"],
-            "depends_on": {
-                "api": {"condition": "service_healthy"},
-            },
-            "environment": {
-                "SIBYL_STORE": "surreal",
-                "SIBYL_AUTH_STORE": "surreal",
-                "SIBYL_COORDINATION_BACKEND": "auto",
-                "SIBYL_SURREAL_URL": "ws://surrealdb:8000/rpc",
-                "SIBYL_SURREAL_USERNAME": "${SIBYL_SURREAL_USERNAME:-root}",
-                "SIBYL_SURREAL_PASSWORD": "${SIBYL_SURREAL_PASSWORD:-sibyl_local}",
-                "SIBYL_OPENAI_API_KEY": "${SIBYL_OPENAI_API_KEY}",
-                "SIBYL_ANTHROPIC_API_KEY": "${SIBYL_ANTHROPIC_API_KEY}",
-                "SIBYL_LLM_PROVIDER": "anthropic",
-                "SIBYL_LLM_MODEL": "claude-haiku-4-5",
-            },
-            "restart": "unless-stopped",
-        },
         "web": {
             "image": f"ghcr.io/hyperb1iss/sibyl-web:{DEFAULT_IMAGE_TAG}",
             "container_name": "sibyl-web",
@@ -143,9 +122,12 @@ COMPOSE_CONFIG = {
                 "SIBYL_API_URL": "http://api:3334/api",  # Server-side (SSR) fetches
                 "NEXT_PUBLIC_API_URL": "http://localhost:3334",  # Client-side fetches
                 "NODE_ENV": "production",
+                # Next.js standalone binds 0.0.0.0 (IPv4 only) by default; :: makes
+                # the server dual-stack so it answers on both ::1 and 127.0.0.1.
+                "HOSTNAME": "::",
             },
             "healthcheck": {
-                "test": ["CMD", "wget", "-q", "--spider", "http://localhost:3337/"],
+                "test": ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3337/"],
                 "interval": "10s",
                 "timeout": "5s",
                 "retries": 3,

--- a/apps/cli/tests/test_local_surreal.py
+++ b/apps/cli/tests/test_local_surreal.py
@@ -15,12 +15,14 @@ def test_local_compose_defaults_to_fully_surreal_runtime() -> None:
     assert services["surrealdb"]["image"] == "${SIBYL_SURREAL_IMAGE:-surrealdb/surrealdb:v3.1.0}"
     assert "falkordb" not in services
     assert "postgres" not in services
+    assert "worker" not in services
 
     api = services["api"]
     assert api["depends_on"] == {"surrealdb": {"condition": "service_healthy"}}
     assert api["environment"]["SIBYL_STORE"] == "surreal"
     assert api["environment"]["SIBYL_AUTH_STORE"] == "surreal"
     assert api["environment"]["SIBYL_SURREAL_URL"] == "ws://surrealdb:8000/rpc"
+    assert api["environment"]["SIBYL_COORDINATION_BACKEND"] == "local"
 
 
 def test_local_compose_uses_versioned_sibyl_images() -> None:
@@ -28,26 +30,19 @@ def test_local_compose_uses_versioned_sibyl_images() -> None:
 
     assert local._version_to_image_tag("1.0.0rc1") == "1.0.0-rc.1"
     assert services["api"]["image"] == f"ghcr.io/hyperb1iss/sibyl-api:{local.DEFAULT_IMAGE_TAG}"
-    assert services["worker"]["image"] == f"ghcr.io/hyperb1iss/sibyl-api:{local.DEFAULT_IMAGE_TAG}"
     assert services["web"]["image"] == f"ghcr.io/hyperb1iss/sibyl-web:{local.DEFAULT_IMAGE_TAG}"
     assert ":latest" not in services["api"]["image"]
-    assert ":latest" not in services["worker"]["image"]
     assert ":latest" not in services["web"]["image"]
 
 
-def test_local_worker_uses_same_surreal_runtime_as_api() -> None:
-    api_env = local.COMPOSE_CONFIG["services"]["api"]["environment"]
-    worker_env = local.COMPOSE_CONFIG["services"]["worker"]["environment"]
+def test_local_compose_web_healthcheck_uses_ipv4_loopback() -> None:
+    web = local.COMPOSE_CONFIG["services"]["web"]
 
-    for key in (
-        "SIBYL_STORE",
-        "SIBYL_AUTH_STORE",
-        "SIBYL_COORDINATION_BACKEND",
-        "SIBYL_SURREAL_URL",
-        "SIBYL_SURREAL_USERNAME",
-        "SIBYL_SURREAL_PASSWORD",
-    ):
-        assert worker_env[key] == api_env[key]
+    assert web["environment"]["HOSTNAME"] == "::"
+    healthcheck_test = web["healthcheck"]["test"]
+    url = healthcheck_test[-1]
+    assert "127.0.0.1" in url
+    assert "localhost" not in url
 
 
 def test_local_env_file_contains_surreal_credentials(


### PR DESCRIPTION
## Changes

- **Remove `worker` service from `local.py` compose generator** — with `auto`/`local` coordination, background jobs run in-process under the API server. The standalone worker had nothing to do and exited immediately, causing a crash-restart loop (954 restarts observed in production).
- **Change `SIBYL_COORDINATION_BACKEND` from `auto` → `local`** in the API service — matches `docker.py` convention and removes ambiguity.
- **Fix web healthcheck: `localhost:3337` → `127.0.0.1:3337`** — `localhost` resolves to `::1` (IPv6) inside the container, but Next.js standalone binds to `0.0.0.0` (IPv4 only) by default. This caused 5730 consecutive healthcheck failures.
- **Add `HOSTNAME: "::"` to web service environment** — makes Next.js dual-stack so it answers on both `::1` and `127.0.0.1`, matching the quickstart compose.
- **Fix `docker.py` surrealdb healthcheck: `--conn` → `--endpoint`** — SurrealDB v3 renamed the flag. Already fixed in `local.py` by `c0084f04` but `docker.py` was missed.

## Reason

Commit `b19a0110` gated workers behind `profiles: ["redis"]` in the quickstart and prod composes but missed the `local.py` compose generator. The parameterized `compose_config()` in `docker.py` already defaults to `with_worker=False`. The `local.py` `COMPOSE_CONFIG` is a drifted hardcoded dict that was never updated.

The web healthcheck `localhost` → IPv6 issue was present in `local.py` but already fixed in the quickstart compose (`docker-compose.quickstart.yml:140-142`), which uses `127.0.0.1` and `HOSTNAME: "::"`.

## Validation

```bash
# Lint + format check
$ uv run ruff check apps/cli/src/sibyl_cli/local.py apps/cli/src/sibyl_cli/docker.py apps/cli/tests/test_local_surreal.py
All checks passed!
$ uv run ruff format --check apps/cli/src/sibyl_cli/local.py apps/cli/src/sibyl_cli/docker.py apps/cli/tests/test_local_surreal.py
3 files already formatted

# Typecheck
$ uv run ty check apps/cli/src/sibyl_cli/local.py apps/cli/src/sibyl_cli/docker.py
All checks passed!

# Full CLI test suite (348 tests)
$ uv run pytest apps/cli/tests/ -v
============================= 348 passed in 8.98s ==============================

# Local surreal test file (4 tests)
$ uv run pytest apps/cli/tests/test_local_surreal.py -v
apps/cli/tests/test_local_surreal.py::test_local_compose_defaults_to_fully_surreal_runtime PASSED
apps/cli/tests/test_local_surreal.py::test_local_compose_uses_versioned_sibyl_images PASSED
apps/cli/tests/test_local_surreal.py::test_local_compose_web_healthcheck_uses_ipv4_loopback PASSED
apps/cli/tests/test_local_surreal.py::test_local_env_file_contains_surreal_credentials PASSED
============================== 4 passed in 2.60s ===============================
```

Runtime evidence (from local deployment before this fix):
- Worker container: 954 restarts, crash loop (`sibyld worker` exits immediately with `auto` backend)
- Web container: 5730 consecutive healthcheck failures (`localhost` → IPv6 → connection refused)
- After applying these fixes manually to the generated compose: all 3 containers healthy, 0 restarts

## Reviewer notes

- **Minimal surface**: 3 files changed, 15 insertions, 38 deletions
- **Precedent**: `b19a0110` already gated workers in quickstart/prod; `docker.py:compose_config(with_worker=False)` is the correct pattern
- **No behavior change**: `local` backend means jobs run in-process under `sibyld serve` — no functional difference for users
- **Tests updated**: removed `test_local_worker_uses_same_surreal_runtime_as_api`, added `test_local_compose_web_healthcheck_uses_ipv4_loopback`, added `assert "worker" not in services` to existing test
- **What this is NOT**: does not address the v3.1.0 rocksdb migration issue (separate concern), does not refactor `local.py` to use `docker.compose_config()` (kept minimal)

## Reversibility

Fully reversible — reverting this commit restores the previous compose config with worker and `localhost` healthcheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local environment startup reliability by updating service readiness checks and loopback networking behavior.
  * Adjusted local compose settings so the app uses the expected backend configuration in local mode.
  * Updated health checks to work more consistently with dual-stack networking, reducing false failures during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->