### PR TITLE
feat(benchmarks): oracle the passage window under part confinement

### DIFF
--- a/benchmarks/longmemeval_v2_chunk_geometry/README.md
+++ b/benchmarks/longmemeval_v2_chunk_geometry/README.md
@@ -62,7 +62,7 @@ up, and nothing in CI imports it — `root:inventory-lint` only lints statically
 
 | Tier | Needs | Scripts |
 | --- | --- | --- |
-| Cheap | standard library only, plus the in-repo `benchmarks/longmemeval_v2_diagnostics.py` | `stage0`, `stage0b`, `stage0c`, `stage0d`, `stage0e`, `stage0f`, `stage0g`, `summarize` |
+| Cheap | standard library only, plus the in-repo `benchmarks/longmemeval_v2_diagnostics.py` | `stage0`, `stage0b`, `stage0c`, `stage0d`, `stage0e`, `stage0f`, `stage0g`, `stage0h`, `summarize` |
 | Middle | `numpy`, `scipy`, `scikit-learn` | `stage1b` |
 | Heavy | the middle tier plus `sentence-transformers` and `torch` | `stage1` |
 
@@ -95,13 +95,15 @@ export SIBYL_A1_DATA_ROOT=/path/to/.moon/cache/benchmarks/longmemeval-v2-full
 
 python benchmarks/longmemeval_v2_chunk_geometry/stage0c.py   # cheapest, stdlib only
 python benchmarks/longmemeval_v2_chunk_geometry/stage0.py    # slowest Stage 0 pass
+python benchmarks/longmemeval_v2_chunk_geometry/stage0h.py   # part-confined arms, ~25s
 python benchmarks/longmemeval_v2_chunk_geometry/stage1.py    # needs the ML stack
 python benchmarks/longmemeval_v2_chunk_geometry/summarize.py # renders the Stage 1 verdict table
 ```
 
 Each stage rewrites its own `out/*_report.json`, so re-running in place produces
-**no git diff** when the corpus is unchanged — verified for `stage0c` and
-`stage0f`, which reproduce their committed receipts byte for byte. Any diff you
+**no git diff** when the corpus is unchanged — verified for `stage0c`,
+`stage0f`, `stage0e` and `stage0h`, which reproduce their committed receipts
+byte for byte. Any diff you
 do see is therefore signal: the corpus, the cutter, or a threshold moved. Set
 `SIBYL_A1_OUT` to a scratch directory when you want to compare without touching
 the receipts.
@@ -115,6 +117,7 @@ the receipts.
 | `stage0c.py` | Band adherence, hard-max overflow, and whether internal subtrees survive intact in one slice. | The boundary-rule evidence: 651 enterprise slices over the hard max, max 4,103 chars — the reason v2 bounds the ancestor prepend. |
 | `stage0d.py` | Oracle exposure ceiling over the **full 451**: fat-state vs fat-chunk vs single slice vs slice+neighbour, plus phrase-level straddle. | "**Straddle rate is zero** — 31,244 of 31,244 triples" (24,083 enterprise + 7,161 web) and the 92 measurable questions (44 + 48). |
 | `stage0e.py` | Exposure as a function of window width w ∈ {1,2,3,5}. | "A 3-adjacent-slice window reaches the fat-state ceiling exactly: 95.5% / 100%", single-slice "93.2% / 97.9%". |
+| `stage0h.py` | Re-runs the `stage0e` widths under the confinement shipped retrieval actually imposes: passages cut per evidence part, windows unable to leave one. Three arms, plus a straddle probe that proves the arms can diverge. | Tests whether "a 3-adjacent window reaches the fat-state ceiling" survives the port to production. It does — zero delta at every width in both domains. |
 | `stage0f.py` | Breadcrumb cost as a design knob: what capping to the last N ancestors saves. | "the breadcrumb is the expensive half (11.5%, mean 134 chars). Capping to the last two ancestors drops it to 3.9%." |
 | `stage0g.py` | v1 vs v2 boundary rules side by side, re-checking band, count, and exposure. | "Boundary rules the data argues for, all verified to preserve exposure and the zero straddle rate." |
 | `stage1.py` | Offline selection simulation. Arms FAT / SLICE / SLICE_GOAL against BM25, dense (local MiniLM), and RRF; recall at both item and character budgets. | The selection-dilution result, the goal-carry lift (RRF 0.727 / 0.812 vs fat 0.682 / 0.792), and the character-budget argument. |
@@ -125,6 +128,68 @@ Support modules: `slicer.py` (the v1 cutter and its constants), `slicer_v2.py`
 (the three candidate boundary fixes), `chunkparse.py` (catalog record →
 preamble / header / body), `corpus.py` (shared unit construction), `paths.py`
 (the roots above).
+
+## Does the whole-state oracle describe what ships? (`stage0h`)
+
+Every Stage 0 exposure number is measured on **reassembled whole states**.
+`stage0.load_states` joins each state's parts back together
+(`entry["tree"] = "".join(...)`), the slicer cuts that joined body, and
+`stage0e` slides its window across the whole state's slice list. Shipped
+retrieval does neither. `_passage_projection` calls `slice_body` on one
+`evidence.content` at a time, and `operational_sources._run_key` keys a passage
+window on `(observation_ordinal, evidence_part_index)`, so a window stops dead
+at a part boundary. Those are two different measurements, and the second is the
+one the design rests on.
+
+The split is not rare. **4,874 of 6,387 enterprise parts (76.3%) and 3,693 of
+4,609 web parts (80.1%) belong to a state that split into several.** Per *state*
+the rate is lower — 1,845/3,358 (54.9%) enterprise and 821/1,737 (47.3%) web —
+so quote whichever denominator you mean; the 76/80 figures are parts, not
+states.
+
+`stage0h` re-runs the `stage0e` widths in three arms over the identical
+question set and the identical `measurable` denominator (44 enterprise, 48 web):
+`whole_state` recomputes stage0e's arm from scratch, `part_confined` keeps the
+whole-state cut but forbids a window from spanning two parts, and `production`
+cuts each part on its own and windows inside it.
+
+**All three arms agree exactly, at every width, in both domains.** Enterprise
+0.9318 / 0.9318 / 0.9545 / 0.9545 and web 0.9792 / 1.0 / 1.0 / 1.0 for
+w ∈ {1,2,3,5}; the `whole_state` arm reproduces the committed `stage0e` receipt
+digit for digit. The delta from confinement is 0.0 everywhere and
+`confinement_losses` is empty. **The concern that motivated this stage was
+unfounded: the shipped ceiling is the measured ceiling.**
+
+The mechanism is in `parts_needed_to_cover_gold`: **42/42 enterprise and 48/48
+questions whose gold lives in one state have that gold inside one evidence
+part.** Not one measurable question needs two parts, so the boundary is never
+between a window and its answer. The two enterprise questions that no arm
+reaches fail as `no_single_state_carries_gold` — their gold was never in one
+state to begin with, which no window width or window scope can fix.
+
+Because a null result is only worth as much as the harness's ability to show a
+non-null one, the stage carries a **positive control**. `boundary_probe` mints
+synthetic gold pairs straddling a real part boundary — last eligible line
+before it, first eligible line after it, kept only when each occurs exactly once
+in the whole state — and scores them through the same three arms at w=3. The
+`whole_state` arm covers **2,555/2,555 enterprise and 1,623/1,623 web** probes;
+the two confined arms cover **0**. The apparatus registers confinement loss at
+full strength when confinement loss exists. It reported zero on the real gold
+because there is zero to report.
+
+Two caveats worth carrying forward. First, the margin is thin: the whole w1→w3
+gain is **one question per domain** (`0cf979c4` enterprise at w3, `c6124506`
+web at w2), and both are bought inside a part, not across a boundary. The
+equality of the 3-window and the fat state is real but rests on a single
+question either side. Second, 30/44 enterprise and 35/48 web measurable
+questions are single-phrase, where extra width can only help if the cutter
+splits a phrase — and `stage0d` already measured that straddle rate at zero.
+
+Incidentally the same run rules out the other shipped divergence in that code
+path: `_passage_projection` drops a rendered passage over
+`MAX_TYPED_ENTITY_CONTENT_CHARS = 18_000`, but the longest passage either
+corpus produces is 4,384 chars (enterprise) and 2,186 (web), so that drop is
+unreachable here.
 
 `out/STAGE1_PREREGISTRATION.md` was written **before** `stage1.py` first ran and
 fixes the decision rule, the falsifiers, and the underpowered-n caveat in

--- a/benchmarks/longmemeval_v2_chunk_geometry/out/stage0h_report.json
+++ b/benchmarks/longmemeval_v2_chunk_geometry/out/stage0h_report.json
@@ -1,0 +1,289 @@
+{
+  "enterprise": {
+    "domain": "enterprise",
+    "measurable": 44,
+    "states": 3358,
+    "multi_part_states": 1845,
+    "parts_total": 6387,
+    "parts_in_multi_part_states": 4874,
+    "whole_state_slices": 83850,
+    "production_slices": 84968,
+    "boundary_straddling_slices": 2828,
+    "longest_production_slice_chars": 4384,
+    "typed_entity_content_cap_chars": 18000,
+    "boundary_probe": {
+      "boundaries": 3029,
+      "usable_probes": 2555,
+      "window": 3,
+      "hits": {
+        "whole_state": 2555,
+        "part_confined": 0,
+        "production": 0
+      },
+      "rates": {
+        "whole_state": 1.0,
+        "part_confined": 0.0,
+        "production": 0.0
+      }
+    },
+    "counts": {
+      "fat_state": 42,
+      "one_part_carries_gold": 42,
+      "part_confined_w1": 41,
+      "part_confined_w2": 41,
+      "part_confined_w3": 42,
+      "part_confined_w5": 42,
+      "production_w1": 41,
+      "production_w2": 41,
+      "production_w3": 42,
+      "production_w5": 42,
+      "whole_state_all_slices": 42,
+      "whole_state_w1": 41,
+      "whole_state_w2": 41,
+      "whole_state_w3": 42,
+      "whole_state_w5": 42
+    },
+    "rates": {
+      "fat_state": 0.9545,
+      "one_part_carries_gold": 0.9545,
+      "part_confined_w1": 0.9318,
+      "part_confined_w2": 0.9318,
+      "part_confined_w3": 0.9545,
+      "part_confined_w5": 0.9545,
+      "production_w1": 0.9318,
+      "production_w2": 0.9318,
+      "production_w3": 0.9545,
+      "production_w5": 0.9545,
+      "whole_state_all_slices": 0.9545,
+      "whole_state_w1": 0.9318,
+      "whole_state_w2": 0.9318,
+      "whole_state_w3": 0.9545,
+      "whole_state_w5": 0.9545
+    },
+    "delta_production_minus_whole_state": {
+      "w1": 0.0,
+      "w2": 0.0,
+      "w3": 0.0,
+      "w5": 0.0
+    },
+    "phrase_count_distribution": {
+      "1": 30,
+      "2": 9,
+      "3": 4,
+      "4": 1
+    },
+    "width_gainers": {
+      "part_confined_w2": [],
+      "part_confined_w3": [
+        "0cf979c4"
+      ],
+      "part_confined_w5": [],
+      "production_w2": [],
+      "production_w3": [
+        "0cf979c4"
+      ],
+      "production_w5": [],
+      "whole_state_w2": [],
+      "whole_state_w3": [
+        "0cf979c4"
+      ],
+      "whole_state_w5": []
+    },
+    "loss_reasons": {
+      "part_confined_w1": {
+        "covered": 41,
+        "window_too_narrow_within_part": 1,
+        "no_single_state_carries_gold": 2
+      },
+      "part_confined_w2": {
+        "covered": 41,
+        "window_too_narrow_within_part": 1,
+        "no_single_state_carries_gold": 2
+      },
+      "part_confined_w3": {
+        "covered": 42,
+        "no_single_state_carries_gold": 2
+      },
+      "part_confined_w5": {
+        "covered": 42,
+        "no_single_state_carries_gold": 2
+      },
+      "production_w1": {
+        "covered": 41,
+        "window_too_narrow_within_part": 1,
+        "no_single_state_carries_gold": 2
+      },
+      "production_w2": {
+        "covered": 41,
+        "window_too_narrow_within_part": 1,
+        "no_single_state_carries_gold": 2
+      },
+      "production_w3": {
+        "covered": 42,
+        "no_single_state_carries_gold": 2
+      },
+      "production_w5": {
+        "covered": 42,
+        "no_single_state_carries_gold": 2
+      },
+      "whole_state_w1": {
+        "covered": 41,
+        "window_too_narrow_within_part": 1,
+        "no_single_state_carries_gold": 2
+      },
+      "whole_state_w2": {
+        "covered": 41,
+        "window_too_narrow_within_part": 1,
+        "no_single_state_carries_gold": 2
+      },
+      "whole_state_w3": {
+        "covered": 42,
+        "no_single_state_carries_gold": 2
+      },
+      "whole_state_w5": {
+        "covered": 42,
+        "no_single_state_carries_gold": 2
+      }
+    },
+    "parts_needed_to_cover_gold": {
+      "1": 42
+    },
+    "confinement_losses": []
+  },
+  "web": {
+    "domain": "web",
+    "measurable": 48,
+    "states": 1737,
+    "multi_part_states": 821,
+    "parts_total": 4609,
+    "parts_in_multi_part_states": 3693,
+    "whole_state_slices": 63804,
+    "production_slices": 65573,
+    "boundary_straddling_slices": 2816,
+    "longest_production_slice_chars": 2186,
+    "typed_entity_content_cap_chars": 18000,
+    "boundary_probe": {
+      "boundaries": 2872,
+      "usable_probes": 1623,
+      "window": 3,
+      "hits": {
+        "whole_state": 1623,
+        "part_confined": 0,
+        "production": 0
+      },
+      "rates": {
+        "whole_state": 1.0,
+        "part_confined": 0.0,
+        "production": 0.0
+      }
+    },
+    "counts": {
+      "fat_state": 48,
+      "one_part_carries_gold": 48,
+      "part_confined_w1": 47,
+      "part_confined_w2": 48,
+      "part_confined_w3": 48,
+      "part_confined_w5": 48,
+      "production_w1": 47,
+      "production_w2": 48,
+      "production_w3": 48,
+      "production_w5": 48,
+      "whole_state_all_slices": 48,
+      "whole_state_w1": 47,
+      "whole_state_w2": 48,
+      "whole_state_w3": 48,
+      "whole_state_w5": 48
+    },
+    "rates": {
+      "fat_state": 1.0,
+      "one_part_carries_gold": 1.0,
+      "part_confined_w1": 0.9792,
+      "part_confined_w2": 1.0,
+      "part_confined_w3": 1.0,
+      "part_confined_w5": 1.0,
+      "production_w1": 0.9792,
+      "production_w2": 1.0,
+      "production_w3": 1.0,
+      "production_w5": 1.0,
+      "whole_state_all_slices": 1.0,
+      "whole_state_w1": 0.9792,
+      "whole_state_w2": 1.0,
+      "whole_state_w3": 1.0,
+      "whole_state_w5": 1.0
+    },
+    "delta_production_minus_whole_state": {
+      "w1": 0.0,
+      "w2": 0.0,
+      "w3": 0.0,
+      "w5": 0.0
+    },
+    "phrase_count_distribution": {
+      "1": 35,
+      "2": 10,
+      "3": 2,
+      "5": 1
+    },
+    "width_gainers": {
+      "part_confined_w2": [
+        "c6124506"
+      ],
+      "part_confined_w3": [],
+      "part_confined_w5": [],
+      "production_w2": [
+        "c6124506"
+      ],
+      "production_w3": [],
+      "production_w5": [],
+      "whole_state_w2": [
+        "c6124506"
+      ],
+      "whole_state_w3": [],
+      "whole_state_w5": []
+    },
+    "loss_reasons": {
+      "part_confined_w1": {
+        "covered": 47,
+        "window_too_narrow_within_part": 1
+      },
+      "part_confined_w2": {
+        "covered": 48
+      },
+      "part_confined_w3": {
+        "covered": 48
+      },
+      "part_confined_w5": {
+        "covered": 48
+      },
+      "production_w1": {
+        "covered": 47,
+        "window_too_narrow_within_part": 1
+      },
+      "production_w2": {
+        "covered": 48
+      },
+      "production_w3": {
+        "covered": 48
+      },
+      "production_w5": {
+        "covered": 48
+      },
+      "whole_state_w1": {
+        "covered": 47,
+        "window_too_narrow_within_part": 1
+      },
+      "whole_state_w2": {
+        "covered": 48
+      },
+      "whole_state_w3": {
+        "covered": 48
+      },
+      "whole_state_w5": {
+        "covered": 48
+      }
+    },
+    "parts_needed_to_cover_gold": {
+      "1": 48
+    },
+    "confinement_losses": []
+  }
+}

--- a/benchmarks/longmemeval_v2_chunk_geometry/stage0h.py
+++ b/benchmarks/longmemeval_v2_chunk_geometry/stage0h.py
@@ -1,0 +1,435 @@
+"""STAGE 0h - exposure when a window may not leave its evidence part.
+
+`stage0e` measured the window-width oracle on **reassembled whole states**:
+`stage0.load_states` joins every part of a state back into one `tree`, the
+slicer cuts that tree, and the window slides across the whole state's slice
+list. Shipped retrieval does neither of those things. Passages are minted one
+evidence part at a time (`_passage_projection` calls `slice_body` on
+`evidence.content`), and the window run key is `(observation_ordinal,
+evidence_part_index)`, so a window can never span two parts of one state.
+
+Most parts belong to a state that split, so the two measurements are different
+questions and only the second describes what ships. This stage runs three arms
+over the same questions and the same `measurable` denominator as `stage0e`:
+
+  * `whole_state`   - stage0e's arm, recomputed here so the other two are read
+                      against a baseline this file produced itself.
+  * `part_confined` - the whole-state cut, windows restricted to slices lying
+                      inside a single evidence part. Isolates the confinement
+                      from the change in cut points.
+  * `production`    - each part sliced on its own and windowed on its own,
+                      which is what `nova/a1-passage-retrieval` ships.
+
+The loss taxonomy separates confinement from everything else. A question no
+window can reach because no single state carries all its gold, or because the
+gold never lands in the passage substrate at all, was already lost before any
+part boundary existed.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from itertools import combinations, pairwise
+from typing import Any
+
+from corpus import OUT, eligible_questions, normalize_text, state_evidence_text
+from longmemeval_v2_diagnostics import is_exact_evidence_eligible
+from slicer import render_slice, slice_body, slice_header
+from stage0 import load_states
+
+WINDOWS = (1, 2, 3, 5)
+ARMS = ("whole_state", "part_confined", "production")
+
+# The width the shipped window runs at (`PASSAGE_WINDOW_UNITS = 3`), used by
+# the straddle probe below.
+PROBE_WINDOW = 3
+
+# `_passage_projection` drops a rendered passage this long rather than emit an
+# over-cap entity. The report records the largest passage the corpus produces
+# so the reader can see whether that drop is reachable at all.
+MAX_TYPED_ENTITY_CONTENT_CHARS = 18_000
+
+
+def part_line_spans(entry: dict[str, Any]) -> list[tuple[int, int]]:
+    """Map each evidence part onto its half-open line range in the joined tree.
+
+    `load_states` joins part bodies with no separator, so this is only exact
+    while every non-final part ends on a newline. Both corpora satisfy that;
+    the assertion keeps a corpus rebuild from silently invalidating the
+    mapping, because a part ending mid-line would merge two lines across the
+    boundary and no per-part cut could ever reproduce that text.
+    """
+    keys = sorted(entry["parts"])
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    for position, key in enumerate(keys):
+        body = entry["parts"][key]
+        is_final = position == len(keys) - 1
+        if not is_final:
+            assert body.endswith("\n"), "non-final part does not end on a line boundary"
+        consumed = len(body.split("\n")) - (0 if is_final else 1)
+        spans.append((cursor, cursor + consumed))
+        cursor += consumed
+    assert cursor == len(entry["tree"].split("\n"))
+    return spans
+
+
+def whole_state_slices(entry: dict[str, Any]) -> tuple[list[str], list[frozenset[int]]]:
+    """Render the whole-state cut and say which parts each slice's lines touch."""
+    pieces, _ = slice_body(entry["tree"])
+    spans = part_line_spans(entry)
+    texts: list[str] = []
+    touched: list[frozenset[int]] = []
+    for order, piece in enumerate(pieces, start=1):
+        header = slice_header(entry["state_index"], entry["url"], order, len(pieces))
+        texts.append(render_slice(header, piece.breadcrumb, piece.content))
+        touched.append(
+            frozenset(
+                index
+                for index, (start, stop) in enumerate(spans)
+                if any(start <= line < stop for line in piece.line_indices)
+            )
+        )
+    return texts, touched
+
+
+def production_slices(entry: dict[str, Any]) -> list[list[str]]:
+    """Cut every evidence part on its own, the way the projection does."""
+    per_part: list[list[str]] = []
+    for key in sorted(entry["parts"]):
+        pieces, _ = slice_body(entry["parts"][key])
+        per_part.append(
+            [
+                render_slice(
+                    slice_header(entry["state_index"], entry["url"], order, len(pieces)),
+                    piece.breadcrumb,
+                    piece.content,
+                )
+                for order, piece in enumerate(pieces, start=1)
+            ]
+        )
+    return per_part
+
+
+def _covers(texts: list[str], phrases: tuple[str, ...]) -> list[set[int]]:
+    return [{index for index, phrase in enumerate(phrases) if phrase in text} for text in texts]
+
+
+def _window_hit(covers: list[set[int]], width: int, total: int) -> bool:
+    for start in range(max(1, len(covers) - width + 1)):
+        merged: set[int] = set()
+        for cover in covers[start : start + width]:
+            merged |= cover
+        if len(merged) == total:
+            return True
+    return False
+
+
+def _runs_within_one_part(touched: list[frozenset[int]]) -> list[list[int]]:
+    """Split the whole-state slice list into maximal runs sharing one part.
+
+    A slice whose lines straddle a boundary touches two parts and joins no run:
+    the per-part cut cannot produce it, so no confined window may use it.
+    """
+    runs: list[list[int]] = []
+    current: list[int] = []
+    current_part: int | None = None
+    for index, parts in enumerate(touched):
+        part = next(iter(parts)) if len(parts) == 1 else None
+        if part is None or part != current_part:
+            if current:
+                runs.append(current)
+            current = []
+            current_part = part
+        if part is not None:
+            current.append(index)
+    if current:
+        runs.append(current)
+    return runs
+
+
+def _min_parts_to_cover(part_covers: list[set[int]], total: int) -> int | None:
+    """Fewest evidence parts whose passages together carry every gold phrase."""
+    carrying = [cover for cover in part_covers if cover]
+    for size in range(1, len(carrying) + 1):
+        for combo in combinations(carrying, size):
+            merged: set[int] = set()
+            for cover in combo:
+                merged |= cover
+            if len(merged) == total:
+                return size
+    return None
+
+
+def _loss_reason(hits: dict[str, bool], arm: str, width: int) -> str:
+    """Name what stopped this arm, distinguishing confinement from prior loss."""
+    if hits[f"{arm}_w{width}"]:
+        return "covered"
+    if not hits["fat_state"]:
+        return "no_single_state_carries_gold"
+    if not hits["whole_state_all_slices"]:
+        return "gold_outside_passage_substrate"
+    if not hits["one_part_carries_gold"]:
+        return "gold_spans_evidence_parts"
+    return "window_too_narrow_within_part"
+
+
+def _evaluate(
+    phrases: tuple[str, ...],
+    carriers: list[tuple[str, int]],
+    norm_state: dict[tuple[str, int], str],
+    whole_cut: dict[tuple[str, int], tuple[list[str], list[frozenset[int]]]],
+    part_cut: dict[tuple[str, int], list[list[str]]],
+) -> tuple[dict[str, bool], int | None]:
+    """Score one question across all arms, and how many parts its gold needs."""
+    total = len(phrases)
+    hits = {f"{arm}_w{width}": False for arm in ARMS for width in WINDOWS}
+    hits["fat_state"] = False
+    hits["whole_state_all_slices"] = False
+    hits["one_part_carries_gold"] = False
+    min_parts: int | None = None
+
+    for key in carriers:
+        whole_complete = all(phrase in norm_state[key] for phrase in phrases)
+        if whole_complete:
+            hits["fat_state"] = True
+
+        whole_texts, touched = whole_cut[key]
+        whole_covers = _covers(whole_texts, phrases)
+        union: set[int] = set()
+        for cover in whole_covers:
+            union |= cover
+        if len(union) == total:
+            hits["whole_state_all_slices"] = True
+        for width in WINDOWS:
+            if _window_hit(whole_covers, width, total):
+                hits[f"whole_state_w{width}"] = True
+        for run in _runs_within_one_part(touched):
+            run_covers = [whole_covers[index] for index in run]
+            for width in WINDOWS:
+                if _window_hit(run_covers, width, total):
+                    hits[f"part_confined_w{width}"] = True
+
+        per_part_union: list[set[int]] = []
+        for group in part_cut[key]:
+            part_covers = _covers(group, phrases)
+            part_union: set[int] = set()
+            for cover in part_covers:
+                part_union |= cover
+            per_part_union.append(part_union)
+            if len(part_union) == total:
+                hits["one_part_carries_gold"] = True
+            for width in WINDOWS:
+                if _window_hit(part_covers, width, total):
+                    hits[f"production_w{width}"] = True
+        if whole_complete:
+            needed = _min_parts_to_cover(per_part_union, total)
+            if needed is not None:
+                min_parts = needed if min_parts is None else min(min_parts, needed)
+
+    return hits, min_parts
+
+
+def _probe_phrase(lines: list[str]) -> str | None:
+    """First line in this order that would pass the real gold-eligibility rule."""
+    for line in lines:
+        candidate = normalize_text(line)
+        if is_exact_evidence_eligible(candidate):
+            return candidate
+    return None
+
+
+def boundary_probe(
+    states: dict[tuple[str, int], dict[str, Any]],
+    norm_state: dict[tuple[str, int], str],
+    whole_cut: dict[tuple[str, int], tuple[list[str], list[frozenset[int]]]],
+    part_cut: dict[tuple[str, int], list[list[str]]],
+) -> dict[str, Any]:
+    """Positive control: synthetic gold placed deliberately across a boundary.
+
+    A zero delta on the real questions only means something if this harness can
+    register a delta at all. Each usable probe takes the last eligible line
+    before a part boundary and the first eligible line after it, keeps the pair
+    only when each occurs exactly once in the whole state, and scores it through
+    the same three arms. A confined window cannot reach both by construction, so
+    a working harness must show `whole_state` high and the confined arms at
+    zero. If all three agreed here, the zero measured above would be an artifact.
+    """
+    attempted = 0
+    usable = 0
+    hits: Counter = Counter()
+    for key, entry in states.items():
+        part_keys = sorted(entry["parts"])
+        for position in range(len(part_keys) - 1):
+            attempted += 1
+            before = entry["parts"][part_keys[position]].split("\n")
+            after = entry["parts"][part_keys[position + 1]].split("\n")
+            phrase_a = _probe_phrase(before[::-1])
+            phrase_b = _probe_phrase(after)
+            if phrase_a is None or phrase_b is None or phrase_a == phrase_b:
+                continue
+            state_text = norm_state[key]
+            if state_text.count(phrase_a) != 1 or state_text.count(phrase_b) != 1:
+                continue
+            usable += 1
+            phrases = (phrase_a, phrase_b)
+            whole_texts, touched = whole_cut[key]
+            whole_covers = _covers(whole_texts, phrases)
+            if _window_hit(whole_covers, PROBE_WINDOW, 2):
+                hits["whole_state"] += 1
+            if any(
+                _window_hit([whole_covers[index] for index in run], PROBE_WINDOW, 2)
+                for run in _runs_within_one_part(touched)
+            ):
+                hits["part_confined"] += 1
+            if any(
+                _window_hit(_covers(group, phrases), PROBE_WINDOW, 2) for group in part_cut[key]
+            ):
+                hits["production"] += 1
+    return {
+        "boundaries": attempted,
+        "usable_probes": usable,
+        "window": PROBE_WINDOW,
+        "hits": {arm: hits[arm] for arm in ARMS},
+        "rates": {arm: round(hits[arm] / usable, 4) if usable else None for arm in ARMS},
+    }
+
+
+def analyse(domain: str) -> dict[str, Any]:
+    states = load_states(domain)
+    norm_state = {key: normalize_text(state_evidence_text(entry)) for key, entry in states.items()}
+    whole_cut: dict[tuple[str, int], tuple[list[str], list[frozenset[int]]]] = {}
+    part_cut: dict[tuple[str, int], list[list[str]]] = {}
+    straddling_slices = 0
+    total_slices = 0
+    production_slice_total = 0
+    longest_production_slice = 0
+    for key, entry in states.items():
+        texts, touched = whole_state_slices(entry)
+        whole_cut[key] = ([normalize_text(text) for text in texts], touched)
+        straddling_slices += sum(1 for parts in touched if len(parts) > 1)
+        total_slices += len(texts)
+        groups = production_slices(entry)
+        production_slice_total += sum(len(group) for group in groups)
+        longest_production_slice = max(
+            longest_production_slice,
+            max((len(text) for group in groups for text in group), default=0),
+        )
+        part_cut[key] = [[normalize_text(text) for text in group] for group in groups]
+
+    counts: dict[str, int] = defaultdict(int)
+    reasons: dict[str, Counter] = {f"{arm}_w{w}": Counter() for arm in ARMS for w in WINDOWS}
+    min_parts_hist: Counter = Counter()
+    confinement_losses: list[dict[str, Any]] = []
+    width_gainers: dict[str, list[str]] = {f"{arm}_w{w}": [] for arm in ARMS for w in WINDOWS[1:]}
+    phrase_counts: Counter = Counter()
+    measurable = 0
+
+    for item in eligible_questions(domain):
+        phrases = item["phrases"]
+        if not all(any(phrase in text for text in norm_state.values()) for phrase in phrases):
+            continue
+        measurable += 1
+        phrase_counts[len(phrases)] += 1
+        carriers = [key for key in states if any(p in norm_state[key] for p in phrases)]
+        hits, min_parts = _evaluate(phrases, carriers, norm_state, whole_cut, part_cut)
+
+        for arm in ARMS:
+            for narrow, wide in pairwise(WINDOWS):
+                if hits[f"{arm}_w{wide}"] and not hits[f"{arm}_w{narrow}"]:
+                    width_gainers[f"{arm}_w{wide}"].append(item["question"]["id"])
+        for name, value in hits.items():
+            if value:
+                counts[name] += 1
+        if hits["fat_state"]:
+            min_parts_hist[min_parts if min_parts is not None else "unreachable"] += 1
+        for arm in ARMS:
+            for width in WINDOWS:
+                reasons[f"{arm}_w{width}"][_loss_reason(hits, arm, width)] += 1
+        for width in WINDOWS:
+            if hits[f"whole_state_w{width}"] and not hits[f"production_w{width}"]:
+                confinement_losses.append(
+                    {
+                        "question_id": item["question"]["id"],
+                        "window": width,
+                        "phrase_count": len(phrases),
+                        "reason": _loss_reason(hits, "production", width),
+                        "min_parts_to_cover": min_parts,
+                    }
+                )
+
+    rates = {name: round(value / measurable, 4) for name, value in sorted(counts.items())}
+    delta = {
+        f"w{width}": round(
+            (counts[f"production_w{width}"] - counts[f"whole_state_w{width}"]) / measurable, 4
+        )
+        for width in WINDOWS
+    }
+    return {
+        "domain": domain,
+        "measurable": measurable,
+        "states": len(states),
+        "multi_part_states": sum(1 for e in states.values() if len(e["parts"]) > 1),
+        "parts_total": sum(len(e["parts"]) for e in states.values()),
+        "parts_in_multi_part_states": sum(
+            len(e["parts"]) for e in states.values() if len(e["parts"]) > 1
+        ),
+        "whole_state_slices": total_slices,
+        "production_slices": production_slice_total,
+        "boundary_straddling_slices": straddling_slices,
+        "longest_production_slice_chars": longest_production_slice,
+        "typed_entity_content_cap_chars": MAX_TYPED_ENTITY_CONTENT_CHARS,
+        "boundary_probe": boundary_probe(states, norm_state, whole_cut, part_cut),
+        "counts": dict(sorted(counts.items())),
+        "rates": rates,
+        "delta_production_minus_whole_state": delta,
+        "phrase_count_distribution": {str(k): v for k, v in sorted(phrase_counts.items())},
+        "width_gainers": {name: sorted(ids) for name, ids in sorted(width_gainers.items())},
+        "loss_reasons": {name: dict(counter) for name, counter in sorted(reasons.items())},
+        "parts_needed_to_cover_gold": {
+            str(k): v for k, v in sorted(min_parts_hist.items(), key=str)
+        },
+        "confinement_losses": confinement_losses,
+    }
+
+
+def main() -> None:
+    report: dict[str, Any] = {}
+    for domain in ("enterprise", "web"):
+        data = analyse(domain)
+        report[domain] = data
+        print(f"\n### {domain}  measurable={data['measurable']}")
+        print(
+            f"states={data['states']} multi_part={data['multi_part_states']} "
+            f"parts={data['parts_total']} "
+            f"parts_in_multi_part_states={data['parts_in_multi_part_states']}"
+        )
+        print(
+            f"slices whole={data['whole_state_slices']} "
+            f"production={data['production_slices']} "
+            f"boundary_straddling={data['boundary_straddling_slices']}"
+        )
+        for arm in ARMS:
+            row = " ".join(f"w{w}={data['rates'].get(f'{arm}_w{w}', 0.0):.4f}" for w in WINDOWS)
+            print(f"  {arm:<14} {row}")
+        print(f"  delta production-whole {data['delta_production_minus_whole_state']}")
+        print(f"  phrases/question {data['phrase_count_distribution']}")
+        gainers = {k: v for k, v in data["width_gainers"].items() if v}
+        print(f"  questions bought by extra width {gainers}")
+        print(f"  parts needed to cover gold {data['parts_needed_to_cover_gold']}")
+        print(f"  loss w3 production {data['loss_reasons']['production_w3']}")
+        probe = data["boundary_probe"]
+        print(
+            f"  straddle probe w{probe['window']} "
+            f"usable={probe['usable_probes']}/{probe['boundaries']} {probe['rates']}"
+        )
+        print(
+            f"  longest production passage {data['longest_production_slice_chars']} chars "
+            f"vs cap {data['typed_entity_content_cap_chars']}"
+        )
+    (OUT / "stage0h_report.json").write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/moon.yml
+++ b/moon.yml
@@ -407,6 +407,7 @@ tasks:
       benchmarks/longmemeval_v2_repair_project.py
       benchmarks/longmemeval_v2_memory
       benchmarks/longmemeval_v2_live_smoke.py benchmarks/longmemeval_v2_projection_audit.py
+      benchmarks/longmemeval_v2_chunk_geometry
     inputs:
       - tools/**/*.py
       - benchmarks/provider_usage.py
@@ -424,6 +425,7 @@ tasks:
       - benchmarks/longmemeval_v2_validation_slice.py
       - benchmarks/longmemeval_v2_validation_slice_v2.py
       - benchmarks/longmemeval_v2_live_retrieval.py
+      - benchmarks/longmemeval_v2_chunk_geometry/**/*.py
       - benchmarks/longmemeval_v2_composition_validation.json
       - benchmarks/longmemeval_v2_composition_validation_v2.json
       - benchmarks/longmemeval_v2_live_smoke.py


### PR DESCRIPTION
# 🧪 Prove the shipped window geometry reaches the measured ceiling

**Stacked on #280.** Measurement only — no product code, no paid calls, stdlib only.

## 💡 The question this answers

A1's central justification is that a **3-adjacent-passage window reaches 95.5% (enterprise) / 100% (web) exposure, exactly equalling the fat-state ceiling**. That equality is what makes slicing "free at the oracle."

But the oracle and production were measuring different geometries. `stage0.py` reassembles whole states from their parts before slicing — `entry["tree"] = "".join(entry["parts"][i] for i in sorted(entry["parts"]))` — and `stage0e` slides windows across that whole-state body. The window shipped in #284 is confined to a single evidence part and never crosses a boundary.

If gold routinely sat across a part boundary, the shipped ceiling would be lower than the cited one, and a gate run would under-perform its own justification **for a reason unrelated to whether slicing works.** That is an expensive way to be confused, so it was worth measuring before spending anything.

## ✅ Result: confinement costs nothing

`stage0h.py` runs three arms over an identical question set and denominator (44 enterprise / 48 web measurable): `whole_state` (the oracle's geometry), `part_confined` (whole-state cut, windows forbidden to span parts), and `production` (each part sliced on its own and windowed inside it, matching #284).

| domain | arm | w=1 | w=2 | w=3 | w=5 |
| --- | --- | --- | --- | --- | --- |
| enterprise | whole_state | 0.9318 | 0.9318 | 0.9545 | 0.9545 |
| enterprise | part_confined | 0.9318 | 0.9318 | 0.9545 | 0.9545 |
| enterprise | production | 0.9318 | 0.9318 | 0.9545 | 0.9545 |
| web | whole_state | 0.9792 | 1.0000 | 1.0000 | 1.0000 |
| web | part_confined | 0.9792 | 1.0000 | 1.0000 | 1.0000 |
| web | production | 0.9792 | 1.0000 | 1.0000 | 1.0000 |

**Delta is 0.0000 at every width in both domains** and `confinement_losses` is empty.

The mechanism, not just the number: `parts_needed_to_cover_gold` is `{1: 42}` enterprise and `{1: 48}` web. Every measurable question whose gold lives in a single state has that gold inside a **single evidence part**, so the boundary never falls between a window and its answer. The only enterprise misses are 2 questions where no single state carries the gold at all — not confinement.

## 🎯 The null has a positive control

A zero delta is only meaningful if the apparatus can detect a non-zero one. `boundary_probe` mints synthetic gold straddling real part boundaries (last eligible line before, first after, kept only when each occurs exactly once in the state) and scores it through the same arms at w=3:

\`\`\`
enterprise: whole_state 2555/2555 (1.0)   part_confined 0   production 0
web:        whole_state 1623/1623 (1.0)   part_confined 0   production 0
\`\`\`

Confinement loss registers at **full strength** when it exists. Measuring zero therefore means zero, not a blind instrument.

## 📐 Verdict

**The A1 window design does not need to change.** Windows need not cross part boundaries; passages need not be minted from reassembled whole states. The confinement in `_run_key` is free on this corpus.

## 🔍 Three things found along the way

1. ⚠️ **The cited split rate has the wrong denominator, and it propagated.** 76% / 80% is the fraction of *parts* belonging to multi-part states (4874/6387, 3693/4609). Per *state* it is **54.9% / 47.3%**. The splitting is real; the noun was wrong, including in the concern that prompted this measurement.
2. **The margin is one question per domain.** The entire w1→w3 gain is `0cf979c4` (enterprise, at w3) and `c6124506` (web, at w2), both bought *inside* a part. The "3-window equals fat state" equality holds, but rests on a single question either side — worth knowing before anyone treats that equality as robust headroom. 30/44 enterprise and 35/48 web questions are single-phrase, where width can only help if the cutter splits a phrase, already measured at zero straddle.
3. **The 18K content cap is inert.** `_passage_projection` drops passages over `MAX_TYPED_ENTITY_CONTENT_CHARS`, but the longest passage either corpus produces is 4,384 / 2,186 chars. A second shipped-vs-oracle divergence that turns out to be a non-issue.

## 🧪 Validation

Baseline reproduction first, to prove the invocation is sound before trusting the new arm: re-running untouched `stage0e.py` produced a receipt **byte-identical to the committed one** (enterprise w1 0.9318 / w3 0.9545, web w1 0.9792 / w3 1.0000).

\`\`\`
stage0e.py  → baseline, 15s     stage0h.py  → new arms, 25s
moon run root:inventory-format && root:inventory-lint  → 131 files clean
\`\`\`

`6032b45e` fixes a pre-existing gap inherited from the parent branch: `inventory-lint` format-*checked* the harness directory but `inventory-format` could not *fix* it, so any new file there was ungreenable through moon.

**Negative space:** stdlib only, no ML stack, no API calls, no spend. `stage0e.py` and every existing stage untouched, so the locked plan's numbers stay reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `stage0h` benchmark to evaluate retrieval windows constrained to individual evidence parts.
  * Added comparisons across whole-state, confined, and production-style retrieval modes.
  * Added boundary straddle validation to detect losses when evidence spans part boundaries.
  * Added benchmark results for enterprise and web domains, including coverage metrics and loss analysis.

* **Documentation**
  * Documented how to run `stage0h` and interpret its measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->