### PR TITLE
fix(bench): pin the eval note reservation to an absolute count

### DIFF
--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -37,6 +37,9 @@ from sibyl_core.evals.longmemeval_v2 import (  # noqa: E402
 )
 from sibyl_core.models import EntityType, OperationalExperience  # noqa: E402
 from sibyl_core.projection import project_operational_experience  # noqa: E402
+from sibyl_core.retrieval.operational_evidence import (  # noqa: E402
+    TYPED_NOTE_RESERVATION_ITEMS,
+)
 from sibyl_core.retrieval.query_ranking import (  # noqa: E402
     QueryCoverageCandidate,
     QueryCoverageRankedCandidate,
@@ -734,9 +737,15 @@ def compile_operational_evidence_set(
         raw_candidates,
         pool="raw",
     )
-    default_reservation = max(1, math.ceil(max_items * 3 / 8))
+    # Absolute, not proportional: the note lane was tuned at three items, and
+    # widening it to five lost the whole measured gain. A slice-granular pack
+    # raises `max_items` from 8 to ~28 for reasons unrelated to how many
+    # distilled notes are worth reading, so a ratio here would silently
+    # reserve eleven slots and argue against slicing.
     requested_reservation = (
-        typed_reservation_items if typed_reservation_items is not None else default_reservation
+        typed_reservation_items
+        if typed_reservation_items is not None
+        else TYPED_NOTE_RESERVATION_ITEMS
     )
     typed_reservation = min(len(ranked_typed), max(1, min(requested_reservation, max_items - 1)))
     raw_budget = min(len(ranked_raw), max_items - typed_reservation)

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -3093,6 +3093,63 @@ def test_compile_evidence_honors_typed_reservation_override() -> None:
     assert len(capped_set) == max_items
 
 
+@pytest.mark.parametrize("max_items", [8, 28])
+def test_eval_reserved_lane_is_an_absolute_count_a_wider_pack_cannot_widen(
+    max_items: int,
+) -> None:
+    """A slice-granular pack raises `max_items`; it must not raise the note lane.
+
+    Mirrors the production pin in `sibyl_core.retrieval.operational_evidence`.
+    The proportional law this replaced reserved eleven of twenty-eight slots
+    at slice granularity, and the tuning kill measured that widening as a
+    total loss of the note gain. Both the shipped pack size and the slice
+    pack size are pinned so neither can drift.
+    """
+    module = _load_memory_module()
+    pinned_reservation = 3
+    override_reservation = 5
+    typed = [
+        {
+            "id": f"note_{i}",
+            "type": "note",
+            "content": f"note {i} about the field",
+            "_selection_origin": "context_pack:typed_stream",
+            "metadata": {"longmemeval_v2_trajectory_id": f"t{i}"},
+        }
+        for i in range(12)
+    ]
+    raw = [
+        {"id": f"session_{i}", "type": "session", "content": f"raw slice {i} of the field"}
+        for i in range(40)
+    ]
+
+    selected, meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=max_items,
+        mode="shared_relevance",
+    )
+
+    assert meta["typed_reservation"] == pinned_reservation
+    assert meta["selected_typed_count"] == pinned_reservation
+    assert meta["selected_raw_count"] == max_items - pinned_reservation
+    assert len(selected) == max_items
+
+    override_selected, override_meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=max_items,
+        mode="shared_relevance",
+        typed_reservation_items=override_reservation,
+    )
+
+    assert override_meta["typed_reservation"] == override_reservation
+    assert override_meta["selected_typed_count"] == override_reservation
+    assert len(override_selected) == max_items
+
+
 def test_entity_overlap_downranks_mismatched_notes() -> None:
     module = _load_memory_module()
     query = "Find the warranty expiration for Chelsea-Cynthia Tran-Dyer's laptop"


### PR DESCRIPTION
# 💎 Stop a slice-substrate run from silently reserving 11 note slots

Small diff, and it guards a paid run. Independent of the A1 stack — this can land on its own.

## 💡 Why

The reserved distilled-note lane is the one benchmark-proven retrieval lever the campaign has: **+3.7pp per domain, stable across four independent 3-pass gates.** A prior tuning experiment measured that widening the reservation from 3 to 5 **lost the entire gain (−3.70pp)**. The tuned quantity is the absolute note count, not a fraction of the pack.

Track A1 raises `max_items` from 8 to roughly 28, for reasons that have nothing to do with how many distilled notes are worth reading. Production was already pinned to an absolute 3 and test-locked at limits 8/24/28. **The eval adapter was not:** it computed `ceil(max_items * 3/8)` whenever `--typed-reservation-items` was absent, and that flag defaults to `None`. So a slice-substrate run would have reserved **eleven** note slots.

The cost of not catching this is specific: a domain regate is ~$5 and a full-451 run ~$10, so it burns a paid run *and* returns a number that argues against slicing — which the plan doc explicitly warns would be misdiagnosed as a slice failure rather than a reservation bug.

## 🛠️ What changed

`compile_operational_evidence_set` now falls back to `TYPED_NOTE_RESERVATION_ITEMS` imported from production instead of recomputing a ratio. The constant lives in exactly one place, so the two sides cannot drift apart again.

`--typed-reservation-items` deliberately keeps `default=None`. `None` now resolves to the production pin, which is what keeps the value single-sourced; making the CLI default a literal `3` would have re-created the duplication this fixes. The explicit-override path is untouched, since tuning arms need it.

The production constant imports cleanly — the adapter already prepends `sibyl-core/src` to `sys.path` and imports four other `sibyl_core` modules, and `operational_evidence.py` itself imports only `typing`, so this pulls in no weight.

## 🧪 Validation

**The test was verified non-vacuous by mutation**, which matters more than it passing. Restoring the old expression and re-running:

\`\`\`
>       assert meta["typed_reservation"] == 3
E       assert 11 == 3
FAILED ...test_eval_reserved_lane_is_an_absolute_count_a_wider_pack_cannot_widen[28]
================= 1 failed, 1 passed, 362 deselected in 0.69s ==================
\`\`\`

⚠️ **Note which case passed against the buggy code.** At `max_items = 8`, `ceil(8 × 3/8)` is 3 — identical to the pin. **The defect was invisible at the shipped pack size and only appears once the pack widens.** That is why it survived this long, and it is why the new test is parametrized at both 8 and 28 rather than just the interesting one: agreement at the current configuration is not evidence the law is right.

With the fix:

\`\`\`
test_compile_evidence_honors_typed_reservation_override PASSED
test_eval_reserved_lane_is_an_absolute_count_a_wider_pack_cannot_widen[8]  PASSED
test_eval_reserved_lane_is_an_absolute_count_a_wider_pack_cannot_widen[28] PASSED
============================= 364 passed in 7.64s =============================
▮▮▮▮ root:bench-gate-test (11s 591ms)
\`\`\`

`moon run inventory-lint inventory-typecheck` both green.

## 🔍 Scope check

Grepped `3 / 8`, `3/8`, and `ceil(` across `benchmarks/` and `tools/`: no other site duplicates the ratio. The five other hits are percentile interpolation, byte-repetition sizing, and token estimation — none reservation-related. The single call path that reaches the default (`SibylLiveApiMemory.__init__` → `self.typed_reservation_items`) passes `None` straight through, so this one change covers the whole chain.

## 📎 Follow-up, not fixed here

`docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md:328` still says *both* the adapter and production compute the lane as a ratio. That sentence is stale on both halves now. It belongs to the plan-amendment branch, which is already correcting several other claims in that section, so it is being fixed there rather than in a conflicting edit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)