### PR TITLE
fix(skills): correct skill-pack drift + harden against observed agent failures

### DIFF
--- a/apps/cli/src/sibyl_cli/data/skill-packs/core.md
+++ b/apps/cli/src/sibyl_cli/data/skill-packs/core.md
@@ -309,18 +309,24 @@ memory IDs that materially shaped the reflection, not every item shown in contex
 ### Synthesis - Source-Grounded Artifacts
 
 ```bash
-# Plan a synthesis from authorized memory
-sibyl synthesis plan "launch readiness brief" --intent plan
+# Plan a synthesis from authorized memory (positional goal; no --intent flag)
+sibyl synthesis plan "launch readiness brief" --type documentation --depth standard
 
-# Draft, verify, and optionally remember the artifact
-sibyl synthesis draft "launch readiness brief" --intent plan
+# Draft a verified synthesis artifact (markdown by default; --format json for scripting)
+sibyl synthesis draft "launch readiness brief" --audience "release team"
 
-# Verify citations, freshness, hidden context, and gap coverage on a draft
-sibyl synthesis verify --content-file ./draft.md
+# Verify citations, freshness, redaction, and gap coverage (re-drafts internally
+# from the same goal — it cannot verify a local file)
+sibyl synthesis verify "launch readiness brief"
 
-# Persist a verified synthesis artifact into memory
-sibyl synthesis remember "Launch readiness brief" --content-file ./draft.md
+# Draft, verify, and persist the artifact into memory in one step
+sibyl synthesis remember "launch readiness brief" --scope project
 ```
+
+All four subcommands take the synthesis goal as a positional argument. Useful scoping flags:
+`--project/-p`, `--all-projects`, `--domain/-d`, `--seed`, and comma-separated `--entity`,
+`--decision`, `--task`, `--artifact` ID lists. There is no `--intent` and no `--content-file`
+anywhere in this group.
 
 **When to use:** When you need a cited, verifiable artifact built from memory rather than a raw
 recall dump. `plan`/`draft`/`verify` mirror the
@@ -494,7 +500,7 @@ sibyl entity create --type episode --name "Redis insight" --content "Discovered 
 # Find related entities
 sibyl entity related epsd_a1b2c3d4e5f6
 
-# Delete (with confirmation)
+# Delete (immediate — there is NO confirmation prompt)
 sibyl entity delete epsd_a1b2c3d4e5f6
 ```
 
@@ -690,7 +696,8 @@ sibyl task complete task_a1b2c3d4e5f6 --hours 4.5 --learnings "Key insight: The 
 
 If a local install still has legacy FalkorDB + PostgreSQL data — typical signs are `moon run dev`
 aborting with `⚠️  Local legacy data detected`, the Sibyl server unreachable, and writes piling up
-in `~/.config/sibyl/pending_writes/` — follow the agent playbook in [MIGRATION.md](MIGRATION.md).
+in `~/.config/sibyl/pending_writes/` — follow the agent playbook in the migration pack
+(`sibyl skill get migration`).
 
 The playbook covers:
 
@@ -874,16 +881,15 @@ Your directory is not linked. Run `sibyl context` — if `Project: none`, link i
 | ----------------------------------- | ------------------------------------------------ |
 | `sibyl task add "..."`              | `sibyl task create --title "..."`                |
 | `sibyl task list --todo`            | `sibyl task list --status todo`                  |
-| `sibyl task create -t "..."`        | `sibyl task create --title "..."` (`-t` is type) |
+| `sibyl task create -t "..."`        | `sibyl task create --title "..."` (no `-t` flag) |
 | `sibyl task update --learnings`     | `sibyl task complete --learnings` (!)            |
 | `sibyl task note` for completion    | `sibyl task complete --learnings` (!)            |
 | `sibyl add note "content..."`       | `sibyl add "Title" "content..." --type note`     |
 | `sibyl search ... 2>/dev/null`      | `sibyl search ...` (never suppress stderr)       |
 | `sibyl search ... \|\| true`        | `sibyl search ...` (let errors surface)          |
 | `sibyl config`                      | `sibyl config show`                              |
-| `sibyl explore path A B` (no depth) | `sibyl explore path <id-a> <id-b> --depth N`     |
 | `sibyl auth token`                  | Not a real command — use `sibyl auth status`     |
-| Using `--kind gotcha` or `learning` | Use `error_pattern` or `note`                    |
+| Using `--kind gotcha` or `learning` | Deprecated aliases — use `error_pattern`/`note`  |
 
 ### Notes vs Learnings
 

--- a/apps/cli/src/sibyl_cli/data/skill-packs/core.md
+++ b/apps/cli/src/sibyl_cli/data/skill-packs/core.md
@@ -14,13 +14,18 @@ These rules exist because real agent sessions consistently fail without them.
    Capture the output first, check the exit code, then parse. Error messages contain diagnostic
    information you need; suppressing them causes silent failures and blind retry spirals.
 
-2. **Link your project BEFORE doing anything else.** Run `sibyl context` first. Use
-   `sibyl context --quick` only as a local link/auth status check later in the same session, not as
-   a replacement for full context or recall. If context shows `Project: none` or
-   `Project: not linked`, you MUST run `sibyl project link <id>` before searching or listing tasks.
-   Without a link, searches return results from unrelated projects and task lists show global noise.
-   Use `sibyl skill get core` when you need to read this canonical skill contract instead of
-   guessing a filesystem path.
+2. **Link your project BEFORE doing anything else — this is a blocking gate.** Run `sibyl context`
+   first. Use `sibyl context --quick` only as a local link/auth status check later in the same
+   session, not as a replacement for full context or recall. If context shows `Project: none` or
+   `Project: not linked`, resolve it before any recall/search/task command, in this order:
+   (a) `sibyl project list` → if the project exists, `sibyl project link <project_id>`;
+   (b) if `sibyl project relink` finds no candidate, `sibyl project create --name <dirname>` then
+   link the new ID; (c) only if the user explicitly declined linking, use `--all-projects` and say
+   so — it orphans memories from the project. `--project` takes a `project_xxx` ID, never a
+   directory name. Links are cwd-scoped: a git worktree of a linked repo shows `Project: none` —
+   relink there too. Unscoped recall returns cross-project noise; never treat unrelated hits as
+   context. Use `sibyl skill get core` when you need to read this canonical skill contract instead
+   of guessing a filesystem path.
 
 3. **Always complete the retrieval pattern.** Search returns truncated previews. When you need
    details, follow up with `sibyl show <id>` using the ID from the search result. Working from
@@ -30,12 +35,44 @@ These rules exist because real agent sessions consistently fail without them.
    `--learnings` on task completion. Do not ask permission first—the whole point is building
    institutional memory.
 
-5. **Check health before retrying.** If a command fails with a connection error, run `sibyl health`.
-   If the server is down, don't retry the same command. Report it and move on.
+5. **Check health before retrying, and follow the auth ladder.** If a command fails with a
+   connection error, run `sibyl health` once. If the server is down, don't retry the same command —
+   report it and move on. On `authentication_required` or `token_refresh_failed`: check
+   `printenv SIBYL_AUTH_TOKEN`, run `sibyl auth status` once, and if it is not recoverable
+   non-interactively, STOP treating memory as available — state in your final output that memory
+   was unavailable and list any learnings that could not be captured. In a sandboxed environment,
+   `sibyl context` succeeding (local cache) while recall/health cannot connect means blocked
+   network egress, not a server outage.
 
-6. **Never invent subcommands.** If you're unsure whether a command exists, run
-   `sibyl <group> --help`. Do not guess. Commands like `sibyl auth token` and `sibyl db backup` do
-   not exist.
+6. **Never invent subcommands, flags, or enum values.** If you're unsure whether a command exists,
+   run `sibyl <group> --help`. Do not guess, and do not pass any flag you have not seen in this
+   document or in this session's `--help` output. Commands like `sibyl auth token` and
+   `sibyl db backup` do not exist. After a context compaction, reload `sibyl skill get quick` (or
+   re-check `--help`) before your first write verb — corrections learned earlier do not survive
+   compaction, but wrong habits do.
+
+7. **Guard shell-special content.** A memory body containing backticks, `$()`, or `<`/`>` must be
+   passed via stdin (`echo ... | sibyl remember "Title" --kind ...`), a single-quoted heredoc, or
+   `--content-file` — never as an inline double-quoted argument. Backticks inside double quotes
+   execute as shell commands; this has re-run real build commands as a side effect of saving a
+   memory. Run sibyl writes as standalone commands, never chained with `&&` after builds or tests.
+
+8. **A failed write is lost knowledge.** A non-zero exit from `remember`/`add` means nothing was
+   saved. Retry exactly once after applying the printed remediation; if it still fails, include the
+   unsaved learning verbatim in your final message so the user can capture it. Never claim a memory
+   was stored unless you can quote the returned entity ID (e.g. `error_pattern_5f40ca...`) as the
+   receipt.
+
+9. **Fetch IDs fresh.** Re-run the list command immediately before `show`/`update`/`complete`;
+   never reuse an entity or task UUID remembered from earlier in a long session, and never run the
+   list and its dependent show in the same parallel batch. `task show` accepts task IDs only —
+   every other entity kind goes through `sibyl show <id>`. A `not_found` means re-list, not retry.
+
+10. **Probe availability once (non-Claude hosts).** If `command -v sibyl` fails, note
+    "sibyl unavailable in this environment — proceeding without memory" once and move on; do not
+    re-derive absence per command. Expect recall/remember to take 1–10 s over the network — in
+    harnesses with exec yield windows (e.g. Codex `exec_command`), use a generous yield
+    (≥ 5000 ms) and poll the same session instead of re-running the command.
 
 ---
 
@@ -210,6 +247,10 @@ sibyl recall "plan the launch" --intent plan --json
 sibyl recall "resume the migration" --budget 1200
 ```
 
+Valid `--intent` values: `build, plan, ideate, research, review, debug, decide, learn, general`.
+There is no `verify` or `audit` intent — verification work uses `review`. `recall` takes one quoted
+GOAL; size the output with `--budget` (tokens) or `--limit` (items). There is no `--max-items`.
+
 **When to use:** Before acting. This is the agent-ready working memory view. The Active Work section
 is grounded in a direct status lookup, so in-flight tasks always lead it; completed work appears
 under Prior Art with its learnings as the content.
@@ -270,7 +311,11 @@ sibyl remember "Planning session" --content-file ./notes.md --kind session
 sibyl add "CSS diagnostic" --content-file ./snippet.css
 ```
 
-**When to use:** During work, whenever future agents should not have to rediscover a detail. Project
+`remember` has **no** `--title`, `--type`, or `--summary` flags — title and body are positional
+(`sibyl remember "TITLE" "BODY" --kind <kind>`), with stdin, `--content`, or `--content-file` as
+body alternatives. If a flag is rejected (exit 2), switch to the positional form — do not retry
+flag variants. `--kind` values are snake_case; `gotcha` and `learning` are deprecated aliases that
+remap to `error_pattern` and `note` with a warning (full 33-kind list: `sibyl remember --help`). whenever future agents should not have to rediscover a detail. Project
 scoping stores both `metadata.project_id` and a project edge, and `remember` links to the single
 active `doing` task when exactly one exists. Future recall can find the memory from structured
 search, graph traversal, or task context. Use `--no-active-task` when the memory belongs to the

--- a/apps/cli/src/sibyl_cli/data/skill-packs/core.md
+++ b/apps/cli/src/sibyl_cli/data/skill-packs/core.md
@@ -927,8 +927,8 @@ Your directory is not linked. Run `sibyl context` — if `Project: none`, link i
 | `sibyl task add "..."`              | `sibyl task create --title "..."`                |
 | `sibyl task list --todo`            | `sibyl task list --status todo`                  |
 | `sibyl task create -t "..."`        | `sibyl task create --title "..."` (no `-t` flag) |
-| `sibyl task update --learnings`     | `sibyl task complete --learnings` (!)            |
-| `sibyl task note` for completion    | `sibyl task complete --learnings` (!)            |
+| `sibyl task update --learnings`     | `sibyl task complete <id> --learnings "..."` (!) |
+| `sibyl task note` for completion    | `sibyl task complete <id> --learnings "..."` (!) |
 | `sibyl add note "content..."`       | `sibyl add "Title" "content..." --type note`     |
 | `sibyl search ... 2>/dev/null`      | `sibyl search ...` (never suppress stderr)       |
 | `sibyl search ... \|\| true`        | `sibyl search ...` (let errors surface)          |

--- a/apps/cli/src/sibyl_cli/data/skill-packs/examples.md
+++ b/apps/cli/src/sibyl_cli/data/skill-packs/examples.md
@@ -213,7 +213,8 @@ sibyl entity related ptrn_a1b2c3d4e5f6
 ### Delete Entity
 
 ```bash
-sibyl entity delete epsd_a1b2c3d4e5f6 --yes
+# Deletes immediately — there is no confirmation prompt
+sibyl entity delete epsd_a1b2c3d4e5f6
 ```
 
 ---

--- a/skills/agent-activity-audit/SKILL.md
+++ b/skills/agent-activity-audit/SKILL.md
@@ -82,8 +82,9 @@ mkdir -p contexts/<name>-$(date +%F)/triage
 cd contexts/<name>-$(date +%F)
 
 # Last 30 days
-find ~/.claude/projects -name '*.jsonl' -newermt "$(date -d '30 days ago' +%F)" > triage/claude_files.txt
-find ~/.codex/sessions -name '*.jsonl' -newermt "$(date -d '30 days ago' +%F)" > triage/codex_files.txt
+CUTOFF=$(date -v-30d +%F 2>/dev/null || date -d '30 days ago' +%F)  # BSD (macOS) or GNU date
+find ~/.claude/projects -name '*.jsonl' -newermt "$CUTOFF" > triage/claude_files.txt
+find ~/.codex/sessions -name '*.jsonl' -newermt "$CUTOFF" > triage/codex_files.txt
 cat triage/claude_files.txt triage/codex_files.txt > triage/all_files.txt
 
 wc -l triage/*.txt
@@ -97,7 +98,7 @@ tool-call counts, error counts, user corrections. Runs in parallel.
 ```bash
 SKILL_DIR=$(dirname "$(realpath "$0")")  # or hard-code the path
 cat triage/all_files.txt | xargs -P 12 -n 5 python3 "$SKILL_DIR/scripts/scan.py" \
-  --target-name <tool-or-skill-keyword> > triage/scan_results.jsonl
+  --target <tool-or-skill-keyword> > triage/scan_results.jsonl
 ```
 
 The scanner detects three shapes of usage:


### PR DESCRIPTION
## Summary
Two commits: an accuracy audit against the shipped CLI, then evidence-driven hardening from mining **~380 real Claude Code + Codex sessions** for sibyl usage (46-agent workflow; full field report saved locally as `sibyl-agent-usage-field-report.md`, kept out of the repo since it quotes personal transcripts).

### Commit 1 — accuracy fixes
- **core.md Synthesis section was fiction**: all four examples used `--intent` / `--content-file`, which don't exist on any `sibyl synthesis` subcommand. Rewritten with the real positional-goal signatures.
- Dead `MIGRATION.md` link → `sibyl skill get migration`; `entity delete` has no confirmation (docs said it did); pitfall-table fixes (`task create -t` is unknown-option not type-shorthand; `explore path` without `--depth` is valid; `--kind gotcha/learning` are warn-and-remap aliases now).
- agent-activity-audit skill: `scan.py --target` (not `--target-name`); BSD/GNU-portable date.

### Commit 2 — field-intel hardening (each edit maps to observed failures)
Top failure modes from the mining, in frequency×severity order: **invented flags/enums** (~25+ exit-2 errors, recurring after every compaction), **project-link lifecycle breakage** (unscoped recall silently returning cross-project noise; worktrees showing `Project: none`), **auth expiry with no non-interactive recovery** (whole sessions silently memory-less), **shell backticks in memory content actually executing build commands**, and **failed writes silently dropped** (confirmed lost memories; one session narrated 14 captures with zero tool calls).

- Rule 2 → blocking gate with the full link-recovery ladder + ID-not-directory-name + worktree caveats.
- Rule 5 → auth-failure ladder + sandbox egress-vs-outage distinction.
- Rule 6 → never-invent extends to flags/enums; post-compaction re-check via `sibyl skill get quick`.
- New rules 7–10: shell-special content via stdin/heredoc/`--content-file`; failed-write retry-once-then-surface with entity-ID receipts; fresh-ID hygiene (`task show` = tasks only); one-shot availability probe + latency expectations for non-Claude hosts.
- Recall/Remember sections: negative-example callouts for the exact invented flags (`--max-items`, `--title/--type/--summary`) and the `--intent` enum inline.

Every claim verified against `apps/cli` source before writing — notably the mining recs themselves had two stale claims (current CLI **does** have `remember --content/--content-file` and `recall --limit`) that were corrected rather than propagated.

### Product follow-ups (not in this PR — filed as tasks)
Non-interactive auth story, link-lifecycle unification (git-toplevel/worktree resolution), enum closest-match hints, `project create --json` description-field bug, `modified_by` schema-drift 500s, MCP surface effectively unused (0 calls across all sessions vs CLI's ~1000+).

## Test plan
- Doc-only change; corrected commands validated against `sibyl ... --help` and CLI source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and reorganized “Agent Rules (READ FIRST)” with clearer project-link workflow and operational guidance for auth failures, safety, and command/flag usage.
  * Tightened Recall/Remember CLI semantics, including allowed `--intent` values, invalid intent clarification, and stricter flag/argument behavior with deprecated `--kind` alias remapping.
  * Rewrote synthesis help to present `sibyl synthesis` subcommands (`plan`, `draft`, `verify`, `remember`) with positional goal input and updated scoping/selection flags.
  * Updated entity deletion guidance/examples to show immediate deletion with no confirmation prompt, plus refreshed migration and common pitfalls command examples.
  * Improved “Last 30 days” transcript inventory to use cross-platform date cutoffs and the updated scanner `--target` invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->