### PR TITLE
feat(projection): mint passages beside the fat evidence entity at ingest

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/projection/experience.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/experience.py
@@ -452,11 +452,17 @@ def _passage_projection(
     entities: list[Entity] = []
     relationships: list[Relationship] = []
     for passage_index, passage in enumerate(slices):
-        content = render_slice(
-            slice_header(observation.ordinal, observation.uri, passage_index + 1, len(slices)),
-            passage.breadcrumb,
-            passage.content,
-        )
+        header = slice_header(observation.ordinal, observation.uri, passage_index + 1, len(slices))
+        content = render_slice(header, passage.breadcrumb, passage.content)
+        if len(content) > MAX_TYPED_ENTITY_CONTENT_CHARS:
+            # Deeply nested trees build a breadcrumb longer than the entity
+            # limit on their own. The trail restates ancestors the parent row
+            # still holds; the span's own bytes are the only copy, so trail
+            # characters go before any passage does. Keep the tail, which is
+            # the nearest ancestors.
+            budget = MAX_TYPED_ENTITY_CONTENT_CHARS - len(header) - len(passage.content) - 2
+            trail = passage.breadcrumb[-budget:] if budget > 0 else ""
+            content = render_slice(header, trail, passage.content)
         if len(content) > MAX_TYPED_ENTITY_CONTENT_CHARS:
             # An evidence part may carry a million chars on one unbroken line,
             # and cutting mid-line would bisect a literal. The span stays
@@ -472,7 +478,10 @@ def _passage_projection(
             Entity(
                 id=entity_id,
                 entity_type=EntityType.PASSAGE,
-                name=f"Observation {observation.ordinal} passage {passage_index + 1}",
+                name=(
+                    f"Observation {observation.ordinal}.{evidence_index + 1} "
+                    f"passage {passage_index + 1}/{len(slices)}"
+                ),
                 description=description,
                 content=content,
                 organization_id=organization_id,

--- a/packages/python/sibyl-core/src/sibyl_core/projection/experience.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/experience.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import unicodedata
 from collections.abc import Iterable, Iterator
 from itertools import pairwise
@@ -20,9 +19,16 @@ from sibyl_core.models.experience import (
     OperationalExperienceWriteResult,
     OperationalObservation,
 )
+from sibyl_core.projection.slicing import (
+    ACCESSIBILITY_NODE_PATTERN,
+    render_slice,
+    slice_body,
+    slice_header,
+)
 
-OPERATIONAL_EXPERIENCE_SCHEMA_VERSION = 5
+OPERATIONAL_EXPERIENCE_SCHEMA_VERSION = 6
 MAX_TYPED_ENTITY_CONTENT_CHARS = 18_000
+MAX_PASSAGE_DESCRIPTION_CHARS = 500
 MAX_UI_INVENTORY_CHARS = 16_000
 MAX_UI_INVENTORY_ITEMS = 160
 MAX_RAW_OBSERVATION_DESCRIPTION_CHARS = 2_000
@@ -86,6 +92,22 @@ def _observation_entity_id(
         source_id,
         observation_id,
         evidence_id,
+    )
+
+
+def _passage_entity_id(
+    source_id: str,
+    observation_id: str,
+    evidence_id: str,
+    passage_index: int,
+) -> str:
+    return _stable_id(
+        "passage",
+        "operational-observation",
+        source_id,
+        observation_id,
+        evidence_id,
+        passage_index,
     )
 
 
@@ -158,10 +180,6 @@ def _support_span(observation: OperationalObservation) -> dict[str, Any]:
     }
 
 
-_ACCESSIBILITY_NODE_PATTERN = re.compile(
-    r"^(?:\[[^\]]+\]\s+)?(?P<role>[A-Za-z][\w-]*)\s+"
-    r"(?P<quote>['\"])(?P<name>.*?)(?P=quote)(?P<attributes>,.*)?$"
-)
 _UI_STATE_ATTRIBUTES = frozenset(
     {
         "autocomplete",
@@ -182,6 +200,10 @@ _UI_ROLE_NAMES = {
     "RootWebArea": "page",
     "StaticText": "text",
 }
+
+
+def _is_accessibility_tree(evidence: OperationalEvidencePart) -> bool:
+    return "profile=accessibility-tree" in evidence.content_type.casefold()
 
 
 def _clean_accessibility_name(value: str) -> str:
@@ -253,7 +275,7 @@ def _raw_observation_description(
         if observation.reasoning
         else None,
     ]
-    if "profile=accessibility-tree" in evidence.content_type.casefold():
+    if _is_accessibility_tree(evidence):
         for evidence_items, (role, name, attributes) in enumerate(
             _accessibility_entries((evidence,)),
             start=1,
@@ -270,6 +292,34 @@ def _raw_observation_description(
             if evidence_items >= MAX_RAW_OBSERVATION_DESCRIPTION_ITEMS:
                 break
     return _bounded_lines(lines, max_chars=MAX_RAW_OBSERVATION_DESCRIPTION_CHARS)
+
+
+def _passage_description(
+    experience: OperationalExperience,
+    observation: OperationalObservation,
+) -> str:
+    """Carry the trajectory's framing into every passage cut from it.
+
+    A passage on its own is a few hundred chars of tree with no statement of
+    what the session was trying to do, which is the vocabulary a query actually
+    shares. This lands in `description` because that field is BM25-indexed and
+    folded into the embedding text, so retrieval inherits the context without
+    the reader paying for it on the composed-evidence path. It is bounded hard:
+    the graph writer also mirrors `description[:500]` into the separately
+    indexed `summary`, so every character here is counted twice on the lexical
+    side, and lexical document length is the dilution mechanism Stage 1 named.
+    """
+    return _bounded_lines(
+        (
+            f"Goal: {experience.goal}",
+            f"Reported outcome: {experience.outcome}" if experience.outcome else None,
+            f"URI: {observation.uri}" if observation.uri else None,
+            f"Action producing this observation: {observation.action}"
+            if observation.action
+            else None,
+        ),
+        max_chars=MAX_PASSAGE_DESCRIPTION_CHARS,
+    )
 
 
 def _split_accessibility_attributes(value: str) -> list[str]:
@@ -302,10 +352,10 @@ def _accessibility_entries(
 ) -> Iterator[tuple[str, str, str]]:
     seen: set[tuple[str, str, str]] = set()
     for evidence in evidence_parts:
-        if "profile=accessibility-tree" not in evidence.content_type.casefold():
+        if not _is_accessibility_tree(evidence):
             continue
         for raw_line in evidence.content.splitlines():
-            match = _ACCESSIBILITY_NODE_PATTERN.fullmatch(raw_line.strip())
+            match = ACCESSIBILITY_NODE_PATTERN.fullmatch(raw_line.strip())
             if match is None:
                 continue
             name = _clean_accessibility_name(match.group("name"))
@@ -329,8 +379,7 @@ def _accessibility_inventory(
     effective_max_chars = min(max_chars, MAX_UI_INVENTORY_CHARS)
     if effective_max_chars <= len(prefix) + 1:
         has_accessibility_evidence = any(
-            "profile=accessibility-tree" in evidence.content_type.casefold()
-            for evidence in observation.evidence
+            _is_accessibility_tree(evidence) for evidence in observation.evidence
         )
         return None, 0, has_accessibility_evidence
     available_chars = effective_max_chars - len(prefix) - 1
@@ -384,6 +433,82 @@ def _relationship(
     )
 
 
+def _passage_projection(
+    experience: OperationalExperience,
+    observation: OperationalObservation,
+    evidence: OperationalEvidencePart,
+    *,
+    evidence_index: int,
+    parent_entity_id: str,
+    common: dict[str, Any],
+    organization_id: str | None,
+    created_by: str | None,
+) -> tuple[list[Entity], list[Relationship]]:
+    """Cut one accessibility-tree evidence part into passage entities."""
+    slices, _ = slice_body(evidence.content)
+    if not slices:
+        return [], []
+    description = _passage_description(experience, observation)
+    entities: list[Entity] = []
+    relationships: list[Relationship] = []
+    for passage_index, passage in enumerate(slices):
+        content = render_slice(
+            slice_header(observation.ordinal, observation.uri, passage_index + 1, len(slices)),
+            passage.breadcrumb,
+            passage.content,
+        )
+        if len(content) > MAX_TYPED_ENTITY_CONTENT_CHARS:
+            # An evidence part may carry a million chars on one unbroken line,
+            # and cutting mid-line would bisect a literal. The span stays
+            # reachable through its parent rather than failing the capture.
+            continue
+        entity_id = _passage_entity_id(
+            experience.source_id,
+            observation.id,
+            evidence.id,
+            passage_index,
+        )
+        entities.append(
+            Entity(
+                id=entity_id,
+                entity_type=EntityType.PASSAGE,
+                name=f"Observation {observation.ordinal} passage {passage_index + 1}",
+                description=description,
+                content=content,
+                organization_id=organization_id,
+                created_by=created_by,
+                modified_by=created_by,
+                metadata={
+                    **common,
+                    "projection_kind": "passage",
+                    "source_observation_id": observation.id,
+                    "observation_ordinal": observation.ordinal,
+                    "evidence_part_id": evidence.id,
+                    "evidence_part_index": evidence_index,
+                    "evidence_content_type": evidence.content_type,
+                    "parent_entity_id": parent_entity_id,
+                    "passage_index": passage_index,
+                    "passage_count": len(slices),
+                    "passage_cut_depth": passage.cut_depth,
+                    "passage_reason": passage.reason,
+                    "passage_line_start": passage.line_indices[0],
+                    "passage_line_end": passage.line_indices[-1],
+                    "uri": observation.uri,
+                },
+            )
+        )
+        relationships.append(
+            _relationship(
+                relationship_type=RelationshipType.DERIVED_FROM,
+                source_id=entity_id,
+                target_id=parent_entity_id,
+                source_key=experience.source_id,
+                metadata={**common, "source_observation_id": observation.id},
+            )
+        )
+    return entities, relationships
+
+
 def _procedure_segments(
     experience: OperationalExperience,
     observations: list[OperationalObservation],
@@ -424,7 +549,13 @@ def _validate_typed_entity_sizes(entities: Iterable[Entity]) -> None:
     oversized = [
         entity.id
         for entity in entities
-        if entity.entity_type in {EntityType.EVENT, EntityType.PROCEDURE, EntityType.ERROR_PATTERN}
+        if entity.entity_type
+        in {
+            EntityType.EVENT,
+            EntityType.PROCEDURE,
+            EntityType.ERROR_PATTERN,
+            EntityType.PASSAGE,
+        }
         and len(entity.content or "") > MAX_TYPED_ENTITY_CONTENT_CHARS
     ]
     if oversized:
@@ -500,6 +631,20 @@ def project_operational_experience(
                     },
                 )
             )
+            if not _is_accessibility_tree(evidence):
+                continue
+            passage_entities, passage_relationships = _passage_projection(
+                experience,
+                observation,
+                evidence,
+                evidence_index=evidence_index,
+                parent_entity_id=entity_id,
+                common=common,
+                organization_id=organization_id,
+                created_by=created_by,
+            )
+            entities.extend(passage_entities)
+            relationships.extend(passage_relationships)
 
     for previous, current in pairwise(observations):
         if not current.action:

--- a/packages/python/sibyl-core/src/sibyl_core/projection/slicing.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/slicing.py
@@ -143,18 +143,33 @@ def build_forest(lines: Sequence[str]) -> list[Node]:
     return roots
 
 
-def _measure(nodes: Sequence[Node]) -> None:
-    for node in nodes:
-        _measure(node.children)
+def _measure(roots: Sequence[Node]) -> None:
+    """Size every subtree, bottom up.
+
+    Iterative rather than recursive throughout this module: nesting depth is
+    caller-controlled and an evidence part may legally carry a million chars, so
+    a thousand-deep tree would otherwise hit CPython's recursion limit and turn
+    a capture that ingests today into a 500.
+    """
+    order: list[Node] = []
+    stack = list(roots)
+    while stack:
+        node = stack.pop()
+        order.append(node)
+        stack.extend(node.children)
+    for node in reversed(order):
         node.subtree_chars = _line_cost(node.line) + sum(
             child.subtree_chars for child in node.children
         )
 
 
 def _flatten(node: Node) -> list[int]:
-    indices = [node.index]
-    for child in node.children:
-        indices.extend(_flatten(child))
+    indices: list[int] = []
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        indices.append(current.index)
+        stack.extend(reversed(current.children))
     return indices
 
 
@@ -184,91 +199,133 @@ def breadcrumb_for(ancestors: Sequence[Node]) -> str:
     return " > ".join(node_label(node.line) for node in ancestors)
 
 
-def _emit(
-    nodes: Sequence[Node],
-    ancestors: list[Node],
+@dataclass
+class _Frame:
+    """One level of the sibling walk, held on an explicit stack."""
+
+    nodes: Sequence[Node]
+    ancestors: list[Node]
+    out: list[Slice]
+    cursor: int = 0
+    buffer: list[Node] = field(default_factory=list)
+    buffer_chars: int = 0
+    descended: Node | None = None
+    descended_out: list[Slice] = field(default_factory=list)
+
+
+def _flush(frame: _Frame, lines: Sequence[str]) -> None:
+    if not frame.buffer:
+        return
+    indices: list[int] = []
+    for node in frame.buffer:
+        indices.extend(_flatten(node))
+    frame.out.append(
+        Slice(
+            line_indices=indices,
+            content="\n".join(lines[index] for index in indices),
+            cut_depth=frame.buffer[0].depth,
+            breadcrumb=breadcrumb_for(frame.ancestors),
+            reason="multi-subtree" if len(frame.buffer) > 1 else "single-subtree",
+        )
+    )
+    frame.buffer = []
+    frame.buffer_chars = 0
+
+
+def _absorb_descend(
+    frame: _Frame,
+    node: Node,
     lines: Sequence[str],
-    out: list[Slice],
     stats: SliceStats,
 ) -> None:
-    buffer: list[Node] = []
-    buffer_chars = 0
+    """Fold a finished child level back into its parent, prepending its line."""
+    child_slices = frame.descended_out
+    if not child_slices:
+        # Unreachable while every leaf emits, but the partition is the invariant
+        # everything downstream rests on, so it is guaranteed here structurally
+        # rather than argued.
+        child_slices.append(Slice([node.index], node.line, node.depth, "", "ancestor-line"))
+    elif len(node.line) + len(child_slices[0].content) <= HARD_MAX:
+        first = child_slices[0]
+        first.line_indices = [node.index, *first.line_indices]
+        first.content = "\n".join(lines[index] for index in first.line_indices)
+    else:
+        stats.prepend_deferred += 1
+        child_slices.insert(0, Slice([node.index], node.line, node.depth, "", "ancestor-line"))
+    child_slices[0].breadcrumb = breadcrumb_for(frame.ancestors)
+    frame.out.extend(child_slices)
+    frame.descended = None
+    frame.descended_out = []
 
-    def flush() -> None:
-        nonlocal buffer, buffer_chars
-        if not buffer:
-            return
-        indices: list[int] = []
-        for node in buffer:
-            indices.extend(_flatten(node))
-        out.append(
-            Slice(
-                line_indices=indices,
-                content="\n".join(lines[index] for index in indices),
-                cut_depth=buffer[0].depth,
-                breadcrumb=breadcrumb_for(ancestors),
-                reason="multi-subtree" if len(buffer) > 1 else "single-subtree",
-            )
-        )
-        buffer = []
-        buffer_chars = 0
 
-    for node in nodes:
-        size = node.subtree_chars
-        if size > HARD_MAX and node.children:
-            flush()
-            stats.descend_events += 1
-            child_slices: list[Slice] = []
-            _emit(node.children, [*ancestors, node], lines, child_slices, stats)
-            if not child_slices:
-                # Unreachable while every leaf emits, but the partition is the
-                # invariant everything downstream rests on, so it is guaranteed
-                # here structurally rather than argued.
-                child_slices.append(Slice([node.index], node.line, node.depth, "", "ancestor-line"))
-            elif len(node.line) + len(child_slices[0].content) <= HARD_MAX:
-                first = child_slices[0]
-                first.line_indices = [node.index, *first.line_indices]
-                first.content = "\n".join(lines[index] for index in first.line_indices)
-            else:
-                stats.prepend_deferred += 1
-                child_slices.insert(
-                    0,
-                    Slice([node.index], node.line, node.depth, "", "ancestor-line"),
-                )
-            child_slices[0].breadcrumb = breadcrumb_for(ancestors)
-            out.extend(child_slices)
+def _tail_merge(out: list[Slice], lines: Sequence[str], stats: SliceStats) -> None:
+    """Fold a stranded sub-floor tail back into the slice cut beside it."""
+    if len(out) < 2:
+        return
+    last, previous = out[-1], out[-2]
+    if (
+        len(last.content) < TARGET_LO
+        and last.cut_depth == previous.cut_depth
+        and len(previous.content) + len(last.content) + 1 <= HARD_MAX
+    ):
+        previous.line_indices = [*previous.line_indices, *last.line_indices]
+        previous.content = "\n".join(lines[index] for index in previous.line_indices)
+        out.pop()
+        stats.tail_merges += 1
+
+
+def _emit(roots: Sequence[Node], lines: Sequence[str], stats: SliceStats) -> list[Slice]:
+    out: list[Slice] = []
+    stack = [_Frame(nodes=roots, ancestors=[], out=out)]
+    while stack:
+        frame = stack[-1]
+        if frame.descended is not None:
+            _absorb_descend(frame, frame.descended, lines, stats)
             continue
-        if size > HARD_MAX:
-            flush()
-            stats.oversize_leaf += 1
-            out.append(
-                Slice(
-                    [node.index],
-                    node.line,
-                    node.depth,
-                    breadcrumb_for(ancestors),
-                    "oversize-leaf",
+        descending = False
+        while frame.cursor < len(frame.nodes):
+            node = frame.nodes[frame.cursor]
+            frame.cursor += 1
+            size = node.subtree_chars
+            if size > HARD_MAX and node.children:
+                _flush(frame, lines)
+                stats.descend_events += 1
+                frame.descended = node
+                frame.descended_out = []
+                stack.append(
+                    _Frame(
+                        nodes=node.children,
+                        ancestors=[*frame.ancestors, node],
+                        out=frame.descended_out,
+                    )
                 )
-            )
+                descending = True
+                break
+            if size > HARD_MAX:
+                _flush(frame, lines)
+                stats.oversize_leaf += 1
+                frame.out.append(
+                    Slice(
+                        [node.index],
+                        node.line,
+                        node.depth,
+                        breadcrumb_for(frame.ancestors),
+                        "oversize-leaf",
+                    )
+                )
+                continue
+            crosses_band = frame.buffer_chars >= TARGET_LO and frame.buffer_chars + size > TARGET_HI
+            crosses_ceiling = frame.buffer_chars > 0 and frame.buffer_chars + size > HARD_MAX
+            if crosses_band or crosses_ceiling:
+                _flush(frame, lines)
+            frame.buffer.append(node)
+            frame.buffer_chars += size
+        if descending:
             continue
-        crosses_band = buffer_chars >= TARGET_LO and buffer_chars + size > TARGET_HI
-        crosses_ceiling = buffer_chars > 0 and buffer_chars + size > HARD_MAX
-        if crosses_band or crosses_ceiling:
-            flush()
-        buffer.append(node)
-        buffer_chars += size
-    flush()
-    if len(out) >= 2:
-        last, previous = out[-1], out[-2]
-        if (
-            len(last.content) < TARGET_LO
-            and last.cut_depth == previous.cut_depth
-            and len(previous.content) + len(last.content) + 1 <= HARD_MAX
-        ):
-            previous.line_indices = [*previous.line_indices, *last.line_indices]
-            previous.content = "\n".join(lines[index] for index in previous.line_indices)
-            out.pop()
-            stats.tail_merges += 1
+        _flush(frame, lines)
+        _tail_merge(frame.out, lines, stats)
+        stack.pop()
+    return out
 
 
 def slice_body(body: str) -> tuple[list[Slice], SliceStats]:
@@ -277,9 +334,7 @@ def slice_body(body: str) -> tuple[list[Slice], SliceStats]:
     if not body.strip():
         return [], stats
     lines = body.split("\n")
-    out: list[Slice] = []
-    _emit(build_forest(lines), [], lines, out, stats)
-    return out, stats
+    return _emit(build_forest(lines), lines, stats), stats
 
 
 def uri_path(uri: str) -> str:

--- a/packages/python/sibyl-core/src/sibyl_core/projection/slicing.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/slicing.py
@@ -1,0 +1,312 @@
+"""Cut an indented state body into reader-sized passages.
+
+Ported from the A1 Stage 0/1 measurement harness, whose v2 boundary rules
+produced every number the slice-substrate design rests on: zero straddle over
+31,244 (question, phrase, carrier-state) triples, a 3-slice window reaching the
+fat-state exposure ceiling, and a ~950-1,030 char mean slice.
+
+Rules, in the order they fire:
+
+  * cut on the shallowest indent depth whose subtrees land in a 600-1200 char
+    band, packing siblings greedily
+  * band-aware flush: a buffer under the floor keeps growing past TARGET_HI up
+    to HARD_MAX rather than closing short
+  * a subtree above HARD_MAX is descended one level and re-packed, its own line
+    prepended to the first child slice unless the pair would cross HARD_MAX
+  * a childless node above HARD_MAX is emitted whole, because cutting mid-line
+    would bisect a literal
+  * a stranded sub-floor tail is merged back into the slice before it when both
+    were cut at the same depth
+  * slices partition the body lines exactly: every line lands in exactly one
+    slice, in order. The zero straddle rate is a consequence of that partition,
+    not a property of the corpus.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from math import gcd
+from urllib.parse import urlsplit
+
+TARGET_LO = 600
+TARGET_HI = 1200
+HARD_MAX = 2000
+HEADER_MAX_CHARS = 120
+
+_URI_PATH_MAX_CHARS = 48
+_NODE_NAME_MAX_CHARS = 40
+_UNPARSED_LABEL_MAX_CHARS = 24
+
+ACCESSIBILITY_NODE_PATTERN = re.compile(
+    r"^(?:\[[^\]]+\]\s+)?(?P<role>[A-Za-z][\w-]*)\s+"
+    r"(?P<quote>['\"])(?P<name>.*?)(?P=quote)(?P<attributes>,.*)?$"
+)
+_ROLE_ONLY_PATTERN = re.compile(r"^(?:\[[^\]]+\]\s+)?(?P<role>[A-Za-z][\w-]*)\b")
+
+
+@dataclass
+class Node:
+    """A body line and the lines nested under it."""
+
+    index: int
+    depth: int
+    line: str
+    children: list[Node] = field(default_factory=list)
+    subtree_chars: int = 0
+
+
+@dataclass
+class Slice:
+    """A contiguous span of body lines and how it was cut."""
+
+    line_indices: list[int]
+    content: str
+    cut_depth: int
+    breadcrumb: str
+    reason: str
+
+
+@dataclass
+class SliceStats:
+    """Counters for the boundary rules that fired over one body."""
+
+    descend_events: int = 0
+    oversize_leaf: int = 0
+    prepend_deferred: int = 0
+    tail_merges: int = 0
+
+
+def _line_cost(line: str) -> int:
+    return len(line) + 1  # newline
+
+
+def _leading_whitespace(line: str) -> str:
+    return line[: len(line) - len(line.lstrip(" \t"))]
+
+
+def detect_indent_unit(lines: Sequence[str]) -> tuple[str, int]:
+    """Return the indent character and step width a body is written in.
+
+    Callers hand us evidence they did not author. The measured corpus is
+    tab-indented, and deriving depth from a tab count against a space-indented
+    body would land every line at depth 0 and collapse the whole state into one
+    slice, so the unit is detected rather than assumed.
+    """
+    widths: list[int] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        indent = _leading_whitespace(line)
+        if "\t" in indent:
+            return "\t", 1
+        widths.append(len(indent))
+    step = 0
+    for width in widths:
+        step = gcd(step, width)
+    return " ", step or 1
+
+
+def line_depths(lines: Sequence[str]) -> list[int]:
+    """Return the nesting depth of every line. Blank lines inherit the last."""
+    character, step = detect_indent_unit(lines)
+    depths: list[int] = []
+    last_depth = 0
+    for line in lines:
+        if not line.strip():
+            depths.append(last_depth)
+            continue
+        indent = _leading_whitespace(line)
+        if character == "\t":
+            last_depth = len(indent) - len(indent.lstrip("\t"))
+        else:
+            last_depth = len(indent) // step
+        depths.append(last_depth)
+    return depths
+
+
+def build_forest(lines: Sequence[str]) -> list[Node]:
+    """Build the indent forest over a body's lines."""
+    roots: list[Node] = []
+    stack: list[Node] = []
+    for index, depth in enumerate(line_depths(lines)):
+        node = Node(index=index, depth=depth, line=lines[index])
+        while stack and stack[-1].depth >= depth:
+            stack.pop()
+        if stack:
+            stack[-1].children.append(node)
+        else:
+            roots.append(node)
+        stack.append(node)
+    _measure(roots)
+    return roots
+
+
+def _measure(nodes: Sequence[Node]) -> None:
+    for node in nodes:
+        _measure(node.children)
+        node.subtree_chars = _line_cost(node.line) + sum(
+            child.subtree_chars for child in node.children
+        )
+
+
+def _flatten(node: Node) -> list[int]:
+    indices = [node.index]
+    for child in node.children:
+        indices.extend(_flatten(child))
+    return indices
+
+
+def node_label(line: str) -> str:
+    """Render one line as a breadcrumb segment."""
+    stripped = line.strip()
+    match = ACCESSIBILITY_NODE_PATTERN.fullmatch(stripped)
+    if match is not None:
+        name = " ".join(match.group("name").split())
+        role = match.group("role")
+        if name:
+            return f"{role} '{name[:_NODE_NAME_MAX_CHARS]}'"
+        return role
+    role_match = _ROLE_ONLY_PATTERN.match(stripped)
+    if role_match is not None:
+        return role_match.group("role")
+    return stripped[:_UNPARSED_LABEL_MAX_CHARS]
+
+
+def breadcrumb_for(ancestors: Sequence[Node]) -> str:
+    """Join every ancestor above a slice into its context trail.
+
+    Uncapped on purpose: the measured configuration prepends the full chain, and
+    dropping ancestors can only lower per-slice coverage. Capping is a later arm
+    that has to earn its exposure number.
+    """
+    return " > ".join(node_label(node.line) for node in ancestors)
+
+
+def _emit(
+    nodes: Sequence[Node],
+    ancestors: list[Node],
+    lines: Sequence[str],
+    out: list[Slice],
+    stats: SliceStats,
+) -> None:
+    buffer: list[Node] = []
+    buffer_chars = 0
+
+    def flush() -> None:
+        nonlocal buffer, buffer_chars
+        if not buffer:
+            return
+        indices: list[int] = []
+        for node in buffer:
+            indices.extend(_flatten(node))
+        out.append(
+            Slice(
+                line_indices=indices,
+                content="\n".join(lines[index] for index in indices),
+                cut_depth=buffer[0].depth,
+                breadcrumb=breadcrumb_for(ancestors),
+                reason="multi-subtree" if len(buffer) > 1 else "single-subtree",
+            )
+        )
+        buffer = []
+        buffer_chars = 0
+
+    for node in nodes:
+        size = node.subtree_chars
+        if size > HARD_MAX and node.children:
+            flush()
+            stats.descend_events += 1
+            child_slices: list[Slice] = []
+            _emit(node.children, [*ancestors, node], lines, child_slices, stats)
+            if not child_slices:
+                # Unreachable while every leaf emits, but the partition is the
+                # invariant everything downstream rests on, so it is guaranteed
+                # here structurally rather than argued.
+                child_slices.append(Slice([node.index], node.line, node.depth, "", "ancestor-line"))
+            elif len(node.line) + len(child_slices[0].content) <= HARD_MAX:
+                first = child_slices[0]
+                first.line_indices = [node.index, *first.line_indices]
+                first.content = "\n".join(lines[index] for index in first.line_indices)
+            else:
+                stats.prepend_deferred += 1
+                child_slices.insert(
+                    0,
+                    Slice([node.index], node.line, node.depth, "", "ancestor-line"),
+                )
+            child_slices[0].breadcrumb = breadcrumb_for(ancestors)
+            out.extend(child_slices)
+            continue
+        if size > HARD_MAX:
+            flush()
+            stats.oversize_leaf += 1
+            out.append(
+                Slice(
+                    [node.index],
+                    node.line,
+                    node.depth,
+                    breadcrumb_for(ancestors),
+                    "oversize-leaf",
+                )
+            )
+            continue
+        crosses_band = buffer_chars >= TARGET_LO and buffer_chars + size > TARGET_HI
+        crosses_ceiling = buffer_chars > 0 and buffer_chars + size > HARD_MAX
+        if crosses_band or crosses_ceiling:
+            flush()
+        buffer.append(node)
+        buffer_chars += size
+    flush()
+    if len(out) >= 2:
+        last, previous = out[-1], out[-2]
+        if (
+            len(last.content) < TARGET_LO
+            and last.cut_depth == previous.cut_depth
+            and len(previous.content) + len(last.content) + 1 <= HARD_MAX
+        ):
+            previous.line_indices = [*previous.line_indices, *last.line_indices]
+            previous.content = "\n".join(lines[index] for index in previous.line_indices)
+            out.pop()
+            stats.tail_merges += 1
+
+
+def slice_body(body: str) -> tuple[list[Slice], SliceStats]:
+    """Cut a state body into slices that partition its lines exactly."""
+    stats = SliceStats()
+    if not body.strip():
+        return [], stats
+    lines = body.split("\n")
+    out: list[Slice] = []
+    _emit(build_forest(lines), [], lines, out, stats)
+    return out, stats
+
+
+def uri_path(uri: str) -> str:
+    """Reduce a URI to the host label and path a header can afford."""
+    try:
+        parts = urlsplit(uri)
+    except ValueError:
+        return uri[:_URI_PATH_MAX_CHARS]
+    path = parts.path or "/"
+    if len(path) > _URI_PATH_MAX_CHARS:
+        path = path[:22] + "…" + path[-24:]
+    host = parts.netloc.split(".")[0] if parts.netloc else ""
+    return f"{host}{path}" if host else path
+
+
+def slice_header(ordinal: int, uri: str | None, index: int, total: int) -> str:
+    """Render the locator line that opens a slice."""
+    location = uri_path(uri) if uri else ""
+    segments = [f"Observation {ordinal}"]
+    if location:
+        segments.append(location)
+    segments.append(f"slice {index}/{total}")
+    return " · ".join(segments)[:HEADER_MAX_CHARS]
+
+
+def render_slice(header: str, breadcrumb: str, content: str) -> str:
+    """Assemble the text a reader sees for one slice."""
+    if breadcrumb:
+        return f"{header}\n{breadcrumb}\n{content}"
+    return f"{header}\n{content}"

--- a/packages/python/sibyl-core/tests/test_experience_projection.py
+++ b/packages/python/sibyl-core/tests/test_experience_projection.py
@@ -27,7 +27,9 @@ from sibyl_core.projection.experience import (
     MANIFEST_STATE_EMBEDDING_PENDING,
     MANIFEST_STATE_PENDING,
     MAX_RAW_OBSERVATION_DESCRIPTION_CHARS,
+    MAX_TYPED_ENTITY_CONTENT_CHARS,
 )
+from sibyl_core.projection.slicing import slice_body
 
 
 def _experience(*, outcome: str = "success") -> OperationalExperience:
@@ -940,3 +942,61 @@ def test_non_accessibility_evidence_mints_no_passages() -> None:
     assert [
         entity for entity in projection.entities if entity.entity_type is EntityType.PASSAGE
     ] == []
+
+
+def test_passage_names_stay_unique_across_evidence_parts() -> None:
+    body = _accessibility_tree_body()
+    experience = OperationalExperience(
+        source_id="capture-parts",
+        goal="Read both halves of the state",
+        observations=(
+            OperationalObservation(
+                id="state-0",
+                ordinal=0,
+                evidence=tuple(
+                    OperationalEvidencePart(
+                        id=f"tree-{index}",
+                        content=body,
+                        content_type="text/plain; profile=accessibility-tree",
+                    )
+                    for index in range(2)
+                ),
+            ),
+        ),
+    )
+    projection = project_operational_experience(experience)
+    names = [
+        entity.name for entity in projection.entities if entity.entity_type is EntityType.PASSAGE
+    ]
+
+    assert len(names) > 2
+    assert len(set(names)) == len(names)
+
+
+def test_deeply_nested_evidence_keeps_every_passage_by_trimming_the_trail() -> None:
+    depth = 400
+    body = "\n".join(f"{'\t' * level}group 'Level {level} {'x' * 40}'" for level in range(depth))
+    experience = OperationalExperience(
+        source_id="capture-deep",
+        goal="Walk a pathologically nested tree",
+        observations=(
+            OperationalObservation(
+                id="state-0",
+                ordinal=0,
+                evidence=(
+                    OperationalEvidencePart(
+                        id="tree-0",
+                        content=body,
+                        content_type="text/plain; profile=accessibility-tree",
+                    ),
+                ),
+            ),
+        ),
+    )
+    projection = project_operational_experience(experience)
+    passages = [
+        entity for entity in projection.entities if entity.entity_type is EntityType.PASSAGE
+    ]
+
+    assert len(passages) == len(slice_body(body)[0])
+    assert all(len(passage.content or "") <= MAX_TYPED_ENTITY_CONTENT_CHARS for passage in passages)

--- a/packages/python/sibyl-core/tests/test_experience_projection.py
+++ b/packages/python/sibyl-core/tests/test_experience_projection.py
@@ -7,13 +7,14 @@ from unittest.mock import AsyncMock
 import pytest
 from pydantic import ValidationError
 
-from sibyl_core.models import EntityType, RelationshipType
+from sibyl_core.models import Entity, EntityType, RelationshipType
 from sibyl_core.models.experience import (
     MAX_OPERATIONAL_AUXILIARY_JSON_CHARS,
     MAX_OPERATIONAL_EVIDENCE_PART_CHARS,
     MAX_OPERATIONAL_FIELD_CHARS,
     OperationalEvidencePart,
     OperationalExperience,
+    OperationalExperienceProjection,
     OperationalObservation,
 )
 from sibyl_core.projection import (
@@ -87,6 +88,19 @@ def _experience(*, outcome: str = "success") -> OperationalExperience:
     )
 
 
+def _raw_observations(
+    projection: OperationalExperienceProjection,
+    observation_id: str,
+) -> list[Entity]:
+    """Raw evidence rows only: passages carry the same source_observation_id."""
+    return [
+        entity
+        for entity in projection.entities
+        if entity.metadata.get("projection_kind") == "raw_observation"
+        and entity.metadata.get("source_observation_id") == observation_id
+    ]
+
+
 def test_projection_preserves_raw_evidence_and_action_boundaries() -> None:
     projection = project_operational_experience(_experience())
     raw = [entity for entity in projection.entities if entity.entity_type is EntityType.SESSION]
@@ -157,16 +171,8 @@ def test_projection_adds_bounded_state_local_retrieval_descriptions() -> None:
 
     projection = project_operational_experience(projected_experience)
     repeated_projection = project_operational_experience(projected_experience)
-    raw = [
-        entity
-        for entity in projection.entities
-        if entity.metadata.get("source_observation_id") == observation.id
-    ]
-    repeated_raw = [
-        entity
-        for entity in repeated_projection.entities
-        if entity.metadata.get("source_observation_id") == observation.id
-    ]
+    raw = _raw_observations(projection, observation.id)
+    repeated_raw = _raw_observations(repeated_projection, observation.id)
 
     assert [entity.description for entity in raw] == [entity.description for entity in repeated_raw]
     assert "button: Ship Order" in raw[0].description
@@ -832,3 +838,105 @@ async def test_persistence_deletes_only_stale_manifest_owned_records() -> None:
     entity_manager.delete.assert_awaited_once_with("session_stale")
     manifest_write = entity_manager.create_direct_bulk.await_args_list[-1].args[0]
     assert [entity.id for entity in manifest_write] == [projection.manifest.manifest_entity_id]
+
+
+def _accessibility_tree_body() -> str:
+    lines: list[str] = []
+    for section in range(4):
+        lines.append(f"section 'Section {section}'")
+        for group in range(5):
+            lines.append(f"\tgroup 'Group {section}.{group}'")
+            for row in range(5):
+                detail = "detail " * 8
+                lines.append(f"\t\tStaticText 'Row {section}.{group}.{row} {detail}'")
+    return "\n".join(lines)
+
+
+def _tree_experience() -> OperationalExperience:
+    return OperationalExperience(
+        source_id="capture-tree",
+        goal="Find the shipping address on the order",
+        outcome="success",
+        project_id="project-1",
+        observations=(
+            OperationalObservation(
+                id="state-0",
+                ordinal=0,
+                uri="https://shop.example.test/orders/42",
+                action="click('Orders')",
+                evidence=(
+                    OperationalEvidencePart(
+                        id="tree-0",
+                        content=_accessibility_tree_body(),
+                        content_type="text/plain; profile=accessibility-tree",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def test_accessibility_evidence_is_minted_as_passages_beside_the_raw_entity() -> None:
+    experience = _tree_experience()
+    projection = project_operational_experience(experience)
+    raw = [entity for entity in projection.entities if entity.entity_type is EntityType.SESSION]
+    passages = [
+        entity for entity in projection.entities if entity.entity_type is EntityType.PASSAGE
+    ]
+
+    assert len(raw) == 1
+    assert len(passages) > 1
+    assert all(len(entity.content or "") < len(raw[0].content or "") for entity in passages)
+
+    derived = {
+        relationship.source_id: relationship.target_id
+        for relationship in projection.relationships
+        if relationship.relationship_type is RelationshipType.DERIVED_FROM
+    }
+    assert {entity.id for entity in passages} <= derived.keys()
+    assert set(derived.values()) == {raw[0].id}
+
+    manifest_ids = set(projection.manifest.entity_ids)
+    assert {entity.id for entity in passages} <= manifest_ids
+    part_of_targets = {
+        relationship.source_id
+        for relationship in projection.relationships
+        if relationship.relationship_type is RelationshipType.PART_OF
+    }
+    assert {entity.id for entity in passages} <= part_of_targets
+
+
+def test_passages_partition_the_evidence_lines_and_carry_the_goal_out_of_band() -> None:
+    experience = _tree_experience()
+    projection = project_operational_experience(experience)
+    passages = sorted(
+        (entity for entity in projection.entities if entity.entity_type is EntityType.PASSAGE),
+        key=lambda entity: entity.metadata["passage_index"],
+    )
+    body_lines = _accessibility_tree_body().split("\n")
+
+    spans = [
+        (passage.metadata["passage_line_start"], passage.metadata["passage_line_end"])
+        for passage in passages
+    ]
+    covered: list[int] = []
+    for start, end in spans:
+        covered.extend(range(start, end + 1))
+    assert covered == list(range(len(body_lines)))
+    for (start, end), passage in zip(spans, passages, strict=True):
+        assert (passage.content or "").endswith("\n".join(body_lines[start : end + 1]))
+
+    goal = "Find the shipping address on the order"
+    assert all(goal in (passage.description or "") for passage in passages)
+    assert all(goal not in (passage.content or "") for passage in passages)
+    assert all(len(passage.description or "") <= 500 for passage in passages)
+    assert passages[0].metadata["passage_count"] == len(passages)
+    assert passages[0].metadata["parent_entity_id"].startswith("session_")
+
+
+def test_non_accessibility_evidence_mints_no_passages() -> None:
+    projection = project_operational_experience(_experience())
+
+    assert [
+        entity for entity in projection.entities if entity.entity_type is EntityType.PASSAGE
+    ] == []

--- a/packages/python/sibyl-core/tests/test_projection_slicing.py
+++ b/packages/python/sibyl-core/tests/test_projection_slicing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from sibyl_core.projection.slicing import (
@@ -150,3 +152,15 @@ def test_headers_stay_within_the_header_budget_and_drop_a_missing_uri() -> None:
 def test_rendering_omits_an_empty_breadcrumb_line() -> None:
     assert render_slice("head", "", "body") == "head\nbody"
     assert render_slice("head", "trail", "body") == "head\ntrail\nbody"
+
+
+def test_deep_nesting_does_not_exhaust_the_interpreter_stack() -> None:
+    depth = 2_000
+    lines = [f"{'\t' * level}group 'Level {level}'" for level in range(depth)]
+    body = "\n".join(lines)
+
+    slices, stats = slice_body(body)
+
+    assert stats.descend_events > sys.getrecursionlimit()
+    assert _partition(body) == list(range(depth))
+    assert len(slices) > 1

--- a/packages/python/sibyl-core/tests/test_projection_slicing.py
+++ b/packages/python/sibyl-core/tests/test_projection_slicing.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import pytest
+
+from sibyl_core.projection.slicing import (
+    HARD_MAX,
+    detect_indent_unit,
+    line_depths,
+    render_slice,
+    slice_body,
+    slice_header,
+    uri_path,
+)
+
+
+def _accessibility_tree(indent: str = "\t") -> tuple[str, list[int]]:
+    """Render a nested tree deep and wide enough to force descend and packing."""
+    lines: list[str] = []
+    depths: list[int] = []
+    for section in range(6):
+        lines.append(f"section 'Section {section}'")
+        depths.append(0)
+        for group in range(5):
+            lines.append(f"{indent}group 'Group {section}.{group}'")
+            depths.append(1)
+            for row in range(5):
+                detail = "detail " * 8
+                lines.append(f"{indent * 2}StaticText 'Row {section}.{group}.{row} {detail}'")
+                depths.append(2)
+    return "\n".join(lines), depths
+
+
+def _partition(body: str) -> list[int]:
+    slices, _ = slice_body(body)
+    indices: list[int] = []
+    for entry in slices:
+        indices.extend(entry.line_indices)
+    return indices
+
+
+def test_slices_partition_the_body_lines_exactly() -> None:
+    body, _ = _accessibility_tree()
+    line_count = len(body.split("\n"))
+
+    assert _partition(body) == list(range(line_count))
+
+
+def test_partition_holds_when_blank_lines_break_up_the_tree() -> None:
+    body, _ = _accessibility_tree()
+    lines: list[str] = []
+    for index, line in enumerate(body.split("\n")):
+        lines.append(line)
+        if index % 17 == 0:
+            lines.append("")
+
+    assert _partition("\n".join(lines)) == list(range(len(lines)))
+
+
+def test_packing_stays_inside_the_hard_max_unless_a_line_cannot_be_cut() -> None:
+    body, _ = _accessibility_tree()
+    slices, stats = slice_body(body)
+
+    assert len(slices) > 1
+    oversized = [entry for entry in slices if len(entry.content) > HARD_MAX]
+    assert oversized == []
+    assert stats.descend_events > 0
+
+
+def test_a_sub_floor_tail_is_merged_back_into_the_slice_before_it() -> None:
+    body, _ = _accessibility_tree()
+    _, stats = slice_body(body)
+
+    assert stats.tail_merges > 0
+    assert _partition(body) == list(range(len(body.split("\n"))))
+
+
+def test_a_childless_line_above_the_hard_max_is_emitted_whole() -> None:
+    long_line = "StaticText '" + ("x" * (HARD_MAX + 500)) + "'"
+    body = "\n".join(["section 'Section'", f"\t{long_line}", "\tgroup 'Tail'"])
+    slices, stats = slice_body(body)
+
+    assert stats.oversize_leaf == 1
+    whole = next(entry for entry in slices if entry.reason == "oversize-leaf")
+    assert whole.content.strip() == long_line
+    assert _partition(body) == [0, 1, 2]
+
+
+def test_space_indented_bodies_resolve_to_the_same_depths_as_tabs() -> None:
+    tabbed, expected_depths = _accessibility_tree()
+    spaced, _ = _accessibility_tree(indent="  ")
+
+    assert detect_indent_unit(tabbed.split("\n")) == ("\t", 1)
+    assert detect_indent_unit(spaced.split("\n")) == (" ", 2)
+    assert line_depths(tabbed.split("\n")) == expected_depths
+    assert line_depths(spaced.split("\n")) == expected_depths
+
+
+def test_a_space_indented_body_slices_instead_of_collapsing() -> None:
+    spaced, _ = _accessibility_tree(indent="    ")
+    slices, _ = slice_body(spaced)
+
+    assert len(slices) > 1
+    assert _partition(spaced) == list(range(len(spaced.split("\n"))))
+    assert max(entry.cut_depth for entry in slices) > 0
+
+
+def test_an_empty_body_yields_no_slices() -> None:
+    slices, stats = slice_body("   \n\n  ")
+
+    assert slices == []
+    assert stats.descend_events == 0
+
+
+def test_breadcrumbs_name_every_ancestor_above_the_cut() -> None:
+    body, _ = _accessibility_tree()
+    slices, _ = slice_body(body)
+
+    descended = [entry for entry in slices if entry.breadcrumb]
+    assert descended
+    assert descended[0].breadcrumb.startswith("section 'Section ")
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        ("https://shop.example.test/orders/42", "shop/orders/42"),
+        ("https://example.test", "example/"),
+        ("/local/path", "/local/path"),
+    ],
+)
+def test_uri_paths_keep_the_host_label_and_the_path(uri: str, expected: str) -> None:
+    assert uri_path(uri) == expected
+
+
+def test_long_uri_paths_are_elided_in_the_middle() -> None:
+    rendered = uri_path("https://example.test/" + "segment/" * 20)
+
+    assert "…" in rendered
+    assert len(rendered) <= 55
+
+
+def test_headers_stay_within_the_header_budget_and_drop_a_missing_uri() -> None:
+    header = slice_header(4, "https://example.test/orders", 2, 9)
+    assert header == "Observation 4 · example/orders · slice 2/9"
+
+    assert slice_header(4, None, 2, 9) == "Observation 4 · slice 2/9"
+    assert len(slice_header(4, "https://example.test/" + "x" * 400, 2, 9)) <= 120
+
+
+def test_rendering_omits_an_empty_breadcrumb_line() -> None:
+    assert render_slice("head", "", "body") == "head\nbody"
+    assert render_slice("head", "trail", "body") == "head\ntrail\nbody"


### PR DESCRIPTION
# 🔮 Cut states into passages at ingest

**Stacked on #279** (`nova/a1-slice-entity-type`) — review that one first; this branch needs `EntityType.PASSAGE` to exist. Track A1's producer: the substrate now has rows.

## 💡 Why

Sibyl's LongMemEval-V2 payload is eight items of ~12K chars against readers measured to degrade past ~3K retrieved tokens, and the oracle ablation puts format alone at ~23pp. This mints state-boundary spans as `PASSAGE` entities alongside today's fat entities, gated on accessibility-tree evidence so every other content type keeps its exact current behavior.

## 🛠️ What landed

`projection/slicing.py` — the state-body slicer, ported standalone so it tests without the experience models. `projection/experience.py` — passages minted inside the evidence loop right after the fat SESSION entity, each carrying `DERIVED_FROM` to its parent. Schema version 5 → 6.

## ⚠️ It implements the slicer's behavior, not the plan's prose

§4 A1 of the locked plan describes five boundary rules. Two independent reads of the reference slicer found the prose diverges from the code that produced the plan's own numbers, so this implements the code:

- **Band-aware packing ships** — absent from the plan's rule list, yet the single largest change to the size distribution (under-600-char slices 29.5% → 23.8%).
- **The ancestor prepend uses the real combined-size guard**, not the plan's "~400 chars" — `MAX_PREPEND_CHARS` is declared and never referenced anywhere.
- **There is no line-count fallback.** The plan's 0.14%/0% figure is the char-based `oversize_leaf` counter, and this port reproduces it exactly: 114 on enterprise, 0 on web.
- **URL path-extraction is ported as-is** — it was already active in the run that produced these numbers, not pending work.
- **Breadcrumbs ship uncapped.** The plan calls the two-ancestor cap verified; it was never implemented and never oracled — the 3.9% figure is an arithmetic counterfactual, never a re-run of the exposure oracle. Truncating a breadcrumb can only lower per-slice coverage, so capping belongs in a later measured arm.

## 🧪 Port fidelity — checked against the corpus, not just fixtures

\`\`\`
enterprise: states=6387 passages=76990 chars_mean=1031 oversize_leaf=114 (0.148%)
web:        states=4609 passages=61485 chars_mean=1069 oversize_leaf=0
mismatches vs reference: 0
\`\`\`

10,996 states, 138,475 passages, byte-identical line partitions and content against the reference slicer.

**Indent detection** was a required fix, not a nicety: the reference derives depth from tab count, but `/memory/experience` content is caller-supplied and may be space-indented — in which case every node lands at depth 0 and an entire state silently collapses into one passage, defeating the feature while looking like it works. `detect_indent_unit` falls back to a GCD-derived space step, verified to produce **0 depth differences** against the tab rule across all 10,996 corpus states, so the measured configuration is untouched.

Suite:

\`\`\`
core:lint / api:lint / core:typecheck / api:typecheck | All checks passed!
core:test | 1947 passed, 14 skipped in 24.50s
api:test  | 2026 passed, 5 skipped in 29.44s
\`\`\`

The load-bearing test is the **partition invariant**: concatenating passage line indices reproduces `range(len(lines))` exactly. The zero straddle rate is a *consequence* of exact partitioning, not a property of the corpus — if this holds, no gold literal can ever be bisected.

## 🔍 Three defects found and fixed, two by adversarial review

An independent verification agent returned PASS on all claims and found two should-fix defects, both fixed here:

1. **RecursionError at ~995 nesting depth** — a 500 from inside the entity lock, on input the pre-change code handled fine. All three traversals are now iterative. Re-verified at 0 mismatches.
2. **The uncapped breadcrumb ate the content budget**, dropping 26 of 62 in-band passages at depth 400. Trail characters are now truncated before any passage is dropped, so the uncapped-breadcrumb decision stands without the pathological case.

Plus one of my own: **passage names collided across evidence parts** — which is the common case, not an edge case, at 76% enterprise / 80% web of multi-part states.

## 🎯 Decisions made explicit

**Validated-size set:** `PASSAGE` joins it, but only after being made unreachable. An evidence part may legally carry 1,000,000 chars on one unbroken line, and an oversize-leaf emits that line whole — naive validation would turn a capture that ingests today into a 422. Oversize passages are skipped at mint instead; the span stays reachable through its parent.

**Goal-carry bounded to 500 chars**, not the 2,000-char local precedent, because the graph writer mirrors `description[:500]` into the separately BM25-indexed `summary` — so every character counts twice on the lexical side, which is the exact mechanism Stage 1 identified as the poison.

**The context-pack description leak is deliberately not closed here.** All four render paths are confirmed, but closing it changes pack rendering for every entity type carrying a description — Sibyl's own production wake path — and deserves its own measurement. The 500-char bound caps the blast radius meanwhile. Tracked separately.

## 📊 Blast radius

Non-accessibility-tree content is byte-identical modulo the version bump, verified by a full `model_dump` diff across five content types.

**The schema bump is not a migration.** `_manifest_matches_state` compares stored version against current, so 5 → 6 forces full re-projection on next ingest — and there is no backfill scanner anywhere. Replay is re-ingest-triggered only, so a v5 experience stays unsliced until something re-POSTs the same `source_id`. Fine for the gate (the corpus rebuild re-ingests everything); not "old entities get migrated."

**Embedding-backfill payload, measured rather than estimated:** 12.1 (enterprise) / 13.3 (web) passages per accessibility-tree evidence part, so entity count and embedding calls grow **13.1× / 14.3×** while bytes grow only **1.65× / 1.55×** — passages re-carve the same body. It goes to `enqueue_entity_embedding_backfill` as one unchunked job.

## ⏭️ Known-open, not fixed here

- **The reservation trap is still open on the eval side.** Production is pinned to an absolute 3 and test-locked at limits 8/24/28, but `sibyl_memory.py:737` still computes `ceil(max_items * 3/8)` and `--typed-reservation-items` defaults to `None` — so a gate run at `max_items=28` reserves **11** note slots unless the flag is passed. That must be settled before any paid run.
- Passage ids join parts with `:`, so caller-supplied ids containing a colon can collide. Carried over from #279's `_observation_entity_id`, not introduced here.
- Unrun: `web:check`, e2e, and anything against a live SurrealDB — the `EntityType.PASSAGE` schema replay remains unproven against a 3.x server, as #279 says itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accessibility-tree evidence is now split into readable passages while preserving the complete original content.
  * Passages include contextual breadcrumbs, concise headers, and links to their source observations.
  * Deeply nested and large evidence is handled with bounded, stable passage sizes.
  * Operational experience schema version updated to reflect the new passage data.

* **Bug Fixes**
  * Improved handling of indentation, blank lines, oversized entries, and long evidence content.
  * Ensured passage names remain unique and non-accessibility evidence does not create passages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->