### PR TITLE
docs: make local self-host the default, enterprise the opt-in

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -52,8 +52,8 @@ export default defineConfig({
 
         nav: [
             { text: 'Guide', link: '/guide/' },
-            { text: 'Users', link: '/users/login' },
-            { text: 'Admins', link: '/admin/installing' },
+            { text: 'Using Sibyl', link: '/users/cli-setup' },
+            { text: 'Self-Hosting & Admin', link: '/admin/installing' },
             { text: 'CLI', link: '/cli/' },
             { text: 'API', link: '/api/' },
             { text: 'Benchmarks', link: '/testing/' },
@@ -65,16 +65,16 @@ export default defineConfig({
                 {
                     text: 'Using Sibyl',
                     items: [
-                        { text: 'Enterprise Sign-In', link: '/users/login' },
                         { text: 'CLI Setup', link: '/users/cli-setup' },
                         { text: 'MCP Setup', link: '/users/mcp-setup' },
                         { text: 'Sharing Memory', link: '/users/sharing-memory' },
+                        { text: 'Signing In', link: '/users/login' },
                     ],
                 },
             ],
             '/admin/': [
                 {
-                    text: 'Enterprise Administration',
+                    text: 'Self-Hosting & Admin',
                     items: [
                         { text: 'Installing Sibyl', link: '/admin/installing' },
                         { text: 'Inviting Users', link: '/admin/inviting-users' },
@@ -91,6 +91,7 @@ export default defineConfig({
                         { text: 'Introduction', link: '/guide/' },
                         { text: 'Installation', link: '/guide/installation' },
                         { text: 'Quick Start', link: '/guide/quick-start' },
+                        { text: 'Run Sibyl for Yourself', link: '/guide/self-hosting' },
                     ],
                 },
                 {

--- a/docs/admin/installing.md
+++ b/docs/admin/installing.md
@@ -1,6 +1,6 @@
 ---
 title: Installing Sibyl
-description: Enterprise Kubernetes installation guide for Sibyl admins
+description: Team and enterprise install guide (Kubernetes, Helm, OIDC). For a personal instance, see Run Sibyl for Yourself.
 ---
 
 # Installing Sibyl
@@ -12,6 +12,11 @@ Sibyl has two supported install shapes:
   explicitly enabled.
 - **Enterprise SSO install:** Kubernetes deployment behind a corporate identity provider, with OIDC
   configured explicitly and local password login disabled only after an OIDC owner can sign in.
+
+::: tip Just want Sibyl for yourself? This guide covers team and enterprise installs on Kubernetes.
+For a personal single-user instance, [Run Sibyl for Yourself](../guide/self-hosting.md) (one command
+with `sibyl up`) or the [single-host Ansible deploy](../deployment/ansible.md) for an always-on VM
+are the simpler paths. :::
 
 SurrealDB is the active data plane in both shapes. Valkey or Redis is only needed for coordination
 when running multiple backend or worker replicas. Enterprise installs add an ingress or Gateway API

--- a/docs/api/auth-api-keys.md
+++ b/docs/api/auth-api-keys.md
@@ -72,14 +72,14 @@ POST /api/auth/api-keys
 ### Authorization Header
 
 ```bash
-curl -X GET "https://api.example.com/api/entities" \
+curl -X GET "http://localhost:3334/api/entities" \
   -H "Authorization: Bearer sk_live_abc123def456ghi789..."
 ```
 
 ### MCP Endpoint
 
 ```bash
-curl -X POST "https://api.example.com/mcp" \
+curl -X POST "http://localhost:3334/mcp" \
   -H "Authorization: Bearer sk_live_abc123..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -304,7 +304,7 @@ For CI/CD and automation, use environment variables:
     SIBYL_API_KEY: ${{ secrets.SIBYL_API_KEY }}
   run: |
     curl -H "Authorization: Bearer $SIBYL_API_KEY" \
-      https://api.example.com/api/entities
+      http://localhost:3334/api/entities
 ```
 
 ## Related

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -96,18 +96,18 @@ Sibyl supports multiple authentication methods and role-based access control:
 ```bash
 # Using JWT token (from login)
 curl -H "Authorization: Bearer $ACCESS_TOKEN" \
-  https://api.example.com/api/entities
+  http://localhost:3334/api/entities
 
 # Using API key
 curl -H "Authorization: Bearer sk_live_abc123..." \
-  https://api.example.com/api/entities
+  http://localhost:3334/api/entities
 ```
 
 **For MCP:**
 
 ```bash
 # API key with mcp scope
-curl -X POST https://api.example.com/mcp \
+curl -X POST http://localhost:3334/mcp \
   -H "Authorization: Bearer sk_live_abc123..." \
   -H "Content-Type: application/json" \
   -d '{"method": "tools/call", "params": {"name": "search", "arguments": {"query": "OAuth patterns"}}}'
@@ -155,7 +155,7 @@ X-RateLimit-Reset: 1704067200
 Real-time updates are available via WebSocket at `/ws`:
 
 ```javascript
-const ws = new WebSocket("wss://api.example.com/ws?token=YOUR_TOKEN");
+const ws = new WebSocket("ws://localhost:3334/ws?token=YOUR_TOKEN");
 
 ws.onmessage = (event) => {
   const data = JSON.parse(event.data);

--- a/docs/api/rest-entities.md
+++ b/docs/api/rest-entities.md
@@ -51,7 +51,7 @@ GET /api/entities
 **Example Request:**
 
 ```bash
-curl -X GET "https://api.example.com/api/entities?entity_type=pattern&language=python&page_size=20" \
+curl -X GET "http://localhost:3334/api/entities?entity_type=pattern&language=python&page_size=20" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -102,7 +102,7 @@ Retrieves a single entity by ID. Transparently handles both:
 **Example Request:**
 
 ```bash
-curl -X GET "https://api.example.com/api/entities/pattern_abc123" \
+curl -X GET "http://localhost:3334/api/entities/pattern_abc123" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -207,7 +207,7 @@ Creates a new entity in the knowledge graph.
 **Example Request:**
 
 ```bash
-curl -X POST "https://api.example.com/api/entities?sync=true" \
+curl -X POST "http://localhost:3334/api/entities?sync=true" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -302,7 +302,7 @@ Updates an existing entity. Only provided fields are updated.
 **Example Request:**
 
 ```bash
-curl -X PATCH "https://api.example.com/api/entities/pattern_abc123" \
+curl -X PATCH "http://localhost:3334/api/entities/pattern_abc123" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -347,7 +347,7 @@ Deletes an entity from the knowledge graph.
 **Example Request:**
 
 ```bash
-curl -X DELETE "https://api.example.com/api/entities/pattern_abc123" \
+curl -X DELETE "http://localhost:3334/api/entities/pattern_abc123" \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/docs/api/rest-projects.md
+++ b/docs/api/rest-projects.md
@@ -63,7 +63,7 @@ GET /api/entities?entity_type=project
 **Example Request:**
 
 ```bash
-curl -X GET "https://api.example.com/api/entities?entity_type=project" \
+curl -X GET "http://localhost:3334/api/entities?entity_type=project" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -106,7 +106,7 @@ GET /api/entities/{project_id}
 **Example Request:**
 
 ```bash
-curl -X GET "https://api.example.com/api/entities/proj_abc123" \
+curl -X GET "http://localhost:3334/api/entities/proj_abc123" \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/docs/api/rest-search.md
+++ b/docs/api/rest-search.md
@@ -91,7 +91,7 @@ Search both knowledge graph entities and crawled documentation.
 **Example Request:**
 
 ```bash
-curl -X POST "https://api.example.com/api/search" \
+curl -X POST "http://localhost:3334/api/search" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -214,7 +214,7 @@ Navigate graph structure without semantic search.
 **Example Request:**
 
 ```bash
-curl -X POST "https://api.example.com/api/search/explore" \
+curl -X POST "http://localhost:3334/api/search/explore" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/cli/context.md
+++ b/docs/cli/context.md
@@ -430,6 +430,18 @@ sibyl task list  # Uses proj_other
 
 ## Common Workflows
 
+### Solo / Local Only
+
+Most personal installs never need more than one context. `sibyl up` sets up a local context for you
+automatically; to create it by hand, this is the whole setup:
+
+```bash
+sibyl context create local --server http://localhost:3334 --use
+sibyl health
+```
+
+Everything else on this page is for people juggling multiple servers or orgs.
+
 ### Development Setup
 
 ```bash

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -23,7 +23,10 @@ moon run cli:install-dev
 ## Quick Start
 
 ```bash
-# Authenticate (creates or uses the active context)
+# Running Sibyl locally? Start it; the CLI points at localhost by default.
+sibyl up
+
+# Connecting to a remote or shared server instead? Authenticate first.
 sibyl auth login
 
 # Link the current directory to a project

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -36,10 +36,10 @@ defaults to `remote` when `--remote` is set and `local` otherwise.
 sibyl init --local
 
 # Point the CLI at a hosted server
-sibyl init --remote https://sibyl.example.com --org acme
+sibyl init --remote https://your-sibyl-host --org acme
 
 # Update an existing context in place
-sibyl init --remote https://sibyl.example.com --force
+sibyl init --remote https://your-sibyl-host --force
 
 # Name a context and set a default project
 sibyl init --local --name dev --project sibyl

--- a/docs/cli/service.md
+++ b/docs/cli/service.md
@@ -8,6 +8,30 @@ daemon comes up.
 This is for running Sibyl directly on the host. For a containerized deployment, use
 [`sibyl docker`](./docker.md) or [`sibyl local`](./local.md).
 
+## Running the Daemon
+
+Three top-level commands run the embedded `sibyld` daemon natively, without Docker:
+
+| Command       | What it does                                      |
+| ------------- | ------------------------------------------------- |
+| `sibyl serve` | Run the daemon in the foreground (Ctrl+C to stop) |
+| `sibyl start` | Start the daemon in the background                |
+| `sibyl stop`  | Stop the background daemon                         |
+
+```bash
+# First-run local setup, then run in the foreground
+sibyl init --local
+sibyl serve
+
+# Or run it in the background and check health
+sibyl start
+sibyl doctor
+sibyl stop
+```
+
+For a daemon that survives reboots, install a user-service file with
+[`sibyl service install`](#service-install) below.
+
 ## Commands
 
 | Command                                     | Description                                                   |

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Build a knowledge graph your team can actually reuse
+description: Build a knowledge graph you and your team can actually reuse
 ---
 
 # Introduction
@@ -167,6 +167,7 @@ tool calls.
 
 1. **[Installation](./installation)**: Get Sibyl running locally
 2. **[Quick Start](./quick-start)**: Create your first knowledge entries
+3. **[Run Sibyl for Yourself](./self-hosting)**: The full solo self-host path, start to finish
 
 ### Working Effectively
 

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -1,0 +1,182 @@
+---
+title: Run Sibyl for Yourself
+description: The solo self-host path - one command to a private memory graph on your own machine
+---
+
+# Run Sibyl for Yourself
+
+Sibyl's default shape is personal. No company, no identity provider, no hosted Sibyl tenant. One
+command brings up a private knowledge graph on your own machine, you create your own owner account,
+and every agent you run talks to it at `localhost`. Your memory graph lives on your hardware and
+stays there. The one caveat: extraction and embeddings call the AI providers you configure (Anthropic
+for entity extraction, OpenAI or Gemini for embeddings), so that text is sent to those APIs the same
+way it would be with any tool that uses them.
+
+This page is the end-to-end solo path. If you administer Sibyl for a team behind corporate SSO, see
+[Self-Hosting & Admin](../admin/installing.md) instead.
+
+## What You Get
+
+- A local SurrealDB knowledge graph, running on your box
+- The full memory loop (`recall → act → remember → reflect`) from any terminal
+- A web UI at `http://localhost:3337` for the graph explorer, tasks, and the memory workspace
+- An MCP endpoint at `http://localhost:3334/mcp` for Claude Code, Codex, Cursor, and anything else
+  that speaks MCP
+- One owner account: you
+
+## Step 1: Install and Start
+
+The batteries-included path runs the whole stack (API, web UI, SurrealDB) in Docker and opens the
+setup wizard when it is ready:
+
+```bash
+# Homebrew (macOS / Linux)
+brew install hyperb1iss/tap/sibyl
+sibyl up
+
+# or the shell installer
+curl -fsSL https://raw.githubusercontent.com/hyperb1iss/sibyl/main/install.sh | sh
+```
+
+`sibyl up` is the front door for personal use. On first run it reads `OPENAI_API_KEY` and
+`ANTHROPIC_API_KEY` from your environment if they are set, generates its own secrets, and writes a
+compose file plus `.env` under `~/.sibyl/local` before opening your browser. If those keys are not in
+your environment, you add them in the setup wizard instead (Step 2). Everything binds to `127.0.0.1`,
+so nothing is exposed to your network.
+
+::: tip Prefer no Docker? Run the embedded daemon directly with `sibyl init --local` then
+`sibyl serve`. See [Keeping It Running](#keeping-it-running) for the daemon options. :::
+
+## Step 2: Finish Setup in the Browser
+
+The first time the web UI opens at `http://localhost:3337`, a short wizard runs:
+
+1. **API keys** — Sibyl needs an Anthropic key for entity extraction and an OpenAI or Gemini key for
+   embeddings. Keys you enter in the wizard are stored encrypted in your local database.
+2. **Your owner account** — the first account you create holds owner privileges. This is local
+   username/password auth; there is no external sign-in to configure. After setup, new accounts are
+   invite-only unless you deliberately turn on public signups.
+3. **Connect** — the wizard shows the MCP config and agent prompt snippet for your tools.
+
+That is the whole account story for a solo install. No OIDC, no role claims, no identity provider.
+
+## Step 3: Point the CLI at Your Local Server
+
+A fresh Sibyl CLI already defaults to `http://localhost:3334`, so on a clean setup you can go straight
+to a health check:
+
+```bash
+sibyl health
+```
+
+`sibyl up` starts the server but does not change your CLI's active context. If you previously pointed
+the CLI at a remote server, create or switch to the local context explicitly (it defaults to
+localhost, so no URL is needed):
+
+```bash
+sibyl init --local        # or: sibyl context use local
+sibyl doctor
+```
+
+Sibyl is now yours from any terminal.
+
+## Step 4: Connect Your Agent
+
+Any MCP-capable agent connects to your local endpoint at `http://localhost:3334/mcp`. The **Connect**
+page in the web UI shows the client config for each tool. You supply an API key with the `mcp` scope,
+created from Settings → Security → API Keys or with the CLI:
+
+```bash
+sibyl auth api-key create --name "claude-code" --scopes mcp
+```
+
+`sibyl up` generates a signing secret on first run, so MCP auth is on by default. Drop the key into
+your client config:
+
+```json
+{
+  "mcpServers": {
+    "sibyl": {
+      "type": "http",
+      "url": "http://localhost:3334/mcp",
+      "headers": {
+        "Authorization": "Bearer sk_live_replace_me"
+      }
+    }
+  }
+}
+```
+
+That same entry works for Claude Code, Cursor, Claude Desktop, and other MCP clients. Sibyl
+auto-generates a signing secret even for a bare `sibyl serve`, so MCP auth stays on by default. If you
+want an unauthenticated endpoint for local development only, set `SIBYL_MCP_AUTH_MODE=off` and drop
+the `Authorization` header. See [Agents & MCP](./claude-code.md) and
+[MCP Configuration](./mcp-configuration.md) for per-client details.
+
+## Step 5: Run the Memory Loop
+
+The payoff. Capture something worth keeping, then pull it back:
+
+```bash
+# Remember a hard-won gotcha
+sibyl remember "Async gotcha" \
+  "Use asyncio.gather for concurrent awaits, not a sequential loop" \
+  --kind pattern
+
+# Recall it as working context before you act
+sibyl recall "async concurrency" --intent build
+
+# Or search the whole graph by meaning
+sibyl search "running awaits at the same time"
+```
+
+Link a repo so commands auto-scope to it:
+
+```bash
+cd ~/dev/my-project
+sibyl project link <project_id>
+```
+
+Everything you capture lives in your own graph. On a solo install you naturally work in a single
+auto-created org, so you can ignore org and multi-tenancy concepts entirely until you have a reason
+to care about them.
+
+## Keeping It Running
+
+You have three ways to run the server on your own machine. Pick one:
+
+| Command                          | What it is                                                   | Best for                                       |
+| -------------------------------- | ----------------------------------------------------------- | ---------------------------------------------- |
+| [`sibyl up` / `sibyl local`](../cli/local.md) | Batteries-included Docker stack, `~/.sibyl/local` | The default. Easiest personal instance.        |
+| [`sibyl serve` / `start` / `stop`](../cli/service.md) | Embedded native daemon, no Docker              | Lightweight, no container runtime              |
+| [`sibyl docker`](../cli/docker.md) | Pinned Docker stack with explicit image tags              | Reproducible upgrades, worker/crawler services |
+
+Common lifecycle commands:
+
+```bash
+sibyl up            # start the local stack and open the UI
+sibyl down          # stop it (data persists)
+sibyl local status  # is it running?
+sibyl local logs    # tail the logs
+```
+
+To keep the daemon alive across reboots without Docker, install a native user service:
+
+```bash
+sibyl service install
+```
+
+## Going Remote Later
+
+Nothing about the solo path locks you in. If you later want Sibyl on a small cloud VM you can reach
+from anywhere, the [single-host Ansible guide](../deployment/ansible.md) provisions one box with TLS,
+pairs cleanly with Tailscale for a private zero-public-port setup, and keeps the same local-first
+auth. Point any CLI at it with `sibyl init --remote https://your-host`.
+
+## Where to Go Next
+
+- [The Memory Loop](./memory-loop.md) — recall, act, remember, reflect
+- [Capturing Knowledge](./capturing-knowledge.md) — what is worth saving
+- [Agents & MCP](./claude-code.md) — connect any AI agent
+- [Skills & Hooks](./skills.md) — automatic context injection
+- [Single-Host Deployment](../deployment/ansible.md) — your own always-on instance on a VM

--- a/docs/users/cli-setup.md
+++ b/docs/users/cli-setup.md
@@ -31,15 +31,25 @@ python -m pip install sibyl-dev
 
 ## Point The CLI At Your Server
 
-Create a remote context for the enterprise server:
+A fresh Sibyl CLI defaults to `http://localhost:3334`, so if you run Sibyl locally with `sibyl up`
+you can usually skip ahead to [Daily Checks](#daily-checks). `sibyl up` does not change your CLI's
+active context, though, so if you previously pointed it at a remote server, switch back to the local
+context (it defaults to localhost, so no URL is needed):
 
 ```bash
-sibyl init --remote https://sibyl.example.com
+sibyl init --local        # or: sibyl context use local
+sibyl doctor
+```
+
+To point the CLI at a remote or shared server instead:
+
+```bash
+sibyl init --remote https://your-sibyl-host
 sibyl auth login
 ```
 
-`sibyl auth login` opens the browser sign-in flow. In enterprise deployments, that browser flow uses
-the same corporate OIDC provider as the web app.
+`sibyl auth login` opens the browser sign-in flow. On a team server behind corporate SSO, that
+browser flow uses the same OIDC provider as the web app.
 
 For headless terminals, print the login URL instead:
 

--- a/docs/users/login.md
+++ b/docs/users/login.md
@@ -1,13 +1,23 @@
 ---
-title: Enterprise Sign-In
-description: Signing in to Sibyl with a corporate OIDC identity provider
+title: Signing In
+description: How Sibyl sign-in works, from a local single-user install to enterprise OIDC
 ---
 
-# Enterprise Sign-In
+# Signing In
 
-This page applies when an operator has enabled enterprise OIDC. The default Sibyl install is
-local-first: the first setup signup creates the owner/admin user, and later users join by invitation
-unless public signups are enabled.
+How you sign in depends on how Sibyl was installed.
+
+## Local Sign-In (Default)
+
+The default Sibyl install is local-first. The first account you create during setup is the
+owner/admin; after that, new users join by invitation unless public signups are explicitly enabled.
+Sign in from the web login screen with your username and password. If you forget it, see
+[Forgot Your Password](#forgot-your-password) below.
+
+That is the whole story for a personal or small-team self-host. The rest of this page covers
+enterprise SSO, which only applies when an operator has enabled OIDC.
+
+## Enterprise SSO
 
 In enterprise SSO mode, Sibyl signs users in through your organization's OpenID Connect provider.
 The production shape is intentionally boring: the identity provider proves who you are, Sibyl reads

--- a/docs/users/mcp-setup.md
+++ b/docs/users/mcp-setup.md
@@ -24,14 +24,15 @@ sibyl auth api-key create --name "project-agent" \
 
 ## Shared HTTP Configuration
 
-Most MCP clients accept the same HTTP shape:
+Most MCP clients accept the same HTTP shape. A local `sibyl up` install lives at
+`http://localhost:3334/mcp`; on a remote or shared server, swap in your own host:
 
 ```json
 {
   "mcpServers": {
     "sibyl": {
       "type": "http",
-      "url": "https://sibyl.example.com/mcp",
+      "url": "http://localhost:3334/mcp",
       "headers": {
         "Authorization": "Bearer sk_live_replace_me"
       }
@@ -52,7 +53,7 @@ Add Sibyl as an HTTP MCP server in Cursor's MCP settings:
   "mcpServers": {
     "sibyl": {
       "type": "http",
-      "url": "https://sibyl.example.com/mcp",
+      "url": "http://localhost:3334/mcp",
       "headers": {
         "Authorization": "Bearer sk_live_replace_me"
       }
@@ -72,7 +73,7 @@ Use Claude Code's MCP configuration with the same HTTP server entry:
   "mcpServers": {
     "sibyl": {
       "type": "http",
-      "url": "https://sibyl.example.com/mcp",
+      "url": "http://localhost:3334/mcp",
       "headers": {
         "Authorization": "Bearer sk_live_replace_me"
       }
@@ -97,7 +98,7 @@ Claude Desktop can use the same HTTP MCP server entry in its MCP server config:
   "mcpServers": {
     "sibyl": {
       "type": "http",
-      "url": "https://sibyl.example.com/mcp",
+      "url": "http://localhost:3334/mcp",
       "headers": {
         "Authorization": "Bearer sk_live_replace_me"
       }
@@ -115,5 +116,5 @@ Sibyl for a known memory. If the request fails:
 
 - Confirm the API key starts with `sk_live_` or `sk_test_`.
 - Confirm the key has the `mcp` scope.
-- Confirm the client can reach `https://sibyl.example.com/mcp`.
+- Confirm the client can reach `http://localhost:3334/mcp`.
 - Check Settings, Security, API Keys to make sure the key was not revoked.


### PR DESCRIPTION
## Why

The docs site sells memory sovereignty on the landing page ("self-hosted on
your own hardware so the memory stays yours"), and then the whole funnel
behaves like you work at a company with an identity provider. A solo
self-hoster hits enterprise framing at every entry point:

- The **Users** nav tab opened on *Enterprise Sign-In* (OIDC), even though the
  default install is local username/password.
- Every CLI and API example pointed at a remote `sibyl.example.com` server. The
  entire `users/` section had **zero** mentions of `localhost`.
- There was no single page describing how to run Sibyl just for yourself. The
  pieces existed (`sibyl up`, `sibyl serve`, the Ansible single-host guide) but
  were scattered and undiscoverable from the guide funnel.

This PR rebalances the docs so the local/personal path is the neutral default
and enterprise is a clearly-marked opt-in. No product behavior changes — this
is documentation only.

## What changed

**New narrative page** — `guide/self-hosting.md` ("Run Sibyl for Yourself")
chains the full solo path start to finish: `sibyl up`, the setup wizard and
owner account, pointing the CLI at `localhost`, connecting an agent over MCP,
the memory loop, daemon lifecycle, and how to go remote later. It's wired into
the guide's Getting Started funnel.

**Navigation** — renamed the nav tabs from "Users" / "Admins" to **Using
Sibyl** / **Self-Hosting & Admin**, and reordered the Users section to lead
with the local path (CLI Setup first, sign-in options last). The `users/`
section went from 0 to 8 `localhost` mentions.

**Example sweep** — the CLI and REST reference now default to
`http://localhost:3334`. Remote/`example.com` examples are kept only where the
remote server is genuinely the subject: OIDC redirect URIs, and the
multi-context / multi-org workflows in `cli/context.md`.

**Coverage gaps closed** — documented `serve` / `start` / `stop` in the service
reference (previously only one-line rows), added a "Solo / Local Only" workflow
to `cli/context.md`, softened the guide's "your team" default to "you and your
team", and pointed the Kubernetes admin install at the simpler personal paths.

## How it was verified

- `moon run docs:build` passes clean — 105 markdown files, no dead links.
- A cross-model review pass (Codex) checked the new page's factual claims
  against the actual code and **caught five real accuracy bugs**, all now
  fixed:
  - MCP auth is **on** by default even for a bare `sibyld serve`, because the
    server auto-generates and persists a JWT secret to `~/.sibyl/jwt.key`
    (`config.py`); the only way to an unauthenticated endpoint is
    `SIBYL_MCP_AUTH_MODE=off`. The first draft wrongly said "no secret = auth
    off."
  - `sibyl up` reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the
    environment (no interactive prompt) and does **not** repoint the CLI's
    active context. The page now says a fresh CLI defaults to localhost and
    tells existing remote users to switch contexts.
  - The privacy claim is now honest: your graph stays local, but extraction and
    embeddings do call the AI providers you configure.
  - The Connect page shows client config, not a ready-to-paste API key; keys
    come from Settings or `sibyl auth api-key create`.

## Blast radius

Documentation only — 16 files, +290/−41. Branched off `main`, so it does **not**
include the in-progress per-directory-context-routing work. Fully reversible.

## Follow-up (out of scope)

`guide/mcp-configuration.md` still says "auth is enabled when `SIBYL_JWT_SECRET`
is set", which is technically true but misleading given the server auto-creates
one. Worth a small clarifying edit in a later pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new self-hosting guide for running Sibyl locally, including setup, first-run steps, MCP connection, and ongoing service management.
  * Added a dedicated section for running the daemon directly on the host.

* **Documentation**
  * Reorganized navigation and sidebar links for users and admins.
  * Clarified local vs. remote sign-in and CLI setup flows.
  * Updated API and MCP examples to use local server addresses.
  * Expanded hosting docs to better distinguish personal, team, and enterprise setup paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->