### PR TITLE
fix(retrieval): pin the distilled-note lane to an absolute slot count

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_evidence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_evidence.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
-import math
 from typing import Any, Protocol
+
+# The tuned quantity is an absolute note count, not a share of the pack.
+# Widening the lane from 3 to 5 lost the entire measured note gain
+# (-3.70pp/domain), so the reservation must not scale with `limit`: a
+# slice-granular pack raises `limit` from 8 to ~28 for reasons that have
+# nothing to do with how many distilled notes are worth reading.
+TYPED_NOTE_RESERVATION_ITEMS = 3
 
 
 class OperationalEvidenceResult(Protocol):
@@ -25,8 +31,14 @@ def compose_operational_evidence[ResultT: OperationalEvidenceResult](
     typed_results: list[ResultT],
     raw_results: list[ResultT],
     limit: int,
+    typed_reservation_items: int = TYPED_NOTE_RESERVATION_ITEMS,
 ) -> tuple[list[ResultT], dict[str, Any]]:
-    """Reserve three eighths of output slots for independently ranked notes."""
+    """Reserve a fixed count of output slots for independently ranked notes.
+
+    The reservation is absolute rather than proportional; see
+    `TYPED_NOTE_RESERVATION_ITEMS`. Small packs still shrink it, because a
+    reservation may never consume the whole pack.
+    """
     output_limit = max(1, limit)
     typed_candidates: list[ResultT] = []
     raw_candidates: list[ResultT] = []
@@ -54,7 +66,7 @@ def compose_operational_evidence[ResultT: OperationalEvidenceResult](
         raw_candidates.append(result)
         seen_ids.add(result.id)
 
-    reservation_target = max(1, math.ceil(output_limit * 3 / 8))
+    reservation_target = max(1, typed_reservation_items)
     typed_reservation = min(
         len(typed_candidates),
         max(1, min(reservation_target, output_limit - 1)),
@@ -91,6 +103,7 @@ def compose_operational_evidence[ResultT: OperationalEvidenceResult](
 
 
 __all__ = [
+    "TYPED_NOTE_RESERVATION_ITEMS",
     "compose_operational_evidence",
     "is_distilled_operational_note",
 ]

--- a/packages/python/sibyl-core/tests/test_operational_evidence.py
+++ b/packages/python/sibyl-core/tests/test_operational_evidence.py
@@ -26,29 +26,31 @@ def _result(
     )
 
 
-@pytest.mark.parametrize(
-    ("limit", "expected_typed", "expected_raw"),
-    [(1, 1, 0), (2, 1, 1), (3, 2, 1), (8, 3, 5)],
-)
-def test_reserved_lane_matches_three_eighths_law(
-    limit: int,
-    expected_typed: int,
-    expected_raw: int,
-) -> None:
-    typed = [
+def _note_pool(count: int) -> list[SearchResult]:
+    return [
         _result(
             f"note-{index}",
             result_type="note",
             source_id=f"capture-{index}",
             distilled=True,
         )
-        for index in range(8)
+        for index in range(count)
     ]
-    raw = [_result(f"raw-{index}") for index in range(8)]
 
+
+@pytest.mark.parametrize(
+    ("limit", "expected_typed", "expected_raw"),
+    [(1, 1, 0), (2, 1, 1), (3, 2, 1), (8, 3, 5)],
+)
+def test_reserved_lane_never_consumes_a_small_pack(
+    limit: int,
+    expected_typed: int,
+    expected_raw: int,
+) -> None:
+    """Packs at or below the shipped size keep the behaviour they shipped with."""
     selected, receipt = compose_operational_evidence(
-        typed_results=typed,
-        raw_results=raw,
+        typed_results=_note_pool(8),
+        raw_results=[_result(f"raw-{index}") for index in range(8)],
         limit=limit,
     )
 
@@ -58,6 +60,42 @@ def test_reserved_lane_matches_three_eighths_law(
     ]
     assert receipt["selected_typed_count"] == expected_typed
     assert receipt["selected_raw_count"] == expected_raw
+
+
+@pytest.mark.parametrize("limit", [8, 24, 28])
+def test_reserved_lane_is_an_absolute_count_a_wider_pack_cannot_widen(limit: int) -> None:
+    """A slice-granular pack raises `limit`; it must not raise the note lane.
+
+    The proportional law this replaced would have reserved 11 of 28 slots,
+    and the tuning kill measured that widening as a total loss of the note
+    gain. Both ends are pinned so neither the shipped pack size nor the
+    slice pack size can drift.
+    """
+    selected, receipt = compose_operational_evidence(
+        typed_results=_note_pool(limit),
+        raw_results=[_result(f"raw-{index}") for index in range(limit)],
+        limit=limit,
+    )
+
+    assert receipt["reservation_target"] == 3
+    assert receipt["selected_typed_count"] == 3
+    assert receipt["selected_raw_count"] == limit - 3
+    assert len(selected) == limit
+    assert [item.id for item in selected[:3]] == ["note-0", "note-1", "note-2"]
+
+
+def test_reserved_lane_honours_an_explicit_override() -> None:
+    """The pin is the default, not a hard-coded constant callers cannot move."""
+    _, receipt = compose_operational_evidence(
+        typed_results=_note_pool(8),
+        raw_results=[_result(f"raw-{index}") for index in range(16)],
+        limit=16,
+        typed_reservation_items=5,
+    )
+
+    assert receipt["reservation_target"] == 5
+    assert receipt["typed_reservation"] == 5
+    assert receipt["selected_typed_overflow_count"] == 0
 
 
 def test_reserved_lane_preserves_source_diversity_and_excludes_generic_notes() -> None:


### PR DESCRIPTION
## Why

First code chunk of v1.2 Track A, and it's a trap that had to be defused *before* the slice substrate lands rather than after.

The reserved note lane was computed as `ceil(limit * 3/8)`. That reads like a tuning constant but isn't one: the tuning work measured the **absolute** note count, and widening the lane from 3 to 5 lost the entire note gain (−3.70pp/domain). The share only ever looked correct because the shipped pack is 8 items, where three eighths happens to equal three.

A1 makes that coincidence dangerous. Slice-granular retrieval raises the pack from 8 items to ~28 for reasons that have nothing to do with how many distilled notes are worth reading — and the proportional law would have silently widened the lane to **11 slots**. The A1 arm would then have measured as a notes regression and been misdiagnosed as a slice failure.

## What changed

The reservation is an absolute count with the tuned value as its default, overridable per call. The plan called for a parameter, but a parameter alone isn't sufficient — one that accepts any value doesn't pin the value that matters — so the *default* is the pin.

**Every pack at or below the shipped size keeps its exact behaviour.** The existing clamp already forbade a reservation from consuming the whole pack, so at limits 1, 2, 3 and 8 the proportional and absolute laws agree — verified by keeping the original parametrised case list green, unmodified.

## Behaviour change worth naming

Packs above 8 change. Concretely, the default context pack at `limit=24` now reserves **3** note slots instead of 9. That configuration was never tuned; 3 is the measured constant. Flagging it explicitly rather than burying it in a diff.

## Tests

- Both ends locked: at limits **8, 24 and 28** the composed set carries exactly 3 note slots, so neither the shipped configuration nor the slice configuration can drift.
- The override path asserts on `reservation_target`/`typed_reservation` with a full raw pool — the first draft asserted `selected_typed_count` and correctly failed, because notes legitimately backfill leftover slots when the raw pool is short.
- `pytest test_operational_evidence.py` → 10 passed. `pytest apps/api/tests/test_routes_context.py` → 43 passed (the route-level reservation test passes unchanged, since it runs at limit 8).

## Note for the second enforcement site

The eval adapter computes the same ratio independently at `sibyl_memory.py:737` and already accepts `typed_reservation_items` (wired to `--typed-reservation-items`). Production was the gap; that's what this closes. The A1 runs must pass the absolute value on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Operational evidence selection now reserves a consistent number of typed notes, regardless of the requested result limit.
  * Small result sets retain their expected balance without allowing the reserved portion to consume available results.
  * Advanced configurations can customize the number of reserved typed notes when needed.
* **Bug Fixes**
  * Corrected result ordering and allocation for larger result sets, ensuring reserved typed notes appear first and remaining results are filled appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->