### PR TITLE
fix(api): thread verified project access to the explore scope guard

### DIFF
--- a/apps/api/src/sibyl/api/routes/search.py
+++ b/apps/api/src/sibyl/api/routes/search.py
@@ -275,6 +275,10 @@ async def explore(
                 detail="dependencies mode does not support project_ids",
             )
 
+        # The verified set must reach the core in every mode: the scope guard
+        # denies unstamped project rows when accessible_projects is None, so a
+        # list-mode None empties the board for members whose access was just
+        # verified above.
         if request.project_ids:
             for project_id in request.project_ids:
                 await verify_entity_project_access(
@@ -284,9 +288,7 @@ async def explore(
                     required_role=ProjectRole.VIEWER,
                     require_existing_project=True,
                 )
-            accessible_filter = (
-                set(request.project_ids) if request.mode in {"related", "traverse"} else None
-            )
+            accessible_filter = set(request.project_ids)
         elif request.project:
             await verify_entity_project_access(
                 None,
@@ -295,9 +297,7 @@ async def explore(
                 required_role=ProjectRole.VIEWER,
                 require_existing_project=True,
             )
-            accessible_filter = (
-                {request.project} if request.mode in {"related", "traverse"} else None
-            )
+            accessible_filter = {request.project}
         else:
             accessible_filter = await list_accessible_project_graph_ids(ctx)
 

--- a/apps/api/tests/test_routes_search.py
+++ b/apps/api/tests/test_routes_search.py
@@ -371,7 +371,41 @@ class TestExploreRoute:
         assert response.total == 1
         assert response.entities[0]["id"] == "task_1"
         assert core_explore.await_args.kwargs["project_ids"] == ["proj_1"]
-        assert core_explore.await_args.kwargs["accessible_projects"] is None
+        # The verified projects must reach the core as the accessible set: the
+        # scope guard denies unstamped project rows on None, which emptied
+        # every scoped task list in 1.1.3.
+        assert core_explore.await_args.kwargs["accessible_projects"] == {"proj_1"}
+
+    @pytest.mark.asyncio
+    async def test_explore_list_with_single_project_threads_verified_access(self) -> None:
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        ctx = stub_auth_context()
+        result = SimpleNamespace(
+            mode="list",
+            entities=[{"id": "task_1", "name": "Ship it"}],
+            total=1,
+            filters={"project": "proj_1"},
+            limit=10,
+            offset=0,
+            has_more=False,
+            actual_total=1,
+        )
+
+        with (
+            patch(
+                "sibyl.api.routes.search.verify_entity_project_access",
+                AsyncMock(return_value=ProjectRole.VIEWER),
+            ),
+            patch("sibyl_core.tools.core.explore", AsyncMock(return_value=result)) as core_explore,
+        ):
+            await explore(
+                request=ExploreRequest(mode="list", types=["task"], project="proj_1"),
+                org=org,
+                ctx=ctx,
+            )
+
+        assert core_explore.await_args.kwargs["project_ids"] == ["proj_1"]
+        assert core_explore.await_args.kwargs["accessible_projects"] == {"proj_1"}
 
     @pytest.mark.asyncio
     async def test_explore_related_with_project_ids_preserves_accessible_filter(self) -> None:
@@ -481,7 +515,9 @@ class TestExploreRoute:
         assert response.total == 1
         assert core_explore.await_args.kwargs["project"] == "proj_1"
         assert core_explore.await_args.kwargs["project_ids"] is None
-        assert core_explore.await_args.kwargs["accessible_projects"] is None
+        # Dependencies mode threads the verified project too: the scope guard
+        # denies unstamped project rows when the accessible set is None.
+        assert core_explore.await_args.kwargs["accessible_projects"] == {"proj_1"}
 
     @pytest.mark.asyncio
     async def test_explore_rejects_inaccessible_projects(self) -> None:

--- a/apps/api/tests/test_wire_scope.py
+++ b/apps/api/tests/test_wire_scope.py
@@ -630,3 +630,66 @@ class TestGrantContractDrift:
             "read the grant directly so a missing field raises instead of "
             f"granting private scope: {offenders}"
         )
+
+
+class TestScopedTaskListWire:
+    """A member's scoped task list must return their tasks, and only theirs.
+
+    1.1.3 regression: list mode verified project access, then handed the core
+    accessible_projects=None, which the scope guard reads as "memberships
+    unresolvable" and denies every unstamped project row — an empty board for
+    the very member whose access was just verified.
+    """
+
+    def _scoped_list(self, *, project: str) -> Any:
+        from sibyl.api.routes import search as search_routes
+        from sibyl_core.auth import ProjectRole
+        from sibyl_core.models.entities import EntityType
+
+        mine = SimpleNamespace(
+            id="task_mine",
+            entity_type=EntityType.TASK,
+            name="My task",
+            description="ordinary",
+            metadata={"project_id": "proj-mine"},
+        )
+        foreign = SimpleNamespace(
+            id="task_victim",
+            entity_type=EntityType.TASK,
+            name=SECRET_NAME,
+            description=SECRET_TEXT,
+            metadata={"project_id": "proj-victim"},
+        )
+        runtime = SimpleNamespace(
+            entity_manager=SimpleNamespace(list_by_type=AsyncMock(return_value=[mine, foreign]))
+        )
+
+        with (
+            patch(
+                "sibyl.api.routes.search.verify_entity_project_access",
+                AsyncMock(return_value=ProjectRole.VIEWER),
+            ),
+            patch(
+                "sibyl_core.tools.explore.get_graph_runtime",
+                AsyncMock(return_value=runtime),
+            ),
+            _wire(search_routes.router, OWNER_ID) as client,
+        ):
+            return client.post(
+                "/search/explore",
+                json={"mode": "list", "types": ["task"], "project": project},
+            )
+
+    def test_member_sees_their_project_tasks_in_a_scoped_list(self) -> None:
+        response = self._scoped_list(project="proj-mine")
+
+        assert response.status_code == 200
+        assert "task_mine" in response.text
+
+    def test_scoped_list_still_drops_rows_from_an_unrequested_project(self) -> None:
+        """The verified set admits exactly the named project, nothing wider."""
+        response = self._scoped_list(project="proj-mine")
+
+        assert response.status_code == 200
+        assert "task_victim" not in response.text
+        assert SECRET_NAME not in response.text

--- a/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # Sibyl v1.2 Implementation Plan — "Retrieve It"
 
-- Status: active execution plan
-- Created: 2026-07-24 (the day v1.1.0 → v1.1.2 shipped)
+- Status: **locked 2026-07-25** (SOTA-validated; industry landscape in §2.7)
+- Created: 2026-07-24 (the day v1.1.0 → v1.1.2 shipped); v1.1.3 shipped 2026-07-25
 - Fills the v1.2 slot of [`SIBYL_POST_1_0_ROADMAP.md`](SIBYL_POST_1_0_ROADMAP.md) §5 and **re-scopes
   it from "Coalesce It" to "Retrieve It"**: live coalescence (roadmap v1.2 W1–W3) and TeamMemBench
   (W5) slide to v1.3; the projection layers (W6–W7) stay; retroactive re-extraction (W8) stays as
@@ -174,12 +174,22 @@ fixtures. Relatedly, the only unit test of `_candidate_scope_allowed` hand-injec
 `memory_scope` field whose absence is the bug, proving the filter works while hiding that it never
 fires. **Any gate whose receipt is hand-authored must be regenerated or deleted in v1.2.**
 
-### 2.6 The 1.1.3 recommendation
+### 2.6 The 1.1.3 recommendation — EXECUTED 2026-07-25
 
-Cut a patch release before 1.2 feature work. Drivers, in order: offline write loss (`df317be0`), the
-private-memory leak (`4736bf2d`), the schema deadlock, and the exit-code cluster. Not drivers: the
-fulltext lanes and raw-memory CREATE, both of which were overstated. Root `moon run :check` was
-verified green (55 tasks) on the 1.1.2 cut, so the release gate is clear.
+**v1.1.3 shipped 2026-07-25** (tag `774a9c65`, 78 commits): PR 264 closed the private-memory leak
+whole (~60 commits scoping every read surface to the reader), PR 265 fixed offline write loss (409
+retention deny-list) plus the exit-code cluster, PR 266 unwedged the schema ladder, PR 267 landed
+the A1 design docs. The tag was deliberately held ~12h for 264 to land whole
+(`decision_a34d2503a05e`) rather than ship a trust release with the trust defect open. Original
+drivers, for the record: offline write loss (`df317be0`), the private-memory leak (`4736bf2d`), the
+schema deadlock, and the exit-code cluster. Not drivers: the fulltext lanes and raw-memory CREATE,
+both of which were overstated.
+
+**Known 1.1.3 regression** (found same day, task `bcdf1b3a`): project-scoped `task list` returns
+empty for an org owner with no membership rows — `org_role` fails to resolve on the explore surface,
+so the non-admin branch of `list_accessible_project_graph_ids` filters everything. Workaround
+`--all`; fix folds into Track C item 1 (the scope-model chokepoint work), and the fix must add an
+owner-role fallback test on every list surface — the leak tests all guard the opposite direction.
 
 Deferred out of the patch by design: the `_candidate_scope_allowed` fail-open flip (would hide
 legitimately unscoped tasks/epics — needs a first-class `Entity.memory_scope` column), the scope
@@ -192,6 +202,33 @@ UNIQUE index builds will fail, be silently swallowed, and never retry — leavin
 unenforced. Collapse duplicates **first**, then run schema repair, then verify both indexes exist.
 Usage counts from 2026-07-11 onward carry a ~1.4% upward bias from unenforced dedupe, so retention
 multipliers derived from that window are slightly inflated.
+
+### 2.7 Industry landscape (SOTA sweep, 2026-07-25)
+
+Six-lane sweep (competitors, benchmarks, academic, platform memory, retrieval practice,
+team/privacy) run before locking this plan; full synthesis with sources in
+[`SOTA_LANDSCAPE_2026-07-25.md`](SOTA_LANDSCAPE_2026-07-25.md). The short version:
+
+- **Every Track A/B/C bet is independently validated** by 2026 production practice and literature.
+  Slices-with-inherited-context, char budgets, reserved notes lane, and bounded substrate-first
+  traversal are the field's consensus shapes — the differentiation is execution speed and the graph
+  substrate, not the ideas.
+- **The official LME-V2 leaderboard is live and EMPTY.** No vendor has published a v2 number;
+  Sibyl's would be the first third-party entry, and the official LAFS metric is the accuracy+latency
+  shape we already report. The A4 hold stays; the payoff for passing it grew.
+- **The field re-sorted**: Letta vacated the memory-layer lane (pivoted to a coding agent), Zep
+  killed self-hosting (enterprise cloud only), Cognee is the live OSS threat (17.5k→29.3k stars in
+  ~2 months, weekly ships). Big-lab memory is default-on everywhere and siloed per platform —
+  fragmentation Sibyl exists to solve, actively getting worse.
+- **Projection layers are the industry-standard architecture** (OpenAI/Anthropic/Google all ship
+  distilled-summary + greppable-index + detail-on-demand, per-tool siloed), and Google published OKF
+  v0.1 (2026-06-12) as a public spec Sibyl already exports. The window to be the cross-agent
+  convention is ~6–12 months — B2 is on the clock.
+- **Coalescence-under-privacy is still shipped by nobody** — the v1.3 deferral holds, with named
+  tripwires (§7).
+- **Three adjustments adopted** from the sweep, marked ⚡SOTA in the tracks below: A2's lexical
+  escape hatch / rerank stage, A1's contextualized-embedder offline arm, A3's single-hop routing
+  rule.
 
 ## 3. Protocol law (binds every Track A experiment)
 
@@ -214,7 +251,9 @@ multipliers derived from that window are slightly inflated.
 ## 4. Track A — beat the naive-RAG baseline (headline)
 
 Target: combined full-451 **≥ 42.8%** (193/451) at ≤ 10s avg. Stretch: approach the 51.0%
-slice+notes frontier. Phases are ordered by evidence strength; each gates before the next spends.
+slice+notes frontier. Both reference numbers are the paper's **Small-tier** baselines (Medium tier:
+38.1%/45.9%) — our harness runs the Small-tier haystack; say the tier in every writeup. Phases are
+ordered by evidence strength; each gates before the next spends.
 
 ### A1. Slice-granular substrate + compact rendering
 
@@ -273,6 +312,12 @@ and preventing one strong domain from carrying a regression in the other.
 - **Labelled projection, not measurement:** the dense arm used local MiniLM (384-dim, mean-pooled)
   as a proxy for the production 1024-dim long-context embedder. Mean-pooling favours the fat arm, so
   the proxy is conservative toward the hypothesis; only the fat-vs-slice contrast transfers.
+- ⚡SOTA **Contextualized-embedder offline arm** (adopted 2026-07-25): contextualized chunk
+  embeddings (voyage-context-4, 2026-06-29, $0.12/1M) beat manual header prepends ~7% chunk-level on
+  their benchmarks by baking document context into the chunk vector. Run one offline arm comparing
+  goal-carry headers vs a contextualized-embedding proxy before the paid corpus rebuild locks an
+  embedder. Headers stay regardless — they feed BM25 and the reader; this arm decides only the
+  vector side.
 
 **The reservation trap.** Slices push `max_items` from 8 to ~28, and both the adapter and production
 compute the note lane as `ceil(max_items × 3/8)` — which would silently widen the reserved note lane
@@ -304,10 +349,22 @@ already-shipped configuration.
 Semantic/embedding region scoring where query-anchored ranking misses no-vocabulary-overlap gold;
 entity-overlap ranking for typed notes (the known `fa504f5e` refinement); gotcha/premise notes aimed
 at the errors-gotchas pool (67–71% confidently wrong — the one pool where notes can check a premise
-instead of answering it).
+instead of answering it; MemSyco-Bench, arXiv `2607.01071`, now measures exactly this failure class
+and is a candidate secondary eval).
+
+⚡SOTA **Named requirement (adopted 2026-07-25): identifier-shaped queries need a lexical escape
+hatch or a rerank stage.** Dropping BM25 from the fusion is measured and stands (mechanism confirmed
+by the sweep: rank-only RRF weights a weak arm equally — the industry moved defaults to score-aware
+fusion; b=0.75 is mistuned for <100-word chunks, and inherited headers crater IDF on slice corpora).
+But identifiers, error strings, and exact names are lexical's win zone, and the field's fix of
+record is retrieve-wide + cross-encoder rerank (+50–200ms; Anthropic's ladder −35/−49/−67%). A1 may
+ship dense-first; A2 must close the flank with either (a) an exact-match lexical arm that fires only
+on identifier-shaped queries, or (b) a rerank stage over a widened candidate set — measured per
+protocol law, chosen by receipts.
 
 - Gate `ranking-gate`: recovers ≥ 2 of the 3 known no-vocab misses on the 23-phrase slice without
-  net exposure regression; scored effects per protocol law.
+  net exposure regression; scored effects per protocol law. The identifier-flank fix ships with a
+  regression probe: an identifier/error-string query set that dense-alone measurably misses.
 
 ### A3. Agentic graph retrieval — multi-step done right
 
@@ -316,6 +373,15 @@ verbs, ≤ 3 rounds, deterministic final composition (the evidence composer and 
 stay; the model chooses what to gather, never how it renders). This is the graph-backed path of
 decision `0f4ab0c8a0cc`, attempted only after A1 — traversal over fat states would re-buy the format
 defect at higher latency.
+
+⚡SOTA (adopted 2026-07-25): **route single-hop queries around the loop entirely.** The June 2026
+ablation literature (arXiv `2606.21553`) finds two retrieval iterations capture 95% of the gain of
+five, fixed pipelines beat un-learned adaptive routing (the accurate-mode −4pp/2.5× kill is textbook
+— predicted, not anomalous), and token-space agentic loops run ~15× single-step latency (arXiv
+`2605.06285`). Expect the win concentrated in rounds 1–2 on genuinely multi-hop questions; prefer a
+sufficiency-style stop ("is the evidence gap closed?") over always spending the round budget. Graph
+traversal pays on associative/multi-hop and temporal queries (HippoRAG 2, ICML 2025); flat dense
+wins factoid lookups — route, don't force.
 
 - Gate `agentic-retrieval-gate`: score-blind, question-text-only; p95 memory latency ≤ 15s (hard
   ceiling: the 27s knee); GO = ≥ +3pp mean paired over the then-best config, numbers pre-registered
@@ -327,6 +393,15 @@ defect at higher latency.
   **Submission is held until this gate passes** (Bliss, 2026-07-24): a dominated point on an empty
   board invites the wrong comparison. When it passes, submit promptly — first credible entry on an
   empty leaderboard is the payoff the v1.1 W5 harness was built for.
+- ⚡SOTA context (2026-07-25): the official leaderboard is **confirmed live and empty** — no vendor
+  has published any LME-V2 number; ours would be the first third-party number in existence. The
+  official metric is LAFS Gain (accuracy over 1s–200s latency budgets vs the reference frontier),
+  i.e. exactly the accuracy+latency reporting Sibyl already produces; submissions are
+  multi-operating-point packages (`submission_overview.json`, repo `leaderboard/README.md`). Sizing
+  note: LAFS gain is computed against the Small-tier frontier, so a below-frontier accuracy point
+  contributes only where its latency sits left of the frontier — one more reason the hold is right.
+  Watch item: if someone else lands the first v2 entry, the first-mover payoff shrinks; the gate's
+  numbers do not change.
 
 ### A5. Accurate-mode fate
 
@@ -358,8 +433,19 @@ read-only files. Filesystem-native agents grep at zero marginal latency and surv
 the citation contract still routes usage back over the API. Structured substrate, curated
 projection.
 
+⚡SOTA context (2026-07-25): this is now the **industry-standard architecture, on a clock**. OpenAI
+(Agents SDK `memory_summary.md` + `MEMORY.md`, Codex `~/.codex/memories/`), Anthropic (Claude Code
+auto-memory), and Google (Gemini CLI) all shipped distilled-summary + greppable-index +
+detail-on-demand memory in Feb–May 2026 — each siloed per tool. A repo-local `.sibyl/memory/` is
+readable by every one of them with zero integration work, and Google's OKF v0.1 (2026-06-12,
+Markdown + YAML frontmatter in git-shippable directories) gives the export a public spec to align
+with where cheap — Sibyl already ships OKF export. The window to be the cross-agent convention is
+~6–12 months (AGENTS.md went launch → 60k repos → Linux Foundation in about a year). B2 is the
+plan's most time-sensitive item after Track A.
+
 - Gate `files-projection-gate`: deterministic re-materialization; grep-usable with the server down;
-  citations still recorded when it returns.
+  citations still recorded when it returns; materialized layout OKF-compatible (frontmatter `type`
+  at minimum) unless a measured cost says otherwise.
 
 ### B3. Retroactive re-extraction loop (stretch)
 
@@ -415,6 +501,21 @@ untouched; only its timing moves: the credibility spend has to go to retrieval f
 team substrate plus usage loop remain in place, un-rotted, for a v1.3 engine. Nothing in Track A/B
 forecloses any coalescence decision.
 
+⚡SOTA verdict on the window (2026-07-25): **the deferral holds — cross-user merge under privacy
+constraints is shipped by zero products** (within-scope consolidation is commoditized; the giants
+chose containment over gradation and explicitly declined org-shared memory). Closest threats are
+papers, not products (MemClaw, arXiv `2606.24535`; AgentPrizm, weak signals). The literature also
+backs the order: retention beats consolidation at loose token budgets (arXiv `2607.17545`), so
+substrate-first is measured, not just convenient. **Named tripwires**: (1) that same paper's
+crossover means consolidation becomes load-bearing exactly when packs stop fitting budgets — if A1
+regularly saturates its char budget, coalescence's priority rises; (2) interference research says an
+unconsolidated store eventually degrades retrieval _precision_, so the deferral is time-boxed, not
+indefinite; (3) the strategic risk is narrative capture ("governed team memory") before our version
+is demonstrable — keep the scope/provenance story visibly intact in every v1.2 surface. Bonus for
+v1.3 planning: GroupMemBench (Microsoft, arXiv `2605.14498`) now exists as a public multi-party
+memory benchmark — best system 46%, BM25 matches most memory systems — a ready-made external target
+for the TeamMemBench slot.
+
 ## 8. Task board: triage and grooming
 
 ### 8.1 Sidequests pulled into v1.2
@@ -428,7 +529,10 @@ gates), `48395009` (attach audits beyond session chunks).
 `6e69bc0c` bulk personal-archive ingestion (strong v1.3 candidate beside the OKF importer),
 `41aba0d4` namespace-cleanup retries, `e5b328c3` GitOps-stable Surreal secret.
 
-### 8.3 Stale-task dispositions (grooming pass to execute)
+### 8.3 Stale-task dispositions (grooming pass — EXECUTED, verified 2026-07-25)
+
+All eight dispositions below are done: the three archives landed, the five completions carry
+learnings pointers, and the 1.1.3 trust-patch task (`7d549bc9`) was completed on release day.
 
 - `04e5f940` refresh same-SHA RC evidence (critical) → archive; superseded by 1.1 release receipts.
 - `801e1f67` align 1.0 RC version metadata → archive.
@@ -453,6 +557,10 @@ Planned per this doc (flag before reversing):
 
 - Coalescence W1–W3 + TeamMemBench slide to v1.3; W1 design-doc optional in v1.2.
 - Accurate mode deprecated; no per-domain retrieval-mode fork.
+- ⚡SOTA adjustments (2026-07-25, receipts in `SOTA_LANDSCAPE_2026-07-25.md`): A2 identifier-flank
+  requirement (lexical escape hatch or rerank), A1 contextualized-embedder offline arm, A3
+  single-hop routing, B2 OKF alignment. A 1.1.4 point release for the owner-role task-list
+  regression (`bcdf1b3a`) runs as a separate lane and does not gate Track A/B work.
 
 Open (decide during execution):
 
@@ -494,4 +602,7 @@ v2 GO), `01e6ed6e4006` (enterprise v2 GO), `7a6a1d49b32c` (reservation tuning ki
 agentic path). Plans: `17188e6e7820`. Runs: `.moon/cache/evals/nova-full-451-fast/`. Commits:
 `12ac2243` (note distillation), `430dea04` (content-aware digest v2), `1f086b22` (conjunctive-safe
 fulltext), `83c8dd7b` (defaults reverted after tuning kill). Production port: task `1e1caf57`
-(done).
+(done). SOTA sweep 2026-07-25: [`SOTA_LANDSCAPE_2026-07-25.md`](SOTA_LANDSCAPE_2026-07-25.md) (six
+lanes, primary-sourced; anchors: LME-V2 arXiv `2605.12493` + empty official leaderboard,
+Fidelity-Before-Structure `2601.00821`, Dissecting-Agentic-RAG `2606.21553`, Retain-or-Consolidate
+`2607.17545`, TriMem `2605.19952`, MemClaw `2606.24535`, OKF v0.1, Penfield LoCoMo audit).

--- a/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
@@ -185,11 +185,16 @@ drivers, for the record: offline write loss (`df317be0`), the private-memory lea
 schema deadlock, and the exit-code cluster. Not drivers: the fulltext lanes and raw-memory CREATE,
 both of which were overstated.
 
-**Known 1.1.3 regression** (found same day, task `bcdf1b3a`): project-scoped `task list` returns
-empty for an org owner with no membership rows — `org_role` fails to resolve on the explore surface,
-so the non-admin branch of `list_accessible_project_graph_ids` filters everything. Workaround
-`--all`; fix folds into Track C item 1 (the scope-model chokepoint work), and the fix must add an
-owner-role fallback test on every list surface — the leak tests all guard the opposite direction.
+**1.1.3 regression, fixed in 1.1.4** (found and fixed same day, task `bcdf1b3a`): every
+project-scoped `task list`/`epic list` returned empty. Diagnosis correction with receipts: the org
+role resolved fine — the explore route verified VIEWER access on the named project, then handed the
+core `accessible_projects=None` in list/dependencies modes (only related/traverse got the verified
+set), and the PR 264 read rule denies scope-unstamped project rows on None by design ("a caller that
+cannot resolve memberships must pass None, which denies rather than admits"). Fix: thread the
+verified project set in every mode (`search.py`), with a wire-level allow/deny regression pair — the
+member sees their board, an unrequested project's rows still drop. Lesson stands from both
+directions now: scope hardening needs the allow-direction test pair on every surface, not just leak
+tests.
 
 Deferred out of the patch by design: the `_candidate_scope_allowed` fail-open flip (would hide
 legitimately unscoped tasks/epics — needs a first-class `Entity.memory_scope` column), the scope

--- a/docs/architecture/SOTA_LANDSCAPE_2026-07-25.md
+++ b/docs/architecture/SOTA_LANDSCAPE_2026-07-25.md
@@ -1,0 +1,236 @@
+---
+title: "SOTA Landscape — Agent Memory, July 2026"
+description: Six-lane industry/academic sweep validating the v1.2 "Retrieve It" plan
+date: 2026-07-25
+status: research
+---
+
+# SOTA Landscape: Agent Memory — 2026-07-25
+
+Six parallel research lanes (competitors, benchmarks, academic literature, platform-native memory,
+retrieval production practice, team-memory/privacy) run 2026-07-25 to validate the v1.2 plan
+([`SIBYL_1_2_IMPLEMENTATION_PLAN.md`](SIBYL_1_2_IMPLEMENTATION_PLAN.md)) before locking it. Every
+load-bearing claim below was pinned to a primary source (GitHub repo, arXiv ID, official doc,
+release page) fetched on the research date; vendor benchmark numbers are labeled as claims with
+their axis. Supersedes the competitive read of
+[`COMPETITIVE_ANALYSIS_SIBYL_VS_COGNEE_VS_HINDSIGHT_2026-05-31.md`](COMPETITIVE_ANALYSIS_SIBYL_VS_COGNEE_VS_HINDSIGHT_2026-05-31.md).
+
+## TL;DR
+
+**The v1.2 plan survives SOTA contact intact — every Track A/B/C bet is independently validated by
+both production practice and 2026 literature — and three of its strategic payoffs got bigger since
+it was drafted.** The official LongMemEval-V2 leaderboard is live and empty (first credible entry is
+still available, and its scoring metric is the accuracy+latency shape Sibyl already reports). The
+projection-layer bet turned out to be the industry-standard architecture (OpenAI, Anthropic, and
+Google all independently shipped distilled-summary + greppable-index + detail-on-demand memory in
+Feb–May 2026), with a Google-backed public spec (OKF v0.1) as the export target Sibyl already
+supports. And coalescence-under-privacy remains shipped by nobody, so the v1.3 deferral holds.
+
+Three adjustments were adopted into the plan from this sweep; nothing was removed:
+
+1. **A2 gains a named requirement**: an exact-match lexical escape hatch or cross-encoder rerank
+   stage. Dropping BM25 from fusion is measured and defensible; dropping _lexical signal entirely_
+   leaves identifier/error-string queries unprotected, and retrieve-wide-then-rerank is the 2026 fix
+   of record.
+2. **A1 gains an offline eval arm**: contextualized chunk embeddings (voyage-context-4, 2026-06-29)
+   now beat manual header prepends on the vector side by ~7% chunk-level. Headers stay (they feed
+   BM25 and the reader); the embedder arm is cheap to measure.
+3. **A3 gains a routing rule**: single-hop queries route around the agentic loop entirely. The June
+   2026 ablation literature shows two retrieval iterations capture 95% of the gain of five, and the
+   win concentrates on genuinely multi-hop questions.
+
+## 1. Competitive field (delta since 2026-05-31)
+
+The field re-sorted dramatically in two months:
+
+- **Letta vacated the lane.** The flagship repo is now labeled legacy infrastructure; development
+  moved to Letta Code (April 2026, a memory-first coding agent, 2.9k stars). The strongest research
+  brand in agent memory left the embeddable-memory-layer market. Sleep-time compute shipped as its
+  "dreaming" feature — validation for the v1.3 dream-cycle direction, no longer competition for the
+  memory-layer lane.
+- **Zep closed the self-host door.** Community Edition dead (Apr 2025, more retirements Feb 2026);
+  repositioned as enterprise "Context Lake" (SOC 2, ABAC, BYOC — cloud only). Graphiti (29.2k stars,
+  Apache-2.0) remains as an engine: no auth, no tenancy, no product.
+- **Cognee is the live OSS threat.** 17.5k → 29.3k stars in ~2 months around its 1.0 launch
+  (2026-06-26), weekly releases, €7.5M seed, 70+ orgs in production incl. Bayer. Positioning:
+  "open-source memory platform," single-Postgres simplicity pitch, dataset-level RBAC.
+- **Mem0 is the volume leader** (61.7k stars, $24M raised): April 2026 algorithm rewrite, July 2026
+  "State of AI Agent Memory" report claiming LongMemEval-v1 94.4% — and, unusually, admitting real
+  caveats (privacy is "application-layer decisions today"; identity resolution unsolved).
+- **Hindsight** (18.8k stars, MIT) keeps the benchmark-marketing crown (LongMemEval-v1 91.4%, BEAM
+  10M 64.1%) plus a July integration blitz and Hindsight Cloud.
+- **New entrants**: EverMind EverOS (11.5k stars, Markdown-native, anomalous star/commit ratio),
+  MemMachine, MemOS/MemTensor, Supermemory, CaviraOSS OpenMemory (ships migration importers _from_
+  Mem0/Zep/Supermemory). No YC-batch breakout; consolidation around incumbents.
+- **The big-lab squeeze is real but siloed.** Anthropic Managed Agents memory (public beta Apr
+  2026), OpenAI Agents SDK memory primitives (Apr 2026), Copilot Memory default-on (Mar 2026),
+  ChatGPT "Dreaming" (Jun 2026). Every one is a per-platform silo; the only cross-vendor motion is
+  one-time import-to-switch weapons (Mar 2026), and MCP's roadmap explicitly leaves memory out of
+  protocol scope.
+
+**Sibyl-only ground, confirmed by absence across the whole field:** schema-level memory-scope
+privacy (private→team→org ladder with grant semantics), deterministic/LLM-free write path (100% of
+surveyed systems put an LLM in the write path; Graphiti ships hallucination "defenses" to treat the
+symptom), memory + task coordination in one graph, hard namespace-per-org tenant isolation in OSS,
+CLI-first cross-agent surface, and honest benchmark culture (three vendors simultaneously claim
+LongMemEval-v1 SOTA; arXiv 2605.24060 documents the incomparability).
+
+## 2. Benchmark state
+
+- **LongMemEval-v1 is saturating** (vendor claims cluster 88–95%, all self-published, axes conflated
+  — Supermemory's "95%" is Recall@15, not e2e QA). **LoCoMo is discredited**: the Penfield Labs
+  audit (2026-04-04) found 6.4% of the answer key wrong and the judge accepting 62.8% of
+  adversarially wrong answers — theoretical ceiling ≈93.6%, which several vendor claims exceed.
+  Nobody serious treats these as differentiators anymore.
+- **LongMemEval-V2 (arXiv 2605.12493) is the new agentic standard, and its official leaderboard is
+  EMPTY as of 2026-07-25.** No vendor has published a v2 number anywhere. Sibyl's 31.26% full-451
+  would be the first third-party number in existence. The official metric is **LAFS Gain**
+  (latency-aware frontier score, 1s–200s budgets, multi-operating-point submissions) — exactly the
+  accuracy+latency reporting shape Sibyl already produces. Precision note for all our writeups: the
+  42.8%/51.0% reference numbers are the **Small-tier** baselines (Medium tier: 38.1%/45.9%); Sibyl's
+  harness runs the Small-tier haystack.
+- **Every reported score is (system × backbone × judge × dataset-era)**, not a system property: Zep
+  spans 71.2→90.2 across eras; Hindsight moves ~8pp by backbone; MemDelta (arXiv 2606.29914) shows
+  swapping only the embedding model moves accuracy ±6.2pp — enough to reverse rankings.
+- **Integrity discourse is loud and moving our way**: Penfield's six-requirement checklist,
+  MemDelta's confound analysis, survey-level calls for a GLUE-style shared harness, and Mem0's own
+  concession that "accuracy without a token budget is a half-finished score." The credibility
+  markers the field converged on (pinned dataset version, named judge + published prompt, fixed
+  embedder across comparisons, tokens+latency alongside accuracy, open harness) are things Sibyl's
+  protocol law already does.
+- **Adjacent new benchmarks worth knowing**: GroupMemBench (Microsoft, arXiv 2605.14498) for
+  multi-party memory — best system scores 46% and plain BM25 matches most dedicated memory systems,
+  so the team-memory space is wide open (relevant to the v1.3 TeamMemBench ambition — a public
+  target now exists). GateMem (arXiv 2606.18829) for shared-memory governance. MemSyco-Bench (arXiv
+  2607.01071) for memory sycophancy — externally validates the errors-gotchas pool diagnosis
+  (premise never checked) and is a candidate secondary eval for the A2 gotcha/premise notes.
+
+## 3. Track A bets vs the evidence
+
+Every bet validated; citations are the load-bearing ones.
+
+- **Slice-granular substrate (A1) — validated twice over.** Academic: verbatim chunk stores beat
+  extraction pipelines by 16–22 points ("Fidelity Before Structure," arXiv 2601.00821);
+  boundary-segmented units beat turn/session/summary granularity (SeCom arXiv 2502.05589, ES-Mem
+  arXiv 2601.07582); small units must carry inherited context (late chunking arXiv 2409.04701;
+  Anthropic contextual retrieval, −49% retrieval failures). Production: 256–512-token chunks with
+  prepended context are the 2026 standard; Sibyl's ~1K-char slices sit in the child-chunk class of
+  parent-child retrieval, and the 3-slice window is the small-to-big pattern. Frontier caveat →
+  **new offline arm**: contextualized chunk embedders (voyage-context-4, $0.12/1M) beat
+  manual-header embeddings ~7% chunk-level; headers stay for BM25 + reader visibility.
+- **Character-budgeted packs (A1) — validated.** Context-rot research (Chroma 2025-07, 18 models;
+  "More Documents, Same Length" arXiv 2503.04388: more retrieved docs at constant length cuts
+  performance up to 20%) makes budget, not item-count, the correct control knob. "Fishing for
+  Answers" (arXiv 2509.04820) shows budget-constrained one-shot selection competitive with iterative
+  retrieval.
+- **Dense-first fusion (A1) — mechanism confirmed, one exposed flank.** The industry abandoned naive
+  RRF for score-aware fusion (Weaviate relativeScoreFusion default since v1.24; Qdrant DBSF) because
+  rank-only fusion weights a weak arm equally — exactly the measured poisoning. BM25's b=0.75 is
+  mistuned for <100-word chunks (b≈0.3 advised), and inherited headers crater IDF discrimination on
+  slice corpora — the mechanism behind our offline result. **But** the field's fix of record is
+  retrieve-wide + cross-encoder rerank (Anthropic ladder −35/−49/−67%; Zep runs RRF→cross-encoder;
+  rerank cost +50–200ms, zerank-2 / Cohere Rerank 4 current leaders), not dense-only. → **A2
+  requirement**: lexical escape hatch or rerank stage for identifier-shaped queries.
+- **Reserved 3-slot notes lane (A1/A2) — specifically vindicated.** TriMem (arXiv 2605.19952) wins
+  with three _parallel_ layers (raw + facts + profiles); 2601.00821's explicit recommendation is
+  "structured memory should augment verbatim text rather than replace it"; production working-memory
+  injections are tiny and always-on (Mem0 ~130–166 tokens/call). Absolute slots are the right shape
+  under context rot. Cost caution (ICLR 2026 MemAgents, arXiv 2603.02473): write strategy moves
+  accuracy 3–8 points while retrieval moves 20 — distillation must stay cheap relative to retrieval
+  work.
+- **Bounded agentic traversal (A3) — validated on both halves, plus a routing rule.**
+  Substrate-first: Claude Code's pivot to agentic search worked because the primitives were fast and
+  precise — the loop is only as good as its substrate. Bounded: "Dissecting Agentic RAG" (arXiv
+  2606.21553) — two retrieval iterations capture 95% of the gain of five, and fixed pipelines beat
+  un-learned adaptive routing (the accurate-mode −4pp/2.5× result is textbook, predicted by the
+  literature); LatentRAG (arXiv 2605.06285) measures token-space agentic loops at ~15× single-step
+  latency. Interactive round budgets in the wild: 2–5. → **Route single-hop queries around the
+  loop**; expect the win in rounds 1–2 on genuinely multi-hop questions; a sufficiency-style stop
+  beats a fixed iteration count.
+- **Graph retrieval routing (A3) — supported with the same caveat.** HippoRAG 2 (ICML 2025) shows
+  graphs pay off on associative/multi-hop (+7 F1) while flat dense wins factoid lookups; GraphRAG
+  evaluations (arXiv 2502.11371) show complementarity, not dominance. Route, don't force every query
+  through the graph.
+
+## 4. Track B — the projection-layer window
+
+**The riskiest-looking part of the plan turned out to be the industry-standard part.** OpenAI
+(Agents SDK `memory_summary.md` + `MEMORY.md` + rollout summaries; Codex CLI `~/.codex/memories/`),
+Anthropic (Claude Code auto-memory `MEMORY.md` + topic files; client-side API memory tool), and
+Google (Gemini CLI `GEMINI.md`; OKF) all independently converged on distilled-summary +
+greppable-index + detail-files-on-demand in Feb–May 2026. B1 (handbook) and B2 (`.sibyl/memory/`)
+are the same shape — projected from a graph instead of siloed per harness.
+
+- **OKF v0.1 (Google Cloud, 2026-06-12)**: vendor-neutral Markdown + YAML frontmatter in
+  git-shippable directories. Sibyl's OKF export now targets a Google-backed public spec. B2's
+  materialized files should align with it where cheap.
+- **The window is ~6–12 months.** AGENTS.md went launch → 60k repos → Linux Foundation stewardship
+  in about a year; the learned-memory-layer contest opened Feb–May 2026 and no cross-tool convention
+  has won. A repo-local `.sibyl/memory/` is greppable by every harness in the table with zero
+  integration work — the only graph-backed entrant in the file conventions race. W3C AI Agent Memory
+  Interop CG exists (June 2026) but is small and 12+ months from anything normative; MCP is
+  explicitly not standardizing memory (2026 roadmap).
+- **Platform-risk verdict**: the labs commoditized within-platform memory while actively
+  manufacturing cross-platform fragmentation (three default-on silos learning the same lessons
+  separately in one repo). "Your agent forgets" is dead as a pitch; the wedge is cross-agent + graph
+  structure + scope/provenance + sovereignty. Nobody big has claimed the "memory sovereignty"
+  phrase; the discourse (arXiv 2604.16548, OWASP) is arriving at it.
+
+## 5. Track C — security tailwind
+
+The June 2026 research wave handed Track C a public blueprint that matches what it already planned:
+OWASP Agentic Top 10 formalized **ASI06 Memory & Context Poisoning** with provenance-per-write +
+tenancy-separation guidance; TMA-NM (arXiv 2606.24322) demonstrates origin-bound write authority
+with 0% attack success; incidents pile up on incumbents (Tenable HackedGPT memory injection, Radware
+ZombieAgent, Claude Code MemoryTrap). No cross-tenant CVE exists against Mem0/Zep/Letta/Cognee, but
+MemTrust (arXiv 2601.07004) explicitly flags their soft-label isolation as latent risk — the 1.1.3
+scope closure puts Sibyl ahead of the disclosure curve, not behind it. Enterprise buyers now name
+per-write provenance and verifiable deletion as purchase criteria; Sibyl's basis/provenance fields
+and org-namespace isolation map directly onto what auditors test.
+
+## 6. Coalescence window (the v1.3 deferral)
+
+**Holds, and is narrowing measurably.** Team _scoping_ went from differentiator to table stakes
+(Cognee dataset RBAC Oct 2025 → OpenAI shared projects / workspace agents Apr 2026), but the giants
+chose **containment over gradation** (project-only walls; "per user and per agent … not a single
+shared brain") — they validated demand and declined to build the hard thing. Within-scope
+consolidation is commoditized (Mem0 ADD/UPDATE/DELETE, Graphiti entity resolution, AgentCore
+strategies, Microsoft Memora); **cross-user merge under privacy constraints is shipped by zero
+products**. Closest threats are papers, not products: MemClaw ("Governed Shared Memory," arXiv
+2606.24535 — right vocabulary, agent-fleet focus, unknown adoption) and AgentPrizm (July 2026
+launch, weak credibility signals).
+
+Academic support for the deferral order: "Retain or Consolidate?" (arXiv 2607.17545) — retention
+beats consolidation at loose token budgets; consolidation wins (up to +48%) only under tight ones.
+Substrate-first is the measured order. **Two named tripwires**: (1) the crossover means
+consolidation becomes load-bearing exactly when packs stop fitting budgets — watch that trigger
+during A1; (2) interference research (arXiv 2605.08538, 2603.11768) says an unconsolidated store
+eventually degrades retrieval _precision_, so the deferral is time-boxed, not indefinite. The
+strategic risk is not someone shipping coalescence first — it is someone credible claiming the
+"governed team memory" _narrative_ before Sibyl's version is demonstrable, which argues for keeping
+the scope/provenance story visibly intact in every v1.2 surface.
+
+## 7. Watch list
+
+- **Cognee release cadence** (weekly ships, enterprise logos) — the OSS competitor to track.
+- **LME-V2 leaderboard first entry** — if someone else lands a v2 number first, the first-mover
+  payoff of `baseline-beat-gate` shrinks; the gate's numbers don't change.
+- **Zep bolting ACLs onto Graphiti group graphs** — shortest path for a fast follower on governed
+  team memory.
+- **MemClaw / AgentPrizm adoption signals** — narrative-capture risk on "governed memory."
+- **voyage-context-class embedders** — if the A1 offline arm confirms, the header strategy for the
+  _vector_ side may be superseded within the release.
+- **Learned memory policies (RL for write/retrieve/stop) and latent-space loops** — the research
+  frontier moving past hand-designed architectures; nothing shippable yet.
+
+## 8. Wave provenance
+
+Six research lanes, run 2026-07-25, each with dated primary-source citations (GitHub repos, arXiv
+abstracts, official docs fetched same-day). Full lane reports lived in session scratchpad; the
+load-bearing claims and all primary sources are carried inline above. Key benchmark/paper anchors:
+LME-V2 arXiv 2605.12493 + project leaderboard page · Penfield LoCoMo audit (2026-04-04) · MemDelta
+2606.29914 · Fidelity-Before-Structure 2601.00821 · SeCom 2502.05589 · TriMem 2605.19952 ·
+Dissecting Agentic RAG 2606.21553 · Retain-or- Consolidate 2607.17545 · MemClaw 2606.24535 · TMA-NM
+2606.24322 · GroupMemBench 2605.14498 · OKF (Google Cloud, 2026-06-12) · MCP 2026 roadmap +
+2026-07-28 spec RC · Anthropic contextual retrieval + context engineering posts · Chroma Context Rot
+(2025-07).

--- a/docs/research/rust-port/INVENTORY.md
+++ b/docs/research/rust-port/INVENTORY.md
@@ -12,7 +12,7 @@ Generated from code by `tools/inventory/runtime_surface.py`. Do not hand-edit.
 - Raw SQL query usage files: 0
 - Session-backed storage access files: 0
 - Graphiti import files: 0
-- Retained legacy term files: 88
+- Retained legacy term files: 89
 - Dependency records: 4
 
 ## API Surface
@@ -131,6 +131,7 @@ must carry an owner and reason here.
 | `docs/architecture/SIBYL_1_0_ROADMAP.md` | `graphiti`, `redis` | 33 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/architecture/SIBYL_NORTHSTAR.md` | `falkor`, `graphiti`, `postgres`, `redis` | 46 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/architecture/SIBYL_POST_1_0_ROADMAP.md` | `falkor`, `graphiti`, `postgres`, `redis` | 4 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
+| `docs/architecture/SOTA_LANDSCAPE_2026-07-25.md` | `graphiti`, `postgres` | 5 | competitive research | SOTA and competitive landscape docs name rival stacks as external products, not dependencies. |
 | `docs/architecture/retrieval-system.md` | `graphiti` | 1 | v0.8 architecture | Architecture and release plans preserve migration, benchmark, and compatibility history. |
 | `docs/cli/add.md` | `redis` | 2 | v0.8 API/CLI docs | API and CLI docs reference memory history, migration payloads, or optional coordination. |
 | `docs/cli/docker.md` | `valkey` | 2 | v0.8 API/CLI docs | API and CLI docs reference memory history, migration payloads, or optional coordination. |

--- a/tools/inventory/runtime_surface.py
+++ b/tools/inventory/runtime_surface.py
@@ -265,6 +265,7 @@ ARCHITECTURE_LEGACY_TERM_FILES = (
     "docs/architecture/SIBYL_NORTHSTAR.md",
     "docs/architecture/SIBYL_POST_1_0_ROADMAP.md",
 )
+COMPETITIVE_RESEARCH_LEGACY_TERM_FILES = ("docs/architecture/SOTA_LANDSCAPE_2026-07-25.md",)
 ENTERPRISE_LEGACY_TERM_FILES = (
     "docs/admin/installing.md",
     "docs/users/sharing-memory.md",
@@ -432,6 +433,11 @@ LEGACY_TERM_ALLOWLIST = (
         ARCHITECTURE_LEGACY_TERM_FILES,
         owner="v0.8 architecture",
         reason="Architecture and release plans preserve migration, benchmark, and compatibility history.",
+    ),
+    *legacy_term_allowlist_records(
+        COMPETITIVE_RESEARCH_LEGACY_TERM_FILES,
+        owner="competitive research",
+        reason="SOTA and competitive landscape docs name rival stacks as external products, not dependencies.",
     ),
     *legacy_term_allowlist_records(
         ENTERPRISE_LEGACY_TERM_FILES,


### PR DESCRIPTION
## Why

Every project-scoped `sibyl task list` / `epic list` returns **empty** on v1.1.3 — for the org owner, on the project they just verified access to. Filed same-day as task `bcdf1b3a`; this is the 1.1.4 driver.

## Mechanism

The explore route (`/search/explore`) verifies VIEWER access on the named project, then hands the core `accessible_projects=None` in **list** and **dependencies** modes — only related/traverse got the verified set. PR #264's shared read rule denies scope-unstamped project rows (tasks, epics) when the accessible set is `None`, by design:

> a caller that cannot resolve memberships must pass None, which denies rather than admits

So the scope guard emptied the board for the very member the route had just verified. `--all` worked because the unscoped branch passes the full resolver set — which is what made this look like a role-resolution bug at first (it isn't; the role resolves fine).

## Fix

Thread the verified project set to the core in **every** mode (`search.py`, one branch per filter shape). Blast radius is tight:

- Unassigned entities: unchanged (guard already admits rows with no project).
- Unrequested projects' rows: unchanged (already dropped by the project filter; now doubly by the accessible set).
- The only behavior change is the intended one: the verified project's work items pass the guard again.

## Tests

- Two existing route tests **asserted the `None`** and locked the bug in (`test_routes_search.py`) — both flipped to assert the verified set.
- New wire-level allow/deny pair (`test_wire_scope.py::TestScopedTaskListWire`) drives the **real** `core_explore` + scope guard through the HTTP path: member sees their board; an unrequested project's rows still drop even when the fetch over-returns.
- Receipts: `36 passed` across both touched test files; `ruff` + `ty` clean; live consumption check on the dev API — `sibyl task list --status doing,todo` and `sibyl epic list` both return the board again.

Also updates the 1.2 plan's §2.6 regression note with the corrected diagnosis (it names the read rule, not role resolution) and the recorded lesson: scope hardening needs the allow-direction test pair on every list surface, not just leak tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project-scoped search exploration so verified project scope is consistently enforced across modes.
  * Ensured scoped lists drop tasks from unrequested projects, preventing private or secret rows from appearing.
* **Tests**
  * Expanded search/scoping coverage with new end-to-end HTTP route assertions and updated expected scope parameters.
* **Documentation**
  * Refreshed architecture and SOTA landscape materials with updated planning notes, benchmark/status updates, and security guidance.
* **Chores**
  * Updated runtime inventory/allowlist for newly documented competitive research materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->