### PR TITLE
feat(benchmarks): measure the pack knobs before the paid gate spends

### DIFF
--- a/benchmarks/longmemeval_v2_chunk_geometry/README.md
+++ b/benchmarks/longmemeval_v2_chunk_geometry/README.md
@@ -62,7 +62,7 @@ up, and nothing in CI imports it — `root:inventory-lint` only lints statically
 
 | Tier | Needs | Scripts |
 | --- | --- | --- |
-| Cheap | standard library only, plus the in-repo `benchmarks/longmemeval_v2_diagnostics.py` | `stage0`, `stage0b`, `stage0c`, `stage0d`, `stage0e`, `stage0f`, `stage0g`, `stage0h`, `summarize` |
+| Cheap | standard library only, plus the in-repo `benchmarks/longmemeval_v2_diagnostics.py` | `stage0`, `stage0b`, `stage0c`, `stage0d`, `stage0e`, `stage0f`, `stage0g`, `stage0h`, `stage2`, `summarize` |
 | Middle | `numpy`, `scipy`, `scikit-learn` | `stage1b` |
 | Heavy | the middle tier plus `sentence-transformers` and `torch` | `stage1` |
 
@@ -96,6 +96,7 @@ export SIBYL_A1_DATA_ROOT=/path/to/.moon/cache/benchmarks/longmemeval-v2-full
 python benchmarks/longmemeval_v2_chunk_geometry/stage0c.py   # cheapest, stdlib only
 python benchmarks/longmemeval_v2_chunk_geometry/stage0.py    # slowest Stage 0 pass
 python benchmarks/longmemeval_v2_chunk_geometry/stage0h.py   # part-confined arms, ~25s
+python benchmarks/longmemeval_v2_chunk_geometry/stage2.py    # pack-knob sweep, stdlib BM25
 python benchmarks/longmemeval_v2_chunk_geometry/stage1.py    # needs the ML stack
 python benchmarks/longmemeval_v2_chunk_geometry/summarize.py # renders the Stage 1 verdict table
 ```
@@ -122,6 +123,7 @@ the receipts.
 | `stage0g.py` | v1 vs v2 boundary rules side by side, re-checking band, count, and exposure. | "Boundary rules the data argues for, all verified to preserve exposure and the zero straddle rate." |
 | `stage1.py` | Offline selection simulation. Arms FAT / SLICE / SLICE_GOAL against BM25, dense (local MiniLM), and RRF; recall at both item and character budgets. | The selection-dilution result, the goal-carry lift (RRF 0.727 / 0.812 vs fat 0.682 / 0.792), and the character-budget argument. |
 | `stage1b.py` | Falsification: strip the trajectory preamble from the fat arm and see whether its BM25 lead collapses. | "the mechanism is BM25 document length, not semantics — stripping the goal preamble from fat chunks barely moves them." |
+| `stage2.py` | The two pack-composition knobs on the production passage substrate: `max_chunks_per_trajectory` x evidence-lane depth, at the staged gate geometry. Ranking-free cap ceiling, a stdlib BM25 grid, and the loss cause behind every miss. | Sets both knobs for the paid slice-substrate gate run, and records which enforcement paths a fast-mode run actually has. |
 | `summarize.py` | Renders the Stage 1 tables and evaluates the pre-registered rules. | Produces `out/stage1_summary.txt`. |
 
 Support modules: `slicer.py` (the v1 cutter and its constants), `slicer_v2.py`
@@ -194,6 +196,179 @@ unreachable here.
 `out/STAGE1_PREREGISTRATION.md` was written **before** `stage1.py` first ran and
 fixes the decision rule, the falsifiers, and the underpowered-n caveat in
 advance. Read it before reinterpreting any Stage 1 number.
+
+## What the pack knobs are worth (`stage2`)
+
+Every Stage 0 number is an oracle number. `stage2` is the first stage that
+composes a **pack**: the ranked, capped, budgeted set of passages a reader
+would actually receive, at the geometry the slice-substrate gate is staged to
+run (`max_context_items 28`, `evidence_char_budget 48000`). It exists because
+two caps were about to be set by guess, and both were tuned when one retrieval
+unit was one whole state.
+
+### Which caps a fast-mode run actually has
+
+The first result is a code reading, not a measurement, and it moved what the
+rest of the stage sweeps. Three of the four paths below are dead in the
+configuration the gate runs (`retrieval_mode` `fast`, the campaign's winning
+arm); the third is the one that actually binds.
+
+- **`max_results_per_source` is inert in fast mode.** The adapter puts
+  `max_chunks_per_trajectory` on the wire as `max_results_per_source`, but its
+  only consumer is `_fuse_context_evidence` (`apps/api/src/sibyl/api/routes/context.py`),
+  reached only from `_execute_accurate_context_evidence_search`. A fast-mode run
+  sends the field and nothing reads it. The knob's one live enforcement is the
+  eval adapter's `_select_diverse_results`, which **drops** over-cap rows where
+  the server would have deferred and backfilled them.
+- **`MAX_CANDIDATES_PER_SIGNAL` cannot reach a passage.** It bounds
+  `CandidateLimits` for `build_context_retrieval_plan` / `context_search`, whose
+  only non-test caller is `sibyl_core/tools/context.py` serving context-pack
+  *facet sections*. The evidence lane goes `execute_search_request` ->
+  `tools.search.search` -> `hybrid_search`, which constructs no `CandidateLimits`
+  and reads candidates at `limit * 3`. Sections cannot carry a passage either:
+  `_types_for_facets` unions `FACET_TYPES` into a hard type filter and no entry
+  there names a passage, and `context_pack_to_search_results` then admits only
+  note / procedure / error_pattern / event. **Sweeping it at {8, 16, 24} would
+  have bought nothing and widened every facet read for every caller.**
+- **The seed budget the passage lane really has** is the evidence request's own
+  `limit`, `min(max(search_limit, max_context_items), 50)`, applied in
+  `tools/search.py` as `all_results[offset : offset + limit]`. That is the axis
+  `stage2` sweeps in place of the signal cap, and `--search-limit` is the flag
+  that moves it.
+- **`PASSAGE_WINDOW_UNITS = 3` is accurate-mode only.** `select_operational_source_span`
+  is reached only through `expand_operational_source_evidence`, whose single
+  call site is inside the accurate path. A fast-mode pack holds individually
+  ranked passages, so the 3-adjacent window that `stage0e`/`stage0h` measured is
+  not what a fast gate run composes. The window's value has to come from the
+  ranker pulling neighbours in on their own merits.
+
+### Baseline first
+
+The stage rebuilds the production substrate from `stage0h.production_slices` and
+reproduces four committed numbers from its own structures before any new arm is
+read: **84,968 / 65,573 passages, 44 / 48 measurable questions, single-passage
+exposure 0.9318 / 0.9792 and 3-adjacent exposure 0.9545 / 1.0**, all identical
+to `out/stage0h_report.json`. The stdlib BM25 is checked separately against
+Stage 1's scikit-learn scorer: **0.2045 / 0.1667 at depth 50 against Stage 1's
+SLICE bm25 recall@50 of 0.204 / 0.167**, on a slightly different cut.
+
+### `max_chunks_per_trajectory`: the exposure curve flattens at 2
+
+The cap ceiling arm is ranking-free. For a cap it asks whether *any* selection
+holding at most that many passages per trajectory covers the gold, by exact
+search over per-trajectory coverage masks, so whatever it cannot reach no ranker
+can reach either.
+
+| cap | 1 | 2 | 4 | 8 | 16 | none |
+| --- | --- | --- | --- | --- | --- | --- |
+| enterprise | 0.9318 | 0.9545 | 0.9545 | 0.9545 | 0.9545 | 0.9545 |
+| web | 0.9792 | 1.0 | 1.0 | 1.0 | 1.0 | 1.0 |
+
+**Flat from 2 onward, and 2 is exactly the whole-state ceiling** — the same
+0.9545 / 1.0 `stage0h` measured for a 3-adjacent window. The mechanism is that
+gold is not spread out: **41 of 44 enterprise and 47 of 48 web questions need
+exactly one passage of one trajectory**, one question each needs two, and two
+enterprise questions have gold in no single trajectory at any cap — the same
+count `stage0h` records as `no_single_state_carries_gold`, though this stage
+does not check that they are the same two, because a whole state's evidence text
+includes action and thought lines that no passage carries. Under BM25 the cap
+excludes reachable gold in **one question, only at cap 1 or 2**, and never at cap
+4 or above in either domain.
+
+So the guessed 8 is not wrong on exposure. Nothing above 2 is. **The cap's real
+cost is payload**, and at the staged geometry it is severe (depth 28, mean chars
+of the composed pack against a 48,000 budget):
+
+| cap | 2 | 4 | 8 | 16 | none |
+| --- | --- | --- | --- | --- | --- |
+| enterprise | 7,487 | 14,456 | 27,683 | 40,676 | 45,630 |
+| web | 18,485 | 26,365 | 33,391 | 39,308 | 39,976 |
+
+At the shipped default of 2 an enterprise pack spends **16% of the budget the
+run was configured for**; at the guessed 8 it spends 58%. The cause is that BM25
+top-k over passages concentrates: the top 28 span **1.73 enterprise trajectories
+on average**.
+
+The source-diversity argument for keeping the cap low does not survive contact
+with `_select_diverse_results`. Its first pass admits at most one row per
+trajectory *before* the cap can bind, so every distinct trajectory in the pool is
+represented at any cap. Measured: **the mean number of distinct trajectories in
+the pack is identical at every cap** — 1.73 enterprise, 7.79 web at depth 28,
+unchanged from cap 1 to uncapped. The cap adds no diversity the first pass has
+not already delivered; it only truncates the second pass.
+
+**Recommendation: `--max-chunks-per-trajectory 50`.** Fifty is the
+`max_results_per_source` schema ceiling and is effectively uncapped at any legal
+depth, which makes the character budget the one thing bounding the pack — which
+is what the budget was added for. 16 is the conservative alternative and still
+leaves 5,000 enterprise characters unspent. Anything at or below 8 hands the
+substrate arm a payload handicap against a fat baseline that renders up to
+`max_context_total_chars`, and a paid run cannot tell that apart from slicing
+not working.
+
+### Evidence-lane depth: still climbing at the schema maximum
+
+Exposure over the depth axis, at cap 8 (identical at every cap above 4):
+
+| depth | 8 | 16 | 24 | 28 | 50 |
+| --- | --- | --- | --- | --- | --- |
+| enterprise | 0.1364 | 0.1591 | 0.1818 | 0.1818 | 0.2045 |
+| web | 0.0833 | 0.1042 | 0.1250 | 0.1458 | 0.1667 |
+
+Monotone, and **not flattening at 50** in either domain. Depth costs no money —
+it is a wider read on a corpus already on disk — so **recommendation:
+`--search-limit 50`**, which raises the evidence request's `limit` to the schema
+maximum independently of `max_context_items`.
+
+The caveat belongs to the ranker, not the knob. BM25 alone is the weakest arm
+Stage 1 measured on a sliced substrate (median first-gold rank 282 / 302 against
+19 / 40 dense), so these absolute numbers are a floor, and a hybrid lane would
+flatten this curve earlier than 50. That is why the cap recommendation is read
+off the ranking-free ceiling and only the depth recommendation is read off BM25,
+where being conservative means recommending *more* depth than needed rather than
+less.
+
+### Where the knobs collide with everything else
+
+- **Depth and the character budget trade.** Once the cap stops binding, depth 50
+  fills the budget: enterprise 46,498 of 48,000, web 46,956. At that point web
+  loses one question to `char_budget_excluded_reachable_gold` — the same question
+  cap 2 loses to the cap, so exposure is unchanged, but the crossover is real and
+  a larger budget would move it.
+- **48,000 is not the largest legal budget, and it is not payload-matched to the
+  comparator.** `validate_evidence_char_budget` rejects only a budget above
+  `max_context_total_chars`, which defaults to 60,000 — and 60,000 is what the
+  fat baseline's renderer already spends, since eight whole states compact down
+  to that cap. At 60,000 the passage pack reaches **58,596 enterprise / 57,257
+  web characters** against 46,498 / 46,956 at 48,000. Exposure does not move
+  under BM25 (24,000, 48,000 and 60,000 all score 0.2045 / 0.1667, the arm being
+  ranking-limited), but the gate is a paid comparison of reader payloads, and
+  budgeting the substrate arm 20% under its comparator is a handicap chosen by
+  default rather than by measurement.
+- **The pinned note lane spends the budget first.** `TYPED_NOTE_RESERVATION_ITEMS`
+  is three items, and those characters come off the top. Three notes of 4,000
+  characters leave the passage lane 36,000 of 48,000. Exposure does not move at
+  any probe size here because the BM25 arm is ranking-limited well before the
+  budget binds, so this is arithmetic to carry forward rather than a measured
+  loss: the distilled notes are not in the frozen catalogs and their size on this
+  corpus is unmeasured.
+- **Neighbour stitch is inert for passages.** `_neighbor_results` requires an
+  integer `longmemeval_v2_chunk_index`, which a passage does not carry, so
+  `--neighbor-stitch-items 2` silently does nothing on a passage arm.
+- **A metadata cleanup could tighten the cap to one passage per state.** The
+  second diversity pass refuses a row whose `(trajectory, state)` key is already
+  present, and it never fires today only because `_result_diversity_key` looks
+  for `longmemeval_v2_state_index`, which passages do not carry. They do carry
+  `observation_ordinal`, which the eval sets to the state index, and
+  `_source_support_state` already recovers a state index that way. Teaching the
+  diversity key the same trick would cap the pack at **one passage per state**,
+  far below any `max_chunks_per_trajectory`, while reading like tidying.
+- **The one server-side per-source cap in fast mode is not this knob.**
+  `reserve_distilled_notes` defaults true and the adapter never overrides it, so
+  a fast run also composes the note lane, and `compose_operational_evidence`
+  holds the typed lane to one result per `operational_source_id`. That cap is
+  hardwired, applies only to notes, and moves nothing measured here — but "fast
+  mode does no server-side source capping at all" is the wrong summary.
 
 ## What is committed, and what is not
 

--- a/benchmarks/longmemeval_v2_chunk_geometry/out/stage2_report.json
+++ b/benchmarks/longmemeval_v2_chunk_geometry/out/stage2_report.json
@@ -1,0 +1,1023 @@
+{
+  "enterprise": {
+    "domain": "enterprise",
+    "baseline": {
+      "source": "out/stage0h_report.json",
+      "measured": {
+        "production_slices": 84968,
+        "measurable": 44,
+        "production_w1": 0.9318,
+        "production_w3": 0.9545
+      },
+      "committed": {
+        "production_slices": 84968,
+        "measurable": 44,
+        "production_w1": 0.9318,
+        "production_w3": 0.9545
+      },
+      "reproduces": true,
+      "stage1_bm25_slice_at_50": {
+        "source": "out/stage1_summary.txt",
+        "measured": 0.2045,
+        "committed": 0.204
+      }
+    },
+    "shipped_enforcement": {
+      "max_chunks_per_trajectory": "wire value reaches `max_results_per_source`, whose only consumer is `_fuse_context_evidence` on the accurate path; a fast-mode run enforces it solely in the adapter's `_select_diverse_results`",
+      "max_candidates_per_signal": "bounds `build_context_retrieval_plan`, which serves context-pack facet sections; the evidence lane runs `execute_search_request` -> `tools.search.search` -> `hybrid_search` and never constructs a `CandidateLimits`, and no `FACET_TYPES` entry names a passage",
+      "evidence_lane_depth": "`min(max(search_limit, max_context_items), 50)`, applied as `all_results[offset : offset + limit]`; this is the seed budget the passage lane actually has",
+      "passage_window_units": "`select_operational_source_span` is reached only through `expand_operational_source_evidence`, whose single call site is the accurate path, so a fast-mode pack holds individually ranked passages rather than 3-adjacent windows"
+    },
+    "substrate": {
+      "passages": 84968,
+      "trajectories": 100,
+      "evidence_parts": 6387,
+      "mean_passage_chars": 1107.1,
+      "max_passage_chars": 4384,
+      "measurable": 44
+    },
+    "gate_geometry": {
+      "max_context_items": 28,
+      "char_budget": 48000,
+      "note_reservation_items": 3
+    },
+    "mechanism": {
+      "gold_carrying_trajectories": {
+        "1": 5,
+        "10": 1,
+        "12": 1,
+        "13": 1,
+        "14": 1,
+        "16": 2,
+        "2": 2,
+        "21": 1,
+        "26": 1,
+        "3": 3,
+        "30": 2,
+        "31": 1,
+        "32": 1,
+        "4": 1,
+        "43": 1,
+        "51": 1,
+        "52": 1,
+        "57": 1,
+        "58": 1,
+        "6": 1,
+        "67": 5,
+        "7": 2,
+        "70": 1,
+        "79": 1,
+        "8": 2,
+        "82": 4
+      },
+      "trajectories_covering_all_gold_alone": {
+        "0": 2,
+        "1": 5,
+        "11": 1,
+        "12": 1,
+        "13": 1,
+        "16": 1,
+        "18": 1,
+        "2": 2,
+        "21": 1,
+        "26": 1,
+        "3": 4,
+        "30": 2,
+        "32": 1,
+        "4": 1,
+        "43": 1,
+        "5": 2,
+        "51": 1,
+        "57": 1,
+        "58": 1,
+        "6": 1,
+        "67": 5,
+        "68": 1,
+        "7": 1,
+        "8": 1,
+        "82": 4,
+        "9": 1
+      },
+      "passages_of_one_trajectory_needed": {
+        "1": 41,
+        "2": 1,
+        "no_single_trajectory_covers": 2
+      },
+      "smallest_trajectory_cap_that_reaches_gold": {
+        "1": 44
+      },
+      "passages_the_cheapest_covering_selection_uses": {
+        "1": 38,
+        "2": 5,
+        "3": 1
+      }
+    },
+    "cap_ceiling": {
+      "cap=1": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 0.9318,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=2": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 0.9545,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=4": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 0.9545,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=8": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 0.9545,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=16": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 0.9545,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=none": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 0.9545,
+        "max_passages_a_covering_selection_needs": 3
+      }
+    },
+    "bm25_grid": {
+      "cap=1|depth=8": {
+        "exposure": 0.1364,
+        "mean_pack_items": 1.2,
+        "mean_pack_trajectories": 1.2,
+        "mean_pack_chars": 2824.3,
+        "budget_headroom_chars": 45175.7,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 38
+        }
+      },
+      "cap=1|depth=16": {
+        "exposure": 0.1364,
+        "mean_pack_items": 1.48,
+        "mean_pack_trajectories": 1.48,
+        "mean_pack_chars": 3452.4,
+        "budget_headroom_chars": 44547.6,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 37,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=1|depth=24": {
+        "exposure": 0.1591,
+        "mean_pack_items": 1.68,
+        "mean_pack_trajectories": 1.68,
+        "mean_pack_chars": 3868.8,
+        "budget_headroom_chars": 44131.2,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 36,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=1|depth=28": {
+        "exposure": 0.1591,
+        "mean_pack_items": 1.73,
+        "mean_pack_trajectories": 1.73,
+        "mean_pack_chars": 3922.8,
+        "budget_headroom_chars": 44077.2,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 36,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=1|depth=50": {
+        "exposure": 0.1818,
+        "mean_pack_items": 2.2,
+        "mean_pack_trajectories": 2.2,
+        "mean_pack_chars": 4935.0,
+        "budget_headroom_chars": 43065.0,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 35,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=2|depth=8": {
+        "exposure": 0.1364,
+        "mean_pack_items": 2.23,
+        "mean_pack_trajectories": 1.2,
+        "mean_pack_chars": 5321.7,
+        "budget_headroom_chars": 42678.3,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 38
+        }
+      },
+      "cap=2|depth=16": {
+        "exposure": 0.1364,
+        "mean_pack_items": 2.75,
+        "mean_pack_trajectories": 1.48,
+        "mean_pack_chars": 6663.4,
+        "budget_headroom_chars": 41336.6,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 37,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=2|depth=24": {
+        "exposure": 0.1591,
+        "mean_pack_items": 3.09,
+        "mean_pack_trajectories": 1.68,
+        "mean_pack_chars": 7406.6,
+        "budget_headroom_chars": 40593.4,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 36,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=2|depth=28": {
+        "exposure": 0.1591,
+        "mean_pack_items": 3.16,
+        "mean_pack_trajectories": 1.73,
+        "mean_pack_chars": 7487.0,
+        "budget_headroom_chars": 40513.0,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 36,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=2|depth=50": {
+        "exposure": 0.1818,
+        "mean_pack_items": 4.07,
+        "mean_pack_trajectories": 2.2,
+        "mean_pack_chars": 9459.9,
+        "budget_headroom_chars": 38540.1,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 35,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=4|depth=8": {
+        "exposure": 0.1364,
+        "mean_pack_items": 4.25,
+        "mean_pack_trajectories": 1.2,
+        "mean_pack_chars": 10295.2,
+        "budget_headroom_chars": 37704.8,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 38
+        }
+      },
+      "cap=4|depth=16": {
+        "exposure": 0.1591,
+        "mean_pack_items": 5.2,
+        "mean_pack_trajectories": 1.48,
+        "mean_pack_chars": 13010.3,
+        "budget_headroom_chars": 34989.7,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 37
+        }
+      },
+      "cap=4|depth=24": {
+        "exposure": 0.1818,
+        "mean_pack_items": 5.77,
+        "mean_pack_trajectories": 1.68,
+        "mean_pack_chars": 14319.6,
+        "budget_headroom_chars": 33680.4,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 36
+        }
+      },
+      "cap=4|depth=28": {
+        "exposure": 0.1818,
+        "mean_pack_items": 5.86,
+        "mean_pack_trajectories": 1.73,
+        "mean_pack_chars": 14455.6,
+        "budget_headroom_chars": 33544.4,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 36
+        }
+      },
+      "cap=4|depth=50": {
+        "exposure": 0.2045,
+        "mean_pack_items": 7.3,
+        "mean_pack_trajectories": 2.2,
+        "mean_pack_chars": 17711.6,
+        "budget_headroom_chars": 30288.4,
+        "loss_reasons": {
+          "covered": 9,
+          "search_depth_never_reached_gold": 35
+        }
+      },
+      "cap=8|depth=8": {
+        "exposure": 0.1364,
+        "mean_pack_items": 8.0,
+        "mean_pack_trajectories": 1.2,
+        "mean_pack_chars": 19667.9,
+        "budget_headroom_chars": 28332.1,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 38
+        }
+      },
+      "cap=8|depth=16": {
+        "exposure": 0.1591,
+        "mean_pack_items": 9.64,
+        "mean_pack_trajectories": 1.48,
+        "mean_pack_chars": 24652.4,
+        "budget_headroom_chars": 23347.6,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 37
+        }
+      },
+      "cap=8|depth=24": {
+        "exposure": 0.1818,
+        "mean_pack_items": 10.5,
+        "mean_pack_trajectories": 1.68,
+        "mean_pack_chars": 26891.8,
+        "budget_headroom_chars": 21108.2,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 36
+        }
+      },
+      "cap=8|depth=28": {
+        "exposure": 0.1818,
+        "mean_pack_items": 10.86,
+        "mean_pack_trajectories": 1.73,
+        "mean_pack_chars": 27683.0,
+        "budget_headroom_chars": 20317.0,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 36
+        }
+      },
+      "cap=8|depth=50": {
+        "exposure": 0.2045,
+        "mean_pack_items": 12.75,
+        "mean_pack_trajectories": 2.2,
+        "mean_pack_chars": 32278.8,
+        "budget_headroom_chars": 15721.2,
+        "loss_reasons": {
+          "covered": 9,
+          "search_depth_never_reached_gold": 35
+        }
+      },
+      "cap=16|depth=8": {
+        "exposure": 0.1364,
+        "mean_pack_items": 8.0,
+        "mean_pack_trajectories": 1.2,
+        "mean_pack_chars": 19667.9,
+        "budget_headroom_chars": 28332.1,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 38
+        }
+      },
+      "cap=16|depth=16": {
+        "exposure": 0.1591,
+        "mean_pack_items": 14.57,
+        "mean_pack_trajectories": 1.48,
+        "mean_pack_chars": 36421.3,
+        "budget_headroom_chars": 11578.7,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 37
+        }
+      },
+      "cap=16|depth=24": {
+        "exposure": 0.1818,
+        "mean_pack_items": 16.09,
+        "mean_pack_trajectories": 1.68,
+        "mean_pack_chars": 39930.7,
+        "budget_headroom_chars": 8069.3,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 36
+        }
+      },
+      "cap=16|depth=28": {
+        "exposure": 0.1818,
+        "mean_pack_items": 16.48,
+        "mean_pack_trajectories": 1.73,
+        "mean_pack_chars": 40676.1,
+        "budget_headroom_chars": 7323.9,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 36
+        }
+      },
+      "cap=16|depth=50": {
+        "exposure": 0.2045,
+        "mean_pack_items": 17.91,
+        "mean_pack_trajectories": 2.2,
+        "mean_pack_chars": 43663.0,
+        "budget_headroom_chars": 4337.0,
+        "loss_reasons": {
+          "covered": 9,
+          "search_depth_never_reached_gold": 35
+        }
+      },
+      "cap=none|depth=8": {
+        "exposure": 0.1364,
+        "mean_pack_items": 8.0,
+        "mean_pack_trajectories": 1.2,
+        "mean_pack_chars": 19667.9,
+        "budget_headroom_chars": 28332.1,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 38
+        }
+      },
+      "cap=none|depth=16": {
+        "exposure": 0.1591,
+        "mean_pack_items": 14.57,
+        "mean_pack_trajectories": 1.48,
+        "mean_pack_chars": 36421.3,
+        "budget_headroom_chars": 11578.7,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 37
+        }
+      },
+      "cap=none|depth=24": {
+        "exposure": 0.1818,
+        "mean_pack_items": 18.25,
+        "mean_pack_trajectories": 1.68,
+        "mean_pack_chars": 44572.1,
+        "budget_headroom_chars": 3427.9,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 36
+        }
+      },
+      "cap=none|depth=28": {
+        "exposure": 0.1818,
+        "mean_pack_items": 18.84,
+        "mean_pack_trajectories": 1.73,
+        "mean_pack_chars": 45630.1,
+        "budget_headroom_chars": 2369.9,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 36
+        }
+      },
+      "cap=none|depth=50": {
+        "exposure": 0.2045,
+        "mean_pack_items": 19.41,
+        "mean_pack_trajectories": 2.2,
+        "mean_pack_chars": 46497.8,
+        "budget_headroom_chars": 1502.2,
+        "loss_reasons": {
+          "covered": 9,
+          "search_depth_never_reached_gold": 35
+        }
+      }
+    },
+    "char_budget_probe": {
+      "24000": {
+        "exposure": 0.2045,
+        "mean_pack_items": 10.55,
+        "mean_pack_chars": 22692.4
+      },
+      "48000": {
+        "exposure": 0.2045,
+        "mean_pack_items": 19.41,
+        "mean_pack_chars": 46497.8
+      },
+      "60000": {
+        "exposure": 0.2045,
+        "mean_pack_items": 23.82,
+        "mean_pack_chars": 58595.9
+      }
+    },
+    "note_lane_interaction": {
+      "0": {
+        "passage_budget_chars": 48000,
+        "exposure": 0.1818
+      },
+      "1000": {
+        "passage_budget_chars": 45000,
+        "exposure": 0.1818
+      },
+      "2000": {
+        "passage_budget_chars": 42000,
+        "exposure": 0.1818
+      },
+      "4000": {
+        "passage_budget_chars": 36000,
+        "exposure": 0.1818
+      }
+    }
+  },
+  "web": {
+    "domain": "web",
+    "baseline": {
+      "source": "out/stage0h_report.json",
+      "measured": {
+        "production_slices": 65573,
+        "measurable": 48,
+        "production_w1": 0.9792,
+        "production_w3": 1.0
+      },
+      "committed": {
+        "production_slices": 65573,
+        "measurable": 48,
+        "production_w1": 0.9792,
+        "production_w3": 1.0
+      },
+      "reproduces": true,
+      "stage1_bm25_slice_at_50": {
+        "source": "out/stage1_summary.txt",
+        "measured": 0.1667,
+        "committed": 0.167
+      }
+    },
+    "shipped_enforcement": {
+      "max_chunks_per_trajectory": "wire value reaches `max_results_per_source`, whose only consumer is `_fuse_context_evidence` on the accurate path; a fast-mode run enforces it solely in the adapter's `_select_diverse_results`",
+      "max_candidates_per_signal": "bounds `build_context_retrieval_plan`, which serves context-pack facet sections; the evidence lane runs `execute_search_request` -> `tools.search.search` -> `hybrid_search` and never constructs a `CandidateLimits`, and no `FACET_TYPES` entry names a passage",
+      "evidence_lane_depth": "`min(max(search_limit, max_context_items), 50)`, applied as `all_results[offset : offset + limit]`; this is the seed budget the passage lane actually has",
+      "passage_window_units": "`select_operational_source_span` is reached only through `expand_operational_source_evidence`, whose single call site is the accurate path, so a fast-mode pack holds individually ranked passages rather than 3-adjacent windows"
+    },
+    "substrate": {
+      "passages": 65573,
+      "trajectories": 100,
+      "evidence_parts": 4609,
+      "mean_passage_chars": 1095.8,
+      "max_passage_chars": 2186,
+      "measurable": 48
+    },
+    "gate_geometry": {
+      "max_context_items": 28,
+      "char_budget": 48000,
+      "note_reservation_items": 3
+    },
+    "mechanism": {
+      "gold_carrying_trajectories": {
+        "1": 14,
+        "10": 5,
+        "12": 2,
+        "19": 1,
+        "2": 3,
+        "21": 1,
+        "3": 4,
+        "37": 1,
+        "38": 2,
+        "4": 3,
+        "40": 1,
+        "48": 4,
+        "6": 2,
+        "7": 1,
+        "71": 1,
+        "8": 1,
+        "88": 1,
+        "9": 1
+      },
+      "trajectories_covering_all_gold_alone": {
+        "1": 15,
+        "10": 5,
+        "12": 3,
+        "15": 2,
+        "2": 2,
+        "3": 5,
+        "37": 1,
+        "4": 3,
+        "40": 1,
+        "48": 1,
+        "5": 1,
+        "6": 2,
+        "7": 1,
+        "8": 4,
+        "88": 1,
+        "9": 1
+      },
+      "passages_of_one_trajectory_needed": {
+        "1": 47,
+        "2": 1
+      },
+      "smallest_trajectory_cap_that_reaches_gold": {
+        "1": 48
+      },
+      "passages_the_cheapest_covering_selection_uses": {
+        "1": 45,
+        "2": 2,
+        "3": 1
+      }
+    },
+    "cap_ceiling": {
+      "cap=1": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 0.9792,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=2": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 1.0,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=4": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 1.0,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=8": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 1.0,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=16": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 1.0,
+        "max_passages_a_covering_selection_needs": 3
+      },
+      "cap=none": {
+        "exposure_any_source": 1.0,
+        "exposure_single_source": 1.0,
+        "max_passages_a_covering_selection_needs": 3
+      }
+    },
+    "bm25_grid": {
+      "cap=1|depth=8": {
+        "exposure": 0.0833,
+        "mean_pack_items": 3.35,
+        "mean_pack_trajectories": 3.35,
+        "mean_pack_chars": 4691.9,
+        "budget_headroom_chars": 43308.1,
+        "loss_reasons": {
+          "covered": 4,
+          "search_depth_never_reached_gold": 44
+        }
+      },
+      "cap=1|depth=16": {
+        "exposure": 0.1042,
+        "mean_pack_items": 5.06,
+        "mean_pack_trajectories": 5.06,
+        "mean_pack_chars": 6906.9,
+        "budget_headroom_chars": 41093.1,
+        "loss_reasons": {
+          "covered": 5,
+          "search_depth_never_reached_gold": 43
+        }
+      },
+      "cap=1|depth=24": {
+        "exposure": 0.125,
+        "mean_pack_items": 6.88,
+        "mean_pack_trajectories": 6.88,
+        "mean_pack_chars": 9053.9,
+        "budget_headroom_chars": 38946.1,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 42
+        }
+      },
+      "cap=1|depth=28": {
+        "exposure": 0.1458,
+        "mean_pack_items": 7.79,
+        "mean_pack_trajectories": 7.79,
+        "mean_pack_chars": 10124.3,
+        "budget_headroom_chars": 37875.7,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 41
+        }
+      },
+      "cap=1|depth=50": {
+        "exposure": 0.1667,
+        "mean_pack_items": 13.54,
+        "mean_pack_trajectories": 13.54,
+        "mean_pack_chars": 16211.2,
+        "budget_headroom_chars": 31788.8,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 39,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=2|depth=8": {
+        "exposure": 0.0833,
+        "mean_pack_items": 6.02,
+        "mean_pack_trajectories": 3.35,
+        "mean_pack_chars": 8456.7,
+        "budget_headroom_chars": 39543.3,
+        "loss_reasons": {
+          "covered": 4,
+          "search_depth_never_reached_gold": 44
+        }
+      },
+      "cap=2|depth=16": {
+        "exposure": 0.1042,
+        "mean_pack_items": 9.21,
+        "mean_pack_trajectories": 5.06,
+        "mean_pack_chars": 12680.7,
+        "budget_headroom_chars": 35319.3,
+        "loss_reasons": {
+          "covered": 5,
+          "search_depth_never_reached_gold": 43
+        }
+      },
+      "cap=2|depth=24": {
+        "exposure": 0.125,
+        "mean_pack_items": 12.44,
+        "mean_pack_trajectories": 6.88,
+        "mean_pack_chars": 16535.5,
+        "budget_headroom_chars": 31464.5,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 42
+        }
+      },
+      "cap=2|depth=28": {
+        "exposure": 0.1458,
+        "mean_pack_items": 14.1,
+        "mean_pack_trajectories": 7.79,
+        "mean_pack_chars": 18485.2,
+        "budget_headroom_chars": 29514.8,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 41
+        }
+      },
+      "cap=2|depth=50": {
+        "exposure": 0.1667,
+        "mean_pack_items": 24.6,
+        "mean_pack_trajectories": 13.54,
+        "mean_pack_chars": 29577.6,
+        "budget_headroom_chars": 18422.4,
+        "loss_reasons": {
+          "covered": 8,
+          "search_depth_never_reached_gold": 39,
+          "trajectory_cap_excluded_reachable_gold": 1
+        }
+      },
+      "cap=4|depth=8": {
+        "exposure": 0.0833,
+        "mean_pack_items": 7.52,
+        "mean_pack_trajectories": 3.35,
+        "mean_pack_chars": 10890.6,
+        "budget_headroom_chars": 37109.4,
+        "loss_reasons": {
+          "covered": 4,
+          "search_depth_never_reached_gold": 44
+        }
+      },
+      "cap=4|depth=16": {
+        "exposure": 0.1042,
+        "mean_pack_items": 12.38,
+        "mean_pack_trajectories": 5.06,
+        "mean_pack_chars": 17703.8,
+        "budget_headroom_chars": 30296.2,
+        "loss_reasons": {
+          "covered": 5,
+          "search_depth_never_reached_gold": 43
+        }
+      },
+      "cap=4|depth=24": {
+        "exposure": 0.125,
+        "mean_pack_items": 16.85,
+        "mean_pack_trajectories": 6.88,
+        "mean_pack_chars": 23527.0,
+        "budget_headroom_chars": 24473.0,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 42
+        }
+      },
+      "cap=4|depth=28": {
+        "exposure": 0.1458,
+        "mean_pack_items": 19.1,
+        "mean_pack_trajectories": 7.79,
+        "mean_pack_chars": 26364.6,
+        "budget_headroom_chars": 21635.4,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 41
+        }
+      },
+      "cap=4|depth=50": {
+        "exposure": 0.1667,
+        "mean_pack_items": 30.69,
+        "mean_pack_trajectories": 13.54,
+        "mean_pack_chars": 39510.9,
+        "budget_headroom_chars": 8489.1,
+        "loss_reasons": {
+          "char_budget_excluded_reachable_gold": 1,
+          "covered": 8,
+          "search_depth_never_reached_gold": 39
+        }
+      },
+      "cap=8|depth=8": {
+        "exposure": 0.0833,
+        "mean_pack_items": 8.0,
+        "mean_pack_trajectories": 3.35,
+        "mean_pack_chars": 11710.1,
+        "budget_headroom_chars": 36289.9,
+        "loss_reasons": {
+          "covered": 4,
+          "search_depth_never_reached_gold": 44
+        }
+      },
+      "cap=8|depth=16": {
+        "exposure": 0.1042,
+        "mean_pack_items": 14.83,
+        "mean_pack_trajectories": 5.06,
+        "mean_pack_chars": 21725.2,
+        "budget_headroom_chars": 26274.8,
+        "loss_reasons": {
+          "covered": 5,
+          "search_depth_never_reached_gold": 43
+        }
+      },
+      "cap=8|depth=24": {
+        "exposure": 0.125,
+        "mean_pack_items": 20.88,
+        "mean_pack_trajectories": 6.88,
+        "mean_pack_chars": 29980.9,
+        "budget_headroom_chars": 18019.1,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 42
+        }
+      },
+      "cap=8|depth=28": {
+        "exposure": 0.1458,
+        "mean_pack_items": 23.54,
+        "mean_pack_trajectories": 7.79,
+        "mean_pack_chars": 33391.2,
+        "budget_headroom_chars": 14608.8,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 41
+        }
+      },
+      "cap=8|depth=50": {
+        "exposure": 0.1667,
+        "mean_pack_items": 34.25,
+        "mean_pack_trajectories": 13.54,
+        "mean_pack_chars": 45775.8,
+        "budget_headroom_chars": 2224.2,
+        "loss_reasons": {
+          "char_budget_excluded_reachable_gold": 1,
+          "covered": 8,
+          "search_depth_never_reached_gold": 39
+        }
+      },
+      "cap=16|depth=8": {
+        "exposure": 0.0833,
+        "mean_pack_items": 8.0,
+        "mean_pack_trajectories": 3.35,
+        "mean_pack_chars": 11710.1,
+        "budget_headroom_chars": 36289.9,
+        "loss_reasons": {
+          "covered": 4,
+          "search_depth_never_reached_gold": 44
+        }
+      },
+      "cap=16|depth=16": {
+        "exposure": 0.1042,
+        "mean_pack_items": 16.0,
+        "mean_pack_trajectories": 5.06,
+        "mean_pack_chars": 23684.4,
+        "budget_headroom_chars": 24315.6,
+        "loss_reasons": {
+          "covered": 5,
+          "search_depth_never_reached_gold": 43
+        }
+      },
+      "cap=16|depth=24": {
+        "exposure": 0.125,
+        "mean_pack_items": 23.77,
+        "mean_pack_trajectories": 6.88,
+        "mean_pack_chars": 34538.9,
+        "budget_headroom_chars": 13461.1,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 42
+        }
+      },
+      "cap=16|depth=28": {
+        "exposure": 0.1458,
+        "mean_pack_items": 27.4,
+        "mean_pack_trajectories": 7.79,
+        "mean_pack_chars": 39308.1,
+        "budget_headroom_chars": 8691.9,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 41
+        }
+      },
+      "cap=16|depth=50": {
+        "exposure": 0.1667,
+        "mean_pack_items": 34.9,
+        "mean_pack_trajectories": 13.54,
+        "mean_pack_chars": 46861.8,
+        "budget_headroom_chars": 1138.2,
+        "loss_reasons": {
+          "char_budget_excluded_reachable_gold": 1,
+          "covered": 8,
+          "search_depth_never_reached_gold": 39
+        }
+      },
+      "cap=none|depth=8": {
+        "exposure": 0.0833,
+        "mean_pack_items": 8.0,
+        "mean_pack_trajectories": 3.35,
+        "mean_pack_chars": 11710.1,
+        "budget_headroom_chars": 36289.9,
+        "loss_reasons": {
+          "covered": 4,
+          "search_depth_never_reached_gold": 44
+        }
+      },
+      "cap=none|depth=16": {
+        "exposure": 0.1042,
+        "mean_pack_items": 16.0,
+        "mean_pack_trajectories": 5.06,
+        "mean_pack_chars": 23684.4,
+        "budget_headroom_chars": 24315.6,
+        "loss_reasons": {
+          "covered": 5,
+          "search_depth_never_reached_gold": 43
+        }
+      },
+      "cap=none|depth=24": {
+        "exposure": 0.125,
+        "mean_pack_items": 24.0,
+        "mean_pack_trajectories": 6.88,
+        "mean_pack_chars": 34839.9,
+        "budget_headroom_chars": 13160.1,
+        "loss_reasons": {
+          "covered": 6,
+          "search_depth_never_reached_gold": 42
+        }
+      },
+      "cap=none|depth=28": {
+        "exposure": 0.1458,
+        "mean_pack_items": 27.94,
+        "mean_pack_trajectories": 7.79,
+        "mean_pack_chars": 39976.3,
+        "budget_headroom_chars": 8023.7,
+        "loss_reasons": {
+          "covered": 7,
+          "search_depth_never_reached_gold": 41
+        }
+      },
+      "cap=none|depth=50": {
+        "exposure": 0.1667,
+        "mean_pack_items": 35.12,
+        "mean_pack_trajectories": 13.54,
+        "mean_pack_chars": 46955.5,
+        "budget_headroom_chars": 1044.5,
+        "loss_reasons": {
+          "char_budget_excluded_reachable_gold": 1,
+          "covered": 8,
+          "search_depth_never_reached_gold": 39
+        }
+      }
+    },
+    "char_budget_probe": {
+      "24000": {
+        "exposure": 0.1667,
+        "mean_pack_items": 18.19,
+        "mean_pack_chars": 23324.3
+      },
+      "48000": {
+        "exposure": 0.1667,
+        "mean_pack_items": 35.12,
+        "mean_pack_chars": 46955.5
+      },
+      "60000": {
+        "exposure": 0.1667,
+        "mean_pack_items": 42.79,
+        "mean_pack_chars": 57256.9
+      }
+    },
+    "note_lane_interaction": {
+      "0": {
+        "passage_budget_chars": 48000,
+        "exposure": 0.1458
+      },
+      "1000": {
+        "passage_budget_chars": 45000,
+        "exposure": 0.1458
+      },
+      "2000": {
+        "passage_budget_chars": 42000,
+        "exposure": 0.1458
+      },
+      "4000": {
+        "passage_budget_chars": 36000,
+        "exposure": 0.1458
+      }
+    }
+  }
+}

--- a/benchmarks/longmemeval_v2_chunk_geometry/stage2.py
+++ b/benchmarks/longmemeval_v2_chunk_geometry/stage2.py
@@ -1,0 +1,787 @@
+"""STAGE 2 - the pack-composition knobs on a passage substrate.
+
+Every Stage 0 number is an **oracle** number: does some slice, or some window
+of slices, carry the gold at all. A gate run does not read an oracle. It reads
+the pack a ranker filled under two caps that were both tuned when one retrieval
+unit was one whole state, and this stage measures what those caps do once the
+unit is a ~1,030-char passage.
+
+**Which caps actually bind was not obvious, and the answer moved the
+measurement.** Three code reads over the eight-PR A1 stack say:
+
+  * `max_chunks_per_trajectory` reaches the server as `max_results_per_source`,
+    but `_fuse_context_evidence` is the only consumer and it runs on the
+    **accurate** path alone. A FAST gate run - the campaign's winning
+    configuration - puts the value on the wire and nothing reads it. Its one
+    live enforcement is the eval adapter's `_select_diverse_results`, which
+    drops over-cap rows outright with no backfill, unlike the server's
+    defer-then-backfill.
+  * `MAX_CANDIDATES_PER_SIGNAL` bounds `build_context_retrieval_plan`, which
+    serves the **context-pack facet sections**. The evidence lane does not go
+    that way: `/context/pack` builds a `SearchRequest` and runs
+    `execute_search_request` -> `tools.search.search` -> `hybrid_search`, where
+    candidate depth is `limit * 3` and no `CandidateLimits` object exists.
+    Passages appear in no `FACET_TYPES` entry, and `context_pack_to_search_results`
+    admits only note / procedure / error_pattern / event, so no passage can
+    reach the pack through the lane that constant governs.
+  * What plays the seed-budget role for passages is the evidence lane's own
+    `limit`, `min(max(search_limit, max_context_items), 50)`. `tools.search`
+    returns `all_results[offset : offset + limit]`, so that number is a hard
+    ceiling on how many passages exist to be capped, composed, or read.
+
+So the sweep is `max_chunks_per_trajectory` x **evidence-lane depth**, and the
+`MAX_CANDIDATES_PER_SIGNAL` result is a null one recorded against the code.
+
+Two arms, because a cap and a ranker fail differently:
+
+  * `cap_ceiling` is ranking-free. For a cap T it asks whether *any* selection
+    holding at most T passages per trajectory covers the gold, by exact search
+    over per-trajectory coverage masks. Whatever this arm cannot reach, no
+    ranker can reach either, so it is the honest ceiling of the knob.
+  * `bm25` applies the same caps to a real ranking. Its exposure is a floor,
+    not an estimate: the shipped lane is `hybrid_search`, vector-weighted and
+    graph-expanded, and Stage 1 already measured BM25 alone as the weakest
+    ranker on a sliced substrate. A dense arm would move this arm's absolute
+    numbers and cannot move `cap_ceiling`, which is why the knob recommendation
+    is read off the ceiling and the depth recommendation is read off BM25 as a
+    conservative bound.
+
+The loss taxonomy separates the knob from everything else. Gold that is in no
+passage was lost at ingest, gold the pool never reached was lost by the ranker
+or the depth, and only gold that the pool held and the cap then dropped is
+caused by the cap.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from corpus import OUT, eligible_questions, normalize_text, state_evidence_text
+from stage0 import load_states
+from stage0h import production_slices
+
+# The staged gate geometry. Item count and character budget are held fixed so
+# the grid moves only the two knobs under test.
+GATE_MAX_CONTEXT_ITEMS = 28
+GATE_CHAR_BUDGET = 48_000
+
+# `max_chunks_per_trajectory`. 2 is the shipped default, 8 is the value the
+# staged gate command guesses, None is uncapped.
+TRAJECTORY_CAPS: tuple[int | None, ...] = (1, 2, 4, 8, 16, None)
+
+# Evidence-lane depth: the `limit` the pack request carries, which is what
+# `MAX_CANDIDATES_PER_SIGNAL` was believed to be. 28 is the staged geometry
+# (`max_context_items` beats the default `search_limit` of 12); 50 is the
+# schema maximum, reachable with `--search-limit 50`.
+POOL_DEPTHS = (8, 16, 24, 28, 50)
+
+# `TYPED_NOTE_RESERVATION_ITEMS`, pinned absolutely rather than proportionally.
+# The note lane spends its characters before the passage lane sees any, so its
+# per-note size is subtracted from the budget the passages compete for.
+NOTE_RESERVATION_ITEMS = 3
+NOTE_SIZE_PROBES = (0, 1_000, 2_000, 4_000)
+
+# The staged 48,000 is not the largest legal budget. `validate_evidence_char_budget`
+# rejects a budget above `max_context_total_chars`, which defaults to 60,000, and
+# 60,000 is what the fat baseline's renderer already spends. A substrate arm
+# budgeted below its comparator is handicapped before any knob is set, so the
+# budget is probed here rather than assumed.
+CHAR_BUDGET_PROBES = (24_000, 48_000, 60_000)
+
+# Same scoring constants as `stage1.py`, so a BM25 number here is readable
+# against the Stage 1 tables rather than being a second private convention.
+BM25_K1 = 1.2
+BM25_B = 0.75
+
+COMMITTED_RECEIPT = Path(__file__).resolve().parent / "out" / "stage0h_report.json"
+BASELINE_WINDOW = 3
+
+# `out/stage1_summary.txt`, SLICE arm, bm25 ranker, recall@50. Stage 1 cut whole
+# reassembled states rather than one evidence part at a time, so this is a
+# near-match rather than an identity: a second independent check that this
+# file's stdlib BM25 is the same scorer Stage 1 ran through scikit-learn.
+STAGE1_SLICE_BM25_AT_50 = {"enterprise": 0.204, "web": 0.167}
+
+
+def build_passages(
+    states: dict[Any, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[list[int]]]:
+    """Cut the corpus the way the projection does and index every passage.
+
+    `production_slices` is `stage0h`'s arm verbatim - each evidence part cut on
+    its own - so the substrate this stage composes packs from is the same one
+    the part-confined oracle scored. That shared cut is what lets the baseline
+    below reproduce a committed number rather than merely resemble it.
+    """
+    passages: list[dict[str, Any]] = []
+    parts: list[list[int]] = []
+    for key in sorted(states):
+        entry = states[key]
+        for part_index, group in enumerate(production_slices(entry)):
+            indices: list[int] = []
+            for passage_index, rendered in enumerate(group):
+                indices.append(len(passages))
+                passages.append(
+                    {
+                        "trajectory": entry["trajectory_id"],
+                        "state": entry["state_index"],
+                        "part": part_index,
+                        "passage": passage_index,
+                        "text": normalize_text(rendered),
+                        "chars": len(rendered),
+                    }
+                )
+            parts.append(indices)
+    return passages, parts
+
+
+def measurable_questions(
+    domain: str,
+    states: dict[Any, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """The `stage0h` denominator: phrase-eligible and carried by some state."""
+    norm_state = [normalize_text(state_evidence_text(entry)) for entry in states.values()]
+    out: list[dict[str, Any]] = []
+    for item in eligible_questions(domain):
+        phrases = item["phrases"]
+        if all(any(phrase in text for text in norm_state) for phrase in phrases):
+            out.append(item)
+    return out
+
+
+def passage_covers(passages: list[dict[str, Any]], phrases: tuple[str, ...]) -> dict[int, int]:
+    """Map each carrying passage onto the bitmask of phrases it holds."""
+    covers: dict[int, int] = {}
+    for index, passage in enumerate(passages):
+        text = passage["text"]
+        mask = 0
+        for position, phrase in enumerate(phrases):
+            if phrase in text:
+                mask |= 1 << position
+        if mask:
+            covers[index] = mask
+    return covers
+
+
+def _window_covers(indices: list[int], covers: dict[int, int], full: int, width: int) -> bool:
+    for start in range(max(1, len(indices) - width + 1)):
+        merged = 0
+        for index in indices[start : start + width]:
+            merged |= covers.get(index, 0)
+        if merged == full:
+            return True
+    return False
+
+
+def baseline(
+    domain: str,
+    passages: list[dict[str, Any]],
+    parts: list[list[int]],
+    questions: list[dict[str, Any]],
+    covers_by_question: list[dict[int, int]],
+) -> dict[str, Any]:
+    """Reproduce committed `stage0h` numbers from this stage's own structures.
+
+    A grid of new arms is only worth reading if the substrate underneath it is
+    the substrate the campaign already measured. This recomputes the passage
+    count, the question denominator, and the single-passage and 3-adjacent
+    production exposure rates from the data structures this file builds, then
+    compares them to `out/stage0h_report.json`. A mismatch means the corpus,
+    the cutter, or the eligibility rule moved, and every number below is void.
+    """
+    committed = json.loads(COMMITTED_RECEIPT.read_text())[domain]
+    single = 0
+    windowed = 0
+    for item, covers in zip(questions, covers_by_question, strict=True):
+        full = (1 << len(item["phrases"])) - 1
+        if any(mask == full for mask in covers.values()):
+            single += 1
+        if any(_window_covers(indices, covers, full, BASELINE_WINDOW) for indices in parts):
+            windowed += 1
+    measured = {
+        "production_slices": len(passages),
+        "measurable": len(questions),
+        "production_w1": round(single / len(questions), 4),
+        f"production_w{BASELINE_WINDOW}": round(windowed / len(questions), 4),
+    }
+    expected = {
+        "production_slices": committed["production_slices"],
+        "measurable": committed["measurable"],
+        "production_w1": committed["rates"]["production_w1"],
+        f"production_w{BASELINE_WINDOW}": committed["rates"][f"production_w{BASELINE_WINDOW}"],
+    }
+    return {
+        "source": "out/stage0h_report.json",
+        "measured": measured,
+        "committed": expected,
+        "reproduces": measured == expected,
+    }
+
+
+def _reachable_masks(patterns: set[int], cap: int | None, phrase_count: int) -> dict[int, int]:
+    """Coverage masks one trajectory can reach, and the fewest passages each costs."""
+    steps = phrase_count if cap is None else min(cap, phrase_count)
+    reachable = {0: 0}
+    for _ in range(steps):
+        for mask, cost in list(reachable.items()):
+            for pattern in patterns:
+                merged = mask | pattern
+                if reachable.get(merged, math.inf) > cost + 1:
+                    reachable[merged] = cost + 1
+    return reachable
+
+
+def cap_feasibility(
+    covers: dict[int, int],
+    passages: list[dict[str, Any]],
+    phrase_count: int,
+    cap: int | None,
+) -> int | None:
+    """Fewest passages covering every phrase with at most `cap` per trajectory.
+
+    Exact rather than greedy. Choosing each trajectory's largest coverage mask
+    is not optimal - a trajectory that can reach either {A,B} or {C,D} must
+    pick the one its neighbours do not already hold - so this carries the whole
+    reachable set forward and lets the join decide. The state space is bounded
+    by 2**phrase_count, at most 32 here.
+    """
+    full = (1 << phrase_count) - 1
+    patterns_by_trajectory: dict[str, set[int]] = defaultdict(set)
+    for index, mask in covers.items():
+        patterns_by_trajectory[passages[index]["trajectory"]].add(mask)
+    best = {0: 0}
+    for patterns in patterns_by_trajectory.values():
+        reachable = _reachable_masks(patterns, cap, phrase_count)
+        merged_best: dict[int, int] = {}
+        for state, spent in best.items():
+            for mask, cost in reachable.items():
+                key = state | mask
+                if merged_best.get(key, math.inf) > spent + cost:
+                    merged_best[key] = spent + cost
+        best = merged_best
+        if full in best:
+            return best[full]
+    return best.get(full)
+
+
+def passages_of_one_trajectory_needed(
+    covers: dict[int, int],
+    passages: list[dict[str, Any]],
+    phrase_count: int,
+) -> int | None:
+    """Fewest passages of a single trajectory that carry every phrase."""
+    full = (1 << phrase_count) - 1
+    patterns_by_trajectory: dict[str, set[int]] = defaultdict(set)
+    for index, mask in covers.items():
+        patterns_by_trajectory[passages[index]["trajectory"]].add(mask)
+    cheapest: int | None = None
+    for patterns in patterns_by_trajectory.values():
+        cost = _reachable_masks(patterns, None, phrase_count).get(full)
+        if cost is not None:
+            cheapest = cost if cheapest is None else min(cheapest, cost)
+    return cheapest
+
+
+def mechanism(
+    questions: list[dict[str, Any]],
+    passages: list[dict[str, Any]],
+    covers_by_question: list[dict[int, int]],
+) -> dict[str, Any]:
+    """Where the gold sits, independent of any ranking.
+
+    The per-trajectory cap can only exclude gold that a question must draw from
+    one trajectory more than `cap` times. This counts exactly that, plus how
+    much room the question has to route around the cap: a question several
+    trajectories can each answer alone is insensitive to the cap in a way that
+    a question with a single carrier is not.
+    """
+    carriers: Counter = Counter()
+    solo_covering: Counter = Counter()
+    within_one: Counter = Counter()
+    required_cap: Counter = Counter()
+    min_items: Counter = Counter()
+    for item, covers in zip(questions, covers_by_question, strict=True):
+        phrase_count = len(item["phrases"])
+        full = (1 << phrase_count) - 1
+        patterns_by_trajectory: dict[str, set[int]] = defaultdict(set)
+        for index, mask in covers.items():
+            patterns_by_trajectory[passages[index]["trajectory"]].add(mask)
+        carriers[len(patterns_by_trajectory)] += 1
+
+        solo = 0
+        cheapest: int | None = None
+        for patterns in patterns_by_trajectory.values():
+            reachable = _reachable_masks(patterns, None, phrase_count)
+            cost = reachable.get(full)
+            if cost is None:
+                continue
+            solo += 1
+            cheapest = cost if cheapest is None else min(cheapest, cost)
+        solo_covering[solo] += 1
+        within_one[cheapest if cheapest is not None else "no_single_trajectory_covers"] += 1
+
+        smallest: int | str = "unreachable"
+        for cap in range(1, phrase_count + 1):
+            spent = cap_feasibility(covers, passages, phrase_count, cap)
+            if spent is not None:
+                smallest = cap
+                min_items[spent] += 1
+                break
+        required_cap[smallest] += 1
+    return {
+        "gold_carrying_trajectories": _histogram(carriers),
+        "trajectories_covering_all_gold_alone": _histogram(solo_covering),
+        "passages_of_one_trajectory_needed": _histogram(within_one),
+        "smallest_trajectory_cap_that_reaches_gold": _histogram(required_cap),
+        "passages_the_cheapest_covering_selection_uses": _histogram(min_items),
+    }
+
+
+def _histogram(counter: Counter) -> dict[str, int]:
+    return {
+        str(key): value for key, value in sorted(counter.items(), key=lambda pair: str(pair[0]))
+    }
+
+
+def build_bm25(
+    passages: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+) -> tuple[dict[str, list[tuple[int, int]]], dict[str, float], list[int], float]:
+    """Index only the terms some question asks for.
+
+    The full inverted index over 85k passages is never needed: BM25 touches a
+    document only through the query terms it contains, and every query is known
+    before the first pass. Restricting the postings to that vocabulary is what
+    keeps this arm inside the stdlib tier.
+    """
+    vocabulary = set()
+    for item in questions:
+        vocabulary.update(normalize_text(item["question"]["question"]).split())
+    postings: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    lengths: list[int] = []
+    for index, passage in enumerate(passages):
+        counts: Counter = Counter(passage["text"].split())
+        lengths.append(sum(counts.values()))
+        for term, frequency in counts.items():
+            if term in vocabulary:
+                postings[term].append((index, frequency))
+    document_count = len(passages)
+    idf = {
+        term: math.log(
+            1.0 + (document_count - len(entries) + 0.5) / (len(entries) + 0.5),
+        )
+        for term, entries in postings.items()
+    }
+    average_length = sum(lengths) / max(1, len(lengths))
+    return postings, idf, lengths, average_length
+
+
+def bm25_order(
+    query: str,
+    depth: int,
+    postings: dict[str, list[tuple[int, int]]],
+    idf: dict[str, float],
+    lengths: list[int],
+    average_length: float,
+) -> list[int]:
+    """Top-`depth` passages, ties broken by index as a stable argsort would."""
+    scores: dict[int, float] = defaultdict(float)
+    for term in set(query.split()):
+        entries = postings.get(term)
+        if not entries:
+            continue
+        weight = idf[term]
+        for index, frequency in entries:
+            denominator = frequency + BM25_K1 * (
+                1 - BM25_B + BM25_B * lengths[index] / average_length
+            )
+            scores[index] += weight * frequency * (BM25_K1 + 1) / denominator
+    ranked = sorted(scores.items(), key=lambda pair: (-pair[1], pair[0]))
+    return [index for index, _score in ranked[:depth]]
+
+
+def select_diverse(
+    pool: list[int],
+    passages: list[dict[str, Any]],
+    cap: int | None,
+    limit: int,
+) -> list[int]:
+    """`sibyl_memory._select_diverse_results`, over passage rows.
+
+    Two passes: the first admits at most one row per trajectory, the second
+    fills up to `cap`. The second pass also refuses a row whose diversity key
+    is already present, but a passage carries no `longmemeval_v2_state_index` -
+    the projection stamps the experience's metadata block, which has the
+    trajectory id and not the state - so its key falls back to the row id and
+    that guard never fires. Over-cap rows are dropped, not deferred: the
+    server's backfill lives in `_fuse_context_evidence`, which only the
+    accurate path calls.
+
+    That fallback is a key-name mismatch rather than missing information, and
+    the difference is a live hazard. `_passage_projection` does stamp
+    `observation_ordinal`, and the eval sets an observation's ordinal to the
+    state index, so the state a passage came from is recoverable - which is
+    exactly what `_source_support_state` already does for the source-support
+    path. Teaching `_result_diversity_key` that trick would make the second
+    pass admit **one passage per state**, a far tighter bound than any value of
+    `max_chunks_per_trajectory`, and it would look like a metadata cleanup.
+    """
+    selected: list[int] = []
+    seen: set[int] = set()
+    counts: Counter = Counter()
+    for trajectory_pass in (True, False):
+        for index in pool:
+            if index in seen:
+                continue
+            trajectory = passages[index]["trajectory"]
+            if cap is not None and counts[trajectory] >= cap:
+                continue
+            if trajectory_pass and counts[trajectory] > 0:
+                continue
+            selected.append(index)
+            seen.add(index)
+            counts[trajectory] += 1
+            if len(selected) >= limit:
+                return selected
+    return selected
+
+
+def admit_within_budget(
+    indices: list[int],
+    passages: list[dict[str, Any]],
+    budget: int,
+) -> tuple[list[int], int]:
+    """Longest rank prefix that fits, stopping at the first row that does not."""
+    admitted: list[int] = []
+    spent = 0
+    for index in indices:
+        chars = passages[index]["chars"]
+        if spent + chars > budget:
+            break
+        admitted.append(index)
+        spent += chars
+    return admitted, spent
+
+
+def compose_pack(
+    order: list[int],
+    passages: list[dict[str, Any]],
+    cap: int | None,
+    depth: int,
+    budget: int,
+) -> tuple[list[int], list[int], int]:
+    """Search depth, then the trajectory cap, then the character budget."""
+    pool = order[:depth]
+    # `context_pack_item_ceiling` raises the item ceiling to the candidate count
+    # whenever a character budget is in force, so the composer is the only
+    # place the pack is bounded and this ceiling cannot bind.
+    seed_limit = max(GATE_MAX_CONTEXT_ITEMS, len(pool))
+    selected = select_diverse(pool, passages, cap, seed_limit)
+    pack, spent = admit_within_budget(selected, passages, budget)
+    return selected, pack, spent
+
+
+def _merged_cover(indices: list[int], covers: dict[int, int]) -> int:
+    merged = 0
+    for index in indices:
+        merged |= covers.get(index, 0)
+    return merged
+
+
+def _loss_reason(
+    *,
+    covered: bool,
+    in_corpus: bool,
+    in_pool: bool,
+    survives_cap: bool,
+) -> str:
+    if covered:
+        return "covered"
+    if not in_corpus:
+        return "gold_outside_passage_substrate"
+    if not in_pool:
+        return "search_depth_never_reached_gold"
+    if not survives_cap:
+        return "trajectory_cap_excluded_reachable_gold"
+    return "char_budget_excluded_reachable_gold"
+
+
+def run_grid(
+    questions: list[dict[str, Any]],
+    passages: list[dict[str, Any]],
+    covers_by_question: list[dict[int, int]],
+    orders: list[list[int]],
+) -> dict[str, Any]:
+    """Exposure over the cap x depth grid, with the loss cause for each miss."""
+    grid: dict[str, Any] = {}
+    corpus_masks = [_merged_cover(list(covers), covers) for covers in covers_by_question]
+    for cap in TRAJECTORY_CAPS:
+        for depth in POOL_DEPTHS:
+            hits = 0
+            reasons: Counter = Counter()
+            pack_items = 0
+            pack_chars = 0
+            pack_trajectories = 0
+            for position, item in enumerate(questions):
+                covers = covers_by_question[position]
+                order = orders[position]
+                full = (1 << len(item["phrases"])) - 1
+                selected, pack, spent = compose_pack(order, passages, cap, depth, GATE_CHAR_BUDGET)
+                covered = _merged_cover(pack, covers) == full
+                hits += covered
+                pack_items += len(pack)
+                pack_chars += spent
+                pack_trajectories += len({passages[index]["trajectory"] for index in pack})
+                reasons[
+                    _loss_reason(
+                        covered=covered,
+                        in_corpus=corpus_masks[position] == full,
+                        in_pool=_merged_cover(order[:depth], covers) == full,
+                        survives_cap=_merged_cover(selected, covers) == full,
+                    )
+                ] += 1
+            key = f"cap={'none' if cap is None else cap}|depth={depth}"
+            grid[key] = {
+                "exposure": round(hits / len(questions), 4),
+                "mean_pack_items": round(pack_items / len(questions), 2),
+                "mean_pack_trajectories": round(pack_trajectories / len(questions), 2),
+                "mean_pack_chars": round(pack_chars / len(questions), 1),
+                "budget_headroom_chars": round(
+                    GATE_CHAR_BUDGET - pack_chars / len(questions),
+                    1,
+                ),
+                "loss_reasons": dict(sorted(reasons.items())),
+            }
+    return grid
+
+
+def char_budget_probe(
+    questions: list[dict[str, Any]],
+    passages: list[dict[str, Any]],
+    covers_by_question: list[dict[int, int]],
+    orders: list[list[int]],
+    cap: int | None,
+    depth: int,
+) -> dict[str, Any]:
+    """Exposure and payload against the budget, at the widest knob setting."""
+    out: dict[str, Any] = {}
+    for budget in CHAR_BUDGET_PROBES:
+        hits = 0
+        items = 0
+        chars = 0
+        for item, covers, order in zip(questions, covers_by_question, orders, strict=True):
+            full = (1 << len(item["phrases"])) - 1
+            _selected, pack, spent = compose_pack(order, passages, cap, depth, budget)
+            hits += _merged_cover(pack, covers) == full
+            items += len(pack)
+            chars += spent
+        out[str(budget)] = {
+            "exposure": round(hits / len(questions), 4),
+            "mean_pack_items": round(items / len(questions), 2),
+            "mean_pack_chars": round(chars / len(questions), 1),
+        }
+    return out
+
+
+def note_lane_interaction(
+    questions: list[dict[str, Any]],
+    passages: list[dict[str, Any]],
+    covers_by_question: list[dict[int, int]],
+    orders: list[list[int]],
+    cap: int | None,
+    depth: int,
+) -> dict[str, Any]:
+    """What the pinned note lane costs the passage lane at one grid point.
+
+    The note reservation is an absolute count of items, so its cost to the
+    passage lane is a number of characters nobody has measured on this corpus -
+    the distilled notes are not in the frozen catalogs. This sweeps plausible
+    per-note sizes instead, which is enough to say whether the coupling can
+    reach the passage lane at all at this budget.
+    """
+    out: dict[str, Any] = {}
+    for note_chars in NOTE_SIZE_PROBES:
+        budget = GATE_CHAR_BUDGET - NOTE_RESERVATION_ITEMS * note_chars
+        hits = 0
+        for item, covers, order in zip(questions, covers_by_question, orders, strict=True):
+            full = (1 << len(item["phrases"])) - 1
+            _selected, pack, _spent = compose_pack(order, passages, cap, depth, budget)
+            hits += _merged_cover(pack, covers) == full
+        out[str(note_chars)] = {
+            "passage_budget_chars": budget,
+            "exposure": round(hits / len(questions), 4),
+        }
+    return out
+
+
+def analyse(domain: str) -> dict[str, Any]:
+    states = load_states(domain)
+    passages, parts = build_passages(states)
+    questions = measurable_questions(domain, states)
+    covers_by_question = [passage_covers(passages, item["phrases"]) for item in questions]
+
+    solo_cost = [
+        passages_of_one_trajectory_needed(covers, passages, len(item["phrases"]))
+        for item, covers in zip(questions, covers_by_question, strict=True)
+    ]
+    ceiling: dict[str, Any] = {}
+    for cap in TRAJECTORY_CAPS:
+        reached = 0
+        spends: list[int] = []
+        for item, covers in zip(questions, covers_by_question, strict=True):
+            spent = cap_feasibility(covers, passages, len(item["phrases"]), cap)
+            if spent is not None:
+                reached += 1
+                spends.append(spent)
+        # The single-source arm is the one that speaks to answerability: it
+        # requires every phrase to come from one trajectory, the way `stage0d`
+        # and `stage0h` required one carrier state. The any-source arm above
+        # lets phrases be assembled from unrelated trajectories, which is a
+        # true statement about the pack's text and a weak one about whether a
+        # reader could have answered from it.
+        solo_reached = sum(
+            1 for cost in solo_cost if cost is not None and (cap is None or cost <= cap)
+        )
+        ceiling[f"cap={'none' if cap is None else cap}"] = {
+            "exposure_any_source": round(reached / len(questions), 4),
+            "exposure_single_source": round(solo_reached / len(questions), 4),
+            "max_passages_a_covering_selection_needs": max(spends, default=0),
+        }
+
+    postings, idf, lengths, average_length = build_bm25(passages, questions)
+    orders = [
+        bm25_order(
+            normalize_text(item["question"]["question"]),
+            max(POOL_DEPTHS),
+            postings,
+            idf,
+            lengths,
+            average_length,
+        )
+        for item in questions
+    ]
+
+    grid = run_grid(questions, passages, covers_by_question, orders)
+    checks = baseline(domain, passages, parts, questions, covers_by_question)
+    checks["stage1_bm25_slice_at_50"] = {
+        "source": "out/stage1_summary.txt",
+        "measured": grid[f"cap=none|depth={max(POOL_DEPTHS)}"]["exposure"],
+        "committed": STAGE1_SLICE_BM25_AT_50[domain],
+    }
+
+    chars = [passage["chars"] for passage in passages]
+    return {
+        "domain": domain,
+        "baseline": checks,
+        "shipped_enforcement": {
+            "max_chunks_per_trajectory": (
+                "wire value reaches `max_results_per_source`, whose only consumer "
+                "is `_fuse_context_evidence` on the accurate path; a fast-mode run "
+                "enforces it solely in the adapter's `_select_diverse_results`"
+            ),
+            "max_candidates_per_signal": (
+                "bounds `build_context_retrieval_plan`, which serves context-pack "
+                "facet sections; the evidence lane runs `execute_search_request` -> "
+                "`tools.search.search` -> `hybrid_search` and never constructs a "
+                "`CandidateLimits`, and no `FACET_TYPES` entry names a passage"
+            ),
+            "evidence_lane_depth": (
+                "`min(max(search_limit, max_context_items), 50)`, applied as "
+                "`all_results[offset : offset + limit]`; this is the seed budget "
+                "the passage lane actually has"
+            ),
+            "passage_window_units": (
+                "`select_operational_source_span` is reached only through "
+                "`expand_operational_source_evidence`, whose single call site is "
+                "the accurate path, so a fast-mode pack holds individually ranked "
+                "passages rather than 3-adjacent windows"
+            ),
+        },
+        "substrate": {
+            "passages": len(passages),
+            "trajectories": len({passage["trajectory"] for passage in passages}),
+            "evidence_parts": len(parts),
+            "mean_passage_chars": round(sum(chars) / len(chars), 1),
+            "max_passage_chars": max(chars),
+            "measurable": len(questions),
+        },
+        "gate_geometry": {
+            "max_context_items": GATE_MAX_CONTEXT_ITEMS,
+            "char_budget": GATE_CHAR_BUDGET,
+            "note_reservation_items": NOTE_RESERVATION_ITEMS,
+        },
+        "mechanism": mechanism(questions, passages, covers_by_question),
+        "cap_ceiling": ceiling,
+        "bm25_grid": grid,
+        "char_budget_probe": char_budget_probe(
+            questions,
+            passages,
+            covers_by_question,
+            orders,
+            cap=None,
+            depth=max(POOL_DEPTHS),
+        ),
+        "note_lane_interaction": note_lane_interaction(
+            questions,
+            passages,
+            covers_by_question,
+            orders,
+            cap=8,
+            depth=28,
+        ),
+    }
+
+
+def main() -> None:
+    report: dict[str, Any] = {}
+    for domain in ("enterprise", "web"):
+        data = analyse(domain)
+        report[domain] = data
+        print(f"\n### {domain}  measurable={data['substrate']['measurable']}")
+        print(f"baseline reproduces stage0h: {data['baseline']['reproduces']}")
+        print(f"  measured  {data['baseline']['measured']}")
+        print(f"  committed {data['baseline']['committed']}")
+        print(f"  stage1 bm25 slice@50 {data['baseline']['stage1_bm25_slice_at_50']}")
+        print(
+            f"substrate passages={data['substrate']['passages']} "
+            f"trajectories={data['substrate']['trajectories']} "
+            f"mean_chars={data['substrate']['mean_passage_chars']}"
+        )
+        print("  cap ceiling (ranking-free):")
+        for name, block in data["cap_ceiling"].items():
+            print(
+                f"    {name:<10} single_source={block['exposure_single_source']:.4f} "
+                f"any_source={block['exposure_any_source']:.4f}"
+            )
+        for metric, label in (
+            ("exposure", "exposure"),
+            ("mean_pack_items", "items"),
+            ("mean_pack_chars", "chars"),
+        ):
+            print(f"  bm25 grid {label}:")
+            print("    cap".ljust(12) + "".join(f"d={d}".rjust(10) for d in POOL_DEPTHS))
+            for cap in TRAJECTORY_CAPS:
+                key = "none" if cap is None else str(cap)
+                row = "".join(
+                    f"{data['bm25_grid'][f'cap={key}|depth={d}'][metric]:.2f}".rjust(10)
+                    for d in POOL_DEPTHS
+                )
+                print(f"    {key:<8}{row}")
+        cap_losses = {
+            name: block["loss_reasons"]["trajectory_cap_excluded_reachable_gold"]
+            for name, block in data["bm25_grid"].items()
+            if "trajectory_cap_excluded_reachable_gold" in block["loss_reasons"]
+        }
+        print(f"  grid points where the cap excluded reachable gold: {cap_losses}")
+        print(f"  gold in one trajectory: {data['mechanism']['passages_of_one_trajectory_needed']}")
+        print(f"  char budget at cap=none depth={max(POOL_DEPTHS)}: {data['char_budget_probe']}")
+        print(f"  note lane at cap=8 depth=28: {data['note_lane_interaction']}")
+    (OUT / "stage2_report.json").write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# 🎯 Replace two guessed numbers with measured ones — and find that a third path is dead

**Stacked on #285.** Measurement only, stdlib, no paid calls. It was meant to settle two knobs. It settled them, and found that **three of the four enforcement paths it was asked to sweep are inert in the configuration the gate actually runs** (`retrieval_mode=fast`, the campaign's Pareto-winning arm).

## 🚨 The finding that changes the gate plan

**`PASSAGE_WINDOW_UNITS = 3` never executes in fast mode.** `select_operational_source_span` is reachable only via `expand_operational_source_evidence`, whose sole call site sits inside `_execute_accurate_context_evidence_search`, and `routes/context.py:699` gates that on `retrieval_mode == "accurate"`. The fast branch calls `_execute_context_evidence_search` and never expands sources.

So a fast gate run composes **individually ranked passages, not 3-adjacent windows.** The 95.5% / 100% ceiling that justifies A1's window design is not the geometry a fast run composes; single-passage is 93.2% / 97.9%.

This is the third instance of one class of error in this campaign: *measured geometry is not shipped geometry*. The first two were caught and both turned out benign. This one is real.

**But the trade is now quantifiable, and it argues against fixing it here.** #285 established that the entire w1→w3 gain is **one question per domain** (`0cf979c4` enterprise at w3, `c6124506` web at w2). Wiring source expansion into the fast path would change production behavior and latency for every caller in order to buy one question per domain — and accurate mode, the only path where the window runs today, is slated for deprecation in A5. The window belongs to the A3 traversal conversation, not to A1's substrate gate.

## 🔧 Two more dead paths, worth knowing before anyone tunes them

**`max_results_per_source` is inert in fast mode.** The adapter puts `max_chunks_per_trajectory` on the wire, but its only consumer is `_fuse_context_evidence`, called only from the accurate path. The knob's one live enforcement is the eval adapter's `_select_diverse_results`, which *drops* over-cap rows where the server would have deferred and backfilled them.

**`MAX_CANDIDATES_PER_SIGNAL` cannot reach a passage at all.** It bounds `CandidateLimits` for `build_context_retrieval_plan`, whose only non-test caller serves context-pack *facet sections* — and no `FACET_TYPES` entry names a passage. The evidence lane runs `execute_search_request` → `tools.search.search` → `hybrid_search`, which builds no `CandidateLimits` and reads at `limit * 3`. **The recommended {8, 16, 24} sweep would have measured nothing while widening every facet read for every caller.** #284's seven-site routing is correct work; the experiment it enables is a no-op for this substrate.

What actually plays the seed-budget role is the evidence request's own `limit` = `min(max(search_limit, max_context_items), 50)`, enforced as a slice. That is the axis swept in its place.

## ✅ Knob 1: `max_chunks_per_trajectory` — recommend **50**, not the guessed 8

Ranking-free cap ceiling (exact search over per-trajectory coverage masks — what this cannot reach, no ranker can):

| cap | 1 | 2 | 4 | 8 | 16 | none |
| --- | --- | --- | --- | --- | --- | --- |
| enterprise | 0.9318 | 0.9545 | 0.9545 | 0.9545 | 0.9545 | 0.9545 |
| web | 0.9792 | 1.0 | 1.0 | 1.0 | 1.0 | 1.0 |

**The exposure curve flattens at 2.** So the guess of 8 is not wrong on exposure — nothing above 2 is. **It is wrong on payload:**

| mean composed pack chars | cap 2 | 4 | 8 | 16 | none |
| --- | --- | --- | --- | --- | --- |
| enterprise | 7,487 | 14,456 | 27,683 | 40,676 | 45,630 |
| web | 18,485 | 26,365 | 33,391 | 39,308 | 39,976 |

The shipped default of 2 spends **16%** of the configured enterprise budget; the guessed 8 spends 58%. BM25 over passages concentrates — the top 28 span 1.73 enterprise trajectories on average.

⚠️ **And the source-diversity rationale does not survive the code.** `_select_diverse_results`' first pass admits one row per trajectory *before* the cap can bind, so the measured mean distinct-trajectory count of the pack is **identical at every cap** (1.73 / 7.79 at depth 28, unchanged from cap 1 to uncapped). The cap buys no diversity and costs most of the payload.

Anything ≤ 8 hands the substrate arm a payload handicap against a fat baseline that renders up to 60,000 chars — and a paid run cannot distinguish that handicap from slicing not working.

## ✅ Knob 2: leave the constant, raise the lane depth to **50**

`MAX_CANDIDATES_PER_SIGNAL`: leave at 8, do not sweep. Null result, recorded against the code.

Evidence-lane depth, BM25 exposure (identical at every cap above 4):

| depth | 8 | 16 | 24 | 28 | 50 |
| --- | --- | --- | --- | --- | --- |
| enterprise | 0.1364 | 0.1591 | 0.1818 | 0.1818 | 0.2045 |
| web | 0.0833 | 0.1042 | 0.1250 | 0.1458 | 0.1667 |

Monotone and **not flattening at 50**. Depth costs only a wider read.

Honest caveat, stated because it bounds the claim: BM25 alone is the weakest ranker Stage 1 measured on slices (median first-gold rank 282/302 vs 19/40 dense), so these absolutes are a floor and a hybrid lane would flatten this curve earlier. That is precisely why the *cap* recommendation is read off the ranking-free ceiling and only the *depth* recommendation off BM25 — where being conservative means recommending more depth than needed. A dense arm would move the BM25 absolutes and cannot move the cap ceiling.

## 🧪 Baseline reproduction

`stage2` rebuilds the production substrate from `stage0h.production_slices` and reproduces from its own structures: **84,968 / 65,573 passages, 44 / 48 measurable questions, single-passage exposure 0.9318 / 0.9792, 3-adjacent 0.9545 / 1.0** — identical to the committed `stage0h_report.json`. Separately, the stdlib BM25 reproduces Stage 1's scikit-learn scorer at depth 50 (0.2045 / 0.1667 vs 0.204 / 0.167).

Re-running with `SIBYL_A1_OUT` at a scratch path produces a byte-identical receipt, verified three times including after a post-lint refactor.

## 🔬 Loss mechanism

**41 of 44 enterprise and 47 of 48 web questions need exactly one passage of one trajectory.** One each needs two. `trajectory_cap_excluded_reachable_gold` fires on exactly 1 question, only at cap ∈ {1,2}. Everything else is `search_depth_never_reached_gold` — ranking, not the knobs.

## 📌 Three interactions to decide before the run

- **48,000 is not payload-matched to the comparator.** `validate_evidence_char_budget` allows up to 60,000, which is what the fat baseline's renderer already spends. At 60,000 the passage pack reaches 58,596 / 57,257 chars vs 46,498 / 46,956 at 48,000. Exposure is flat under BM25 across 24K/48K/60K, but this is a paid payload comparison and 48K concedes ~20% by default rather than by measurement.
- **The pinned note lane spends first** — three notes at 4,000 chars leave the passage lane 36,000 of 48,000. Note size on this corpus is unmeasured (distilled notes are not in the frozen catalogs), so this is arithmetic to carry forward, not a measurement.
- **Neighbour stitch is inert for passages** — `_neighbor_results` needs an integer `longmemeval_v2_chunk_index` that passages do not carry, so `--neighbor-stitch-items 2` silently does nothing.

## ⚠️ One latent hazard, documented in the source

`_result_diversity_key` falls back to row id for passages because they lack `longmemeval_v2_state_index`. But passages *do* carry `observation_ordinal`, which the eval sets to the state index, and `_source_support_state` already recovers a state index that way. **Teaching the diversity key that same trick would cap the pack at one passage per state** — far below any `max_chunks_per_trajectory` — while looking like a routine metadata cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)