### PR TITLE
fix(core): satisfy ty 0.0.59 provider narrowing

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/embeddings/providers.py
+++ b/packages/python/sibyl-core/src/sibyl_core/embeddings/providers.py
@@ -649,7 +649,7 @@ def configured_embedding_provider() -> EmbeddingProvider | None:
         log.info("graph_embeddings_disabled", provider=provider, reason="missing_key")
         return None
 
-    provider_name = cast(EmbeddingProviderName, provider)
+    provider_name = provider
     cache_entry = _configured_provider_cache_entry(
         provider=provider_name,
         model=model,


### PR DESCRIPTION
## Why

The ty 0.0.59 upgrade preserves the validated provider literal type. The old explicit cast is now redundant and fails strict type checking on current main.

## What changed

Remove the redundant cast. Runtime behavior is unchanged.

## Validation

- `moon run --force core:check`
- lint and type checking passed
- 1832 tests passed, 16 skipped

## Reviewer focus

This is a type-only compatibility cleanup for ty 0.0.59.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal embedding provider configuration without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->