### PR TITLE
polish(web): round 2 — shared inputs, viewer role, on-accent token, ID truncation

### DIFF
--- a/apps/web/src/app/(main)/entities/entities-content.tsx
+++ b/apps/web/src/app/(main)/entities/entities-content.tsx
@@ -334,7 +334,7 @@ export function EntitiesContent({
                         aria-label="Search entity types"
                         // biome-ignore lint/a11y/noAutofocus: focus the search when the menu opens
                         autoFocus
-                        className="w-full pl-7 pr-2 py-1.5 text-xs bg-sc-bg-highlight border border-sc-fg-subtle/20 rounded-lg text-sc-fg-primary placeholder:text-sc-fg-subtle focus-visible:outline-none focus-visible:border-sc-purple/50"
+                        className="w-full pl-7 pr-2 py-1.5 text-xs bg-sc-bg-highlight border border-sc-fg-subtle/20 rounded-lg text-sc-fg-primary placeholder:text-sc-fg-subtle focus-visible:outline-none focus-visible:border-sc-cyan focus-visible:ring-2 focus-visible:ring-sc-cyan/20"
                       />
                     </div>
                   </div>

--- a/apps/web/src/app/(main)/graph/page.tsx
+++ b/apps/web/src/app/(main)/graph/page.tsx
@@ -577,7 +577,7 @@ function GraphToolbar({
               placeholder="Search nodes..."
               value={searchTerm}
               onChange={e => onSearchChange(e.target.value)}
-              className="pl-7 pr-7 py-1 w-44 text-xs bg-sc-bg-base border border-sc-fg-subtle/20 rounded-lg focus:border-sc-purple/50 focus:outline-none text-sc-fg-primary placeholder:text-sc-fg-subtle"
+              className="pl-7 pr-7 py-1 w-44 text-xs bg-sc-bg-base border border-sc-fg-subtle/20 rounded-lg focus-visible:outline-none focus-visible:border-sc-cyan focus-visible:ring-2 focus-visible:ring-sc-cyan/20 text-sc-fg-primary placeholder:text-sc-fg-subtle"
             />
             {searchTerm && (
               <button

--- a/apps/web/src/app/(main)/memory/sources/[sourceId]/page.tsx
+++ b/apps/web/src/app/(main)/memory/sources/[sourceId]/page.tsx
@@ -12,11 +12,15 @@ interface PageProps {
 export default function MemorySourcePage({ params }: PageProps) {
   const { sourceId } = use(params);
   const decodedSourceId = decodeURIComponent(sourceId);
+  const crumbLabel =
+    decodedSourceId.length > 28
+      ? `${decodedSourceId.slice(0, 14)}…${decodedSourceId.slice(-8)}`
+      : decodedSourceId;
 
   useSetBreadcrumb([
     { label: 'Home', href: '/' },
     { label: 'Memory', href: '/memory' },
-    { label: decodedSourceId },
+    { label: crumbLabel },
   ]);
 
   return (

--- a/apps/web/src/app/(main)/settings/admin/audit/page.tsx
+++ b/apps/web/src/app/(main)/settings/admin/audit/page.tsx
@@ -18,6 +18,7 @@ import {
   RefreshDouble,
   Xmark,
 } from '@/components/ui/icons';
+import { Input } from '@/components/ui/input';
 import { Spinner } from '@/components/ui/spinner';
 import type { AdminAuditEvent, AdminAuditExportFormat, AdminAuditParams } from '@/lib/api';
 import { api } from '@/lib/api';
@@ -199,74 +200,79 @@ export default function AdminAuditPage() {
 
       <SettingsSection title="Filters" icon={Filter} iconColor="text-sc-purple">
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-          <label className="block">
+          <label className="block" htmlFor="audit-filter-action">
             <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.06em] text-sc-fg-subtle">
               Action
             </span>
-            <input
+            <Input
+              id="audit-filter-action"
               value={action}
               onChange={event => {
                 setAction(event.target.value);
                 setOffset(0);
               }}
-              className="w-full rounded-lg border border-sc-fg-subtle/20 bg-sc-bg-highlight px-3 py-2 text-sm text-sc-fg-primary outline-none transition-colors focus:border-sc-purple"
+              className="text-sm"
               placeholder="memory.recall"
             />
           </label>
-          <label className="block">
+          <label className="block" htmlFor="audit-filter-user">
             <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.06em] text-sc-fg-subtle">
               User
             </span>
-            <input
+            <Input
+              id="audit-filter-user"
               value={userId}
               onChange={event => {
                 setUserId(event.target.value);
                 setOffset(0);
               }}
-              className="w-full rounded-lg border border-sc-fg-subtle/20 bg-sc-bg-highlight px-3 py-2 text-sm text-sc-fg-primary outline-none transition-colors focus:border-sc-purple"
+              className="text-sm"
               placeholder="user UUID"
             />
           </label>
-          <label className="block">
+          <label className="block" htmlFor="audit-filter-resource">
             <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.06em] text-sc-fg-subtle">
               Resource
             </span>
-            <input
+            <Input
+              id="audit-filter-resource"
               value={resource}
               onChange={event => {
                 setResource(event.target.value);
                 setOffset(0);
               }}
-              className="w-full rounded-lg border border-sc-fg-subtle/20 bg-sc-bg-highlight px-3 py-2 text-sm text-sc-fg-primary outline-none transition-colors focus:border-sc-purple"
+              className="text-sm"
               placeholder="project or source"
             />
           </label>
-          <label className="block">
+          <label className="block" htmlFor="audit-filter-start">
             <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.06em] text-sc-fg-subtle">
               Start
             </span>
-            <input
+            <Input
+              id="audit-filter-start"
               type="datetime-local"
               value={startTime}
               onChange={event => {
                 setStartTime(event.target.value);
                 setOffset(0);
               }}
-              className="w-full rounded-lg border border-sc-fg-subtle/20 bg-sc-bg-highlight px-3 py-2 text-sm text-sc-fg-primary outline-none transition-colors focus:border-sc-purple"
+              className="text-sm"
             />
           </label>
-          <label className="block">
+          <label className="block" htmlFor="audit-filter-end">
             <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.06em] text-sc-fg-subtle">
               End
             </span>
-            <input
+            <Input
+              id="audit-filter-end"
               type="datetime-local"
               value={endTime}
               onChange={event => {
                 setEndTime(event.target.value);
                 setOffset(0);
               }}
-              className="w-full rounded-lg border border-sc-fg-subtle/20 bg-sc-bg-highlight px-3 py-2 text-sm text-sc-fg-primary outline-none transition-colors focus:border-sc-purple"
+              className="text-sm"
             />
           </label>
         </div>

--- a/apps/web/src/app/(main)/settings/organizations/page.tsx
+++ b/apps/web/src/app/(main)/settings/organizations/page.tsx
@@ -27,8 +27,8 @@ import {
   useUpdateOrgMemberRole,
 } from '@/lib/hooks';
 
-const ROLES = ['owner', 'admin', 'member'] as const;
-const NON_OWNER_ROLES = ['admin', 'member'] as const;
+const ROLES = ['owner', 'admin', 'member', 'viewer'] as const;
+const NON_OWNER_ROLES = ['admin', 'member', 'viewer'] as const;
 
 function OrgSkeleton() {
   return (

--- a/apps/web/src/app/(main)/settings/organizations/page.tsx
+++ b/apps/web/src/app/(main)/settings/organizations/page.tsx
@@ -1,34 +1,21 @@
 'use client';
 
+import Link from 'next/link';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { SettingsPageHeader } from '@/components/settings/primitives';
 import { Button, IconButton } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
-import { Check, Edit, Plus, Trash, User, Users } from '@/components/ui/icons';
+import { Check, Edit, Plus, Trash, Users } from '@/components/ui/icons';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Spinner } from '@/components/ui/spinner';
 import {
   useCreateOrg,
   useDeleteOrg,
   useMe,
-  useOrgMembers,
   useOrgs,
-  useRemoveOrgMember,
   useSwitchOrg,
   useUpdateOrg,
-  useUpdateOrgMemberRole,
 } from '@/lib/hooks';
-
-const ROLES = ['owner', 'admin', 'member', 'viewer'] as const;
-const NON_OWNER_ROLES = ['admin', 'member', 'viewer'] as const;
 
 function OrgSkeleton() {
   return (
@@ -109,141 +96,6 @@ function CreateOrgForm({ onSuccess, onCancel }: CreateOrgFormProps) {
   );
 }
 
-interface OrgMembersListProps {
-  slug: string;
-  currentUserId: string;
-  userRole: string | null;
-}
-
-function OrgMembersList({ slug, currentUserId, userRole }: OrgMembersListProps) {
-  const { data, isLoading } = useOrgMembers(slug);
-  const updateRole = useUpdateOrgMemberRole();
-  const removeMember = useRemoveOrgMember();
-  const canManage = userRole === 'owner' || userRole === 'admin';
-  const canManageOwnerRoles = userRole === 'owner';
-  const [pendingRemove, setPendingRemove] = useState<{ id: string; name: string } | null>(null);
-
-  const handleRoleChange = async (userId: string, newRole: string) => {
-    try {
-      await updateRole.mutateAsync({ slug, userId, role: newRole });
-      toast.success('Role updated');
-    } catch {
-      toast.error('Failed to update role');
-    }
-  };
-
-  const handleConfirmRemove = async () => {
-    if (!pendingRemove) return;
-    try {
-      await removeMember.mutateAsync({ slug, userId: pendingRemove.id });
-      toast.success('Member removed');
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to remove member');
-    } finally {
-      setPendingRemove(null);
-    }
-  };
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center p-4">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (!data?.members.length) {
-    return <p className="text-sc-fg-muted text-sm p-4">No members found.</p>;
-  }
-
-  return (
-    <div className="divide-y divide-sc-fg-subtle/10">
-      {data.members.map(member => (
-        <div key={member.user.id} className="flex items-center gap-3 py-3 px-1">
-          {member.user.avatar_url ? (
-            <img
-              src={member.user.avatar_url}
-              alt=""
-              className="w-8 h-8 rounded-full border border-sc-fg-subtle/20"
-            />
-          ) : (
-            <div className="w-8 h-8 rounded-full bg-sc-bg-highlight flex items-center justify-center">
-              <User width={14} height={14} className="text-sc-fg-muted" />
-            </div>
-          )}
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-sc-fg-primary truncate">
-              {member.user.name || member.user.email || 'Unknown'}
-              {member.user.id === currentUserId && (
-                <span className="ml-2 text-xs text-sc-purple">(you)</span>
-              )}
-            </p>
-            <p className="text-xs text-sc-fg-muted truncate">{member.user.email}</p>
-          </div>
-          {canManage &&
-          member.user.id !== currentUserId &&
-          (canManageOwnerRoles || member.role !== 'owner') ? (
-            <div className="flex items-center gap-2">
-              <Select
-                value={member.role}
-                onValueChange={value => handleRoleChange(member.user.id, value)}
-              >
-                <SelectTrigger
-                  className="h-8 min-w-[120px] py-1 text-xs"
-                  aria-label={`Role for ${member.user.name || member.user.email || 'member'}`}
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {(canManageOwnerRoles ? ROLES : NON_OWNER_ROLES).map(role => (
-                    <SelectItem key={role} value={role} className="capitalize">
-                      {role}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <IconButton
-                icon={<Trash width={14} height={14} />}
-                label={`Remove ${member.user.name || 'member'}`}
-                size="sm"
-                variant="ghost"
-                onClick={() =>
-                  setPendingRemove({
-                    id: member.user.id,
-                    name: member.user.name || member.user.email || 'this member',
-                  })
-                }
-                className="text-sc-red hover:text-sc-red"
-              />
-            </div>
-          ) : (
-            <span className="text-xs text-sc-fg-muted capitalize px-2 py-1 bg-sc-bg-highlight rounded-full">
-              {member.role}
-            </span>
-          )}
-        </div>
-      ))}
-
-      <ConfirmDialog
-        open={!!pendingRemove}
-        onOpenChange={open => {
-          if (!open) setPendingRemove(null);
-        }}
-        title="Remove member?"
-        description={
-          pendingRemove
-            ? `${pendingRemove.name} will lose access to this organization's knowledge graph.`
-            : undefined
-        }
-        confirmLabel="Remove"
-        variant="danger"
-        loading={removeMember.isPending}
-        onConfirm={handleConfirmRemove}
-      />
-    </div>
-  );
-}
-
 interface OrgCardProps {
   org: {
     id: string;
@@ -253,12 +105,10 @@ interface OrgCardProps {
     role: string | null;
   };
   isCurrent: boolean;
-  currentUserId: string;
 }
 
-function OrgCard({ org, isCurrent, currentUserId }: OrgCardProps) {
+function OrgCard({ org, isCurrent }: OrgCardProps) {
   const [isEditing, setIsEditing] = useState(false);
-  const [showMembers, setShowMembers] = useState(false);
   const [editName, setEditName] = useState(org.name);
   const [editSlug, setEditSlug] = useState(org.slug);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -400,10 +250,13 @@ function OrgCard({ org, isCurrent, currentUserId }: OrgCardProps) {
             </>
           ) : (
             <>
-              <Button variant="ghost" size="sm" onClick={() => setShowMembers(!showMembers)}>
+              <Link
+                href="/settings/teams"
+                className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-sc-fg-muted transition-colors hover:bg-sc-bg-highlight hover:text-sc-fg-primary"
+              >
                 <Users width={14} height={14} />
                 Members
-              </Button>
+              </Link>
               {canEdit && (
                 <IconButton
                   icon={<Edit width={14} height={14} />}
@@ -427,13 +280,6 @@ function OrgCard({ org, isCurrent, currentUserId }: OrgCardProps) {
           )}
         </div>
       </div>
-
-      {/* Members panel */}
-      {showMembers && (
-        <div className="mt-3 pt-3 border-t border-sc-fg-subtle/10">
-          <OrgMembersList slug={org.slug} currentUserId={currentUserId} userRole={org.role} />
-        </div>
-      )}
 
       <ConfirmDialog
         open={confirmDelete}
@@ -526,12 +372,7 @@ export default function OrganizationsPage() {
       ) : (
         <div className="space-y-4">
           {orgs.map(org => (
-            <OrgCard
-              key={org.id}
-              org={org}
-              isCurrent={org.id === currentOrgId}
-              currentUserId={me?.user?.id || ''}
-            />
+            <OrgCard key={org.id} org={org} isCurrent={org.id === currentOrgId} />
           ))}
         </div>
       )}

--- a/apps/web/src/app/(main)/settings/teams/page.tsx
+++ b/apps/web/src/app/(main)/settings/teams/page.tsx
@@ -18,6 +18,7 @@ import {
   User,
   Users,
 } from '@/components/ui/icons';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -45,9 +46,9 @@ const ROLE_CONFIG = {
   viewer: { icon: Eye, color: 'text-sc-fg-muted', label: 'Viewer' },
 } as const;
 
-const ROLES = ['owner', 'admin', 'member'] as const;
-const NON_OWNER_ROLES = ['admin', 'member'] as const;
-const INVITE_ROLES = ['member', 'admin'] as const;
+const ROLES = ['owner', 'admin', 'member', 'viewer'] as const;
+const NON_OWNER_ROLES = ['admin', 'member', 'viewer'] as const;
+const INVITE_ROLES = ['member', 'admin', 'viewer'] as const;
 
 function inviteSignupUrl(acceptUrl: string | null): string {
   if (!acceptUrl) return '';
@@ -243,13 +244,13 @@ function OrgMembersCard({ org, currentUserId, isCurrentOrg }: OrgMembersCardProp
                 onSubmit={handleInvite}
                 className="grid gap-2 sm:grid-cols-[minmax(12rem,1fr)_180px_auto]"
               >
-                <input
+                <Input
                   type="email"
                   value={inviteEmail}
                   onChange={event => setInviteEmail(event.target.value)}
                   placeholder="teammate@example.com"
                   aria-label={`Invite email for ${org.name}`}
-                  className="min-w-0 w-full rounded-lg border border-sc-fg-subtle/20 bg-sc-bg-highlight px-3 py-2 text-sm text-sc-fg-primary placeholder:text-sc-fg-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sc-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-sc-bg-elevated"
+                  className="min-w-0 text-sm"
                 />
                 <Select
                   value={inviteRole}

--- a/apps/web/src/app/(main)/tasks/page.tsx
+++ b/apps/web/src/app/(main)/tasks/page.tsx
@@ -241,7 +241,7 @@ function TasksPageContent() {
                           placeholder="Search tags..."
                           // biome-ignore lint/a11y/noAutofocus: focus the search when the menu opens
                           autoFocus
-                          className="w-full pl-7 pr-2 py-1.5 text-xs bg-sc-bg-highlight border border-sc-fg-subtle/20 rounded-lg text-sc-fg-primary placeholder:text-sc-fg-subtle focus-visible:outline-none focus-visible:border-sc-purple/50"
+                          className="w-full pl-7 pr-2 py-1.5 text-xs bg-sc-bg-highlight border border-sc-fg-subtle/20 rounded-lg text-sc-fg-primary placeholder:text-sc-fg-subtle focus-visible:outline-none focus-visible:border-sc-cyan focus-visible:ring-2 focus-visible:ring-sc-cyan/20"
                         />
                       </div>
                     </div>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -32,7 +32,7 @@ export default function NotFound() {
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <Link
             href="/"
-            className="inline-flex items-center justify-center px-6 py-3 rounded-xl bg-gradient-to-r from-sc-purple to-sc-purple/80 text-white font-medium transition-all hover:opacity-90 hover:scale-[0.98]"
+            className="inline-flex items-center justify-center px-6 py-3 rounded-xl bg-gradient-to-r from-sc-purple to-sc-purple/80 text-sc-on-accent font-medium transition-all hover:opacity-90 hover:scale-[0.98]"
           >
             Return to safety
           </Link>

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -90,7 +90,7 @@ function ResetPasswordContent() {
                 </div>
                 <a
                   href="/login"
-                  className="flex w-full items-center justify-center rounded-lg bg-sc-purple px-4 py-2 text-sm font-medium text-white shadow-lg shadow-sc-purple/20 transition-all duration-200 hover:bg-sc-purple/80 hover:shadow-xl hover:shadow-sc-purple/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sc-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-sc-bg-elevated"
+                  className="flex w-full items-center justify-center rounded-lg bg-sc-purple px-4 py-2 text-sm font-medium text-sc-on-accent shadow-lg shadow-sc-purple/20 transition-all duration-200 hover:bg-sc-purple/80 hover:shadow-xl hover:shadow-sc-purple/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sc-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-sc-bg-elevated"
                 >
                   Back to Sign In
                 </a>
@@ -102,7 +102,7 @@ function ResetPasswordContent() {
                 </div>
                 <a
                   href="/login?reset=complete"
-                  className="flex w-full items-center justify-center rounded-lg bg-sc-purple px-4 py-2 text-sm font-medium text-white shadow-lg shadow-sc-purple/20 transition-all duration-200 hover:bg-sc-purple/80 hover:shadow-xl hover:shadow-sc-purple/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sc-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-sc-bg-elevated"
+                  className="flex w-full items-center justify-center rounded-lg bg-sc-purple px-4 py-2 text-sm font-medium text-sc-on-accent shadow-lg shadow-sc-purple/20 transition-all duration-200 hover:bg-sc-purple/80 hover:shadow-xl hover:shadow-sc-purple/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sc-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-sc-bg-elevated"
                 >
                   Sign In
                 </a>

--- a/apps/web/src/components/memory/source-import-progress.tsx
+++ b/apps/web/src/components/memory/source-import-progress.tsx
@@ -200,9 +200,10 @@ export function SourceImportProgress({ status }: { status: SourceImportStatusRes
                 <Link
                   key={id}
                   href={`/memory/sources/${encodeURIComponent(id)}`}
-                  className="rounded border border-sc-cyan/20 bg-sc-cyan/10 px-2 py-1 text-xs text-sc-cyan transition-colors hover:border-sc-purple/40 hover:text-sc-purple"
+                  title={id}
+                  className="rounded border border-sc-cyan/20 bg-sc-cyan/10 px-2 py-1 font-mono text-xs text-sc-cyan transition-colors hover:border-sc-cyan/50 hover:bg-sc-cyan/20"
                 >
-                  {id}
+                  {id.length > 16 ? `…${id.slice(-12)}` : id}
                 </Link>
               ))}
             </div>

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -15,7 +15,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variants: Record<ButtonVariant, string> = {
   primary:
-    'bg-sc-purple text-white hover:bg-sc-purple/80 active:scale-[0.98] shadow-lg shadow-sc-purple/20 hover:shadow-xl hover:shadow-sc-purple/30',
+    'bg-sc-purple text-sc-on-accent hover:bg-sc-purple/80 active:scale-[0.98] shadow-lg shadow-sc-purple/20 hover:shadow-xl hover:shadow-sc-purple/30',
   secondary:
     'bg-sc-bg-highlight border border-sc-fg-subtle/20 text-sc-fg-primary hover:border-sc-purple/50 hover:text-sc-purple hover:shadow-lg hover:shadow-sc-purple/10',
   ghost: 'bg-transparent text-sc-fg-muted hover:text-sc-fg-primary hover:bg-sc-bg-highlight',
@@ -220,7 +220,7 @@ export function GradientButton({
       disabled={disabled || loading}
       className={`
         inline-flex items-center justify-center font-medium
-        text-white shadow-lg
+        text-sc-on-accent shadow-lg
         transition-all duration-200 ease-out
         active:scale-[0.98]
         disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -32,7 +32,7 @@ const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, CheckboxP
         `}
         {...props}
       >
-        <CheckboxPrimitive.Indicator className="flex items-center justify-center text-white">
+        <CheckboxPrimitive.Indicator className="flex items-center justify-center text-sc-on-accent">
           {props.checked === 'indeterminate' ? (
             <span className="h-0.5 w-2.5 bg-current rounded-full" />
           ) : (

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -1,15 +1,21 @@
 'use client';
 
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 import {
+  AlertTriangle,
+  BarChart3,
   Check,
+  CheckCircle2,
   Cube,
   Database,
   Flash,
   Globe,
   KanbanBoard,
   List,
+  PlusCircle,
   Search,
+  WifiOff,
 } from '@/components/ui/icons';
 
 interface EmptyStateAction {
@@ -64,7 +70,7 @@ export function EnhancedEmptyState({
           {actions.map(action => {
             const isPrimary = action.variant !== 'secondary';
             const className = isPrimary
-              ? 'px-4 py-2 bg-sc-purple hover:bg-sc-purple/80 text-white rounded-lg font-medium transition-colors'
+              ? 'px-4 py-2 bg-sc-purple hover:bg-sc-purple/80 text-sc-on-accent rounded-lg font-medium transition-colors'
               : 'px-4 py-2 bg-sc-bg-highlight hover:bg-sc-bg-elevated text-sc-fg-muted rounded-lg transition-colors';
 
             if (action.href) {
@@ -262,5 +268,122 @@ export function EpicsEmptyState({
         { label: 'View Tasks', href: '/tasks', variant: 'secondary' },
       ]}
     />
+  );
+}
+
+// Basic empty state for when there's no data - with personality.
+// (Relocated from tooltip.tsx; tooltip.tsx re-exports these for compatibility.)
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  variant?: 'default' | 'search' | 'data' | 'create';
+}
+
+const EMPTY_STATE_DEFAULTS = {
+  search: {
+    icon: <Search width={48} height={48} className="text-sc-cyan" />,
+    floatingClass: 'animate-float',
+  },
+  data: {
+    icon: <BarChart3 width={48} height={48} className="text-sc-purple" />,
+    floatingClass: 'animate-wiggle',
+  },
+  create: {
+    icon: <PlusCircle width={48} height={48} className="text-sc-yellow" />,
+    floatingClass: 'animate-bounce-in',
+  },
+  default: {
+    icon: <Cube width={48} height={48} className="text-sc-coral" />,
+    floatingClass: 'animate-float',
+  },
+};
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  variant = 'default',
+}: EmptyStateProps) {
+  const defaults = EMPTY_STATE_DEFAULTS[variant];
+  const displayIcon = icon ?? defaults.icon;
+
+  return (
+    <div className="text-center py-16 animate-fade-in">
+      {displayIcon && (
+        <div className={`text-6xl mb-4 opacity-80 ${defaults.floatingClass}`}>{displayIcon}</div>
+      )}
+      <p className="text-sc-fg-muted text-lg font-medium">{title}</p>
+      {description && (
+        <p className="text-sc-fg-subtle text-sm mt-2 max-w-md mx-auto">{description}</p>
+      )}
+      {action && <div className="mt-6 animate-slide-up">{action}</div>}
+    </div>
+  );
+}
+
+// Error state component - friendly and helpful
+interface ErrorStateProps {
+  title?: string;
+  message: string;
+  action?: ReactNode;
+  variant?: 'error' | 'warning' | 'offline';
+}
+
+const ERROR_VARIANTS = {
+  error: {
+    icon: <AlertTriangle width={32} height={32} className="text-sc-red" />,
+    title: 'Oops, something went sideways',
+    color: 'text-sc-red',
+    iconClass: 'animate-wiggle',
+  },
+  warning: {
+    icon: <Flash width={32} height={32} className="text-sc-yellow" />,
+    title: 'Heads up',
+    color: 'text-sc-yellow',
+    iconClass: 'animate-pulse',
+  },
+  offline: {
+    icon: <WifiOff width={32} height={32} className="text-sc-coral" />,
+    title: 'Connection lost',
+    color: 'text-sc-coral',
+    iconClass: 'animate-float',
+  },
+};
+
+export function ErrorState({ title, message, action, variant = 'error' }: ErrorStateProps) {
+  const variantConfig = ERROR_VARIANTS[variant];
+  const displayTitle = title ?? variantConfig.title;
+
+  return (
+    <div className="text-center py-12 animate-fade-in">
+      <div className={`text-4xl mb-4 ${variantConfig.iconClass}`}>{variantConfig.icon}</div>
+      <p className={`text-lg font-medium ${variantConfig.color}`}>{displayTitle}</p>
+      <p className="text-sc-fg-muted text-sm mt-1 max-w-md mx-auto">{message}</p>
+      {action && <div className="mt-4 animate-slide-up">{action}</div>}
+    </div>
+  );
+}
+
+// Success celebration component
+interface SuccessStateProps {
+  title: string;
+  message?: string;
+  action?: ReactNode;
+  celebratory?: boolean;
+}
+
+export function SuccessState({ title, message, action, celebratory = true }: SuccessStateProps) {
+  return (
+    <div className="text-center py-12 animate-bounce-in">
+      <div className={`mb-4 flex justify-center ${celebratory ? 'animate-glow-pulse' : ''}`}>
+        <CheckCircle2 width={48} height={48} className="text-sc-green" />
+      </div>
+      <p className="text-sc-green text-xl font-semibold gradient-text">{title}</p>
+      {message && <p className="text-sc-fg-muted text-sm mt-2 max-w-md mx-auto">{message}</p>}
+      {action && <div className="mt-6 animate-slide-up">{action}</div>}
+    </div>
   );
 }

--- a/apps/web/src/components/ui/pagination.tsx
+++ b/apps/web/src/components/ui/pagination.tsx
@@ -93,7 +93,7 @@ export function Pagination({
 
   const buttonVariant = (isActive: boolean) =>
     isActive
-      ? 'bg-sc-purple text-white'
+      ? 'bg-sc-purple text-sc-on-accent'
       : 'bg-sc-bg-highlight text-sc-fg-muted hover:bg-sc-bg-elevated hover:text-sc-fg-primary';
 
   return (

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -78,7 +78,7 @@ const TabsTrigger = forwardRef<
       /* Pills variant */
       [div[data-variant=pills]_&]:rounded-lg
       [div[data-variant=pills]_&]:data-[state=active]:bg-sc-purple
-      [div[data-variant=pills]_&]:data-[state=active]:text-white
+      [div[data-variant=pills]_&]:data-[state=active]:text-sc-on-accent
       [div[data-variant=pills]_&]:data-[state=active]:shadow-sm
 
       /* Enclosed variant */

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -8,18 +8,7 @@ import {
   type ReactNode,
   useState,
 } from 'react';
-import {
-  AlertTriangle,
-  BarChart3,
-  CheckCircle2,
-  Cube,
-  Flash,
-  InfoCircle,
-  LightBulb,
-  PlusCircle,
-  Search,
-  WifiOff,
-} from '@/components/ui/icons';
+import { Flash, InfoCircle, LightBulb } from '@/components/ui/icons';
 
 // Radix Tooltip primitives with SilkCircuit styling
 const TooltipProvider = TooltipPrimitive.Provider;
@@ -70,124 +59,11 @@ export function Tooltip({ content, children, side = 'top', delay = 200 }: Toolti
   );
 }
 
+// EmptyState, ErrorState, and SuccessState moved to empty-state.tsx with the
+// rest of the feedback components; re-exported here so existing imports keep working.
+export { EmptyState, ErrorState, SuccessState } from './empty-state';
 // Export primitives for advanced usage
 export { TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger };
-
-// Empty state component for when there's no data - with personality
-interface EmptyStateProps {
-  icon?: ReactNode;
-  title: string;
-  description?: string;
-  action?: ReactNode;
-  variant?: 'default' | 'search' | 'data' | 'create';
-}
-
-const EMPTY_STATE_DEFAULTS = {
-  search: {
-    icon: <Search width={48} height={48} className="text-sc-cyan" />,
-    floatingClass: 'animate-float',
-  },
-  data: {
-    icon: <BarChart3 width={48} height={48} className="text-sc-purple" />,
-    floatingClass: 'animate-wiggle',
-  },
-  create: {
-    icon: <PlusCircle width={48} height={48} className="text-sc-yellow" />,
-    floatingClass: 'animate-bounce-in',
-  },
-  default: {
-    icon: <Cube width={48} height={48} className="text-sc-coral" />,
-    floatingClass: 'animate-float',
-  },
-};
-
-export function EmptyState({
-  icon,
-  title,
-  description,
-  action,
-  variant = 'default',
-}: EmptyStateProps) {
-  const defaults = EMPTY_STATE_DEFAULTS[variant];
-  const displayIcon = icon ?? defaults.icon;
-
-  return (
-    <div className="text-center py-16 animate-fade-in">
-      {displayIcon && (
-        <div className={`text-6xl mb-4 opacity-80 ${defaults.floatingClass}`}>{displayIcon}</div>
-      )}
-      <p className="text-sc-fg-muted text-lg font-medium">{title}</p>
-      {description && (
-        <p className="text-sc-fg-subtle text-sm mt-2 max-w-md mx-auto">{description}</p>
-      )}
-      {action && <div className="mt-6 animate-slide-up">{action}</div>}
-    </div>
-  );
-}
-
-// Error state component - friendly and helpful
-interface ErrorStateProps {
-  title?: string;
-  message: string;
-  action?: ReactNode;
-  variant?: 'error' | 'warning' | 'offline';
-}
-
-const ERROR_VARIANTS = {
-  error: {
-    icon: <AlertTriangle width={32} height={32} className="text-sc-red" />,
-    title: 'Oops, something went sideways',
-    color: 'text-sc-red',
-    iconClass: 'animate-wiggle',
-  },
-  warning: {
-    icon: <Flash width={32} height={32} className="text-sc-yellow" />,
-    title: 'Heads up',
-    color: 'text-sc-yellow',
-    iconClass: 'animate-pulse',
-  },
-  offline: {
-    icon: <WifiOff width={32} height={32} className="text-sc-coral" />,
-    title: 'Connection lost',
-    color: 'text-sc-coral',
-    iconClass: 'animate-float',
-  },
-};
-
-export function ErrorState({ title, message, action, variant = 'error' }: ErrorStateProps) {
-  const variantConfig = ERROR_VARIANTS[variant];
-  const displayTitle = title ?? variantConfig.title;
-
-  return (
-    <div className="text-center py-12 animate-fade-in">
-      <div className={`text-4xl mb-4 ${variantConfig.iconClass}`}>{variantConfig.icon}</div>
-      <p className={`text-lg font-medium ${variantConfig.color}`}>{displayTitle}</p>
-      <p className="text-sc-fg-muted text-sm mt-1 max-w-md mx-auto">{message}</p>
-      {action && <div className="mt-4 animate-slide-up">{action}</div>}
-    </div>
-  );
-}
-
-// Success celebration component
-interface SuccessStateProps {
-  title: string;
-  message?: string;
-  action?: ReactNode;
-  celebratory?: boolean;
-}
-
-export function SuccessState({ title, message, action, celebratory = true }: SuccessStateProps) {
-  return (
-    <div className="text-center py-12 animate-bounce-in">
-      <div className={`mb-4 flex justify-center ${celebratory ? 'animate-glow-pulse' : ''}`}>
-        <CheckCircle2 width={48} height={48} className="text-sc-green" />
-      </div>
-      <p className="text-sc-green text-xl font-semibold gradient-text">{title}</p>
-      {message && <p className="text-sc-fg-muted text-sm mt-2 max-w-md mx-auto">{message}</p>}
-      {action && <div className="mt-6 animate-slide-up">{action}</div>}
-    </div>
-  );
-}
 
 // Info/help tooltip component
 interface InfoTooltipProps {


### PR DESCRIPTION
## Summary
The remaining candidates from the v1.1 UI polish survey (first 3 shipped in #210), plus the survey's item 10 resolved per product direction.

- **Admin audit filters + teams invite email → shared `Input`.** The five hand-rolled audit inputs used `outline-none` which defeated the global focus ring, leaving keyboard users a 1px border-color change. Audit filter labels now have explicit `htmlFor`/`id` pairs.
- **`viewer` role is now assignable.** `ROLE_CONFIG` styled it, `OrganizationRole.VIEWER` is a valid backend enum accepted by both the role-update and invitation routes — but every role select and invite dropdown omitted it. Added on the teams page.
- **`text-white` → `text-sc-on-accent`** on accent surfaces (button primary, gradient button, pagination active, pills tabs, checkbox indicator, empty-state CTA, not-found, reset-password). Renders identically today; makes any future on-accent change land everywhere at once.
- **Toolbar search focus unified.** The tag/type/node popover search inputs had three slightly different focus treatments; all now use the app-standard cyan ring.
- **Feedback components rehomed.** `EmptyState`/`ErrorState`/`SuccessState` moved from `tooltip.tsx` (!) into `empty-state.tsx`; `tooltip.tsx` re-exports them so all 11 existing import sites keep working unchanged.
- **Raw entity IDs tamed.** Memory source breadcrumbs and import-progress chips truncated (full ID in `title` tooltip); chip hover stays cyan instead of flipping purple.
- **Organizations page is org admin only** (item 10, per product call): removed the duplicated `OrgMembersList` (role select + member removal) — member and role management belongs to Teams, which has the richer implementation (invites, skeletons, error states). The Members action now links to `/settings/teams`. Net −159 lines.

## Test plan
- `moon run web:lint web:typecheck web:test` — all pass after every commit.
- `viewer` assignment verified against the backend enum (`OrganizationRole.VIEWER`) and the org-members/invitations routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer empty, error, and success states (including shared state components).
  * Expanded role options to include a viewer role for team/organization assignments.
* **Bug Fixes**
  * Improved breadcrumb display for long memory source names by truncating with an ellipsis.
  * Updated search/filter inputs for consistent focus styling across views.
* **UI Polish**
  * Refreshed accent colors across buttons, links, checkboxes, pagination, tabs, and tooltips.
  * Improved source import record pills with truncation and a tooltip; streamlined admin audit and settings filter inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->