### PR TITLE
polish(web): surface graph fetch errors + token drift fixes

### DIFF
--- a/apps/web/src/app/(main)/graph/page.tsx
+++ b/apps/web/src/app/(main)/graph/page.tsx
@@ -24,6 +24,7 @@ import {
   X,
 } from '@/components/ui/icons';
 import { LoadingState } from '@/components/ui/spinner';
+import { ErrorState } from '@/components/ui/tooltip';
 import type {
   GraphResolution,
   HierarchicalCluster,
@@ -868,7 +869,7 @@ function GraphPageContent() {
   const {
     data,
     isLoading,
-    error: _error,
+    error: graphError,
   } = useHierarchicalGraph({
     max_nodes: GRAPH_DEFAULTS.MAX_NODES,
     max_edges: GRAPH_DEFAULTS.MAX_EDGES,
@@ -1629,8 +1630,26 @@ function GraphPageContent() {
             </div>
           )}
 
+          {/* Error state */}
+          {!isLoading && graphError && graphData.nodes.length === 0 && (
+            <div
+              className="flex items-center justify-center h-full"
+              style={{ backgroundColor: colors.bg }}
+              suppressHydrationWarning
+            >
+              <ErrorState
+                title="Couldn't load the graph"
+                message={
+                  graphError instanceof Error
+                    ? graphError.message
+                    : 'The graph request failed. Check your connection and try again.'
+                }
+              />
+            </div>
+          )}
+
           {/* Empty state */}
-          {!isLoading && graphData.nodes.length === 0 && (
+          {!isLoading && !graphError && graphData.nodes.length === 0 && (
             <div
               className="flex items-center justify-center h-full"
               style={{ backgroundColor: colors.bg }}

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -227,7 +227,7 @@ export function GraphEmptyState() {
       title="Graph is empty"
       description="Add some knowledge to see your connections visualized. Entities and their relationships will appear here."
       actions={[
-        { label: 'Add Knowledge', href: '/entities' },
+        { label: 'Add Knowledge', href: '/memory' },
         { label: 'Browse Entities', href: '/entities', variant: 'secondary' },
       ]}
     />

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -109,7 +109,7 @@ function GradientSpinner({ size = 'md' }: { size: SpinnerSize }) {
       style={{
         backgroundClip: 'padding-box, border-box',
         backgroundOrigin: 'padding-box, border-box',
-        borderImage: 'linear-gradient(135deg, #e135ff, #80ffea, #ff6ac1) 1',
+        borderImage: 'linear-gradient(135deg, var(--sc-purple), var(--sc-cyan), var(--sc-coral)) 1',
       }}
       role="status"
       aria-label="Loading"


### PR DESCRIPTION
## Summary
Three S-sized, low-risk UI polish wins for v1.1, from a systematic survey of `apps/web`:

- **Graph page no longer masks fetch errors as an empty graph.** The hierarchical-graph query error was discarded (`error: _error`), so an API failure rendered *"Graph is empty — add some knowledge…"* to orgs with populated graphs. Errors now render the shared `ErrorState` with the failure message; the empty state only shows when the fetch succeeded with zero nodes.
- **GraphEmptyState CTAs were duplicates** — both "Add Knowledge" and "Browse Entities" linked to `/entities`. "Add Knowledge" now points at `/memory`.
- **GradientSpinner used hardcoded neon hexes** (`#e135ff/#80ffea/#ff6ac1`), which go off-palette in the Dawn theme where the SilkCircuit tokens are remapped darker. Now uses `var(--sc-purple/cyan/coral)`.

The full survey produced 9 more candidates (shared-`Input` adoption on the teams/audit pages, `viewer` role shown-but-unassignable, raw UUIDs in breadcrumbs/import chips, `text-white` vs `--sc-on-accent` drift, member-management duplication between Organizations and Teams) — left out to keep this PR trivially reviewable; happy to follow up.

## Test plan
- `moon run web:lint web:typecheck web:test` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear error panel when the graph cannot load, instead of showing an empty state in that case.
  * Improved the graph empty-state action so it now takes people to the correct knowledge page.
* **Style**
  * Updated the loading spinner to use theme colors for more consistent visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->