### PR TITLE
docs(architecture): resolve the A1 slice fork with measured evidence

### DIFF
--- a/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
@@ -232,9 +232,20 @@ only re-cut fat parents that were already selected, which is the killed geometry
 server-side. As rows on the existing table they inherit the HNSW, BM25, and type indexes free, and
 the schema delta is one DDL statement plus a version bump.
 
-**Stage 0/1 measured offline, 2026-07-24/25 (free, no paid calls).** Scored at official fidelity:
-the `lme_v2_small` haystack for all 451 questions is set-identical to the era-3 catalogs, so the
-oracle ran on 92 measurable questions rather than the 45-question subset.
+**Stage 0/1 measured offline, 2026-07-24/25.** No paid API calls: local BM25 and a local embedding
+model over catalogs already on disk, so the only cost was local compute. Scored at official
+fidelity: the `lme_v2_small` haystack for all 451 questions is set-identical to the era-3 catalogs,
+so the oracle ran on **92 measurable questions** — every question that is phrase-eligible and
+source-complete across both domains (44 enterprise, 48 web) — rather than the 45-question subset.
+
+**Cohort contract.** Two cohorts appear in this section and they are not interchangeable. The
+**92-question cohort is authoritative for the design decision** above: it is the largest set the
+oracle can score, so it is the honest denominator for "does slicing lose gold." The
+**enterprise-45/web-45 replay cohort is authoritative for `slice-substrate-gate`**, because the
+replay harness, its frozen prompts, and every prior campaign gate are built on it — switching gate
+cohorts mid-campaign would make the +3pp GO threshold incomparable to the four gates already run.
+**Gate thresholds are evaluated per domain, not pooled**, matching the campaign's existing practice
+and preventing one strong domain from carrying a regression in the other.
 
 - **Straddle rate is zero** — 31,244 of 31,244 (question, phrase, carrier-state) triples land inside
   a single slice. Slicing never cuts a gold literal.
@@ -266,15 +277,27 @@ oracle ran on 92 measurable questions rather than the 45-question subset.
 **The reservation trap.** Slices push `max_items` from 8 to ~28, and both the adapter and production
 compute the note lane as `ceil(max_items × 3/8)` — which would silently widen the reserved note lane
 from 3 slots to 11. The tuning kill established that the tuned quantity is the **absolute** note
-count, so notes must be pinned at 3. The adapter has a `typed_reservation_items` override;
-production `compose_operational_evidence` has none and must gain one. Missing this makes A1 measure
-as a notes regression and get misdiagnosed as a slice failure.
+count, so notes must be pinned at 3. Missing this makes A1 measure as a notes regression and get
+misdiagnosed as a slice failure.
 
-- Gate `slice-substrate-gate`: on the enterprise-45/web-45 replay slices, gold-literal exposure ≥
-  50% (from 32%/21%) AND state-level recall@10 ≥ 85% (from 68%) within ≤ 60K chars (target ≤ 48K);
-  then a scored 3-pass paired run vs frozen FAST+notes, GO per protocol law. Because
-  `/memory/experience` makes no per-entity LLM call, a corpus rebuild is embeddings-only
-  (~$0.62–0.75/domain) and **this gate is decidable for pennies before any reader spend**.
+The requirement is **normative, not merely configurable**: exposing a `typed_reservation_items`
+parameter on production `compose_operational_evidence` is necessary but not sufficient, because a
+parameter that accepts any value does not pin the one value that matters. Production must pass the
+absolute value **3** on the slice path — not a ratio, and not a new default that a caller can widen
+by raising `max_items`. Acceptance criterion, to be enforced by a regression test rather than
+review: **at `max_items = 28` the composed evidence set contains exactly 3 typed-note slots**, and
+the same assertion holds at the current `max_items = 8` so the pin cannot silently regress the
+already-shipped configuration.
+
+- Gate `slice-substrate-gate`: on the enterprise-45/web-45 replay cohort, evaluated **per domain**,
+  gold-literal exposure ≥ 50% (from 32%/21%) AND state-level recall@10 ≥ 85% (from 68%) within ≤ 60K
+  chars (target ≤ 48K); then a scored 3-pass paired run vs frozen FAST+notes, GO per protocol law.
+  Cost note, distinct from the free Stage 0/1 work above: reaching this gate does require one paid
+  step, a corpus rebuild whose **embedding calls cost
+  ~$0.62–0.75/domain**. It is cheap only
+  relative to reader spend, because `/memory/experience` makes no per-entity LLM call — so the gate
+  is decidable for roughly a dollar before committing to a ~$5/domain
+  scored regate or a ~$10 full-451 run.
 
 ### A2. Ranking refinements
 

--- a/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
@@ -223,12 +223,58 @@ compact renderer. This is where the paper's 42.8% lives (query→slice at 0.2s),
 surviving re-architecture direction: the client-side kill (geometry reshaping) reshaped fat
 retrievals at read time; this changes what is retrieved. Design seeds from decision `0e0677006a04`:
 state-boundary slice chunking, typed note/event pools (already live at ingest), multi-stream
-retrieval, neighbor-stitch that raises exposure while **shrinking** context. Open design choice
-(§9): slices as graph entities vs a retrieval-layer view over states.
+retrieval, neighbor-stitch that raises exposure while **shrinking** context.
+
+**Design fork RESOLVED (decision `9dd8e3972f42`): slices are first-class graph entities** — new
+`EntityType` rows on the existing `entity` table, not a new table and not a retrieval-layer view. A
+view cannot be ranked: the vector and BM25 lanes are properties of an indexed row, so a view could
+only re-cut fat parents that were already selected, which is the killed geometry approach
+server-side. As rows on the existing table they inherit the HNSW, BM25, and type indexes free, and
+the schema delta is one DDL statement plus a version bump.
+
+**Stage 0/1 measured offline, 2026-07-24/25 (free, no paid calls).** Scored at official fidelity:
+the `lme_v2_small` haystack for all 451 questions is set-identical to the era-3 catalogs, so the
+oracle ran on 92 measurable questions rather than the 45-question subset.
+
+- **Straddle rate is zero** — 31,244 of 31,244 (question, phrase, carrier-state) triples land inside
+  a single slice. Slicing never cuts a gold literal.
+- **A 3-adjacent-slice window reaches the fat-state ceiling exactly**: 95.5% enterprise / 100% web,
+  versus fat 95.5% / 100%. Single-slice is 93.2% / 97.9%. Retrieving a window, not a slice, is
+  therefore load-bearing for the ceiling.
+- Slices per state ~25 (enterprise) / ~37 (web); slice chars mean ~950–1,030. The depth rule holds:
+  line-count fallback fires on 0.14% of enterprise slices and never on web.
+- **Header tax 19% enterprise / 12% web**, and on enterprise the _breadcrumb_ is the expensive half
+  (11.5%, mean 134 chars). Capping to the last two ancestors drops it to 3.9%.
+- **The selection-dilution risk is real but mis-attributed.** The pre-registered rule confirmed
+  (slice recall@10 below fat recall@10 in every arm), but the mechanism is BM25 document length, not
+  semantics — stripping the goal preamble from fat chunks barely moves them, falsifying "the goal
+  carried the query vocabulary." Dense retrieval does not suffer it: dense slices _beat_ dense fat
+  at equal payload on enterprise (0.659 vs 0.591). An unmodified BM25 arm actively poisons the
+  fusion on a sliced substrate (RRF 0.523 vs dense-alone 0.659).
+- **Therefore A2 need not precede A1**, but A1 cannot ship bare-slice index text. Two fixes inside
+  A1 make budget-matched slicing win in both domains: index-time inherited context (goal-carry lifts
+  RRF to 0.727 enterprise / 0.812 web, beating fat's 0.682 / 0.792, at zero reader-token cost
+  because it need not be rendered), and expressing the retrieval budget in **characters** rather
+  than items, since k=10 is a payload knob that must move when unit size drops ~11×.
+- Boundary rules the data argues for, all verified to preserve exposure and the zero straddle rate:
+  3-slice window; bound the ancestor prepend to ~400 chars; cap the breadcrumb at two ancestors;
+  tail-merge sub-floor leftovers; path-extract and truncate header URLs.
+- **Labelled projection, not measurement:** the dense arm used local MiniLM (384-dim, mean-pooled)
+  as a proxy for the production 1024-dim long-context embedder. Mean-pooling favours the fat arm, so
+  the proxy is conservative toward the hypothesis; only the fat-vs-slice contrast transfers.
+
+**The reservation trap.** Slices push `max_items` from 8 to ~28, and both the adapter and production
+compute the note lane as `ceil(max_items × 3/8)` — which would silently widen the reserved note lane
+from 3 slots to 11. The tuning kill established that the tuned quantity is the **absolute** note
+count, so notes must be pinned at 3. The adapter has a `typed_reservation_items` override;
+production `compose_operational_evidence` has none and must gain one. Missing this makes A1 measure
+as a notes regression and get misdiagnosed as a slice failure.
 
 - Gate `slice-substrate-gate`: on the enterprise-45/web-45 replay slices, gold-literal exposure ≥
   50% (from 32%/21%) AND state-level recall@10 ≥ 85% (from 68%) within ≤ 60K chars (target ≤ 48K);
-  then a scored 3-pass paired run vs frozen FAST+notes, GO per protocol law.
+  then a scored 3-pass paired run vs frozen FAST+notes, GO per protocol law. Because
+  `/memory/experience` makes no per-entity LLM call, a corpus rebuild is embeddings-only
+  (~$0.62–0.75/domain) and **this gate is decidable for pennies before any reader spend**.
 
 ### A2. Ranking refinements
 
@@ -387,7 +433,9 @@ Planned per this doc (flag before reversing):
 
 Open (decide during execution):
 
-- A1: slices as first-class graph entities vs retrieval-layer views over states.
+- ~~A1: slices as first-class graph entities vs retrieval-layer views over states.~~ **Resolved
+  2026-07-24 (decision `9dd8e3972f42`): first-class entities on the existing `entity` table.** See
+  §4 A1 for the reasoning and the Stage 0/1 measurements.
 - A3: server-side traversal loop vs client-exposed verbs (MCP surface implications).
 - B1: handbook regeneration trigger (graph-delta threshold vs schedule).
 - Whether B3 (re-extraction) ships in v1.2 or moves whole to v1.3.


### PR DESCRIPTION
# 🎯 Resolve the A1 slice fork, with the measurements that decide it

> Docs only. Closes the open design question in the v1.2 plan and records the free offline measurements that de-risk the release's headline work.

## 💡 What this is

The v1.2 plan left one question open: should retrieval slices be first-class graph entities, or a retrieval-layer view over existing state records? This resolves it as **entities**, and records the Stage 0 and Stage 1 measurements that were run offline against the existing eval catalogs at zero cost.

## 🤔 Why entities

A view cannot be ranked. The two lanes that actually select evidence are the HNSW vector lane and BM25 over content, and both are properties of an indexed row. A view has no vector of its own and inherits its parent's length-normalized score, so it could only re-cut fat parents that were already selected — which is the client-side geometry reshaping the campaign already killed with receipts, relocated to the server. As rows on the existing `entity` table, slices inherit the HNSW, BM25, and type indexes for free, and the schema delta is one DDL statement plus a version bump.

## 🛠️ What the measurements say

Scored at official fidelity: the `lme_v2_small` haystack for all 451 questions turns out to be set-identical to the era-3 catalogs, so the oracle ran on 92 measurable questions rather than the 45-question run subset.

- **Straddle rate is zero.** 31,244 of 31,244 (question, phrase, carrier-state) triples land inside a single slice. Slicing never cuts a gold literal.
- **A three-adjacent-slice window reaches the fat-state ceiling exactly** — 95.5% enterprise / 100% web against fat's 95.5% / 100%. So the format change costs nothing at the oracle, provided retrieval returns a window rather than a slice.
- **The selection-dilution risk confirmed against its pre-registered rule, but the mechanism is not what the rule assumed.** It is BM25 document length, not semantics: stripping the goal preamble from fat chunks barely moves them, which falsifies the idea that the goal text was carrying the query vocabulary. Dense retrieval does not suffer it — dense slices beat dense fat states at equal payload on enterprise. What actually breaks is naive lexical fusion, where an unmodified BM25 arm scores worse than dense alone on a sliced substrate.
- **Consequence: A2 does not have to precede A1.** What A1 needs instead is inherited context at index time, which costs zero reader tokens because it need not be rendered, and a retrieval budget expressed in characters rather than items.

## 🔍 The trap worth reading

Slices push `max_items` from 8 to roughly 28. Both the benchmark adapter and production compute the reserved note lane as a **ratio** of that number, so it would silently widen from 3 slots to 11 — and the tuning kill established that the tuned quantity is the absolute note count, not the fraction. Left unnoticed, A1 would have measured as a notes regression and been misdiagnosed as a slice failure. Production's evidence composer has no override parameter today and needs one.

## 🧪 Validation

Docs only; no code paths touched. Prettier formatted, commit body wrapped at 76 characters. The underlying measurements were produced read-only against existing catalogs with local embeddings and local BM25 — no paid API calls and no services touched.

⚠️ Labelled honestly in the doc: the dense arm used local MiniLM as a proxy for the production long-context embedder. Mean-pooling favours the fat arm, so the proxy is conservative toward the hypothesis under test, but only the fat-versus-slice contrast transfers — not the absolute dense numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the v1.2 “Retrieve It” implementation plan with the resolved slice-granular retrieval design (slices as first-class graph entities).
  * Added offline measurement results (oracle over a 92-question cohort) and a replay cohort for the slice-substrate gate.
  * Documented operational slicing constraints (e.g., zero straddle, required 3-slice window, boundary/ancestor/header rules) and selection-dilution behavior.
  * Expanded the rollout gating procedure, including the typed-note reservation-count handling and acceptance criteria.
  * Marked the A1 decision as resolved with references to reasoning and measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->