### PR TITLE
feat(infra): state the SurrealDB image instead of inheriting a default

### DIFF
--- a/infra/ansible/roles/sibyl/defaults/main.yml
+++ b/infra/ansible/roles/sibyl/defaults/main.yml
@@ -5,6 +5,12 @@ sibyl_dir: /opt/sibyl
 # ghcr.io/hyperb1iss/sibyl-api and sibyl-web image tag to run.
 sibyl_version: "1.1.5"
 
+# SurrealDB image to run. Stated here rather than left to the compose
+# fallback so the engine a host runs is a deliberate, reviewable value: an
+# unset variable would otherwise let a checkout's default silently upgrade
+# the database on the next restart, independently of sibyl_version.
+sibyl_surreal_image: "surrealdb/surrealdb:v3.2.3"
+
 # Public hostname Caddy serves and requests a certificate for.
 sibyl_domain: sibyl.hyperbliss.tech
 

--- a/infra/ansible/roles/sibyl/templates/env.j2
+++ b/infra/ansible/roles/sibyl/templates/env.j2
@@ -1,6 +1,7 @@
 ## {{ ansible_managed }}
 ## Rendered by the sibyl Ansible role. Do not edit by hand.
 SIBYL_VERSION={{ sibyl_version }}
+SIBYL_SURREAL_IMAGE={{ sibyl_surreal_image }}
 SIBYL_DOMAIN={{ sibyl_domain }}
 SIBYL_BIND_IP={{ sibyl_bind_ip | default(sibyl_tailscale_ip.stdout | trim) }}
 SIBYL_LOCAL_AUTH_ENABLED={{ sibyl_local_auth_enabled | lower }}


### PR DESCRIPTION
## Why

Found while preparing the eternia upgrade. `env.j2` renders `SIBYL_VERSION` but never the database image, and compose reads:

```yaml
image: ${SIBYL_SURREAL_IMAGE:-surrealdb/surrealdb:v3.2.3}
```

With the variable unset, the deployed engine is whatever the **checked-out compose file** defaults to — a property of the deploying checkout, not of the host.

**Concretely on eternia today:** it runs SurrealDB `v3.1.0`, and `.env` contains only `SIBYL_VERSION`. A routine `ansible-playbook` run — with no variable changed and nothing engine-related in the diff — would have upgraded the database to `v3.2.3` on restart, while the app stayed pinned at `1.0.0-rc.8`. A database engine upgrade should never be a silent side effect of a config sync.

## Change

`sibyl_surreal_image` is a role default (set to the version compose already targets, so behaviour is unchanged for anyone at the default) and is rendered into `.env` like every other setting.

Now the engine version is reviewable in a diff, and a host can pin a different one when an engine upgrade needs to be separated from an application upgrade — or held back deliberately.

## Verification

- `rg` confirms the three-way wiring: role default → `env.j2` → compose interpolation.
- `pytest tools/tests/test_release_workflow.py` → 20 passed.
- `ansible-playbook --check --diff` against eternia is what surfaced this in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned the SurrealDB container image version to prevent unintended database upgrades during restarts.
  * Ensured the configured database image is consistently passed through deployment environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->