### PR TITLE
fix(ci): expect one SBOM per image per architecture

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -933,7 +933,10 @@ jobs:
           cp "$formula" "release-assets/sibyl-homebrew-${version}.rb"
           cp "$pkgbuild" "release-assets/sibyl-${version}-PKGBUILD"
 
-          test "$(find release-assets -maxdepth 1 -type f -name '*.cdx.json' | wc -l)" -eq 2
+          # One SBOM per image per architecture. This was two while a single
+          # scan covered the merged manifest, which silently meant only one
+          # architecture was ever examined.
+          test "$(find release-assets -maxdepth 1 -type f -name '*.cdx.json' | wc -l)" -eq 4
           test "$(find release-assets -maxdepth 1 -type f -name '*-cosign-receipt.json' | wc -l)" -eq 2
           test "$(find release-assets -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 3
           test "$(find release-assets -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 3


### PR DESCRIPTION
## Why

The v1.1.5 publish went **19/20 green** ([run 30181802273](https://github.com/hyperb1iss/sibyl/actions/runs/30181802273)) — including the jobs that had never run before: `Docker Sign` (both images) and `Helm: Publish repository`. Images, signatures, chart, PyPI, Homebrew and AUR all shipped.

The single failure was `Release: Update`, at this assertion:

```bash
test "$(find release-assets -maxdepth 1 -type f -name '*.cdx.json' | wc -l)" -eq 2
```

Per-architecture scanning produces **four** SBOMs (api/web × amd64/arm64), not two. So the GitHub release never received its asset bundle, even though every artifact that bundle describes had already published.

## Note worth keeping

Two was only ever correct *because one architecture went unexamined*. The old single scan of the merged manifest resolved to one platform, so arm64 was never scanned and never produced an SBOM. The count going up is the coverage gap closing — that's recorded in a comment beside the assertion so the next person reading it doesn't "simplify" it back.

## Verification

- `actionlint` clean; `pytest tools/tests/test_release_workflow.py` → 20 passed.
- Confirmed live for v1.1.5: `ghcr.io/.../sibyl-api:1.1.5` and `sibyl-web:1.1.5` present, `sibyl-core` 1.1.5 on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release validation to verify that software bill of materials artifacts are available for both application images across supported architectures.
  * Releases now fail validation if any expected security artifact is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->