### PR TITLE
test: repair LongMemEval CI assertions

### DIFF
--- a/tools/tests/test_longmemeval_live.py
+++ b/tools/tests/test_longmemeval_live.py
@@ -137,7 +137,7 @@ def test_eval_workflow_compares_local_and_openai_smoke_receipts() -> None:
     assert "if: github.event_name != 'pull_request'" in comparison_job
     assert "longmemeval-live-smoke" in comparison_job
     assert "longmemeval-local-smoke" in comparison_job
-    assert "actions/download-artifact@v7" in comparison_job
+    assert "actions/download-artifact@v8" in comparison_job
     assert "longmemeval-live-smoke-${{ github.sha }}" in comparison_job
     assert "longmemeval-local-smoke-${{ github.sha }}" in comparison_job
     assert (

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 from pathlib import Path
 from types import ModuleType
+from typing import TypedDict
 
 import pytest
 from tools.bench import eval_gate
@@ -18,6 +19,13 @@ EXPECTED_BULK_MAX_ENTITIES = 16
 EXPECTED_BULK_MAX_CONTENT_CHARS = 200_000
 EXPECTED_EMBEDDING_BACKFILL_MAX_PENDING_JOBS = 8
 TEST_CONTENT_MAX_CHARS = 420
+
+
+class _RequestCall(TypedDict):
+    method: str
+    path: str
+    json: dict[str, object]
+    params: dict[str, object]
 
 
 def _load_module(path: Path, name: str) -> ModuleType:
@@ -331,7 +339,7 @@ def test_sibyl_memory_insert_defers_embeddings_and_tracks_backfill_job() -> None
     module = _load_memory_module()
     memory = module.SibylLiveApiMemory.__new__(module.SibylLiveApiMemory)
     module.Memory.__init__(memory, {})
-    calls: list[dict[str, object]] = []
+    calls: list[_RequestCall] = []
 
     def fake_request(
         method: str,
@@ -465,7 +473,7 @@ def test_sibyl_memory_query_waits_for_embedding_backfill_before_search() -> None
     module = _load_memory_module()
     memory = module.SibylLiveApiMemory.__new__(module.SibylLiveApiMemory)
     module.Memory.__init__(memory, {})
-    status_responses = [
+    status_responses: list[dict[str, object]] = [
         {"status": "queued"},
         {"status": "complete", "error": None},
     ]


### PR DESCRIPTION
## Why

Two merged dependency updates exposed stale CI assumptions:

- `ty 0.0.56` from #214 now flags loose fixtures in `root:inventory-typecheck`.
- `actions/download-artifact@v8` from #230 left one LongMemEval workflow assertion expecting v7.

Both showed up while refreshing the remaining dependency PRs, so this keeps the dependency lane honest instead of papering over red checks.

## What Changed

- Added a tiny `TypedDict` for captured request calls.
- Typed the fake embedding status responses as `list[dict[str, object]]`.
- Updated the LongMemEval workflow test to expect `download-artifact@v8`.

## Validation

- `moon run root:inventory-lint` → `Tasks: 1 completed` / `All checks passed!`
- `moon run root:inventory-typecheck` → `Tasks: 1 completed` / `All checks passed!`
- `moon run root:bench-gate-test` → `109 passed in 4.71s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test clarity and consistency by adding stronger type annotations for captured request data and polling responses.
  * Updated the live/compare workflow test to use the newer `actions/download-artifact` version.
  * No user-facing behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->