### PR TITLE
fix(schema): unwedge the migration ladder and verify invariants independently

### DIFF
--- a/apps/api/src/sibyl/cli/db.py
+++ b/apps/api/src/sibyl/cli/db.py
@@ -911,6 +911,7 @@ def db_duplicates(
     from sibyl.persistence.surreal.content import build_surreal_content_client
     from sibyl_core.backends.surreal.auth_schema import auth_schema_invariant_plan
     from sibyl_core.backends.surreal.content_schema import content_schema_invariant_plan
+    from sibyl_core.backends.surreal.records import normalize_records
 
     @run_async
     async def _duplicates() -> None:
@@ -1002,8 +1003,13 @@ def db_duplicates(
             try:
                 for start in range(0, len(doomed), 200):
                     batch = doomed[start : start + 200]
-                    await client.execute_query("DELETE $ids;", ids=batch)
-                    collapsed += len(batch)
+                    # A bare DELETE returns nothing, so counting the batch size would
+                    # report the request rather than the rows that were actually there.
+                    removed = await client.execute_query(
+                        "DELETE $ids RETURN BEFORE;",
+                        ids=batch,
+                    )
+                    collapsed += len(normalize_records(removed))
             finally:
                 await client.close()
 

--- a/apps/api/src/sibyl/cli/db.py
+++ b/apps/api/src/sibyl/cli/db.py
@@ -818,6 +818,26 @@ class _DuplicateGroup:
         return len(self.record_ids) - 1
 
 
+def _duplicate_bucket_key(
+    row: Mapping[str, object],
+    fields: tuple[str, ...],
+) -> tuple[tuple[str, str], ...] | None:
+    """Return the key a UNIQUE index would enforce over, or None if it enforces nothing.
+
+    SurrealDB skips an index entry whose key has a missing component, so rows without a
+    value for an optional column are all legitimately distinct and must never be
+    collapsed. The type name rides along because the index treats 1 and '1' as separate
+    entries, and stringifying alone would merge them.
+    """
+    key: list[tuple[str, str]] = []
+    for field in fields:
+        value = row.get(field)
+        if value is None:
+            return None
+        key.append((type(value).__name__, str(value)))
+    return tuple(key)
+
+
 async def _duplicate_groups_for_plane(client: Any, invariant_plan: Any) -> list[_DuplicateGroup]:
     """Group rows under every UNIQUE index the schema promises but the store lacks.
 
@@ -849,12 +869,14 @@ async def _duplicate_groups_for_plane(client: Any, invariant_plan: Any) -> list[
                 f"SELECT id AS duplicate_record_id, {projection} FROM {requirement.table};"  # noqa: S608
             )
         )
-        buckets: dict[tuple[str, ...], list[object]] = {}
+        buckets: dict[tuple[tuple[str, str], ...], list[object]] = {}
         for row in rows:
             record_id = row.get("duplicate_record_id")
             if record_id is None:
                 continue
-            key = tuple(str(row.get(field)) for field in requirement.fields)
+            key = _duplicate_bucket_key(row, requirement.fields)
+            if key is None:
+                continue
             buckets.setdefault(key, []).append(record_id)
         for key, record_ids in buckets.items():
             if len(record_ids) > 1:
@@ -862,7 +884,7 @@ async def _duplicate_groups_for_plane(client: Any, invariant_plan: Any) -> list[
                     _DuplicateGroup(
                         table=requirement.table,
                         index_name=requirement.name,
-                        key=key,
+                        key=tuple(value for _, value in key),
                         # Sorted so the surviving row is the same on every run.
                         record_ids=tuple(sorted(record_ids, key=str)),
                     )

--- a/apps/api/src/sibyl/cli/db.py
+++ b/apps/api/src/sibyl/cli/db.py
@@ -651,6 +651,129 @@ def restore_db(
     _restore()
 
 
+async def _plane_schema_version(client: Any, *, name: str) -> int:
+    from sibyl_core.backends.surreal.schema_version import get_schema_version
+
+    try:
+        return await get_schema_version(client.execute_query, name=name)
+    except Exception:
+        return 0
+
+
+async def _init_plane(
+    *,
+    plane: str,
+    build_client: Any,
+    bootstrap: Any,
+    schema_name: str,
+    target_version: int,
+) -> dict[str, object]:
+    client = build_client()
+    try:
+        before = await _plane_schema_version(client, name=schema_name)
+        try:
+            await bootstrap(client)
+            error_text: str | None = None
+        except Exception as exc:
+            error_text = str(exc)
+        after = await _plane_schema_version(client, name=schema_name)
+    finally:
+        await client.close()
+    entry: dict[str, object] = {
+        "plane": plane,
+        "version_before": before,
+        "version_after": after,
+        "target_version": target_version,
+    }
+    if error_text:
+        entry["error"] = error_text
+    return entry
+
+
+@app.command("init")
+def db_init(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Print the result as JSON"),
+    ] = False,
+) -> None:
+    """Apply pending auth and content schema migrations.
+
+    Safe to run repeatedly: it never drops tables or deletes rows, and migrations
+    already recorded in schema_version are skipped.
+    """
+    from sibyl.config import settings
+    from sibyl.persistence.surreal.auth import build_surreal_auth_client
+    from sibyl.persistence.surreal.content import build_surreal_content_client
+    from sibyl_core.backends.surreal import bootstrap_auth_schema, bootstrap_content_schema
+    from sibyl_core.backends.surreal.auth_schema import (
+        AUTH_SCHEMA_CURRENT_VERSION,
+        AUTH_SCHEMA_NAME,
+    )
+    from sibyl_core.backends.surreal.content_schema import (
+        CONTENT_SCHEMA_CURRENT_VERSION,
+        CONTENT_SCHEMA_NAME,
+    )
+
+    @run_async
+    async def _init() -> None:
+        results = [
+            await _init_plane(
+                plane="auth",
+                build_client=build_surreal_auth_client,
+                bootstrap=bootstrap_auth_schema,
+                schema_name=AUTH_SCHEMA_NAME,
+                target_version=AUTH_SCHEMA_CURRENT_VERSION,
+            )
+        ]
+        if settings.store == "surreal":
+            results.append(
+                await _init_plane(
+                    plane="content",
+                    build_client=build_surreal_content_client,
+                    bootstrap=bootstrap_content_schema,
+                    schema_name=CONTENT_SCHEMA_NAME,
+                    target_version=CONTENT_SCHEMA_CURRENT_VERSION,
+                )
+            )
+
+        failed = [entry for entry in results if entry.get("error")]
+        if json_output:
+            print_json({"planes": results, "ok": not failed})
+        else:
+            console.print(f"\n[{NEON_CYAN}]Schema init[/{NEON_CYAN}]\n")
+            for entry in results:
+                plane = entry["plane"]
+                before = entry["version_before"]
+                after = entry["version_after"]
+                target = entry["target_version"]
+                if entry.get("error"):
+                    console.print(
+                        f"  [{ERROR_RED}]{plane}[/{ERROR_RED}]: "
+                        f"v{before} -> v{after} (target v{target})"
+                    )
+                    console.print(f"    [{ERROR_RED}]{entry['error']}[/{ERROR_RED}]")
+                elif after == before:
+                    console.print(
+                        f"  [{ELECTRIC_PURPLE}]{plane}[/{ELECTRIC_PURPLE}]: already at v{after}"
+                    )
+                else:
+                    console.print(
+                        f"  [{SUCCESS_GREEN}]{plane}[/{SUCCESS_GREEN}]: v{before} -> v{after}"
+                    )
+
+        if failed:
+            planes = ", ".join(str(entry["plane"]) for entry in failed)
+            error(f"Schema init incomplete: {planes}")
+            print_db_hint()
+            raise typer.Exit(code=1)
+
+        if not json_output:
+            success("Schema up to date")
+
+    _init()
+
+
 @app.command("clear")
 def clear_db(
     yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,

--- a/apps/api/src/sibyl/cli/db.py
+++ b/apps/api/src/sibyl/cli/db.py
@@ -5,7 +5,7 @@ Commands for backup, restore, and database management.
 
 import json
 from collections.abc import Mapping
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -58,6 +58,12 @@ def _normalize_rows(rows: object) -> list[dict[str, object]]:
     if not isinstance(rows, list):
         return []
     return [dict(row) for row in rows if isinstance(row, Mapping)]
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
 
 
 def _extract_definitions(value: object) -> list[dict[str, str]]:
@@ -652,12 +658,14 @@ def restore_db(
 
 
 async def _plane_schema_version(client: Any, *, name: str) -> int:
+    """Read the recorded version, letting a read failure surface.
+
+    Swallowing the failure and reporting version 0 makes an unreachable or broken
+    store look like a fresh one, which then reads as a successful migration.
+    """
     from sibyl_core.backends.surreal.schema_version import get_schema_version
 
-    try:
-        return await get_schema_version(client.execute_query, name=name)
-    except Exception:
-        return 0
+    return await get_schema_version(client.execute_query, name=name)
 
 
 async def _init_plane(
@@ -667,26 +675,33 @@ async def _init_plane(
     bootstrap: Any,
     schema_name: str,
     target_version: int,
+    invariant_plan: Any,
 ) -> dict[str, object]:
+    from sibyl_core.backends.surreal.schema_invariants import ensure_schema_invariants
+
+    entry: dict[str, object] = {"plane": plane, "target_version": target_version}
     client = build_client()
     try:
-        before = await _plane_schema_version(client, name=schema_name)
+        entry["version_before"] = await _plane_schema_version(client, name=schema_name)
         try:
             await bootstrap(client)
-            error_text: str | None = None
         except Exception as exc:
-            error_text = str(exc)
+            entry["error"] = str(exc)
+
         after = await _plane_schema_version(client, name=schema_name)
+        entry["version_after"] = after
+        if after != target_version and "error" not in entry:
+            entry["error"] = f"schema stopped at v{after}, expected v{target_version}"
+
+        report = await ensure_schema_invariants(client.execute_query, invariant_plan)
+        entry["repaired_indexes"] = list(report.repaired_indexes)
+        entry["violations"] = [violation.describe() for violation in report.violations]
+        if report.violations and "error" not in entry:
+            entry["error"] = f"{len(report.violations)} schema invariant(s) unmet"
+    except Exception as exc:
+        entry.setdefault("error", f"schema state could not be read: {exc}")
     finally:
         await client.close()
-    entry: dict[str, object] = {
-        "plane": plane,
-        "version_before": before,
-        "version_after": after,
-        "target_version": target_version,
-    }
-    if error_text:
-        entry["error"] = error_text
     return entry
 
 
@@ -709,10 +724,12 @@ def db_init(
     from sibyl_core.backends.surreal.auth_schema import (
         AUTH_SCHEMA_CURRENT_VERSION,
         AUTH_SCHEMA_NAME,
+        auth_schema_invariant_plan,
     )
     from sibyl_core.backends.surreal.content_schema import (
         CONTENT_SCHEMA_CURRENT_VERSION,
         CONTENT_SCHEMA_NAME,
+        content_schema_invariant_plan,
     )
 
     @run_async
@@ -724,6 +741,7 @@ def db_init(
                 bootstrap=bootstrap_auth_schema,
                 schema_name=AUTH_SCHEMA_NAME,
                 target_version=AUTH_SCHEMA_CURRENT_VERSION,
+                invariant_plan=auth_schema_invariant_plan(),
             )
         ]
         if settings.store == "surreal":
@@ -734,6 +752,7 @@ def db_init(
                     bootstrap=bootstrap_content_schema,
                     schema_name=CONTENT_SCHEMA_NAME,
                     target_version=CONTENT_SCHEMA_CURRENT_VERSION,
+                    invariant_plan=content_schema_invariant_plan(),
                 )
             )
 
@@ -744,8 +763,8 @@ def db_init(
             console.print(f"\n[{NEON_CYAN}]Schema init[/{NEON_CYAN}]\n")
             for entry in results:
                 plane = entry["plane"]
-                before = entry["version_before"]
-                after = entry["version_after"]
+                before = entry.get("version_before", "?")
+                after = entry.get("version_after", "?")
                 target = entry["target_version"]
                 if entry.get("error"):
                     console.print(
@@ -761,10 +780,23 @@ def db_init(
                     console.print(
                         f"  [{SUCCESS_GREEN}]{plane}[/{SUCCESS_GREEN}]: v{before} -> v{after}"
                     )
+                for repaired in _string_list(entry.get("repaired_indexes")):
+                    console.print(
+                        f"    [{SUCCESS_GREEN}]rebuilt index {repaired}[/{SUCCESS_GREEN}]"
+                    )
+                for violation in _string_list(entry.get("violations")):
+                    console.print(f"    [{ERROR_RED}]unmet: {violation}[/{ERROR_RED}]")
 
         if failed:
             planes = ", ".join(str(entry["plane"]) for entry in failed)
             error(f"Schema init incomplete: {planes}")
+            if any(_string_list(entry.get("violations")) for entry in results):
+                warn(
+                    "Unique indexes a migration skipped stay unenforced until the "
+                    "duplicate rows are removed. Run 'sibyld db duplicates' to inventory "
+                    "them, then 'sibyld db duplicates --collapse' to keep one row per "
+                    "group, then re-run 'sibyld db init'."
+                )
             print_db_hint()
             raise typer.Exit(code=1)
 
@@ -772,6 +804,194 @@ def db_init(
             success("Schema up to date")
 
     _init()
+
+
+@dataclass(frozen=True, slots=True)
+class _DuplicateGroup:
+    table: str
+    index_name: str
+    key: tuple[str, ...]
+    record_ids: tuple[object, ...]
+
+    @property
+    def excess(self) -> int:
+        return len(self.record_ids) - 1
+
+
+async def _duplicate_groups_for_plane(client: Any, invariant_plan: Any) -> list[_DuplicateGroup]:
+    """Group rows under every UNIQUE index the schema promises but the store lacks.
+
+    Deriving the scan from the missing indexes rather than a hardcoded table list means
+    the inventory always targets whatever is actually blocking the migration.
+    """
+    from sibyl_core.backends.surreal.records import normalize_records
+    from sibyl_core.backends.surreal.schema_invariants import (
+        fetch_table_definitions,
+        fetch_table_indexes,
+    )
+    from sibyl_core.backends.surreal.schema_version import validate_identifier
+
+    definitions = await fetch_table_definitions(client.execute_query)
+    groups: list[_DuplicateGroup] = []
+    for requirement in invariant_plan.unique_indexes:
+        if requirement.table not in definitions:
+            continue
+        if requirement.name in await fetch_table_indexes(client.execute_query, requirement.table):
+            continue
+
+        validate_identifier(requirement.table)
+        for field_name in requirement.fields:
+            validate_identifier(field_name)
+        projection = ", ".join(requirement.fields)
+        # normalize_records drops a bare `id`, so the record id has to ride an alias.
+        rows = normalize_records(
+            await client.execute_query(
+                f"SELECT id AS duplicate_record_id, {projection} FROM {requirement.table};"  # noqa: S608
+            )
+        )
+        buckets: dict[tuple[str, ...], list[object]] = {}
+        for row in rows:
+            record_id = row.get("duplicate_record_id")
+            if record_id is None:
+                continue
+            key = tuple(str(row.get(field)) for field in requirement.fields)
+            buckets.setdefault(key, []).append(record_id)
+        for key, record_ids in buckets.items():
+            if len(record_ids) > 1:
+                groups.append(
+                    _DuplicateGroup(
+                        table=requirement.table,
+                        index_name=requirement.name,
+                        key=key,
+                        # Sorted so the surviving row is the same on every run.
+                        record_ids=tuple(sorted(record_ids, key=str)),
+                    )
+                )
+    return groups
+
+
+@app.command("duplicates")
+def db_duplicates(
+    collapse: Annotated[
+        bool,
+        typer.Option("--collapse", help="Delete excess rows, keeping one per duplicate group"),
+    ] = False,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Print the result as JSON")] = False,
+) -> None:
+    """Inventory rows that block a UNIQUE index the schema requires.
+
+    Without --collapse this only reads. Collapsing deletes rows, so it stays an
+    explicit operator decision and is never run as part of a migration.
+    """
+    from sibyl.config import settings
+    from sibyl.persistence.surreal.auth import build_surreal_auth_client
+    from sibyl.persistence.surreal.content import build_surreal_content_client
+    from sibyl_core.backends.surreal.auth_schema import auth_schema_invariant_plan
+    from sibyl_core.backends.surreal.content_schema import content_schema_invariant_plan
+
+    @run_async
+    async def _duplicates() -> None:
+        planes: list[tuple[str, Any, Any]] = [
+            ("auth", build_surreal_auth_client, auth_schema_invariant_plan())
+        ]
+        if settings.store == "surreal":
+            planes.append(
+                ("content", build_surreal_content_client, content_schema_invariant_plan())
+            )
+
+        found: list[tuple[str, _DuplicateGroup]] = []
+        for plane, build_client, plan in planes:
+            client = build_client()
+            try:
+                found.extend(
+                    (plane, group) for group in await _duplicate_groups_for_plane(client, plan)
+                )
+            finally:
+                await client.close()
+
+        if not found:
+            if json_output:
+                print_json({"groups": [], "excess_rows": 0, "collapsed": 0})
+            else:
+                success("No duplicate rows block any required unique index")
+            return
+
+        excess = sum(group.excess for _, group in found)
+        if not json_output:
+            console.print(f"\n[{NEON_CYAN}]Duplicate rows blocking unique indexes[/{NEON_CYAN}]\n")
+            by_index: dict[tuple[str, str, str], list[_DuplicateGroup]] = {}
+            for plane, group in found:
+                by_index.setdefault((plane, group.table, group.index_name), []).append(group)
+            for (plane, table, index_name), groups in by_index.items():
+                console.print(
+                    f"  [{ELECTRIC_PURPLE}]{plane}.{table}[/{ELECTRIC_PURPLE}] {index_name}: "
+                    f"{len(groups)} duplicated key(s), "
+                    f"{sum(item.excess for item in groups)} excess row(s)"
+                )
+                for group in groups[:5]:
+                    console.print(
+                        f"    [dim]{' / '.join(group.key)} x{len(group.record_ids)}[/dim]"
+                    )
+                if len(groups) > 5:
+                    console.print(f"    [dim]...and {len(groups) - 5} more[/dim]")
+
+        if not collapse:
+            if json_output:
+                print_json(
+                    {
+                        "groups": [
+                            {
+                                "plane": plane,
+                                "table": group.table,
+                                "index": group.index_name,
+                                "key": list(group.key),
+                                "copies": len(group.record_ids),
+                            }
+                            for plane, group in found
+                        ],
+                        "excess_rows": excess,
+                        "collapsed": 0,
+                    }
+                )
+            else:
+                warn(f"{excess} excess row(s) would be deleted by --collapse")
+            return
+
+        if not yes:
+            console.print(
+                f"\n[{ERROR_RED}]This deletes {excess} row(s), keeping one per group.[/{ERROR_RED}]"
+            )
+            if not typer.confirm("Continue?"):
+                info("Cancelled")
+                return
+
+        collapsed = 0
+        for plane, build_client, _ in planes:
+            doomed = [
+                record_id
+                for entry_plane, group in found
+                if entry_plane == plane
+                for record_id in group.record_ids[1:]
+            ]
+            if not doomed:
+                continue
+            client = build_client()
+            try:
+                for start in range(0, len(doomed), 200):
+                    batch = doomed[start : start + 200]
+                    await client.execute_query("DELETE $ids;", ids=batch)
+                    collapsed += len(batch)
+            finally:
+                await client.close()
+
+        if json_output:
+            print_json({"groups": [], "excess_rows": excess, "collapsed": collapsed})
+        else:
+            success(f"Deleted {collapsed} excess row(s)")
+            info("Run 'sibyld db init' to rebuild the unique indexes")
+
+    _duplicates()
 
 
 @app.command("clear")

--- a/apps/api/src/sibyl/persistence/auth_archive.py
+++ b/apps/api/src/sibyl/persistence/auth_archive.py
@@ -9,6 +9,8 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
+import structlog
+
 from sibyl.persistence.surreal.auth import build_surreal_auth_client
 from sibyl_core.backends.surreal import bootstrap_auth_schema
 from sibyl_core.backends.surreal.records import (
@@ -16,6 +18,12 @@ from sibyl_core.backends.surreal.records import (
     query_error as _query_error,
     raise_on_error as _raise_on_error,
 )
+from sibyl_core.backends.surreal.schema_invariants import (
+    drop_undeclared_fields as _drop_undeclared_fields,
+    fetch_declared_fields,
+)
+
+log = structlog.get_logger()
 
 AUTH_ARCHIVE_VERSION = "1.0"
 _AUTH_ARCHIVE_SQL = {
@@ -234,6 +242,7 @@ class AuthArchiveRestoreResult:
     tables_restored: int
     rows_restored: int
     errors: list[str] = field(default_factory=list)
+    dropped_fields: dict[str, list[str]] = field(default_factory=dict)
 
 
 def _serialize_value(value: object) -> object:
@@ -492,6 +501,42 @@ async def export_auth_archive_payload(
     return await _export_surreal_auth_archive_payload(organization_id)
 
 
+def _auth_archive_record(
+    row: dict[Any, Any],
+    declared: frozenset[str],
+) -> tuple[dict[str, object], str, tuple[str, ...]]:
+    normalized_row = {str(key): value for key, value in row.items()}
+    record = {
+        str(key): _deserialize_value(value) for key, value in normalized_row.items() if key != "id"
+    }
+    uuid = str(normalized_row.get("id") or normalized_row.get("uuid") or "").strip()
+    if not uuid:
+        return record, "", ()
+    record["uuid"] = uuid
+    record, dropped = _drop_undeclared_fields(record, declared)
+    return record, uuid, dropped
+
+
+async def _create_auth_archive_row(
+    client: Any,
+    table: str,
+    *,
+    uuid: str,
+    record: dict[str, object],
+) -> bool:
+    existing_result = await client.execute_query(_SELECT_BY_UUID[table], uuid=uuid)
+    existing_error = _query_error(existing_result)
+    if existing_error is not None:
+        raise RuntimeError(existing_error)
+    if _normalize_records(existing_result):
+        return False
+    create_result = await client.execute_query(_CREATE_RECORD[table], record=record)
+    create_error = _query_error(create_result)
+    if create_error is not None:
+        raise RuntimeError(create_error)
+    return True
+
+
 async def restore_auth_archive_payload(
     payload: dict[str, object],
     *,
@@ -512,6 +557,7 @@ async def restore_auth_archive_payload(
     tables_restored = 0
     rows_restored = 0
     errors: list[str] = []
+    dropped_fields: dict[str, set[str]] = {}
 
     try:
         await bootstrap_auth_schema(client, reset=False)
@@ -528,46 +574,42 @@ async def restore_auth_archive_payload(
             if not rows:
                 continue
 
+            declared = await fetch_declared_fields(client.execute_query, table)
             restored_table = False
             for row in rows:
                 if not isinstance(row, dict):
                     errors.append(f"{table} row payload must be an object")
                     continue
-                normalized_row = {str(key): value for key, value in row.items()}
-
-                record = {
-                    str(key): _deserialize_value(value)
-                    for key, value in normalized_row.items()
-                    if key != "id"
-                }
-                uuid = str(normalized_row.get("id") or normalized_row.get("uuid") or "").strip()
+                record, uuid, dropped = _auth_archive_record(row, declared)
                 if not uuid:
                     errors.append(f"{table} row is missing id")
                     continue
-                record["uuid"] = uuid
+                if dropped:
+                    dropped_fields.setdefault(table, set()).update(dropped)
 
                 try:
-                    existing_result = await client.execute_query(_SELECT_BY_UUID[table], uuid=uuid)
-                    existing_error = _query_error(existing_result)
-                    if existing_error is not None:
-                        raise RuntimeError(existing_error)
-                    if _normalize_records(existing_result):
-                        continue
-                    create_result = await client.execute_query(_CREATE_RECORD[table], record=record)
-                    create_error = _query_error(create_result)
-                    if create_error is not None:
-                        raise RuntimeError(create_error)
-                    rows_restored += 1
-                    restored_table = True
+                    if await _create_auth_archive_row(client, table, uuid=uuid, record=record):
+                        rows_restored += 1
+                        restored_table = True
                 except Exception as exc:
                     errors.append(f"{table}:{uuid}: {exc}")
             if restored_table:
                 tables_restored += 1
+        if dropped_fields:
+            log.warning(
+                "auth_archive_restore_dropped_undeclared_fields",
+                dropped_fields={
+                    table: sorted(names) for table, names in sorted(dropped_fields.items())
+                },
+            )
         return AuthArchiveRestoreResult(
             success=not errors,
             tables_restored=tables_restored,
             rows_restored=rows_restored,
             errors=errors[:50],
+            dropped_fields={
+                table: sorted(names) for table, names in sorted(dropped_fields.items())
+            },
         )
     finally:
         await client.close()

--- a/apps/api/src/sibyl/persistence/content_archive.py
+++ b/apps/api/src/sibyl/persistence/content_archive.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime
 from enum import Enum
 from uuid import UUID
 
+import structlog
+
 from sibyl import config as config_module
 from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
 from sibyl_core.backends.surreal.records import (
@@ -15,6 +17,12 @@ from sibyl_core.backends.surreal.records import (
     query_error as _query_error,
     raise_on_error as _raise_on_error,
 )
+from sibyl_core.backends.surreal.schema_invariants import (
+    drop_undeclared_fields as _drop_undeclared_fields,
+    fetch_declared_fields,
+)
+
+log = structlog.get_logger()
 
 CONTENT_ARCHIVE_VERSION = "1.0"
 
@@ -198,6 +206,7 @@ class ContentArchiveRestoreResult:
     tables_restored: int
     rows_restored: int
     errors: list[str] = field(default_factory=list)
+    dropped_fields: dict[str, list[str]] = field(default_factory=dict)
 
 
 def build_surreal_content_client() -> SurrealContentClient:
@@ -444,6 +453,7 @@ async def restore_content_archive_payload(
     tables_restored = 0
     rows_restored = 0
     errors: list[str] = []
+    dropped_fields: dict[str, set[str]] = {}
 
     try:
         await bootstrap_content_schema(client, reset=False)
@@ -460,6 +470,7 @@ async def restore_content_archive_payload(
             if not rows:
                 continue
 
+            declared = await fetch_declared_fields(client.execute_query, spec.name)
             tables_restored += 1
             for row in rows:
                 if not isinstance(row, dict):
@@ -489,6 +500,9 @@ async def restore_content_archive_payload(
                 if spec.name == "document_chunks":
                     record["embedding"] = _deserialize_vector(record.get("embedding"))
                 record[spec.target_identity_field] = identity
+                record, dropped = _drop_undeclared_fields(record, declared)
+                if dropped:
+                    dropped_fields.setdefault(spec.name, set()).update(dropped)
 
                 # Delete+create must be atomic: a create that fails after the
                 # delete would otherwise drop the existing row on a restore, the
@@ -511,11 +525,21 @@ async def restore_content_archive_payload(
                 except Exception as exc:
                     errors.append(f"{spec.name}:{identity}: {exc}")
 
+        if dropped_fields:
+            log.warning(
+                "content_archive_restore_dropped_undeclared_fields",
+                dropped_fields={
+                    table: sorted(names) for table, names in sorted(dropped_fields.items())
+                },
+            )
         return ContentArchiveRestoreResult(
             success=not errors,
             tables_restored=tables_restored,
             rows_restored=rows_restored,
             errors=errors[:50],
+            dropped_fields={
+                table: sorted(names) for table, names in sorted(dropped_fields.items())
+            },
         )
     finally:
         await client.close()

--- a/apps/api/src/sibyl/surreal_runtime_startup.py
+++ b/apps/api/src/sibyl/surreal_runtime_startup.py
@@ -99,10 +99,12 @@ async def bootstrap_surreal_runtime_schemas() -> bool:
                 error=str(exc),
             )
         )
-        log.warning(
+        log.exception(
             "Surreal auth schema bootstrap failed",
+            plane="auth",
             target_version=AUTH_SCHEMA_CURRENT_VERSION,
             error=str(exc),
+            remediation="run `sibyld db init` to retry the pending migrations",
         )
 
     try:
@@ -120,10 +122,12 @@ async def bootstrap_surreal_runtime_schemas() -> bool:
                 error=str(exc),
             )
         )
-        log.warning(
+        log.exception(
             "Surreal content schema bootstrap failed",
+            plane="content",
             target_version=CONTENT_SCHEMA_CURRENT_VERSION,
             error=str(exc),
+            remediation="run `sibyld db init` to retry the pending migrations",
         )
 
     _schema_bootstrap_state.status = RuntimeSchemaBootstrapStatus(

--- a/apps/api/tests/test_archive_schema_drift.py
+++ b/apps/api/tests/test_archive_schema_drift.py
@@ -1,0 +1,198 @@
+"""Archive restore behaviour once a populated table has been converted to SCHEMAFULL."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from surrealdb import AsyncSurreal
+
+from sibyl.persistence import content_archive
+from sibyl.persistence.auth_archive import restore_auth_archive_payload
+from sibyl.persistence.content_archive import restore_content_archive_payload
+from sibyl.persistence.surreal import auth as surreal_auth, content as surreal_content
+from sibyl_core.backends.surreal import (
+    SurrealAuthClient,
+    SurrealContentClient,
+    bootstrap_auth_schema,
+    bootstrap_content_schema,
+)
+from sibyl_core.backends.surreal.records import normalize_records
+
+
+@pytest_asyncio.fixture
+async def content_client():
+    await surreal_content.close_shared_surreal_content_client()
+    client = SurrealContentClient(url="memory://")
+    await bootstrap_content_schema(client, reset=True)
+    try:
+        yield client
+    finally:
+        await surreal_content.close_shared_surreal_content_client()
+        await client.close()
+
+
+@pytest_asyncio.fixture
+async def auth_client():
+    await surreal_auth.close_shared_surreal_auth_client()
+    client = SurrealAuthClient(url="memory://")
+    await bootstrap_auth_schema(client, reset=True)
+    try:
+        yield client
+    finally:
+        await surreal_auth.close_shared_surreal_auth_client()
+        await client.close()
+
+
+@pytest.mark.skipif(
+    os.environ.get("SIBYL_LIVE_SURREAL_TESTS") != "1",
+    reason="undeclared-field rejection only reproduces on a real SurrealDB 3.x server",
+)
+@pytest.mark.asyncio
+async def test_schemafull_conversion_blocks_writes_to_rows_carrying_a_drifted_field() -> None:
+    """The cost the SCHEMAFULL repair sweep imposes, pinned.
+
+    Converting a populated table revalidates the stored row as a whole, so an undeclared
+    key left over from an older build blocks every later write to that row -- including
+    an update that only sets declared fields.
+
+    The SDK-embedded engine is lenient here and accepts all three writes, so this can
+    only be pinned against a server.
+    """
+    url = os.environ.get("SIBYL_SURREAL_URL", "")
+    if not url or url.startswith(("memory://", "surrealkv://", "rocksdb://", "file://")):
+        pytest.skip("requires SIBYL_SURREAL_URL pointing at a SurrealDB server")
+
+    connection = AsyncSurreal(url)
+    await connection.signin(
+        {
+            "username": os.environ.get("SIBYL_SURREAL_USERNAME", "root"),
+            "password": os.environ.get("SIBYL_SURREAL_PASSWORD", "root"),
+        }
+    )
+    await connection.use("drifted", "content")
+    try:
+        await connection.query("REMOVE TABLE IF EXISTS raw_captures;")
+        await connection.query(
+            "CREATE raw_captures CONTENT { uuid: 'cap-1', legacy_extra: 'from-an-older-build' };"
+        )
+        await connection.query("ALTER TABLE IF EXISTS raw_captures SCHEMAFULL;")
+        await connection.query("DEFINE FIELD IF NOT EXISTS uuid ON raw_captures TYPE string;")
+
+        errors: dict[str, str] = {}
+        for label, statement in (
+            ("create", "CREATE raw_captures CONTENT { uuid: 'cap-2', legacy_extra: 'x' };"),
+            ("update_declared_only", "UPDATE raw_captures SET uuid = 'cap-1b';"),
+            ("merge", "UPDATE raw_captures MERGE { legacy_extra: 'y' };"),
+        ):
+            try:
+                await connection.query(statement)
+            except Exception as exc:
+                errors[label] = str(exc)
+    finally:
+        await connection.close()
+
+    assert set(errors) == {"create", "update_declared_only", "merge"}
+    for message in errors.values():
+        assert "legacy_extra" in message
+
+
+@pytest.mark.asyncio
+async def test_content_restore_drops_undeclared_fields_and_reports_them(
+    content_client: SurrealContentClient,
+) -> None:
+    """A drifted archive key must cost one field, not the whole row.
+
+    Rejecting the row would lose strictly more on the disaster-recovery path than
+    shedding a key the schema no longer declares, so the restore filters and reports.
+    """
+    capture_id = uuid4()
+    payload = {
+        "version": content_archive.CONTENT_ARCHIVE_VERSION,
+        "organization_id": "org-123",
+        "tables": {
+            "raw_captures": [
+                {
+                    "id": str(capture_id),
+                    "organization_id": "org-123",
+                    "source_id": "source:docs:1",
+                    "principal_id": "user-123",
+                    "memory_scope": "private",
+                    "scope_key": "user-123",
+                    "title": "Capture",
+                    "raw_content": "captured",
+                    "entity_type": "note",
+                    "tags": ["capture"],
+                    "metadata": {"source": "manual"},
+                    "provenance": {},
+                    "capture_surface": "source_import",
+                    "created_at": "2026-04-20T00:00:00+00:00",
+                    "legacy_extra": "from-an-older-build",
+                }
+            ],
+        },
+    }
+
+    with (
+        patch.object(content_client, "close", AsyncMock()),
+        patch(
+            "sibyl.persistence.content_archive.build_surreal_content_client",
+            return_value=content_client,
+        ),
+    ):
+        result = await restore_content_archive_payload(payload)
+
+    stored = await content_client.execute_query(
+        "SELECT uuid, title FROM raw_captures WHERE uuid = $uuid;",
+        uuid=str(capture_id),
+    )
+
+    assert result.success, result.errors
+    assert result.rows_restored == 1
+    assert result.dropped_fields == {"raw_captures": ["legacy_extra"]}
+    assert normalize_records(stored) == [{"uuid": str(capture_id), "title": "Capture"}]
+
+
+@pytest.mark.asyncio
+async def test_auth_restore_drops_undeclared_fields_and_reports_them(
+    auth_client: SurrealAuthClient,
+) -> None:
+    user_id = uuid4()
+    payload = {
+        "version": "1.0",
+        "organization_id": "org-123",
+        "tables": {
+            "users": [
+                {
+                    "id": str(user_id),
+                    "email": "drift@example.com",
+                    "name": "Drift",
+                    "created_at": "2026-04-20T00:00:00+00:00",
+                    "updated_at": "2026-04-20T00:00:00+00:00",
+                    "legacy_extra": "from-an-older-build",
+                }
+            ],
+        },
+    }
+
+    with (
+        patch.object(auth_client, "close", AsyncMock()),
+        patch(
+            "sibyl.persistence.auth_archive.build_surreal_auth_client",
+            return_value=auth_client,
+        ),
+    ):
+        result = await restore_auth_archive_payload(payload)
+
+    stored = await auth_client.execute_query(
+        "SELECT uuid, email FROM users WHERE uuid = $uuid;",
+        uuid=str(user_id),
+    )
+
+    assert result.success, result.errors
+    assert result.rows_restored == 1
+    assert result.dropped_fields == {"users": ["legacy_extra"]}
+    assert normalize_records(stored) == [{"uuid": str(user_id), "email": "drift@example.com"}]

--- a/apps/api/tests/test_cli_db.py
+++ b/apps/api/tests/test_cli_db.py
@@ -710,3 +710,67 @@ def test_duplicates_collapse_spares_rows_with_a_missing_unique_key_component() -
     assert {"u1", "u2"}.issubset(survivors)
     assert len([uuid for uuid in survivors if uuid in {"u3", "u4"}]) == 1
     assert len(survivors) == 3
+
+
+class _StubDuplicateClient:
+    """Serves one table with three colliding rows but deletes fewer than it is asked to."""
+
+    def __init__(self) -> None:
+        self.deleted_batches: list[int] = []
+
+    async def execute_query(self, statement: str, **params: object) -> object:
+        stripped = statement.strip()
+        if stripped == "INFO FOR DB;":
+            return [{"tables": {"widgets": "DEFINE TABLE widgets TYPE ANY SCHEMAFULL"}}]
+        if stripped.startswith("INFO FOR TABLE "):
+            return [{"indexes": {}}]
+        if stripped.startswith("SELECT id AS duplicate_record_id"):
+            return [
+                {"duplicate_record_id": f"widgets:{suffix}", "uuid": "same"}
+                for suffix in ("a", "b", "c")
+            ]
+        if stripped.startswith("DELETE"):
+            ids = params.get("ids")
+            self.deleted_batches.append(len(ids) if isinstance(ids, list) else 0)
+            # Only one of the two requested rows was still present.
+            return [{"id": "widgets:b", "uuid": "same"}]
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+def test_duplicates_collapse_counts_rows_actually_removed_not_ids_requested() -> None:
+    """A bare DELETE returns nothing, so the count has to come from the query result."""
+    from sibyl_core.backends.surreal.schema_invariants import (
+        SchemaInvariantPlan,
+        UniqueIndexRequirement,
+    )
+
+    client = _StubDuplicateClient()
+    plan = SchemaInvariantPlan(
+        unique_indexes=(
+            UniqueIndexRequirement(
+                name="idx_widgets_uuid",
+                table="widgets",
+                fields=("uuid",),
+                statement="DEFINE INDEX idx_widgets_uuid ON widgets FIELDS uuid UNIQUE;",
+            ),
+        ),
+    )
+    with (
+        patch("sibyl.persistence.surreal.auth.build_surreal_auth_client", lambda: client),
+        patch(
+            "sibyl_core.backends.surreal.auth_schema.auth_schema_invariant_plan",
+            lambda: plan,
+        ),
+        patch("sibyl.config.settings.store", "relational"),
+    ):
+        result = runner.invoke(db_cli.app, ["duplicates", "--collapse", "--yes", "--json"])
+
+    payload = json.loads(result.output)
+
+    assert result.exit_code == 0
+    assert client.deleted_batches == [2]
+    assert payload["excess_rows"] == 2
+    assert payload["collapsed"] == 1

--- a/apps/api/tests/test_cli_db.py
+++ b/apps/api/tests/test_cli_db.py
@@ -359,3 +359,272 @@ def test_backup_create_uses_database_dump_request_field() -> None:
         "include_database_dump": False,
         "include_graph": True,
     }
+
+
+class _StubSchemaClient:
+    """Minimal Surreal stand-in for the schema-init introspection queries."""
+
+    def __init__(
+        self,
+        *,
+        version: int,
+        tables: dict[str, str] | None = None,
+        indexes: dict[str, dict[str, str]] | None = None,
+        version_read_error: str = "",
+    ) -> None:
+        self.version = version
+        self.tables = tables or {}
+        self.indexes = indexes or {}
+        self.version_read_error = version_read_error
+        self.statements: list[str] = []
+
+    async def execute_query(self, statement: str, **_params: object) -> object:
+        self.statements.append(statement)
+        stripped = statement.strip()
+        if stripped.startswith("SELECT version FROM schema_version"):
+            if self.version_read_error:
+                raise RuntimeError(self.version_read_error)
+            return [{"version": self.version}]
+        if stripped == "INFO FOR DB;":
+            return [{"tables": self.tables}]
+        if stripped.startswith("INFO FOR TABLE "):
+            table = stripped.removeprefix("INFO FOR TABLE ").rstrip(";").strip()
+            return [{"indexes": self.indexes.get(table, {})}]
+        if stripped.startswith("DEFINE INDEX"):
+            raise RuntimeError("Database index already contains 'dirty'")
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+def _run_db_init(auth_client: object, content_client: object, *, args: list[str] | None = None):
+    from sibyl_core.backends.surreal.schema_invariants import SchemaInvariantPlan
+
+    empty_plan = SchemaInvariantPlan()
+    with (
+        patch("sibyl.persistence.surreal.auth.build_surreal_auth_client", lambda: auth_client),
+        patch(
+            "sibyl.persistence.surreal.content.build_surreal_content_client",
+            lambda: content_client,
+        ),
+        patch("sibyl_core.backends.surreal.bootstrap_auth_schema", AsyncMock()),
+        patch("sibyl_core.backends.surreal.bootstrap_content_schema", AsyncMock()),
+        patch(
+            "sibyl_core.backends.surreal.auth_schema.auth_schema_invariant_plan",
+            lambda: empty_plan,
+        ),
+        patch(
+            "sibyl_core.backends.surreal.content_schema.content_schema_invariant_plan",
+            lambda **_kwargs: empty_plan,
+        ),
+        patch("sibyl.config.settings.store", "surreal"),
+    ):
+        return runner.invoke(db_cli.app, ["init", *(args or [])])
+
+
+def test_db_init_reports_a_version_read_failure_instead_of_assuming_zero() -> None:
+    """A store that cannot be read must not look like a fresh one that migrated cleanly."""
+    from sibyl_core.backends.surreal.auth_schema import AUTH_SCHEMA_CURRENT_VERSION
+    from sibyl_core.backends.surreal.content_schema import CONTENT_SCHEMA_CURRENT_VERSION
+
+    result = _run_db_init(
+        _StubSchemaClient(version=AUTH_SCHEMA_CURRENT_VERSION, version_read_error="socket closed"),
+        _StubSchemaClient(version=CONTENT_SCHEMA_CURRENT_VERSION),
+    )
+
+    assert result.exit_code == 1
+    assert "schema state could not be read" in result.output
+    assert "socket closed" in result.output
+
+
+def test_db_init_fails_when_migrations_stop_short_of_the_target() -> None:
+    from sibyl_core.backends.surreal.auth_schema import AUTH_SCHEMA_CURRENT_VERSION
+    from sibyl_core.backends.surreal.content_schema import CONTENT_SCHEMA_CURRENT_VERSION
+
+    result = _run_db_init(
+        _StubSchemaClient(version=AUTH_SCHEMA_CURRENT_VERSION),
+        _StubSchemaClient(version=CONTENT_SCHEMA_CURRENT_VERSION - 1),
+    )
+
+    assert result.exit_code == 1
+    assert f"expected v{CONTENT_SCHEMA_CURRENT_VERSION}" in result.output
+
+
+def test_db_init_succeeds_when_both_planes_reach_their_target() -> None:
+    from sibyl_core.backends.surreal.auth_schema import AUTH_SCHEMA_CURRENT_VERSION
+    from sibyl_core.backends.surreal.content_schema import CONTENT_SCHEMA_CURRENT_VERSION
+
+    result = _run_db_init(
+        _StubSchemaClient(version=AUTH_SCHEMA_CURRENT_VERSION),
+        _StubSchemaClient(version=CONTENT_SCHEMA_CURRENT_VERSION),
+    )
+
+    assert result.exit_code == 0
+    assert "Schema up to date" in result.output
+
+
+def test_db_init_fails_when_a_required_unique_index_is_missing() -> None:
+    """Reaching the target version is not enough if a skipped index left dedupe unenforced."""
+    from sibyl_core.backends.surreal.auth_schema import AUTH_SCHEMA_CURRENT_VERSION
+    from sibyl_core.backends.surreal.content_schema import CONTENT_SCHEMA_CURRENT_VERSION
+    from sibyl_core.backends.surreal.schema_invariants import (
+        SchemaInvariantPlan,
+        UniqueIndexRequirement,
+    )
+
+    plan = SchemaInvariantPlan(
+        schemafull_tables=("memory_usage_events",),
+        unique_indexes=(
+            UniqueIndexRequirement(
+                name="idx_memory_usage_events_uuid",
+                table="memory_usage_events",
+                fields=("uuid",),
+                statement=(
+                    "DEFINE INDEX IF NOT EXISTS idx_memory_usage_events_uuid "
+                    "ON memory_usage_events FIELDS uuid UNIQUE;"
+                ),
+            ),
+        ),
+    )
+    content_client = _StubSchemaClient(
+        version=CONTENT_SCHEMA_CURRENT_VERSION,
+        tables={"memory_usage_events": "DEFINE TABLE memory_usage_events TYPE ANY SCHEMAFULL"},
+        indexes={"memory_usage_events": {}},
+    )
+
+    with (
+        patch(
+            "sibyl.persistence.surreal.auth.build_surreal_auth_client",
+            lambda: _StubSchemaClient(version=AUTH_SCHEMA_CURRENT_VERSION),
+        ),
+        patch(
+            "sibyl.persistence.surreal.content.build_surreal_content_client",
+            lambda: content_client,
+        ),
+        patch("sibyl_core.backends.surreal.bootstrap_auth_schema", AsyncMock()),
+        patch("sibyl_core.backends.surreal.bootstrap_content_schema", AsyncMock()),
+        patch(
+            "sibyl_core.backends.surreal.auth_schema.auth_schema_invariant_plan",
+            SchemaInvariantPlan,
+        ),
+        patch(
+            "sibyl_core.backends.surreal.content_schema.content_schema_invariant_plan",
+            lambda **_kwargs: plan,
+        ),
+        patch("sibyl.config.settings.store", "surreal"),
+    ):
+        result = runner.invoke(db_cli.app, ["init"])
+
+    assert result.exit_code == 1
+    assert "unmet" in result.output
+    assert "idx_memory_usage_events_uuid" in result.output
+    assert "sibyld db duplicates" in result.output
+
+
+class _EmbeddedClient:
+    """Adapter that gives the CLI its client shape over an embedded SurrealDB."""
+
+    def __init__(self, connection: object) -> None:
+        self._connection = connection
+
+    async def execute_query(self, statement: str, **params: object) -> object:
+        return await self._connection.query(statement, params or None)
+
+    async def close(self) -> None:
+        return None
+
+
+def _usage_event(uuid: str, item_id: str) -> str:
+    return f"""
+    CREATE memory_usage_events CONTENT {{
+        uuid: '{uuid}',
+        organization_id: 'org-a',
+        session_key: 's',
+        message_key: 'm',
+        source_surface: 'recall',
+        item_kind: 'raw_capture',
+        item_id: '{item_id}',
+        signal_type: 'exposure',
+        metadata: {{}},
+        event_at: d'2026-07-11T00:00:00Z',
+        created_at: d'2026-07-11T00:00:00Z'
+    }};
+    """
+
+
+async def _seeded_usage_store():
+    from surrealdb import AsyncSurreal
+
+    connection = AsyncSurreal("memory://")
+    await connection.use("cli_duplicates", "content")
+    for item_id in ("item-0", "item-1", "item-2"):
+        await connection.query(_usage_event("dup", item_id))
+    await connection.query(_usage_event("solo", "item-3"))
+    return connection
+
+
+def _run_duplicates(connection: object, args: list[str]):
+    from sibyl_core.backends.surreal.content_schema import content_schema_invariant_plan
+    from sibyl_core.backends.surreal.schema_invariants import SchemaInvariantPlan
+
+    plan = content_schema_invariant_plan()
+    usage_only = SchemaInvariantPlan(
+        unique_indexes=tuple(
+            item for item in plan.unique_indexes if item.table == "memory_usage_events"
+        ),
+    )
+    client = _EmbeddedClient(connection)
+    with (
+        patch(
+            "sibyl.persistence.surreal.auth.build_surreal_auth_client",
+            lambda: _StubSchemaClient(version=0),
+        ),
+        patch("sibyl.persistence.surreal.content.build_surreal_content_client", lambda: client),
+        patch(
+            "sibyl_core.backends.surreal.auth_schema.auth_schema_invariant_plan",
+            SchemaInvariantPlan,
+        ),
+        patch(
+            "sibyl_core.backends.surreal.content_schema.content_schema_invariant_plan",
+            lambda **_kwargs: usage_only,
+        ),
+        patch("sibyl.config.settings.store", "surreal"),
+    ):
+        return runner.invoke(db_cli.app, ["duplicates", *args])
+
+
+def test_duplicates_inventories_rows_blocking_a_missing_unique_index() -> None:
+    import asyncio
+
+    connection = asyncio.run(_seeded_usage_store())
+    try:
+        result = _run_duplicates(connection, ["--json"])
+    finally:
+        asyncio.run(connection.close())
+
+    payload = json.loads(result.output)
+
+    assert result.exit_code == 0
+    assert payload["excess_rows"] == 2
+    assert payload["collapsed"] == 0
+    uuid_groups = [item for item in payload["groups"] if item["index"].endswith("_uuid")]
+    assert uuid_groups[0]["copies"] == 3
+    assert uuid_groups[0]["key"] == ["dup"]
+
+
+def test_duplicates_collapse_keeps_one_row_per_group() -> None:
+    import asyncio
+
+    connection = asyncio.run(_seeded_usage_store())
+    try:
+        result = _run_duplicates(connection, ["--collapse", "--yes", "--json"])
+        remaining = asyncio.run(
+            connection.query("SELECT uuid FROM memory_usage_events ORDER BY uuid;")
+        )
+    finally:
+        asyncio.run(connection.close())
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["collapsed"] == 2
+    assert [row["uuid"] for row in remaining] == ["dup", "solo"]

--- a/apps/api/tests/test_cli_db.py
+++ b/apps/api/tests/test_cli_db.py
@@ -628,3 +628,85 @@ def test_duplicates_collapse_keeps_one_row_per_group() -> None:
     assert result.exit_code == 0
     assert json.loads(result.output)["collapsed"] == 2
     assert [row["uuid"] for row in remaining] == ["dup", "solo"]
+
+
+async def _seeded_users_store():
+    """Users whose optional github_id is absent, plus one genuinely duplicated pair."""
+    from surrealdb import AsyncSurreal
+
+    connection = AsyncSurreal("memory://")
+    await connection.use("cli_users", "auth")
+    for uuid, email, github_id in (
+        ("u1", "a@example.com", None),
+        ("u2", "b@example.com", None),
+        ("u3", "c@example.com", 7),
+        ("u4", "d@example.com", 7),
+    ):
+        github = "" if github_id is None else f", github_id: {github_id}"
+        await connection.query(
+            f"CREATE users CONTENT {{ uuid: '{uuid}', email: '{email}'{github} }};"
+        )
+    return connection
+
+
+def _run_auth_duplicates(connection: object, args: list[str]):
+    from sibyl_core.backends.surreal.auth_schema import auth_schema_invariant_plan
+    from sibyl_core.backends.surreal.schema_invariants import SchemaInvariantPlan
+
+    plan = auth_schema_invariant_plan()
+    users_only = SchemaInvariantPlan(
+        unique_indexes=tuple(item for item in plan.unique_indexes if item.table == "users"),
+    )
+    client = _EmbeddedClient(connection)
+    with (
+        patch("sibyl.persistence.surreal.auth.build_surreal_auth_client", lambda: client),
+        patch(
+            "sibyl_core.backends.surreal.auth_schema.auth_schema_invariant_plan",
+            lambda: users_only,
+        ),
+        patch("sibyl.config.settings.store", "relational"),
+    ):
+        return runner.invoke(db_cli.app, ["duplicates", *args])
+
+
+def test_duplicates_never_groups_rows_whose_unique_key_component_is_missing() -> None:
+    """SurrealDB lets many rows share a UNIQUE index key that has a missing component.
+
+    `github_id` is `option<int>`, so every user who never linked GitHub is a legitimately
+    distinct row. Bucketing them together would make --collapse delete real accounts.
+    """
+    import asyncio
+
+    connection = asyncio.run(_seeded_users_store())
+    try:
+        result = _run_auth_duplicates(connection, ["--json"])
+    finally:
+        asyncio.run(connection.close())
+
+    payload = json.loads(result.output)
+    github_groups = [item for item in payload["groups"] if item["index"].endswith("github_id")]
+
+    assert result.exit_code == 0
+    assert payload["excess_rows"] == 1
+    assert [item["key"] for item in github_groups] == [["7"]]
+
+
+def test_duplicates_collapse_spares_rows_with_a_missing_unique_key_component() -> None:
+    import asyncio
+
+    connection = asyncio.run(_seeded_users_store())
+    try:
+        result = _run_auth_duplicates(connection, ["--collapse", "--yes", "--json"])
+        remaining = asyncio.run(connection.query("SELECT uuid FROM users ORDER BY uuid;"))
+    finally:
+        asyncio.run(connection.close())
+
+    survivors = [row["uuid"] for row in remaining]
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["collapsed"] == 1
+    # Both github-less users survive; the duplicated pair keeps whichever record id
+    # sorts first, which is not tied to the uuid.
+    assert {"u1", "u2"}.issubset(survivors)
+    assert len([uuid for uuid in survivors if uuid in {"u3", "u4"}]) == 1
+    assert len(survivors) == 3

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,8 +62,14 @@ services:
       SIBYL_SERVER_HOST: 0.0.0.0
       SIBYL_SERVER_PORT: 3334
     healthcheck:
+      # Readiness, not liveness: /api/health is always 200 once the process is up, so it
+      # cannot see a failed schema bootstrap. /api/health/ready returns 503 for that, and
+      # raise_for_status turns the 503 into a non-zero exit the healthcheck acts on.
       test:
-        ["CMD-SHELL", 'python -c "import httpx; httpx.get(''http://localhost:3334/api/health'')"']
+        [
+          "CMD-SHELL",
+          'python -c "import httpx; httpx.get(''http://localhost:3334/api/health/ready'').raise_for_status()"',
+        ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -70,7 +70,16 @@ services:
     volumes:
       - sibyl_secrets:/home/sibyl/.sibyl
     healthcheck:
-      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:3334/api/health')"]
+      # Readiness, not liveness: /api/health is always 200 once the process is up, so it
+      # cannot see a failed schema bootstrap. /api/health/ready returns 503 for that, and
+      # raise_for_status turns the 503 into a non-zero exit the healthcheck acts on.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import httpx; httpx.get('http://localhost:3334/api/health/ready').raise_for_status()",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/infra/ansible/roles/sibyl/files/docker-compose.yml
+++ b/infra/ansible/roles/sibyl/files/docker-compose.yml
@@ -84,8 +84,14 @@ services:
       SIBYL_SERVER_HOST: 0.0.0.0
       SIBYL_SERVER_PORT: "3334"
     healthcheck:
+      # Readiness, not liveness: /api/health is always 200 once the process is up, so it
+      # cannot see a failed schema bootstrap. /api/health/ready returns 503 for that, and
+      # raise_for_status turns the 503 into a non-zero exit the healthcheck acts on.
       test:
-        ["CMD-SHELL", 'python -c "import httpx; httpx.get(''http://localhost:3334/api/health'')"']
+        [
+          "CMD-SHELL",
+          'python -c "import httpx; httpx.get(''http://localhost:3334/api/health/ready'').raise_for_status()"',
+        ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/infra/ansible/roles/sibyl/files/docker-compose.yml
+++ b/infra/ansible/roles/sibyl/files/docker-compose.yml
@@ -90,7 +90,8 @@ services:
       test:
         [
           "CMD-SHELL",
-          'python -c "import httpx; httpx.get(''http://localhost:3334/api/health/ready'').raise_for_status()"',
+          'python -c "import httpx;
+          httpx.get(''http://localhost:3334/api/health/ready'').raise_for_status()"',
         ]
       interval: 30s
       timeout: 10s

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/auth_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/auth_schema.py
@@ -43,7 +43,7 @@ EXTENDED_AUTH_TABLES = (
     "llm_usage_buckets",
 )
 AUTH_TABLES = (*CORE_AUTH_TABLES, *EXTENDED_AUTH_TABLES)
-AUTH_SCHEMA_CURRENT_VERSION = 5
+AUTH_SCHEMA_CURRENT_VERSION = 6
 AUTH_SCHEMA_NAME = "auth"
 _AUTH_ORGANIZATION_ROLE_VALUES = tuple(role.value for role in OrganizationRole)
 _AUTH_PROJECT_ROLE_VALUES = tuple(role.value for role in ProjectRole)
@@ -59,6 +59,7 @@ def _surql_string_array(values: tuple[str, ...]) -> str:
 
 AUTH_SCHEMA_DEFINITIONS = """
 DEFINE TABLE IF NOT EXISTS users SCHEMAFULL;
+ALTER TABLE IF EXISTS users SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON users TYPE string;
 DEFINE FIELD IF NOT EXISTS github_id ON users TYPE option<int>;
 DEFINE FIELD IF NOT EXISTS email ON users TYPE option<string>;
@@ -84,6 +85,7 @@ DEFINE INDEX IF NOT EXISTS idx_users_github_id ON users FIELDS github_id UNIQUE;
 DEFINE INDEX IF NOT EXISTS idx_users_purge_after ON users FIELDS purge_after;
 
 DEFINE TABLE IF NOT EXISTS identity_provider SCHEMAFULL;
+ALTER TABLE IF EXISTS identity_provider SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON identity_provider TYPE string;
 DEFINE FIELD IF NOT EXISTS name ON identity_provider TYPE string;
 DEFINE FIELD IF NOT EXISTS issuer ON identity_provider TYPE string;
@@ -102,6 +104,7 @@ DEFINE INDEX IF NOT EXISTS idx_identity_provider_issuer
     ON identity_provider FIELDS issuer;
 
 DEFINE TABLE IF NOT EXISTS user_identity SCHEMAFULL;
+ALTER TABLE IF EXISTS user_identity SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON user_identity TYPE string;
 DEFINE FIELD IF NOT EXISTS provider_name ON user_identity TYPE string;
 DEFINE FIELD IF NOT EXISTS issuer ON user_identity TYPE string;
@@ -121,6 +124,7 @@ DEFINE INDEX IF NOT EXISTS idx_user_identity_provider_subject
 DEFINE INDEX IF NOT EXISTS idx_user_identity_email ON user_identity FIELDS email;
 
 DEFINE TABLE IF NOT EXISTS llm_usage_buckets SCHEMAFULL;
+ALTER TABLE IF EXISTS llm_usage_buckets SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON llm_usage_buckets TYPE string;
 DEFINE FIELD IF NOT EXISTS bucket_key ON llm_usage_buckets TYPE string;
 DEFINE FIELD IF NOT EXISTS bucket_month ON llm_usage_buckets TYPE string;
@@ -141,6 +145,7 @@ DEFINE INDEX IF NOT EXISTS idx_llm_usage_buckets_org
     ON llm_usage_buckets FIELDS organization_id, bucket_month;
 
 DEFINE TABLE IF NOT EXISTS organizations SCHEMAFULL;
+ALTER TABLE IF EXISTS organizations SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON organizations TYPE string;
 DEFINE FIELD IF NOT EXISTS name ON organizations TYPE string DEFAULT '';
 DEFINE FIELD IF NOT EXISTS slug ON organizations TYPE string DEFAULT '';
@@ -153,6 +158,7 @@ DEFINE INDEX IF NOT EXISTS idx_organizations_uuid ON organizations FIELDS uuid U
 DEFINE INDEX IF NOT EXISTS idx_organizations_slug ON organizations FIELDS slug UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS organization_members SCHEMAFULL;
+ALTER TABLE IF EXISTS organization_members SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON organization_members TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON organization_members TYPE string;
 DEFINE FIELD IF NOT EXISTS user_id ON organization_members TYPE string;
@@ -167,6 +173,7 @@ DEFINE INDEX IF NOT EXISTS idx_organization_members_org_user
     ON organization_members FIELDS organization_id, user_id UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS user_sessions SCHEMAFULL;
+ALTER TABLE IF EXISTS user_sessions SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON user_sessions TYPE string;
 DEFINE FIELD IF NOT EXISTS user_id ON user_sessions TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON user_sessions TYPE option<string>;
@@ -198,6 +205,7 @@ DEFINE INDEX IF NOT EXISTS idx_user_sessions_last_active
     ON user_sessions FIELDS last_active_at;
 
 DEFINE TABLE IF NOT EXISTS password_reset_tokens SCHEMAFULL;
+ALTER TABLE IF EXISTS password_reset_tokens SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON password_reset_tokens TYPE string;
 DEFINE FIELD IF NOT EXISTS user_id ON password_reset_tokens TYPE string;
 DEFINE FIELD IF NOT EXISTS token_hash ON password_reset_tokens TYPE string;
@@ -218,6 +226,7 @@ DEFINE INDEX IF NOT EXISTS idx_password_reset_tokens_expires
     ON password_reset_tokens FIELDS expires_at;
 
 DEFINE TABLE IF NOT EXISTS login_history SCHEMAFULL;
+ALTER TABLE IF EXISTS login_history SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON login_history TYPE string;
 DEFINE FIELD IF NOT EXISTS user_id ON login_history TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS event_type ON login_history TYPE string;
@@ -237,6 +246,7 @@ DEFINE INDEX IF NOT EXISTS idx_login_history_event ON login_history FIELDS event
 DEFINE INDEX IF NOT EXISTS idx_login_history_created ON login_history FIELDS created_at;
 
 DEFINE TABLE IF NOT EXISTS organization_invitations SCHEMAFULL;
+ALTER TABLE IF EXISTS organization_invitations SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON organization_invitations TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON organization_invitations TYPE string;
 DEFINE FIELD IF NOT EXISTS invited_email ON organization_invitations TYPE string;
@@ -260,6 +270,7 @@ DEFINE INDEX IF NOT EXISTS idx_organization_invitations_email
     ON organization_invitations FIELDS invited_email;
 
 DEFINE TABLE IF NOT EXISTS api_keys SCHEMAFULL;
+ALTER TABLE IF EXISTS api_keys SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON api_keys TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON api_keys TYPE string;
 DEFINE FIELD IF NOT EXISTS user_id ON api_keys TYPE string;
@@ -280,6 +291,7 @@ DEFINE INDEX IF NOT EXISTS idx_api_keys_user ON api_keys FIELDS user_id;
 DEFINE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys FIELDS key_prefix;
 
 DEFINE TABLE IF NOT EXISTS api_key_project_scopes SCHEMAFULL;
+ALTER TABLE IF EXISTS api_key_project_scopes SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON api_key_project_scopes TYPE string;
 DEFINE FIELD IF NOT EXISTS api_key_id ON api_key_project_scopes TYPE string;
 DEFINE FIELD IF NOT EXISTS project_id ON api_key_project_scopes TYPE string;
@@ -300,6 +312,7 @@ DEFINE INDEX IF NOT EXISTS idx_api_key_project_scopes_key_project
     ON api_key_project_scopes FIELDS api_key_id, project_id UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS api_key_memory_space_scopes SCHEMAFULL;
+ALTER TABLE IF EXISTS api_key_memory_space_scopes SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON api_key_memory_space_scopes TYPE string;
 DEFINE FIELD IF NOT EXISTS api_key_id ON api_key_memory_space_scopes TYPE string;
 DEFINE FIELD IF NOT EXISTS memory_space_id ON api_key_memory_space_scopes TYPE string;
@@ -320,6 +333,7 @@ DEFINE INDEX IF NOT EXISTS idx_api_key_memory_space_scopes_key_space
     ON api_key_memory_space_scopes FIELDS api_key_id, memory_space_id UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS oauth_client_registrations SCHEMAFULL;
+ALTER TABLE IF EXISTS oauth_client_registrations SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON oauth_client_registrations TYPE string;
 DEFINE FIELD IF NOT EXISTS client_id ON oauth_client_registrations TYPE string;
 DEFINE FIELD IF NOT EXISTS client_info ON oauth_client_registrations TYPE object FLEXIBLE;
@@ -334,6 +348,7 @@ DEFINE INDEX IF NOT EXISTS idx_oauth_client_registrations_client
     ON oauth_client_registrations FIELDS client_id UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS device_authorization_requests SCHEMAFULL;
+ALTER TABLE IF EXISTS device_authorization_requests SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON device_authorization_requests TYPE string;
 DEFINE FIELD IF NOT EXISTS device_code_hash ON device_authorization_requests TYPE string;
 DEFINE FIELD IF NOT EXISTS user_code ON device_authorization_requests TYPE string;
@@ -369,6 +384,7 @@ DEFINE INDEX IF NOT EXISTS idx_device_authorization_requests_org
     ON device_authorization_requests FIELDS organization_id;
 
 DEFINE TABLE IF NOT EXISTS audit_logs SCHEMAFULL;
+ALTER TABLE IF EXISTS audit_logs SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON audit_logs TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON audit_logs TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS user_id ON audit_logs TYPE option<string>;
@@ -385,6 +401,7 @@ DEFINE INDEX IF NOT EXISTS idx_audit_logs_user ON audit_logs FIELDS user_id;
 DEFINE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs FIELDS action;
 
 DEFINE TABLE IF NOT EXISTS teams SCHEMAFULL;
+ALTER TABLE IF EXISTS teams SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON teams TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON teams TYPE string;
 DEFINE FIELD IF NOT EXISTS name ON teams TYPE string DEFAULT '';
@@ -403,6 +420,7 @@ DEFINE INDEX IF NOT EXISTS idx_teams_org ON teams FIELDS organization_id;
 DEFINE INDEX IF NOT EXISTS idx_teams_org_slug ON teams FIELDS organization_id, slug UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS team_members SCHEMAFULL;
+ALTER TABLE IF EXISTS team_members SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON team_members TYPE string;
 DEFINE FIELD IF NOT EXISTS team_id ON team_members TYPE string;
 DEFINE FIELD IF NOT EXISTS user_id ON team_members TYPE string;
@@ -418,6 +436,7 @@ DEFINE INDEX IF NOT EXISTS idx_team_members_team_user
     ON team_members FIELDS team_id, user_id UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS projects SCHEMAFULL;
+ALTER TABLE IF EXISTS projects SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON projects TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON projects TYPE string;
 DEFINE FIELD IF NOT EXISTS name ON projects TYPE string DEFAULT '';
@@ -441,6 +460,7 @@ DEFINE INDEX IF NOT EXISTS idx_projects_org_graph_id
     ON projects FIELDS organization_id, graph_project_id UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS project_members SCHEMAFULL;
+ALTER TABLE IF EXISTS project_members SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON project_members TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON project_members TYPE string;
 DEFINE FIELD IF NOT EXISTS project_id ON project_members TYPE string;
@@ -462,6 +482,7 @@ DEFINE INDEX IF NOT EXISTS idx_project_members_user
     ON project_members FIELDS user_id;
 
 DEFINE TABLE IF NOT EXISTS team_projects SCHEMAFULL;
+ALTER TABLE IF EXISTS team_projects SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON team_projects TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON team_projects TYPE string;
 DEFINE FIELD IF NOT EXISTS team_id ON team_projects TYPE string;
@@ -482,6 +503,7 @@ DEFINE INDEX IF NOT EXISTS idx_team_projects_project
     ON team_projects FIELDS project_id;
 
 DEFINE TABLE IF NOT EXISTS memory_spaces SCHEMAFULL;
+ALTER TABLE IF EXISTS memory_spaces SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON memory_spaces TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON memory_spaces TYPE string;
 DEFINE FIELD IF NOT EXISTS memory_scope ON memory_spaces TYPE string;
@@ -505,6 +527,7 @@ DEFINE INDEX IF NOT EXISTS idx_memory_spaces_creator
     ON memory_spaces FIELDS created_by_user_id;
 
 DEFINE TABLE IF NOT EXISTS memory_space_members SCHEMAFULL;
+ALTER TABLE IF EXISTS memory_space_members SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON memory_space_members TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON memory_space_members TYPE string;
 DEFINE FIELD IF NOT EXISTS space_id ON memory_space_members TYPE string;
@@ -609,6 +632,14 @@ ALTER TABLE IF EXISTS memory_space_members PERMISSIONS
     FOR select, create, update, delete WHERE organization_id = $token.org OR organization_id = $auth.organization_id;
 """
 
+# `DEFINE TABLE IF NOT EXISTS ... SCHEMAFULL` silently no-ops against a table Surreal
+# already auto-created SCHEMALESS on an application write, so a table whose writer shipped
+# ahead of its migration stays SCHEMALESS forever. Every DEFINE is paired with an ALTER at
+# the definition site; this sweep repairs tables that already drifted before that pairing.
+AUTH_SCHEMAFULL_REPAIR_DEFINITIONS = "\n".join(
+    f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" for table in AUTH_TABLES
+)
+
 AUTH_SCHEMA_MIGRATIONS = (
     SchemaMigration(
         version=1,
@@ -634,6 +665,11 @@ AUTH_SCHEMA_MIGRATIONS = (
         version=5,
         name="auth_table_permissions",
         statements=tuple(split_statements(AUTH_PERMISSION_MIGRATION_DEFINITIONS)),
+    ),
+    SchemaMigration(
+        version=6,
+        name="auth_schemafull_repair",
+        statements=tuple(split_statements(AUTH_SCHEMAFULL_REPAIR_DEFINITIONS)),
     ),
 )
 
@@ -769,6 +805,7 @@ __all__ = [
     "AUTH_INVITATION_TOKEN_MIGRATION_DEFINITIONS",
     "AUTH_PERMISSION_MIGRATION_DEFINITIONS",
     "AUTH_PROJECT_SLUG_MIGRATION_DEFINITIONS",
+    "AUTH_SCHEMAFULL_REPAIR_DEFINITIONS",
     "AUTH_SCHEMA_CURRENT_VERSION",
     "AUTH_SCHEMA_DEFINITIONS",
     "AUTH_SCHEMA_MIGRATIONS",

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/auth_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/auth_schema.py
@@ -6,6 +6,10 @@ from typing import TYPE_CHECKING
 
 from sibyl_core.auth import OrganizationRole, ProjectRole, ProjectVisibility
 from sibyl_core.backends.surreal.schema_helpers import is_missing_table_error, split_statements
+from sibyl_core.backends.surreal.schema_invariants import (
+    SchemaInvariantPlan,
+    expected_unique_indexes,
+)
 from sibyl_core.backends.surreal.schema_version import (
     SCHEMA_VERSION_TABLE,
     SchemaMigration,
@@ -674,6 +678,13 @@ AUTH_SCHEMA_MIGRATIONS = (
 )
 
 
+def auth_schema_invariant_plan() -> SchemaInvariantPlan:
+    return SchemaInvariantPlan(
+        schemafull_tables=AUTH_TABLES,
+        unique_indexes=expected_unique_indexes(AUTH_SCHEMA_MIGRATIONS),
+    )
+
+
 async def bootstrap_auth_schema(client: SurrealAuthClient, *, reset: bool = False) -> None:
     if reset:
         for table in (*AUTH_TABLES, SCHEMA_VERSION_TABLE):
@@ -813,5 +824,6 @@ __all__ = [
     "AUTH_TABLES",
     "CORE_AUTH_TABLES",
     "EXTENDED_AUTH_TABLES",
+    "auth_schema_invariant_plan",
     "bootstrap_auth_schema",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -30,12 +31,17 @@ if TYPE_CHECKING:
     from sibyl_core.backends.surreal.content_client import SurrealContentClient
 
 
-CONTENT_RELATION_TABLES = (
-    "derived_from",
-    "chunk_of",
-    "supersedes",
-    "extracted_into",
-)
+# RELATE auto-creates an absent edge table as `TYPE ANY SCHEMALESS`, and a guarded
+# `DEFINE TABLE IF NOT EXISTS` then no-ops against it. ALTER accepts the full relation
+# clause on SurrealDB 3.x, so the repair has to carry IN/OUT/ENFORCED as well as the
+# schema mode or the table stays untyped while reporting itself repaired.
+CONTENT_RELATION_SPECS: Mapping[str, str] = {
+    "derived_from": "TYPE RELATION IN raw_captures OUT source_imports ENFORCED",
+    "chunk_of": "TYPE RELATION IN document_chunks OUT crawled_documents ENFORCED",
+    "supersedes": "TYPE RELATION IN raw_captures OUT raw_captures ENFORCED",
+    "extracted_into": "TYPE RELATION IN entity OUT document_chunks",
+}
+CONTENT_RELATION_TABLES = tuple(CONTENT_RELATION_SPECS)
 CONTENT_TABLES = (
     *CONTENT_RELATION_TABLES,
     "entity",
@@ -77,6 +83,12 @@ _SCHEMA_DIR = Path(__file__).with_name("schemas") / "content"
 
 def _surql_string_array(values: tuple[str, ...]) -> str:
     return "[" + ", ".join(f"'{value}'" for value in values) + "]"
+
+
+def content_schemafull_repair_statement(table: str) -> str:
+    relation_clause = CONTENT_RELATION_SPECS.get(table)
+    suffix = f"{relation_clause} SCHEMAFULL" if relation_clause else "SCHEMAFULL"
+    return f"ALTER TABLE IF EXISTS {table} {suffix};"
 
 
 def _load_schema_file(filename: str) -> str:
@@ -253,9 +265,9 @@ DEFINE INDEX IF NOT EXISTS idx_raw_captures_embedding ON raw_captures FIELDS emb
     HNSW DIMENSION {EMBEDDING_DIM} DIST COSINE TYPE F32 EFC 150 M 12;
 """
 
-CONTENT_LINEAGE_RELATION_MIGRATION_DEFINITIONS = """
+CONTENT_LINEAGE_RELATION_MIGRATION_DEFINITIONS = f"""
 DEFINE TABLE IF NOT EXISTS derived_from SCHEMAFULL TYPE RELATION IN raw_captures OUT source_imports ENFORCED;
-ALTER TABLE IF EXISTS derived_from SCHEMAFULL;
+{content_schemafull_repair_statement("derived_from")}
 DEFINE FIELD IF NOT EXISTS uuid ON derived_from TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON derived_from TYPE string;
 DEFINE FIELD IF NOT EXISTS raw_memory_id ON derived_from TYPE string;
@@ -269,7 +281,7 @@ ALTER TABLE IF EXISTS derived_from PERMISSIONS
     FOR select, create, update, delete WHERE organization_id = $token.org OR organization_id = $auth.organization_id;
 
 DEFINE TABLE IF NOT EXISTS chunk_of SCHEMAFULL TYPE RELATION IN document_chunks OUT crawled_documents ENFORCED;
-ALTER TABLE IF EXISTS chunk_of SCHEMAFULL;
+{content_schemafull_repair_statement("chunk_of")}
 DEFINE FIELD IF NOT EXISTS uuid ON chunk_of TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON chunk_of TYPE string;
 DEFINE FIELD IF NOT EXISTS chunk_id ON chunk_of TYPE string;
@@ -283,7 +295,7 @@ ALTER TABLE IF EXISTS chunk_of PERMISSIONS
     FOR select, create, update, delete WHERE organization_id = $token.org OR organization_id = $auth.organization_id;
 
 DEFINE TABLE IF NOT EXISTS supersedes SCHEMAFULL TYPE RELATION IN raw_captures OUT raw_captures ENFORCED;
-ALTER TABLE IF EXISTS supersedes SCHEMAFULL;
+{content_schemafull_repair_statement("supersedes")}
 DEFINE FIELD IF NOT EXISTS uuid ON supersedes TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON supersedes TYPE string;
 DEFINE FIELD IF NOT EXISTS raw_memory_id ON supersedes TYPE string;
@@ -297,7 +309,7 @@ ALTER TABLE IF EXISTS supersedes PERMISSIONS
     FOR select, create, update, delete WHERE organization_id = $token.org OR organization_id = $auth.organization_id;
 
 DEFINE TABLE IF NOT EXISTS extracted_into SCHEMAFULL TYPE RELATION IN entity OUT document_chunks;
-ALTER TABLE IF EXISTS extracted_into SCHEMAFULL;
+{content_schemafull_repair_statement("extracted_into")}
 DEFINE FIELD IF NOT EXISTS uuid ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS entity_id ON extracted_into TYPE string;
@@ -312,9 +324,9 @@ ALTER TABLE IF EXISTS extracted_into PERMISSIONS
     FOR select, create, update, delete WHERE organization_id = $token.org OR organization_id = $auth.organization_id;
 """
 
-CONTENT_EXTRACTED_INTO_RELATION_MIGRATION_DEFINITIONS = """
+CONTENT_EXTRACTED_INTO_RELATION_MIGRATION_DEFINITIONS = f"""
 DEFINE TABLE IF NOT EXISTS extracted_into SCHEMAFULL TYPE RELATION IN entity OUT document_chunks;
-ALTER TABLE IF EXISTS extracted_into SCHEMAFULL;
+{content_schemafull_repair_statement("extracted_into")}
 DEFINE FIELD IF NOT EXISTS uuid ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS entity_id ON extracted_into TYPE string;
@@ -557,7 +569,7 @@ DEFINE FIELD OVERWRITE misled_count ON raw_captures TYPE int DEFAULT 0;
 # ahead of its migration stays SCHEMALESS forever. Every DEFINE is paired with an ALTER at
 # the definition site; this sweep repairs tables that already drifted before that pairing.
 CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS = "\n".join(
-    f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" for table in CONTENT_TABLES
+    content_schemafull_repair_statement(table) for table in CONTENT_TABLES
 )
 
 
@@ -1058,6 +1070,7 @@ __all__ = [
     "CONTENT_RAW_CAPTURE_REQUIRED_FIELD_OPTIONAL_DEFINITIONS",
     "CONTENT_RAW_CAPTURE_REQUIRED_FIELD_REPAIR_DEFINITIONS",
     "CONTENT_RAW_CAPTURE_REVISION_MIGRATION_DEFINITIONS",
+    "CONTENT_RELATION_SPECS",
     "CONTENT_RELATION_TABLES",
     "CONTENT_REVIEW_STATE_DEFERRED_MIGRATION_DEFINITIONS",
     "CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS",
@@ -1069,4 +1082,5 @@ __all__ = [
     "CONTENT_TABLES",
     "CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS",
     "bootstrap_content_schema",
+    "content_schemafull_repair_statement",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -11,6 +11,10 @@ from sibyl_core.backends.surreal.schema import (
     render_surreal_compatible_sql,
 )
 from sibyl_core.backends.surreal.schema_helpers import is_missing_table_error, split_statements
+from sibyl_core.backends.surreal.schema_invariants import (
+    SchemaInvariantPlan,
+    expected_unique_indexes,
+)
 from sibyl_core.backends.surreal.schema_version import (
     SCHEMA_VERSION_TABLE,
     SchemaMigration,
@@ -726,6 +730,14 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
     )
 
 
+def content_schema_invariant_plan(*, url: str = "") -> SchemaInvariantPlan:
+    return SchemaInvariantPlan(
+        schemafull_tables=CONTENT_TABLES,
+        relation_tables=CONTENT_RELATION_TABLES,
+        unique_indexes=expected_unique_indexes(_content_schema_migrations(url=url)),
+    )
+
+
 async def bootstrap_content_schema(client: SurrealContentClient, *, reset: bool = False) -> None:
     if reset:
         for table in (*CONTENT_TABLES, SCHEMA_VERSION_TABLE):
@@ -1082,5 +1094,6 @@ __all__ = [
     "CONTENT_TABLES",
     "CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS",
     "bootstrap_content_schema",
+    "content_schema_invariant_plan",
     "content_schemafull_repair_statement",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -52,7 +52,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 23
+CONTENT_SCHEMA_CURRENT_VERSION = 24
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -202,6 +202,7 @@ CONTENT_RAW_CAPTURE_CHANGEFEED_MIGRATION_DEFINITIONS = """
 ALTER TABLE IF EXISTS raw_captures CHANGEFEED 7d;
 
 DEFINE TABLE IF NOT EXISTS content_changefeed_cursors SCHEMAFULL;
+ALTER TABLE IF EXISTS content_changefeed_cursors SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON content_changefeed_cursors TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON content_changefeed_cursors TYPE string;
 DEFINE FIELD IF NOT EXISTS table_name ON content_changefeed_cursors TYPE string;
@@ -254,6 +255,7 @@ DEFINE INDEX IF NOT EXISTS idx_raw_captures_embedding ON raw_captures FIELDS emb
 
 CONTENT_LINEAGE_RELATION_MIGRATION_DEFINITIONS = """
 DEFINE TABLE IF NOT EXISTS derived_from SCHEMAFULL TYPE RELATION IN raw_captures OUT source_imports ENFORCED;
+ALTER TABLE IF EXISTS derived_from SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON derived_from TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON derived_from TYPE string;
 DEFINE FIELD IF NOT EXISTS raw_memory_id ON derived_from TYPE string;
@@ -267,6 +269,7 @@ ALTER TABLE IF EXISTS derived_from PERMISSIONS
     FOR select, create, update, delete WHERE organization_id = $token.org OR organization_id = $auth.organization_id;
 
 DEFINE TABLE IF NOT EXISTS chunk_of SCHEMAFULL TYPE RELATION IN document_chunks OUT crawled_documents ENFORCED;
+ALTER TABLE IF EXISTS chunk_of SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON chunk_of TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON chunk_of TYPE string;
 DEFINE FIELD IF NOT EXISTS chunk_id ON chunk_of TYPE string;
@@ -280,6 +283,7 @@ ALTER TABLE IF EXISTS chunk_of PERMISSIONS
     FOR select, create, update, delete WHERE organization_id = $token.org OR organization_id = $auth.organization_id;
 
 DEFINE TABLE IF NOT EXISTS supersedes SCHEMAFULL TYPE RELATION IN raw_captures OUT raw_captures ENFORCED;
+ALTER TABLE IF EXISTS supersedes SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON supersedes TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON supersedes TYPE string;
 DEFINE FIELD IF NOT EXISTS raw_memory_id ON supersedes TYPE string;
@@ -293,6 +297,7 @@ ALTER TABLE IF EXISTS supersedes PERMISSIONS
     FOR select, create, update, delete WHERE organization_id = $token.org OR organization_id = $auth.organization_id;
 
 DEFINE TABLE IF NOT EXISTS extracted_into SCHEMAFULL TYPE RELATION IN entity OUT document_chunks;
+ALTER TABLE IF EXISTS extracted_into SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS entity_id ON extracted_into TYPE string;
@@ -309,6 +314,7 @@ ALTER TABLE IF EXISTS extracted_into PERMISSIONS
 
 CONTENT_EXTRACTED_INTO_RELATION_MIGRATION_DEFINITIONS = """
 DEFINE TABLE IF NOT EXISTS extracted_into SCHEMAFULL TYPE RELATION IN entity OUT document_chunks;
+ALTER TABLE IF EXISTS extracted_into SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS entity_id ON extracted_into TYPE string;
@@ -325,6 +331,7 @@ ALTER TABLE IF EXISTS extracted_into PERMISSIONS
 
 CONTENT_ENTITY_ANCHOR_MIGRATION_DEFINITIONS = """
 DEFINE TABLE IF NOT EXISTS entity SCHEMAFULL;
+ALTER TABLE IF EXISTS entity SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON entity TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON entity TYPE string;
 DEFINE FIELD IF NOT EXISTS created_at ON entity TYPE datetime DEFAULT time::now();
@@ -383,6 +390,7 @@ DEFINE INDEX IF NOT EXISTS idx_raw_captures_last_used
     ON raw_captures FIELDS organization_id, last_used_at, uuid;
 
 DEFINE TABLE IF NOT EXISTS memory_usage_events SCHEMAFULL;
+ALTER TABLE IF EXISTS memory_usage_events SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON memory_usage_events TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON memory_usage_events TYPE string;
 DEFINE FIELD IF NOT EXISTS session_key ON memory_usage_events TYPE string;
@@ -544,6 +552,15 @@ DEFINE FIELD OVERWRITE misled_count ON raw_captures TYPE int DEFAULT 0;
 )
 
 
+# `DEFINE TABLE IF NOT EXISTS ... SCHEMAFULL` silently no-ops against a table Surreal
+# already auto-created SCHEMALESS on an application write, so a table whose writer shipped
+# ahead of its migration stays SCHEMALESS forever. Every DEFINE is paired with an ALTER at
+# the definition site; this sweep repairs tables that already drifted before that pairing.
+CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS = "\n".join(
+    f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" for table in CONTENT_TABLES
+)
+
+
 def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
     compatible_schema = render_fulltext_compatible_sql(
         CONTENT_SCHEMA_DEFINITIONS,
@@ -688,6 +705,11 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             statements=tuple(
                 split_statements(CONTENT_RAW_CAPTURE_REQUIRED_FIELD_REPAIR_DEFINITIONS)
             ),
+        ),
+        SchemaMigration(
+            version=24,
+            name="content_schemafull_repair",
+            statements=tuple(split_statements(CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS)),
         ),
     )
 
@@ -1038,6 +1060,7 @@ __all__ = [
     "CONTENT_RAW_CAPTURE_REVISION_MIGRATION_DEFINITIONS",
     "CONTENT_RELATION_TABLES",
     "CONTENT_REVIEW_STATE_DEFERRED_MIGRATION_DEFINITIONS",
+    "CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS",
     "CONTENT_SCHEMA_CURRENT_VERSION",
     "CONTENT_SCHEMA_DEFINITIONS",
     "CONTENT_SCHEMA_NAME",

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_invariants.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_invariants.py
@@ -1,0 +1,258 @@
+"""Invariant checks that validate a schema plane independently of its recorded version.
+
+`execute_schema_statement` swallows a `DEFINE INDEX ... UNIQUE` that fails because the
+table already holds duplicate rows, and `apply_schema_migrations` then records the
+migration as applied. Nothing ever retries the index, so a plane can sit at its target
+version with deduplication permanently unenforced. These checks re-derive what the
+migrations promised and compare it against what the database actually has, so a missing
+guarantee is reported instead of assumed.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import cast
+
+from sibyl_core.backends.surreal.schema_version import SchemaMigration, SurrealExecute
+
+_IDENTIFIER = r"[A-Za-z_][A-Za-z0-9_]*"
+
+_DEFINE_INDEX_RE = re.compile(
+    rf"^\s*DEFINE\s+INDEX\s+(?:IF\s+NOT\s+EXISTS\s+|OVERWRITE\s+)?"
+    rf"(?P<name>{_IDENTIFIER})\s+ON\s+(?:TABLE\s+)?"
+    rf"(?P<table>{_IDENTIFIER})\s+FIELDS\s+(?P<body>.+?)\s*;?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+_REMOVE_INDEX_RE = re.compile(
+    rf"^\s*REMOVE\s+INDEX\s+(?:IF\s+EXISTS\s+)?"
+    rf"(?P<name>{_IDENTIFIER})\s+ON\s+(?:TABLE\s+)?"
+    rf"(?P<table>{_IDENTIFIER})\s*;?\s*$",
+    re.IGNORECASE,
+)
+_UNIQUE_TAIL_RE = re.compile(r"\bUNIQUE\b\s*$", re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class UniqueIndexRequirement:
+    """A `UNIQUE` index the migrations promise, plus the statement that rebuilds it."""
+
+    name: str
+    table: str
+    fields: tuple[str, ...]
+    statement: str
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaInvariantViolation:
+    kind: str
+    table: str
+    detail: str
+
+    def describe(self) -> str:
+        return f"{self.table}: {self.detail}"
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaInvariantPlan:
+    """What a schema plane must look like once its migrations have all landed."""
+
+    schemafull_tables: tuple[str, ...] = ()
+    relation_tables: tuple[str, ...] = ()
+    unique_indexes: tuple[UniqueIndexRequirement, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaInvariantReport:
+    violations: tuple[SchemaInvariantViolation, ...] = ()
+    repaired_indexes: tuple[str, ...] = ()
+    unrepairable_indexes: tuple[tuple[str, str], ...] = ()
+    skipped_tables: tuple[str, ...] = field(default=())
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+
+def expected_unique_indexes(
+    migrations: Sequence[SchemaMigration],
+) -> tuple[UniqueIndexRequirement, ...]:
+    """Replay the migration statements to derive the surviving set of UNIQUE indexes.
+
+    Replay order matters: several migrations drop a unique index and redefine it over
+    different fields, so only the last definition of a name counts.
+    """
+    surviving: dict[tuple[str, str], UniqueIndexRequirement] = {}
+    for migration in sorted(migrations, key=lambda item: item.version):
+        for statement in migration.statements:
+            removal = _REMOVE_INDEX_RE.match(statement)
+            if removal is not None:
+                surviving.pop(
+                    (removal.group("table").lower(), removal.group("name").lower()),
+                    None,
+                )
+                continue
+            definition = _DEFINE_INDEX_RE.match(statement)
+            if definition is None:
+                continue
+            key = (definition.group("table").lower(), definition.group("name").lower())
+            requirement = _unique_requirement(definition, statement)
+            if requirement is None:
+                # A redefinition that is no longer UNIQUE retires the guarantee.
+                surviving.pop(key, None)
+                continue
+            surviving[key] = requirement
+    return tuple(surviving.values())
+
+
+def _unique_requirement(
+    definition: re.Match[str],
+    statement: str,
+) -> UniqueIndexRequirement | None:
+    body = definition.group("body")
+    unique = _UNIQUE_TAIL_RE.search(body)
+    if unique is None:
+        return None
+    fields = tuple(part.strip() for part in body[: unique.start()].split(",") if part.strip())
+    if not fields:
+        return None
+    return UniqueIndexRequirement(
+        name=definition.group("name"),
+        table=definition.group("table"),
+        fields=fields,
+        statement=statement,
+    )
+
+
+async def fetch_table_definitions(execute_query: SurrealExecute) -> dict[str, str]:
+    result = await execute_query("INFO FOR DB;")
+    info = _as_mapping(result)
+    tables = info.get("tables") if info else None
+    if not isinstance(tables, Mapping):
+        return {}
+    typed = cast(Mapping[str, object], tables)
+    return {str(name): str(definition) for name, definition in typed.items()}
+
+
+async def fetch_table_indexes(execute_query: SurrealExecute, table: str) -> dict[str, str]:
+    result = await execute_query(f"INFO FOR TABLE {table};")
+    info = _as_mapping(result)
+    indexes = info.get("indexes") if info else None
+    if not isinstance(indexes, Mapping):
+        return {}
+    typed = cast(Mapping[str, object], indexes)
+    return {str(name): str(definition) for name, definition in typed.items()}
+
+
+async def check_schema_invariants(
+    execute_query: SurrealExecute,
+    plan: SchemaInvariantPlan,
+) -> tuple[SchemaInvariantViolation, ...]:
+    definitions = await fetch_table_definitions(execute_query)
+    violations: list[SchemaInvariantViolation] = []
+
+    for table in plan.schemafull_tables:
+        definition = definitions.get(table)
+        if definition is None:
+            continue
+        if "SCHEMAFULL" not in definition.upper():
+            violations.append(
+                SchemaInvariantViolation(
+                    kind="table_mode",
+                    table=table,
+                    detail="table is SCHEMALESS but the schema declares it SCHEMAFULL",
+                )
+            )
+
+    for table in plan.relation_tables:
+        definition = definitions.get(table)
+        if definition is None:
+            continue
+        if "TYPE RELATION" not in definition.upper():
+            violations.append(
+                SchemaInvariantViolation(
+                    kind="table_type",
+                    table=table,
+                    detail="edge table is missing TYPE RELATION metadata",
+                )
+            )
+
+    index_cache: dict[str, dict[str, str]] = {}
+    for requirement in plan.unique_indexes:
+        if requirement.table not in definitions:
+            continue
+        if requirement.table not in index_cache:
+            index_cache[requirement.table] = await fetch_table_indexes(
+                execute_query,
+                requirement.table,
+            )
+        if requirement.name not in index_cache[requirement.table]:
+            violations.append(
+                SchemaInvariantViolation(
+                    kind="unique_index",
+                    table=requirement.table,
+                    detail=(
+                        f"missing UNIQUE index {requirement.name} on "
+                        f"({', '.join(requirement.fields)})"
+                    ),
+                )
+            )
+    return tuple(violations)
+
+
+async def ensure_schema_invariants(
+    execute_query: SurrealExecute,
+    plan: SchemaInvariantPlan,
+) -> SchemaInvariantReport:
+    """Rebuild any missing UNIQUE index, then report what is still unmet.
+
+    Rebuilding is safe to attempt unconditionally: creating an index never deletes rows,
+    and a table that still holds duplicates simply refuses again and stays a violation.
+    """
+    repaired: list[str] = []
+    unrepairable: list[tuple[str, str]] = []
+
+    definitions = await fetch_table_definitions(execute_query)
+    for requirement in plan.unique_indexes:
+        if requirement.table not in definitions:
+            continue
+        existing = await fetch_table_indexes(execute_query, requirement.table)
+        if requirement.name in existing:
+            continue
+        try:
+            await execute_query(requirement.statement)
+        except Exception as exc:
+            unrepairable.append((requirement.name, str(exc)))
+            continue
+        repaired.append(requirement.name)
+
+    violations = await check_schema_invariants(execute_query, plan)
+    return SchemaInvariantReport(
+        violations=violations,
+        repaired_indexes=tuple(repaired),
+        unrepairable_indexes=tuple(unrepairable),
+    )
+
+
+def _as_mapping(result: object) -> Mapping[str, object] | None:
+    if isinstance(result, Mapping):
+        return cast(Mapping[str, object], result)
+    if isinstance(result, list) and result:
+        first = result[0]
+        if isinstance(first, Mapping):
+            return cast(Mapping[str, object], first)
+    return None
+
+
+__all__ = [
+    "SchemaInvariantPlan",
+    "SchemaInvariantReport",
+    "SchemaInvariantViolation",
+    "UniqueIndexRequirement",
+    "check_schema_invariants",
+    "ensure_schema_invariants",
+    "expected_unique_indexes",
+    "fetch_table_definitions",
+    "fetch_table_indexes",
+]

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_invariants.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_invariants.py
@@ -19,10 +19,12 @@ from sibyl_core.backends.surreal.schema_version import SchemaMigration, SurrealE
 
 _IDENTIFIER = r"[A-Za-z_][A-Za-z0-9_]*"
 
+# `COLUMNS` is a synonym for `FIELDS` that SurrealDB normalizes away on read, so a
+# migration written either way defines the same index and both spellings must parse.
 _DEFINE_INDEX_RE = re.compile(
     rf"^\s*DEFINE\s+INDEX\s+(?:IF\s+NOT\s+EXISTS\s+|OVERWRITE\s+)?"
     rf"(?P<name>{_IDENTIFIER})\s+ON\s+(?:TABLE\s+)?"
-    rf"(?P<table>{_IDENTIFIER})\s+FIELDS\s+(?P<body>.+?)\s*;?\s*$",
+    rf"(?P<table>{_IDENTIFIER})\s+(?:FIELDS|COLUMNS)\s+(?P<body>.+?)\s*;?\s*$",
     re.IGNORECASE | re.DOTALL,
 )
 _REMOVE_INDEX_RE = re.compile(
@@ -31,7 +33,9 @@ _REMOVE_INDEX_RE = re.compile(
     rf"(?P<table>{_IDENTIFIER})\s*;?\s*$",
     re.IGNORECASE,
 )
-_UNIQUE_TAIL_RE = re.compile(r"\bUNIQUE\b\s*$", re.IGNORECASE)
+# UNIQUE is a modifier, not necessarily the last token: `... FIELDS uuid UNIQUE
+# CONCURRENTLY;` is valid, so anchoring at the end would read it as non-unique.
+_UNIQUE_RE = re.compile(r"\bUNIQUE\b", re.IGNORECASE)
 
 
 @dataclass(frozen=True, slots=True)
@@ -111,7 +115,7 @@ def _unique_requirement(
     statement: str,
 ) -> UniqueIndexRequirement | None:
     body = definition.group("body")
-    unique = _UNIQUE_TAIL_RE.search(body)
+    unique = _UNIQUE_RE.search(body)
     if unique is None:
         return None
     fields = tuple(part.strip() for part in body[: unique.start()].split(",") if part.strip())

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_invariants.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_invariants.py
@@ -145,6 +145,45 @@ async def fetch_table_indexes(execute_query: SurrealExecute, table: str) -> dict
     return {str(name): str(definition) for name, definition in typed.items()}
 
 
+async def fetch_declared_fields(execute_query: SurrealExecute, table: str) -> frozenset[str]:
+    """Return the top-level field names a table declares.
+
+    Nested declarations (`errors.*`, `metadata.foo`) are folded into their top-level
+    parent because a declared `object FLEXIBLE` field accepts arbitrary keys beneath it,
+    so only the top level of an incoming record needs checking. An empty result means the
+    table declares nothing and therefore constrains nothing.
+    """
+    result = await execute_query(f"INFO FOR TABLE {table};")
+    info = _as_mapping(result)
+    fields = info.get("fields") if info else None
+    if not isinstance(fields, Mapping):
+        return frozenset()
+    typed = cast(Mapping[str, object], fields)
+    return frozenset(str(name).split(".", 1)[0] for name in typed)
+
+
+_IMPLICIT_FIELDS = frozenset({"id", "in", "out"})
+
+
+def drop_undeclared_fields(
+    record: Mapping[str, object],
+    declared: frozenset[str],
+) -> tuple[dict[str, object], tuple[str, ...]]:
+    """Conform a record to a SCHEMAFULL table, returning it with the names it shed.
+
+    A SCHEMAFULL table hard-errors on any undeclared key, and the error names one field
+    at a time, so a record carrying historical drift can never be written. Shedding the
+    unmapped keys loses strictly less than losing the whole row, which is what a restore
+    would otherwise do. The caller is expected to report the names.
+    """
+    if not declared:
+        return dict(record), ()
+    keep = declared | _IMPLICIT_FIELDS
+    kept = {key: value for key, value in record.items() if key in keep}
+    dropped = tuple(sorted(key for key in record if key not in keep))
+    return kept, dropped
+
+
 async def check_schema_invariants(
     execute_query: SurrealExecute,
     plan: SchemaInvariantPlan,
@@ -251,8 +290,10 @@ __all__ = [
     "SchemaInvariantViolation",
     "UniqueIndexRequirement",
     "check_schema_invariants",
+    "drop_undeclared_fields",
     "ensure_schema_invariants",
     "expected_unique_indexes",
+    "fetch_declared_fields",
     "fetch_table_definitions",
     "fetch_table_indexes",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
@@ -262,10 +262,13 @@ def _optional_int(value: object) -> int | None:
         return None
 
 
-def _validate_identifier(value: str) -> None:
+def validate_identifier(value: str) -> None:
     if not _IDENTIFIER_RE.fullmatch(value):
         msg = f"invalid SurrealDB identifier: {value!r}"
         raise ValueError(msg)
+
+
+_validate_identifier = validate_identifier
 
 
 def schema_version_record_id(name: str) -> str:
@@ -289,5 +292,6 @@ __all__ = [
     "rebuild_index_concurrently",
     "record_schema_version",
     "schema_version_record_id",
+    "validate_identifier",
     "wait_for_index_ready",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
@@ -274,7 +274,7 @@ DEFINE INDEX IF NOT EXISTS idx_content_changefeed_cursors_updated_at
     ON content_changefeed_cursors FIELDS updated_at;
 
 DEFINE TABLE IF NOT EXISTS derived_from SCHEMAFULL TYPE RELATION IN raw_captures OUT source_imports ENFORCED;
-ALTER TABLE IF EXISTS derived_from SCHEMAFULL;
+ALTER TABLE IF EXISTS derived_from TYPE RELATION IN raw_captures OUT source_imports ENFORCED SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON derived_from TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON derived_from TYPE string;
 DEFINE FIELD IF NOT EXISTS raw_memory_id ON derived_from TYPE string;
@@ -287,7 +287,7 @@ DEFINE INDEX IF NOT EXISTS idx_derived_from_org_raw ON derived_from FIELDS organ
 DEFINE INDEX IF NOT EXISTS idx_derived_from_org_import ON derived_from FIELDS organization_id, source_import_id;
 
 DEFINE TABLE IF NOT EXISTS chunk_of SCHEMAFULL TYPE RELATION IN document_chunks OUT crawled_documents ENFORCED;
-ALTER TABLE IF EXISTS chunk_of SCHEMAFULL;
+ALTER TABLE IF EXISTS chunk_of TYPE RELATION IN document_chunks OUT crawled_documents ENFORCED SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON chunk_of TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON chunk_of TYPE string;
 DEFINE FIELD IF NOT EXISTS chunk_id ON chunk_of TYPE string;
@@ -300,7 +300,7 @@ DEFINE INDEX IF NOT EXISTS idx_chunk_of_org_chunk ON chunk_of FIELDS organizatio
 DEFINE INDEX IF NOT EXISTS idx_chunk_of_org_document ON chunk_of FIELDS organization_id, document_id;
 
 DEFINE TABLE IF NOT EXISTS supersedes SCHEMAFULL TYPE RELATION IN raw_captures OUT raw_captures ENFORCED;
-ALTER TABLE IF EXISTS supersedes SCHEMAFULL;
+ALTER TABLE IF EXISTS supersedes TYPE RELATION IN raw_captures OUT raw_captures ENFORCED SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON supersedes TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON supersedes TYPE string;
 DEFINE FIELD IF NOT EXISTS raw_memory_id ON supersedes TYPE string;
@@ -313,7 +313,7 @@ DEFINE INDEX IF NOT EXISTS idx_supersedes_org_raw ON supersedes FIELDS organizat
 DEFINE INDEX IF NOT EXISTS idx_supersedes_org_superseded ON supersedes FIELDS organization_id, superseded_raw_memory_id;
 
 DEFINE TABLE IF NOT EXISTS extracted_into SCHEMAFULL TYPE RELATION IN entity OUT document_chunks;
-ALTER TABLE IF EXISTS extracted_into SCHEMAFULL;
+ALTER TABLE IF EXISTS extracted_into TYPE RELATION IN entity OUT document_chunks SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS entity_id ON extracted_into TYPE string;

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
@@ -1,4 +1,5 @@
 DEFINE TABLE IF NOT EXISTS crawl_sources SCHEMAFULL;
+ALTER TABLE IF EXISTS crawl_sources SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON crawl_sources TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON crawl_sources TYPE string;
 DEFINE FIELD IF NOT EXISTS name ON crawl_sources TYPE string DEFAULT '';
@@ -32,6 +33,7 @@ DEFINE INDEX IF NOT EXISTS idx_crawl_sources_org_status_created ON crawl_sources
 DEFINE INDEX IF NOT EXISTS idx_crawl_sources_name_ft ON crawl_sources FIELDS name FULLTEXT ANALYZER title_analyzer BM25 HIGHLIGHTS;
 
 DEFINE TABLE IF NOT EXISTS crawled_documents SCHEMAFULL;
+ALTER TABLE IF EXISTS crawled_documents SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON crawled_documents TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON crawled_documents TYPE option<string> DEFAULT '';
 DEFINE FIELD IF NOT EXISTS source_id ON crawled_documents TYPE string;
@@ -68,6 +70,7 @@ DEFINE INDEX IF NOT EXISTS idx_crawled_documents_title_ft ON crawled_documents F
 DEFINE INDEX IF NOT EXISTS idx_crawled_documents_content_ft ON crawled_documents FIELDS content FULLTEXT ANALYZER content_analyzer BM25 HIGHLIGHTS;
 
 DEFINE TABLE IF NOT EXISTS document_chunks SCHEMAFULL;
+ALTER TABLE IF EXISTS document_chunks SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON document_chunks TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON document_chunks TYPE option<string> DEFAULT '';
 DEFINE FIELD IF NOT EXISTS source_id ON document_chunks TYPE option<string> DEFAULT '';
@@ -106,6 +109,7 @@ DEFINE INDEX IF NOT EXISTS idx_document_chunks_embedding ON document_chunks FIEL
     HNSW DIMENSION {EMBEDDING_DIM} DIST COSINE TYPE F32 EFC 150 M 12;
 
 DEFINE TABLE IF NOT EXISTS entity SCHEMAFULL;
+ALTER TABLE IF EXISTS entity SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON entity TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON entity TYPE string;
 DEFINE FIELD IF NOT EXISTS created_at ON entity TYPE datetime DEFAULT time::now();
@@ -115,6 +119,7 @@ DEFINE INDEX IF NOT EXISTS idx_content_entity_uuid ON entity FIELDS uuid UNIQUE;
 DEFINE INDEX IF NOT EXISTS idx_content_entity_org_uuid ON entity FIELDS organization_id, uuid UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS raw_captures SCHEMAFULL CHANGEFEED 7d;
+ALTER TABLE IF EXISTS raw_captures SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON raw_captures TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON raw_captures TYPE string;
 DEFINE FIELD IF NOT EXISTS source_id ON raw_captures TYPE string DEFAULT '';
@@ -170,6 +175,7 @@ DEFINE INDEX IF NOT EXISTS idx_raw_captures_last_used ON raw_captures FIELDS org
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_created_at ON raw_captures FIELDS created_at;
 
 DEFINE TABLE IF NOT EXISTS memory_usage_events SCHEMAFULL;
+ALTER TABLE IF EXISTS memory_usage_events SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON memory_usage_events TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON memory_usage_events TYPE string;
 DEFINE FIELD IF NOT EXISTS session_key ON memory_usage_events TYPE string;
@@ -194,6 +200,7 @@ DEFINE INDEX IF NOT EXISTS idx_memory_usage_events_session ON memory_usage_event
 DEFINE INDEX IF NOT EXISTS idx_memory_usage_events_created_at ON memory_usage_events FIELDS created_at;
 
 DEFINE TABLE IF NOT EXISTS api_idempotency_records SCHEMAFULL;
+ALTER TABLE IF EXISTS api_idempotency_records SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON api_idempotency_records TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON api_idempotency_records TYPE string;
 DEFINE FIELD IF NOT EXISTS principal_id ON api_idempotency_records TYPE string;
@@ -211,6 +218,7 @@ DEFINE INDEX IF NOT EXISTS idx_api_idempotency_records_scope ON api_idempotency_
 DEFINE INDEX IF NOT EXISTS idx_api_idempotency_records_created_at ON api_idempotency_records FIELDS created_at;
 
 DEFINE TABLE IF NOT EXISTS source_imports SCHEMAFULL;
+ALTER TABLE IF EXISTS source_imports SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON source_imports TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON source_imports TYPE string;
 DEFINE FIELD IF NOT EXISTS principal_id ON source_imports TYPE string;
@@ -248,6 +256,7 @@ DEFINE INDEX IF NOT EXISTS idx_source_imports_principal ON source_imports FIELDS
 DEFINE INDEX IF NOT EXISTS idx_source_imports_status ON source_imports FIELDS organization_id, status;
 
 DEFINE TABLE IF NOT EXISTS content_changefeed_cursors SCHEMAFULL;
+ALTER TABLE IF EXISTS content_changefeed_cursors SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON content_changefeed_cursors TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON content_changefeed_cursors TYPE string;
 DEFINE FIELD IF NOT EXISTS table_name ON content_changefeed_cursors TYPE string;
@@ -265,6 +274,7 @@ DEFINE INDEX IF NOT EXISTS idx_content_changefeed_cursors_updated_at
     ON content_changefeed_cursors FIELDS updated_at;
 
 DEFINE TABLE IF NOT EXISTS derived_from SCHEMAFULL TYPE RELATION IN raw_captures OUT source_imports ENFORCED;
+ALTER TABLE IF EXISTS derived_from SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON derived_from TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON derived_from TYPE string;
 DEFINE FIELD IF NOT EXISTS raw_memory_id ON derived_from TYPE string;
@@ -277,6 +287,7 @@ DEFINE INDEX IF NOT EXISTS idx_derived_from_org_raw ON derived_from FIELDS organ
 DEFINE INDEX IF NOT EXISTS idx_derived_from_org_import ON derived_from FIELDS organization_id, source_import_id;
 
 DEFINE TABLE IF NOT EXISTS chunk_of SCHEMAFULL TYPE RELATION IN document_chunks OUT crawled_documents ENFORCED;
+ALTER TABLE IF EXISTS chunk_of SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON chunk_of TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON chunk_of TYPE string;
 DEFINE FIELD IF NOT EXISTS chunk_id ON chunk_of TYPE string;
@@ -289,6 +300,7 @@ DEFINE INDEX IF NOT EXISTS idx_chunk_of_org_chunk ON chunk_of FIELDS organizatio
 DEFINE INDEX IF NOT EXISTS idx_chunk_of_org_document ON chunk_of FIELDS organization_id, document_id;
 
 DEFINE TABLE IF NOT EXISTS supersedes SCHEMAFULL TYPE RELATION IN raw_captures OUT raw_captures ENFORCED;
+ALTER TABLE IF EXISTS supersedes SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON supersedes TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON supersedes TYPE string;
 DEFINE FIELD IF NOT EXISTS raw_memory_id ON supersedes TYPE string;
@@ -301,6 +313,7 @@ DEFINE INDEX IF NOT EXISTS idx_supersedes_org_raw ON supersedes FIELDS organizat
 DEFINE INDEX IF NOT EXISTS idx_supersedes_org_superseded ON supersedes FIELDS organization_id, superseded_raw_memory_id;
 
 DEFINE TABLE IF NOT EXISTS extracted_into SCHEMAFULL TYPE RELATION IN entity OUT document_chunks;
+ALTER TABLE IF EXISTS extracted_into SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON extracted_into TYPE string;
 DEFINE FIELD IF NOT EXISTS entity_id ON extracted_into TYPE string;
@@ -314,6 +327,7 @@ DEFINE INDEX IF NOT EXISTS idx_extracted_into_org_entity ON extracted_into FIELD
 DEFINE INDEX IF NOT EXISTS idx_extracted_into_org_chunk ON extracted_into FIELDS organization_id, chunk_id;
 
 DEFINE TABLE IF NOT EXISTS system_settings SCHEMAFULL;
+ALTER TABLE IF EXISTS system_settings SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS key ON system_settings TYPE string;
 DEFINE FIELD IF NOT EXISTS value ON system_settings TYPE string DEFAULT '';
 DEFINE FIELD IF NOT EXISTS is_secret ON system_settings TYPE bool DEFAULT false;
@@ -324,6 +338,7 @@ DEFINE FIELD IF NOT EXISTS updated_at ON system_settings TYPE datetime DEFAULT t
 DEFINE INDEX IF NOT EXISTS idx_system_settings_key ON system_settings FIELDS key UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS telemetry_rollups SCHEMAFULL;
+ALTER TABLE IF EXISTS telemetry_rollups SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON telemetry_rollups TYPE string;
 DEFINE FIELD IF NOT EXISTS bucket_key ON telemetry_rollups TYPE string;
 DEFINE FIELD IF NOT EXISTS bucket_start ON telemetry_rollups TYPE datetime;
@@ -341,6 +356,7 @@ DEFINE INDEX IF NOT EXISTS idx_telemetry_rollups_bucket_key ON telemetry_rollups
 DEFINE INDEX IF NOT EXISTS idx_telemetry_rollups_bucket_start ON telemetry_rollups FIELDS bucket_start;
 
 DEFINE TABLE IF NOT EXISTS backup_settings SCHEMAFULL;
+ALTER TABLE IF EXISTS backup_settings SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON backup_settings TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON backup_settings TYPE string;
 DEFINE FIELD IF NOT EXISTS enabled ON backup_settings TYPE bool DEFAULT true;
@@ -357,6 +373,7 @@ DEFINE INDEX IF NOT EXISTS idx_backup_settings_uuid ON backup_settings FIELDS uu
 DEFINE INDEX IF NOT EXISTS idx_backup_settings_org ON backup_settings FIELDS organization_id UNIQUE;
 
 DEFINE TABLE IF NOT EXISTS backups SCHEMAFULL;
+ALTER TABLE IF EXISTS backups SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS uuid ON backups TYPE string;
 DEFINE FIELD IF NOT EXISTS organization_id ON backups TYPE string;
 DEFINE FIELD IF NOT EXISTS backup_id ON backups TYPE string DEFAULT '';

--- a/packages/python/sibyl-core/tests/test_surreal_schema_invariants.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_invariants.py
@@ -1,0 +1,254 @@
+"""Checks that a schema plane is validated against reality, not its recorded version."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from surrealdb import AsyncSurreal
+
+from sibyl_core.backends.surreal.auth_schema import auth_schema_invariant_plan
+from sibyl_core.backends.surreal.content_schema import (
+    CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS,
+    content_schema_invariant_plan,
+)
+from sibyl_core.backends.surreal.schema_helpers import split_statements
+from sibyl_core.backends.surreal.schema_invariants import (
+    SchemaInvariantPlan,
+    check_schema_invariants,
+    ensure_schema_invariants,
+    expected_unique_indexes,
+)
+from sibyl_core.backends.surreal.schema_version import SchemaMigration, SurrealExecute
+
+_USAGE_EVENT_TEMPLATE = """
+CREATE memory_usage_events CONTENT {{
+    uuid: '{uuid}',
+    organization_id: 'org-a',
+    session_key: 's',
+    message_key: 'm',
+    source_surface: 'recall',
+    item_kind: 'raw_capture',
+    item_id: '{item}',
+    signal_type: 'exposure',
+    metadata: {{}},
+    event_at: d'2026-07-11T00:00:00Z',
+    created_at: d'2026-07-11T00:00:00Z'
+}};
+"""
+
+
+@pytest.fixture
+async def db() -> AsyncIterator[AsyncSurreal]:
+    connection = AsyncSurreal("memory://")
+    await connection.use("invariants", "content")
+    try:
+        yield connection
+    finally:
+        await connection.close()
+
+
+def _execute(connection: AsyncSurreal) -> SurrealExecute:
+    async def run(statement: str, /, **params: object) -> object:
+        return await connection.query(statement, params or None)
+
+    return run
+
+
+def test_expected_unique_indexes_ignores_non_unique_definitions() -> None:
+    migrations = (
+        SchemaMigration(
+            version=1,
+            name="one",
+            statements=(
+                "DEFINE INDEX IF NOT EXISTS idx_a ON widgets FIELDS uuid UNIQUE;",
+                "DEFINE INDEX IF NOT EXISTS idx_b ON widgets FIELDS org, created_at;",
+            ),
+        ),
+    )
+
+    requirements = expected_unique_indexes(migrations)
+
+    assert [item.name for item in requirements] == ["idx_a"]
+    assert requirements[0].fields == ("uuid",)
+    assert requirements[0].table == "widgets"
+
+
+def test_expected_unique_indexes_retires_indexes_a_later_migration_drops() -> None:
+    migrations = (
+        SchemaMigration(
+            version=1,
+            name="one",
+            statements=("DEFINE INDEX IF NOT EXISTS idx_url ON sources FIELDS url UNIQUE;",),
+        ),
+        SchemaMigration(
+            version=2,
+            name="two",
+            statements=(
+                "REMOVE INDEX IF EXISTS idx_url ON TABLE sources;",
+                "DEFINE INDEX IF NOT EXISTS idx_org_url ON sources FIELDS org, url UNIQUE;",
+            ),
+        ),
+    )
+
+    assert [item.name for item in expected_unique_indexes(migrations)] == ["idx_org_url"]
+
+
+def test_expected_unique_indexes_retires_an_index_redefined_without_unique() -> None:
+    migrations = (
+        SchemaMigration(
+            version=1,
+            name="one",
+            statements=("DEFINE INDEX IF NOT EXISTS idx_a ON widgets FIELDS uuid UNIQUE;",),
+        ),
+        SchemaMigration(
+            version=2,
+            name="two",
+            statements=("DEFINE INDEX OVERWRITE idx_a ON widgets FIELDS uuid;",),
+        ),
+    )
+
+    assert expected_unique_indexes(migrations) == ()
+
+
+def test_content_plan_requires_both_usage_event_dedupe_indexes() -> None:
+    plan = content_schema_invariant_plan()
+    names = {item.name for item in plan.unique_indexes}
+
+    assert "idx_memory_usage_events_uuid" in names
+    assert "idx_memory_usage_events_dedupe" in names
+    assert "derived_from" in plan.relation_tables
+    assert "memory_usage_events" in plan.schemafull_tables
+    # v2 drops this index in favour of the org-scoped one; it must not be demanded back.
+    assert "idx_crawl_sources_url" not in names
+
+
+def test_auth_plan_requires_the_user_identity_indexes() -> None:
+    names = {item.name for item in auth_schema_invariant_plan().unique_indexes}
+
+    assert "idx_users_uuid" in names
+    assert "idx_users_email" in names
+
+
+@pytest.mark.asyncio
+async def test_check_flags_a_schemaless_table_and_an_untyped_edge(db: AsyncSurreal) -> None:
+    await db.query("CREATE widgets CONTENT { uuid: 'w1' };")
+    await db.query("CREATE node_a:1; CREATE node_b:1;")
+    await db.query("RELATE node_a:1->links->node_b:1 SET uuid = 'l1';")
+
+    violations = await check_schema_invariants(
+        _execute(db),
+        SchemaInvariantPlan(schemafull_tables=("widgets",), relation_tables=("links",)),
+    )
+
+    assert {item.kind for item in violations} == {"table_mode", "table_type"}
+
+
+@pytest.mark.asyncio
+async def test_check_ignores_tables_that_do_not_exist_yet(db: AsyncSurreal) -> None:
+    violations = await check_schema_invariants(
+        _execute(db),
+        SchemaInvariantPlan(schemafull_tables=("never_created",)),
+    )
+
+    assert violations == ()
+
+
+@pytest.mark.asyncio
+async def test_ensure_rebuilds_a_unique_index_that_was_skipped(db: AsyncSurreal) -> None:
+    await db.query("DEFINE TABLE widgets SCHEMAFULL;")
+    await db.query("DEFINE FIELD uuid ON widgets TYPE string;")
+    await db.query("CREATE widgets CONTENT { uuid: 'w1' };")
+    plan = SchemaInvariantPlan(
+        schemafull_tables=("widgets",),
+        unique_indexes=expected_unique_indexes(
+            (
+                SchemaMigration(
+                    version=1,
+                    name="one",
+                    statements=(
+                        "DEFINE INDEX IF NOT EXISTS idx_widgets_uuid "
+                        "ON widgets FIELDS uuid UNIQUE;",
+                    ),
+                ),
+            )
+        ),
+    )
+
+    report = await ensure_schema_invariants(_execute(db), plan)
+
+    assert report.ok
+    assert report.repaired_indexes == ("idx_widgets_uuid",)
+    assert report.unrepairable_indexes == ()
+
+
+@pytest.mark.asyncio
+async def test_ensure_reports_a_unique_index_duplicate_rows_still_block(db: AsyncSurreal) -> None:
+    await db.query("DEFINE TABLE widgets SCHEMAFULL;")
+    await db.query("DEFINE FIELD uuid ON widgets TYPE string;")
+    await db.query("CREATE widgets CONTENT { uuid: 'w1' };")
+    await db.query("CREATE widgets CONTENT { uuid: 'w1' };")
+    plan = SchemaInvariantPlan(
+        schemafull_tables=("widgets",),
+        unique_indexes=expected_unique_indexes(
+            (
+                SchemaMigration(
+                    version=1,
+                    name="one",
+                    statements=(
+                        "DEFINE INDEX IF NOT EXISTS idx_widgets_uuid "
+                        "ON widgets FIELDS uuid UNIQUE;",
+                    ),
+                ),
+            )
+        ),
+    )
+
+    report = await ensure_schema_invariants(_execute(db), plan)
+
+    assert not report.ok
+    assert [item.kind for item in report.violations] == ["unique_index"]
+    assert report.repaired_indexes == ()
+    assert [name for name, _ in report.unrepairable_indexes] == ["idx_widgets_uuid"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_rows_leave_dedupe_unenforced_after_a_clean_migration(
+    db: AsyncSurreal,
+) -> None:
+    """The dishonest state the invariant check exists to catch.
+
+    Duplicate rows make `DEFINE INDEX ... UNIQUE` fail. The bootstrap swallows that and
+    records the migration as applied, so the plane sits at its target version while the
+    deduplication the usage service depends on is not enforced at all.
+    """
+    for index in range(2):
+        await db.query(_USAGE_EVENT_TEMPLATE.format(uuid="dup", item=f"item-{index}"))
+
+    skipped: list[str] = []
+    for statement in split_statements(CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS):
+        if "memory_usage_events" not in statement:
+            continue
+        try:
+            await db.query(statement)
+        except Exception:
+            skipped.append(statement)
+
+    plan = content_schema_invariant_plan()
+    usage_only = SchemaInvariantPlan(
+        schemafull_tables=("memory_usage_events",),
+        unique_indexes=tuple(
+            item for item in plan.unique_indexes if item.table == "memory_usage_events"
+        ),
+    )
+    report = await ensure_schema_invariants(_execute(db), usage_only)
+
+    assert any("idx_memory_usage_events_uuid" in statement for statement in skipped)
+    assert not report.ok
+    assert any("idx_memory_usage_events_uuid" in item.detail for item in report.violations)
+
+    await db.query("DELETE memory_usage_events WHERE item_id = 'item-1';")
+    healed = await ensure_schema_invariants(_execute(db), usage_only)
+
+    assert healed.ok
+    assert "idx_memory_usage_events_uuid" in healed.repaired_indexes

--- a/packages/python/sibyl-core/tests/test_surreal_schema_invariants.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_invariants.py
@@ -252,3 +252,83 @@ async def test_duplicate_rows_leave_dedupe_unenforced_after_a_clean_migration(
 
     assert healed.ok
     assert "idx_memory_usage_events_uuid" in healed.repaired_indexes
+
+
+@pytest.mark.parametrize(
+    ("statement", "expected_fields"),
+    [
+        ("DEFINE INDEX idx_a ON widgets FIELDS uuid UNIQUE;", ("uuid",)),
+        ("DEFINE INDEX idx_a ON widgets COLUMNS uuid UNIQUE;", ("uuid",)),
+        ("DEFINE INDEX idx_a ON widgets FIELDS uuid UNIQUE CONCURRENTLY;", ("uuid",)),
+        ("DEFINE INDEX idx_a ON widgets COLUMNS uuid UNIQUE CONCURRENTLY;", ("uuid",)),
+        (
+            "DEFINE INDEX IF NOT EXISTS idx_a ON TABLE widgets COLUMNS org, uuid UNIQUE;",
+            ("org", "uuid"),
+        ),
+    ],
+)
+def test_expected_unique_indexes_reads_both_spellings_and_trailing_clauses(
+    statement: str,
+    expected_fields: tuple[str, ...],
+) -> None:
+    """COLUMNS is a synonym for FIELDS and UNIQUE is a modifier, not the final token.
+
+    SurrealDB accepts every spelling here and normalizes them to the same index, so a
+    parser that only reads `FIELDS ... UNIQUE;` silently drops a required invariant.
+    """
+    requirements = expected_unique_indexes(
+        (SchemaMigration(version=1, name="one", statements=(statement,)),)
+    )
+
+    assert [item.name for item in requirements] == ["idx_a"]
+    assert requirements[0].fields == expected_fields
+    assert requirements[0].table == "widgets"
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "DEFINE INDEX idx_a ON widgets FIELDS org, created_at;",
+        "DEFINE INDEX idx_a ON widgets COLUMNS org, created_at CONCURRENTLY;",
+        "DEFINE INDEX idx_a ON widgets FIELDS content FULLTEXT ANALYZER title_analyzer BM25;",
+        (
+            "DEFINE INDEX idx_a ON widgets FIELDS embedding "
+            "HNSW DIMENSION 8 DIST COSINE TYPE F32 EFC 150 M 12;"
+        ),
+    ],
+)
+def test_expected_unique_indexes_ignores_indexes_that_promise_no_uniqueness(
+    statement: str,
+) -> None:
+    assert (
+        expected_unique_indexes((SchemaMigration(version=1, name="one", statements=(statement,)),))
+        == ()
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_rebuilds_a_unique_index_declared_with_columns(db: AsyncSurreal) -> None:
+    """The COLUMNS spelling has to survive the whole derive-then-rebuild round trip."""
+    await db.query("DEFINE TABLE widgets SCHEMAFULL;")
+    await db.query("DEFINE FIELD uuid ON widgets TYPE string;")
+    await db.query("CREATE widgets CONTENT { uuid: 'w1' };")
+    plan = SchemaInvariantPlan(
+        schemafull_tables=("widgets",),
+        unique_indexes=expected_unique_indexes(
+            (
+                SchemaMigration(
+                    version=1,
+                    name="one",
+                    statements=(
+                        "DEFINE INDEX IF NOT EXISTS idx_widgets_uuid "
+                        "ON widgets COLUMNS uuid UNIQUE CONCURRENTLY;",
+                    ),
+                ),
+            )
+        ),
+    )
+
+    report = await ensure_schema_invariants(_execute(db), plan)
+
+    assert report.ok
+    assert report.repaired_indexes == ("idx_widgets_uuid",)

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -37,6 +37,7 @@ from sibyl_core.backends.surreal.content_schema import (
     CONTENT_RAW_CAPTURE_LOOKUP_MIGRATION_DEFINITIONS,
     CONTENT_RAW_CAPTURE_REQUIRED_FIELD_REPAIR_DEFINITIONS,
     CONTENT_RAW_CAPTURE_REVISION_MIGRATION_DEFINITIONS,
+    CONTENT_RELATION_SPECS,
     CONTENT_RELATION_TABLES,
     CONTENT_REVIEW_STATE_DEFERRED_MIGRATION_DEFINITIONS,
     CONTENT_SCHEMA_CURRENT_VERSION,
@@ -46,6 +47,7 @@ from sibyl_core.backends.surreal.content_schema import (
     CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS,
     _content_schema_migrations,
     bootstrap_content_schema,
+    content_schemafull_repair_statement,
 )
 from sibyl_core.backends.surreal.schema import (
     CURRENT_SCHEMA_MAINTENANCE_DEFINITIONS,
@@ -201,7 +203,7 @@ def test_runtime_schemafull_tables_pair_define_with_alter() -> None:
     assert "ALTER TABLE IF EXISTS raw_captures SCHEMAFULL;" in schema
     for table in CONTENT_RELATION_TABLES:
         assert f"DEFINE TABLE IF NOT EXISTS {table} SCHEMAFULL TYPE RELATION" in schema
-        assert f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" in schema
+        assert content_schemafull_repair_statement(table) in schema
 
 
 def test_auth_invitation_schema_supports_hashed_tokens() -> None:
@@ -1410,7 +1412,12 @@ def _schemafull_define_pairing_gaps(text: str) -> list[str]:
             continue
         table = match.group(1)
         following = lines[index + 1].strip() if index + 1 < len(lines) else ""
-        if following != f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;":
+        paired = re.fullmatch(
+            rf"ALTER TABLE IF EXISTS {table}(?: TYPE RELATION [^;]+?)? SCHEMAFULL;"
+            rf"|\{{content_schemafull_repair_statement\(['\"]{table}['\"]\)\}}",
+            following,
+        )
+        if paired is None:
             gaps.append(f"{table} (line {index + 1})")
     return gaps
 
@@ -1465,7 +1472,7 @@ def test_schemafull_repair_migrations_cover_every_table() -> None:
     assert CONTENT_SCHEMA_CURRENT_VERSION >= 24
     assert repair.version == 24
     for table in CONTENT_TABLES:
-        assert f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" in repair.statements
+        assert content_schemafull_repair_statement(table) in repair.statements
 
     auth_repair = next(
         migration
@@ -1545,3 +1552,71 @@ async def test_schemafull_repair_migration_converts_drifted_table() -> None:
     assert "SCHEMALESS" in before["tables"]["entity"]
     assert "SCHEMAFULL" in after["tables"]["entity"]
     assert rows == [{"uuid": "entity-a"}]
+
+
+def test_relation_repair_alter_matches_the_relation_define() -> None:
+    """The repair ALTER must promise exactly what the DEFINE promises.
+
+    `ALTER TABLE ... SCHEMAFULL` alone fixes the schema mode but leaves an edge table
+    RELATE auto-created as `TYPE ANY`, so the table would report itself repaired while
+    its IN/OUT contract stayed absent.
+    """
+    schema = "\n".join(
+        (
+            CONTENT_SCHEMA_DEFINITIONS,
+            CONTENT_LINEAGE_RELATION_MIGRATION_DEFINITIONS,
+            CONTENT_EXTRACTED_INTO_RELATION_MIGRATION_DEFINITIONS,
+        )
+    )
+    for table, clause in CONTENT_RELATION_SPECS.items():
+        assert f"DEFINE TABLE IF NOT EXISTS {table} SCHEMAFULL {clause};" in schema
+        assert content_schemafull_repair_statement(table) == (
+            f"ALTER TABLE IF EXISTS {table} {clause} SCHEMAFULL;"
+        )
+
+    for table in CONTENT_TABLES:
+        if table in CONTENT_RELATION_SPECS:
+            continue
+        assert content_schemafull_repair_statement(table) == (
+            f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;"
+        )
+
+
+@pytest.mark.asyncio
+async def test_schemafull_repair_restores_relation_metadata_on_auto_created_edge() -> None:
+    """RELATE auto-creates a missing edge table as TYPE ANY SCHEMALESS.
+
+    A guarded DEFINE then no-ops against it forever, so the sweep is the only statement
+    that can restore the relation contract on a store that already drifted.
+    """
+    from sibyl_core.backends.surreal.content_schema import CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS
+
+    db = AsyncSurreal("memory://")
+    try:
+        await db.use("relation_repair", "content")
+        await db.query("CREATE raw_captures:one; CREATE source_imports:one;")
+        await db.query("RELATE raw_captures:one->derived_from->source_imports:one SET uuid='e1';")
+        before = await db.query("INFO FOR DB;")
+
+        await db.query(
+            "DEFINE TABLE IF NOT EXISTS derived_from SCHEMAFULL "
+            "TYPE RELATION IN raw_captures OUT source_imports ENFORCED;"
+        )
+        guarded = await db.query("INFO FOR DB;")
+
+        for statement in split_statements(CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS):
+            await db.query(statement)
+
+        after = await db.query("INFO FOR DB;")
+        rows = await db.query("SELECT uuid FROM derived_from;")
+    finally:
+        await db.close()
+
+    assert "TYPE ANY SCHEMALESS" in before["tables"]["derived_from"]
+    assert "TYPE ANY" in guarded["tables"]["derived_from"]
+    assert (
+        "TYPE RELATION IN raw_captures OUT source_imports ENFORCED"
+        in (after["tables"]["derived_from"])
+    )
+    assert "SCHEMAFULL" in after["tables"]["derived_from"]
+    assert rows == [{"uuid": "e1"}]

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import re
 import time
+from pathlib import Path
 
 import jwt
 import pytest
@@ -174,7 +176,13 @@ def test_flexible_object_fields_keep_server_accepted_token_order() -> None:
     assert "TYPE object FLEXIBLE" in schema
 
 
-def test_runtime_schemafull_tables_define_schemafull_without_redundant_alter() -> None:
+def test_runtime_schemafull_tables_pair_define_with_alter() -> None:
+    """The ALTER is not redundant with the DEFINE: it is the only statement that converts.
+
+    `DEFINE TABLE IF NOT EXISTS` no-ops against a table Surreal already auto-created
+    SCHEMALESS on a first application write, so without the ALTER such a table never
+    becomes SCHEMAFULL and its FLEXIBLE fields fail forever.
+    """
     schema = "\n".join((AUTH_SCHEMA_DEFINITIONS, CONTENT_SCHEMA_DEFINITIONS))
     content_tables = tuple(
         table
@@ -188,11 +196,12 @@ def test_runtime_schemafull_tables_define_schemafull_without_redundant_alter() -
 
     for table in tables:
         assert f"DEFINE TABLE IF NOT EXISTS {table} SCHEMAFULL;" in schema
-        assert f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" not in schema
+        assert f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" in schema
     assert "DEFINE TABLE IF NOT EXISTS raw_captures SCHEMAFULL CHANGEFEED 7d;" in schema
+    assert "ALTER TABLE IF EXISTS raw_captures SCHEMAFULL;" in schema
     for table in CONTENT_RELATION_TABLES:
         assert f"DEFINE TABLE IF NOT EXISTS {table} SCHEMAFULL TYPE RELATION" in schema
-        assert f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" not in schema
+        assert f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" in schema
 
 
 def test_auth_invitation_schema_supports_hashed_tokens() -> None:
@@ -1390,3 +1399,149 @@ async def test_content_bootstrap_does_not_repeat_migrations_after_recording_vers
     assert not any(
         "DEFINE TABLE IF NOT EXISTS crawl_sources" in statement for statement in second_calls
     )
+
+
+def _schemafull_define_pairing_gaps(text: str) -> list[str]:
+    lines = text.splitlines()
+    gaps: list[str] = []
+    for index, line in enumerate(lines):
+        match = re.match(r"^\s*DEFINE TABLE (?:IF NOT EXISTS|OVERWRITE) (\w+) SCHEMAFULL\b", line)
+        if match is None:
+            continue
+        table = match.group(1)
+        following = lines[index + 1].strip() if index + 1 < len(lines) else ""
+        if following != f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;":
+            gaps.append(f"{table} (line {index + 1})")
+    return gaps
+
+
+def _schema_source_texts() -> dict[str, str]:
+    from sibyl_core.backends.surreal import auth_schema, content_schema, schema
+
+    sources = {
+        module.__name__: Path(str(module.__file__)).read_text(encoding="utf-8")
+        for module in (content_schema, auth_schema, schema)
+    }
+    surql = Path(str(content_schema.__file__)).with_name("schemas") / "content" / "10_tables.surql"
+    sources[surql.name] = surql.read_text(encoding="utf-8")
+    return sources
+
+
+def test_every_schemafull_define_is_paired_with_an_alter() -> None:
+    """`DEFINE TABLE IF NOT EXISTS ... SCHEMAFULL` no-ops on an auto-created SCHEMALESS table.
+
+    Without the paired ALTER the table stays SCHEMALESS forever, so any FLEXIBLE field in the
+    same migration fails on every startup and blocks every later migration.
+    """
+    gaps = {
+        name: found
+        for name, text in _schema_source_texts().items()
+        if (found := _schemafull_define_pairing_gaps(text))
+    }
+
+    assert not gaps, f"SCHEMAFULL DEFINE without paired ALTER: {gaps}"
+
+
+def test_usage_signal_migration_pairs_define_with_alter() -> None:
+    statements = split_statements(CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS)
+    define_index = statements.index("DEFINE TABLE IF NOT EXISTS memory_usage_events SCHEMAFULL;")
+
+    assert statements[define_index + 1] == "ALTER TABLE IF EXISTS memory_usage_events SCHEMAFULL;"
+    flexible_index = next(
+        index
+        for index, statement in enumerate(statements)
+        if "metadata ON memory_usage_events" in statement and "FLEXIBLE" in statement
+    )
+    assert define_index + 1 < flexible_index
+
+
+def test_schemafull_repair_migrations_cover_every_table() -> None:
+    repair = next(
+        migration
+        for migration in _content_schema_migrations(url="memory://")
+        if migration.name == "content_schemafull_repair"
+    )
+
+    assert CONTENT_SCHEMA_CURRENT_VERSION >= 24
+    assert repair.version == 24
+    for table in CONTENT_TABLES:
+        assert f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" in repair.statements
+
+    auth_repair = next(
+        migration
+        for migration in AUTH_SCHEMA_MIGRATIONS
+        if migration.name == "auth_schemafull_repair"
+    )
+
+    assert AUTH_SCHEMA_CURRENT_VERSION >= 6
+    for table in AUTH_TABLES:
+        assert f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" in auth_repair.statements
+
+
+@pytest.mark.asyncio
+async def test_usage_signal_migration_converts_auto_created_schemaless_table() -> None:
+    """The exact scenario that deadlocked a live store.
+
+    `memory_usage_events` is written by the usage service, which shipped ahead of the
+    migration that defines it, so Surreal auto-created the table SCHEMALESS. The guarded
+    DEFINE then no-ops and the table can never accept its FLEXIBLE metadata field.
+    """
+    db = AsyncSurreal("memory://")
+    try:
+        await db.use("schemafull_repair", "content")
+        await db.query(
+            """
+            CREATE memory_usage_events CONTENT {
+                uuid: 'event-a',
+                organization_id: 'org-a',
+                session_key: 's',
+                message_key: 'm',
+                source_surface: 'recall',
+                item_kind: 'raw_capture',
+                item_id: 'item-a',
+                signal_type: 'exposure',
+                metadata: { nested: { depth: 2 } },
+                event_at: d'2026-07-11T00:00:00Z',
+                created_at: d'2026-07-11T00:00:00Z'
+            };
+            """
+        )
+        before = await db.query("INFO FOR DB;")
+
+        for statement in split_statements(CONTENT_USAGE_SIGNAL_MIGRATION_DEFINITIONS):
+            if "memory_usage_events" not in statement:
+                continue
+            await db.query(statement)
+
+        after = await db.query("INFO FOR DB;")
+        rows = await db.query("SELECT uuid, metadata FROM memory_usage_events;")
+    finally:
+        await db.close()
+
+    assert "SCHEMALESS" in before["tables"]["memory_usage_events"]
+    assert "SCHEMAFULL" in after["tables"]["memory_usage_events"]
+    assert rows == [{"uuid": "event-a", "metadata": {"nested": {"depth": 2}}}]
+
+
+@pytest.mark.asyncio
+async def test_schemafull_repair_migration_converts_drifted_table() -> None:
+    """Tables that drifted SCHEMALESS before the pairing shipped are healed by the sweep."""
+    from sibyl_core.backends.surreal.content_schema import CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS
+
+    db = AsyncSurreal("memory://")
+    try:
+        await db.use("schemafull_sweep", "content")
+        await db.query("CREATE entity CONTENT { uuid: 'entity-a', organization_id: 'org-a' };")
+        before = await db.query("INFO FOR DB;")
+
+        for statement in split_statements(CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS):
+            await db.query(statement)
+
+        after = await db.query("INFO FOR DB;")
+        rows = await db.query("SELECT uuid FROM entity;")
+    finally:
+        await db.close()
+
+    assert "SCHEMALESS" in before["tables"]["entity"]
+    assert "SCHEMAFULL" in after["tables"]["entity"]
+    assert rows == [{"uuid": "entity-a"}]


### PR DESCRIPTION
# 🗄️ Unwedge the schema ladder, and stop it reporting success it cannot substantiate

> Fixes a migration deadlock that can halt the content and auth schema ladders permanently and silently. A store in this state has been observed stuck at content v15 of 24 since 2026-07-11, through the entire 1.1.x series, while `/api/health` reported healthy. Candidate for a 1.1.3 patch.

## 💡 What this is

`DEFINE TABLE IF NOT EXISTS <x> SCHEMAFULL` looks like it guarantees the table ends up SCHEMAFULL. It does not. If SurrealDB already auto-created that table as SCHEMALESS on an application's first write, the guard matches on existence alone and the statement is a no-op — the table stays SCHEMALESS forever.

Migration v16 then runs `DEFINE FIELD … TYPE object FLEXIBLE` against it and hard-fails with `FLEXIBLE can only be used in SCHEMAFULL tables`. Because a migration's version is recorded only after every statement succeeds, v16 re-runs and re-fails on every startup, and v17 through v24 never execute. There is no error path out of this: the ladder is wedged until someone hand-writes SurrealQL.

The repo already knew the shape of the fix. `schema_version.py` pairs its own `DEFINE TABLE IF NOT EXISTS … SCHEMAFULL` with an `ALTER TABLE IF EXISTS … SCHEMAFULL`, and a docstring in `migrate.py` warns that "surreal lazily creates SCHEMALESS tables on first insert". That pairing was never applied to the content or auth tables.

## 🤔 Why we need it & what it replaces

Fresh installs are unaffected — a new store defines the table SCHEMAFULL in migration v1, so v16's guard is a harmless no-op. The exposed population is **upgraders** whose store predates the table being added to the base definitions, and whose application wrote a usage event into the gap.

Because the failure surfaces only on `/api/health/ready` and the shipped Compose healthcheck probes `/api/health` (liveness, which is always healthy), a wedged store looks fine from the outside indefinitely. The Helm chart already probes readiness correctly; Compose did not.

Pairing every guarded `DEFINE` with an `ALTER` fixes migrations that have not run yet, but it cannot help a table that already drifted under an *already-recorded* version. Two repair sweeps (content v24, auth v6) close that gap by altering every table.

## 🎯 The invariant

Anchor the review on one property: **a migration must not record success it cannot substantiate.**

The deadlock is the loud half of the problem. The quiet half is that `execute_schema_statement` swallows duplicate-data index failures, so a `DEFINE INDEX … UNIQUE` that fails on existing duplicate rows is skipped, the migration records as applied, and the index is never retried. Dedupe would be permanently unenforced while every version number looked correct. This branch makes that state observable and repairable instead of silent.

## 🛠️ How it works

**1. Pair every guarded SCHEMAFULL define with an alter** — `content_schema.py`, `auth_schema.py`, `schemas/content/10_tables.surql`

48 tables. A test scans all four sources and fails on any unpaired `DEFINE`, so the next table added cannot reintroduce the wedge.

**2. Repair relation metadata, not just schema mode** — `content_schema.py`

`RELATE` can auto-create an edge table as SCHEMALESS `TYPE ANY`. Altering only the schema mode leaves `derived_from`, `chunk_of`, `supersedes`, and `extracted_into` without their relation metadata while reporting them repaired. The ALTER now carries the full clause, rendered from one map shared with the DEFINE sites.

An independent review asserted `ALTER TABLE` *cannot* add `TYPE RELATION`, `IN`, `OUT`, or `ENFORCED`. Tested against a real SurrealDB 3.2.3 server, it can:

```
before: DEFINE TABLE edge2 TYPE ANY SCHEMALESS PERMISSIONS NONE
ALTER TABLE IF EXISTS edge2 TYPE RELATION IN node_a OUT node_b ENFORCED SCHEMAFULL;  -> OK
after : DEFINE TABLE edge2 TYPE RELATION IN node_a OUT node_b ENFORCED SCHEMAFULL PERMISSIONS NONE
```

The defect the review found was real; only its stated cause was wrong. Bare `ENFORCED` *is* a parse error — it must follow `TYPE RELATION IN … OUT …`. The conversion preserves rows, declared fields, and permissions, is idempotent on replay, works when the IN/OUT target tables do not exist yet, and does not retro-validate existing rows.

**3. Verify invariants independently of the version number** — new `schema_invariants.py`

The expected UNIQUE-index set is **derived by replaying the migration statements**, not hand-listed, so an index a later migration drops or redefines as non-unique retires from the expectation automatically. 30 content invariants, 43 auth. `sibyld db init` rebuilds any missing index first — creating an index cannot lose rows — then reports what remains unmet and exits non-zero.

**4. Keep row deletion an operator decision** — `sibyld db duplicates`

Read-only inventory by default, `--collapse` to delete, keeping the lowest record id per group. Driven by *which* required index is missing rather than a hardcoded table list. No migration deletes user rows.

**5. Shed undeclared fields on restore instead of losing the row** — `content_archive.py`, `auth_archive.py`

Converting a populated table to SCHEMAFULL makes archived drift fields fail on restore. This is worse than it first appears: verified on 3.2.3, a pre-existing drift row breaks **any** later write to that row, including an `UPDATE … SET` touching only declared fields, because the stored row is revalidated whole. Restore now filters unknown top-level keys, collects the dropped names per table, logs them loudly, and returns them on the restore result. On a disaster-recovery path, shedding one unmapped key loses strictly less than losing the record.

**6. Gate Compose health on readiness** — all three compose files

Now probing `/api/health/ready`. The endpoint swap alone was not enough: `httpx.get` does not raise on 5xx, so the probe also needs `raise_for_status()` or it reports healthy against a 503. Bootstrap failure now logs at error level with the failing plane, target version, and the remediation command. The `FLEXIBLE` error itself stays fatal by design — making it non-fatal would paper over the defect.

## 🚦 Repairing an already-wedged store

Verified end to end against a throwaway 3.2.3 server seeded with the same shape (SCHEMALESS usage table, `TYPE ANY` edge table, 24 rows with 8 duplicated uuids):

1. `sibyld db init` — migrates v15 → v24, converts the tables, exits **1** naming both blocked indexes.
2. `sibyld db duplicates` — read-only inventory.
3. `sibyld db duplicates --collapse --yes` — deletes excess rows. **Back up first; this is the only destructive step.**
4. `sibyld db init` — rebuilds both indexes, verifies, exits **0**.

Replaying the same signals afterward produced no new duplicates, confirming dedupe is genuinely enforced rather than merely reported.

On the observed dogfood store, expect roughly 179 duplicate groups and 181 excess rows out of 13,081. All 13,081 rows carry exactly the declared key set, so the SCHEMAFULL conversion is safe there.

## 🧪 Validation

`moon run :check` on this branch after rebase onto current `main` → **55 tasks completed, exit 0**.

- `core:test` → 1865 passed, 14 skipped
- `api:test` → 1964 passed, 5 skipped
- `cli:test` → 422 passed
- `web:test` → 161 passed; all lint and typecheck tasks clean

Targeted evidence:

- The deadlock test seeds a table auto-created SCHEMALESS and asserts the migration converts it and proceeds — the exact scenario that wedged. Red-green verified by removing the fix, which reproduces the production symptom.
- `test_archive_schema_drift.py` → 3 passed against a live 3.2.3 server; 2 passed, 1 skipped by default.
- Duplicate-index rollback confirmed directly: after a failed UNIQUE build the table reports `indexes: {}`.

⚠️ An existing test asserted the ALTER was redundant and must be **absent**. It encoded the belief that caused the outage and is inverted here.

⚠️ The embedded SDK test engine is lenient about undeclared-field writes and accepts all three cases a real 3.2.3 server rejects — the known 2.x/3.x engine-fidelity gap. That test therefore carries the repo's `SIBYL_LIVE_SURREAL_TESTS` gate.

⚠️ `pytest tests/test_surreal_content_persistence.py` run **in isolation** fails to collect, because `crawl4ai` has a `return` inside a `finally` block, which is a syntax error on Python 3.14. Confirmed identical on the base commit with these changes stashed, so it is pre-existing and not introduced here. It collects and passes under the moon-configured invocation.

⚠️ The first `moon run :check` on this branch failed on a vitest worker crash under heavy parallel load; the immediately following run passed all 55 tasks. Recorded as environmental rather than claimed clean.

## 🔍 What reviewers should focus on

- Statement ordering: every `ALTER` must precede any `DEFINE FIELD` on the same table, or the fields land while the table is still SCHEMALESS.
- Whether the v24 and auth v6 sweeps are genuinely idempotent and cannot themselves wedge the ladder the way v16 did.
- The restore filter's choice of shedding keys over rejecting the record, and whether the dropped-name reporting is loud enough for a DR path.
- The derived invariant set — specifically that replaying migrations to compute expectations correctly retires indexes that later migrations drop or redefine.

## 📌 Follow-ups (deliberate non-fixes)

- No migration deletes rows. Collapsing duplicates stays an explicit operator action behind its own command and confirmation.
- The 1.4% upward bias in usage counters accumulated while dedupe was unenforced is not corrected; the counts stay as recorded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database CLI commands to initialize schema readiness across planes and to inventory duplicate records that block UNIQUE enforcement, with optional confirmation-based cleanup.
* **Bug Fixes**
  * Archive restores now drop undeclared fields and report which fields were removed.
  * Improved schema-full repair behavior so drifted tables/relations and missing UNIQUE indexes are detected and repaired when possible.
* **Chores**
  * Updated service health checks to use the readiness endpoint so schema/bootstrap readiness is accurately reflected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->