### PR TITLE
Fix device approval and raw import issues

### DIFF
--- a/apps/api/src/sibyl/api/routes/auth.py
+++ b/apps/api/src/sibyl/api/routes/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from html import escape
 from ipaddress import ip_address, ip_network
 from typing import Protocol
 from urllib.parse import quote, urlencode, urlparse
@@ -1092,6 +1093,7 @@ def _render_device_verify_page(
 ) -> HTMLResponse:
     """Render the device verification page with SilkCircuit styling."""
     safe_code = user_code or ""
+    safe_code_attr = escape(safe_code, quote=True)
     err = error_code or ""
     is_authed = authed_user is not None
 
@@ -1241,15 +1243,54 @@ def _render_device_verify_page(
       text-decoration: none;
     }
     .link:hover { text-decoration: underline; }
+    .provider-divider {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin: 20px 0 0;
+      color: #686888;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .provider-divider::before,
+    .provider-divider::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: #2a2640;
+    }
+    .provider-actions {
+      display: grid;
+      gap: 10px;
+      margin-top: 14px;
+    }
+    .provider-link {
+      display: block;
+      padding: 12px 14px;
+      border-radius: 10px;
+      border: 1px solid #2a2640;
+      background: #1a1624;
+      color: #f0f0f8;
+      font-size: 14px;
+      font-weight: 600;
+      text-align: center;
+      text-decoration: none;
+    }
+    .provider-link:hover {
+      border-color: #80ffea;
+      background: #221e30;
+    }
     """
 
     # Page content varies by state
     if err:
         # Error state: show message with option to try again
+        error_html = escape(error_message)
         body_html = f"""
         <div class="err">
           <div class="err-icon">⚠</div>
-          {error_message}
+          {error_html}
         </div>
         <a href="/api/auth/device/verify" class="link">← Enter a different code</a>
         """
@@ -1278,7 +1319,7 @@ def _render_device_verify_page(
         body_html = f"""
         <form method="post" action="/api/auth/device/verify">
           <input type="hidden" name="action" value="login" />
-          <input type="hidden" name="user_code" value="{safe_code}" />
+          <input type="hidden" name="user_code" value="{safe_code_attr}" />
           <label>Email</label>
           <input name="email" type="email" autocomplete="username" required autofocus />
           <label>Password</label>
@@ -1286,25 +1327,28 @@ def _render_device_verify_page(
           {break_glass_reason_field}
           <button type="submit">Sign in & Continue</button>
         </form>
+        {_render_device_verify_oidc_links(safe_code)}
         """
         title = "Sign In to Approve"
     else:
         # Logged in with valid code: show approve/deny
         client_name = str(pending.get("client_name") or "sibyl-cli") if pending else "sibyl-cli"
         scope = str(pending.get("scope") or "mcp") if pending else "mcp"
+        client_name_html = escape(client_name)
+        scope_html = escape(scope)
         body_html = f"""
         <div class="card">
-          <div><strong>Application:</strong> {client_name}</div>
-          <div><strong>Permissions:</strong> <code>{scope}</code></div>
+          <div><strong>Application:</strong> {client_name_html}</div>
+          <div><strong>Permissions:</strong> <code>{scope_html}</code></div>
         </div>
         <form method="post" action="/api/auth/device/verify">
           <input type="hidden" name="action" value="approve" />
-          <input type="hidden" name="user_code" value="{safe_code}" />
+          <input type="hidden" name="user_code" value="{safe_code_attr}" />
           <button type="submit">Approve Device</button>
         </form>
         <form method="post" action="/api/auth/device/verify">
           <input type="hidden" name="action" value="deny" />
-          <input type="hidden" name="user_code" value="{safe_code}" />
+          <input type="hidden" name="user_code" value="{safe_code_attr}" />
           <button type="submit" class="secondary">Deny</button>
         </form>
         """
@@ -1312,7 +1356,8 @@ def _render_device_verify_page(
 
     # Auth status banner
     if authed_user is not None and not err:
-        authed_banner = f"<div class='sub'>Signed in as <strong>{authed_user.email or authed_user.name}</strong></div>"
+        identity = escape(str(authed_user.email or authed_user.name))
+        authed_banner = f"<div class='sub'>Signed in as <strong>{identity}</strong></div>"
     elif not safe_code:
         authed_banner = "<div class='sub'>Enter the code shown in your terminal</div>"
     elif not err:
@@ -1340,6 +1385,28 @@ def _render_device_verify_page(
 </body>
 </html>"""
     return HTMLResponse(html, status_code=200)
+
+
+def _render_device_verify_oidc_links(user_code: str) -> str:
+    providers = enabled_oidc_providers()
+    if not providers:
+        return ""
+
+    redirect = f"/api/auth/device/verify?{urlencode({'user_code': user_code}, quote_via=quote)}"
+    links = []
+    for provider in providers:
+        separator = "&" if "?" in provider.login_url else "?"
+        query = urlencode({"redirect": redirect}, quote_via=quote)
+        href = escape(f"{provider.login_url}{separator}{query}", quote=True)
+        label = escape(provider.label or provider.name)
+        links.append(f'<a class="provider-link" href="{href}">Continue with {label}</a>')
+
+    return f"""
+        <div class="provider-divider">or</div>
+        <div class="provider-actions">
+          {"".join(links)}
+        </div>
+        """
 
 
 @router.get("/device/verify", response_model=None)

--- a/apps/api/tests/test_routes_auth.py
+++ b/apps/api/tests/test_routes_auth.py
@@ -927,6 +927,42 @@ async def test_device_verify_get_uses_runtime_helpers(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
+async def test_device_verify_get_offers_oidc_provider_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = FakeRequest(query_params={"user_code": "ABCD-EFGH"})
+    get_request = AsyncMock(
+        return_value=SimpleNamespace(
+            client_name="sibyl-cli",
+            scope="mcp",
+            expires_at=datetime.now(UTC).replace(tzinfo=None) + timedelta(minutes=10),
+            status="pending",
+        )
+    )
+    provider = SimpleNamespace(
+        name="entra",
+        label="Entra ID",
+        login_url="/api/auth/oidc/entra/login",
+    )
+
+    monkeypatch.setattr(
+        auth_routes, "_require_jwt_secret", lambda: "test-jwt-secret-key-for-api-tests"
+    )
+    monkeypatch.setattr(auth_routes, "resolve_request_user", AsyncMock(return_value=None))
+    monkeypatch.setattr(auth_routes, "get_device_request_by_user_code", get_request)
+    monkeypatch.setattr(auth_routes, "enabled_oidc_providers", lambda: [provider])
+
+    response = await _call_route(auth_routes.device_verify_get, request=request)
+    body = response.body.decode()
+
+    redirect = "%2Fapi%2Fauth%2Fdevice%2Fverify%3Fuser_code%3DABCD-EFGH"
+    assert "Continue with Entra ID" in body
+    assert f"/api/auth/oidc/entra/login?redirect={redirect}" in body
+    assert "Application:" not in body
+    get_request.assert_awaited_once_with("ABCD-EFGH")
+
+
+@pytest.mark.asyncio
 async def test_device_verify_post_login_uses_runtime_helper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -49,7 +49,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 17
+CONTENT_SCHEMA_CURRENT_VERSION = 18
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -428,6 +428,13 @@ DEFINE FIELD OVERWRITE skipped_records.* ON source_imports TYPE object FLEXIBLE;
 DEFINE FIELD OVERWRITE errors.* ON source_imports TYPE object FLEXIBLE;
 """
 
+CONTENT_RAW_CAPTURE_LOOKUP_MIGRATION_DEFINITIONS = """
+DEFINE INDEX IF NOT EXISTS idx_raw_captures_dedupe_lookup
+    ON raw_captures FIELDS metadata.dedupe_key, organization_id, memory_scope, scope_key;
+DEFINE INDEX IF NOT EXISTS idx_raw_captures_source_lookup
+    ON raw_captures FIELDS source_id, organization_id, memory_scope, scope_key;
+"""
+
 
 def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
     compatible_schema = render_fulltext_compatible_sql(
@@ -532,6 +539,11 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             version=17,
             name="content_source_import_receipt_arrays",
             statements=tuple(split_statements(CONTENT_SOURCE_IMPORT_RECEIPT_MIGRATION_DEFINITIONS)),
+        ),
+        SchemaMigration(
+            version=18,
+            name="content_raw_capture_lookup_indexes",
+            statements=tuple(split_statements(CONTENT_RAW_CAPTURE_LOOKUP_MIGRATION_DEFINITIONS)),
         ),
     )
 
@@ -874,13 +886,14 @@ __all__ = [
     "CONTENT_LINEAGE_RELATION_MIGRATION_DEFINITIONS",
     "CONTENT_LOOKUP_INDEX_MIGRATION_DEFINITIONS",
     "CONTENT_PERMISSION_MIGRATION_DEFINITIONS",
+    "CONTENT_RAW_CAPTURE_LOOKUP_MIGRATION_DEFINITIONS",
     "CONTENT_RELATION_TABLES",
     "CONTENT_REVIEW_STATE_DEFERRED_MIGRATION_DEFINITIONS",
     "CONTENT_SCHEMA_CURRENT_VERSION",
     "CONTENT_SCHEMA_DEFINITIONS",
     "CONTENT_SCHEMA_NAME",
-    "CONTENT_SOURCE_URL_SCOPE_MIGRATION_DEFINITIONS",
     "CONTENT_SOURCE_IMPORT_RECEIPT_MIGRATION_DEFINITIONS",
+    "CONTENT_SOURCE_URL_SCOPE_MIGRATION_DEFINITIONS",
     "CONTENT_TABLES",
     "CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS",
     "bootstrap_content_schema",

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -49,7 +49,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 16
+CONTENT_SCHEMA_CURRENT_VERSION = 17
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -421,6 +421,13 @@ WHERE last_recalled_at = NONE
     );
 """
 
+CONTENT_SOURCE_IMPORT_RECEIPT_MIGRATION_DEFINITIONS = """
+DEFINE FIELD IF NOT EXISTS skipped_records.* ON source_imports TYPE object FLEXIBLE;
+DEFINE FIELD IF NOT EXISTS errors.* ON source_imports TYPE object FLEXIBLE;
+DEFINE FIELD OVERWRITE skipped_records.* ON source_imports TYPE object FLEXIBLE;
+DEFINE FIELD OVERWRITE errors.* ON source_imports TYPE object FLEXIBLE;
+"""
+
 
 def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
     compatible_schema = render_fulltext_compatible_sql(
@@ -520,6 +527,11 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             version=16,
             name="content_usage_signals",
             statements=tuple(split_statements(CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS)),
+        ),
+        SchemaMigration(
+            version=17,
+            name="content_source_import_receipt_arrays",
+            statements=tuple(split_statements(CONTENT_SOURCE_IMPORT_RECEIPT_MIGRATION_DEFINITIONS)),
         ),
     )
 
@@ -868,6 +880,7 @@ __all__ = [
     "CONTENT_SCHEMA_DEFINITIONS",
     "CONTENT_SCHEMA_NAME",
     "CONTENT_SOURCE_URL_SCOPE_MIGRATION_DEFINITIONS",
+    "CONTENT_SOURCE_IMPORT_RECEIPT_MIGRATION_DEFINITIONS",
     "CONTENT_TABLES",
     "CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS",
     "bootstrap_content_schema",

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
@@ -146,6 +146,8 @@ DEFINE FIELD IF NOT EXISTS created_at ON raw_captures TYPE datetime DEFAULT time
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_uuid ON raw_captures FIELDS uuid UNIQUE;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_org ON raw_captures FIELDS organization_id;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_source ON raw_captures FIELDS source_id;
+DEFINE INDEX IF NOT EXISTS idx_raw_captures_source_lookup ON raw_captures
+    FIELDS source_id, organization_id, memory_scope, scope_key;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_principal ON raw_captures FIELDS principal_id;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_scope ON raw_captures FIELDS organization_id, memory_scope, scope_key;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_agent ON raw_captures FIELDS organization_id, agent_id;
@@ -154,6 +156,8 @@ DEFINE INDEX IF NOT EXISTS idx_raw_captures_review ON raw_captures FIELDS organi
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_purge_after ON raw_captures FIELDS purge_after;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_entity_id ON raw_captures FIELDS entity_id;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_org_dedupe ON raw_captures FIELDS organization_id, metadata.dedupe_key;
+DEFINE INDEX IF NOT EXISTS idx_raw_captures_dedupe_lookup ON raw_captures
+    FIELDS metadata.dedupe_key, organization_id, memory_scope, scope_key;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_title_ft ON raw_captures FIELDS title FULLTEXT ANALYZER title_analyzer BM25 HIGHLIGHTS;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_content_ft ON raw_captures FIELDS raw_content FULLTEXT ANALYZER content_analyzer BM25 HIGHLIGHTS;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_embedding ON raw_captures FIELDS embedding

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
@@ -226,7 +226,9 @@ DEFINE FIELD IF NOT EXISTS source_ids ON source_imports TYPE array<string> DEFAU
 DEFINE FIELD IF NOT EXISTS dedupe_keys ON source_imports TYPE array<string> DEFAULT [];
 DEFINE FIELD IF NOT EXISTS duplicate_dedupe_keys ON source_imports TYPE array<string> DEFAULT [];
 DEFINE FIELD IF NOT EXISTS skipped_records ON source_imports TYPE array<object> DEFAULT [];
+DEFINE FIELD IF NOT EXISTS skipped_records.* ON source_imports TYPE object FLEXIBLE;
 DEFINE FIELD IF NOT EXISTS errors ON source_imports TYPE array<object> DEFAULT [];
+DEFINE FIELD IF NOT EXISTS errors.* ON source_imports TYPE object FLEXIBLE;
 DEFINE FIELD IF NOT EXISTS raw_memory_by_source_id ON source_imports TYPE object FLEXIBLE DEFAULT {{}};
 DEFINE FIELD IF NOT EXISTS batch_size ON source_imports TYPE int DEFAULT 100;
 DEFINE FIELD IF NOT EXISTS promotion_preview_approved ON source_imports TYPE bool DEFAULT false;

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -33,6 +33,7 @@ from sibyl_core.backends.surreal.content_schema import (
     CONTENT_REVIEW_STATE_DEFERRED_MIGRATION_DEFINITIONS,
     CONTENT_SCHEMA_CURRENT_VERSION,
     CONTENT_SCHEMA_DEFINITIONS,
+    CONTENT_SOURCE_IMPORT_RECEIPT_MIGRATION_DEFINITIONS,
     CONTENT_TABLES,
     CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS,
     _content_schema_migrations,
@@ -434,7 +435,7 @@ def test_content_usage_signals_are_versioned() -> None:
         statement for migration in migrations for statement in migration.statements
     )
 
-    assert CONTENT_SCHEMA_CURRENT_VERSION == 16
+    assert CONTENT_SCHEMA_CURRENT_VERSION >= 16
     assert "memory_usage_events" in CONTENT_TABLES
     assert "content_usage_signals" in [migration.name for migration in migrations]
     for field in (
@@ -455,6 +456,26 @@ def test_content_usage_signals_are_versioned() -> None:
         CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS
     )
     assert CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS.strip().splitlines()[0] in migration_sql
+
+
+def test_content_source_import_receipt_arrays_are_versioned() -> None:
+    migrations = _content_schema_migrations(url="memory://")
+    migration_sql = "\n".join(
+        statement for migration in migrations for statement in migration.statements
+    )
+
+    assert CONTENT_SCHEMA_CURRENT_VERSION == 17
+    assert "content_source_import_receipt_arrays" in [
+        migration.name for migration in migrations
+    ]
+    for field in ("skipped_records", "errors"):
+        assert f"DEFINE FIELD IF NOT EXISTS {field}.* ON source_imports" in (
+            CONTENT_SCHEMA_DEFINITIONS
+        )
+        assert f"DEFINE FIELD OVERWRITE {field}.* ON source_imports" in (
+            CONTENT_SOURCE_IMPORT_RECEIPT_MIGRATION_DEFINITIONS
+        )
+        assert f"DEFINE FIELD OVERWRITE {field}.* ON source_imports" in migration_sql
 
 
 def test_raw_capture_changefeed_cursor_is_versioned() -> None:

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -29,6 +29,7 @@ from sibyl_core.backends.surreal.content_schema import (
     CONTENT_PERMISSION_MIGRATION_DEFINITIONS,
     CONTENT_RAW_CAPTURE_CHANGEFEED_MIGRATION_DEFINITIONS,
     CONTENT_RAW_CAPTURE_INGESTION_MIGRATION_DEFINITIONS,
+    CONTENT_RAW_CAPTURE_LOOKUP_MIGRATION_DEFINITIONS,
     CONTENT_RELATION_TABLES,
     CONTENT_REVIEW_STATE_DEFERRED_MIGRATION_DEFINITIONS,
     CONTENT_SCHEMA_CURRENT_VERSION,
@@ -464,10 +465,8 @@ def test_content_source_import_receipt_arrays_are_versioned() -> None:
         statement for migration in migrations for statement in migration.statements
     )
 
-    assert CONTENT_SCHEMA_CURRENT_VERSION == 17
-    assert "content_source_import_receipt_arrays" in [
-        migration.name for migration in migrations
-    ]
+    assert CONTENT_SCHEMA_CURRENT_VERSION >= 17
+    assert "content_source_import_receipt_arrays" in [migration.name for migration in migrations]
     for field in ("skipped_records", "errors"):
         assert f"DEFINE FIELD IF NOT EXISTS {field}.* ON source_imports" in (
             CONTENT_SCHEMA_DEFINITIONS
@@ -476,6 +475,23 @@ def test_content_source_import_receipt_arrays_are_versioned() -> None:
             CONTENT_SOURCE_IMPORT_RECEIPT_MIGRATION_DEFINITIONS
         )
         assert f"DEFINE FIELD OVERWRITE {field}.* ON source_imports" in migration_sql
+
+
+def test_content_raw_capture_lookup_indexes_are_versioned() -> None:
+    migrations = _content_schema_migrations(url="memory://")
+    migration_sql = "\n".join(
+        statement for migration in migrations for statement in migration.statements
+    )
+
+    assert CONTENT_SCHEMA_CURRENT_VERSION == 18
+    assert "content_raw_capture_lookup_indexes" in [migration.name for migration in migrations]
+    for index_name in (
+        "idx_raw_captures_dedupe_lookup",
+        "idx_raw_captures_source_lookup",
+    ):
+        assert index_name in CONTENT_SCHEMA_DEFINITIONS
+        assert index_name in CONTENT_RAW_CAPTURE_LOOKUP_MIGRATION_DEFINITIONS
+        assert index_name in migration_sql
 
 
 def test_raw_capture_changefeed_cursor_is_versioned() -> None:


### PR DESCRIPTION
## What this is

This fixes the three validated open issue surfaces in one scoped branch: source import receipt persistence, raw capture lookup indexing, and device-code approval through OIDC.

## How it works

- `packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py` and `10_tables.surql` move the content schema to v18. Version 17 defines flexible element fields for `source_imports.skipped_records.*` and `source_imports.errors.*`; version 18 adds scoped raw capture lookup indexes for dedupe and source checks.
- `apps/api/src/sibyl/api/routes/auth.py` renders configured OIDC providers on the unauthenticated device approval page and sends the browser back to `/api/auth/device/verify?user_code=...` after login. It also escapes dynamic approval-page fields while touching that renderer.
- Tests pin both the schema migration ladder and the device approval OIDC link.

## Validation

- `moon run core:test` -> `1672 passed, 14 skipped in 23.29s`
- `moon run api:test` -> `1869 passed, 2 skipped in 43.97s`
- `moon run api:lint` -> `All checks passed! 371 files already formatted`
- `moon run core:check api:check` -> exit 0

Fixes #206.
Fixes #208.
Fixes #231.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Continue with” login options on the device approval screen for enabled sign-in providers.
  * Expanded backend schema support for newer content versions and lookup indexing.

* **Bug Fixes**
  * Improved HTML safety across device approval pages to prevent unsafe content from rendering.
  * Updated data handling for import receipts and raw capture lookups to support more reliable processing and faster access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->