### PR TITLE
feat(enterprise): complete deployment and release contract

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
           fi
           for image in api web; do
             url="https://hub.docker.com/v2/repositories/${DOCKERHUB_NAMESPACE}/sibyl-${image}/"
-            if ! curl --fail --silent --show-error "$url" >/dev/null; then
+            if ! curl --fail --silent --show-error --retry 3 "$url" >/dev/null; then
               echo "::error::Public Docker Hub repository is unavailable: ${DOCKERHUB_NAMESPACE}/sibyl-${image}"
               exit 1
             fi
@@ -764,26 +764,44 @@ jobs:
       - name: "► Publish immutable chart packages"
         run: |
           set -euo pipefail
+          same_chart_contents() {
+            local staged="$1" published="$2" workdir result=0
+            workdir="$(mktemp -d)"
+            mkdir "$workdir/staged" "$workdir/published"
+            tar -xzf "$staged" -C "$workdir/staged"
+            tar -xzf "$published" -C "$workdir/published"
+            diff -r "$workdir/staged" "$workdir/published" >/dev/null || result=1
+            rm -rf "$workdir"
+            return "$result"
+          }
+          mkdir -p new-packages
           added=false
           for package in staged-charts/*.tgz; do
-            destination="helm-repo/$(basename "$package")"
+            name="$(basename "$package")"
+            destination="helm-repo/${name}"
             if [[ -f "$destination" ]]; then
-              if ! cmp --silent "$package" "$destination"; then
-                echo "::error::Refusing to replace immutable chart: $(basename "$package")"
+              # helm package archives are not byte-reproducible across checkouts,
+              # so tag re-runs must compare chart contents rather than bytes.
+              if ! same_chart_contents "$package" "$destination"; then
+                echo "::error::Refusing to replace immutable chart: ${name}"
                 exit 1
               fi
               continue
             fi
-            cp "$package" "$destination"
+            cp "$package" "new-packages/${name}"
             added=true
           done
           if [[ "$added" != "true" ]]; then
             echo "Exact chart packages already published; nothing to do."
             exit 0
           fi
-          helm repo index helm-repo \
+          # Index only the new packages so previously published entries keep
+          # their original created timestamps and archive digests.
+          helm repo index new-packages \
             --url https://raw.githubusercontent.com/hyperb1iss/sibyl/gh-pages \
             --merge helm-repo/index.yaml
+          cp new-packages/*.tgz helm-repo/
+          mv new-packages/index.yaml helm-repo/index.yaml
           git -C helm-repo config user.name github-actions[bot]
           git -C helm-repo config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git -C helm-repo add index.yaml '*.tgz'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,13 @@ on:
         default: false
 
 env:
-  REGISTRY: ghcr.io
+  GHCR_REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
+  DOCKERHUB_NAMESPACE: hyperb1iss
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
 
 jobs:
   # =========================================================================
@@ -60,6 +66,47 @@ jobs:
 
       - name: "◇ Run RC gate bundle"
         run: moon run :check
+
+  # =========================================================================
+  # Registry preflight: fail before native builds when live publishing is not ready
+  # =========================================================================
+  registry-preflight:
+    name: "◇ Docker: Registry preflight"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: "◇ Verify Docker Hub publishing contract"
+        if: ${{ !inputs.dry_run }}
+        env:
+          DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${DOCKERHUB_USERNAME:-}" ]]; then
+            echo "::error::DOCKERHUB_USERNAME repository variable is not configured."
+            exit 1
+          fi
+          if [[ -z "${DOCKERHUB_TOKEN:-}" ]]; then
+            echo "::error::DOCKERHUB_TOKEN repository secret is not configured."
+            exit 1
+          fi
+          for image in api web; do
+            url="https://hub.docker.com/v2/repositories/${DOCKERHUB_NAMESPACE}/sibyl-${image}/"
+            if ! curl --fail --silent --show-error "$url" >/dev/null; then
+              echo "::error::Public Docker Hub repository is unavailable: ${DOCKERHUB_NAMESPACE}/sibyl-${image}"
+              exit 1
+            fi
+          done
+
+      - name: "◇ Login to Docker Hub"
+        if: ${{ !inputs.dry_run }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
   # =========================================================================
   # Python: build + publish to PyPI
@@ -311,7 +358,7 @@ jobs:
   # =========================================================================
   docker-build:
     name: "△ Docker: ${{ matrix.image }} (${{ matrix.platform }})"
-    needs: rc-gate
+    needs: [rc-gate, registry-preflight]
     runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 30
     permissions:
@@ -335,9 +382,17 @@ jobs:
         if: ${{ !inputs.dry_run }}
         uses: docker/login-action@v4
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "◇ Login to Docker Hub"
+        if: ${{ !inputs.dry_run }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "△ Build & push by digest"
         id: build
@@ -347,8 +402,9 @@ jobs:
           file: apps/${{ matrix.image }}/Dockerfile
           platforms: linux/${{ matrix.platform }}
           outputs: >-
-            type=image,name=${{ env.REGISTRY }}/${{ github.repository_owner }}/sibyl-${{
-            matrix.image }},push-by-digest=true,name-canonical=true,push=${{ !inputs.dry_run }}
+            type=image,"name=${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{
+            matrix.image }},${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_NAMESPACE }}/sibyl-${{
+            matrix.image }}",push-by-digest=true,name-canonical=true,push=${{ !inputs.dry_run }}
           cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.platform }}
 
@@ -403,31 +459,52 @@ jobs:
       - name: "◇ Login to GHCR"
         uses: docker/login-action@v4
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "◇ Login to Docker Hub"
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "► Create manifest list"
         working-directory: /tmp/digests
         env:
-          REPO: ${{ env.REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}
+          GHCR_REPO:
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}
+          DOCKERHUB_REPO:
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_NAMESPACE }}/sibyl-${{ matrix.image }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          refs=()
-          for digest in *; do
-            refs+=("${REPO}@sha256:${digest}")
+          for repo in "$GHCR_REPO" "$DOCKERHUB_REPO"; do
+            refs=()
+            for digest in *; do
+              refs+=("${repo}@sha256:${digest}")
+            done
+            docker buildx imagetools create \
+              -t "${repo}:latest" \
+              -t "${repo}:${VERSION}" \
+              "${refs[@]}"
           done
-          docker buildx imagetools create \
-            -t "${REPO}:latest" \
-            -t "${REPO}:${VERSION}" \
-            "${refs[@]}"
 
-      - name: "△ Inspect image"
+      - name: "△ Verify registry manifest parity"
         env:
-          REPO: ${{ env.REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}
+          GHCR_REPO:
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}
+          DOCKERHUB_REPO:
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_NAMESPACE }}/sibyl-${{ matrix.image }}
           VERSION: ${{ steps.version.outputs.version }}
-        run: docker buildx imagetools inspect "${REPO}:${VERSION}"
+        run: |
+          set -euo pipefail
+          ghcr_digest="$(docker buildx imagetools inspect "${GHCR_REPO}:${VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          dockerhub_digest="$(docker buildx imagetools inspect "${DOCKERHUB_REPO}:${VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          test -n "$ghcr_digest"
+          test "$ghcr_digest" = "$dockerhub_digest"
+          echo "Shared manifest digest: $ghcr_digest"
 
   # =========================================================================
   # Docker: generate SBOMs and fail on high/critical CVEs before signing
@@ -455,7 +532,7 @@ jobs:
       - name: "◇ Login to GHCR"
         uses: docker/login-action@v4
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -463,7 +540,7 @@ jobs:
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: >-
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}:${{
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}:${{
             steps.version.outputs.version }}
           format: cyclonedx
           output: sibyl-${{ matrix.image }}-${{ steps.version.outputs.version }}.cdx.json
@@ -481,7 +558,7 @@ jobs:
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: >-
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}:${{
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}:${{
             steps.version.outputs.version }}
           format: table
           exit-code: "1"
@@ -521,40 +598,71 @@ jobs:
       - name: "◇ Login to GHCR"
         uses: docker/login-action@v4
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "◇ Login to Docker Hub"
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: "◆ Sign image digest"
         env:
-          REPO: ${{ env.REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}
+          GHCR_REPO:
+            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}
+          DOCKERHUB_REPO:
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_NAMESPACE }}/sibyl-${{ matrix.image }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          digest="$(
-            docker buildx imagetools inspect "${REPO}:${VERSION}" \
+          ghcr_digest="$(
+            docker buildx imagetools inspect "${GHCR_REPO}:${VERSION}" \
               --format '{{json .Manifest.Digest}}' \
               | tr -d '"'
           )"
-          test -n "$digest"
-          image_ref="${REPO}@${digest}"
-          cosign sign --yes "${image_ref}"
+          dockerhub_digest="$(
+            docker buildx imagetools inspect "${DOCKERHUB_REPO}:${VERSION}" \
+              --format '{{json .Manifest.Digest}}' \
+              | tr -d '"'
+          )"
+          test -n "$ghcr_digest"
+          test "$ghcr_digest" = "$dockerhub_digest"
+          ghcr_ref="${GHCR_REPO}@${ghcr_digest}"
+          dockerhub_ref="${DOCKERHUB_REPO}@${dockerhub_digest}"
+          cosign sign --yes "$ghcr_ref"
+          cosign sign --yes "$dockerhub_ref"
           mkdir -p cosign-receipts
           receipt="cosign-receipts/sibyl-${{ matrix.image }}-${VERSION}-cosign-receipt.json"
-          IMAGE="${{ matrix.image }}" REPO="$REPO" VERSION="$VERSION" DIGEST="$digest" IMAGE_REF="$image_ref" RECEIPT="$receipt" python - <<'PY'
+          IMAGE="${{ matrix.image }}" GHCR_REPO="$GHCR_REPO" DOCKERHUB_REPO="$DOCKERHUB_REPO" VERSION="$VERSION" DIGEST="$ghcr_digest" GHCR_REF="$ghcr_ref" DOCKERHUB_REF="$dockerhub_ref" RECEIPT="$receipt" python - <<'PY'
           import json
           import os
           from datetime import UTC, datetime
           from pathlib import Path
 
           payload = {
+              "schema_version": "sibyl-cosign-receipt-v2",
               "status": "PASS",
               "signer": "github-actions-oidc-keyless",
               "image": os.environ["IMAGE"],
-              "repository": os.environ["REPO"],
+              "repository": os.environ["GHCR_REPO"],
               "version": os.environ["VERSION"],
               "digest": os.environ["DIGEST"],
-              "image_ref": os.environ["IMAGE_REF"],
+              "image_ref": os.environ["GHCR_REF"],
+              "signed_images": [
+                  {
+                      "repository": os.environ["GHCR_REPO"],
+                      "digest": os.environ["DIGEST"],
+                      "image_ref": os.environ["GHCR_REF"],
+                  },
+                  {
+                      "repository": os.environ["DOCKERHUB_REPO"],
+                      "digest": os.environ["DIGEST"],
+                      "image_ref": os.environ["DOCKERHUB_REF"],
+                  },
+              ],
               "workflow_run_id": os.environ["GITHUB_RUN_ID"],
               "workflow_sha": os.environ["GITHUB_SHA"],
               "workflow_ref": os.environ["GITHUB_REF"],
@@ -577,11 +685,122 @@ jobs:
           retention-days: 90
 
   # =========================================================================
+  # Helm: validate and package immutable charts from the tagged checkout
+  # =========================================================================
+  helm-package:
+    name: "△ Helm: Package charts"
+    needs: rc-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: "◆ Checkout"
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: "◇ Setup Helm"
+        uses: azure/setup-helm@v5.0.0
+        with:
+          version: v3.20.2
+
+      - name: "△ Validate and package charts"
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          mkdir -p dist/charts
+          for chart in charts/sibyl charts/surrealdb; do
+            chart_version="$(helm show chart "$chart" | awk '$1 == "version:" { print $2 }' | tail -1)"
+            test "$chart_version" = "$version"
+            helm lint "$chart"
+          done
+          helm dependency list charts/surrealdb | tee /tmp/surrealdb-dependencies.txt
+          grep -Eq '^surrealdb[[:space:]]+0\.4\.0.*[[:space:]]ok[[:space:]]*$' /tmp/surrealdb-dependencies.txt
+          helm package charts/sibyl --destination dist/charts
+          helm package charts/surrealdb --destination dist/charts
+          test -f "dist/charts/sibyl-${version}.tgz"
+          test -f "dist/charts/sibyl-surrealdb-${version}.tgz"
+
+      - name: "► Upload Helm chart artifact"
+        uses: actions/upload-artifact@v7
+        with:
+          name: sibyl-helm-${{ inputs.tag }}
+          path: dist/charts/*.tgz
+          if-no-files-found: error
+          retention-days: 90
+
+  # =========================================================================
+  # Helm: publish immutable packages and merge the raw gh-pages repository index
+  # =========================================================================
+  helm-publish:
+    name: "► Helm: Publish repository"
+    needs: [helm-package, python, homebrew, aur, docker-sign]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: "◆ Checkout Helm repository"
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          path: helm-repo
+
+      - name: "◇ Setup Helm"
+        uses: azure/setup-helm@v5.0.0
+        with:
+          version: v3.20.2
+
+      - name: "► Download Helm chart artifact"
+        uses: actions/download-artifact@v8
+        with:
+          name: sibyl-helm-${{ inputs.tag }}
+          path: staged-charts
+
+      - name: "► Publish immutable chart packages"
+        run: |
+          set -euo pipefail
+          added=false
+          for package in staged-charts/*.tgz; do
+            destination="helm-repo/$(basename "$package")"
+            if [[ -f "$destination" ]]; then
+              if ! cmp --silent "$package" "$destination"; then
+                echo "::error::Refusing to replace immutable chart: $(basename "$package")"
+                exit 1
+              fi
+              continue
+            fi
+            cp "$package" "$destination"
+            added=true
+          done
+          if [[ "$added" != "true" ]]; then
+            echo "Exact chart packages already published; nothing to do."
+            exit 0
+          fi
+          helm repo index helm-repo \
+            --url https://raw.githubusercontent.com/hyperb1iss/sibyl/gh-pages \
+            --merge helm-repo/index.yaml
+          git -C helm-repo config user.name github-actions[bot]
+          git -C helm-repo config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git -C helm-repo add index.yaml '*.tgz'
+          git -C helm-repo commit -F - <<'EOF'
+          chore(helm): publish release charts
+
+          Add the immutable Sibyl application and SurrealDB wrapper packages,
+          then merge them into the raw-content Helm repository index.
+          EOF
+          git -C helm-repo push origin HEAD:gh-pages
+
+  # =========================================================================
   # Release: update GitHub release with install instructions
   # =========================================================================
   release:
     name: "◆ Release: Update"
-    needs: [python, homebrew, aur, docker-sign]
+    needs: [python, homebrew, aur, docker-sign, helm-publish]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -619,6 +838,12 @@ jobs:
           pattern: sibyl-*-${{ steps.version.outputs.version }}-*
           merge-multiple: true
 
+      - name: "► Download Helm charts"
+        uses: actions/download-artifact@v8
+        with:
+          name: sibyl-helm-${{ inputs.tag }}
+          path: release-evidence/helm
+
       - name: "◇ Prepare release evidence assets"
         run: |
           set -euo pipefail
@@ -632,6 +857,7 @@ jobs:
             -name "*.whl" -o \
             -name "*.tar.gz" \
           \) -exec cp {} release-assets/ \;
+          find release-evidence/helm -type f -name "*.tgz" -exec cp {} release-assets/ \;
 
           formula="$(find release-evidence/homebrew -type f -name "sibyl.rb" -print -quit)"
           pkgbuild="$(find release-evidence/aur -type f -name "PKGBUILD" -print -quit)"
@@ -644,6 +870,7 @@ jobs:
           test "$(find release-assets -maxdepth 1 -type f -name '*-cosign-receipt.json' | wc -l)" -eq 2
           test "$(find release-assets -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 3
           test "$(find release-assets -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 3
+          test "$(find release-assets -maxdepth 1 -type f -name '*.tgz' | wc -l)" -eq 2
           test -f "release-assets/sibyl-homebrew-${version}.rb"
           test -f "release-assets/sibyl-${version}-PKGBUILD"
 
@@ -699,11 +926,19 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/hyperb1iss/sibyl/main/install.sh | sh -s -- --version ${{ steps.version.outputs.version }} --no-open
           ```
 
+          **Kubernetes (Helm)**
+          ```bash
+          helm repo add sibyl https://raw.githubusercontent.com/hyperb1iss/sibyl/gh-pages
+          helm repo update sibyl
+          helm upgrade --install sibyl sibyl/sibyl --version ${{ steps.version.outputs.version }}
+          ```
+
           ## Artifacts
 
           This release includes Python wheels and sdists, the generated
-          Homebrew formula, the generated AUR PKGBUILD, Docker SBOMs,
-          cosign receipts, and a SHA256 checksum manifest.
+          Homebrew formula, the generated AUR PKGBUILD, Helm charts, Docker
+          SBOMs, aggregate dual-registry cosign receipts, and a SHA256 checksum
+          manifest.
           EOF
 
       - name: "◆ Update release with install instructions"
@@ -731,4 +966,11 @@ jobs:
             echo "### Docker Images (multi-arch: linux/amd64, linux/arm64)"
             echo "- \`ghcr.io/hyperb1iss/sibyl-api:${{ steps.version.outputs.version }}\`"
             echo "- \`ghcr.io/hyperb1iss/sibyl-web:${{ steps.version.outputs.version }}\`"
+            echo "- \`docker.io/hyperb1iss/sibyl-api:${{ steps.version.outputs.version }}\`"
+            echo "- \`docker.io/hyperb1iss/sibyl-web:${{ steps.version.outputs.version }}\`"
+            echo ""
+            echo "### Helm Charts"
+            echo "- Repository: https://raw.githubusercontent.com/hyperb1iss/sibyl/gh-pages"
+            echo "- \`sibyl/sibyl --version ${{ steps.version.outputs.version }}\`"
+            echo "- \`sibyl/sibyl-surrealdb --version ${{ steps.version.outputs.version }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/api/src/sibyl/auth/jit.py
+++ b/apps/api/src/sibyl/auth/jit.py
@@ -21,6 +21,7 @@ async def provision_oidc_user(
         client_id=identity.provider.client_id,
         scopes=list(identity.provider.scopes),
         role_claim=identity.provider.role_claim_override,
+        organization_slug=identity.provider.organization_slug,
         subject=identity.subject,
         subject_key=identity.subject_key,
         email=_optional_str(claims.get("email")),

--- a/apps/api/src/sibyl/auth/oidc.py
+++ b/apps/api/src/sibyl/auth/oidc.py
@@ -248,16 +248,17 @@ def _role_from_claim(value: object) -> OrganizationRole | None:
         values = list(value)
     else:
         values = [value]
-    for item in values:
-        role = {
-            "Sibyl.Owner": OrganizationRole.OWNER,
-            "Sibyl.Admin": OrganizationRole.ADMIN,
-            "Sibyl.Member": OrganizationRole.MEMBER,
-            "owner": OrganizationRole.OWNER,
-            "admin": OrganizationRole.ADMIN,
-            "member": OrganizationRole.MEMBER,
-        }.get(str(item))
-        if role is not None:
+    role_map = {
+        "Sibyl.Owner": OrganizationRole.OWNER,
+        "Sibyl.Admin": OrganizationRole.ADMIN,
+        "Sibyl.Member": OrganizationRole.MEMBER,
+        "owner": OrganizationRole.OWNER,
+        "admin": OrganizationRole.ADMIN,
+        "member": OrganizationRole.MEMBER,
+    }
+    roles = {role_map[str(item)] for item in values if str(item) in role_map}
+    for role in (OrganizationRole.OWNER, OrganizationRole.ADMIN, OrganizationRole.MEMBER):
+        if role in roles:
             return role
     return None
 

--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -40,10 +40,11 @@ class OIDCProviderSettings(BaseModel):
     issuer: str
     client_id: str
     client_secret_env: str
+    organization_slug: str
     scopes: list[str] = Field(default_factory=lambda: ["openid", "profile", "email"])
     role_claim_override: str | None = None
 
-    @field_validator("name", "issuer", "client_id", "client_secret_env")
+    @field_validator("name", "issuer", "client_id", "client_secret_env", "organization_slug")
     @classmethod
     def strip_required_string(cls, value: str) -> str:
         stripped = value.strip()
@@ -88,6 +89,13 @@ class OIDCSettings(BaseModel):
     @classmethod
     def strip_string(cls, value: str) -> str:
         return value.strip()
+
+    @model_validator(mode="after")
+    def validate_provider_names(self) -> "OIDCSettings":
+        names = [provider.name.lower() for provider in self.providers]
+        if len(names) != len(set(names)):
+            raise ValueError("OIDC provider names must be unique")
+        return self
 
 
 def _get_or_create_jwt_secret() -> str:

--- a/apps/api/src/sibyl/persistence/surreal/auth_runtime/login.py
+++ b/apps/api/src/sibyl/persistence/surreal/auth_runtime/login.py
@@ -106,41 +106,85 @@ async def _upsert_identity_provider(
     await repo.replace_record("identity_provider", uuid=provider_id, record=record)
 
 
+async def _resolve_oidc_organization_record(
+    client: QueryClient,
+    *,
+    organization_slug: str,
+) -> SurrealRecord:
+    slug = organization_slug.strip()
+    if not slug:
+        msg = "OIDC organization slug is required"
+        raise ValueError(msg)
+    organization = await _SurrealRepository(client).select_one(
+        """
+            SELECT * FROM organizations
+            WHERE slug = $slug AND is_personal = false
+            LIMIT 1;
+        """,
+        slug=slug,
+    )
+    if organization is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "oidc_organization_unavailable",
+                "message": "OIDC organization is not configured",
+            },
+        )
+    return organization
+
+
 async def _ensure_oidc_organization_membership_record(
     client: QueryClient,
     *,
     user_id: UUID,
-    user_name: str,
+    organization: SurrealRecord,
+    role: OrganizationRole,
 ) -> SurrealRecord:
     repo = _SurrealRepository(client)
-    # SECURITY: OIDC JIT provisioning must never auto-join global organizations.
-    # Require an existing membership and keep the existing role assignment.
+    organization_id = _coerce_uuid(organization.get("uuid"), field_name="organization.uuid")
     membership = await repo.select_one(
         """
-            SELECT *
-            FROM organization_members
-            WHERE user_id = $user_id
-              AND organization_id IN (
-                  SELECT VALUE uuid FROM organizations WHERE is_personal = false
-              )
-            ORDER BY created_at ASC
+            SELECT * FROM organization_members
+            WHERE organization_id = $organization_id AND user_id = $user_id
             LIMIT 1;
         """,
+        organization_id=str(organization_id),
         user_id=str(user_id),
     )
+    now = _utcnow()
     if membership is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"code": "oidc_membership_required", "message": "OIDC membership required"},
+        write_result = await client.execute_query(
+            "CREATE organization_members CONTENT $record;",
+            record={
+                "uuid": str(uuid4()),
+                "organization_id": str(organization_id),
+                "user_id": str(user_id),
+                "role": role.value,
+                "created_at": now,
+                "updated_at": now,
+            },
         )
-    organization_id = _coerce_uuid(membership.get("organization_id"), field_name="organization_id")
-    organization = await repo.select_one(
-        "SELECT * FROM organizations WHERE uuid = $uuid LIMIT 1;",
-        uuid=str(organization_id),
-    )
-    if organization is None:
-        msg = f"Failed to resolve OIDC organization for {user_name or user_id}"
-        raise RuntimeError(msg)
+    elif _role_value(membership.get("role")) != role.value:
+        write_result = await client.execute_query(
+            """
+                UPDATE organization_members
+                SET role = $role, updated_at = $updated_at
+                WHERE uuid = $uuid;
+            """,
+            uuid=str(_coerce_uuid(membership.get("uuid"), field_name="membership.uuid")),
+            role=role.value,
+            updated_at=now,
+        )
+    else:
+        write_result = None
+    if write_result is not None:
+        error = _query_error(write_result)
+        if error is not None:
+            raise RuntimeError(error)
+        if not _normalize_records(write_result):
+            msg = "Failed to write OIDC organization membership"
+            raise RuntimeError(msg)
     return organization
 
 
@@ -148,6 +192,7 @@ async def login_oidc_identity(
     *,
     provider_name: str,
     issuer: str,
+    organization_slug: str,
     client_id: str | None = None,
     scopes: list[str] | None = None,
     role_claim: str | None = None,
@@ -172,6 +217,10 @@ async def login_oidc_identity(
         _auth_client_scope() as client,
     ):
         repo = _SurrealRepository(client)
+        oidc_organization = await _resolve_oidc_organization_record(
+            client,
+            organization_slug=organization_slug,
+        )
         await _upsert_identity_provider(
             client,
             provider_name=provider,
@@ -291,7 +340,8 @@ async def login_oidc_identity(
                 await _ensure_oidc_organization_membership_record(
                     client,
                     user_id=user_id,
-                    user_name=display_name,
+                    organization=oidc_organization,
+                    role=org_role,
                 )
             ),
             label="organization",

--- a/apps/api/src/sibyl/persistence/surreal/auth_runtime/login.py
+++ b/apps/api/src/sibyl/persistence/surreal/auth_runtime/login.py
@@ -166,6 +166,9 @@ async def _ensure_oidc_organization_membership_record(
             },
         )
     elif _role_value(membership.get("role")) != role.value:
+        # The verified IdP claim is authoritative here, unlike operator-driven role
+        # changes: demoting the last owner is allowed, and ownership returns with the
+        # next login that carries an owner claim.
         write_result = await client.execute_query(
             """
                 UPDATE organization_members

--- a/apps/api/tests/test_auth_settings.py
+++ b/apps/api/tests/test_auth_settings.py
@@ -13,6 +13,7 @@ def _oidc_provider(**overrides) -> dict[str, object]:
         "issuer": "https://login.microsoftonline.com/tenant/v2.0",
         "client_id": "sibyl-client",
         "client_secret_env": "SIBYL_OIDC_ENTRA_CLIENT_SECRET",
+        "organization_slug": "acme",
     }
     provider.update(overrides)
     return provider
@@ -339,9 +340,31 @@ def test_settings_oidc_accepts_corporate_provider_config() -> None:
     assert provider.name == "entra"
     assert provider.scopes == ["openid", "profile", "email", "groups"]
     assert provider.role_claim_override is None
+    assert provider.organization_slug == "acme"
     assert s.oidc.role_claim == "resource_access.sibyl.roles"
     assert s.oidc.redirect_uri_base == "https://sibyl.example.com/"
     assert s.oidc.session_minutes == 45
+
+
+def test_settings_oidc_requires_provider_organization_binding() -> None:
+    provider = _oidc_provider()
+    provider.pop("organization_slug")
+
+    with pytest.raises(ValidationError, match="organization_slug"):
+        Settings(_env_file=None, oidc={"providers": [provider]})
+
+
+def test_settings_oidc_rejects_duplicate_provider_names() -> None:
+    with pytest.raises(ValidationError, match="provider names must be unique"):
+        Settings(
+            _env_file=None,
+            oidc={
+                "providers": [
+                    _oidc_provider(name="entra"),
+                    _oidc_provider(name="ENTRA", organization_slug="other"),
+                ]
+            },
+        )
 
 
 def test_settings_oidc_parses_json_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -355,7 +378,8 @@ def test_settings_oidc_parses_json_env(monkeypatch: pytest.MonkeyPatch) -> None:
               "issuer": "https://example.okta.com/oauth2/default",
               "client_id": "sibyl-client",
               "client_secret_env": "SIBYL_OIDC_OKTA_CLIENT_SECRET",
-              "role_claim_override": "groups"
+              "role_claim_override": "groups",
+              "organization_slug": "  acme  "
             }
           ],
           "role_claim": "groups"
@@ -368,6 +392,7 @@ def test_settings_oidc_parses_json_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert s.oidc.providers[0].name == "okta"
     assert s.oidc.providers[0].scopes == ["openid", "profile", "email"]
     assert s.oidc.providers[0].role_claim_override == "groups"
+    assert s.oidc.providers[0].organization_slug == "acme"
     assert s.oidc.role_claim == "groups"
 
 

--- a/apps/api/tests/test_jit_provisioning.py
+++ b/apps/api/tests/test_jit_provisioning.py
@@ -18,6 +18,7 @@ def _provider() -> OIDCProviderSettings:
         issuer="https://example.okta.com/oauth2/default",
         client_id="sibyl-client",
         client_secret_env="SIBYL_OIDC_OKTA_CLIENT_SECRET",
+        organization_slug="acme",
     )
 
 
@@ -64,6 +65,7 @@ async def test_jit_provisions_member_role_without_email_matching(
     assert call["subject_key"] == "oidc:https://example.okta.com/oauth2/default:subject"
     assert call["email"] == "shared@example.com"
     assert call["role"] is OrganizationRole.MEMBER
+    assert call["organization_slug"] == "acme"
 
 
 def test_jit_rejects_user_after_sibyl_role_removed(

--- a/apps/api/tests/test_oidc.py
+++ b/apps/api/tests/test_oidc.py
@@ -33,6 +33,7 @@ def _provider() -> OIDCProviderSettings:
         issuer="https://login.microsoftonline.com/tenant/v2.0",
         client_id="sibyl-client",
         client_secret_env="SIBYL_OIDC_ENTRA_CLIENT_SECRET",
+        organization_slug="acme",
     )
 
 
@@ -71,6 +72,19 @@ def test_oidc_role_claim_supports_dotted_paths(monkeypatch: pytest.MonkeyPatch) 
     )
 
     assert role is OrganizationRole.MEMBER
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        ["Sibyl.Member", "Sibyl.Admin"],
+        ["Sibyl.Admin", "Sibyl.Member"],
+    ],
+)
+def test_oidc_role_claim_uses_deterministic_privilege_precedence(claims: list[str]) -> None:
+    role = oidc.extract_sibyl_role({"roles": claims}, provider=_provider())
+
+    assert role is OrganizationRole.ADMIN
 
 
 def test_oidc_stable_subject_uses_entra_tenant_object_id() -> None:

--- a/apps/api/tests/test_silent_refresh.py
+++ b/apps/api/tests/test_silent_refresh.py
@@ -34,6 +34,7 @@ def _provider() -> OIDCProviderSettings:
         issuer="https://login.microsoftonline.com/tenant/v2.0",
         client_id="sibyl-client",
         client_secret_env="SIBYL_OIDC_ENTRA_CLIENT_SECRET",
+        organization_slug="acme",
     )
 
 

--- a/apps/api/tests/test_surreal_auth_runtime.py
+++ b/apps/api/tests/test_surreal_auth_runtime.py
@@ -2054,62 +2054,145 @@ async def test_list_user_org_records_batches_organization_reads() -> None:
 
 
 @pytest.mark.asyncio
-async def test_oidc_membership_lookup_uses_surrealql_without_table_alias() -> None:
-    user_id = uuid4()
+async def test_oidc_organization_binding_resolves_exact_non_personal_slug() -> None:
     organization_id = uuid4()
     client = _SequenceAuthClient(
         [
             [
                 {
-                    "uuid": str(uuid4()),
-                    "user_id": str(user_id),
-                    "organization_id": str(organization_id),
-                    "role": "member",
-                }
-            ],
-            [
-                {
                     "uuid": str(organization_id),
-                    "name": "Team Org",
-                    "slug": "team-org",
+                    "name": "Acme",
+                    "slug": "acme",
                     "is_personal": False,
                 }
-            ],
+            ]
         ]
     )
 
-    organization = await auth_login._ensure_oidc_organization_membership_record(
+    organization = await auth_login._resolve_oidc_organization_record(
         client,
-        user_id=user_id,
-        user_name="Bliss",
+        organization_slug="acme",
     )
 
+    assert organization is not None
     assert organization["uuid"] == str(organization_id)
     query, params = client.calls[0]
-    assert "FROM organization_members" in query
-    assert "FROM organization_members om" not in query
-    assert "om." not in query
-    assert params == {"user_id": str(user_id)}
+    assert "slug = $slug AND is_personal = false" in query
+    assert params == {"slug": "acme"}
 
 
 @pytest.mark.asyncio
-async def test_oidc_membership_lookup_requires_existing_non_personal_membership() -> None:
-    user_id = uuid4()
+async def test_oidc_organization_binding_fails_closed_when_slug_is_missing() -> None:
     client = _SequenceAuthClient([[]])
 
     with pytest.raises(HTTPException) as exc_info:
-        await auth_login._ensure_oidc_organization_membership_record(
+        await auth_login._resolve_oidc_organization_record(
             client,
-            user_id=user_id,
-            user_name="Bliss",
+            organization_slug="missing",
         )
 
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail["code"] == "oidc_membership_required"
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail["code"] == "oidc_organization_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_oidc_login_resolves_binding_before_persisting_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _SequenceAuthClient([[]])
+    monkeypatch.setattr(
+        auth_login,
+        "_auth_client_scope",
+        lambda: _StaticAuthClientScope(client),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_login.login_oidc_identity(
+            provider_name="entra",
+            issuer="https://login.microsoftonline.com/tenant/v2.0",
+            organization_slug="missing",
+            subject="subject",
+            subject_key="entra:tenant:object",
+            email="bliss@example.com",
+            name="Bliss",
+            avatar_url=None,
+            role=OrganizationRole.MEMBER,
+            claims={"roles": ["Sibyl.Member"]},
+            request=SimpleNamespace(),
+        )
+
+    assert exc_info.value.detail["code"] == "oidc_organization_unavailable"
     assert len(client.calls) == 1
+    assert "FROM organizations" in client.calls[0][0]
+
+
+@pytest.mark.asyncio
+async def test_oidc_organization_binding_creates_claim_role_membership() -> None:
+    user_id = uuid4()
+    organization_id = uuid4()
+    organization = {
+        "uuid": str(organization_id),
+        "name": "Acme",
+        "slug": "acme",
+        "is_personal": False,
+    }
+    client = _SequenceAuthClient([[], [{"uuid": str(uuid4())}]])
+
+    result = await auth_login._ensure_oidc_organization_membership_record(
+        client,
+        user_id=user_id,
+        organization=organization,
+        role=OrganizationRole.ADMIN,
+    )
+
+    assert result == organization
     query, params = client.calls[0]
-    assert "is_personal = false" in query
-    assert params == {"user_id": str(user_id)}
+    assert "organization_id = $organization_id AND user_id = $user_id" in query
+    assert params == {
+        "organization_id": str(organization_id),
+        "user_id": str(user_id),
+    }
+    create_query, create_params = client.calls[1]
+    assert "CREATE organization_members CONTENT $record" in create_query
+    assert create_params["record"]["role"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_oidc_organization_binding_updates_claim_role_membership() -> None:
+    user_id = uuid4()
+    organization_id = uuid4()
+    membership_id = uuid4()
+    organization = {
+        "uuid": str(organization_id),
+        "name": "Acme",
+        "slug": "acme",
+        "is_personal": False,
+    }
+    client = _SequenceAuthClient(
+        [
+            [
+                {
+                    "uuid": str(membership_id),
+                    "organization_id": str(organization_id),
+                    "user_id": str(user_id),
+                    "role": "owner",
+                }
+            ],
+            [{"uuid": str(membership_id), "role": "member"}],
+        ]
+    )
+
+    await auth_login._ensure_oidc_organization_membership_record(
+        client,
+        user_id=user_id,
+        organization=organization,
+        role=OrganizationRole.MEMBER,
+    )
+
+    update_query, update_params = client.calls[1]
+    assert "UPDATE organization_members" in update_query
+    assert update_params["uuid"] == str(membership_id)
+    assert update_params["role"] == "member"
 
 
 @pytest.mark.asyncio

--- a/charts/sibyl/templates/_helpers.tpl
+++ b/charts/sibyl/templates/_helpers.tpl
@@ -128,7 +128,7 @@ Fail fast when a non-corporate extra provider is configured without the explicit
 */}}
 {{- define "sibyl.validateOidcProviders" -}}
 {{- range $provider := .Values.oidc.providers }}
-{{- if not (default "" $provider.organization_slug) -}}
+{{- if not (trim (default "" $provider.organization_slug)) -}}
 {{- fail "every OIDC provider requires organization_slug for an exact non-personal organization binding" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/sibyl/templates/_helpers.tpl
+++ b/charts/sibyl/templates/_helpers.tpl
@@ -127,6 +127,11 @@ app.kubernetes.io/component: worker
 Fail fast when a non-corporate extra provider is configured without the explicit opt-in.
 */}}
 {{- define "sibyl.validateOidcProviders" -}}
+{{- range $provider := .Values.oidc.providers }}
+{{- if not (default "" $provider.organization_slug) -}}
+{{- fail "every OIDC provider requires organization_slug for an exact non-personal organization binding" -}}
+{{- end -}}
+{{- end -}}
 {{- if not .Values.oidc.extra_providers_enabled -}}
 {{- range $provider := .Values.oidc.providers }}
 {{- $name := lower (default "" $provider.name) -}}

--- a/charts/sibyl/templates/backend-deployment.yaml
+++ b/charts/sibyl/templates/backend-deployment.yaml
@@ -74,6 +74,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.backend.existingSecret }}
                   key: SIBYL_JWT_SECRET
+            - name: SIBYL_SETTINGS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backend.existingSecret }}
+                  key: SIBYL_SETTINGS_KEY
             - name: SIBYL_OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/sibyl/templates/worker-deployment.yaml
+++ b/charts/sibyl/templates/worker-deployment.yaml
@@ -72,6 +72,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.backend.existingSecret }}
                   key: SIBYL_JWT_SECRET
+            - name: SIBYL_SETTINGS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backend.existingSecret }}
+                  key: SIBYL_SETTINGS_KEY
             - name: SIBYL_OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/sibyl/values.yaml
+++ b/charts/sibyl/values.yaml
@@ -32,6 +32,7 @@ oidc:
   #     issuer: "https://login.microsoftonline.com/<tenant-id>/v2.0"
   #     client_id: ""
   #     client_secret_env: "SIBYL_OIDC_ENTRA_CLIENT_SECRET"
+  #     organization_slug: "acme"
   #     scopes: ["openid", "profile", "email"]
   #     role_claim_override: ""
   # -- Global role claim, supports dotted paths such as "resource_access.sibyl.roles".

--- a/charts/sibyl/values.yaml
+++ b/charts/sibyl/values.yaml
@@ -163,7 +163,8 @@ backend:
     NUMEXPR_NUM_THREADS: "1"
 
   # -- Reference to existing secret for sensitive env vars
-  # Must contain: SIBYL_JWT_SECRET, SIBYL_OPENAI_API_KEY, SIBYL_ANTHROPIC_API_KEY
+  # Must contain: SIBYL_JWT_SECRET and SIBYL_SETTINGS_KEY.
+  # Add provider and LLM API keys as needed. Production and read-only containers require this.
   existingSecret: ""
 
   # -- SurrealDB connection settings

--- a/docs/admin/installing.md
+++ b/docs/admin/installing.md
@@ -77,6 +77,7 @@ oidc:
       issuer: "https://login.microsoftonline.com/<tenant-id>/v2.0"
       client_id: "<app-client-id>"
       client_secret_env: "SIBYL_OIDC_ENTRA_CLIENT_SECRET"
+      organization_slug: "acme"
       scopes: ["openid", "profile", "email"]
   role_claim: "roles"
   session_minutes: 60
@@ -120,6 +121,10 @@ networkPolicy:
 podSecurity:
   enforceRestricted: true
 ```
+
+`organization_slug` is required for every OIDC provider and must exactly match a bootstrapped
+non-personal Sibyl organization. A verified role claim creates or updates membership only in that
+bound organization.
 
 Keep cloud-specific annotations, certificate issuers, secret references, object storage mounts, and
 SIEM wiring in a deployment overlay.

--- a/docs/admin/inviting-users.md
+++ b/docs/admin/inviting-users.md
@@ -61,6 +61,10 @@ identity binding on the provider subject and only stores safe profile data.
 Sibyl never chooses the oldest or first organization membership and never changes the user's other
 organization memberships during OIDC login.
 
+The role claim is authoritative for the bound organization. Unlike in-app role management, an OIDC
+login carrying a lower role can demote the organization's last owner; grant the owner role in the
+identity provider and ownership is restored on that user's next login.
+
 ## Giving Access
 
 Grant access in the identity provider:

--- a/docs/admin/inviting-users.md
+++ b/docs/admin/inviting-users.md
@@ -42,7 +42,8 @@ link. See [Installing Sibyl](installing.md#transactional-email).
 
 ## JIT Provisioning (Enterprise SSO)
 
-Enterprise Sibyl uses just-in-time provisioning. Users do not need pre-created Sibyl accounts when
+Enterprise Sibyl uses just-in-time provisioning. Each OIDC provider is bound to one exact
+non-personal organization by `organization_slug`. Users do not need pre-created Sibyl accounts when
 the identity provider sends a valid stable subject and a Sibyl role claim.
 
 On first OIDC login, Sibyl:
@@ -51,11 +52,14 @@ On first OIDC login, Sibyl:
 2. Reads the stable subject key.
 3. Reads the configured role claim.
 4. Creates a User record if the subject has not been seen before.
-5. Creates or updates the Organization membership from the role claim.
+5. Creates or updates membership in the provider-bound organization from the role claim.
 6. Records an audit event for the login.
 
 Email is not used to find the user. If an email address collides with another user, Sibyl keeps
 identity binding on the provider subject and only stores safe profile data.
+
+Sibyl never chooses the oldest or first organization membership and never changes the user's other
+organization memberships during OIDC login.
 
 ## Giving Access
 

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -103,6 +103,7 @@ an owner can sign in through it, and only then set `SIBYL_LOCAL_AUTH_ENABLED=fal
       "issuer": "https://login.microsoftonline.com/<tenant-id>/v2.0",
       "client_id": "<app-client-id>",
       "client_secret_env": "SIBYL_OIDC_ENTRA_CLIENT_SECRET",
+      "organization_slug": "acme",
       "scopes": ["openid", "profile", "email"]
     }
   ],
@@ -113,6 +114,9 @@ an owner can sign in through it, and only then set `SIBYL_LOCAL_AUTH_ENABLED=fal
   "extra_providers_enabled": false
 }
 ```
+
+Every provider requires `organization_slug`. It binds that provider to one exact non-personal
+organization; OIDC login never chooses an organization from the user's other memberships.
 
 Non-corporate providers such as GitHub or Google require `"extra_providers_enabled": true`; leave it
 false for enterprise SSO.

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -336,6 +336,7 @@ export SIBYL_LOG_LEVEL=DEBUG
 ```bash
 SIBYL_ENVIRONMENT=production
 SIBYL_JWT_SECRET=<generate with: openssl rand -hex 32>
+SIBYL_SETTINGS_KEY=<generate with: openssl rand -base64 32 | tr '+/' '-_'>
 
 # Public URL (Kong/ingress domain)
 SIBYL_PUBLIC_URL=https://sibyl.example.com
@@ -370,6 +371,7 @@ payload. New production deployments should use the fully Surreal example above.
 ```bash
 SIBYL_ENVIRONMENT=production
 SIBYL_JWT_SECRET=<generate with: openssl rand -hex 32>
+SIBYL_SETTINGS_KEY=<generate with: openssl rand -base64 32 | tr '+/' '-_'>
 SIBYL_PUBLIC_URL=https://sibyl.example.com
 
 # Surreal target

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -226,9 +226,15 @@ backend:
 ```yaml
 backend:
   # Reference to existing secret for sensitive env vars
-  # Must contain: SIBYL_JWT_SECRET, SIBYL_OPENAI_API_KEY, SIBYL_ANTHROPIC_API_KEY
+  # Must contain: SIBYL_JWT_SECRET and SIBYL_SETTINGS_KEY.
+  # Add provider and LLM API keys as needed.
   existingSecret: ""
 ```
+
+Production and read-only containers must set `existingSecret`. Both required keys are non-optional
+pod references, so a missing key fails before Sibyl starts instead of silently generating an
+ephemeral replacement. Keep `SIBYL_SETTINGS_KEY` stable across upgrades and pod replacements;
+changing it makes encrypted settings unreadable.
 
 ### Storage Mode
 

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -67,6 +67,21 @@ For enterprise SSO deployments, configure a corporate OIDC provider and set
 `auth.localAuthEnabled=false` only after an owner has successfully signed in through OIDC.
 Break-glass access remains a separate, bounded opt-in.
 
+Each configured provider requires an exact organization binding:
+
+```yaml
+oidc:
+  providers:
+    - name: entra
+      issuer: "https://login.microsoftonline.com/<tenant-id>/v2.0"
+      client_id: "<app-client-id>"
+      client_secret_env: "SIBYL_OIDC_ENTRA_CLIENT_SECRET"
+      organization_slug: "acme"
+```
+
+The organization must already exist and must not be personal. Helm rejects providers without this
+binding, and Sibyl fails closed if the bound organization cannot be resolved.
+
 ## Backend Configuration
 
 ### Basic Settings

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -45,6 +45,7 @@ kubectl create namespace sibyl
 # Create secrets (Surreal default)
 kubectl create secret generic sibyl-secrets -n sibyl \
   --from-literal=SIBYL_JWT_SECRET=$(openssl rand -hex 32) \
+  --from-literal=SIBYL_SETTINGS_KEY=$(openssl rand -base64 32 | tr '+/' '-_') \
   --from-literal=SIBYL_OPENAI_API_KEY=sk-... \
   --from-literal=SIBYL_ANTHROPIC_API_KEY=sk-ant-...
 

--- a/docs/users/login.md
+++ b/docs/users/login.md
@@ -31,11 +31,14 @@ a role claim, then Sibyl issues its own short-lived session for the web app.
    access.
 4. The browser returns to Sibyl with an ID token.
 5. Sibyl verifies the token signature, issuer, audience, expiry, nonce, and role claim.
-6. If the role claim contains a Sibyl role, Sibyl creates or updates your user record and signs you
-   in.
+6. If the role claim contains a Sibyl role, Sibyl creates or updates your membership in the
+   provider-bound organization and signs you in.
 
 Sibyl does not use your email address as the identity key. Email is only a profile field for display
 and audit readability.
+
+Operators bind each provider to one non-personal organization with `organization_slug`. Login never
+selects an organization from your other memberships.
 
 ## Role Claims
 

--- a/tools/tests/test_enterprise_readiness_evidence.py
+++ b/tools/tests/test_enterprise_readiness_evidence.py
@@ -103,6 +103,42 @@ def _cosign_receipt(image: str) -> str:
     )
 
 
+def _cosign_receipt_v2(image: str) -> str:
+    payload = json.loads(_cosign_receipt(image))
+    digest = payload["digest"]
+    repositories = [
+        f"ghcr.io/hyperb1iss/sibyl-{image}",
+        f"docker.io/hyperb1iss/sibyl-{image}",
+    ]
+    payload["schema_version"] = "sibyl-cosign-receipt-v2"
+    payload["signed_images"] = [
+        {
+            "repository": repository,
+            "digest": digest,
+            "image_ref": f"{repository}@{digest}",
+        }
+        for repository in repositories
+    ]
+    return json.dumps(payload)
+
+
+def test_validate_cosign_receipt_accepts_dual_registry_v2(tmp_path: Path) -> None:
+    receipt = tmp_path / "sibyl-api-1.2.3-cosign-receipt.json"
+    receipt.write_text(_cosign_receipt_v2("api"), encoding="utf-8")
+
+    evidence._validate_cosign_receipt(receipt, image="api")
+
+
+def test_validate_cosign_receipt_rejects_v2_without_docker_hub(tmp_path: Path) -> None:
+    payload = json.loads(_cosign_receipt_v2("api"))
+    payload["signed_images"] = payload["signed_images"][:1]
+    receipt = tmp_path / "sibyl-api-1.2.3-cosign-receipt.json"
+    receipt.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(evidence.EvidenceFailure, match="both registry signatures"):
+        evidence._validate_cosign_receipt(receipt, image="api")
+
+
 def test_required_evidence_covers_external_acceptance_gates() -> None:
     keys = {requirement.key for requirement in evidence.REQUIRED_EVIDENCE}
 
@@ -686,6 +722,8 @@ def test_capture_rendered_helm_manifests_updates_manifest(
 ) -> None:
     def fake_helm_output(args: list[str]) -> str:
         if args[2] == "charts/sibyl":
+            assert "oidc.providers[0].organization_slug=enterprise" in args
+            assert "bootstrap.organization.slug=enterprise" in args
             return """
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/tools/tests/test_release_workflow.py
+++ b/tools/tests/test_release_workflow.py
@@ -291,7 +291,8 @@ def test_publish_workflow_packages_and_publishes_immutable_helm_charts() -> None
     assert "helm package charts/sibyl" in workflow
     assert "helm package charts/surrealdb" in workflow
     assert "Refusing to replace immutable chart" in workflow
-    assert "helm repo index helm-repo" in workflow
+    assert "same_chart_contents" in workflow
+    assert "helm repo index new-packages" in workflow
     assert "--merge helm-repo/index.yaml" in workflow
     assert "https://raw.githubusercontent.com/hyperb1iss/sibyl/gh-pages" in workflow
     assert "git -C helm-repo push origin HEAD:gh-pages" in workflow

--- a/tools/tests/test_release_workflow.py
+++ b/tools/tests/test_release_workflow.py
@@ -231,7 +231,7 @@ def test_publish_workflow_keeps_install_instructions_current() -> None:
 def test_publish_workflow_attaches_docker_and_release_evidence() -> None:
     workflow = _publish_workflow()
 
-    assert "needs: [python, homebrew, aur, docker-sign]" in workflow
+    assert "needs: [python, homebrew, aur, docker-sign, helm-publish]" in workflow
     assert "docker-security:" in workflow
     assert "fail-fast: false" in workflow
     assert "docker-sign:" in workflow
@@ -259,6 +259,45 @@ def test_publish_workflow_attaches_docker_and_release_evidence() -> None:
     assert "append_body:" not in workflow
     assert "release-assets/*" in workflow
     assert "fail_on_unmatched_files: true" in workflow
+
+
+def test_publish_workflow_dual_publishes_identical_signed_images() -> None:
+    workflow = _publish_workflow()
+
+    assert "registry-preflight:" in workflow
+    assert "DOCKERHUB_USERNAME" in workflow
+    assert "DOCKERHUB_TOKEN" in workflow
+    assert "hub.docker.com/v2/repositories/${DOCKERHUB_NAMESPACE}/sibyl-${image}" in workflow
+    assert "needs: [rc-gate, registry-preflight]" in workflow
+    assert "GHCR_REPO" in workflow
+    assert "DOCKERHUB_REPO" in workflow
+    assert 'type=image,"name=${{ env.GHCR_REGISTRY }}' in workflow
+    assert 'test "$ghcr_digest" = "$dockerhub_digest"' in workflow
+    assert workflow.count('cosign sign --yes "$ghcr_ref"') == 1
+    assert workflow.count('cosign sign --yes "$dockerhub_ref"') == 1
+    assert '"schema_version": "sibyl-cosign-receipt-v2"' in workflow
+    assert '"signed_images": [' in workflow
+    assert workflow.count("Upload Cosign receipt") == 1
+
+
+def test_publish_workflow_packages_and_publishes_immutable_helm_charts() -> None:
+    workflow = _publish_workflow()
+
+    assert "helm-package:" in workflow
+    assert "helm-publish:" in workflow
+    assert "azure/setup-helm@v5.0.0" in workflow
+    assert "version: v3.20.2" in workflow
+    assert "helm dependency list charts/surrealdb" in workflow
+    assert "helm package charts/sibyl" in workflow
+    assert "helm package charts/surrealdb" in workflow
+    assert "Refusing to replace immutable chart" in workflow
+    assert "helm repo index helm-repo" in workflow
+    assert "--merge helm-repo/index.yaml" in workflow
+    assert "https://raw.githubusercontent.com/hyperb1iss/sibyl/gh-pages" in workflow
+    assert "git -C helm-repo push origin HEAD:gh-pages" in workflow
+    assert "sibyl-helm-${{ inputs.tag }}" in workflow
+    assert "Download Helm charts" in workflow
+    assert "-name '*.tgz'" in workflow
 
 
 def test_publish_workflow_summary_links_all_package_channels() -> None:

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -129,12 +129,12 @@ def test_install_surfaces_default_to_local_first_auth() -> None:
 
 
 def test_helm_runtime_secret_requires_stable_settings_key() -> None:
-    backend = (
-        REPO_ROOT / "charts/sibyl/templates/backend-deployment.yaml"
-    ).read_text(encoding="utf-8")
-    worker = (
-        REPO_ROOT / "charts/sibyl/templates/worker-deployment.yaml"
-    ).read_text(encoding="utf-8")
+    backend = (REPO_ROOT / "charts/sibyl/templates/backend-deployment.yaml").read_text(
+        encoding="utf-8"
+    )
+    worker = (REPO_ROOT / "charts/sibyl/templates/worker-deployment.yaml").read_text(
+        encoding="utf-8"
+    )
 
     assert "key: SIBYL_SETTINGS_KEY" in backend
     assert "key: SIBYL_SETTINGS_KEY" in worker

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -128,6 +128,18 @@ def test_install_surfaces_default_to_local_first_auth() -> None:
     assert "extra_providers_enabled: false" in helm_values
 
 
+def test_helm_runtime_secret_requires_stable_settings_key() -> None:
+    backend = (
+        REPO_ROOT / "charts/sibyl/templates/backend-deployment.yaml"
+    ).read_text(encoding="utf-8")
+    worker = (
+        REPO_ROOT / "charts/sibyl/templates/worker-deployment.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert "key: SIBYL_SETTINGS_KEY" in backend
+    assert "key: SIBYL_SETTINGS_KEY" in worker
+
+
 CORE_LEGACY_GRAPH_CONTRACT_MARKED_TESTS = (
     "tests/test_models.py",
     "tests/test_retrieval_advanced.py",

--- a/tools/trust/enterprise_readiness_evidence.py
+++ b/tools/trust/enterprise_readiness_evidence.py
@@ -36,6 +36,8 @@ DEFAULT_GITHUB_REPO = "hyperb1iss/sibyl"
 DEFAULT_GITHUB_WORKFLOW = "publish.yml"
 GITHUB_RELEASE_IMAGES = ("api", "web")
 COSIGN_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+COSIGN_RECEIPT_V2 = "sibyl-cosign-receipt-v2"
+COSIGN_V2_SIGNATURE_COUNT = 2
 LOCAL_KUBERNETES_CONTEXTS = (
     "orbstack",
     "docker-desktop",
@@ -103,6 +105,10 @@ SIBYL_HELM_RENDER_ARGS = (
     "oidc.providers[0].client_id=sibyl-client",
     "--set",
     "oidc.providers[0].client_secret_env=SIBYL_OIDC_ENTRA_CLIENT_SECRET",
+    "--set",
+    "oidc.providers[0].organization_slug=enterprise",
+    "--set",
+    "bootstrap.organization.slug=enterprise",
 )
 SURREALDB_HELM_RENDER_ARGS = (
     "template",
@@ -2827,6 +2833,50 @@ def _validate_cosign_receipt(path: Path, *, image: str) -> None:
     signer = payload.get("signer")
     if not isinstance(signer, str) or not signer.strip():
         msg = f"Cosign receipt for {image} must include signer metadata: {path.name}"
+        raise EvidenceFailure(msg)
+
+    schema_version = payload.get("schema_version")
+    if schema_version is None:
+        return
+    if schema_version != COSIGN_RECEIPT_V2:
+        msg = f"Cosign receipt for {image} has unsupported schema: {path.name}"
+        raise EvidenceFailure(msg)
+    _validate_dual_registry_cosign_receipt(payload, path=path, image=image, digest=digest)
+
+
+def _validate_dual_registry_cosign_receipt(
+    payload: Mapping[str, object],
+    *,
+    path: Path,
+    image: str,
+    digest: str,
+) -> None:
+    signed_images = payload.get("signed_images")
+    if not isinstance(signed_images, list) or len(signed_images) != COSIGN_V2_SIGNATURE_COUNT:
+        msg = f"Cosign receipt for {image} must include both registry signatures: {path.name}"
+        raise EvidenceFailure(msg)
+    expected_repositories = {
+        f"ghcr.io/hyperb1iss/sibyl-{image}",
+        f"docker.io/hyperb1iss/sibyl-{image}",
+    }
+    repositories: set[str] = set()
+    for signed_image in signed_images:
+        if not isinstance(signed_image, Mapping):
+            msg = f"Cosign receipt for {image} has invalid signed image metadata: {path.name}"
+            raise EvidenceFailure(msg)
+        repository = signed_image.get("repository")
+        signed_digest = signed_image.get("digest")
+        signed_ref = signed_image.get("image_ref")
+        if (
+            not isinstance(repository, str)
+            or signed_digest != digest
+            or signed_ref != f"{repository}@{digest}"
+        ):
+            msg = f"Cosign receipt for {image} has mismatched registry digest: {path.name}"
+            raise EvidenceFailure(msg)
+        repositories.add(repository)
+    if repositories != expected_repositories:
+        msg = f"Cosign receipt for {image} must sign GHCR and Docker Hub: {path.name}"
         raise EvidenceFailure(msg)
 
 


### PR DESCRIPTION
# 🔗 Enterprise identity and release channels

> Completes Sibyl's application-side contract for the first managed internal-cluster deployment. No release, registry repository, or external account state is created by this PR.

## 💡 What this is

Enterprise OIDC providers now bind identities to one explicit, pre-existing organization instead of relying on ambient organization state. The release pipeline also gains a second public container channel and a maintained Helm repository, so downstream deployments can choose Docker Hub without introducing registry-specific infrastructure into their own stacks.

## 🤔 Why we need it & what it replaces

The previous JIT flow persisted a user before it had resolved an enterprise organization, then inferred authorization from broader user state. That is unsafe for a managed tenant because a valid identity token must never choose its organization implicitly.

The existing release workflow published only GHCR images and expected Helm charts to be published manually. This change keeps GHCR fully supported while adding Docker Hub parity and automated immutable chart publication. GHCR remains the default image source until the first dual-registry release is verified.

## 🎯 Review anchor

A provider's `organization_slug` is resolved as one exact non-personal organization before any user or identity persistence. The verified role claim can update membership only in that organization; it cannot change global admin state or memberships elsewhere.

For releases, each architecture is built once. GHCR and Docker Hub manifests must resolve to the same digest before scanning, signing, or release creation can continue.

## 🛠️ How it works

1. `apps/api/src/sibyl/auth/oidc.py` requires a unique organization binding on every provider. `apps/api/src/sibyl/persistence/surreal/auth_runtime/login.py` resolves that organization before persistence and synchronizes only its membership. Role precedence is deterministic: owner, admin, then member.
2. `charts/sibyl/templates/backend-deployment.yaml` and `worker-deployment.yaml` require `SIBYL_SETTINGS_KEY` whenever `backend.existingSecret` is configured. The deployment docs now describe both stable runtime keys.
3. `.github/workflows/publish.yml` pushes the same per-architecture build output to GHCR and Docker Hub, assembles matching multi-architecture manifests, verifies digest parity, scans once, and signs both registry-qualified references.
4. The same workflow packages `sibyl` and `sibyl-surrealdb`, rejects mutable replacements, merges the Helm index on `gh-pages`, and attaches both charts to the GitHub release. Immutability is judged on extracted chart contents rather than archive bytes, because `helm package` is not byte-reproducible across checkouts; re-running a tag's workflow after a partial failure is safe, and only new packages are re-indexed so published entries keep their original timestamps and digests.
5. `tools/trust/enterprise_readiness_evidence.py` validates the aggregate dual-registry signing receipt while retaining compatibility with existing v1 receipts.

## 🚦 Rollout sequencing

1. Merge this code without changing the current GHCR defaults.
2. Create the public Docker Hub repositories `hyperb1iss/sibyl-api` and `hyperb1iss/sibyl-web`.
3. Add `DOCKERHUB_USERNAME=hyperb1iss` as a repository variable and `DOCKERHUB_TOKEN` as a repository secret.
4. Cut the next release. Its preflight fails before native builds if that one-time setup is absent, and release creation waits for both signed registries plus Helm publication.
5. Downstream deployments may switch to Docker Hub only after that release's digest parity receipt is available.

## 🧪 Validation

- `moon run api:lint api:typecheck api:test` → 1,937 passed, 4 expected live-runtime skips; lint and typecheck clean.
- `moon run root:release-workflow-test root:enterprise-readiness-evidence-test` → 104 passed.
- `moon run root:inventory-lint root:inventory-typecheck` → both clean.
- `actionlint .github/workflows/publish.yml` → clean.
- `helm lint charts/sibyl && helm lint charts/surrealdb` → 2 charts linted, 0 failed.
- Local packaging rehearsal → `sibyl-1.0.2.tgz` and `sibyl-surrealdb-1.0.2.tgz` produced with the expected names and versions.
- Publish-step rehearsal with the extracted workflow script against the real `gh-pages` chart → content-identical re-run skips cleanly, a mutated same-version chart is refused, and a new version publishes with prior index entries preserved.
- Independent adversarial review → PASS with no branch-owned findings.
- Deep follow-up review (Nova/Claude) → one operational fix landed: the byte-level `cmp` immutability gate rejected every same-tag re-run because `helm package` archives embed file mtimes; now compares extracted contents. Also trims `organization_slug` at Helm render and documents the deliberate last-owner demotion behavior of authoritative role sync.

No live release, Docker Hub repository creation, signing, `gh-pages` push, or cluster mutation was performed.

## 🔍 What reviewers should focus on

- The persistence ordering and organization scope in the OIDC callback.
- Last-owner downgrade behavior during authoritative enterprise role sync.
- Digest comparison before scanning and signing both registry references.
- Immutable Helm package handling and serialized `gh-pages` updates.
- Backward compatibility of the release evidence receipt parser.

## 📌 Required before the next release

The two public Docker Hub repositories, repository variable, and write-scoped token are external setup, not code. The workflow intentionally fails closed until they exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases now publish signed container images to both GHCR and Docker Hub, with improved release-chain evidence.
  * Helm charts are packaged and published immutably to the Helm index, and included in release assets with updated install instructions.
  * OIDC providers now require an `organization_slug`, binding logins to a single non-personal organization and provisioning/updating membership from role claims.
  * Added `SIBYL_SETTINGS_KEY` secret wiring for Helm deployments.

* **Bug Fixes**
  * OIDC role selection is deterministic with explicit priority.
  * Stricter validation rejects missing or duplicate provider organization bindings.

* **Documentation**
  * Updated OIDC, Helm, Kubernetes, login, and enterprise SSO guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
