### PR TITLE
fix(ci): name the platform when scanning a single-platform digest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -526,11 +526,9 @@ jobs:
     name: "◆ Docker: Security ${{ matrix.image }} (${{ matrix.platform }})"
     needs: docker-build
     if: ${{ !inputs.dry_run }}
-    # Each digest is scanned on its own architecture, mirroring docker-build.
-    # A push-by-digest reference resolves to a single-platform index, so an
-    # amd64 runner asks for an amd64 child that an arm64 digest does not have
-    # and the scan fails before it reads a single package.
-    runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    # Analysing an image needs no matching host: the scan reads layers from
+    # the registry, and the platform is named explicitly per step below.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
@@ -573,6 +571,14 @@ jobs:
 
       - name: "◆ Generate Trivy SBOM"
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          # Trivy resolves a remote index to linux/amd64 unless told otherwise,
+          # and it does not infer the platform from the host it runs on. A
+          # push-by-digest reference is a single-platform index, so scanning
+          # the arm64 digest without this asks for an amd64 child that is not
+          # there and fails before reading a package. The action exposes no
+          # platform input; trivy derives TRIVY_PLATFORM from its own flag.
+          TRIVY_PLATFORM: linux/${{ matrix.platform }}
         with:
           image-ref: >-
             ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}@${{
@@ -597,6 +603,8 @@ jobs:
 
       - name: "◆ Trivy CVE gate"
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_PLATFORM: linux/${{ matrix.platform }}
         with:
           image-ref: >-
             ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}@${{


### PR DESCRIPTION
## Correcting a wrong fix

PR #275 moved each scan onto a runner matching its architecture, on the theory that Trivy infers platform from its host. **That theory was wrong.** Verified on the re-publish ([run 30181569045](https://github.com/hyperb1iss/sibyl/actions/runs/30181569045)): the arm64 jobs *did* run on arm64 runners —

```
◆ Docker: Security api (arm64) | labels=["ubuntu-24.04-arm"]
```

— and still failed with `no child with platform linux/amd64 in index`. The runner change fixed nothing, so it's reverted here.

## Actual mechanism

Trivy resolves a remote index to `linux/amd64` **unconditionally** unless told otherwise; it does not consult the host architecture. A `push-by-digest` reference is a single-platform index, so the arm64 digest never contains the amd64 child Trivy asks for, and it fails before reading a package.

`trivy-action@v0.36.0` exposes no `platform` input — confirmed by reading its `action.yaml`. But Trivy derives env names from its own flag definitions:

```go
// pkg/flag/options.go
envName := strings.ToUpper("trivy_" + strings.ReplaceAll(f.Name, "-", "_"))
// pkg/flag/image_flags.go
PlatformFlag = Flag[string]{ Name: "platform", ... }
```

So `TRIVY_PLATFORM` reaches `--platform`. Both the SBOM step and the CVE gate now name the platform they scan.

Scanning reads layers from the registry and executes nothing, so an amd64 runner is fine once the platform is explicit — the job returns to `ubuntu-latest` rather than consuming arm64 capacity for no benefit.

## Verification

- `actionlint` clean; `pytest tools/tests/test_release_workflow.py` → 20 passed.
- Env-var derivation and flag name read from Trivy source rather than assumed — the previous attempt failed because I reasoned from plausibility instead of checking.
- Real proof is the re-dispatched `v1.1.5` publish.

## Context

Both failed publishes stopped cleanly with **nothing shipped** (`ghcr.io/.../sibyl-api:1.1.5` absent, PyPI still 1.1.4). The scan gating the merge is working; only the scan itself was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-architecture container security scans to analyze the correct target architecture.
  * Standardized the scanning environment for more consistent vulnerability and SBOM results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->