### PR TITLE
feat(bench): make passages reachable and character-bounded in the eval

### DIFF
--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -121,7 +121,16 @@ DEFAULT_RETRIEVAL_MODE = "fast"
 RETRIEVAL_MODES = frozenset({"accurate", "fast"})
 DEFAULT_TYPED_STREAM_RETRIEVAL = False
 DEFAULT_TYPED_STREAM_LIMIT = 8
+# The distilled-note lane, retrieved on its own request. It is not the raw
+# evidence lane below and the two must not be conflated: this tuple selects the
+# typed entities a note reservation is drawn from, and widening it changes the
+# one lever the campaign has measured a gain from.
 TYPED_STREAM_TYPES = ("note", "event", "procedure", "error_pattern")
+# The raw evidence lane. `types` reaches the search as a hard node-type filter,
+# so a type absent here never enters the candidate pool at all, however well it
+# would have ranked.
+DEFAULT_EVIDENCE_TYPES = ("session",)
+SUPPORTED_EVIDENCE_TYPES = frozenset({"passage", "session"})
 DEFAULT_RETRIEVAL_MAX_PLANNED_QUERIES = 3
 DEFAULT_API_TIMEOUT_SECONDS = 600.0
 DEFAULT_API_RETRY_ATTEMPTS = 3
@@ -173,6 +182,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "state_part_completion_items",
         "state_part_refinement",
         "context_expansion_max_ratio",
+        "evidence_types",
         "evidence_composition_mode",
         "source_evidence_bundling",
         "retrieval_mode",
@@ -2916,6 +2926,11 @@ class SibylLiveApiMemory(Memory):
             "state_part_refinement",
             DEFAULT_STATE_PART_REFINEMENT,
         )
+        self.evidence_types = _param_evidence_types(
+            memory_params,
+            "evidence_types",
+            DEFAULT_EVIDENCE_TYPES,
+        )
         self.evidence_composition_mode = _param_str(
             memory_params,
             "evidence_composition_mode",
@@ -3858,6 +3873,28 @@ class SibylLiveApiMemory(Memory):
         if getattr(self, "typed_stream_retrieval", DEFAULT_TYPED_STREAM_RETRIEVAL):
             stream_executor = ThreadPoolExecutor(max_workers=1)
             stream_future = stream_executor.submit(self._typed_stream_results, query)
+        evidence_limit = min(max(self.search_limit, self.max_context_items), 50)
+        evidence_request: dict[str, object] = {
+            "types": list(getattr(self, "evidence_types", DEFAULT_EVIDENCE_TYPES)),
+            "limit": evidence_limit,
+            "max_results_per_source": getattr(
+                self,
+                "max_chunks_per_trajectory",
+                DEFAULT_MAX_CHUNKS_PER_TRAJECTORY,
+            ),
+            "content_max_chars": self.max_context_chars_per_item,
+            "include_retrieval_diagnostics": True,
+            "retrieval_mode": getattr(
+                self,
+                "retrieval_mode",
+                DEFAULT_RETRIEVAL_MODE,
+            ),
+            "max_planned_queries": getattr(
+                self,
+                "retrieval_max_planned_queries",
+                DEFAULT_RETRIEVAL_MAX_PLANNED_QUERIES,
+            ),
+        }
         context_response = self._request_json(
             "POST",
             "/context/pack",
@@ -3866,32 +3903,12 @@ class SibylLiveApiMemory(Memory):
                 "intent": "learn",
                 "layer": "deep_search",
                 "project": self.project_id,
-                "limit": min(max(self.search_limit, self.max_context_items), 50),
+                "limit": evidence_limit,
                 "include_related": True,
                 "related_limit": 3,
                 "audit": True,
                 "record_exposure": False,
-                "evidence": {
-                    "types": ["session"],
-                    "limit": min(max(self.search_limit, self.max_context_items), 50),
-                    "max_results_per_source": getattr(
-                        self,
-                        "max_chunks_per_trajectory",
-                        DEFAULT_MAX_CHUNKS_PER_TRAJECTORY,
-                    ),
-                    "content_max_chars": self.max_context_chars_per_item,
-                    "include_retrieval_diagnostics": True,
-                    "retrieval_mode": getattr(
-                        self,
-                        "retrieval_mode",
-                        DEFAULT_RETRIEVAL_MODE,
-                    ),
-                    "max_planned_queries": getattr(
-                        self,
-                        "retrieval_max_planned_queries",
-                        DEFAULT_RETRIEVAL_MAX_PLANNED_QUERIES,
-                    ),
-                },
+                "evidence": evidence_request,
             },
         )
         typed_results = context_pack_to_search_results(
@@ -5342,6 +5359,36 @@ def _store_cli_auth(
 def _param_str(params: dict[str, object], key: str, default: str) -> str:
     value = params.get(key)
     return value.strip() if isinstance(value, str) and value.strip() else default
+
+
+def _param_evidence_types(
+    params: dict[str, object],
+    key: str,
+    default: tuple[str, ...],
+) -> tuple[str, ...]:
+    value = params.get(key)
+    if value is None:
+        return default
+    if isinstance(value, str):
+        requested = [item.strip() for item in value.split(",")]
+    elif isinstance(value, list | tuple):
+        requested = [str(item).strip() for item in value]
+    else:
+        raise ValueError(f"{key} must be a list of entity types or a comma-separated string")
+    ordered: list[str] = []
+    for entity_type in requested:
+        if not entity_type or entity_type in ordered:
+            continue
+        if entity_type not in SUPPORTED_EVIDENCE_TYPES:
+            msg = (
+                f"Unknown evidence type {entity_type!r}; "
+                f"expected one of {sorted(SUPPORTED_EVIDENCE_TYPES)}"
+            )
+            raise ValueError(msg)
+        ordered.append(entity_type)
+    if not ordered:
+        raise ValueError(f"{key} must name at least one entity type")
+    return tuple(ordered)
 
 
 def _param_bool(params: dict[str, object], key: str, default: bool) -> bool:

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -2609,8 +2609,13 @@ def _result_diversity_key(result: dict[str, object]) -> tuple[str, int | str]:
     if not trajectory_id:
         trajectory_id = _stripped_str(result.get("id")) or f"unknown:{id(result)}"
     state_index = metadata.get("longmemeval_v2_state_index")
-    state_key: int | str = state_index if isinstance(state_index, int) else "unknown"
-    return trajectory_id, state_key
+    if isinstance(state_index, int):
+        return trajectory_id, state_index
+    # A row cut below state granularity carries no state index, so the state is
+    # not a unit it can be spread across; its own identity is. Collapsing every
+    # such row of a trajectory onto one shared key would admit exactly one of
+    # them and call the rest duplicates of each other.
+    return trajectory_id, _stripped_str(result.get("id")) or "unknown"
 
 
 def _result_chunk_key(result: dict[str, object]) -> tuple[str, int | str]:
@@ -2619,8 +2624,15 @@ def _result_chunk_key(result: dict[str, object]) -> tuple[str, int | str]:
     if not trajectory_id:
         trajectory_id = _stripped_str(result.get("id")) or f"unknown:{id(result)}"
     chunk_index = metadata.get("longmemeval_v2_chunk_index")
-    chunk_key: int | str = chunk_index if isinstance(chunk_index, int) else trajectory_id
-    return trajectory_id, chunk_key
+    if isinstance(chunk_index, int):
+        return trajectory_id, chunk_index
+    # Falling back to the trajectory says "this row is the whole trajectory",
+    # which was true while every trajectory-tagged row was a numbered chunk. A
+    # substrate cut finer than the chunk index breaks that: siblings would share
+    # one key and dedupe each other down to a single admitted row. The row's own
+    # id is the finest stable identity available, and the trajectory component
+    # above already falls back to it the same way.
+    return trajectory_id, _stripped_str(result.get("id")) or trajectory_id
 
 
 def _restore_catalog_content(

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -183,6 +183,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "state_part_refinement",
         "context_expansion_max_ratio",
         "evidence_types",
+        "evidence_char_budget",
         "evidence_composition_mode",
         "source_evidence_bundling",
         "retrieval_mode",
@@ -682,10 +683,32 @@ def compile_operational_evidence_set(
     max_items: int,
     mode: str = DEFAULT_EVIDENCE_COMPOSITION_MODE,
     typed_reservation_items: int | None = None,
+    char_budget: int | None = None,
 ) -> tuple[list[dict[str, object]], dict[str, object]]:
+    """Compose the reader's pack from the typed and raw evidence pools.
+
+    `char_budget` changes what bounds the pack, mirroring the server-side
+    `compose_operational_evidence` contract. Without one the pack is bounded by
+    `max_items` and composes exactly as it shipped. With one, item count stops
+    bounding the lanes: candidates are admitted in rank order while the running
+    total of rendered content fits, so the pack stays a prefix of its ranking
+    and never exceeds the budget.
+
+    The adapter has to bound in characters too rather than leaning on the
+    server's budget alone. It merges its own distilled-note stream into the
+    server's pack and it restores full catalog content over the transport-
+    truncated content the server counted, so the reader payload is not the one
+    the server bounded.
+    """
     if mode not in EVIDENCE_COMPOSITION_MODES:
         msg = f"Unknown evidence composition mode {mode!r}; expected {sorted(EVIDENCE_COMPOSITION_MODES)}"
         raise ValueError(msg)
+    if char_budget is not None:
+        if char_budget < 1:
+            raise ValueError("char_budget must be positive")
+        if mode != "shared_relevance":
+            msg = f"char_budget is only defined for shared_relevance composition, not {mode!r}"
+            raise ValueError(msg)
     max_items = max(1, max_items)
     typed_candidates: list[dict[str, object]] = []
     raw_candidates: list[dict[str, object]] = []
@@ -757,14 +780,42 @@ def compile_operational_evidence_set(
         if typed_reservation_items is not None
         else TYPED_NOTE_RESERVATION_ITEMS
     )
-    typed_reservation = min(len(ranked_typed), max(1, min(requested_reservation, max_items - 1)))
-    raw_budget = min(len(ranked_raw), max_items - typed_reservation)
-    selected_raw = _select_role_complete_raw_evidence(ranked_raw, budget=raw_budget)
-    selected = [*ranked_typed[:typed_reservation], *selected_raw]
-    if len(selected) < max_items:
-        selected.extend(
-            ranked_typed[typed_reservation : typed_reservation + max_items - len(selected)]
+    if char_budget is None:
+        typed_reservation = min(
+            len(ranked_typed),
+            max(1, min(requested_reservation, max_items - 1)),
         )
+        raw_budget = min(len(ranked_raw), max_items - typed_reservation)
+        selected_raw = _select_role_complete_raw_evidence(ranked_raw, budget=raw_budget)
+        selected = [*ranked_typed[:typed_reservation], *selected_raw]
+        if len(selected) < max_items:
+            selected.extend(
+                ranked_typed[typed_reservation : typed_reservation + max_items - len(selected)]
+            )
+        selected_chars = sum(len(_stripped_str(item.get("content"))) for item in selected)
+    else:
+        # The note lane keeps its absolute count inside the budget, but the
+        # budget outranks the pin when it cannot hold that many: a lane allowed
+        # to overrun the budget is not a budget.
+        reserved, spent = _admit_within_char_budget(
+            ranked_typed[: max(1, requested_reservation)],
+            budget=char_budget,
+            spent=0,
+        )
+        ordered_raw = _select_role_complete_raw_evidence(ranked_raw, budget=len(ranked_raw))
+        selected_raw, spent = _admit_within_char_budget(
+            ordered_raw,
+            budget=char_budget,
+            spent=spent,
+        )
+        overflow, spent = _admit_within_char_budget(
+            ranked_typed[len(reserved) :],
+            budget=char_budget,
+            spent=spent,
+        )
+        typed_reservation = len(reserved)
+        selected = [*reserved, *selected_raw, *overflow]
+        selected_chars = spent
     for selection_rank, candidate in enumerate(selected, start=1):
         candidate["_evidence_selection_rank"] = selection_rank
 
@@ -788,7 +839,33 @@ def compile_operational_evidence_set(
         ),
         "selected_typed_count": selected_typed,
         "selected_raw_count": len(selected) - selected_typed,
+        "budget_mode": "items" if char_budget is None else "characters",
+        "char_budget": char_budget,
+        "selected_chars": selected_chars,
     }
+
+
+def _admit_within_char_budget(
+    candidates: list[dict[str, object]],
+    *,
+    budget: int,
+    spent: int,
+) -> tuple[list[dict[str, object]], int]:
+    """Take the longest rank prefix of `candidates` that still fits.
+
+    Admission stops at the first candidate that does not fit rather than
+    skipping it for a smaller one further down. Packing by size would reorder
+    relevance against length and cost the guarantee that a pack is a prefix of
+    its ranking.
+    """
+    admitted: list[dict[str, object]] = []
+    for candidate in candidates:
+        candidate_chars = len(_stripped_str(candidate.get("content")))
+        if spent + candidate_chars > budget:
+            break
+        admitted.append(candidate)
+        spent += candidate_chars
+    return admitted, spent
 
 
 _ENTITY_TOKEN_RE = re.compile(r"\b[A-Z][a-zA-Z0-9]+(?:[-'][A-Z][a-zA-Z0-9]+)*\b")
@@ -2089,6 +2166,79 @@ def build_retrieval_trace(
     return trace
 
 
+def validate_evidence_char_budget(
+    *,
+    char_budget: int | None,
+    content_max_chars: int,
+    max_context_chars_per_item: int,
+    max_context_total_chars: int,
+) -> None:
+    """Reject the configurations in which a character budget stops measuring size.
+
+    A budget in characters only distinguishes substrates while items are allowed
+    to cost what they actually cost. Every evidence result is truncated to
+    `max_context_chars_per_item` on the way back, so once that cap is below the
+    size of a stored unit, a 1K passage and a 12K state both spend the cap and
+    the budget silently degenerates into an item budget with extra steps. The
+    coupling is checkable rather than a matter of taste: ingest already bounds
+    every stored unit at `content_max_chars`, so a per-item cap at least that
+    large means truncation can never be the binding constraint.
+
+    The render total is the other end of the same pack. A budget larger than
+    `max_context_total_chars` cannot reach the reader, because rendering would
+    compact the pack back down and the run would measure compaction while
+    reporting a substrate.
+
+    Both are hard errors rather than warnings. The failure mode is a paid run
+    that returns a plausible number arguing against the substrate, and a warning
+    in a CI log is not a thing anyone reads before paying for it. A run that
+    genuinely wants to measure compaction says so by lowering
+    `max_context_total_chars`, which is the knob that already means that.
+    """
+    if char_budget is None:
+        return
+    if char_budget < 1:
+        raise ValueError("evidence_char_budget must be positive")
+    if max_context_chars_per_item < content_max_chars:
+        msg = (
+            f"evidence_char_budget requires max_context_chars_per_item "
+            f"({max_context_chars_per_item}) to be at least content_max_chars "
+            f"({content_max_chars}); below that every result is truncated to the "
+            "same size and the character budget degenerates into an item budget"
+        )
+        raise ValueError(msg)
+    if char_budget > max_context_total_chars:
+        msg = (
+            f"evidence_char_budget ({char_budget}) exceeds max_context_total_chars "
+            f"({max_context_total_chars}); the pack would be composed to the budget "
+            "and then compacted back down at render, so the run would measure "
+            "compaction rather than the substrate"
+        )
+        raise ValueError(msg)
+
+
+def context_pack_item_ceiling(
+    *,
+    max_items: int,
+    char_budget: int | None,
+    candidate_count: int,
+) -> int:
+    """Item ceiling for the pack stages that run after the API answers.
+
+    An item count and a character budget are two bounds on the same pack and
+    only one of them can be the binding one. Without a budget the item count
+    binds, exactly as it shipped. With a budget in force the composer bounds the
+    pack in characters, so an item ceiling upstream or downstream of it would
+    silently clip a budgeted pack back to the old geometry and the budget would
+    never be measurable. The ceiling then rises to whatever the stage was handed
+    so it cannot bind, and the composer stays the one place the pack is bounded.
+    """
+    max_items = max(1, max_items)
+    if char_budget is None:
+        return max_items
+    return max(max_items, candidate_count)
+
+
 def context_assembly_candidate_limit(
     *,
     max_items: int,
@@ -3009,6 +3159,18 @@ class SibylLiveApiMemory(Memory):
                 DEFAULT_CONTEXT_TOTAL_CHARS,
             ),
         )
+        raw_char_budget = memory_params.get("evidence_char_budget")
+        self.evidence_char_budget = (
+            _param_int(memory_params, "evidence_char_budget", 0, minimum=1)
+            if raw_char_budget is not None
+            else None
+        )
+        validate_evidence_char_budget(
+            char_budget=self.evidence_char_budget,
+            content_max_chars=self.content_max_chars,
+            max_context_chars_per_item=self.max_context_chars_per_item,
+            max_context_total_chars=self.max_context_total_chars,
+        )
         self.context_expansion_max_ratio = _param_context_expansion_ratio(
             memory_params,
             "context_expansion_max_ratio",
@@ -3895,6 +4057,11 @@ class SibylLiveApiMemory(Memory):
                 DEFAULT_RETRIEVAL_MAX_PLANNED_QUERIES,
             ),
         }
+        char_budget = getattr(self, "evidence_char_budget", None)
+        if char_budget is not None:
+            # Omitted rather than sent as null when unset, so a run reproducing
+            # the old geometry puts a byte-identical request on the wire.
+            evidence_request["char_budget"] = char_budget
         context_response = self._request_json(
             "POST",
             "/context/pack",
@@ -3954,7 +4121,11 @@ class SibylLiveApiMemory(Memory):
             results,
             chunk_catalog=chunk_catalog,
             max_items=context_assembly_candidate_limit(
-                max_items=self.max_context_items,
+                max_items=context_pack_item_ceiling(
+                    max_items=self.max_context_items,
+                    char_budget=char_budget,
+                    candidate_count=len(results),
+                ),
                 neighbor_stitch_items=neighbor_stitch_items,
                 state_part_completion_items=state_part_completion_items,
                 has_chunk_catalog=bool(chunk_catalog),
@@ -3998,6 +4169,12 @@ class SibylLiveApiMemory(Memory):
                 DEFAULT_EVIDENCE_COMPOSITION_MODE,
             ),
             typed_reservation_items=getattr(self, "typed_reservation_items", None),
+            char_budget=char_budget,
+        )
+        rendered_item_ceiling = context_pack_item_ceiling(
+            max_items=self.max_context_items,
+            char_budget=char_budget,
+            candidate_count=len(evidence_set),
         )
         assembly_metadata["typed_context_candidate_count"] = len(typed_results)
         assembly_metadata["typed_context_selected_count"] = sum(
@@ -4009,7 +4186,7 @@ class SibylLiveApiMemory(Memory):
         memory_context, context_budget = render_memory_context(
             evidence_set,
             query=query,
-            max_items=self.max_context_items,
+            max_items=rendered_item_ceiling,
             max_chars_per_item=self.max_context_chars_per_item,
             max_total_chars=getattr(
                 self,
@@ -4020,7 +4197,7 @@ class SibylLiveApiMemory(Memory):
         assembly_metadata["context_budget"] = context_budget
         self._query_local.retrieval_trace = build_retrieval_trace(
             evidence_set,
-            max_items=self.max_context_items,
+            max_items=rendered_item_ceiling,
             max_chars_per_item=self.max_context_chars_per_item,
             context_budget=context_budget,
         )
@@ -4036,7 +4213,11 @@ class SibylLiveApiMemory(Memory):
             search_results_to_memory_context(
                 results,
                 query=query,
-                max_items=self.max_context_items,
+                max_items=context_pack_item_ceiling(
+                    max_items=self.max_context_items,
+                    char_budget=getattr(self, "evidence_char_budget", None),
+                    candidate_count=len(results),
+                ),
                 max_chars_per_item=self.max_context_chars_per_item,
                 max_total_chars=getattr(
                     self,

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -72,6 +72,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "state_part_refinement",
         "context_expansion_max_ratio",
         "evidence_types",
+        "evidence_char_budget",
         "evidence_composition_mode",
         "source_evidence_bundling",
         "typed_stream_retrieval",
@@ -454,6 +455,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
         ),
     )
     parser.add_argument(
+        "--evidence-char-budget",
+        type=int,
+        default=None,
+        help=(
+            "Bound the composed pack by characters of returned content instead of item "
+            "count. Item count only bounds reader payload while item size is stable, "
+            "which stops holding once passages and whole states share a pack. Leave "
+            "unset to reproduce the shipped item-bounded geometry."
+        ),
+    )
+    parser.add_argument(
         "--evidence-composition-mode",
         choices=["reserved_support", "shared_relevance"],
         default="shared_relevance",
@@ -663,6 +675,7 @@ def build_memory_config(args: argparse.Namespace) -> dict[str, object]:
         "state_part_refinement": args.state_part_refinement,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "evidence_types": list(args.evidence_types),
+        "evidence_char_budget": args.evidence_char_budget,
         "evidence_composition_mode": args.evidence_composition_mode,
         "source_evidence_bundling": args.source_evidence_bundling,
         "typed_stream_retrieval": args.typed_stream_retrieval,
@@ -808,6 +821,7 @@ def build_run_plan(
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "max_context_total_chars": args.max_context_total_chars,
         "evidence_types": list(args.evidence_types),
+        "evidence_char_budget": args.evidence_char_budget,
         "evidence_composition_mode": args.evidence_composition_mode,
         "source_evidence_bundling": args.source_evidence_bundling,
         "typed_stream_retrieval": args.typed_stream_retrieval,

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -71,6 +71,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "state_part_completion_items",
         "state_part_refinement",
         "context_expansion_max_ratio",
+        "evidence_types",
         "evidence_composition_mode",
         "source_evidence_bundling",
         "typed_stream_retrieval",
@@ -442,6 +443,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
     )
     parser.add_argument("--context-expansion-max-ratio", type=float, default=0.0)
     parser.add_argument(
+        "--evidence-types",
+        nargs="+",
+        choices=["passage", "session"],
+        default=["session"],
+        help=(
+            "Entity types the raw evidence lane may retrieve. The list reaches the search "
+            "as a hard node-type filter, so a type left out never enters the candidate pool. "
+            "Defaults to the shipped whole-state substrate."
+        ),
+    )
+    parser.add_argument(
         "--evidence-composition-mode",
         choices=["reserved_support", "shared_relevance"],
         default="shared_relevance",
@@ -650,6 +662,7 @@ def build_memory_config(args: argparse.Namespace) -> dict[str, object]:
         "state_part_completion_items": args.state_part_completion_items,
         "state_part_refinement": args.state_part_refinement,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
+        "evidence_types": list(args.evidence_types),
         "evidence_composition_mode": args.evidence_composition_mode,
         "source_evidence_bundling": args.source_evidence_bundling,
         "typed_stream_retrieval": args.typed_stream_retrieval,
@@ -794,6 +807,7 @@ def build_run_plan(
         "neighbor_stitch_span": args.neighbor_stitch_span,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "max_context_total_chars": args.max_context_total_chars,
+        "evidence_types": list(args.evidence_types),
         "evidence_composition_mode": args.evidence_composition_mode,
         "source_evidence_bundling": args.source_evidence_bundling,
         "typed_stream_retrieval": args.typed_stream_retrieval,

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -2235,6 +2235,66 @@ def test_sibyl_memory_context_token_count_matches_official_processor_contract(
     }
 
 
+def test_passages_of_one_trajectory_are_distinct_assembly_candidates() -> None:
+    """Sub-state rows must not dedupe each other down to one row per trajectory.
+
+    Passages carry the trajectory id but neither a chunk index nor a state
+    index, so keying their fallback on the trajectory made every passage of a
+    trajectory the same candidate. Assembly then admitted the first and
+    discarded its siblings as duplicates, which is a slice substrate that
+    returns one slice per trajectory however many the search found.
+    """
+    module = _load_memory_module()
+    passages = [
+        _passage_result("t1", observation_ordinal=3, passage_index=index, score=1.0 - index / 10)
+        for index in range(4)
+    ]
+
+    chunk_keys = {module._result_chunk_key(passage) for passage in passages}
+    diversity_keys = {module._result_diversity_key(passage) for passage in passages}
+    assembled, _metadata = module.assemble_context_results(
+        passages,
+        chunk_catalog={},
+        max_items=len(passages),
+        max_chunks_per_trajectory=len(passages),
+        neighbor_stitch_items=0,
+        neighbor_stitch_span=0,
+    )
+
+    assert len(chunk_keys) == len(passages)
+    assert len(diversity_keys) == len(passages)
+    assert [result["id"] for result in assembled] == [passage["id"] for passage in passages]
+
+
+def test_chunk_indexed_rows_keep_their_existing_identity() -> None:
+    """The fat-state substrate keys exactly as it did; only the fallback moved.
+
+    Every frozen campaign number came from rows that carry an integer chunk
+    index and an integer state index, and both keys short-circuit on those
+    before reaching the new fallback.
+    """
+    module = _load_memory_module()
+    results = [
+        _search_result("t1", chunk_index=0, state_index=0, score=1.0),
+        _search_result("t1", chunk_index=1, state_index=1, score=0.9),
+        _search_result("t2", chunk_index=0, state_index=0, score=0.8),
+    ]
+
+    assert [module._result_chunk_key(result) for result in results] == [
+        ("t1", 0),
+        ("t1", 1),
+        ("t2", 0),
+    ]
+    assert [module._result_diversity_key(result) for result in results] == [
+        ("t1", 0),
+        ("t1", 1),
+        ("t2", 0),
+    ]
+
+    untagged = {"id": "entity:loose", "type": "session", "content": "no trajectory", "metadata": {}}
+    assert module._result_chunk_key(untagged) == ("entity:loose", "entity:loose")
+
+
 def test_sibyl_memory_assembles_diverse_seeds_with_neighbors() -> None:
     module = _load_memory_module()
     t1_seed = _search_result("t1", chunk_index=1, state_index=1, score=1.0)
@@ -6042,5 +6102,35 @@ def _search_result(
             "longmemeval_v2_chunk_index": chunk_index,
             "longmemeval_v2_state_index": state_index,
             "longmemeval_v2_state_indices": [state_index],
+        },
+    }
+
+
+def _passage_result(
+    trajectory_id: str,
+    *,
+    observation_ordinal: int,
+    passage_index: int,
+    score: float,
+    content_chars: int = 1_000,
+) -> dict[str, Any]:
+    """A passage row as the operational projection actually mints it.
+
+    The metadata bag is the projection's shared `common` block plus the
+    passage's own fields, so it carries the trajectory id but neither the
+    chunk index nor the state index the fat-state substrate keys on.
+    """
+    return {
+        "id": f"entity:{trajectory_id}:state-{observation_ordinal}:passage-{passage_index}",
+        "type": "passage",
+        "name": f"Observation {observation_ordinal} passage {passage_index + 1}",
+        "content": "x" * content_chars,
+        "score": score,
+        "result_origin": "graph",
+        "metadata": {
+            "longmemeval_v2_trajectory_id": trajectory_id,
+            "projection_kind": "passage",
+            "observation_ordinal": observation_ordinal,
+            "passage_index": passage_index,
         },
     }

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -55,6 +55,8 @@ EXPECTED_SAVED_USAGE_COST_USD = 0.25
 EXPECTED_USAGE_ATTEMPTS = 2
 EXPECTED_OPERATIONAL_CREATED_ENTITIES = 4
 EXPECTED_OPERATIONAL_EVIDENCE_ITEMS = 8
+EXPECTED_TYPED_NOTE_RESERVATION = 3
+EXPECTED_BUDGETED_RAW_ITEMS = 10
 EXPECTED_OPERATIONAL_RAW_ITEMS = 6
 EXPECTED_OPERATIONAL_TYPED_ITEMS = 2
 EXPECTED_OPERATIONAL_SUPPORT_ITEMS = 3
@@ -3210,6 +3212,175 @@ def test_eval_reserved_lane_is_an_absolute_count_a_wider_pack_cannot_widen(
     assert len(override_selected) == max_items
 
 
+def _budget_pools(
+    *,
+    note_chars: int,
+    raw_chars: int,
+    note_count: int = 12,
+    raw_count: int = 40,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    typed = [
+        {
+            "id": f"note_{index}",
+            "type": "note",
+            "content": f"note {index} about the field ".ljust(note_chars, "x"),
+            "_selection_origin": "context_pack:typed_stream",
+            "metadata": {"longmemeval_v2_trajectory_id": f"t{index}"},
+        }
+        for index in range(note_count)
+    ]
+    raw = [
+        {
+            "id": f"session_{index}",
+            "type": "session",
+            "content": f"raw slice {index} of the field ".ljust(raw_chars, "x"),
+            "metadata": {"longmemeval_v2_trajectory_id": f"t{index}"},
+        }
+        for index in range(raw_count)
+    ]
+    return typed, raw
+
+
+@pytest.mark.parametrize("max_items", [8, 28])
+def test_char_budget_bounds_the_pack_and_item_count_stops_binding(max_items: int) -> None:
+    """With a budget in force the pack is bounded by characters, not by `max_items`.
+
+    The same budget must produce the same pack at both pack sizes, otherwise
+    `max_items` is still the real bound and the budget is decoration.
+    """
+    module = _load_memory_module()
+    note_chars = 200
+    raw_chars = 1_000
+    budget = 3 * note_chars + 10 * raw_chars
+    typed, raw = _budget_pools(note_chars=note_chars, raw_chars=raw_chars)
+
+    selected, meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=max_items,
+        mode="shared_relevance",
+        char_budget=budget,
+    )
+
+    assert meta["budget_mode"] == "characters"
+    assert meta["char_budget"] == budget
+    assert meta["selected_chars"] <= budget
+    assert meta["selected_chars"] == sum(len(str(item["content"])) for item in selected)
+    assert meta["selected_chars"] == budget
+    assert len(selected) == EXPECTED_TYPED_NOTE_RESERVATION + EXPECTED_BUDGETED_RAW_ITEMS
+    assert meta["selected_typed_count"] == EXPECTED_TYPED_NOTE_RESERVATION
+    assert meta["selected_raw_count"] == EXPECTED_BUDGETED_RAW_ITEMS
+
+
+@pytest.mark.parametrize("max_items", [8, 28])
+def test_char_budget_keeps_the_note_lane_pinned_at_its_absolute_count(max_items: int) -> None:
+    """The parent branch's pin survives the budget at both pack sizes.
+
+    The note lane is the campaign's one proven lever and it was tuned as an
+    absolute count. A budget changes what bounds the pack, not how many
+    distilled notes are worth reading.
+    """
+    module = _load_memory_module()
+    typed, raw = _budget_pools(note_chars=200, raw_chars=1_000)
+
+    _selected, meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=max_items,
+        mode="shared_relevance",
+        char_budget=200 * 3 + 1_000 * 10,
+    )
+
+    assert meta["typed_reservation"] == EXPECTED_TYPED_NOTE_RESERVATION
+    assert meta["selected_typed_count"] == EXPECTED_TYPED_NOTE_RESERVATION
+
+
+def test_char_budget_outranks_the_note_pin_when_it_cannot_hold_three_notes() -> None:
+    """A lane allowed to overrun the budget is not a budget."""
+    module = _load_memory_module()
+    note_chars = 500
+    typed, raw = _budget_pools(note_chars=note_chars, raw_chars=1_000)
+
+    selected, meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=8,
+        mode="shared_relevance",
+        char_budget=note_chars,
+    )
+
+    assert meta["typed_reservation"] == 1
+    assert meta["selected_chars"] <= note_chars
+    assert len(selected) == 1
+
+
+def test_char_budget_admits_a_rank_prefix_rather_than_packing_by_size() -> None:
+    """Admission stops at the first candidate that does not fit.
+
+    Skipping a large candidate for a smaller one further down would reorder
+    relevance against length and cost the guarantee that a pack is a prefix of
+    its ranking.
+    """
+    module = _load_memory_module()
+    raw = [
+        {"id": "session_big", "type": "session", "content": "the field " * 400},
+        {"id": "session_small", "type": "session", "content": "the field again"},
+    ]
+
+    selected, meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=[],
+        raw_results=raw,
+        max_items=8,
+        mode="shared_relevance",
+        char_budget=100,
+    )
+
+    assert selected == []
+    assert meta["raw_candidate_count"] == len(raw)
+    assert meta["selected_raw_count"] == 0
+
+
+def test_composition_without_a_char_budget_reproduces_the_item_bounded_pack() -> None:
+    """The frozen geometry is what a run gets when it does not ask for a budget."""
+    module = _load_memory_module()
+    typed, raw = _budget_pools(note_chars=200, raw_chars=1_000)
+
+    selected, meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=8,
+        mode="shared_relevance",
+    )
+
+    assert meta["budget_mode"] == "items"
+    assert meta["char_budget"] is None
+    assert len(selected) == EXPECTED_OPERATIONAL_EVIDENCE_ITEMS
+    assert meta["typed_reservation"] == EXPECTED_TYPED_NOTE_RESERVATION
+    assert meta["selected_raw_count"] == EXPECTED_OPERATIONAL_EVIDENCE_ITEMS - (
+        EXPECTED_TYPED_NOTE_RESERVATION
+    )
+
+
+def test_char_budget_is_rejected_for_composition_modes_that_cannot_honor_it() -> None:
+    module = _load_memory_module()
+    typed, raw = _budget_pools(note_chars=200, raw_chars=1_000)
+
+    with pytest.raises(ValueError, match="only defined for shared_relevance"):
+        module.compile_operational_evidence_set(
+            query="find the field",
+            typed_results=typed,
+            raw_results=raw,
+            max_items=8,
+            mode="reserved_support",
+            char_budget=5_000,
+        )
+
+
 def test_entity_overlap_downranks_mismatched_notes() -> None:
     module = _load_memory_module()
     query = "Find the warranty expiration for Chelsea-Cynthia Tran-Dyer's laptop"
@@ -3868,6 +4039,47 @@ def test_official_runner_checkpoint_restart_reuses_saved_project(tmp_path: Path)
     assert params["retrieval_max_planned_queries"] == EXPECTED_RETRIEVAL_MAX_PLANNED_QUERIES
 
 
+def test_official_runner_carries_substrate_and_budget_arms_into_memory_params(
+    tmp_path: Path,
+) -> None:
+    """A slice arm has to be expressible on the command line, and reproducibly absent.
+
+    Both knobs default to the shipped configuration, so a run that names
+    neither builds the same memory params the frozen baseline did.
+    """
+    module = _load_runner_module()
+    data_root = tmp_path / "data"
+    _write_dataset(data_root)
+    base_argv = [
+        "--data-root",
+        str(data_root),
+        "--domain",
+        "enterprise",
+        "--output-dir",
+        str(tmp_path / "output"),
+        "--plan-only",
+    ]
+
+    default_params = module.build_memory_config(module.parse_args(base_argv))["memory_params"]
+    slice_params = module.build_memory_config(
+        module.parse_args(
+            [
+                *base_argv,
+                "--evidence-types",
+                "session",
+                "passage",
+                "--evidence-char-budget",
+                "60000",
+            ]
+        )
+    )["memory_params"]
+
+    assert default_params["evidence_types"] == ["session"]
+    assert default_params["evidence_char_budget"] is None
+    assert slice_params["evidence_types"] == ["session", "passage"]
+    assert slice_params["evidence_char_budget"] == EXPECTED_CONTEXT_TOTAL_CHARS
+
+
 def test_sibyl_memory_query_context_exposes_only_question_and_image() -> None:
     module = _load_memory_module()
     memory = module.SibylLiveApiMemory.__new__(module.SibylLiveApiMemory)
@@ -4015,6 +4227,65 @@ def test_query_reaches_passage_evidence_when_the_type_is_requested() -> None:
         assert f"passage-body-2-{index}" in rendered
 
 
+def _wide_passage_pool(count: int, *, content_chars: int) -> list[dict[str, Any]]:
+    return [
+        _passage_result(
+            f"t{index}",
+            observation_ordinal=1,
+            passage_index=0,
+            score=1.0 - index / 100,
+            content_chars=content_chars,
+        )
+        for index in range(count)
+    ]
+
+
+def test_query_with_a_char_budget_is_not_re_clipped_to_the_item_count() -> None:
+    """The adapter's own item budget must stop binding once a budget is in force.
+
+    A budget the server honors is defeated silently if the adapter then clips
+    the pack back to `max_context_items` on the way to the reader, which is
+    what every post-API stage did unconditionally.
+    """
+    module = _load_memory_module()
+    passage_chars = 1_000
+    passages = _wide_passage_pool(20, content_chars=passage_chars)
+    request_payloads: list[dict[str, Any]] = []
+    memory = _passage_query_memory(
+        module,
+        results=passages,
+        request_payloads=request_payloads,
+    )
+    memory.evidence_types = ("session", "passage")
+    memory.max_context_chars_per_item = passage_chars
+    memory.max_context_total_chars = 400_000
+    memory.evidence_char_budget = len(passages) * passage_chars
+
+    context = memory.query("Which filter was selected?")
+
+    assert request_payloads[0]["evidence"]["char_budget"] == len(passages) * passage_chars
+    assert memory.max_context_items == EXPECTED_OPERATIONAL_EVIDENCE_ITEMS
+    assert len(context) == len(passages)
+
+
+def test_query_without_a_char_budget_keeps_the_item_bounded_geometry() -> None:
+    """The frozen baseline arm still sends the same request and gets the same pack."""
+    module = _load_memory_module()
+    passages = _wide_passage_pool(20, content_chars=1_000)
+    request_payloads: list[dict[str, Any]] = []
+    memory = _passage_query_memory(
+        module,
+        results=passages,
+        request_payloads=request_payloads,
+    )
+    memory.evidence_types = ("session", "passage")
+
+    context = memory.query("Which filter was selected?")
+
+    assert "char_budget" not in request_payloads[0]["evidence"]
+    assert len(context) == EXPECTED_OPERATIONAL_EVIDENCE_ITEMS
+
+
 def test_per_trajectory_chunk_cap_still_bounds_passages_from_one_trajectory() -> None:
     """`max_chunks_per_trajectory` is load-bearing once the unit is a passage.
 
@@ -4083,6 +4354,59 @@ def test_evidence_types_param_accepts_explicit_substrates(
         module._param_evidence_types(params, "evidence_types", module.DEFAULT_EVIDENCE_TYPES)
         == expected
     )
+
+
+def test_char_budget_accepts_the_shipped_per_item_and_total_caps() -> None:
+    """The eval's own defaults must not trip the coupling check.
+
+    Ingest and retrieval both cap at 18,000 today, so nothing truncates before
+    the budget does and the budget spends what items actually cost.
+    """
+    module = _load_memory_module()
+
+    module.validate_evidence_char_budget(
+        char_budget=60_000,
+        content_max_chars=module.DEFAULT_CONTENT_MAX_CHARS,
+        max_context_chars_per_item=module.DEFAULT_CONTEXT_CHARS_PER_ITEM,
+        max_context_total_chars=module.DEFAULT_CONTEXT_TOTAL_CHARS,
+    )
+    module.validate_evidence_char_budget(
+        char_budget=None,
+        content_max_chars=module.DEFAULT_CONTENT_MAX_CHARS,
+        max_context_chars_per_item=500,
+        max_context_total_chars=module.DEFAULT_CONTEXT_TOTAL_CHARS,
+    )
+
+
+def test_char_budget_rejects_a_per_item_cap_that_flattens_every_item() -> None:
+    """A per-item cap below the stored unit size turns the budget into an item budget.
+
+    A 1K passage and a 12K state both spend the cap once truncation binds, so
+    the budget stops measuring size and starts counting items again. This is a
+    hard error because the failure mode is a paid run reporting a plausible
+    number that argues against the substrate.
+    """
+    module = _load_memory_module()
+
+    with pytest.raises(ValueError, match="degenerates into an item budget"):
+        module.validate_evidence_char_budget(
+            char_budget=60_000,
+            content_max_chars=18_000,
+            max_context_chars_per_item=500,
+            max_context_total_chars=module.DEFAULT_CONTEXT_TOTAL_CHARS,
+        )
+
+
+def test_char_budget_rejects_a_budget_the_render_total_cannot_carry() -> None:
+    module = _load_memory_module()
+
+    with pytest.raises(ValueError, match="exceeds max_context_total_chars"):
+        module.validate_evidence_char_budget(
+            char_budget=135_000,
+            content_max_chars=18_000,
+            max_context_chars_per_item=18_000,
+            max_context_total_chars=module.DEFAULT_CONTEXT_TOTAL_CHARS,
+        )
 
 
 @pytest.mark.parametrize("requested", [["slice"], [""], 7])
@@ -4331,6 +4655,9 @@ def test_operational_evidence_set_calibrates_typed_and_raw_score_pools() -> None
         "selected_raw_support_count": 0,
         "selected_typed_count": 3,
         "selected_raw_count": 5,
+        "budget_mode": "items",
+        "char_budget": None,
+        "selected_chars": sum(len(str(item["content"])) for item in selected),
     }
 
 
@@ -5459,6 +5786,9 @@ def test_sibyl_memory_finalize_drains_jobs_before_search() -> None:
                 "selected_raw_support_count": 0,
                 "selected_typed_count": 0,
                 "selected_raw_count": 0,
+                "budget_mode": "items",
+                "char_budget": None,
+                "selected_chars": 0,
             },
             "context_budget": {
                 "enabled": True,

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -3943,6 +3943,161 @@ def test_sibyl_memory_accurate_query_rejects_planner_fallback() -> None:
     }
 
 
+def _passage_query_memory(
+    module: ModuleType,
+    *,
+    results: list[dict[str, Any]],
+    request_payloads: list[dict[str, Any]],
+) -> Any:
+    memory = module.SibylLiveApiMemory.__new__(module.SibylLiveApiMemory)
+    module.Memory.__init__(memory, {})
+
+    def fake_request(
+        _method: str,
+        path: str,
+        *,
+        json: dict[str, object] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        assert path == "/context/pack"
+        assert json is not None
+        request_payloads.append(json)
+        return {
+            "sections": [],
+            "evidence": {
+                "results": results,
+                "filters": {"retrieval_mode": "native"},
+            },
+        }
+
+    memory.project_id = "project_lme"
+    memory.search_limit = 12
+    memory.max_context_items = 8
+    memory.max_context_chars_per_item = TEST_CONTEXT_MAX_CHARS
+    memory.retrieval_mode = "fast"
+    memory.retrieval_max_planned_queries = 3
+    memory._pending_embedding_job_ids = set()
+    memory._pending_projection_job_ids = set()
+    memory._ingest_finalized = True
+    memory._query_local = threading.local()
+    memory._request_json = fake_request
+    return memory
+
+
+def test_query_reaches_passage_evidence_when_the_type_is_requested() -> None:
+    """`types` is a hard node-type filter, so passages need naming to exist.
+
+    The composer never filtered by entity type, which is why passages looked
+    reachable. The search that feeds it does: the requested list becomes a
+    `node_types` filter, so a slice substrate that is not named here never
+    enters the candidate pool and a gate run would score an empty slice lane.
+    """
+    module = _load_memory_module()
+    passages = [
+        _passage_result("t1", observation_ordinal=2, passage_index=index, score=1.0 - index / 10)
+        for index in range(3)
+    ]
+    request_payloads: list[dict[str, Any]] = []
+    memory = _passage_query_memory(
+        module,
+        results=passages,
+        request_payloads=request_payloads,
+    )
+    memory.evidence_types = ("session", "passage")
+    memory.max_chunks_per_trajectory = len(passages)
+
+    context = memory.query("Which filter was selected?")
+
+    assert request_payloads[0]["evidence"]["types"] == ["session", "passage"]
+    assert len(context) == len(passages)
+    rendered = "\n".join(str(item["value"]) for item in context)
+    for index in range(len(passages)):
+        assert f"passage-body-2-{index}" in rendered
+
+
+def test_per_trajectory_chunk_cap_still_bounds_passages_from_one_trajectory() -> None:
+    """`max_chunks_per_trajectory` is load-bearing once the unit is a passage.
+
+    It defaults to two, which was a sane source-diversity floor when a chunk was
+    a whole state. At slice granularity it is a hard cap on how much of any one
+    trajectory the reader can ever see, so a passage arm has to raise it
+    deliberately. Pinned here so the cap is a stated configuration rather than a
+    surprise in a scored run.
+    """
+    module = _load_memory_module()
+    passages = [
+        _passage_result("t1", observation_ordinal=2, passage_index=index, score=1.0 - index / 10)
+        for index in range(5)
+    ]
+    request_payloads: list[dict[str, Any]] = []
+    memory = _passage_query_memory(
+        module,
+        results=passages,
+        request_payloads=request_payloads,
+    )
+    memory.evidence_types = ("session", "passage")
+
+    context = memory.query("Which filter was selected?")
+
+    assert module.DEFAULT_MAX_CHUNKS_PER_TRAJECTORY == EXPECTED_MAX_CHUNKS_PER_TRAJECTORY
+    assert len(context) == EXPECTED_MAX_CHUNKS_PER_TRAJECTORY
+
+
+def test_query_requests_the_whole_state_substrate_by_default() -> None:
+    """The shipped arm must still put exactly `["session"]` on the wire.
+
+    Every frozen campaign number came from the whole-state substrate, and the
+    gate is a paired comparison against it, so opting in to passages has to be
+    something a run states rather than something it inherits.
+    """
+    module = _load_memory_module()
+    request_payloads: list[dict[str, Any]] = []
+    memory = _passage_query_memory(
+        module,
+        results=[_search_result("t1", chunk_index=0, state_index=0, score=1.0)],
+        request_payloads=request_payloads,
+    )
+
+    memory.query("Which filter was selected?")
+
+    assert request_payloads[0]["evidence"]["types"] == ["session"]
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        (None, ("session",)),
+        (["session", "passage"], ("session", "passage")),
+        ("session,passage", ("session", "passage")),
+        (["passage", "passage", "session"], ("passage", "session")),
+    ],
+)
+def test_evidence_types_param_accepts_explicit_substrates(
+    requested: object,
+    expected: tuple[str, ...],
+) -> None:
+    module = _load_memory_module()
+    params = {} if requested is None else {"evidence_types": requested}
+
+    assert (
+        module._param_evidence_types(params, "evidence_types", module.DEFAULT_EVIDENCE_TYPES)
+        == expected
+    )
+
+
+@pytest.mark.parametrize("requested", [["slice"], [""], 7])
+def test_evidence_types_param_rejects_types_the_substrate_cannot_serve(requested: object) -> None:
+    """A typo here costs a paid run and returns an empty lane, so it fails loudly."""
+    module = _load_memory_module()
+
+    with pytest.raises(ValueError, match=r"evidence type|at least one entity type|must be a list"):
+        module._param_evidence_types(
+            {"evidence_types": requested},
+            "evidence_types",
+            module.DEFAULT_EVIDENCE_TYPES,
+        )
+
+
 def test_operational_experience_payload_preserves_oversized_state_evidence() -> None:
     module = _load_memory_module()
     trajectory = _trajectory("t1", tree="Priority field\n" * 2_000)
@@ -6124,7 +6279,7 @@ def _passage_result(
         "id": f"entity:{trajectory_id}:state-{observation_ordinal}:passage-{passage_index}",
         "type": "passage",
         "name": f"Observation {observation_ordinal} passage {passage_index + 1}",
-        "content": "x" * content_chars,
+        "content": f"passage-body-{observation_ordinal}-{passage_index} ".ljust(content_chars, "x"),
         "score": score,
         "result_origin": "graph",
         "metadata": {


### PR DESCRIPTION
# 🎯 Make the eval able to measure a slice substrate at all

**Stacked on #282.** Without these three fixes, a slice-substrate gate run scores an artifact of the harness rather than the substrate.

## 🚨 The defect nobody had found

`c55643bf` fixes the one that mattered most, and it was not on anyone's list.

`_result_chunk_key` and `_result_diversity_key` both fell back to the **trajectory id** when a row carried no chunk index or state index. Passages carry the projection's shared `common` metadata block, which has the trajectory id but neither eval-specific key. So **every passage of a trajectory produced one identical key, and assembly discarded the siblings as duplicates.**

Fixing only the known type-filter bug would have produced a "slice substrate" that returned **one passage per trajectory** — a catastrophic result that looks like slicing failed, arriving after a paid run. Both keys now fall back to the row's own id, symmetric with how the trajectory component already falls back. Rows carrying integer indices short-circuit above the fallback, so the fat-state geometry is bit-identical.

Falsifier: reverting the fix gives `assert 1 == 4`.

## 🛠️ The two known defects

`2ad65992` — `evidence_types` replaces the hard-coded `["session"]` that `_node_types_for_requested_types` turned into a hard filter. Defaults to `("session",)`, validated against an allow-list so a typo fails at config time rather than buying an empty lane and a plausible-looking zero. `TYPED_STREAM_TYPES` is untouched and both tuples now carry comments naming which lane they serve.

`92b5425e` — `evidence_char_budget` goes on the wire as `evidence.char_budget`, the composer admits candidates in rank order while the running total fits, and the item ceilings around it rise to what each stage was handed. Falsifier: reverting the ceiling wiring gives `assert 8 == 20`.

## ⚠️ Three things the brief for this work got wrong

**"`assemble_context_results` re-clips the pack" is one of four clips, not the clip.** `compile_operational_evidence_set`, `render_memory_context`, `build_retrieval_trace`, and `_count_context_result_tokens` all take `max_items` too. Fixing assembly alone leaves the pack clipped back to eight three stages later.

**A non-binding item ceiling alone would have silently un-pinned the note lane.** The composer appends typed overflow while `len(selected) < max_items`, so simply raising `max_items` admits *every* distilled note — undoing #282's absolute pin from the opposite direction. That is why the composer had to become genuinely char-bounded rather than item-unbounded, and why the pin tests are parametrized over both pack sizes *with a budget in force*.

**Adapter-side char accounting is not redundant with the server's.** The adapter merges its own distilled-note stream into the server's pack afterwards and restores full catalog content over the transport-truncated content the server counted. The payload the reader sees is not the payload the server bounded.

## 🔒 Keeping the old configuration reproducible

Every prior campaign number came from the fat-state path and the gate is a paired comparison against a frozen FAST+notes baseline, so the old geometry has to survive exactly.

Explicitly parameterized rather than a mode flag, and the two knobs are independent so an arm can move substrate and bounding separately — which the paired comparison needs. With neither set, the wire request is byte-identical (`char_budget` is **omitted, not sent as `null`**, enforced by two exact-match wire assertions), the composer runs the shipped path, and every ceiling binds as before.

## ⚖️ The `content_max_chars` coupling: rejected, not warned

`validate_evidence_char_budget` makes it a hard error. The coupling is checkable rather than a matter of taste: ingest already bounds every stored unit at `content_max_chars`, so requiring `max_context_chars_per_item >= content_max_chars` guarantees truncation can never bind before the budget does. A budget above `max_context_total_chars` is rejected at the other end, since the pack would be composed to budget then compacted back at render — measuring compaction while reporting a substrate. The shipped 18,000/18,000 pair passes untouched.

**Errors rather than warnings** because the failure mode is a paid run returning a plausible number that argues against slicing, and nobody reads a CI warning before paying.

## 🧪 Validation

\`\`\`
root:bench-gate-test     → 390 passed in 7.31s   (366 at branch point)
root:inventory-test      → 66 passed in 10.75s
root:inventory-lint      → All checks passed! / 115 files already formatted
root:inventory-typecheck → All checks passed!
\`\`\`

#282's pin still passes at both sizes. Two existing exact-receipt assertions were updated because `evidence_composition` gained `budget_mode` / `char_budget` / `selected_chars`, mirroring #284's core receipt; selection counts in both are unchanged. No paid API calls.

## 🧩 Before a gate run means anything, the whole stack must merge

This branch descends from `main ← a1-eval-reservation-pin`, while the passage work is `main ← a1-slice-entity-type ← a1-passage-projection ← a1-passage-retrieval`. Neither `EntityType.PASSAGE` nor `ContextEvidenceRequest.char_budget` exists here. The adapter only sends strings and ints over HTTP so it builds and tests cleanly — but against a server built from this branch alone, `char_budget` is **silently dropped** (`ContextEvidenceRequest` has no `extra=`, so pydantic v2 defaults to `extra="ignore"`) and `types: ["passage"]` returns nothing because no passage rows are minted.

## 📌 Two knobs a passage arm must raise on purpose

- **`max_chunks_per_trajectory`, default 2.** A sane source-diversity floor when a chunk was a whole state; a hard ceiling on how much of one trajectory the reader can ever see once the unit is a passage. Pinned by a test so it cannot surprise a scored run.
- **`search_limit`, default 12.** The request limit is `min(max(search_limit, max_context_items), 50)`, so a char budget can never spend more items than the server was asked for. A slice arm needs `--search-limit 50`.

Also left alone: `.github/workflows/longmemeval-v2.yml` has no inputs for the new flags, so a CI-driven arm cannot request either yet — that belongs with whoever schedules the paid run. And every passage renders as `Chunk: unknown` in the header, which is cosmetic but part of the measured render, so it was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)