### PR TITLE
fix(ci): scan each image digest on its own architecture

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -526,7 +526,11 @@ jobs:
     name: "◆ Docker: Security ${{ matrix.image }} (${{ matrix.platform }})"
     needs: docker-build
     if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-latest
+    # Each digest is scanned on its own architecture, mirroring docker-build.
+    # A push-by-digest reference resolves to a single-platform index, so an
+    # amd64 runner asks for an amd64 child that an arm64 digest does not have
+    # and the scan fails before it reads a single package.
+    runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 15
     permissions:
       contents: read


### PR DESCRIPTION
## Why

The v1.1.5 publish failed on both **arm64** security jobs ([run 30181234175](https://github.com/hyperb1iss/sibyl/actions/runs/30181234175)). Both amd64 jobs passed.

This was **not** a vulnerability — it was a broken scan:

```
FATAL  unable to find the specified image "ghcr.io/.../sibyl-api@sha256:7931..."
  * remote error: no child with platform linux/amd64 in index ...
```

The per-architecture scan introduced with the publish reorder ran every matrix leg on `ubuntu-latest` (amd64). A `push-by-digest` reference resolves to a single-platform index, so scanning the **arm64** digest from an amd64 runner makes Trivy look for a `linux/amd64` child that isn't there. It fails before reading a single package.

## Silver lining

The pipeline behaved exactly as rebuilt. Because the scan gates the merge, **nothing shipped**: no public image tag, no signature, no Helm publish, no PyPI version burned. Compare 1.1.3/1.1.4, where the identical scan-stage failure left public unsigned images behind. The failure mode moved from "half-shipped release" to "release stopped cleanly", which is the whole point of the reorder.

## Fix

`docker-security` now selects its runner the same way `docker-build` already does at line 369:

```yaml
runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
```

Each digest is read on the architecture it was built for. `trivy-action@v0.36.0` exposes no `platform` input, so matching the runner is the mechanism already proven in this file rather than a new one.

## Verification

- `actionlint` clean.
- `pytest tools/tests/test_release_workflow.py` → 20 passed (the ordering assertions still hold).
- Real proof is the re-dispatched publish for `v1.1.5`, which runs off `main`'s workflow while building the existing tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker security scanning across supported architectures.
  * Added architecture-specific runner selection to ensure scans run on matching environments.
  * Clarified workflow documentation for per-architecture image scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->