### PR TITLE
fix(bench): account passages apart from the invention bound

### DIFF
--- a/benchmarks/longmemeval_v2_projection_audit.py
+++ b/benchmarks/longmemeval_v2_projection_audit.py
@@ -46,19 +46,22 @@ MAX_WRITE_AMPLIFICATION = 2.0
 # against MAX_WRITE_AMPLIFICATION would compare a re-carving to an invention and
 # reject the substrate by construction (measured fan-out is 11x to 14.5x rows).
 #
-# Bytes, not rows, because embedding spend is what this substrate buys (the
-# capture path makes no per-entity model call) and because every passage carries
-# a floor of non-content bytes: entity type, name, the 500-char-capped
-# description, the 120-char-capped header, and the breadcrumb, measured at 453
-# chars minimum. Bounding bytes therefore bounds rows too.
+# Bytes, not rows, because embedding spend is what this substrate buys: the
+# capture path makes no per-entity model call, so the per-row cost is embedding
+# tokens. Each passage also carries non-content bytes (entity type, name, the
+# 500-char-capped description, the 120-char-capped header, the breadcrumb),
+# which is what makes a runaway show up here at all. That per-row floor is
+# framing-dependent rather than structural, measured between 101 and 622 chars,
+# so this bounds rows only loosely and _audit_passage_spans carries the rest.
 #
-# 2.5 against a measured legitimate ceiling of 1.66x. The widest amplification
-# the real slicer reaches over production-shaped trees is 1.66x (24-deep
-# nesting, 60K-char states, descriptions saturated at their cap), and the A1
-# corpus measurement puts the real corpus at 1.65x enterprise / 1.55x web. A
-# slicer that splits every slice four ways measures 2.86x and one that emits a
-# passage per line measures 7.17x, so the bound clears every shape the slicer
-# legitimately produces and still catches a runaway.
+# 2.5 against amplification that rises with nesting depth, since breadcrumbs are
+# uncapped: 1.22x at depth 10, 1.65x at depth 24, 2.20x at depth 48. The A1
+# corpus measures 1.65x enterprise / 1.55x web, and the deepest nesting in the
+# corpus artifacts is 10, so the real substrate sits at the bottom of that
+# curve. A slicer splitting every slice eight ways measures 5.70x and one
+# emitting a passage per line 7.17x. The bound therefore clears the corpus by
+# roughly 2x while still catching a runaway; a synthetic tree nested past ~48
+# would exceed it, which is five times anything the corpus contains.
 MAX_PASSAGE_BYTE_AMPLIFICATION = 2.5
 
 
@@ -86,6 +89,7 @@ class ProjectionIndex:
     raw_by_id: dict[str, Entity]
     derived: list[Entity]
     passages: list[Entity]
+    passages_by_evidence: dict[tuple[str, str], list[Entity]]
     raw_supported: set[str]
 
 
@@ -245,6 +249,13 @@ def _projection_indexes(projection: OperationalExperienceProjection) -> Projecti
     passages = [
         entity for entity in projection.entities if entity.entity_type is EntityType.PASSAGE
     ]
+    passages_by_evidence: dict[tuple[str, str], list[Entity]] = {}
+    for passage in passages:
+        key = (
+            str(passage.metadata.get("source_observation_id")),
+            str(passage.metadata.get("evidence_part_id")),
+        )
+        passages_by_evidence.setdefault(key, []).append(passage)
     raw_supported = {
         relationship.source_id
         for relationship in projection.relationships
@@ -258,6 +269,7 @@ def _projection_indexes(projection: OperationalExperienceProjection) -> Projecti
         raw_by_id=raw_by_id,
         derived=derived_entities,
         passages=passages,
+        passages_by_evidence=passages_by_evidence,
         raw_supported=raw_supported,
     )
 
@@ -348,6 +360,14 @@ def _audit_observations(
                 raw_entity,
                 content_max_chars=content_max_chars,
             )
+            _audit_passage_spans(
+                audit.issues,
+                trajectory_id,
+                observation.id,
+                evidence.id,
+                evidence.content,
+                index.passages_by_evidence.get((observation.id, evidence.id), []),
+            )
 
         if not observation.action:
             continue
@@ -367,6 +387,66 @@ def _audit_observations(
                 observation.action,
                 index.derived,
             )
+
+
+def _audit_passage_spans(
+    issues: list[dict[str, object]],
+    trajectory_id: str,
+    observation_id: str,
+    evidence_id: str,
+    evidence_content: str,
+    passages: list[Entity],
+) -> None:
+    """Hold passages to the partition the slicer promises.
+
+    Excluding passages from the invention bound is only sound while they really
+    are a re-carving of their parent, so the claim is checked rather than
+    assumed: every span lands inside the parent body, carries that body's own
+    bytes, and no line is claimed twice. Without this a slicer could mint
+    unbounded rows that discard the content they name, and the byte bound would
+    read it as thrift.
+    """
+    if not passages:
+        return
+    details = {"observation_id": observation_id, "evidence_id": evidence_id}
+    lines = evidence_content.split("\n")
+    claimed: set[int] = set()
+    for passage in passages:
+        start = passage.metadata.get("passage_line_start")
+        end = passage.metadata.get("passage_line_end")
+        if not isinstance(start, int) or not isinstance(end, int):
+            _issue(issues, trajectory_id, "passage_span_missing", **details, entity_id=passage.id)
+            continue
+        if not 0 <= start <= end < len(lines):
+            _issue(
+                issues,
+                trajectory_id,
+                "passage_span_outside_parent",
+                **details,
+                entity_id=passage.id,
+                observed=[start, end],
+            )
+            continue
+        content = passage.content or ""
+        if any(lines[edge] not in content for edge in (start, end)):
+            _issue(
+                issues,
+                trajectory_id,
+                "passage_not_byte_exact",
+                **details,
+                entity_id=passage.id,
+            )
+        overlap = claimed.intersection(range(start, end + 1))
+        if overlap:
+            _issue(
+                issues,
+                trajectory_id,
+                "passage_span_overlaps_sibling",
+                **details,
+                entity_id=passage.id,
+                observed=sorted(overlap)[:8],
+            )
+        claimed.update(range(start, end + 1))
 
 
 def _audit_raw_evidence(

--- a/benchmarks/longmemeval_v2_projection_audit.py
+++ b/benchmarks/longmemeval_v2_projection_audit.py
@@ -21,6 +21,7 @@ from longmemeval_v2_memory.sibyl_memory import (  # noqa: E402
     build_operational_experience_payload,
 )
 
+from sibyl_core.embeddings import entity_embedding_text  # noqa: E402
 from sibyl_core.models import (  # noqa: E402
     Entity,
     EntityType,
@@ -30,8 +31,35 @@ from sibyl_core.models import (  # noqa: E402
 )
 from sibyl_core.projection import project_operational_experience  # noqa: E402
 
-AUDIT_SCHEMA_VERSION = "sibyl-longmemeval-v2-projection-audit-v1"
+AUDIT_SCHEMA_VERSION = "sibyl-longmemeval-v2-projection-audit-v2"
+
+# Inferred rows per byte-exact raw evidence row. The projector's structural
+# ceiling is exactly one inferred row per raw row: one transition event per
+# action, one procedure segment, and at most one error pattern, against one raw
+# row per evidence part. 2.0 is that ceiling, so anything above it is the
+# extractor minting rows no source row accounts for.
 MAX_WRITE_AMPLIFICATION = 2.0
+
+# Passage embedding bytes per byte of the raw evidence rows they were cut from.
+# Passages are not inference: the slicer partitions a state body's lines
+# exactly, so a passage re-carves bytes its parent already holds. Counting them
+# against MAX_WRITE_AMPLIFICATION would compare a re-carving to an invention and
+# reject the substrate by construction (measured fan-out is 11x to 14.5x rows).
+#
+# Bytes, not rows, because embedding spend is what this substrate buys (the
+# capture path makes no per-entity model call) and because every passage carries
+# a floor of non-content bytes: entity type, name, the 500-char-capped
+# description, the 120-char-capped header, and the breadcrumb, measured at 453
+# chars minimum. Bounding bytes therefore bounds rows too.
+#
+# 2.5 against a measured legitimate ceiling of 1.66x. The widest amplification
+# the real slicer reaches over production-shaped trees is 1.66x (24-deep
+# nesting, 60K-char states, descriptions saturated at their cap), and the A1
+# corpus measurement puts the real corpus at 1.65x enterprise / 1.55x web. A
+# slicer that splits every slice four ways measures 2.86x and one that emits a
+# passage per line measures 7.17x, so the bound clears every shape the slicer
+# legitimately produces and still catches a runaway.
+MAX_PASSAGE_BYTE_AMPLIFICATION = 2.5
 
 
 @dataclass
@@ -43,8 +71,22 @@ class AuditAccumulator:
     max_evidence_chars: int = 0
     max_entity_chars: int = 0
     max_embeddable_entity_chars: int = 0
-    max_total_write_amplification: float = 0.0
-    trajectories_above_2x: int = 0
+    max_write_amplification: float = 0.0
+    max_passage_byte_amplification: float = 0.0
+    max_passage_fanout: float = 0.0
+    trajectories_above_write_limit: int = 0
+    trajectories_above_passage_limit: int = 0
+
+
+@dataclass(frozen=True)
+class ProjectionIndex:
+    """The projected rows split by the account each one belongs to."""
+
+    raw_by_evidence: dict[tuple[str, str], Entity]
+    raw_by_id: dict[str, Entity]
+    derived: list[Entity]
+    passages: list[Entity]
+    raw_supported: set[str]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -93,17 +135,30 @@ def audit_trajectories(
             content_max_chars=content_max_chars,
         )
 
-    total_write_amplification = (
+    aggregate_write_amplification = (
         audit.counts["raw_entities"] + audit.counts["derived_entities"]
     ) / max(audit.counts["raw_entities"], 1)
-    if total_write_amplification > MAX_WRITE_AMPLIFICATION:
+    if aggregate_write_amplification > MAX_WRITE_AMPLIFICATION:
         _issue(
             audit.issues,
             "corpus",
-            "aggregate_write_amplification_above_2x",
-            observed=total_write_amplification,
+            "aggregate_write_amplification_above_limit",
+            observed=aggregate_write_amplification,
+            limit=MAX_WRITE_AMPLIFICATION,
         )
-    audit.counts["trajectories_above_2x"] = audit.trajectories_above_2x
+    aggregate_passage_byte_amplification = audit.counts["passage_embedding_chars"] / max(
+        audit.counts["passage_parent_embedding_chars"], 1
+    )
+    if aggregate_passage_byte_amplification > MAX_PASSAGE_BYTE_AMPLIFICATION:
+        _issue(
+            audit.issues,
+            "corpus",
+            "aggregate_passage_byte_amplification_above_limit",
+            observed=aggregate_passage_byte_amplification,
+            limit=MAX_PASSAGE_BYTE_AMPLIFICATION,
+        )
+    audit.counts["trajectories_above_write_limit"] = audit.trajectories_above_write_limit
+    audit.counts["trajectories_above_passage_limit"] = audit.trajectories_above_passage_limit
     audit.counts["issues"] = len(audit.issues)
     return {
         "schema_version": AUDIT_SCHEMA_VERSION,
@@ -121,8 +176,16 @@ def audit_trajectories(
             "max_evidence_part_chars": audit.max_evidence_chars,
             "max_projected_entity_chars": audit.max_entity_chars,
             "max_embeddable_entity_chars": audit.max_embeddable_entity_chars,
-            "max_total_write_amplification": audit.max_total_write_amplification,
-            "aggregate_write_amplification": total_write_amplification,
+            "max_write_amplification": audit.max_write_amplification,
+            "aggregate_write_amplification": aggregate_write_amplification,
+            "max_passage_byte_amplification": audit.max_passage_byte_amplification,
+            "aggregate_passage_byte_amplification": aggregate_passage_byte_amplification,
+            # Reported, not gated. Row fan-out swings with tree shape, and the
+            # per-passage byte floor already bounds it; this is the budget
+            # signal a corpus rebuild is priced against.
+            "max_passage_fanout": audit.max_passage_fanout,
+            "aggregate_passage_fanout": audit.counts["passage_entities"]
+            / max(audit.counts["raw_entities"], 1),
         },
         "issues": audit.issues,
     }
@@ -148,43 +211,41 @@ def _audit_trajectory(
     if projection_signature(projection) != projection_signature(replay):
         _issue(audit.issues, trajectory_id, "projection_not_deterministic")
 
-    raw_entities, derived_entities, derived_support = _projection_indexes(projection)
-    _record_projection_stats(audit, experience, projection, raw_entities, derived_entities)
+    index = _projection_indexes(projection)
+    _record_projection_stats(audit, experience, projection, index)
     _audit_observations(
         audit,
         trajectory_id,
         experience,
-        raw_entities,
-        derived_entities,
+        index,
         content_max_chars=content_max_chars,
     )
-    _audit_derived_support(
-        audit,
-        trajectory_id,
-        projection,
-        derived_entities,
-        derived_support,
-    )
+    _audit_derived_support(audit, trajectory_id, projection, index)
 
 
-def _projection_indexes(
-    projection: OperationalExperienceProjection,
-) -> tuple[dict[tuple[str, str], Entity], list[Entity], set[str]]:
+def _projection_indexes(projection: OperationalExperienceProjection) -> ProjectionIndex:
     entities_by_id = {entity.id: entity for entity in projection.entities}
-    raw_entities = {
+    raw_by_id = {
+        entity.id: entity
+        for entity in projection.entities
+        if entity.metadata.get("projection_kind") == "raw_observation"
+    }
+    raw_by_evidence = {
         (
             str(entity.metadata.get("source_observation_id")),
             str(entity.metadata.get("evidence_part_id")),
         ): entity
-        for entity in projection.entities
-        if entity.metadata.get("projection_kind") == "raw_observation"
+        for entity in raw_by_id.values()
     }
     derived_entities = [
         entity
         for entity in projection.entities
         if entity.entity_type in {EntityType.EVENT, EntityType.PROCEDURE, EntityType.ERROR_PATTERN}
     ]
-    derived_support = {
+    passages = [
+        entity for entity in projection.entities if entity.entity_type is EntityType.PASSAGE
+    ]
+    raw_supported = {
         relationship.source_id
         for relationship in projection.relationships
         if relationship.relationship_type is RelationshipType.DERIVED_FROM
@@ -192,15 +253,20 @@ def _projection_indexes(
         and entities_by_id[relationship.target_id].metadata.get("projection_kind")
         == "raw_observation"
     }
-    return raw_entities, derived_entities, derived_support
+    return ProjectionIndex(
+        raw_by_evidence=raw_by_evidence,
+        raw_by_id=raw_by_id,
+        derived=derived_entities,
+        passages=passages,
+        raw_supported=raw_supported,
+    )
 
 
 def _record_projection_stats(
     audit: AuditAccumulator,
     experience: OperationalExperience,
     projection: OperationalExperienceProjection,
-    raw_entities: dict[tuple[str, str], Entity],
-    derived_entities: list[Entity],
+    index: ProjectionIndex,
 ) -> None:
     audit.counts["trajectories"] += 1
     audit.counts["observations"] += len(experience.observations)
@@ -217,31 +283,54 @@ def _record_projection_stats(
     for relationship in projection.relationships:
         audit.relationship_types[relationship.relationship_type.value] += 1
 
-    raw_count = len(raw_entities)
-    amplification = (len(projection.entities) - 1) / max(raw_count, 1)
-    audit.max_total_write_amplification = max(
-        audit.max_total_write_amplification,
-        amplification,
-    )
+    raw_count = len(index.raw_by_evidence)
+    amplification = (raw_count + len(index.derived)) / max(raw_count, 1)
+    audit.max_write_amplification = max(audit.max_write_amplification, amplification)
     audit.counts["raw_entities"] += raw_count
-    audit.counts["derived_entities"] += len(derived_entities)
+    audit.counts["derived_entities"] += len(index.derived)
     audit.counts["manifest_entities"] += 1
     if amplification > MAX_WRITE_AMPLIFICATION:
-        audit.trajectories_above_2x += 1
+        audit.trajectories_above_write_limit += 1
+
+    _record_passage_stats(audit, index)
+
+
+def _record_passage_stats(audit: AuditAccumulator, index: ProjectionIndex) -> None:
+    """Account the re-carved rows against the raw rows they were cut from."""
+    if not index.passages:
+        return
+    parents = [
+        index.raw_by_id[parent_id]
+        for parent_id in {
+            str(passage.metadata.get("parent_entity_id")) for passage in index.passages
+        }
+        if parent_id in index.raw_by_id
+    ]
+    passage_chars = sum(len(entity_embedding_text(passage)) for passage in index.passages)
+    parent_chars = sum(len(entity_embedding_text(parent)) for parent in parents)
+    byte_amplification = passage_chars / max(parent_chars, 1)
+    fanout = len(index.passages) / max(len(parents), 1)
+    audit.max_passage_byte_amplification = max(
+        audit.max_passage_byte_amplification,
+        byte_amplification,
+    )
+    audit.max_passage_fanout = max(audit.max_passage_fanout, fanout)
+    audit.counts["passage_entities"] += len(index.passages)
+    audit.counts["passage_embedding_chars"] += passage_chars
+    audit.counts["passage_parent_embedding_chars"] += parent_chars
+    if byte_amplification > MAX_PASSAGE_BYTE_AMPLIFICATION:
+        audit.trajectories_above_passage_limit += 1
 
 
 def _audit_observations(
     audit: AuditAccumulator,
     trajectory_id: str,
     experience: OperationalExperience,
-    raw_entities: dict[tuple[str, str], Entity],
-    derived_entities: list[Entity],
+    index: ProjectionIndex,
     *,
     content_max_chars: int,
 ) -> None:
-    procedures = [
-        entity for entity in derived_entities if entity.entity_type is EntityType.PROCEDURE
-    ]
+    procedures = [entity for entity in index.derived if entity.entity_type is EntityType.PROCEDURE]
     for observation_index, observation in enumerate(experience.observations):
         for evidence in observation.evidence:
             audit.counts["evidence_parts"] += 1
@@ -249,7 +338,7 @@ def _audit_observations(
                 audit.max_evidence_chars,
                 len(evidence.content),
             )
-            raw_entity = raw_entities.get((observation.id, evidence.id))
+            raw_entity = index.raw_by_evidence.get((observation.id, evidence.id))
             _audit_raw_evidence(
                 audit.issues,
                 trajectory_id,
@@ -276,7 +365,7 @@ def _audit_observations(
                 trajectory_id,
                 observation.id,
                 observation.action,
-                derived_entities,
+                index.derived,
             )
 
 
@@ -331,16 +420,28 @@ def _audit_derived_support(
     audit: AuditAccumulator,
     trajectory_id: str,
     projection: OperationalExperienceProjection,
-    derived_entities: list[Entity],
-    derived_support: set[str],
+    index: ProjectionIndex,
 ) -> None:
-    unsupported = [entity.id for entity in derived_entities if entity.id not in derived_support]
+    unsupported = [entity.id for entity in index.derived if entity.id not in index.raw_supported]
     if unsupported:
         _issue(
             audit.issues,
             trajectory_id,
             "derived_entity_without_raw_support",
             entity_ids=unsupported,
+        )
+    orphan_passages = [
+        passage.id
+        for passage in index.passages
+        if passage.id not in index.raw_supported
+        or str(passage.metadata.get("parent_entity_id")) not in index.raw_by_id
+    ]
+    if orphan_passages:
+        _issue(
+            audit.issues,
+            trajectory_id,
+            "passage_without_raw_parent",
+            entity_ids=orphan_passages,
         )
     unsupported_claims = [
         entity.id for entity in projection.entities if entity.entity_type is EntityType.CLAIM

--- a/tools/tests/test_longmemeval_v2_projection_audit.py
+++ b/tools/tests/test_longmemeval_v2_projection_audit.py
@@ -131,6 +131,49 @@ def test_a_runaway_slicer_trips_the_passage_byte_bound(
     assert report["bounds"]["aggregate_write_amplification"] <= EXPECTED_MAX_WRITE_AMPLIFICATION
 
 
+def test_passages_that_discard_the_body_they_name_are_caught_under_the_byte_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hollowed rows stay cheap in bytes, so the span check has to catch them."""
+
+    def hollow_slices(body: str) -> tuple[list[Any], Any]:
+        entries, stats = slicing.slice_body(body)
+        for entry in entries:
+            entry.content = entry.content[:1]
+        return entries, stats
+
+    monkeypatch.setattr("sibyl_core.projection.experience.slice_body", hollow_slices)
+
+    report = _report(tmp_path, _wide_trajectory(states=2), content_max_chars=18_000)
+
+    assert report["passed"] is False
+    assert "passage_not_byte_exact" in {issue["code"] for issue in report["issues"]}
+    # The byte bound alone would have called this thrift, which is the point.
+    assert (
+        report["bounds"]["aggregate_passage_byte_amplification"]
+        <= EXPECTED_MAX_PASSAGE_BYTE_AMPLIFICATION
+    )
+
+
+def test_passages_claiming_the_same_parent_lines_twice_are_caught(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A duplicating slicer re-carves nothing; it copies."""
+
+    def doubled_slices(body: str) -> tuple[list[Any], Any]:
+        entries, stats = slicing.slice_body(body)
+        return [entry for entry in entries for _ in range(2)], stats
+
+    monkeypatch.setattr("sibyl_core.projection.experience.slice_body", doubled_slices)
+
+    report = _report(tmp_path, _wide_trajectory(states=2), content_max_chars=18_000)
+
+    assert report["passed"] is False
+    assert "passage_span_overlaps_sibling" in {issue["code"] for issue in report["issues"]}
+
+
 def test_a_passage_cut_loose_from_its_parent_is_reported(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tools/tests/test_longmemeval_v2_projection_audit.py
+++ b/tools/tests/test_longmemeval_v2_projection_audit.py
@@ -5,10 +5,17 @@ import json
 import sys
 from pathlib import Path
 from types import ModuleType
+from typing import Any
+
+import pytest
+
+from sibyl_core.projection import experience as projection
+from sibyl_core.projection import slicing
 
 EXPECTED_MIN_EVIDENCE_PARTS = 2
 EXPECTED_MAX_EVIDENCE_PART_CHARS = 220
 EXPECTED_MAX_WRITE_AMPLIFICATION = 2.0
+EXPECTED_MAX_PASSAGE_BYTE_AMPLIFICATION = 2.5
 
 
 def _load_module() -> ModuleType:
@@ -22,12 +29,15 @@ def _load_module() -> ModuleType:
     return module
 
 
-def test_projection_audit_proves_source_support_and_replay(tmp_path: Path) -> None:
+def _report(tmp_path: Path, trajectory: dict[str, object], **kwargs: Any) -> dict[str, Any]:
     module = _load_module()
     source = tmp_path / "trajectories.jsonl"
-    source.write_text(json.dumps(_trajectory()) + "\n", encoding="utf-8")
+    source.write_text(json.dumps(trajectory) + "\n", encoding="utf-8")
+    return module.audit_trajectories(source, **kwargs)
 
-    report = module.audit_trajectories(source, content_max_chars=220)
+
+def test_projection_audit_proves_source_support_and_replay(tmp_path: Path) -> None:
+    report = _report(tmp_path, _trajectory(), content_max_chars=220)
 
     assert report["passed"] is True, report["issues"]
     assert report["counts"]["trajectories"] == 1
@@ -35,7 +45,109 @@ def test_projection_audit_proves_source_support_and_replay(tmp_path: Path) -> No
     assert report["counts"]["actions"] == 1
     assert report["relationship_types"]["DERIVED_FROM"] > 0
     assert report["bounds"]["max_evidence_part_chars"] <= EXPECTED_MAX_EVIDENCE_PART_CHARS
-    assert report["bounds"]["max_total_write_amplification"] <= EXPECTED_MAX_WRITE_AMPLIFICATION
+    assert report["bounds"]["max_write_amplification"] <= EXPECTED_MAX_WRITE_AMPLIFICATION
+    assert report["bounds"]["aggregate_write_amplification"] <= EXPECTED_MAX_WRITE_AMPLIFICATION
+
+
+def test_passage_rows_are_accounted_by_bytes_not_against_the_inference_bound(
+    tmp_path: Path,
+) -> None:
+    report = _report(tmp_path, _trajectory(), content_max_chars=220)
+
+    passages = report["counts"]["passage_entities"]
+    assert passages > 0
+    assert report["entity_types"]["passage"] == passages
+    # Passages outnumber the inferred rows several times over, which is exactly
+    # why they cannot share the inference bound.
+    assert passages > report["counts"]["derived_entities"]
+    assert report["counts"]["derived_entities"] == report["counts"]["entities"] - (
+        report["counts"]["raw_entities"] + passages + report["counts"]["manifest_entities"]
+    )
+    assert (
+        report["bounds"]["max_passage_byte_amplification"]
+        <= EXPECTED_MAX_PASSAGE_BYTE_AMPLIFICATION
+    )
+    assert report["counts"]["trajectories_above_passage_limit"] == 0
+
+
+def test_a_fragmenting_segmenter_trips_the_write_amplification_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A projector that mints one inferred row per action is the runaway."""
+
+    def fragmented_segments(
+        experience: Any, observations: list[Any]
+    ) -> list[tuple[str, list[Any]]]:
+        segments = [
+            (f"Goal: {experience.goal}\n{item.ordinal}. {item.action}", [item])
+            for item in observations
+            if item.action
+        ]
+        return segments or [(f"Goal: {experience.goal}", list(observations))]
+
+    monkeypatch.setattr(
+        "sibyl_core.projection.experience._procedure_segments",
+        fragmented_segments,
+    )
+
+    report = _report(tmp_path, _wide_trajectory(states=20), content_max_chars=18_000)
+
+    assert report["passed"] is False
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "aggregate_write_amplification_above_limit" in codes
+    assert report["bounds"]["aggregate_write_amplification"] > EXPECTED_MAX_WRITE_AMPLIFICATION
+    assert report["counts"]["trajectories_above_write_limit"] == 1
+
+
+def test_a_runaway_slicer_trips_the_passage_byte_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slicer that emits a passage per line pays the per-passage floor per line."""
+
+    def one_line_slices(body: str) -> tuple[list[Any], Any]:
+        entries, stats = slicing.slice_body(body)
+        lines = body.split("\n")
+        return [
+            slicing.Slice([index], lines[index], entry.cut_depth, entry.breadcrumb, "runaway")
+            for entry in entries
+            for index in entry.line_indices
+        ], stats
+
+    monkeypatch.setattr("sibyl_core.projection.experience.slice_body", one_line_slices)
+
+    report = _report(tmp_path, _wide_trajectory(states=4), content_max_chars=18_000)
+
+    assert report["passed"] is False
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "aggregate_passage_byte_amplification_above_limit" in codes
+    assert (
+        report["bounds"]["aggregate_passage_byte_amplification"]
+        > EXPECTED_MAX_PASSAGE_BYTE_AMPLIFICATION
+    )
+    assert report["counts"]["trajectories_above_passage_limit"] == 1
+    # The inference bound is indifferent to the slicer, which is the split.
+    assert report["bounds"]["aggregate_write_amplification"] <= EXPECTED_MAX_WRITE_AMPLIFICATION
+
+
+def test_a_passage_cut_loose_from_its_parent_is_reported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passages are excluded from the inference bound, not from provenance."""
+    original = projection._passage_projection
+
+    def without_support(*args: Any, **kwargs: Any) -> tuple[list[Any], list[Any]]:
+        entities, _ = original(*args, **kwargs)
+        return entities, []
+
+    monkeypatch.setattr(projection, "_passage_projection", without_support)
+
+    report = _report(tmp_path, _wide_trajectory(states=2), content_max_chars=18_000)
+
+    assert report["passed"] is False
+    assert "passage_without_raw_parent" in {issue["code"] for issue in report["issues"]}
 
 
 def _trajectory() -> dict[str, object]:
@@ -65,5 +177,35 @@ def _trajectory() -> dict[str, object]:
                 "accessibility_tree": "Root\n" + "Deployment complete\n" * 20,
                 "screenshot": None,
             },
+        ],
+    }
+
+
+def _wide_trajectory(*, states: int) -> dict[str, object]:
+    """Many acting states, each small enough to stay one evidence part."""
+    return {
+        "id": "trajectory-wide",
+        "domain": "web",
+        "environment": "test",
+        "goal": "Update the deployment",
+        "outcome": "success",
+        "start_url": "https://example.test/step-0",
+        "states": [
+            {
+                "state_index": index,
+                "step": index,
+                "url": f"https://example.test/step-{index}",
+                "action": None if index == 0 else f"click('Step {index}')",
+                "thought": f"Work through step {index}.",
+                "accessibility_tree": "\n".join(
+                    [f"section 'Step {index}'"]
+                    + [
+                        f"\tStaticText 'Step {index} row {row} detail detail detail'"
+                        for row in range(60)
+                    ]
+                ),
+                "screenshot": None,
+            }
+            for index in range(states)
         ],
     }


### PR DESCRIPTION
# 🔧 Unbreak main: teach the projection audit what a passage is

**main is currently red.** `test_projection_audit_proves_source_support_and_replay` fails with `assert 2.021505376344086 <= 2.0` since the A1 passage substrate landed. This fixes it without moving the line the guard guards.

## 💡 Why this is not a constant raise

`total_write_amplification = (raw + derived) / raw`, bounded at 2.0 — derived entities may at most equal raw ones. Passages are derived entities, so minting them breaks that bound **by construction**.

The 2.02 in the failing assert badly understates the situation, because the fixture is a tiny synthetic trajectory. At real scale, passage minting grows **entity count 13.1× (enterprise) / 14.3× (web)** while growing **bytes only 1.65× / 1.55×** — passages re-carve content their parent already holds rather than inventing new content. Raising the constant to accommodate that would have deleted a signal worth keeping, since embeddings are per-entity and a 13× entity-count growth is a real cost.

So passages are now accounted **apart from** the invention bound, against a byte-based limit that reflects what they actually cost, while every other derived class stays under the original bound unchanged.

## 🔍 The invariant that earns the exclusion

Passages are allowed outside the invention bound *only because* they re-carve their parent — and `slicing.py` already promises the spans partition the parent body exactly. `_audit_passage_spans` now verifies that promise rather than assuming it: every span lands inside the parent body, carries that body's bytes at both edges, and claims no line twice.

That check exists because of an adversarial finding during verification, and it is the interesting part of this PR. **A slicer minting ~195 rows per raw row while discarding the body each one names stays cheap in bytes and passed the byte bound** — the byte bound alone read it as thrift. `test_passages_that_discard_the_body_they_name_are_caught_under_the_byte_bound` pins exactly that case: caught *while its byte amplification is still under the limit*.

## 🧪 The guard still fails on runaway

Five tests, each naming the runaway class it defends:

\`\`\`
test_a_fragmenting_segmenter_trips_the_write_amplification_bound
test_a_runaway_slicer_trips_the_passage_byte_bound
test_passages_that_discard_the_body_they_name_are_caught_under_the_byte_bound
test_passages_claiming_the_same_parent_lines_twice_are_caught
test_a_passage_cut_loose_from_its_parent_is_reported
\`\`\`

Against the verifier's exact adversarial shape:

\`\`\`
--- healthy control
  passed: True   agg_passage_bytes: 0.841  codes: []
--- RUNAWAY near-empty passages
  passed: False  codes: ['aggregate_passage_byte_amplification_above_limit',
                         'passage_not_byte_exact']
\`\`\`

\`\`\`
root:bench-gate-test                         370 passed in 9.15s
root:bench-longmemeval-v2-operational-test    27 passed in 0.68s
inventory-lint / format / typecheck          All checks passed!
\`\`\`

An independent verifier also reproduced that the pre-change formula and the post-change formula are **identical arithmetic** on the historical five entity classes, confirming this changes accounting for passages only and leaves every prior shape's verdict untouched. No consumer of the renamed report keys exists anywhere.

## ⚖️ Sourcing, stated at the strength it deserves

Passage byte amplification rises with nesting depth because breadcrumbs are uncapped: measured **1.22× at depth 10, 1.65× at depth 24, 2.20× at depth 48**. An earlier draft of this reasoning claimed the bound "clears every shape the slicer legitimately produces"; that was overstated, and the honest version is that it clears every shape measured. Verification grounded it usefully by measuring the actual corpus artifacts — **max nesting depth 10** — which puts the real substrate at the bottom of that curve with roughly 2× headroom. The constant's comment now states the depth curve and the corpus ceiling rather than implying an unbounded guarantee.

## 📌 Known-open, deliberately not fixed here

- The gate is **corpus-aggregate only**, so a runaway confined to a few trajectories among ~451 dilutes below the limit. The write bound has always behaved this way, and a code-path runaway hits every trajectory, so aggregate gating is defensible for the runaway class — but it is not per-trajectory detection.
- `passage_without_raw_parent` checks that *a* parent exists, not that the `DERIVED_FROM` target equals the declared `parent_entity_id`. Re-parenting onto a wrong-but-real parent still passes. Cheapest remaining gap; tracked separately rather than expanded into a PR that is unblocking main.
- The per-trajectory diagnostic narrowed: an entity class outside the derived whitelist now reports 2.0 where main reported 45.0. Neither gates, and the `entity_types` histogram still surfaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)