### PR TITLE
fix(cli): stop discarding offline writes the server may have applied

### DIFF
--- a/apps/cli/src/sibyl_cli/auth.py
+++ b/apps/cli/src/sibyl_cli/auth.py
@@ -529,7 +529,7 @@ def _login_auto(
     if email or password:
         if not email or not password:
             error("Local login requires both --email and --password.")
-            return
+            raise typer.Exit(1)
         try:
             tok = _login_via_local_password(
                 api_url=api_url,
@@ -539,12 +539,12 @@ def _login_auto(
             )
         except SibylClientError as e:
             error(str(e))
-            return
+            raise typer.Exit(1) from e
         except _OAuthLoginError as e:
             error(str(e))
             if e.payload is not None:
                 print_json(e.payload)
-            return
+            raise typer.Exit(1) from e
 
         _persist_tokens(
             api_url=api_url,
@@ -578,19 +578,19 @@ def _login_auto(
     except _NoBrowserLoginPrinted as e:
         success(str(e))
         return
-    except TimeoutError:
+    except TimeoutError as e:
         error("Timed out waiting for approval")
-        return
+        raise typer.Exit(1) from e
     except httpx.HTTPStatusError as e:
         # Not supported on server -> fall through to OAuth.
         if e.response.status_code not in {404, 405}:
             error(f"Device login failed: {e}")
-            return
+            raise typer.Exit(1) from e
     except _DeviceLoginError as e:
         error(str(e))
         if e.payload is not None:
             print_json(e.payload)
-        return
+        raise typer.Exit(1) from e
     except Exception as e:
         # Best-effort fall-through to OAuth when device flow isn't available.
         info(f"Device login unavailable ({type(e).__name__}); trying OAuth login.")
@@ -617,13 +617,13 @@ def _login_auto(
     except _NoBrowserLoginPrinted as e:
         success(str(e))
         return
-    except TimeoutError:
+    except TimeoutError as e:
         error("Timed out waiting for browser login")
-        return
+        raise typer.Exit(1) from e
     except httpx.HTTPStatusError as e:
         if e.response.status_code not in {404, 405}:
             error(f"OAuth login failed: {e}")
-            return
+            raise typer.Exit(1) from e
     except _OAuthLoginError as e:
         # OAuth isn't available / misconfigured -> try local.
         if e.payload is not None:
@@ -638,6 +638,7 @@ def _login_auto(
     error(
         "No supported login methods detected for this server (need device/oauth, or provide --email/--password)."
     )
+    raise typer.Exit(1)
 
 
 def _warn_if_env_token_overrides_login() -> None:
@@ -664,7 +665,7 @@ def status_cmd() -> None:
 
     if not token:
         error("No auth token found (set one with: sibyl auth set-token <token>)")
-        return
+        raise typer.Exit(1)
 
     if expires_at is not None and time.time() >= int(expires_at):
         info(f"Stored access token is expired (server: {api_url})")
@@ -692,7 +693,7 @@ def status_cmd() -> None:
         _run()
     except SibylClientError as e:
         error(str(e))
-        return
+        raise typer.Exit(1) from e
 
     success(f"Auth is valid (server: {api_url})")
 
@@ -857,6 +858,7 @@ def local_signup_cmd(
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 api_key_app = typer.Typer(help="API key management")
@@ -876,6 +878,7 @@ def api_key_list() -> None:
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 @api_key_app.command("create")
@@ -934,6 +937,7 @@ def api_key_create(
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 @api_key_app.command("revoke")
@@ -949,3 +953,4 @@ def api_key_revoke(api_key_id: str) -> None:
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e

--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -25,7 +25,11 @@ from sibyl_cli.auth_store import (
     read_server_credentials,
     set_tokens,
 )
-from sibyl_cli.pending_writes import create_pending_write, delete_pending_write
+from sibyl_cli.pending_writes import (
+    create_pending_write,
+    delete_pending_write,
+    record_pending_metric,
+)
 
 # Default server port (matches sibyl-server default)
 DEFAULT_SERVER_PORT = 3334
@@ -268,8 +272,29 @@ def _requires_initialized_context(method: str, path: str) -> bool:
     return not path.startswith("/auth/")
 
 
+# Discarding a buffered write destroys the only copy of its payload: the server
+# stores a request hash, never the body. So the queue only drops a write when
+# the status proves the server rejected the payload itself and no retry could
+# ever land it. Everything else stays buffered, including 409 - a stranded
+# idempotency reservation reports 409 for a write that may already have applied,
+# and the client cannot tell the two apart.
+UNAPPLIED_WRITE_STATUS_CODES = {400, 422}
+
+
 def _should_keep_pending_write(status_code: int) -> bool:
-    return status_code in {401, 408, 429} or status_code >= 500
+    return status_code not in UNAPPLIED_WRITE_STATUS_CODES
+
+
+def _resolve_pending_write(write_id: str | None, outcome: str | None) -> None:
+    """Drop a buffered write from the queue and record why it left.
+
+    A replay is accounted by the flush command that drives it, so it resolves
+    with no outcome of its own here.
+    """
+    if write_id is None:
+        return
+    if delete_pending_write(write_id) and outcome is not None:
+        record_pending_metric(outcome)
 
 
 def _refresh_failure_status_code(message: str | None) -> int | None:
@@ -540,6 +565,7 @@ class SibylClient:
         _retry_on_401: bool = True,
         _buffer_pending: bool = True,
         _pending_write_id: str | None = None,
+        _pending_write_created: bool = False,
         _idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         """Make an HTTP request to the API.
@@ -572,6 +598,7 @@ class SibylClient:
                 )
 
         pending_write_id = _pending_write_id
+        pending_write_created = _pending_write_created
         idempotency_key = _idempotency_key
         if _buffer_pending and pending_write_id is None and _should_buffer_request(method, path):
             pending = create_pending_write(
@@ -582,6 +609,7 @@ class SibylClient:
                 params=params,
             )
             pending_write_id = str(pending["id"])
+            pending_write_created = True
             idempotency_key = str(pending["idempotency_key"])
 
         refresh_failure: str | None = None
@@ -627,13 +655,14 @@ class SibylClient:
                         _retry_on_401=False,
                         _buffer_pending=False,
                         _pending_write_id=pending_write_id,
+                        _pending_write_created=pending_write_created,
                         _idempotency_key=idempotency_key,
                     )
 
             # Handle error responses
             if response.status_code >= 400:
-                if pending_write_id and not _should_keep_pending_write(response.status_code):
-                    delete_pending_write(pending_write_id)
+                if not _should_keep_pending_write(response.status_code):
+                    _resolve_pending_write(pending_write_id, "dropped")
                 try:
                     payload = _parse_error_payload(response.json())
                 except Exception:
@@ -665,16 +694,16 @@ class SibylClient:
                     details=payload.details,
                 )
 
+            applied_outcome = "completed" if pending_write_created else None
+
             # Return empty dict for 204 No Content
             if response.status_code == 204:
-                if pending_write_id:
-                    delete_pending_write(pending_write_id)
+                _resolve_pending_write(pending_write_id, applied_outcome)
                 _record_success(breaker_key)
                 return {}
 
             data = response.json()
-            if pending_write_id:
-                delete_pending_write(pending_write_id)
+            _resolve_pending_write(pending_write_id, applied_outcome)
             _record_success(breaker_key)
             return data
 

--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -26,6 +26,7 @@ from sibyl_cli.auth_store import (
     set_tokens,
 )
 from sibyl_cli.pending_writes import (
+    PendingMetric,
     create_pending_write,
     delete_pending_write,
     record_pending_metric,
@@ -285,7 +286,7 @@ def _should_keep_pending_write(status_code: int) -> bool:
     return status_code not in UNAPPLIED_WRITE_STATUS_CODES
 
 
-def _resolve_pending_write(write_id: str | None, outcome: str | None) -> None:
+def _resolve_pending_write(write_id: str | None, outcome: PendingMetric | None) -> None:
     """Drop a buffered write from the queue and record why it left.
 
     A replay is accounted by the flush command that drives it, so it resolves

--- a/apps/cli/src/sibyl_cli/org.py
+++ b/apps/cli/src/sibyl_cli/org.py
@@ -50,6 +50,7 @@ def list_cmd() -> None:
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 @app.command("create")
@@ -83,6 +84,7 @@ def create_cmd(
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 @app.command("switch")
@@ -111,6 +113,7 @@ def switch_cmd(slug: str) -> None:
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 # =============================================================================
@@ -160,6 +163,7 @@ def list_members_cmd(
         console.print(table)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 @members_app.command("add")
@@ -181,6 +185,7 @@ def add_member_cmd(
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 @members_app.command("remove")
@@ -206,6 +211,7 @@ def remove_member_cmd(
         success(f"Removed user {user_id} from {slug}")
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e
 
 
 @members_app.command("role")
@@ -227,3 +233,4 @@ def update_role_cmd(
         print_json(result)
     except SibylClientError as e:
         error(str(e))
+        raise typer.Exit(1) from e

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -156,7 +156,13 @@ def read_pending_metrics() -> dict[str, int]:
         data = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return defaults
-    return {key: int(data.get(key) or 0) for key in defaults}
+    metrics = {key: int(data.get(key) or 0) for key in defaults}
+    # `expired` was retired in favour of the outcome names above. Folding its
+    # historical count into `discarded` keeps the sum invariant true across the
+    # upgrade; projecting it away would leave `attempted` describing writes with
+    # no recorded outcome.
+    metrics["discarded"] += int(data.get("expired") or 0)
+    return metrics
 
 
 def record_pending_metric(name: PendingMetric, count: int = 1) -> dict[str, int]:

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -11,6 +11,11 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+# Every buffered write leaves the queue through exactly one of these outcomes,
+# so `attempted` should equal their sum plus whatever is still queued. A gap
+# means writes are vanishing without an accounted reason.
+PENDING_METRIC_NAMES = ("attempted", "completed", "replayed", "dropped", "discarded")
+
 
 def pending_writes_dir() -> Path:
     return Path.home() / ".config" / "sibyl" / "pending_writes"
@@ -142,7 +147,7 @@ def increment_attempts(write_id: str) -> dict[str, Any]:
 
 def read_pending_metrics() -> dict[str, int]:
     path = pending_metrics_path()
-    defaults = {"attempted": 0, "replayed": 0, "expired": 0, "discarded": 0}
+    defaults = dict.fromkeys(PENDING_METRIC_NAMES, 0)
     if not path.exists():
         return defaults
     try:

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -8,13 +8,15 @@ import stat
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, get_args
 from uuid import uuid4
 
 # Every buffered write leaves the queue through exactly one of these outcomes,
 # so `attempted` should equal their sum plus whatever is still queued. A gap
-# means writes are vanishing without an accounted reason.
-PENDING_METRIC_NAMES = ("attempted", "completed", "replayed", "dropped", "discarded")
+# means writes are vanishing without an accounted reason. Reads project onto
+# these names, so an unlisted one would be written and then silently dropped.
+PendingMetric = Literal["attempted", "completed", "replayed", "dropped", "discarded"]
+PENDING_METRIC_NAMES: tuple[PendingMetric, ...] = get_args(PendingMetric)
 
 
 def pending_writes_dir() -> Path:
@@ -147,7 +149,7 @@ def increment_attempts(write_id: str) -> dict[str, Any]:
 
 def read_pending_metrics() -> dict[str, int]:
     path = pending_metrics_path()
-    defaults = dict.fromkeys(PENDING_METRIC_NAMES, 0)
+    defaults: dict[str, int] = dict.fromkeys(PENDING_METRIC_NAMES, 0)
     if not path.exists():
         return defaults
     try:
@@ -157,7 +159,7 @@ def read_pending_metrics() -> dict[str, int]:
     return {key: int(data.get(key) or 0) for key in defaults}
 
 
-def record_pending_metric(name: str, count: int = 1) -> dict[str, int]:
+def record_pending_metric(name: PendingMetric, count: int = 1) -> dict[str, int]:
     metrics = read_pending_metrics()
     metrics[name] = int(metrics.get(name) or 0) + count
     _secure_write_json(pending_metrics_path(), metrics)

--- a/apps/cli/src/sibyl_cli/project.py
+++ b/apps/cli/src/sibyl_cli/project.py
@@ -377,9 +377,9 @@ def link_project(
         try:
             project = await client.get_entity(project_id)
             project_name = project.get("name", "Unknown")
-        except SibylClientError:
+        except SibylClientError as exc:
             error(f"Project not found: {project_id}. {PROJECT_RELINK_HINT}.")
-            return
+            raise typer.Exit(1) from exc
 
         # Pin the project together with the context it lives on, so this directory
         # always routes to the right server regardless of the active context.
@@ -453,6 +453,7 @@ def relink_project(
         except (SibylClientError, ValueError) as exc:
             error(str(exc))
             info(PROJECT_RELINK_HINT)
+            raise typer.Exit(1) from exc
 
     _relink()
 

--- a/apps/cli/src/sibyl_cli/task.py
+++ b/apps/cli/src/sibyl_cli/task.py
@@ -902,6 +902,8 @@ def archive_task(
             print_json(
                 _archive_bulk_payload(results, archived, failed) if len(results) > 1 else results[0]
             )
+            if failed:
+                raise typer.Exit(1)
             return
 
         # Table output
@@ -919,6 +921,9 @@ def archive_task(
                 for result in failed_results:
                     detail = _archive_error_detail(result)
                     console.print(f"  [{CORAL}]{result['id']}[/{CORAL}] {detail}")
+
+        if failed:
+            raise typer.Exit(1)
 
     _archive()
 

--- a/apps/cli/tests/test_auth_login.py
+++ b/apps/cli/tests/test_auth_login.py
@@ -4,9 +4,11 @@ import re
 from pathlib import Path
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
-from sibyl_cli import auth, config_store
+from sibyl_cli import auth, auth_store, config_store
+from sibyl_cli.client import SibylClientError
 from sibyl_cli.main import app
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -310,12 +312,55 @@ def test_login_auto_requires_complete_local_credentials(
         lambda **_kwargs: pytest.fail("partial local credentials must not call local login"),
     )
 
-    auth._login_auto(
-        api_url="http://testserver/api",
-        no_browser=False,
-        timeout_seconds=180,
-        email="stef@example.com",
-        password=None,
+    with pytest.raises(typer.Exit) as exc:
+        auth._login_auto(
+            api_url="http://testserver/api",
+            no_browser=False,
+            timeout_seconds=180,
+            email="stef@example.com",
+            password=None,
+        )
+
+    assert exc.value.exit_code == 1
+    assert "Local login requires both --email and --password." in _plain(capsys.readouterr().out)
+
+
+def test_login_auto_exits_non_zero_when_local_login_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def rejected(**_kwargs: object) -> dict:
+        raise SibylClientError("API error: invalid credentials", status_code=401)
+
+    monkeypatch.setattr(auth, "_login_via_local_password", rejected)
+    monkeypatch.setattr(
+        auth,
+        "_persist_tokens",
+        lambda **_kwargs: pytest.fail("a rejected login must not persist tokens"),
     )
 
-    assert "Local login requires both --email and --password." in _plain(capsys.readouterr().out)
+    with pytest.raises(typer.Exit) as exc:
+        auth._login_auto(
+            api_url="http://testserver/api",
+            no_browser=False,
+            timeout_seconds=180,
+            email="stef@example.com",
+            password="wrong",
+        )
+
+    assert exc.value.exit_code == 1
+    assert "invalid credentials" in _plain(capsys.readouterr().out)
+
+
+def test_auth_status_exits_non_zero_without_a_stored_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SIBYL_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(auth_store.Path, "home", lambda: tmp_path)
+
+    result = CliRunner().invoke(auth.app, ["status"])
+
+    assert result.exit_code == 1
+    assert "No auth token found" in _plain(result.stdout)

--- a/apps/cli/tests/test_client_errors.py
+++ b/apps/cli/tests/test_client_errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -418,3 +419,23 @@ async def test_mutating_request_records_completed_pending_write(
     assert metrics["attempted"] == 1
     assert metrics["completed"] == 1
     assert metrics["dropped"] == 0
+
+
+def test_read_pending_metrics_folds_retired_expired_into_discarded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    path = pending_writes.pending_metrics_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"attempted": 10, "discarded": 3, "expired": 4, "replayed": 3}),
+        encoding="utf-8",
+    )
+
+    metrics = pending_writes.read_pending_metrics()
+
+    assert metrics["discarded"] == 7
+    assert "expired" not in metrics
+    outcomes = metrics["completed"] + metrics["replayed"] + metrics["dropped"] + metrics["discarded"]
+    assert outcomes == metrics["attempted"]

--- a/apps/cli/tests/test_client_errors.py
+++ b/apps/cli/tests/test_client_errors.py
@@ -317,3 +317,104 @@ async def test_mutating_request_deletes_pending_write_on_validation_error(
 
     await client.close()
     assert pending_writes.list_pending_writes() == []
+    assert pending_writes.read_pending_metrics()["dropped"] == 1
+
+
+@pytest.mark.parametrize("status_code", [400, 422])
+@pytest.mark.asyncio
+async def test_mutating_request_drops_pending_write_when_payload_is_unusable(
+    status_code: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    client_module._FAILURE_WINDOWS.clear()
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            status_code,
+            json={"error": "validation_error", "message": "Bad payload"},
+        )
+    )
+    client = _client_with_transport(transport)
+
+    with pytest.raises(SibylClientError):
+        await client.post("/memory/raw", json={"title": "Doomed", "raw_content": "Body"})
+
+    await client.close()
+    assert pending_writes.list_pending_writes() == []
+    assert pending_writes.read_pending_metrics()["dropped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mutating_request_keeps_pending_write_on_idempotency_conflict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    client_module._FAILURE_WINDOWS.clear()
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            409,
+            json={
+                "error": "conflict",
+                "message": (
+                    "Idempotent operation is still in progress or was interrupted "
+                    "before its receipt completed"
+                ),
+            },
+        )
+    )
+    client = _client_with_transport(transport)
+
+    with pytest.raises(SibylClientError):
+        await client.post("/memory/raw", json={"title": "Keep me", "raw_content": "Body"})
+
+    await client.close()
+    pending = pending_writes.list_pending_writes()
+    assert len(pending) == 1
+    assert pending[0]["json"] == {"title": "Keep me", "raw_content": "Body"}
+    assert pending_writes.read_pending_metrics()["dropped"] == 0
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 404, 405, 408, 409, 410, 413, 429, 500, 503])
+@pytest.mark.asyncio
+async def test_mutating_request_keeps_pending_write_unless_payload_is_unusable(
+    status_code: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    client_module._FAILURE_WINDOWS.clear()
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            status_code,
+            json={"error": "failed", "message": "Not applied, or unknowable"},
+        )
+    )
+    client = _client_with_transport(transport)
+
+    with pytest.raises(SibylClientError):
+        await client.post("/memory/raw", json={"title": "Keep me", "raw_content": "Body"})
+
+    await client.close()
+    assert len(pending_writes.list_pending_writes()) == 1
+    assert pending_writes.read_pending_metrics()["dropped"] == 0
+
+
+@pytest.mark.asyncio
+async def test_mutating_request_records_completed_pending_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, json={"id": "entity_1"}))
+    client = _client_with_transport(transport)
+
+    await client.post("/memory/raw", json={"title": "Landed", "raw_content": "Body"})
+
+    await client.close()
+    metrics = pending_writes.read_pending_metrics()
+    assert pending_writes.list_pending_writes() == []
+    assert metrics["attempted"] == 1
+    assert metrics["completed"] == 1
+    assert metrics["dropped"] == 0

--- a/apps/cli/tests/test_debug.py
+++ b/apps/cli/tests/test_debug.py
@@ -43,7 +43,7 @@ def test_debug_status_includes_pending_write_metrics(
     mock_get_client.return_value = _FakeClientContext(mock_client)
     mock_pending_write_status.return_value = {
         "count": 2,
-        "metrics": {"attempted": 3, "replayed": 1, "discarded": 1, "expired": 0},
+        "metrics": {"attempted": 3, "completed": 1, "replayed": 1, "dropped": 0, "discarded": 1},
     }
 
     result = CliRunner().invoke(debug.app, ["status", "--json"])

--- a/apps/cli/tests/test_org.py
+++ b/apps/cli/tests/test_org.py
@@ -1,0 +1,43 @@
+"""Tests for organization CLI commands."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from sibyl_cli.client import SibylClientError
+from sibyl_cli.org import app
+
+_REJECTED = SibylClientError(
+    "API error: forbidden",
+    status_code=403,
+    detail="Access denied",
+)
+
+
+@pytest.mark.parametrize(
+    ("client_method", "argv"),
+    [
+        ("list_orgs", ["list"]),
+        ("create_org", ["create", "--name", "Hypercolor"]),
+        ("switch_org", ["switch", "hypercolor"]),
+        ("list_org_members", ["members", "list", "hypercolor"]),
+        ("add_org_member", ["members", "add", "hypercolor", "user_1"]),
+        ("remove_org_member", ["members", "remove", "hypercolor", "user_1", "--force"]),
+        ("update_org_member_role", ["members", "role", "hypercolor", "user_1", "admin"]),
+    ],
+)
+def test_org_commands_exit_non_zero_when_the_api_rejects_them(
+    client_method: str,
+    argv: list[str],
+) -> None:
+    mock_client = MagicMock()
+    setattr(mock_client, client_method, AsyncMock(side_effect=_REJECTED))
+
+    with patch("sibyl_cli.org.get_client", return_value=mock_client):
+        result = CliRunner().invoke(app, argv)
+
+    assert result.exit_code == 1
+    assert "✗ API error: forbidden" in result.stdout

--- a/apps/cli/tests/test_project.py
+++ b/apps/cli/tests/test_project.py
@@ -44,7 +44,7 @@ def test_project_relink_rejects_inaccessible_direct_id() -> None:
             ["relink", "--id", "project_missing", "--path", "/tmp/hypercolor"],
         )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert "Project not found: project_missing" in result.stdout
     mock_set_path_mapping.assert_not_called()
 

--- a/apps/cli/tests/test_task.py
+++ b/apps/cli/tests/test_task.py
@@ -450,7 +450,7 @@ def test_task_archive_stdin_json_reports_failed_ids(mock_get_client: MagicMock) 
         input="task_123456789abc\nnot-a-task\n13364346-8475-4664-8b52-eb963af2fda7\n",
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     payload = json.loads(result.stdout)
     assert payload["total"] == 3
     assert payload["archived"] == 1
@@ -464,6 +464,49 @@ def test_task_archive_stdin_json_reports_failed_ids(mock_get_client: MagicMock) 
     mock_client.archive_task.assert_any_await("task_123456789abc", None)
     mock_client.archive_task.assert_any_await("13364346-8475-4664-8b52-eb963af2fda7", None)
     assert mock_client.archive_task.await_count == 2
+
+
+@patch("sibyl_cli.task.get_client")
+def test_task_archive_exits_non_zero_when_client_rejects_the_id(
+    mock_get_client: MagicMock,
+) -> None:
+    mock_client = MagicMock()
+    mock_client.archive_task = AsyncMock(
+        side_effect=SibylClientError(
+            "API error: not_found",
+            status_code=404,
+            detail="Task not found",
+        )
+    )
+    mock_get_client.return_value = mock_client
+
+    result = CliRunner().invoke(task.app, ["archive", "task_123456789abc"])
+
+    assert result.exit_code == 1
+    assert "Failed" in result.stdout
+
+
+@patch("sibyl_cli.task.get_client")
+def test_task_archive_bulk_exits_non_zero_when_every_id_fails(
+    mock_get_client: MagicMock,
+) -> None:
+    mock_client = MagicMock()
+    mock_client.archive_task = AsyncMock(
+        side_effect=[
+            {"success": False, "message": "already archived"},
+            {"success": False, "message": "already archived"},
+        ]
+    )
+    mock_get_client.return_value = mock_client
+
+    result = CliRunner().invoke(
+        task.app,
+        ["archive", "--stdin", "--yes"],
+        input="task_123456789abc\ntask_abcdef123456\n",
+    )
+
+    assert result.exit_code == 1
+    assert "Failed: 2 task(s)" in result.stdout
 
 
 @patch("sibyl_cli.task.get_client")

--- a/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
@@ -29,11 +29,13 @@ Three facts drive the release shape:
    451-scale: −0.9pp combined and 2.5× latency vs fast mode. "Multi-step retrieval, locked in"
    therefore means **model-directed traversal over a slice-granular substrate** (the graph-backed
    agentic path, decision `0f4ab0c8a0cc`) — not more deterministic query fan-out.
-3. **Our own memory loop carries trust debt.** The pending-writes queue has stranded offline
-   captures since June 11; raw memory CREATE fails on one path after the 1.1 schema change;
-   embedding backfill false-negatives real entities; two fulltext lanes still run pre-3.2 query
-   shapes. A memory product that strands writes cannot preach memory sovereignty. This gets fixed
-   in-release, not someday.
+3. **Our own memory loop carries trust debt — and it is worse than we thought.** Adjudicated
+   2026-07-24 (§2.5): private memories leak to org co-members through unscoped graph entities; the
+   offline write queue silently and unrecoverably deletes buffered writes on a 409; the content
+   schema ladder has been deadlocked at v15 of 23 since 2026-07-11 while `/api/health` reported
+   healthy; and ~15 CLI commands exit 0 on failure. A memory product that leaks private memories and
+   loses offline writes cannot preach memory sovereignty. This warrants **1.1.3 before 1.2** (§2.6),
+   not someday.
 
 Positioning consequence: coalescence — the big differentiator bet — moves to v1.3. The roadmap's own
 sequencing logic ("team coalescence is isolation-correctness-under-merge and cannot ship credibly
@@ -103,18 +105,93 @@ scale (accurate mode, §2.2). Noise floor: 5 replays of one config span 23–27/
 rescored 22–29 across reader passes; per-question churn ~6.7/45 between passes. **Aggregate flatness
 is not per-question stability; sub-noise deltas are NO-GO by default.**
 
-### 2.5 Dogfood trust debt
+### 2.5 Dogfood trust debt — adjudicated 2026-07-24
 
-- `df317be0` pending-writes queue captures read-like requests and strands idempotency receipts; ~121
-  stranded files in `~/.config/sibyl/pending_writes/` dating to June 11, plus one session of
-  release-saga graph writes awaiting replay.
-- `7a52bf39` raw memory CREATE failure after 1.1 schema updates.
-- `85c4dc53` embedding backfill false-negatives entities that exist (bit two corpus rebuilds).
-- `0ea2177e` doc-chunk lexical lane + anchor-rescue lane still use pre-3.2 fulltext shapes
-  (conjunctive-strict semantics silently zero their recall on 3.2.x).
-- `4fd323a5` fresh-store bootstrap: missing tables surface as opaque 500s; no schema-init verb.
-- `4736bf2d` raw-memory promotion does not carry scope onto graph entities.
-- `659b4ada` task archive exits 0 on failure.
+Five parallel investigations verified every claim below against shipped 1.1.2 and the live store.
+Two items were **overstated**, two are **worse than filed**, and two defects were **newly
+discovered**. The corrected picture drives the 1.1.3 recommendation in §2.6.
+
+**Release-blocking (verified, source-traced):**
+
+- **Private-memory leak on the default capture path** (`4736bf2d`, `error_pattern_8e04647be38f`).
+  Worse than filed: the promotion path is fine, but `MemoryCaptureService.capture()` never copies
+  `memory_scope` (which defaults to `private`) or `scope_key` into `graph_metadata`; `Entity` has no
+  scope field in either the model or the graph schema; and `_candidate_scope_allowed` **fails open**
+  on missing scope. A project co-member can therefore read another user's private memory title and
+  full content. Live: 1,292 capture-path entities, 100% unscoped, 100% carrying content. Org
+  namespace isolation **holds** — same-org only. Latent while single-user. Team scope has the
+  inverse bug and fails **closed** (`accessible_teams` never threaded), so team memory is currently
+  write-only and invisible even to its own members.
+- **Silent unrecoverable loss of offline writes** (`df317be0`). `_should_keep_pending_write` omits
+  409, so the queue file is deleted before the exception raises — and 409 is precisely the
+  stranded-reservation case the client cannot prove was not applied. The payload is never persisted
+  server-side. 74 stranded `102` rows observed; flushing mints more. The alarming `discarded: 1180`
+  counter was a **red herring**, proven by controlled experiment: it counts only explicit
+  `pending-writes discard` invocations, so the client-side deletes recorded nothing at all.
+- **Content schema ladder deadlocked at v15 of 23 since 2026-07-11** (`4fd323a5` root cause,
+  `error_pattern_c01dc4698419`). `DEFINE TABLE IF NOT EXISTS x SCHEMAFULL` silently no-ops against a
+  table SurrealDB auto-created SCHEMALESS, so v16's `FLEXIBLE` field fails forever and the version
+  is never recorded. `/api/health` reports healthy while `/api/health/ready` reports the failure,
+  and the shipped compose healthcheck probes the former. Fresh installs are unaffected;
+  **upgraders** whose store predates 2026-07-03 are the population.
+
+**Confirmed, high:**
+
+- **Lying exit codes** (`659b4ada`). `task archive` exits 0 on failure on both paths; ~15 commands
+  swallow `SibylClientError`, incl. a live-reproduced `sibyl auth status`. Tests actively locked the
+  bug in by asserting `exit_code == 0` on failed runs. This breaks the contract the shipped skill
+  pack makes to agents.
+
+**Overstated — corrected:**
+
+- `0ea2177e` fulltext lanes are **not** a 3.2.x regression (`claim_72dd1444fa8e`). A controlled A/B
+  on ephemeral 3.1.0 and 3.2.3 containers with a validated positive control showed the remaining
+  lanes return zero on **both** engines. Pre-existing recall gap; no user is worse off on 1.1.2 than
+  1.1.0. Rescoped to recall quality, priority lowered.
+- `7a52bf39` raw-memory CREATE is **not** currently failing. The acute 500 is gone — but not because
+  the intended repair ran: content v23 (`content_raw_capture_required_field_repair`) is stuck behind
+  the deadlock and has never executed. The write path works by accident of where v16 died.
+- **Epic linking is not broken.** Working IDs come from `sibyl epic list` (`epic_<12hex>`); the
+  original report used a task UUID and invented prefixes. The real defect is that `errors.py` treats
+  bare UUIDs as secrets and replaces the _entire_ message across 44 sites, so Sibyl redacts its own
+  identifiers and makes 400/404s undiagnosable.
+
+**Newly discovered:**
+
+- Document search returns **empty rather than degraded** when the embedder soft-fails: the scan
+  fallback only fires on `RuntimeError`, so a 2s embedding timeout plus a zero-recall lexical lane
+  yields nothing (`411a5611`).
+- `sibyl debug query` appends its org predicate with no leading space (any plain `SELECT` without
+  `GROUP BY` is a parse error) and strips `id` from projections (`3f20f0e2`).
+- Hierarchy drift: `-e` writes only `epic_id` while `parent_task_id` is the field
+  `get_epic_progress` reads, so re-parenting silently miscounts forever.
+
+**Gate false assurance (flag loudly):** `benchmarks/results/ai-memory/team-scope-trust-receipt.json`
+asserts `leak_count: 0` under a declared surface of "private source isolation". It is a
+hand-maintained static file with no generator anywhere in the repo — honest about being static in
+its own `claim_boundary`, but a blocking gate reports zero leaks while the leak lives outside its
+fixtures. Relatedly, the only unit test of `_candidate_scope_allowed` hand-injects the very
+`memory_scope` field whose absence is the bug, proving the filter works while hiding that it never
+fires. **Any gate whose receipt is hand-authored must be regenerated or deleted in v1.2.**
+
+### 2.6 The 1.1.3 recommendation
+
+Cut a patch release before 1.2 feature work. Drivers, in order: offline write loss (`df317be0`), the
+private-memory leak (`4736bf2d`), the schema deadlock, and the exit-code cluster. Not drivers: the
+fulltext lanes and raw-memory CREATE, both of which were overstated. Root `moon run :check` was
+verified green (55 tasks) on the 1.1.2 cut, so the release gate is clear.
+
+Deferred out of the patch by design: the `_candidate_scope_allowed` fail-open flip (would hide
+legitimately unscoped tasks/epics — needs a first-class `Entity.memory_scope` column), the scope
+backfill migration for existing unscoped rows, the pending-writes park/dead-letter directory and
+attempt cap, the server-side `102`-row reaper, and the `epic_id`/`parent_task_id` unification.
+
+**Live-store repair carries an ordering constraint** (`procedure_4e83bec5631f`): the store holds 179
+duplicate usage-event uuids (181 excess rows). Since the uuid is a SHA-256 of the dedupe tuple, the
+UNIQUE index builds will fail, be silently swallowed, and never retry — leaving dedupe permanently
+unenforced. Collapse duplicates **first**, then run schema repair, then verify both indexes exist.
+Usage counts from 2026-07-11 onward carry a ~1.4% upward bias from unenforced dedupe, so retention
+multipliers derived from that window are slightly inflated.
 
 ## 3. Protocol law (binds every Track A experiment)
 
@@ -223,14 +300,42 @@ are green first.
 
 ## 6. Track C — dogfood trust debt (must-fix)
 
-Fix the §2.5 list as a named campaign, not scattered chores. Priority order: `df317be0` (queue
-correctness + drain + release-saga replay), `7a52bf39`, `85c4dc53`, `0ea2177e`, `4fd323a5`,
-`4736bf2d`, `659b4ada`. Opportunistic seconds (CLI/API hygiene, medium): `7c4cb25a`, `e2206767`,
-`41606e9d`, `6fe13e16`.
+Fix the §2.5 list as a named campaign, not scattered chores. **Most of the acute work moves into
+1.1.3** (§2.6); what remains in Track C is the design work deliberately excluded from the patch,
+plus the residue.
+
+Ships in 1.1.3: `df317be0` (409 retention + delete metrics), `659b4ada` (exit-code cluster), the
+schema-deadlock pairing + repair sweep + `sibyld db init`, and the `4736bf2d` capture-time scope
+stamp.
+
+Stays in Track C for 1.2, in priority order:
+
+1. **Scope model, properly.** A first-class `Entity.memory_scope` column with a sane default, the
+   `_candidate_scope_allowed` fail-open decision, and the backfill joining
+   `entity.attributes.raw_memory_id` back to `raw_captures.memory_scope` across the namespace split.
+   Plus threading `accessible_teams` into the three team-read call sites so team memory stops
+   failing closed.
+2. **Regenerate or delete every hand-authored gate receipt**, starting with
+   `team-scope-trust-receipt.json`. A blocking gate whose zero is typed by a human is worse than no
+   gate. Pair each with a test that fails when the defect is reintroduced — the current scope test
+   injects the field whose absence is the bug.
+3. **Pending-writes durability design:** park/dead-letter directory, attempt cap (`attempts` is
+   incremented and nothing branches on it), server-side `102`-row reaper, and releasing the
+   reservation on route failure. Retaining 404 makes a poisoned queue drainable only one ID at a
+   time, so this is now load-bearing rather than optional.
+4. `85c4dc53` embedding backfill false-negatives; `0ea2177e` rescoped to doc-chunk lexical recall
+   (two duplicated call sites) **plus the engine-level test coverage that does not exist today** —
+   current tests assert on generated query strings via fake clients and pass regardless of engine
+   semantics; `411a5611` empty-vs-degraded document search; `3f20f0e2` debug-query defects;
+   `errors.py` identifier redaction across 44 sites; `epic_id`/`parent_task_id` unification.
+
+Opportunistic seconds (CLI/API hygiene, medium): `7c4cb25a`, `e2206767`, `41606e9d`, `6fe13e16`.
 
 - Gate `dogfood-trust-gate`: pending-writes queue drains to zero against a healthy server with
-  per-file receipts; a regression fixture exists for each bug class; fulltext-lane conversion passes
-  baseline parity on both 3.2.3 and 3.1.0.
+  per-file receipts; a regression fixture exists for each bug class; **every gate receipt in
+  `benchmarks/results/` is machine-generated by a committed generator**; a two-principal leak test
+  proves private capture is unreadable by an org co-member; fulltext-lane conversion passes baseline
+  parity on both 3.2.3 and 3.1.0.
 
 ## 7. What slides to v1.3, and why
 

--- a/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,321 @@
+# Sibyl v1.2 Implementation Plan — "Retrieve It"
+
+- Status: active execution plan
+- Created: 2026-07-24 (the day v1.1.0 → v1.1.2 shipped)
+- Fills the v1.2 slot of [`SIBYL_POST_1_0_ROADMAP.md`](SIBYL_POST_1_0_ROADMAP.md) §5 and **re-scopes
+  it from "Coalesce It" to "Retrieve It"**: live coalescence (roadmap v1.2 W1–W3) and TeamMemBench
+  (W5) slide to v1.3; the projection layers (W6–W7) stay; retroactive re-extraction (W8) stays as
+  stretch. Rationale in §7. The product truth remains [`SIBYL_NORTHSTAR.md`](SIBYL_NORTHSTAR.md).
+- Decision provenance: leaderboard timing locked by Bliss 2026-07-24 (hold submission until the
+  naive-RAG baseline is beaten). The re-scoping itself is recommended-and-planned here; §9 tracks
+  locked vs open.
+
+## 1. Thesis
+
+v1.1 built the trust machinery: usage-aware forgetting, citation contract, team scope, OKF export,
+mutation receipts, and five trust gates. v1.2 uses that machinery to fix the one structural defect
+the eval loops exposed — and to make the flagship number honest-good, not just honestly reported.
+
+Three facts drive the release shape:
+
+1. **The headline number is below the paper's own naive baseline.** Sibyl's best full-451
+   LongMemEval-V2 run is 31.26% @ 7.48s; the benchmark paper's reference frontier is 42.8% for naive
+   query→slice RAG and 51.0% @ 0.2s for query→slice+notes. For a product whose moat is honest
+   benchmarks, sitting under `naive RAG` is the single most expensive fact on the books. Everything
+   else in this plan is sequenced around removing it.
+2. **The defect is payload format and exposure, not query planning.** A month of query-side
+   refinement churned inside reader noise while the format gap dominated (receipts in §2.3). The
+   multi-step retrieval that shipped in v1.1 (`retrieval_mode=accurate`) is measured harmful at
+   451-scale: −0.9pp combined and 2.5× latency vs fast mode. "Multi-step retrieval, locked in"
+   therefore means **model-directed traversal over a slice-granular substrate** (the graph-backed
+   agentic path, decision `0f4ab0c8a0cc`) — not more deterministic query fan-out.
+3. **Our own memory loop carries trust debt.** The pending-writes queue has stranded offline
+   captures since June 11; raw memory CREATE fails on one path after the 1.1 schema change;
+   embedding backfill false-negatives real entities; two fulltext lanes still run pre-3.2 query
+   shapes. A memory product that strands writes cannot preach memory sovereignty. This gets fixed
+   in-release, not someday.
+
+Positioning consequence: coalescence — the big differentiator bet — moves to v1.3. The roadmap's own
+sequencing logic ("team coalescence is isolation-correctness-under-merge and cannot ship credibly
+without the harness") extends one step: it also cannot ship credibly while the flagship retrieval
+number loses to `cat *.txt`-adjacent baselines.
+
+## 2. Verified starting point (2026-07-24)
+
+### 2.1 Release state
+
+v1.1.0/1.1.1/1.1.2 shipped 2026-07-24; v1.1.2 is the signed, CVE-clean image (GHCR/Docker Hub digest
+parity verified). The v1.1 "Prove It" slate landed: usage loop (exposure/citation/misled signals,
+retention multiplier 0.1×–4.0×), team control plane, OKF export, `correct`/`blame` + mutation
+receipts, trust gates (`write_path_integrity`, `forgetting`, `usage_loop`, `okf_export`,
+`doc_claim`), SurrealDB pinned 3.2.3 with conjunctive-safe fulltext arms (`1f086b22`). The one
+benchmark-proven retrieval lever — distilled notes + reserved typed lane — is ported to production
+(task `1e1caf57`, done: async distillation job, reserved note lane in evidence composition, digest
+v2 field shapes).
+
+### 2.2 LongMemEval-V2 campaign state
+
+Full-451 three-way, 2026-07-22 (receipts `.moon/cache/evals/nova-full-451-fast/`, decision
+`3da12cba3ccd`):
+
+| Config           | Combined             | Latency (avg / p95) | Enterprise | Web    |
+| ---------------- | -------------------- | ------------------- | ---------- | ------ |
+| FAST+notes       | **141/451 = 31.26%** | **7.48s / 10.35s**  | **35.07%** | 27.92% |
+| ACCURATE+notes   | 137/451 = 30.38%     | 18.73s / 27.46s     | 31.28%     | 29.58% |
+| July-11 baseline | 129/451 = 28.60%     | 8.25s / —           | 33.18%     | 24.58% |
+
+FAST+notes is a strict Pareto win over the July-11 baseline (+2.66pp AND faster) and the best
+pipeline to date; enterprise 35.07% is best-ever. Accurate mode's 3-query planner cost ~4pp accuracy
+and 2.5× latency on enterprise — the v1.1-era "enterprise regression" was an accurate-mode artifact.
+Reference frontier: paper query→slice 42.8%, query→slice+notes 51.0% @ 0.2s; the LAFS latency knee
+~27s holds ~62% of scoring mass. At 31.26%, LAFS gain vs the frontier ≈ 0.
+
+The surviving lever: LLM note distillation at ingest + a **reserved** typed-note lane =
+**+3.7pp/domain, stable across four independent 3-pass gates** (web v2 and enterprise v2 both
++3.70pp; the v1 enterprise +6.67pp was inflated by a depressed fat baseline). Interaction vs the
+no-notes control is +8.15pp — matching the paper's ARB-R note-pool ablation (+8pp) almost exactly.
+Notes without a reserved lane measure **negative**: never let notes compete with raw evidence for
+slots. The ceil(3n/8) = 3-of-8 reservation is near-optimal (widening to 5 lost the entire gain).
+
+### 2.3 Gap anatomy — where the missing ~11.5pp live
+
+- **Selection is nearly solved; rendering is not.** Every deep-search arm selects to the same 82.6%
+  phrase-presence ceiling; rendering exposes at most 65.2% (decision `7b7b46f1d169`).
+- **Granularity is the defect.** trajectory_recall@10 = 94% but state_recall@10 = 68%; gold-literal
+  exposure is only 21% (web) / 32% (enterprise). The reader converts 50–54% when the literal is
+  exposed. Payload is 8 giant items × 12K chars (~34K tokens) against readers that degrade past ~3K
+  retrieved tokens (LME-v1 finding).
+- **Oracle format ablation: slices+notes 82.5% vs raw trajectories 59.6%** (qwen3.5-9b) — format
+  alone is worth ~23pp (decision `0e0677006a04`).
+- **Known residual pools:** query-anchored region ranking misses gold that shares no question
+  vocabulary (3 of 23 phrases on the enterprise-45 slice); counting questions are unwinnable by
+  exposure (2 of 23); the errors-gotchas pool is 67–71% confidently wrong (sycophancy — premise
+  never checked); abstention is reader-prompt-bound (inventory annotations rendered in all 45
+  contexts moved abstention 1/13).
+
+### 2.4 Killed-lever ledger — do not re-run
+
+All killed with 3-pass receipts; re-litigation requires new mechanism evidence, not a re-roll:
+client-side geometry reshaping (fat 24.4% @ 10.52s vs windowed-compact 20.0% @ 36.15s — 3.4× slower,
+past the knee), deep-search compact arms, inventory-annotation abstention chain, typed-stream lane
+without notes (−1.48pp), reservation widening 3→5 (−3.70pp), deterministic multi-query planning at
+scale (accurate mode, §2.2). Noise floor: 5 replays of one config span 23–27/90; identical contexts
+rescored 22–29 across reader passes; per-question churn ~6.7/45 between passes. **Aggregate flatness
+is not per-question stability; sub-noise deltas are NO-GO by default.**
+
+### 2.5 Dogfood trust debt
+
+- `df317be0` pending-writes queue captures read-like requests and strands idempotency receipts; ~121
+  stranded files in `~/.config/sibyl/pending_writes/` dating to June 11, plus one session of
+  release-saga graph writes awaiting replay.
+- `7a52bf39` raw memory CREATE failure after 1.1 schema updates.
+- `85c4dc53` embedding backfill false-negatives entities that exist (bit two corpus rebuilds).
+- `0ea2177e` doc-chunk lexical lane + anchor-rescue lane still use pre-3.2 fulltext shapes
+  (conjunctive-strict semantics silently zero their recall on 3.2.x).
+- `4fd323a5` fresh-store bootstrap: missing tables surface as opaque 500s; no schema-init verb.
+- `4736bf2d` raw-memory promotion does not carry scope onto graph entities.
+- `659b4ada` task archive exits 0 on failure.
+
+## 3. Protocol law (binds every Track A experiment)
+
+1. **Replay before paid.** Exposure-first replay harness screens every idea; scored runs only for
+   arms that move exposure/selection in replay.
+2. **3-pass paired replication on frozen prompts** is the only accepted scoring protocol. GO
+   requires mean paired delta ≥ +3pp with consistent sign (gainers vs losers); pre-register GO/NO-GO
+   numbers before the run.
+3. **Latency receipts are 1-way.** Parallel prompt-build pollutes per-query latency (contention);
+   never claim latency from a parallel arm.
+4. **Budgets:** corpus rebuild ~$0.62–0.75/domain, notes ~$0.15/corpus, domain regate
+   ~$5,
+   full-451 ~$10. Corpora build from committed HEAD only (attach verifier refuses dirty-tree
+   chunking; trajectory-mode fresh ingest is forbidden at HEAD — state mode is the path).
+5. **Integrity boundaries:** the adapter stays score-blind and question-text-only; no benchmark
+   labels near retrieval; no reader answer-shaping for abstention questions (integrity-gray,
+   rejected — it cuts against the honest-benchmark moat). LAFS knee 27s is the hard latency ceiling;
+   10s avg is the working budget.
+
+## 4. Track A — beat the naive-RAG baseline (headline)
+
+Target: combined full-451 **≥ 42.8%** (193/451) at ≤ 10s avg. Stretch: approach the 51.0%
+slice+notes frontier. Phases are ordered by evidence strength; each gates before the next spends.
+
+### A1. Slice-granular substrate + compact rendering
+
+Replace the 8 × 12K fat-item payload with state-boundary slices as first-class retrieval units and a
+compact renderer. This is where the paper's 42.8% lives (query→slice at 0.2s), and it is the
+surviving re-architecture direction: the client-side kill (geometry reshaping) reshaped fat
+retrievals at read time; this changes what is retrieved. Design seeds from decision `0e0677006a04`:
+state-boundary slice chunking, typed note/event pools (already live at ingest), multi-stream
+retrieval, neighbor-stitch that raises exposure while **shrinking** context. Open design choice
+(§9): slices as graph entities vs a retrieval-layer view over states.
+
+- Gate `slice-substrate-gate`: on the enterprise-45/web-45 replay slices, gold-literal exposure ≥
+  50% (from 32%/21%) AND state-level recall@10 ≥ 85% (from 68%) within ≤ 60K chars (target ≤ 48K);
+  then a scored 3-pass paired run vs frozen FAST+notes, GO per protocol law.
+
+### A2. Ranking refinements
+
+Semantic/embedding region scoring where query-anchored ranking misses no-vocabulary-overlap gold;
+entity-overlap ranking for typed notes (the known `fa504f5e` refinement); gotcha/premise notes aimed
+at the errors-gotchas pool (67–71% confidently wrong — the one pool where notes can check a premise
+instead of answering it).
+
+- Gate `ranking-gate`: recovers ≥ 2 of the 3 known no-vocab misses on the 23-phrase slice without
+  net exposure regression; scored effects per protocol law.
+
+### A3. Agentic graph retrieval — multi-step done right
+
+Bounded model-in-the-loop traversal over the A1 substrate: search → expand-neighbors → fetch-slice
+verbs, ≤ 3 rounds, deterministic final composition (the evidence composer and reserved note lane
+stay; the model chooses what to gather, never how it renders). This is the graph-backed path of
+decision `0f4ab0c8a0cc`, attempted only after A1 — traversal over fat states would re-buy the format
+defect at higher latency.
+
+- Gate `agentic-retrieval-gate`: score-blind, question-text-only; p95 memory latency ≤ 15s (hard
+  ceiling: the 27s knee); GO = ≥ +3pp mean paired over the then-best config, numbers pre-registered
+  before the first paid run.
+
+### A4. Full-451 + leaderboard submission
+
+- Gate `baseline-beat-gate`: combined full-451 ≥ 42.8% at ≤ 10s avg with committed receipts.
+  **Submission is held until this gate passes** (Bliss, 2026-07-24): a dominated point on an empty
+  board invites the wrong comparison. When it passes, submit promptly — first credible entry on an
+  empty leaderboard is the payoff the v1.1 W5 harness was built for.
+
+### A5. Accurate-mode fate
+
+Deprecate the `accurate` retrieval mode (measured −4pp enterprise, 2.5× latency at scale). Fold
+sidequest `6338cc8e` (audit orphaned `retrieval/query_planning.py`) into the removal: keep the
+score-blind planner code only if A3 reuses it as a traversal seed, otherwise delete. The web-only
+per-domain fork (+1.7pp) is rejected — mode-forking the product for 1.7pp on one benchmark split is
+surface without a mechanism, and A1–A3 subsume the effect.
+
+## 5. Track B — projection layers (roadmap W6–W7, kept)
+
+Both consume machinery v1.1/1.2 already built: the production note-distillation pipeline, the usage
+signal, and the OKF projection code.
+
+### B1. Distilled per-project handbook
+
+Dream-cycle stage maintaining a navigable per-project summary artifact (handbook + wake summary),
+regenerated on sufficient graph change, built with `synthesis_plan/draft/verify`. Usage signal
+orders what earns prominence; wake bundles and the SessionStart hook serve the distilled artifact
+instead of raw top-k.
+
+- Gate `handbook-integrity-gate`: the v1.1 write-path-integrity gate applied to distiller output —
+  zero hallucinated/self-referential writes on the seeded fixture.
+
+### B2. Materialized memory-as-files (`.sibyl/memory/`)
+
+`sibyl export --project <id>` + session hook materializing the handbook and recent context pack as
+read-only files. Filesystem-native agents grep at zero marginal latency and survive server outages;
+the citation contract still routes usage back over the API. Structured substrate, curated
+projection.
+
+- Gate `files-projection-gate`: deterministic re-materialization; grep-usable with the server down;
+  citations still recorded when it returns.
+
+### B3. Retroactive re-extraction loop (stretch)
+
+`sibyl admin re-extract --since-extractor-version <v>` over raw captures, delta scored by the
+regression harness before promotion, supersession edges for rollback. Ships only if Tracks A and C
+are green first.
+
+## 6. Track C — dogfood trust debt (must-fix)
+
+Fix the §2.5 list as a named campaign, not scattered chores. Priority order: `df317be0` (queue
+correctness + drain + release-saga replay), `7a52bf39`, `85c4dc53`, `0ea2177e`, `4fd323a5`,
+`4736bf2d`, `659b4ada`. Opportunistic seconds (CLI/API hygiene, medium): `7c4cb25a`, `e2206767`,
+`41606e9d`, `6fe13e16`.
+
+- Gate `dogfood-trust-gate`: pending-writes queue drains to zero against a healthy server with
+  per-file receipts; a regression fixture exists for each bug class; fulltext-lane conversion passes
+  baseline parity on both 3.2.3 and 3.1.0.
+
+## 7. What slides to v1.3, and why
+
+Live coalescence engine (roadmap v1.2 W1–W3), the scale-load/team-isolation gates (W4), and
+TeamMemBench (W5) move to v1.3. The coalescence **data model** (W1) may proceed as a design doc in
+v1.2 if bandwidth allows — design-only, no engine. The roadmap's differentiation argument is
+untouched; only its timing moves: the credibility spend has to go to retrieval first, and the v1.1
+team substrate plus usage loop remain in place, un-rotted, for a v1.3 engine. Nothing in Track A/B
+forecloses any coalescence decision.
+
+## 8. Task board: triage and grooming
+
+### 8.1 Sidequests pulled into v1.2
+
+`85c4dc53`, `7a52bf39` (Track C); `6338cc8e` (A5); eval-harness hardening taken opportunistically
+during Track A: `2dbaf3c7` (force fresh artifact comparisons), `5b29a0ee` (mechanical treatment
+gates), `48395009` (attach audits beyond session chunks).
+
+### 8.2 Parked (explicitly not v1.2)
+
+`6e69bc0c` bulk personal-archive ingestion (strong v1.3 candidate beside the OKF importer),
+`41aba0d4` namespace-cleanup retries, `e5b328c3` GitOps-stable Surreal secret.
+
+### 8.3 Stale-task dispositions (grooming pass to execute)
+
+- `04e5f940` refresh same-SHA RC evidence (critical) → archive; superseded by 1.1 release receipts.
+- `801e1f67` align 1.0 RC version metadata → archive.
+- `b4061098` "Sibyl 1.0: autonomous memory workspace" epic (doing/critical) → close; 1.0 shipped.
+- `5f6b964a` diagnose official accuracy collapse → complete with learnings pointer to decision
+  `0e0677006a04` (diagnosis done: format defect).
+- `71b2ef7f` enterprise readiness (review) → verify PR 257 shipped in 1.1, then complete.
+- `7e8915a7` update project dependencies (doing) → complete; CVE chain done through 1.1.2.
+- `8ac84142` clean local docs before RC gate rerun → archive.
+- `c94d0556` improve LongMemEval live retrieval (doing) → superseded by the v1.2 Track A epic; close
+  with a pointer here.
+
+## 9. Decisions locked vs open
+
+Locked:
+
+- **Leaderboard: hold until `baseline-beat-gate` passes** (Bliss, 2026-07-24).
+- **Protocol law (§3)** — standing, inherited from the campaign.
+- **No reader answer-shaping for abstention** — integrity boundary.
+
+Planned per this doc (flag before reversing):
+
+- Coalescence W1–W3 + TeamMemBench slide to v1.3; W1 design-doc optional in v1.2.
+- Accurate mode deprecated; no per-domain retrieval-mode fork.
+
+Open (decide during execution):
+
+- A1: slices as first-class graph entities vs retrieval-layer views over states.
+- A3: server-side traversal loop vs client-exposed verbs (MCP surface implications).
+- B1: handbook regeneration trigger (graph-delta threshold vs schedule).
+- Whether B3 (re-extraction) ships in v1.2 or moves whole to v1.3.
+
+## 10. Exit criteria
+
+- Combined full-451 ≥ 42.8% at ≤ 10s avg with committed receipts; leaderboard submission made.
+- Gold-literal exposure ≥ 50% and state recall@10 ≥ 85% on the replay slices.
+- Accurate-mode fate executed; `query_planning.py` audit closed.
+- Handbook + `.sibyl/memory/` projection shipped and serving wake bundles, both gates green.
+- `dogfood-trust-gate` green: zero stranded pending writes, release-saga replay landed, fixtures for
+  every §2.5 bug class.
+- Task board groomed per §8.3.
+
+## 11. Sequencing rationale
+
+Substrate before traversal: agentic retrieval over fat states re-buys the format defect at higher
+latency, so A1 gates A3. Ranking (A2) rides the A1 replay slices, costing near-zero marginal setup.
+Track C runs parallel to Track A — different surface, different reviewers, and the eval work keeps
+colliding with exactly these bugs (backfill false-negatives cost two corpus rebuilds). Track B
+follows the production notes machinery it reuses and can land any time; it is deliberately not gated
+on Track A. Coalescence waits because credibility compounds: the v1.3 coalescence story lands on top
+of a retrieval number that beats the naive baseline, a leaderboard presence, and a dogfood loop with
+zero stranded writes.
+
+## 12. Receipts index
+
+Sibyl decisions: `3da12cba3ccd` (full-451 Pareto win + accurate-mode kill), `0e0677006a04` (format
+defect synthesis + oracle ablation), `7b7b46f1d169` (exposure sweep, selection ceiling),
+`0d07482dd334` (reader A/B, geometry kill), `024f09dbeb0f` (notes win, era-3), `afe1a65abcdc` (web
+v2 GO), `01e6ed6e4006` (enterprise v2 GO), `7a6a1d49b32c` (reservation tuning kill), `9f3c52581c68`
+(typed-stream-alone kill), `109702d198fe` (abstention lever closed), `0f4ab0c8a0cc` (graph-backed
+agentic path). Plans: `17188e6e7820`. Runs: `.moon/cache/evals/nova-full-451-fast/`. Commits:
+`12ac2243` (note distillation), `430dea04` (content-aware digest v2), `1f086b22` (conjunctive-safe
+fulltext), `83c8dd7b` (defaults reverted after tuning kill). Production port: task `1e1caf57`
+(done).

--- a/docs/architecture/SIBYL_POST_1_0_ROADMAP.md
+++ b/docs/architecture/SIBYL_POST_1_0_ROADMAP.md
@@ -10,6 +10,9 @@
   the product truth remains [`SIBYL_NORTHSTAR.md`](SIBYL_NORTHSTAR.md).
 - Concrete v1.1 execution plan:
   [`SIBYL_1_1_IMPLEMENTATION_PLAN.md`](SIBYL_1_1_IMPLEMENTATION_PLAN.md).
+- Concrete v1.2 execution plan:
+  [`SIBYL_1_2_IMPLEMENTATION_PLAN.md`](SIBYL_1_2_IMPLEMENTATION_PLAN.md) (2026-07-24) — re-scopes
+  v1.2 to "Retrieve It"; coalescence W1–W3 and TeamMemBench slide to v1.3.
 
 This roadmap covers the three releases after 1.0. It was assembled from a full-codebase +
 competitive-landscape research pass and a cross-model review, and it is grounded in verified code


### PR DESCRIPTION
# 🗄️ Stop discarding offline writes the server may have applied

> Fixes silent, unrecoverable loss of user-authored memory in the offline buffer, plus a cluster of commands that report failure and exit 0. Both present in shipped 1.1.2. Candidate for a 1.1.3 patch.

## 💡 What this is

The CLI buffers writes to `~/.config/sibyl/pending_writes/` when the server is unreachable and replays them on `sibyl pending-writes flush`. The replay decided whether to keep a buffered file from an allow-list of HTTP status codes — `{401, 408, 429}` and anything `>= 500`. Every other response deleted the file, and the delete happened *before* the exception was raised.

HTTP 409 was not on that list. It is the one status the client cannot interpret, and it is exactly the status this buffer provokes.

## 🤔 Why we need it & what it replaces

The server reserves an idempotency row before a route body runs and completes it afterward, with no `try`/`except` spanning the two. Any crash, timeout, or downstream error in between strands the row at `response_status_code == 102`, permanently — there is no TTL and no reaper. A later replay of that key gets a 409 meaning "in progress", which is indistinguishable from "already applied" and from "never ran".

So the failure mode was: work offline, reconnect, flush, and every entry that had previously reached a reservation is deleted. The payload is never persisted server-side — the stored row keeps a `request_hash` and a `response_body` that is empty for a 102 — so the only copy of the memory was the file that just got removed. On the dogfood store this is not hypothetical: 74 rows are currently stranded at 102, and flushing mints more.

The metrics hid it. `discarded` counts only explicit `sibyl pending-writes discard` invocations; the three `delete_pending_write` call sites in `client.py` recorded nothing at all, and `expired` had no writer anywhere. A user could lose a hundred buffered memories and every counter would look unremarkable.

The allow-list is replaced by a deny-list built from a single question: does this status *prove* the mutation did not apply?

| Status | Verdict | Why |
| --- | --- | --- |
| 400, 422 | discard | Payload rejected at validation, before any handler body runs. Replaying the same bytes cannot succeed. |
| 409 | retain | Cannot distinguish "never ran" from "already applied". This is the bug. |
| 401, 403 | retain | Auth and permission problems are fixable, then replayable. |
| 404, 405, 410 | retain | Judgment call, see below. |
| 408, 413, 429, 5xx | retain | Ambiguous, or fixable server-side. A 503 here explicitly means "applied, receipt pending". |

## 🎯 The invariant

Anchor the review on one property: **a buffered file is deleted only when the response proves the mutation did not apply.** Everything else is retained, because a polluted queue is recoverable and a deleted payload is not.

That principle is what decides the 404 row, and it is the call most worth challenging. A 404 does prove non-application — but a CLI newer than its server returns 404 for routes the server does not have, which is precisely the offline-and-reconnect world this buffer exists to serve. Reversibility broke the tie toward retention. The cost is real and stated under follow-ups.

## 🛠️ How it works

**1. The predicate inverts** — `apps/cli/src/sibyl_cli/client.py`

`_should_keep_pending_write` becomes a deny-list of provably-rejected statuses instead of an allow-list of retryable ones.

**2. Every delete is now accounted** — `apps/cli/src/sibyl_cli/client.py`, `pending_writes.py`

The dead `expired` counter is replaced by `completed` and `dropped`, giving the invariant `attempted = completed + replayed + dropped + discarded + still-queued`. Deletes route through one `_resolve_pending_write` helper so no path can remove a file silently. A private `_pending_write_created` parameter threads buffer ownership through the 401-refresh recursion, so an inline success counts as `completed` without double-counting the `replayed` that `pending_writes.py` records.

**3. Metric names are a checked type**, so a mistyped counter is a typecheck error rather than a counter that silently reads zero.

**4. Failing commands exit non-zero** — `task.py`, `org.py`, `auth.py`, `project.py`

`sibyl task archive <missing-id>` printed `✗ Failed: API error: not_found` and exited 0; the bulk `--stdin` path printed a green `✓ Archived 0 task(s)` next to `✗ Failed: 2 task(s)` and also exited 0. The same swallow-and-continue shape appeared across the seven `org` verbs, `auth` status/signup/api-key handling and the terminal branches of `_login_auto`, and `project link`/`relink`. `sibyl auth status` was reproduced live printing `✗ No auth token found` and exiting 0.

This is not only a scripting nicety: the shipped agent skill pack tells agents that a `✗` line comes with a non-zero exit and instructs them to check exit codes. The CLI was contradicting its own contract.

Commands that legitimately exit 0 on a miss were left alone: soft lookups that return `None` to a caller, the `doctor` sub-check whose report exits 1 on its own, the per-item loop skip in `session.py`, `relink`'s ambiguous-match branch that asks for `--id`, and the login path where printing a URL *is* the success case.

## 🧪 Validation

Receipts are keyed to this branch head after rebase onto `main`.

- `moon run cli:test` → 421 passed
- `moon run cli:lint` → clean, `moon run cli:typecheck` → clean

The new tests were checked for teeth two ways. Restoring the original predicate and re-running the suite produces 7 failures — exactly the status codes whose retention flipped. Separately, a run with the old predicate confirmed a 409 leaves the queue empty, destroying the payload.

⚠️ Two existing tests asserted `exit_code == 0` on runs where archives had failed (`test_task.py`, `test_project.py`). They encoded the bug rather than the behavior, and are corrected here. `test_org.py` is new.

## 🔍 What reviewers should focus on

- **The 404 retention.** This is the deliberate trade and the place to push back. See the follow-up below for its cost.
- Whether 400 and 422 really are provably-not-applied on *every* buffered write path. If any 400 can be raised after a mutation partially applied, the fix still loses data.
- The metrics invariant across the 401-refresh recursion, which is the one path where a buffer can be created and resolved at different stack depths.
- Whether any command was moved to a non-zero exit where 0 was correct. A false failure in CI is its own bug.

## 📌 Follow-ups (deliberate non-fixes)

- **Retaining 404 makes a typo permanent.** `archive_task` is a buffered write, so `sibyl task archive <nonexistent>` now leaves a queue entry that will never succeed, and `pending-writes flush` will exit 1 until it is drained one ID at a time. This is the strongest argument for the durability work below, and it is why that work should not wait long.
- **Queue durability**: a park/dead-letter directory and an attempt cap. `attempts` is already incremented and nothing branches on it.
- **Server-side**: a reaper for rows stranded at 102, and releasing the reservation when a route fails, so the ambiguous 409 stops being minted in the first place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now exits with non-zero status on authentication, status, organization, project link/relink, task archive, and API-key/local auth errors.
  * Pending-write handling is more reliable: it preserves retryable failures and records detailed completion/drop metrics.
  * Task archiving and archive-by-stdin workflows now correctly report failure as exit code `1`.
* **Documentation**
  * Added the v1.2 “Retrieve It” implementation plan and updated the roadmap scope.
* **Tests**
  * Expanded CLI test coverage for exit codes and pending-write metrics behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->