### PR TITLE
feat(graph): admit passage entities as a first-class retrieval unit

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -638,6 +638,13 @@ GRAPH_SCHEMA_MIGRATIONS = (
         name="entity_schema_drift_repair",
         statements=tuple(split_statements(ENTITY_SCHEMA_DRIFT_REPAIR_DEFINITIONS)),
     ),
+    # The enum allow-list renders from EntityType, so widening it only reaches an
+    # existing database when a new version replays the assertion.
+    SchemaMigration(
+        version=16,
+        name="graph_enum_assertions_passage",
+        statements=tuple(split_statements(GRAPH_ENUM_ASSERTION_DEFINITIONS)),
+    ),
 )
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
@@ -11,7 +11,7 @@ from typing import Protocol, cast
 
 from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement, split_statements
 
-GRAPH_SCHEMA_CURRENT_VERSION = 15
+GRAPH_SCHEMA_CURRENT_VERSION = 16
 GRAPH_SCHEMA_NAME = "graph"
 SCHEMA_VERSION_TABLE = "schema_version"
 

--- a/packages/python/sibyl-core/src/sibyl_core/models/entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/models/entities.py
@@ -56,6 +56,11 @@ class EntityType(StrEnum):
     EVENT = "event"  # Dated activity, milestone, purchase, or other temporal occurrence
     SESSION = "session"  # Work session or conversation checkpoint
 
+    # Retrieval substrate
+    # Design docs call these "slices"; the enum avoids that word because the
+    # benchmarks already use it for dataset subsets.
+    PASSAGE = "passage"  # Independently indexed span cut from a larger source
+
     @classmethod
     def _missing_(cls, value: object) -> "EntityType | None":
         if isinstance(value, str) and value.lower() == "guide":

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -81,6 +81,7 @@ from sibyl_core.backends.surreal.schema_version import (
     GRAPH_SCHEMA_CURRENT_VERSION,
     SCHEMA_VERSION_DEFINITIONS,
 )
+from sibyl_core.models.entities import EntityType
 
 
 class _RecordingSchemaClient:
@@ -1034,6 +1035,26 @@ def test_graph_enum_assertions_are_versioned() -> None:
     assert "ASSERT $value IN ['pattern'" in GRAPH_ENUM_ASSERTION_DEFINITIONS
     assert "graph_enum_assertions" in [migration.name for migration in GRAPH_SCHEMA_MIGRATIONS]
     assert GRAPH_ENUM_ASSERTION_DEFINITIONS.strip().splitlines()[0] in migration_sql
+
+
+def test_graph_enum_assertion_replay_admits_passage_entity_type() -> None:
+    migration = next(
+        item for item in GRAPH_SCHEMA_MIGRATIONS if item.name == "graph_enum_assertions_passage"
+    )
+    migration_sql = "\n".join(migration.statements)
+
+    assert GRAPH_SCHEMA_CURRENT_VERSION >= 16
+    assert migration.version == 16
+    assert "DEFINE FIELD OVERWRITE entity_type ON entity TYPE string" in migration_sql
+    assert f"'{EntityType.PASSAGE.value}'" in migration_sql
+    for entity_type in EntityType:
+        assert f"'{entity_type.value}'" in migration_sql
+
+
+def test_graph_schema_current_version_matches_latest_migration() -> None:
+    latest_migration_version = max(migration.version for migration in GRAPH_SCHEMA_MIGRATIONS)
+
+    assert latest_migration_version == GRAPH_SCHEMA_CURRENT_VERSION
 
 
 def test_graph_entity_actor_attribution_fields_are_versioned() -> None:


### PR DESCRIPTION
# 🔮 Give the v1.2 slice substrate somewhere to live

First implementation step of Track A1. Additive schema only — no producer, no consumer, no behavior change until a later lane mints the first row.

## 💡 Why

Sibyl's flagship LongMemEval-V2 number sits below the benchmark paper's own naive-RAG baseline, and the diagnosed cause is payload format rather than query planning: eight items of roughly 12K chars each, against readers measured to degrade past ~3K retrieved tokens. The oracle ablation puts format alone at ~23pp. Track A1 replaces those fat items with state-boundary spans.

Decision `9dd8e3972f42` settled how those spans are stored, and it is the reason this PR touches the schema at all. A retrieval-layer view was the tempting alternative and it does not work, because **a view cannot be ranked** — the vector and BM25 lanes are properties of an indexed row, so a view could only re-cut fat parents that were already selected. That is the client-side geometry reshaping the campaign already killed with receipts, relocated to the server.

## 🛠️ What this does

A new `EntityType` member, a schema version bump, and the migration that carries the widened allow-list to existing databases.

Because the `entity` table is SCHEMAFULL with its BM25 and HNSW indexes declared at TABLE level, passage rows inherit every index for free. **There is no index DDL in this diff.** The enum allow-list already renders from the Python enum, so the only thing a live database is missing is a migration version that replays it — version 16 replays the exact constant version 8 first installed. Widening an allow-list is safe on every path: existing rows stay valid and the pre-migration guard short-circuits above version 8.

## 🏷️ The name is `PASSAGE`, not `SLICE`

Worth a moment because it propagates. "Slice" is already load-bearing in this repo for *dataset subsets* — the 23-phrase slice, the enterprise-45 cohort — so `entity_type = 'passage'` can never be misread in a query result where `'slice'` would be ambiguous exactly when someone is debugging. "Chunk" was worse, a same-subsystem collision with the content layer's embedder. "Passage" is the standard IR term for a retrievable span of a larger source, which matters because `EntityType` members surface as CLI `--kind` choices and in user-facing docs. The string appears nowhere else in the repo, Python or TypeScript.

## 🧪 Validation

\`moon run core:check\` green across all four tasks:

\`\`\`
core:lint      | All checks passed!  (255 files already formatted)
core:typecheck | All checks passed!
core:test      | 1924 passed, 16 skipped in 24.00s
\`\`\`

Two new tests, named for what they defend:

\`\`\`
test_graph_enum_assertion_replay_admits_passage_entity_type PASSED
test_graph_schema_current_version_matches_latest_migration PASSED
\`\`\`

Also ran \`api:check\` (2026 passed, 5 skipped) and \`cli:check\` (422 passed) because roughly a dozen call sites derive lists from the enum. \`web:check\` not run — nothing here touches TypeScript.

⚠️ **Honest limit:** all of this ran against the SDK-bundled embedded SurrealDB 2.0.0 test engine. The live servers run 3.1/3.2 and 3.x rejects statements 2.x accepts, so the replayed \`DEFINE FIELD\` is **unproven against a live 3.x server**, as is a real 15→16 bootstrap on a populated database. The repo already acknowledges this class of gap (\`test_archive_schema_drift.py:50\` skips for the same reason). Residual risk is low because the statement shape is byte-identical to the v8 migration running in production today, but it is not zero and should not be reported as verified.

## 🎯 Blast radius, and one decision deliberately left open

Additive only. No existing row, query, or code path changes meaning.

**Facet routing is intentionally not wired here**, and the reasoning is narrower than \"another lane owns it.\" \`FACET_TYPES\` governs the context-pack surface alone — \`_types_for_facets\` requests facet-listed types and nothing else — while the operational-experience path these passages are built for composes evidence without consulting facets at all. So passages are already reachable by search, by MCP \`search\`, and by the evidence composer the moment they exist; they are dark only to \`/context\` packs. Wiring a facet now would inject an unmeasured raw-span substrate into every agent's wake and recall pack, which is the fat-payload problem in a new wrapper. The retrieval lane should add it alongside a measurement.

**Follow-up filed, not fixed here:** `_CONSOLIDATION_ENTITY_TYPES` at `jobs/consolidation.py:30` is built as every `EntityType` except `SESSION`, so passages will be swept by consolidation and priority decay as soon as they exist. For a machine-produced substrate of ~25–37 rows per parent state, consolidation merging near-duplicate passages would corrupt the exact spans retrieval depends on. That needs the projection lane's view on passage lifecycle before it is changed, so it is tracked separately rather than guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new `passage` entity type, representing independently indexed content slices.
  * Updated graph schema migrations to recognize and allow passage entities.

* **Bug Fixes**
  * Improved schema version tracking to ensure the active version matches the latest migration.

* **Tests**
  * Added coverage confirming passage entities are accepted and schema versioning remains synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->