### PR TITLE
feat(retrieval): bound evidence by characters and window adjacent passages

### DIFF
--- a/apps/api/src/sibyl/api/context_source_expansion.py
+++ b/apps/api/src/sibyl/api/context_source_expansion.py
@@ -85,6 +85,7 @@ async def expand_operational_source_evidence(
             "expected_entity_count": outcome.expected_entity_count,
             "loaded_entity_count": outcome.loaded_entity_count,
             "raw_observation_count": len(outcome.raw_observations),
+            "passage_count": outcome.passage_count,
             "memory_scope": outcome.memory_scope,
         }
         receipt["sources"].append(source_receipt)
@@ -104,6 +105,7 @@ async def expand_operational_source_evidence(
                 "ranking_applied": span.ranking_applied,
                 "selected_observation_ordinals": list(span.observation_ordinals),
                 "selected_entity_ids": [entity.id for entity in span.entities],
+                "selected_passage_count": span.passage_count,
             }
         )
         if not span.entities:

--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -181,12 +181,14 @@ def _compose_context_evidence_response(
     *,
     limit: int,
     typed_error: str | None,
+    char_budget: int | None = None,
 ) -> SearchResponse:
     typed_results = typed_response.results if typed_response is not None else []
     selected, receipt = compose_operational_evidence(
         typed_results=typed_results,
         raw_results=raw_response.results,
         limit=limit,
+        char_budget=char_budget,
     )
     receipt.update(
         {
@@ -760,6 +762,7 @@ async def _compile_context_with_evidence(
             typed_response,
             limit=request.evidence.limit,
             typed_error=typed_error,
+            char_budget=request.evidence.char_budget,
         )
         if request.record_exposure:
             from sibyl_core.tools.usage_exposure import annotate_search_result_exposures

--- a/apps/api/src/sibyl/api/schemas/context.py
+++ b/apps/api/src/sibyl/api/schemas/context.py
@@ -18,6 +18,14 @@ class ContextEvidenceRequest(BaseModel):
         description="Entity types to include in the evidence pool",
     )
     limit: int = Field(default=24, ge=1, le=50, description="Maximum evidence results")
+    char_budget: int | None = Field(
+        default=None,
+        ge=1,
+        le=500_000,
+        description=(
+            "Bound composed evidence by characters of returned content instead of item count"
+        ),
+    )
     max_results_per_source: int | None = Field(
         default=None,
         ge=1,

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_evidence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_evidence.py
@@ -38,8 +38,8 @@ def compose_operational_evidence[ResultT: OperationalEvidenceResult](
     """Reserve a fixed count of output slots for independently ranked notes.
 
     The reservation is absolute rather than proportional; see
-    `TYPED_NOTE_RESERVATION_ITEMS`. Small packs still shrink it, because a
-    reservation may never consume the whole pack.
+    `TYPED_NOTE_RESERVATION_ITEMS`. Under an item budget a small pack still
+    shrinks it, because a reservation may never consume the whole pack.
 
     `char_budget` changes what bounds the pack. An item count only bounds
     payload while item size is stable, and a passage is roughly a twelfth of the
@@ -50,7 +50,9 @@ def compose_operational_evidence[ResultT: OperationalEvidenceResult](
     the ranking and never exceeds the budget. The note lane stays pinned at its
     absolute count within that budget, but the budget outranks the pin — a
     budget too small for three notes returns fewer, because a hard budget that
-    one lane can overrun is not a budget.
+    one lane can overrun is not a budget. By the same token a budget that only
+    the notes fit into returns an all-note pack: characters, not slot counts,
+    are what a budgeted pack holds back for the raw lane.
     """
     if char_budget is not None and char_budget < 1:
         raise ValueError("char_budget must be positive")

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_evidence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_evidence.py
@@ -15,6 +15,7 @@ TYPED_NOTE_RESERVATION_ITEMS = 3
 class OperationalEvidenceResult(Protocol):
     id: str
     type: str
+    content: str
     metadata: dict[str, Any]
 
 
@@ -32,13 +33,27 @@ def compose_operational_evidence[ResultT: OperationalEvidenceResult](
     raw_results: list[ResultT],
     limit: int,
     typed_reservation_items: int = TYPED_NOTE_RESERVATION_ITEMS,
+    char_budget: int | None = None,
 ) -> tuple[list[ResultT], dict[str, Any]]:
     """Reserve a fixed count of output slots for independently ranked notes.
 
     The reservation is absolute rather than proportional; see
     `TYPED_NOTE_RESERVATION_ITEMS`. Small packs still shrink it, because a
     reservation may never consume the whole pack.
+
+    `char_budget` changes what bounds the pack. An item count only bounds
+    payload while item size is stable, and a passage is roughly a twelfth of the
+    state it was cut from, so the same `limit` means two very different reader
+    payloads on the two substrates. Pass a budget in characters and item count
+    stops bounding the lanes: candidates are admitted in rank order while the
+    running total of returned content fits, so the pack is always a prefix of
+    the ranking and never exceeds the budget. The note lane stays pinned at its
+    absolute count within that budget, but the budget outranks the pin — a
+    budget too small for three notes returns fewer, because a hard budget that
+    one lane can overrun is not a budget.
     """
+    if char_budget is not None and char_budget < 1:
+        raise ValueError("char_budget must be positive")
     output_limit = max(1, limit)
     typed_candidates: list[ResultT] = []
     raw_candidates: list[ResultT] = []
@@ -67,23 +82,45 @@ def compose_operational_evidence[ResultT: OperationalEvidenceResult](
         seen_ids.add(result.id)
 
     reservation_target = max(1, typed_reservation_items)
-    typed_reservation = min(
-        len(typed_candidates),
-        max(1, min(reservation_target, output_limit - 1)),
-    )
-    raw_budget = min(len(raw_candidates), output_limit - typed_reservation)
-    selected = [
-        *typed_candidates[:typed_reservation],
-        *raw_candidates[:raw_budget],
-    ]
-    typed_overflow_count = min(
-        len(typed_candidates) - typed_reservation,
-        output_limit - len(selected),
-    )
-    if typed_overflow_count:
-        selected.extend(
-            typed_candidates[typed_reservation : typed_reservation + typed_overflow_count]
+    if char_budget is None:
+        typed_reservation = min(
+            len(typed_candidates),
+            max(1, min(reservation_target, output_limit - 1)),
         )
+        raw_budget = min(len(raw_candidates), output_limit - typed_reservation)
+        selected = [
+            *typed_candidates[:typed_reservation],
+            *raw_candidates[:raw_budget],
+        ]
+        typed_overflow_count = min(
+            len(typed_candidates) - typed_reservation,
+            output_limit - len(selected),
+        )
+        if typed_overflow_count:
+            selected.extend(
+                typed_candidates[typed_reservation : typed_reservation + typed_overflow_count]
+            )
+        selected_chars = sum(_result_chars(result) for result in selected)
+    else:
+        reserved, spent = _admit_within_budget(
+            typed_candidates[:reservation_target],
+            budget=char_budget,
+            spent=0,
+        )
+        raw_selection, spent = _admit_within_budget(
+            raw_candidates,
+            budget=char_budget,
+            spent=spent,
+        )
+        overflow, spent = _admit_within_budget(
+            typed_candidates[len(reserved) :],
+            budget=char_budget,
+            spent=spent,
+        )
+        typed_reservation = len(reserved)
+        typed_overflow_count = len(overflow)
+        selected = [*reserved, *raw_selection, *overflow]
+        selected_chars = spent
 
     selected_typed_count = typed_reservation + typed_overflow_count
     return selected, {
@@ -98,8 +135,38 @@ def compose_operational_evidence[ResultT: OperationalEvidenceResult](
         "selected_typed_count": selected_typed_count,
         "selected_raw_count": len(selected) - selected_typed_count,
         "output_limit": output_limit,
+        "budget_mode": "items" if char_budget is None else "characters",
+        "char_budget": char_budget,
+        "selected_chars": selected_chars,
         "pool_calibration": "independent_search_ranking",
     }
+
+
+def _result_chars(result: OperationalEvidenceResult) -> int:
+    return len(result.content or "")
+
+
+def _admit_within_budget[ResultT: OperationalEvidenceResult](
+    candidates: list[ResultT],
+    *,
+    budget: int,
+    spent: int,
+) -> tuple[list[ResultT], int]:
+    """Take the longest rank prefix of `candidates` that still fits.
+
+    Admission stops at the first candidate that does not fit rather than
+    skipping it for a smaller one further down. Packing by size would reorder
+    relevance against length and cost the guarantee that a pack is a prefix of
+    its ranking, which is what makes exposure reasoning about the pack hold.
+    """
+    admitted: list[ResultT] = []
+    for candidate in candidates:
+        candidate_chars = _result_chars(candidate)
+        if spent + candidate_chars > budget:
+            break
+        admitted.append(candidate)
+        spent += candidate_chars
+    return admitted, spent
 
 
 __all__ = [

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py
@@ -300,16 +300,13 @@ def select_operational_source_span(
             ranking_applied=False,
         )
 
-    sliced = bool(inventory.passage_count)
     observation_groups = _unit_groups(inventory.raw_observations)
     entity_terms, group_terms = _source_discriminative_terms(observation_groups)
     query_terms = frozenset(extract_keywords(query))
     query_term_weights = _query_term_weights(query_terms, group_terms)
-    window_size = PASSAGE_WINDOW_UNITS if sliced else max_observations
     candidate_windows = _candidate_windows(
         observation_groups,
-        window_size=window_size,
-        confine_to_evidence_part=sliced,
+        max_observations=max_observations,
     )
     selected_start, selected_size = max(
         candidate_windows,
@@ -326,7 +323,8 @@ def select_operational_source_span(
     # A partial window is the regression the window exists to avoid, so a
     # caller's item allowance may shrink the pack but never cut the window
     # itself below the adjacency that was measured.
-    entity_budget = max(max_entities, selected_size) if sliced else max_entities
+    selected_is_sliced = any(_is_passage(entity) for group in selected_window for entity in group)
+    entity_budget = max(max_entities, selected_size) if selected_is_sliced else max_entities
     selected_entities = _select_window_entities(
         selected_window,
         max_entities=entity_budget,
@@ -397,37 +395,46 @@ def _unit_groups(units: Sequence[Entity]) -> list[tuple[Entity, ...]]:
     return [tuple(group) for group in groups]
 
 
+def _run_key(entity: Entity) -> tuple[int, int] | None:
+    """Say which stretch of groups one window may slide within.
+
+    Passages key on the body they were cut from, so a window cannot cross into
+    another: three passages spanning two states are contiguous in source order
+    but are not the adjacency the exposure measurement is about. Whole-part rows
+    all key alike, because sliding across observations is the adjacency that
+    shape has always had, and a source that slices one part must not narrow the
+    windows of the parts it left whole.
+    """
+    return _required_observation_position(entity)[:2] if _is_passage(entity) else None
+
+
 def _candidate_windows(
     groups: Sequence[tuple[Entity, ...]],
     *,
-    window_size: int,
-    confine_to_evidence_part: bool,
+    max_observations: int,
 ) -> list[tuple[int, int]]:
     """Enumerate admissible (start, size) windows over the group list.
 
-    Passage windows may not cross an evidence part: three passages spanning two
-    states are contiguous in source order but are not the adjacency the
-    exposure measurement is about. A part with fewer passages than the window
-    size yields one short window rather than none, which is what keeps a short
-    body and an unsliced part in a mixed source reachable at all.
+    Each run is sized by what it holds: passages by the measured adjacency,
+    whole-part rows by what the caller asked for. A run shorter than its own
+    window yields one short window rather than none, which is what keeps a
+    two-passage body and a lone unsliced part reachable at all.
     """
-    runs = _evidence_part_runs(groups) if confine_to_evidence_part else [(0, len(groups))]
     windows: list[tuple[int, int]] = []
-    for run_start, run_stop in runs:
+    for run_start, run_stop in _window_runs(groups):
+        window_size = (
+            PASSAGE_WINDOW_UNITS if _is_passage(groups[run_start][0]) else max_observations
+        )
         size = min(window_size, run_stop - run_start)
         windows.extend((start, size) for start in range(run_start, run_stop - size + 1))
     return windows
 
 
-def _evidence_part_runs(groups: Sequence[tuple[Entity, ...]]) -> list[tuple[int, int]]:
+def _window_runs(groups: Sequence[tuple[Entity, ...]]) -> list[tuple[int, int]]:
     runs: list[tuple[int, int]] = []
     start = 0
     for index in range(1, len(groups) + 1):
-        if (
-            index == len(groups)
-            or _required_observation_position(groups[index][0])[:2]
-            != _required_observation_position(groups[start][0])[:2]
-        ):
+        if index == len(groups) or _run_key(groups[index][0]) != _run_key(groups[start][0]):
             runs.append((start, index))
             start = index
     return runs

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, Protocol
@@ -14,6 +13,17 @@ from sibyl_core.auth.memory_policy import (
 from sibyl_core.models.entities import Entity, EntityType
 from sibyl_core.projection import MANIFEST_STATE_COMPLETE, operational_experience_manifest_id
 from sibyl_core.retrieval.query_ranking import extract_keywords
+
+PASSAGE_PROJECTION_KIND = "passage"
+RAW_OBSERVATION_PROJECTION_KIND = "raw_observation"
+_UNIT_PROJECTION_KINDS = frozenset({PASSAGE_PROJECTION_KIND, RAW_OBSERVATION_PROJECTION_KIND})
+
+# A passage is roughly a twelfth of the state it was cut from, so a single one
+# carries the gold less often than the whole state did. Three adjacent passages
+# close that gap exactly: the offline oracle scored 95.5% enterprise / 100% web
+# exposure for a 3-adjacent window against 95.5% / 100% for the whole state,
+# where a lone passage reached only 93.2% / 97.9%.
+PASSAGE_WINDOW_UNITS = 3
 
 OperationalSourceStatus = Literal[
     "complete",
@@ -35,6 +45,13 @@ class OperationalSourceEntityReader(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class OperationalSourceInventory:
+    """One source's ordered retrieval units.
+
+    `raw_observations` holds the finest unit each evidence part offers: the
+    passages cut from it when it was sliced, and the whole-part row when it was
+    not. `passage_count` says how many of those units are passages.
+    """
+
     source_id: str
     manifest_id: str
     status: OperationalSourceStatus
@@ -44,6 +61,7 @@ class OperationalSourceInventory:
     memory_scope: str | None = None
     project_id: str | None = None
     scope_key: str | None = None
+    passage_count: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,6 +71,7 @@ class OperationalSourceSpan:
     observation_ordinals: tuple[int, ...]
     candidate_window_count: int
     ranking_applied: bool
+    passage_count: int = 0
 
 
 async def fetch_operational_source_inventory(
@@ -222,10 +241,12 @@ async def fetch_operational_source_inventory(
             scope_key=scope_key,
         )
 
-    raw_observations = [
-        entity for entity in entities if entity.metadata.get("projection_kind") == "raw_observation"
+    projected = [
+        entity
+        for entity in entities
+        if entity.metadata.get("projection_kind") in _UNIT_PROJECTION_KINDS
     ]
-    if any(_observation_position(entity) is None for entity in raw_observations):
+    if any(_observation_position(entity) is None for entity in projected):
         return _inventory(
             normalized_source_id,
             manifest_id,
@@ -236,17 +257,19 @@ async def fetch_operational_source_inventory(
             project_id=project_id,
             scope_key=scope_key,
         )
-    raw_observations.sort(key=lambda entity: (*_required_observation_position(entity), entity.id))
+    units = _finest_granularity_units(projected)
+    units.sort(key=lambda entity: (*_required_observation_position(entity), entity.id))
     return _inventory(
         normalized_source_id,
         manifest_id,
         "complete",
-        raw_observations=tuple(raw_observations),
+        raw_observations=tuple(units),
         expected_entity_count=len(expected_ids),
         loaded_entity_count=len(entities),
         memory_scope=memory_scope,
         project_id=project_id,
         scope_key=scope_key,
+        passage_count=sum(_is_passage(entity) for entity in units),
     )
 
 
@@ -257,7 +280,15 @@ def select_operational_source_span(
     max_observations: int = 4,
     max_entities: int = 6,
 ) -> OperationalSourceSpan:
-    """Select the strongest contiguous observation window and preserve source order."""
+    """Select the best-scoring contiguous window of units and preserve source order.
+
+    The guarantee here is *best-scoring*, not *containing the answer*: the
+    window is picked by query-term coverage over the source's own
+    discriminative vocabulary. The offline oracle that measured a 3-adjacent
+    passage window at the whole-state exposure ceiling measured window
+    **existence** — that some window carries the gold — which no ranked
+    selection inherits.
+    """
     if max_observations < 1 or max_entities < 1:
         raise ValueError("span limits must be positive")
     if inventory.status != "complete" or not inventory.raw_observations:
@@ -269,31 +300,36 @@ def select_operational_source_span(
             ranking_applied=False,
         )
 
-    grouped: dict[int, list[Entity]] = defaultdict(list)
-    for entity in inventory.raw_observations:
-        position = _required_observation_position(entity)
-        grouped[position[0]].append(entity)
-    observation_groups = [tuple(grouped[ordinal]) for ordinal in sorted(grouped)]
+    sliced = bool(inventory.passage_count)
+    observation_groups = _unit_groups(inventory.raw_observations)
     entity_terms, group_terms = _source_discriminative_terms(observation_groups)
     query_terms = frozenset(extract_keywords(query))
     query_term_weights = _query_term_weights(query_terms, group_terms)
-    window_size = min(max_observations, len(observation_groups))
-    candidate_window_count = len(observation_groups) - window_size + 1
-    selected_start = max(
-        range(candidate_window_count),
-        key=lambda start: (
+    window_size = PASSAGE_WINDOW_UNITS if sliced else max_observations
+    candidate_windows = _candidate_windows(
+        observation_groups,
+        window_size=window_size,
+        confine_to_evidence_part=sliced,
+    )
+    selected_start, selected_size = max(
+        candidate_windows,
+        key=lambda window: (
             *_window_coverage_score(
                 query_terms,
-                group_terms[start : start + window_size],
+                group_terms[window[0] : window[0] + window[1]],
                 query_term_weights,
             ),
-            -_required_observation_position(observation_groups[start][0])[0],
+            -_required_observation_position(observation_groups[window[0]][0])[0],
         ),
     )
-    selected_window = tuple(observation_groups[selected_start : selected_start + window_size])
+    selected_window = tuple(observation_groups[selected_start : selected_start + selected_size])
+    # A partial window is the regression the window exists to avoid, so a
+    # caller's item allowance may shrink the pack but never cut the window
+    # itself below the adjacency that was measured.
+    entity_budget = max(max_entities, selected_size) if sliced else max_entities
     selected_entities = _select_window_entities(
         selected_window,
-        max_entities=max_entities,
+        max_entities=entity_budget,
         entity_terms=entity_terms,
         query_terms=query_terms,
         query_term_weights=query_term_weights,
@@ -304,8 +340,11 @@ def select_operational_source_span(
         observation_ordinals=tuple(
             dict.fromkeys(_required_observation_position(entity)[0] for entity in selected_entities)
         ),
-        candidate_window_count=candidate_window_count,
-        ranking_applied=candidate_window_count > 1 and selected_start != 0,
+        candidate_window_count=len(candidate_windows),
+        ranking_applied=(
+            len(candidate_windows) > 1 and (selected_start, selected_size) != candidate_windows[0]
+        ),
+        passage_count=sum(_is_passage(entity) for entity in selected_entities),
     )
 
 
@@ -314,7 +353,106 @@ def operational_observation_signal_text(entity: Entity) -> str:
     return "\n".join(_operational_observation_signal_lines(entity))
 
 
+def _is_passage(entity: Entity) -> bool:
+    return entity.metadata.get("projection_kind") == PASSAGE_PROJECTION_KIND
+
+
+def _finest_granularity_units(entities: list[Entity]) -> list[Entity]:
+    """Keep the finest unit each evidence part offers.
+
+    A passage and the evidence part it was cut from carry the same text, so
+    admitting both would make one window pay twice for one state. Parts that
+    were never sliced have only their whole-part row to offer and keep it.
+    """
+    sliced_parts = {
+        _required_observation_position(entity)[:2] for entity in entities if _is_passage(entity)
+    }
+    return [
+        entity
+        for entity in entities
+        if _is_passage(entity) or _required_observation_position(entity)[:2] not in sliced_parts
+    ]
+
+
+def _group_key(entity: Entity) -> tuple[int, ...]:
+    position = _required_observation_position(entity)
+    return position if _is_passage(entity) else position[:1]
+
+
+def _unit_groups(units: Sequence[Entity]) -> list[tuple[Entity, ...]]:
+    """Group ordered units into the stops a window slides over.
+
+    Every evidence part of one unsliced observation shares a stop, which is the
+    whole-state granularity that shape has always been windowed at. A passage is
+    its own stop, so a window of three groups is three adjacent passages.
+    """
+    groups: list[list[Entity]] = []
+    previous_key: tuple[int, ...] | None = None
+    for entity in units:
+        key = _group_key(entity)
+        if key != previous_key:
+            groups.append([])
+            previous_key = key
+        groups[-1].append(entity)
+    return [tuple(group) for group in groups]
+
+
+def _candidate_windows(
+    groups: Sequence[tuple[Entity, ...]],
+    *,
+    window_size: int,
+    confine_to_evidence_part: bool,
+) -> list[tuple[int, int]]:
+    """Enumerate admissible (start, size) windows over the group list.
+
+    Passage windows may not cross an evidence part: three passages spanning two
+    states are contiguous in source order but are not the adjacency the
+    exposure measurement is about. A part with fewer passages than the window
+    size yields one short window rather than none, which is what keeps a short
+    body and an unsliced part in a mixed source reachable at all.
+    """
+    runs = _evidence_part_runs(groups) if confine_to_evidence_part else [(0, len(groups))]
+    windows: list[tuple[int, int]] = []
+    for run_start, run_stop in runs:
+        size = min(window_size, run_stop - run_start)
+        windows.extend((start, size) for start in range(run_start, run_stop - size + 1))
+    return windows
+
+
+def _evidence_part_runs(groups: Sequence[tuple[Entity, ...]]) -> list[tuple[int, int]]:
+    runs: list[tuple[int, int]] = []
+    start = 0
+    for index in range(1, len(groups) + 1):
+        if (
+            index == len(groups)
+            or _required_observation_position(groups[index][0])[:2]
+            != _required_observation_position(groups[start][0])[:2]
+        ):
+            runs.append((start, index))
+            start = index
+    return runs
+
+
+def _passage_signal_lines(entity: Entity) -> list[str]:
+    """Treat a passage's whole body as signal, minus its locator line.
+
+    A passage is already free of the source-wide preamble the whole-part rows
+    repeat, so nothing needs stripping from the body. The locator the renderer
+    prepends does need dropping: it restates the observation and the passage's
+    own position, which every passage of a body repeats with a different
+    number, so the shared-line filter would let it through as discriminative
+    vocabulary it is not. The URI comes from metadata instead, matching what
+    the whole-part shape contributes.
+    """
+    uri = entity.metadata.get("uri")
+    lines = [uri] if isinstance(uri, str) and uri else []
+    lines.extend(line.strip() for line in (entity.content or "").splitlines()[1:])
+    return [line for line in lines if line]
+
+
 def _operational_observation_signal_lines(entity: Entity) -> list[str]:
+    if _is_passage(entity):
+        return _passage_signal_lines(entity)
     lines: list[str] = []
     in_evidence = False
     for raw_line in (entity.content or entity.description).splitlines():
@@ -444,22 +582,32 @@ def _weighted_term_match(
     return sum(query_term_weights[term] for term in terms & query_terms)
 
 
-def _observation_position(entity: Entity) -> tuple[int, int] | None:
-    ordinal = entity.metadata.get("observation_ordinal")
-    part_index = entity.metadata.get("evidence_part_index")
-    if (
-        isinstance(ordinal, bool)
-        or not isinstance(ordinal, int)
-        or isinstance(part_index, bool)
-        or not isinstance(part_index, int)
-        or ordinal < 0
-        or part_index < 0
-    ):
+def _ordering_index(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         return None
-    return ordinal, part_index
+    return value
 
 
-def _required_observation_position(entity: Entity) -> tuple[int, int]:
+def _observation_position(entity: Entity) -> tuple[int, int, int] | None:
+    """Order a unit by observation, then evidence part, then position within it.
+
+    A whole evidence part and the passages cut from it never coexist as units
+    for the same part, so an unsliced part takes passage slot 0 without ever
+    colliding with a passage.
+    """
+    ordinal = _ordering_index(entity.metadata.get("observation_ordinal"))
+    part_index = _ordering_index(entity.metadata.get("evidence_part_index"))
+    if ordinal is None or part_index is None:
+        return None
+    if not _is_passage(entity):
+        return ordinal, part_index, 0
+    passage_index = _ordering_index(entity.metadata.get("passage_index"))
+    if passage_index is None:
+        return None
+    return ordinal, part_index, passage_index
+
+
+def _required_observation_position(entity: Entity) -> tuple[int, int, int]:
     position = _observation_position(entity)
     if position is None:
         raise ValueError(f"operational observation {entity.id} has invalid ordering metadata")
@@ -484,6 +632,7 @@ def _inventory(
     memory_scope: str | None = None,
     project_id: str | None = None,
     scope_key: str | None = None,
+    passage_count: int = 0,
 ) -> OperationalSourceInventory:
     return OperationalSourceInventory(
         source_id=source_id,
@@ -495,10 +644,14 @@ def _inventory(
         memory_scope=memory_scope,
         project_id=project_id,
         scope_key=scope_key,
+        passage_count=passage_count,
     )
 
 
 __all__ = [
+    "PASSAGE_PROJECTION_KIND",
+    "PASSAGE_WINDOW_UNITS",
+    "RAW_OBSERVATION_PROJECTION_KIND",
     "OperationalSourceEntityReader",
     "OperationalSourceInventory",
     "OperationalSourceSpan",

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -59,6 +59,14 @@ type RawMemoryRecallFn = Callable[..., Awaitable[list[RawMemory] | RawMemoryReca
 DEFAULT_FILTER_SELECTIVITY_THRESHOLD = 0.1
 EDGE_FULLTEXT_MATCH_HEADROOM = 8
 EDGE_FULLTEXT_MIN_MATCH_LIMIT = 32
+# Ceiling on candidates any one lane contributes, however large the caller's
+# `limit` is. This is a seed-diversity budget rather than a payload budget: on a
+# whole-state substrate each candidate is a distinct state, while on a passage
+# substrate several candidates can be cuts of one state, so the distinct sources
+# a lane can reach shrinks as the retrieval unit shrinks. Raising it widens the
+# fulltext and HNSW read on every lane for every caller, so it belongs to a
+# measured arm rather than to whichever substrate landed most recently.
+MAX_CANDIDATES_PER_SIGNAL = 8
 _ACTIVE_TASK_STATUSES = {"doing", "in_progress", "review"}
 _RAW_MEMORY_CONTEXT_TYPES = {"raw_memory", "session", "episode", "note"}
 _EDGE_CONTEXT_TYPES = {"claim", "relationship"}
@@ -300,7 +308,7 @@ def build_context_retrieval_plan(
             )
         )
 
-    per_signal_limit = max(2, min(8, limit))
+    per_signal_limit = max(2, min(MAX_CANDIDATES_PER_SIGNAL, limit))
     facet_types_by_facet = {facet: tuple(facet_types.get(facet, ())) for facet in facets}
     return RetrievalPlan(
         query=query,
@@ -310,7 +318,7 @@ def build_context_retrieval_plan(
         scopes=tuple(scopes),
         denied_scopes=tuple(denied_scopes),
         candidate_limits=CandidateLimits(
-            raw_lexical=max(1, min(8, limit // 4 or 1)),
+            raw_lexical=max(1, min(MAX_CANDIDATES_PER_SIGNAL, limit // 4 or 1)),
             node_fulltext=per_signal_limit,
             episode_fulltext=per_signal_limit,
             edge_fulltext=per_signal_limit,

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -161,12 +161,12 @@ class RetrievalWeights:
 @dataclass(frozen=True, slots=True)
 class CandidateLimits:
     raw_lexical: int = 4
-    node_fulltext: int = 8
-    episode_fulltext: int = 8
-    edge_fulltext: int = 8
-    node_vector: int = 8
-    edge_vector: int = 8
-    graph_expansion: int = 8
+    node_fulltext: int = MAX_CANDIDATES_PER_SIGNAL
+    episode_fulltext: int = MAX_CANDIDATES_PER_SIGNAL
+    edge_fulltext: int = MAX_CANDIDATES_PER_SIGNAL
+    node_vector: int = MAX_CANDIDATES_PER_SIGNAL
+    edge_vector: int = MAX_CANDIDATES_PER_SIGNAL
+    graph_expansion: int = MAX_CANDIDATES_PER_SIGNAL
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/python/sibyl-core/tests/test_operational_evidence.py
+++ b/packages/python/sibyl-core/tests/test_operational_evidence.py
@@ -12,6 +12,7 @@ def _result(
     result_type: str = "session",
     source_id: str | None = None,
     distilled: bool = False,
+    content_chars: int | None = None,
 ) -> SearchResult:
     metadata = {"operational_source_id": source_id} if source_id else {}
     if distilled:
@@ -20,7 +21,7 @@ def _result(
         id=result_id,
         type=result_type,
         name=result_id,
-        content=result_id,
+        content=result_id if content_chars is None else "x" * content_chars,
         score=1.0,
         metadata=metadata,
     )
@@ -151,3 +152,112 @@ def test_reserved_lane_backfills_sparse_pools_without_cross_pool_score_compariso
         "note-e",
     ]
     assert raw_receipt["selected_typed_overflow_count"] == 2
+
+
+def _passage_pool(count: int, *, content_chars: int) -> list[SearchResult]:
+    return [_result(f"passage-{index}", content_chars=content_chars) for index in range(count)]
+
+
+def test_item_budget_stays_the_default_and_is_reported_as_such() -> None:
+    """Callers that never ask for a character budget keep the shipped law."""
+    selected, receipt = compose_operational_evidence(
+        typed_results=_note_pool(8),
+        raw_results=_passage_pool(40, content_chars=100),
+        limit=8,
+    )
+
+    assert len(selected) == 8
+    assert receipt["budget_mode"] == "items"
+    assert receipt["char_budget"] is None
+
+
+def test_char_budget_admits_units_an_item_budget_would_have_truncated() -> None:
+    """A passage is roughly a twelfth of a state, so `limit` stops meaning payload.
+
+    The same eight-item pack that used to be eight whole states is eight
+    passages of a state each: an order of magnitude less for the reader. Under a
+    character budget the pack grows to whatever fits instead.
+    """
+    selected, receipt = compose_operational_evidence(
+        typed_results=[],
+        raw_results=_passage_pool(40, content_chars=100),
+        limit=8,
+        char_budget=3_000,
+    )
+
+    assert len(selected) == 30
+    assert receipt["budget_mode"] == "characters"
+    assert receipt["selected_chars"] == 3_000
+    assert [item.id for item in selected[:3]] == ["passage-0", "passage-1", "passage-2"]
+
+
+def test_char_budget_refuses_a_payload_that_would_exceed_it() -> None:
+    """The budget is hard: the pack stops at the last unit that still fits."""
+    selected, receipt = compose_operational_evidence(
+        typed_results=[],
+        raw_results=_passage_pool(40, content_chars=100),
+        limit=40,
+        char_budget=250,
+    )
+
+    assert sum(len(item.content) for item in selected) <= 250
+    assert [item.id for item in selected] == ["passage-0", "passage-1"]
+    assert receipt["raw_candidate_count"] == 40
+    assert receipt["selected_raw_count"] == 2
+
+
+def test_char_budget_keeps_the_note_lane_pinned_to_its_absolute_count() -> None:
+    """A wider pack must not widen the reserved lane, whichever budget bounds it.
+
+    The character budget is the reason `limit` no longer describes the pack, so
+    it is exactly the knob that could smuggle the proportional reservation back
+    in through a larger pack.
+    """
+    selected, receipt = compose_operational_evidence(
+        typed_results=_note_pool(8),
+        raw_results=_passage_pool(60, content_chars=1_000),
+        limit=8,
+        char_budget=30_000,
+    )
+
+    assert receipt["reservation_target"] == 3
+    assert receipt["typed_reservation"] == 3
+    assert [item.id for item in selected[:3]] == ["note-0", "note-1", "note-2"]
+    assert len(selected) > 8
+
+
+def test_char_budget_outranks_the_note_pin_when_it_cannot_hold_three() -> None:
+    """A lane that may overrun the budget is not a budget.
+
+    The pin fixes how many notes a pack reserves, not whether the pack may be
+    larger than the caller asked for.
+    """
+    selected, receipt = compose_operational_evidence(
+        typed_results=[
+            _result(
+                f"note-{index}",
+                result_type="note",
+                source_id=f"capture-{index}",
+                distilled=True,
+                content_chars=400,
+            )
+            for index in range(8)
+        ],
+        raw_results=_passage_pool(8, content_chars=100),
+        limit=8,
+        char_budget=900,
+    )
+
+    assert [item.id for item in selected] == ["note-0", "note-1", "passage-0"]
+    assert receipt["typed_reservation"] == 2
+    assert receipt["selected_chars"] == 900
+
+
+def test_char_budget_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="char_budget must be positive"):
+        compose_operational_evidence(
+            typed_results=[],
+            raw_results=_passage_pool(2, content_chars=10),
+            limit=8,
+            char_budget=0,
+        )

--- a/packages/python/sibyl-core/tests/test_operational_source_retrieval.py
+++ b/packages/python/sibyl-core/tests/test_operational_source_retrieval.py
@@ -732,6 +732,40 @@ def test_mixed_source_keeps_an_unsliced_evidence_part_reachable() -> None:
     assert span.passage_count == 0
 
 
+def test_slicing_one_part_does_not_narrow_the_windows_of_the_parts_left_whole() -> None:
+    """Whole-part rows keep sliding across observations however the source was cut.
+
+    Only accessibility-tree parts are sliced, so one sliced observation is
+    normal. Confining the rest to their own part would collapse them to a
+    window of one and cost a mixed source most of its span for no measured
+    reason: the adjacency confinement protects belongs to passages.
+    """
+    sliced = tuple(
+        _passage(
+            f"passage-{index}",
+            ordinal=0,
+            passage_index=index,
+            passage_count=2,
+            body=body,
+        )
+        for index, body in enumerate(["dashboard summary panel", "catalog filter sidebar"])
+    )
+    whole = tuple(
+        _entity(f"whole-{ordinal}", ordinal=ordinal, evidence=f"carrier tracking detail {ordinal}")
+        for ordinal in range(1, 4)
+    )
+
+    span = select_operational_source_span(
+        "carrier tracking detail",
+        _passage_inventory(sliced + whole),
+        max_observations=4,
+        max_entities=4,
+    )
+
+    assert [entity.id for entity in span.entities] == ["whole-1", "whole-2", "whole-3"]
+    assert span.passage_count == 0
+
+
 @pytest.mark.asyncio
 async def test_fetch_inventory_prefers_passages_over_the_part_they_were_cut_from() -> None:
     """A passage and its parent carry the same text, so a span may not hold both.

--- a/packages/python/sibyl-core/tests/test_operational_source_retrieval.py
+++ b/packages/python/sibyl-core/tests/test_operational_source_retrieval.py
@@ -82,6 +82,69 @@ def _manifest(
     )
 
 
+def _passage(
+    entity_id: str,
+    *,
+    source_id: str = "capture-1",
+    project_id: str = "project-1",
+    scope_key: str | None = None,
+    memory_scope: str | None = None,
+    principal_id: str | None = None,
+    ordinal: int,
+    part_index: int = 0,
+    passage_index: int,
+    passage_count: int = 3,
+    body: str,
+    uri: str | None = None,
+) -> Entity:
+    header = f"Observation {ordinal} · slice {passage_index + 1}/{passage_count}"
+    return Entity(
+        id=entity_id,
+        entity_type=EntityType.PASSAGE,
+        name=f"Observation {ordinal}.{part_index + 1} passage {passage_index + 1}/{passage_count}",
+        description="Goal: update an order",
+        content=f"{header}\n{body}",
+        metadata={
+            "operational_source_id": source_id,
+            "project_id": project_id,
+            "scope_key": scope_key,
+            "memory_scope": memory_scope,
+            "principal_id": principal_id,
+            "projection_kind": "passage",
+            "observation_ordinal": ordinal,
+            "evidence_part_index": part_index,
+            "passage_index": passage_index,
+            "passage_count": passage_count,
+            "uri": uri,
+        },
+    )
+
+
+def _passage_inventory(passages: tuple[Entity, ...]) -> OperationalSourceInventory:
+    return OperationalSourceInventory(
+        source_id="capture-1",
+        manifest_id=operational_experience_manifest_id("capture-1"),
+        status="complete",
+        raw_observations=passages,
+        passage_count=sum(
+            entity.metadata.get("projection_kind") == "passage" for entity in passages
+        ),
+    )
+
+
+def _numbered_passages(bodies: list[str], *, ordinal: int = 1) -> tuple[Entity, ...]:
+    return tuple(
+        _passage(
+            f"passage-{index}",
+            ordinal=ordinal,
+            passage_index=index,
+            passage_count=len(bodies),
+            body=body,
+        )
+        for index, body in enumerate(bodies)
+    )
+
+
 @pytest.mark.asyncio
 async def test_fetch_inventory_uses_manifest_and_orders_raw_observations() -> None:
     later_part = _entity("later-part", ordinal=4, part_index=1, evidence="Ship control")
@@ -452,3 +515,268 @@ def test_span_selection_keeps_one_relevant_part_per_observation_when_bounded() -
 
     assert [entity.id for entity in span.entities] == ["one-b", "two-b"]
     assert span.observation_ordinals == (1, 2)
+
+
+def test_unsliced_source_window_is_unchanged_by_passage_support() -> None:
+    """A source with no passages is windowed exactly as it always was.
+
+    Whole-state sources still window over observations at the size the caller
+    asks for, not the passage window, and report no passages.
+    """
+    observations = tuple(
+        _entity(f"observation-{ordinal}", ordinal=ordinal, evidence=f"navigation state {ordinal}")
+        for ordinal in range(6)
+    )
+    inventory = OperationalSourceInventory(
+        source_id="capture-1",
+        manifest_id=operational_experience_manifest_id("capture-1"),
+        status="complete",
+        raw_observations=observations,
+    )
+
+    span = select_operational_source_span(
+        "navigation state",
+        inventory,
+        max_observations=4,
+        max_entities=4,
+    )
+
+    assert len(span.entities) == 4
+    assert span.observation_ordinals == (0, 1, 2, 3)
+    assert span.candidate_window_count == 3
+    assert span.passage_count == 0
+
+
+def test_passage_window_returns_three_adjacent_passages_in_source_order() -> None:
+    inventory = _passage_inventory(
+        _numbered_passages(
+            [
+                "dashboard summary panel",
+                "catalog filter sidebar",
+                "order details header",
+                "shipment carrier selector",
+                "tracking number field",
+                "unrelated footer links",
+            ]
+        )
+    )
+
+    span = select_operational_source_span(
+        "order shipment carrier tracking",
+        inventory,
+        max_observations=4,
+        max_entities=4,
+    )
+
+    assert [entity.id for entity in span.entities] == ["passage-2", "passage-3", "passage-4"]
+    assert span.passage_count == 3
+    assert span.observation_ordinals == (1,)
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("dashboard summary", ["passage-0", "passage-1", "passage-2"]),
+        ("unrelated footer", ["passage-3", "passage-4", "passage-5"]),
+    ],
+)
+def test_passage_window_clamps_at_both_ends_of_a_body(query: str, expected: list[str]) -> None:
+    """A match in the first or last passage still yields a whole window.
+
+    There is no passage before the first or after the last, so the window
+    slides inward rather than returning short.
+    """
+    inventory = _passage_inventory(
+        _numbered_passages(
+            [
+                "dashboard summary panel",
+                "catalog filter sidebar",
+                "order details header",
+                "shipment carrier selector",
+                "tracking number field",
+                "unrelated footer links",
+            ]
+        )
+    )
+
+    span = select_operational_source_span(query, inventory, max_observations=4, max_entities=4)
+
+    assert [entity.id for entity in span.entities] == expected
+
+
+@pytest.mark.parametrize("body_count", [1, 2])
+def test_passage_window_returns_every_passage_of_a_short_body(body_count: int) -> None:
+    inventory = _passage_inventory(
+        _numbered_passages(["order details header", "tracking number field"][:body_count])
+    )
+
+    span = select_operational_source_span(
+        "tracking number",
+        inventory,
+        max_observations=4,
+        max_entities=4,
+    )
+
+    assert len(span.entities) == body_count
+    assert span.candidate_window_count == 1
+
+
+def test_passage_window_never_crosses_a_state_boundary() -> None:
+    """Adjacency is within one body, not across the whole source.
+
+    The query term sits in the last passage of the first state and the first
+    passage of the second, so a window free to cross would take both and score
+    twice as well as any confined window can.
+    """
+    first_state = tuple(
+        _passage(
+            f"first-{index}",
+            ordinal=1,
+            passage_index=index,
+            passage_count=4,
+            body=body,
+        )
+        for index, body in enumerate(
+            [
+                "dashboard summary panel",
+                "catalog filter sidebar",
+                "order details header",
+                "carrier tracking selector",
+            ]
+        )
+    )
+    second_state = tuple(
+        _passage(
+            f"second-{index}",
+            ordinal=2,
+            passage_index=index,
+            passage_count=4,
+            body=body,
+        )
+        for index, body in enumerate(
+            [
+                "carrier tracking confirmation",
+                "invoice totals table",
+                "customer address block",
+                "support contact footer",
+            ]
+        )
+    )
+
+    span = select_operational_source_span(
+        "carrier tracking",
+        _passage_inventory(first_state + second_state),
+        max_observations=4,
+        max_entities=4,
+    )
+
+    assert span.observation_ordinals == (1,)
+    assert [entity.id for entity in span.entities] == ["first-1", "first-2", "first-3"]
+
+
+def test_passage_window_survives_an_item_allowance_smaller_than_the_window() -> None:
+    """A caller's item allowance may shrink the pack but never cut the window.
+
+    A partial window is the exposure regression the window exists to close, so
+    a window is returned whole even when the allowance is one item.
+    """
+    inventory = _passage_inventory(
+        _numbered_passages(
+            [
+                "dashboard summary panel",
+                "order details header",
+                "unrelated footer links",
+                "carrier tracking selector",
+            ]
+        )
+    )
+
+    span = select_operational_source_span(
+        "carrier tracking",
+        inventory,
+        max_observations=1,
+        max_entities=1,
+    )
+
+    assert [entity.id for entity in span.entities] == ["passage-1", "passage-2", "passage-3"]
+
+
+def test_mixed_source_keeps_an_unsliced_evidence_part_reachable() -> None:
+    """Only accessibility-tree parts are sliced, so a source can hold both shapes.
+
+    The unsliced part is a run of one, which yields a one-group window rather
+    than dropping out of the candidate set for being shorter than the window.
+    """
+    passages = tuple(
+        _passage(
+            f"passage-{index}",
+            ordinal=1,
+            passage_index=index,
+            passage_count=3,
+            body=body,
+        )
+        for index, body in enumerate(
+            ["dashboard summary panel", "catalog filter sidebar", "order details header"]
+        )
+    )
+    screenshot = _entity("screenshot", ordinal=1, part_index=1, evidence="carrier tracking receipt")
+
+    span = select_operational_source_span(
+        "carrier tracking receipt",
+        _passage_inventory((*passages, screenshot)),
+        max_observations=4,
+        max_entities=4,
+    )
+
+    assert [entity.id for entity in span.entities] == ["screenshot"]
+    assert span.passage_count == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_inventory_prefers_passages_over_the_part_they_were_cut_from() -> None:
+    """A passage and its parent carry the same text, so a span may not hold both.
+
+    Parts that were never sliced still contribute their whole-part row, which
+    is what keeps non-accessibility evidence in the inventory at all.
+    """
+    sliced_parent = _entity("sliced-parent", ordinal=1, evidence="whole accessibility tree")
+    passages = [
+        _passage(
+            f"passage-{index}",
+            ordinal=1,
+            passage_index=index,
+            body=f"passage body {index}",
+        )
+        for index in range(3)
+    ]
+    screenshot = _entity("screenshot", ordinal=1, part_index=1, evidence="carrier tracking receipt")
+    members = [sliced_parent, *passages, screenshot]
+    manifest = _manifest([entity.id for entity in members])
+    reader = AsyncMock()
+    reader.get.return_value = manifest
+    reader.get_many.return_value = [manifest, *reversed(members)]
+
+    inventory = await fetch_operational_source_inventory(reader, "capture-1")
+
+    assert inventory.status == "complete"
+    assert [entity.id for entity in inventory.raw_observations] == [
+        "passage-0",
+        "passage-1",
+        "passage-2",
+        "screenshot",
+    ]
+    assert inventory.passage_count == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_inventory_rejects_a_passage_without_an_ordering_index() -> None:
+    passage = _passage("passage-0", ordinal=1, passage_index=0, body="passage body")
+    unordered = passage.model_copy(update={"metadata": {**passage.metadata, "passage_index": None}})
+    manifest = _manifest([unordered.id])
+    reader = AsyncMock()
+    reader.get.return_value = manifest
+    reader.get_many.return_value = [manifest, unordered]
+
+    inventory = await fetch_operational_source_inventory(reader, "capture-1")
+
+    assert inventory.status == "inventory_invalid"


### PR DESCRIPTION
# 🌊 Make passages retrievable at the geometry they were measured at

**Stacked on #281** → #279. Review the stack bottom-up.

## 💡 Why these two changes and no others

**Character budget.** A passage is ~11× smaller than the fat chunk it replaces (~1,030 chars vs ~12K), so `k=10` stops meaning anything comparable. Stage 1 held payload constant at 135K *characters* precisely because item count is not the invariant. An item budget on a sliced substrate either starves the reader or blows the budget, depending on unit size.

**3-adjacent-passage window.** Load-bearing, not a refinement. Single-passage retrieval reaches 93.2% / 97.9% oracle exposure; a 3-adjacent window reaches **95.5% / 100%, exactly equalling the fat-state ceiling**. Slicing is free at the oracle *only if retrieval returns a window*.

## 🛠️ What changed

`compose_operational_evidence` takes an optional `char_budget`. **Omitted, it composes exactly as it shipped** — proven by a 20,000-case randomized differential against the pre-change function: 0 mismatches across selected order, object identity, and all twelve original receipt keys. Set, candidates are admitted in rank order while cumulative `len(content)` fits, stopping at the first that doesn't.

Prefix semantics over best-fit packing, deliberately: packing by size reorders relevance against length and costs the guarantee that a pack is a prefix of its ranking. The note lane stays pinned at an absolute 3 *inside* the budget — the budget outranks the pin, because a lane that can overrun the budget isn't a budget.

The position tuple went from `(ordinal, part_index)` to `(ordinal, part_index, passage_index)`, unsliced parts taking slot 0. Windows slide over *groups*, where a passage is its own group and all parts of an unsliced observation share one — so "three groups" means three adjacent passages on one substrate and four observations on the other, and the existing path keeps its exact behavior.

Boundary cases verified by enumerating windows for run lengths 1–7: every passage is covered by at least one window, the last window ends exactly at the run end, and bodies of 1–2 passages yield one short window rather than none. `max_entities` is floored at window size so a caller's item allowance can shrink the pack but never cut a window partial.

One thing the surface map didn't predict: the signal extractor looks for whole-part preamble labels that passages don't carry, so every window would have scored zero and returned whichever came first. Passages needed their own branch.

## 🧪 Validation

\`\`\`
moon run core:check api:check --force
core:test 1965 passed, 14 skipped     api:test 2026 passed, 5 skipped
lint + typecheck green on both        8 tasks completed
\`\`\`

An independent adversarial verifier returned PASS **and found a real defect I introduced**: confinement was decided per *source* but applied per *evidence part*, so a single sliced observation collapsed every observation the source left whole down to a window of one. Reproduced (`['w-1']` vs `['w-1','w-2','w-3']`), fixed by keying runs on what they hold, re-confirmed. A 6,000-case differential over passage-free inventories against the parent commit shows 0 mismatches, so the whole-state path is byte-identical.

## 🔒 The per-signal cap does not move

`per_signal_limit = max(2, min(8, limit))` caps every lane at 8 candidates. That is a *seed-diversity* budget, not a payload budget, and on passages it is worse than pinned — 8 passages may be cuts of fewer than 8 distinct states.

It still should not move here. The knob is global to every lane and every caller, and `build_context_retrieval_plan` cannot see which substrate will answer, so raising it widens the fulltext and HNSW read for the entire product to buy recall nobody has measured on passages. It is now named `MAX_CANDIDATES_PER_SIGNAL` with all seven sites routed through it, so the experiment is genuinely one edit. **Recommend measuring at {8, 16, 24}.**

Facet routing is not wired, consistent with #279.

## ⚠️ Three things that block reading a gate result as a pass

These are **not fixed here** and each is real:

1. **Passages are not reachable by the eval as configured.** The composer doesn't consult facets — but the *search* feeding it takes an explicit `types` list that `_node_types_for_requested_types` turns into a hard `node_types` filter, and the harness sends `"types": ["session"]` (`sibyl_memory.py:3854`). Passages never enter the pool. Fix belongs in the eval lane.
2. **A second, adapter-side item budget survives.** `assemble_context_results(max_items=...)` re-clips after the API returns, so a char budget gets clipped back to ~8 items unless that is addressed too.
3. **At the default `content_max_chars=500` the char budget degenerates into an item budget** — a passage and a 12K state both contribute 500. That is correct behavior (it measures what the reader receives) and the eval sets 18,000, but nothing couples the two knobs.

## 🚨 And one that may move the ceiling itself

**The shipped window is confined to an evidence part; the oracle's was not.** Verified directly against the reference harness: `stage0.py:91` does `entry["tree"] = "".join(entry["parts"][i] for i in sorted(entry["parts"]))` — it reassembles whole states from their parts *before* slicing, and `stage0e` slides windows across that whole-state body. Commit `3fd786ed` measured that 76% (enterprise) / 80% (web) of states split into multiple parts.

So a 3-passage window that would have crossed a part boundary in the oracle is truncated in production, and **the 95.5% / 100% figure is not automatically the shipped ceiling.** This needs a part-confined re-run of the oracle before any gate result is interpreted — that measurement is free (local compute, no paid calls) and is being run separately.

## 📌 Known-open, out of scope here

Spans skipped at mint lose the parent fallback `d14617dd` promised; `char_budget` is silently ignored when `reserve_distilled_notes=False`; the budget counts `content` only while passages carry payload in `description` (separately tracked); `_is_raw_observation` in source expansion doesn't know about passages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)