### PR TITLE
feat(cli): materialize project memory into a deterministic .sibyl/memory/ tree

### DIFF
--- a/apps/cli/src/sibyl_cli/export.py
+++ b/apps/cli/src/sibyl_cli/export.py
@@ -1,0 +1,297 @@
+"""Materialize Sibyl memory into repo-local files.
+
+`sibyl export memory` renders the graph into `.sibyl/memory/` so a
+filesystem-native agent can grep the project's memory with no server in the
+loop. The projection itself lives in `sibyl_core.export.memory_files`; this
+module only decides what to fetch and where to put it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+
+from sibyl_cli.client import SibylClientError, get_client
+from sibyl_cli.common import (
+    NEON_CYAN,
+    console,
+    error,
+    handle_client_error,
+    info,
+    run_async,
+    success,
+)
+from sibyl_cli.config_store import resolve_project_from_cwd
+from sibyl_cli.project_refs import resolve_project_reference
+from sibyl_core.export import (
+    MANIFEST_PATH,
+    MemorySnapshot,
+    build_memory_files_bundle,
+    memory_record_from_entity,
+    validate_memory_files_bundle,
+    write_memory_files_bundle,
+)
+
+app = typer.Typer(
+    name="export",
+    help="Materialize memory into files agents can grep",
+    no_args_is_help=True,
+)
+
+DEFAULT_OUTPUT = Path(".sibyl/memory")
+DEFAULT_NOTE_TYPES = (
+    "decision",
+    "pattern",
+    "rule",
+    "guide",
+    "procedure",
+    "error_pattern",
+    "plan",
+    "preference",
+    "claim",
+    "template",
+)
+DEFAULT_TASK_STATUS = "doing,blocked"
+EXPLORE_MAX_LIMIT = 200
+
+
+async def _fetch_project(client: Any, project_id: str) -> dict[str, Any]:
+    try:
+        entity = await client.get_entity(project_id)
+    except SibylClientError as exc:
+        if exc.status_code == 404:
+            return {}
+        raise
+    return entity if isinstance(entity, dict) else {}
+
+
+async def _fetch_entities(client: Any, **filters: Any) -> list[dict[str, Any]]:
+    response = await client.explore(mode="list", **filters)
+    entities = response.get("entities") if isinstance(response, dict) else None
+    return [entity for entity in entities or [] if isinstance(entity, dict)]
+
+
+def _round_robin(pools: list[list[dict[str, Any]]], budget: int) -> list[dict[str, Any]]:
+    """Interleave per-type pools so every type reaches the projection.
+
+    A single multi-type query spends the whole budget on whichever type the
+    backend happens to order first, which is how a 40-item export ends up as 40
+    decisions and nothing else.
+    """
+    selected: list[dict[str, Any]] = []
+    depth = 0
+    while len(selected) < budget and any(len(pool) > depth for pool in pools):
+        for pool in pools:
+            if len(selected) >= budget:
+                break
+            if depth < len(pool):
+                selected.append(pool[depth])
+        depth += 1
+    return selected
+
+
+async def _hydrate(client: Any, entities: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Refetch each entity so the files carry its full body.
+
+    List responses truncate the body at 500 characters; the whole point of the
+    projection is that an agent never has to come back to the server for the
+    rest, so an export without this ships previews pretending to be memories.
+    """
+    hydrated: list[dict[str, Any]] = []
+    for entity in entities:
+        entity_id = str(entity.get("id") or "")
+        if not entity_id:
+            hydrated.append(entity)
+            continue
+        try:
+            full = await client.get_entity(entity_id)
+        except SibylClientError:
+            hydrated.append(entity)
+            continue
+        hydrated.append({**entity, **full} if isinstance(full, dict) else entity)
+    return hydrated
+
+
+async def _fetch_notes(
+    client: Any,
+    *,
+    project_id: str,
+    note_types: tuple[str, ...],
+    note_limit: int,
+    hydrate: bool,
+) -> list[dict[str, Any]]:
+    if not note_limit or not note_types:
+        return []
+    pools = [
+        await _fetch_entities(
+            client,
+            types=[entity_type],
+            project=project_id,
+            limit=min(note_limit, EXPLORE_MAX_LIMIT),
+        )
+        for entity_type in note_types
+    ]
+    selected = _round_robin(pools, note_limit)
+    return await _hydrate(client, selected) if hydrate else selected
+
+
+async def _build_snapshot(
+    *,
+    project_id: str,
+    note_types: tuple[str, ...],
+    note_limit: int,
+    task_limit: int,
+    task_status: str,
+    hydrate: bool,
+) -> MemorySnapshot:
+    async with get_client() as client:
+        project = await _fetch_project(client, project_id)
+        notes = await _fetch_notes(
+            client,
+            project_id=project_id,
+            note_types=note_types,
+            note_limit=note_limit,
+            hydrate=hydrate,
+        )
+        tasks: list[dict[str, Any]] = []
+        if task_limit:
+            tasks = await _fetch_entities(
+                client,
+                types=["task"],
+                project=project_id,
+                status=task_status,
+                limit=min(task_limit, EXPLORE_MAX_LIMIT),
+            )
+            if hydrate:
+                tasks = await _hydrate(client, tasks)
+
+    return MemorySnapshot(
+        project_id=project_id,
+        project_name=str(project.get("name")) if project.get("name") else None,
+        project_description=str(project.get("description")) if project.get("description") else None,
+        notes=tuple(memory_record_from_entity(entity) for entity in notes),
+        tasks=tuple(memory_record_from_entity(entity) for entity in tasks),
+    )
+
+
+@app.command("memory")
+def export_memory(
+    project: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Project id or name (defaults to the linked project)"),
+    ] = None,
+    output: Annotated[
+        Path,
+        typer.Option("--output", "-o", help="Directory to materialize into"),
+    ] = DEFAULT_OUTPUT,
+    note_limit: Annotated[
+        int,
+        typer.Option("--notes", min=0, max=EXPLORE_MAX_LIMIT, help="Maximum memories to include"),
+    ] = 60,
+    task_limit: Annotated[
+        int,
+        typer.Option("--tasks", min=0, max=EXPLORE_MAX_LIMIT, help="Maximum open tasks to include"),
+    ] = 25,
+    task_status: Annotated[
+        str,
+        typer.Option("--task-status", help="Comma-separated task statuses to materialize"),
+    ] = DEFAULT_TASK_STATUS,
+    types: Annotated[
+        list[str] | None,
+        typer.Option("--type", "-T", help="Memory entity type to include (repeatable)"),
+    ] = None,
+    hydrate: Annotated[
+        bool,
+        typer.Option(
+            "--hydrate/--no-hydrate",
+            help="Refetch each entity for its full body instead of the 500-character preview",
+        ),
+    ] = True,
+    writable: Annotated[
+        bool,
+        typer.Option("--writable", help="Leave files writable instead of read-only"),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", "-j", help="Print the export receipt as JSON"),
+    ] = False,
+) -> None:
+    """Materialize a project's memory into greppable files.
+
+    Deterministic by construction: re-running against an unchanged graph
+    rewrites byte-identical files, so the directory is safe to commit.
+    """
+    note_types = tuple(dict.fromkeys(types)) if types else DEFAULT_NOTE_TYPES
+
+    @run_async
+    async def run_export() -> None:
+        try:
+            project_id = await _resolve_project(project)
+            snapshot = await _build_snapshot(
+                project_id=project_id,
+                note_types=note_types,
+                note_limit=note_limit,
+                task_limit=task_limit,
+                task_status=task_status,
+                hydrate=hydrate,
+            )
+        except SibylClientError as exc:
+            handle_client_error(exc)
+            return
+        except ValueError as exc:
+            error(str(exc))
+            raise typer.Exit(code=1) from exc
+
+        bundle = build_memory_files_bundle(snapshot)
+        write_memory_files_bundle(bundle, output, read_only=not writable)
+
+        if validation_errors := validate_memory_files_bundle(output):
+            error("Memory export validation failed")
+            for validation_error in validation_errors:
+                error(f"- {validation_error}")
+            raise typer.Exit(code=1)
+
+        receipt = {
+            "project_id": project_id,
+            "project_name": snapshot.project_name,
+            "output": str(output),
+            "notes": len(snapshot.notes),
+            "tasks": len(snapshot.tasks),
+            "handbook": snapshot.handbook is not None,
+            "files": len(bundle.files),
+            "content_digest": bundle.content_digest,
+            "read_only": not writable,
+            "hydrated": hydrate,
+        }
+        if json_output:
+            console.print_json(json.dumps(receipt))
+            return
+
+        success(f"Materialized memory to {output}")
+        info(
+            f"{len(bundle.files)} files - {len(snapshot.notes)} memories, "
+            f"{len(snapshot.tasks)} open tasks"
+        )
+        console.print(f"[{NEON_CYAN}]digest[/] {bundle.content_digest[:16]}")
+        console.print(f"[{NEON_CYAN}]grep[/]   rg 'your term' {output}")
+        console.print(f"[{NEON_CYAN}]verify[/] cat {output / MANIFEST_PATH}")
+
+    run_export()
+
+
+async def _resolve_project(reference: str | None) -> str:
+    if reference:
+        async with get_client() as client:
+            return await resolve_project_reference(client, reference)
+
+    linked = resolve_project_from_cwd()
+    if not linked:
+        msg = "No project linked to this directory. Pass --project or run: sibyl project link"
+        raise ValueError(msg)
+    return linked
+
+
+__all__ = ["app", "export_memory"]

--- a/apps/cli/src/sibyl_cli/export.py
+++ b/apps/cli/src/sibyl_cli/export.py
@@ -214,6 +214,10 @@ def export_memory(
         bool,
         typer.Option("--writable", help="Leave files writable instead of read-only"),
     ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Write into a populated directory that is not an export"),
+    ] = False,
     json_output: Annotated[
         bool,
         typer.Option("--json", "-j", help="Print the export receipt as JSON"),
@@ -246,7 +250,11 @@ def export_memory(
             raise typer.Exit(code=1) from exc
 
         bundle = build_memory_files_bundle(snapshot)
-        write_memory_files_bundle(bundle, output, read_only=not writable)
+        try:
+            write_memory_files_bundle(bundle, output, read_only=not writable, force=force)
+        except OSError as exc:
+            error(str(exc))
+            raise typer.Exit(code=1) from exc
 
         if validation_errors := validate_memory_files_bundle(output):
             error("Memory export validation failed")

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -53,6 +53,7 @@ from sibyl_cli.entity import app as entity_app
 from sibyl_cli.entity import print_entity_details
 from sibyl_cli.epic import app as epic_app
 from sibyl_cli.explore import app as explore_app
+from sibyl_cli.export import app as export_app
 from sibyl_cli.host import serve as serve_cmd
 from sibyl_cli.host import service_app
 from sibyl_cli.host import start as start_cmd
@@ -124,6 +125,7 @@ app.add_typer(archive_app, name="archive")
 app.add_typer(session_app, name="session")
 app.add_typer(entity_app, name="entity")
 app.add_typer(explore_app, name="explore")
+app.add_typer(export_app, name="export")
 app.add_typer(crawl_app, name="crawl")
 app.add_typer(docs_app, name="docs")
 app.add_typer(debug_app, name="debug")

--- a/apps/cli/tests/test_export_memory.py
+++ b/apps/cli/tests/test_export_memory.py
@@ -172,6 +172,26 @@ def test_export_memory_json_receipt_carries_the_content_digest(tmp_path: Path) -
     assert manifest["content_digest"] == receipt["content_digest"]
 
 
+def test_export_memory_refuses_to_clobber_a_populated_directory(tmp_path: Path) -> None:
+    output = tmp_path / "repo"
+    output.mkdir()
+    readme = output / "README.md"
+    readme.write_text("# Their project\n", encoding="utf-8")
+
+    with patch("sibyl_cli.export.get_client", return_value=_FakeClientContext(_client())):
+        refused = runner.invoke(
+            app,
+            ["export", "memory", "--project", "project_demo", "--output", str(output)],
+        )
+
+    assert refused.exit_code == 1
+    assert "Refusing to overwrite" in refused.stdout
+    assert readme.read_text(encoding="utf-8") == "# Their project\n"
+
+    exit_code, stdout, _ = _run(tmp_path, "--force")
+    assert exit_code == 0, stdout
+
+
 def test_export_memory_requires_a_project(tmp_path: Path) -> None:
     with (
         patch("sibyl_cli.export.get_client", return_value=_FakeClientContext(_client())),

--- a/apps/cli/tests/test_export_memory.py
+++ b/apps/cli/tests/test_export_memory.py
@@ -1,0 +1,260 @@
+"""Tests for `sibyl export memory`, the `.sibyl/memory/` materializer."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from sibyl_cli.main import app
+
+runner = CliRunner()
+
+
+class _FakeClientContext:
+    def __init__(self, client: MagicMock) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> MagicMock:
+        return self._client
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+
+def _entity(entity_id: str, entity_type: str, name: str, **metadata: object) -> dict[str, object]:
+    return {
+        "id": entity_id,
+        "type": entity_type,
+        "name": name,
+        "description": "truncated preview",
+        "metadata": {
+            "description": f"Full body for {name}.",
+            "updated_at": "2026-07-21T12:00:00Z",
+            "project_id": "project_demo",
+            "retrieval_count": 41,
+            "last_recalled_at": "2026-07-25T23:59:59Z",
+            "record_id": "entity:zk3jbstxj8mzl193fmqg",
+            **metadata,
+        },
+    }
+
+
+PROJECT = {"id": "project_demo", "name": "Demo Project", "description": "A demo."}
+
+
+def _client() -> MagicMock:
+    client = MagicMock()
+    pools: dict[str, list[dict[str, object]]] = {
+        "task": [_entity("task_one", "task", "Materialize memory", status="doing")],
+        "decision": [_entity("decision_two", "decision", "Ship files-first memory")],
+        "pattern": [_entity("pattern_one", "pattern", "Pool connections per org")],
+    }
+    by_id = {
+        str(entity["id"]): entity for entities in pools.values() for entity in entities
+    }
+
+    async def explore(**kwargs: object) -> dict[str, object]:
+        requested = kwargs.get("types")
+        entity_type = requested[0] if isinstance(requested, list) and requested else ""
+        return {"entities": list(pools.get(str(entity_type), []))}
+
+    async def get_entity(entity_id: str) -> dict[str, object]:
+        if entity_id == "project_demo":
+            return dict(PROJECT)
+        listed = by_id[entity_id]
+        return {**listed, "content": f"Hydrated body for {listed['name']}."}
+
+    client.explore = AsyncMock(side_effect=explore)
+    client.get_entity = AsyncMock(side_effect=get_entity)
+    return client
+
+
+def _written_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _run(tmp_path: Path, *extra: str) -> tuple[int, str, Path]:
+    output = tmp_path / ".sibyl" / "memory"
+    with patch(
+        "sibyl_cli.export.get_client", return_value=_FakeClientContext(_client())
+    ):
+        result = runner.invoke(
+            app,
+            ["export", "memory", "--project", "project_demo", "--output", str(output), *extra],
+        )
+    return result.exit_code, result.stdout, output
+
+
+def test_export_memory_materializes_the_documented_layout(tmp_path: Path) -> None:
+    exit_code, stdout, output = _run(tmp_path)
+
+    assert exit_code == 0, stdout
+    assert (output / "README.md").is_file()
+    assert (output / "index.md").is_file()
+    assert (output / "recent.md").is_file()
+    assert (output / "tasks.md").is_file()
+    assert (output / "manifest.json").is_file()
+    assert not (output / "handbook.md").exists()
+    assert sorted(path.name for path in (output / "notes").iterdir()) == [
+        "decision-ship-files-first-memory.md",
+        "pattern-pool-connections-per-org.md",
+    ]
+
+
+def test_export_memory_is_byte_identical_across_runs(tmp_path: Path) -> None:
+    first_code, _, output = _run(tmp_path)
+    first = _written_bytes(output)
+    second_code, _, _ = _run(tmp_path)
+    second = _written_bytes(output)
+
+    assert (first_code, second_code) == (0, 0)
+    assert first == second
+
+
+def test_export_memory_writes_read_only_files_by_default(tmp_path: Path) -> None:
+    _, _, output = _run(tmp_path)
+
+    assert stat.S_IMODE((output / "index.md").stat().st_mode) == 0o444
+
+    _run(tmp_path, "--writable")
+    assert stat.S_IMODE((output / "index.md").stat().st_mode) == 0o644
+
+
+def test_export_memory_keeps_volatile_usage_counters_out_of_the_files(tmp_path: Path) -> None:
+    _, _, output = _run(tmp_path)
+
+    for path in sorted(output.rglob("*")):
+        if not path.is_file():
+            continue
+        content = path.read_text(encoding="utf-8")
+        assert "retrieval_count" not in content, path
+        assert "last_recalled_at" not in content, path
+        assert "entity:zk3jbstxj8mzl193fmqg" not in content, path
+
+
+def test_export_memory_content_is_greppable_without_the_server(tmp_path: Path) -> None:
+    _, _, output = _run(tmp_path)
+
+    index = (output / "index.md").read_text(encoding="utf-8")
+    assert "`pattern_one`" in index
+    assert "`decision_two`" in index
+
+    note = (output / "notes" / "pattern-pool-connections-per-org.md").read_text(encoding="utf-8")
+    assert 'sibyl_id: "pattern_one"' in note
+    assert "Hydrated body for Pool connections per org." in note
+
+    tasks = (output / "tasks.md").read_text(encoding="utf-8")
+    assert "[doing] Materialize memory" in tasks
+    assert "`task_one`" in tasks
+
+
+def test_export_memory_json_receipt_carries_the_content_digest(tmp_path: Path) -> None:
+    exit_code, stdout, output = _run(tmp_path, "--json")
+
+    assert exit_code == 0, stdout
+    receipt = json.loads(stdout)
+    assert receipt["project_id"] == "project_demo"
+    assert receipt["project_name"] == "Demo Project"
+    assert receipt["notes"] == 2
+    assert receipt["tasks"] == 1
+    assert receipt["handbook"] is False
+    assert receipt["read_only"] is True
+
+    manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["content_digest"] == receipt["content_digest"]
+
+
+def test_export_memory_requires_a_project(tmp_path: Path) -> None:
+    with (
+        patch("sibyl_cli.export.get_client", return_value=_FakeClientContext(_client())),
+        patch("sibyl_cli.export.resolve_project_from_cwd", return_value=None),
+    ):
+        result = runner.invoke(
+            app,
+            ["export", "memory", "--output", str(tmp_path / "memory")],
+        )
+
+    assert result.exit_code == 1
+    assert "sibyl project link" in result.stdout
+
+
+def test_export_memory_falls_back_to_the_linked_project(tmp_path: Path) -> None:
+    output = tmp_path / "memory"
+    with (
+        patch("sibyl_cli.export.get_client", return_value=_FakeClientContext(_client())),
+        patch("sibyl_cli.export.resolve_project_from_cwd", return_value="project_demo"),
+    ):
+        result = runner.invoke(app, ["export", "memory", "--output", str(output), "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["project_id"] == "project_demo"
+
+
+def test_export_memory_can_skip_tasks(tmp_path: Path) -> None:
+    exit_code, stdout, output = _run(tmp_path, "--tasks", "0", "--json")
+
+    assert exit_code == 0, stdout
+    assert json.loads(stdout)["tasks"] == 0
+    assert "No open tasks" in (output / "tasks.md").read_text(encoding="utf-8")
+
+
+def test_export_memory_hydrates_full_bodies_unless_asked_not_to(tmp_path: Path) -> None:
+    note = "notes/pattern-pool-connections-per-org.md"
+
+    _, _, hydrated = _run(tmp_path / "hydrated")
+    assert "Hydrated body for" in (hydrated / note).read_text(encoding="utf-8")
+
+    _, _, preview = _run(tmp_path / "preview", "--no-hydrate")
+    content = (preview / note).read_text(encoding="utf-8")
+    assert "Hydrated body for" not in content
+    assert "Full body for Pool connections per org." in content
+
+
+def test_export_memory_spends_the_note_budget_across_every_type(tmp_path: Path) -> None:
+    """One shared query lets the first-ordered type eat the whole budget."""
+    client = _client()
+    client.explore = AsyncMock(
+        side_effect=lambda **kwargs: {
+            "entities": [
+                _entity(f"decision_{index}", "decision", f"Decision {index}")
+                for index in range(10)
+            ]
+            if kwargs.get("types") == ["decision"]
+            else [_entity("pattern_one", "pattern", "Pool connections per org")]
+            if kwargs.get("types") == ["pattern"]
+            else []
+        }
+    )
+
+    output = tmp_path / "memory"
+    with patch("sibyl_cli.export.get_client", return_value=_FakeClientContext(client)):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                "memory",
+                "--project",
+                "project_demo",
+                "--output",
+                str(output),
+                "--notes",
+                "4",
+                "--tasks",
+                "0",
+                "--no-hydrate",
+                "--json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["notes"] == 4
+    types = sorted(path.name.split("-", 1)[0] for path in (output / "notes").iterdir())
+    assert types == ["decision", "decision", "decision", "pattern"]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -156,6 +156,7 @@ export default defineConfig({
                         { text: 'show', link: '/cli/show' },
                         { text: 'brief', link: '/cli/brief' },
                         { text: 'session', link: '/cli/session' },
+                        { text: 'export', link: '/cli/export' },
                         { text: 'archive', link: '/cli/archive' },
                     ],
                 },

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -14,15 +14,15 @@ sibyl export memory --project sibyl
 sibyl export memory --output docs/memory --notes 100
 ```
 
-With no `--project`, the command uses the project linked to the current directory
-(see [`sibyl project link`](./project.md)).
+With no `--project`, the command uses the project linked to the current directory (see
+[`sibyl project link`](./project.md)).
 
 ## Why Files
 
 Every major coding agent in 2026 reads Markdown from the repository it is working in. A repo-local
 `.sibyl/memory/` is legible to all of them with zero integration work, costs nothing per read, and
-keeps working when the server does not. Recording usage still goes over the API
-(`sibyl cite <id>`), so the citation signal stays honest.
+keeps working when the server does not. Recording usage still goes over the API (`sibyl cite <id>`),
+so the citation signal stays honest.
 
 ## Layout
 
@@ -47,9 +47,9 @@ project and is simply absent otherwise, so nothing downstream has to special-cas
 
 ## File Format
 
-Every Markdown file opens with YAML frontmatter carrying a `type`, which makes the projection
-OKF v0.1-compatible: Markdown with YAML frontmatter in a git-shippable directory. Sibyl-specific
-keys are namespaced under `sibyl_`.
+Every Markdown file opens with YAML frontmatter carrying a `type`, which makes the projection OKF
+v0.1-compatible: Markdown with YAML frontmatter in a git-shippable directory. Sibyl-specific keys
+are namespaced under `sibyl_`.
 
 ```markdown
 ---
@@ -77,8 +77,8 @@ sibyl_project_id: "project_05eb5c8c782a"
 ```
 
 This differs from `sibyld export okf`, which embeds a lossless JSON payload in frontmatter so an
-archive can round-trip back into a graph. That format is for backup and portability. This one is
-for reading, so it carries only the fields a reader needs.
+archive can round-trip back into a graph. That format is for backup and portability. This one is for
+reading, so it carries only the fields a reader needs.
 
 ## Determinism
 
@@ -90,7 +90,7 @@ Three rules make that hold:
 - **No wall-clock values.** Nothing samples `datetime.now()`. Timestamps in the output come from the
   data. `manifest.json` carries a content digest instead of an export time.
 - **Whitelisted fields.** Retrieval counters, last-recalled stamps, embedding metadata, and internal
-  record handles all change when memory is merely *read*. None of them reach the files.
+  record handles all change when memory is merely _read_. None of them reach the files.
 - **Total ordering.** Records sort by id for file placement and by recency (id as tiebreak) for
   reading order, so the order the server returned them in cannot leak into the bytes.
 
@@ -103,25 +103,25 @@ jq -r .content_digest .sibyl/memory/manifest.json
 
 ## Options
 
-| Option           | Short | Default          | Description                                            |
-| ---------------- | ----- | ---------------- | ------------------------------------------------------ |
-| `--project`      | `-p`  | linked project   | Project id or name to materialize                      |
-| `--output`       | `-o`  | `.sibyl/memory`  | Directory to write into                                |
-| `--notes`        | -     | `60`             | Maximum memories to include                            |
-| `--tasks`        | -     | `25`             | Maximum open tasks to include                          |
-| `--task-status`  | -     | `doing,blocked`  | Comma-separated task statuses to materialize           |
-| `--type`         | `-T`  | ten memory types | Memory entity type to include (repeatable)             |
-| `--hydrate`      | -     | true             | Refetch each entity for its full body                  |
-| `--writable`     | -     | false            | Leave files writable instead of read-only              |
-| `--force`        | -     | false            | Write into a populated directory that is not an export |
-| `--json`         | `-j`  | false            | Print the export receipt as JSON                       |
+| Option          | Short | Default          | Description                                            |
+| --------------- | ----- | ---------------- | ------------------------------------------------------ |
+| `--project`     | `-p`  | linked project   | Project id or name to materialize                      |
+| `--output`      | `-o`  | `.sibyl/memory`  | Directory to write into                                |
+| `--notes`       | -     | `60`             | Maximum memories to include                            |
+| `--tasks`       | -     | `25`             | Maximum open tasks to include                          |
+| `--task-status` | -     | `doing,blocked`  | Comma-separated task statuses to materialize           |
+| `--type`        | `-T`  | ten memory types | Memory entity type to include (repeatable)             |
+| `--hydrate`     | -     | true             | Refetch each entity for its full body                  |
+| `--writable`    | -     | false            | Leave files writable instead of read-only              |
+| `--force`       | -     | false            | Write into a populated directory that is not an export |
+| `--json`        | `-j`  | false            | Print the export receipt as JSON                       |
 
 The note budget is spread across the requested types in round-robin rather than spent on whichever
 type the backend happens to order first, so a 40-item export covers decisions, patterns, procedures,
 claims, and the rest instead of forty decisions.
 
-`--hydrate` costs one extra request per memory. Turning it off is faster and yields
-500-character previews, which defeats the point for anything but a smoke test.
+`--hydrate` costs one extra request per memory. Turning it off is faster and yields 500-character
+previews, which defeats the point for anything but a smoke test.
 
 ## Reading the Result
 

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -113,6 +113,7 @@ jq -r .content_digest .sibyl/memory/manifest.json
 | `--type`         | `-T`  | ten memory types | Memory entity type to include (repeatable)             |
 | `--hydrate`      | -     | true             | Refetch each entity for its full body                  |
 | `--writable`     | -     | false            | Leave files writable instead of read-only              |
+| `--force`        | -     | false            | Write into a populated directory that is not an export |
 | `--json`         | `-j`  | false            | Print the export receipt as JSON                       |
 
 The note budget is spread across the requested types in round-robin rather than spent on whichever
@@ -136,7 +137,13 @@ cat .sibyl/memory/tasks.md
 ```
 
 Files are written read-only. Edit the graph, not the directory: the next export overwrites
-everything Sibyl manages. Files you add yourself are left alone.
+everything Sibyl manages.
+
+`manifest.json` is the only authority on what Sibyl owns, which makes the write path safe in two
+ways. A file this exporter never wrote is never deleted, wherever it sits, so your own notes under
+`notes/` survive a re-export. And a populated directory holding no `manifest.json` is refused rather
+than overwritten, so `--output .` in a repo root cannot eat that repo's `README.md`. Pass `--force`
+when you genuinely mean to write into one.
 
 ## Related Commands
 

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -1,0 +1,145 @@
+# Export Memory to Files
+
+Materialize a project's memory into `.sibyl/memory/`, a directory of Markdown files that any
+filesystem-native agent can read and grep without talking to a Sibyl server.
+
+The graph stays the source of truth. This is a curated projection of it: structured substrate,
+flat-file surface.
+
+## Usage
+
+```bash
+sibyl export memory
+sibyl export memory --project sibyl
+sibyl export memory --output docs/memory --notes 100
+```
+
+With no `--project`, the command uses the project linked to the current directory
+(see [`sibyl project link`](./project.md)).
+
+## Why Files
+
+Every major coding agent in 2026 reads Markdown from the repository it is working in. A repo-local
+`.sibyl/memory/` is legible to all of them with zero integration work, costs nothing per read, and
+keeps working when the server does not. Recording usage still goes over the API
+(`sibyl cite <id>`), so the citation signal stays honest.
+
+## Layout
+
+```
+.sibyl/memory/
+├── README.md         # what this is, how to read it, how to cite it
+├── index.md          # every materialized memory, grouped by type, with ids and paths
+├── handbook.md       # distilled project handbook (written only when one exists)
+├── recent.md         # recency-ordered digest with previews
+├── tasks.md          # open work with task ids
+├── notes/            # one file per memory, full text
+│   └── <type>-<title-slug>.md
+└── manifest.json     # per-file SHA-256 plus a digest over the whole projection
+```
+
+Three tiers, deliberately: `README.md` and `handbook.md` orient, `index.md` / `recent.md` /
+`tasks.md` are the greppable middle, and `notes/` holds the detail an agent opens once grep points
+at it.
+
+`handbook.md` is a reserved slot. It appears when a distilled handbook has been built for the
+project and is simply absent otherwise, so nothing downstream has to special-case a placeholder.
+
+## File Format
+
+Every Markdown file opens with YAML frontmatter carrying a `type`, which makes the projection
+OKF v0.1-compatible: Markdown with YAML frontmatter in a git-shippable directory. Sibyl-specific
+keys are namespaced under `sibyl_`.
+
+```markdown
+---
+type: "Sibyl Pattern"
+title: "Pool Surreal connections per org"
+description: "Each org gets a dedicated connection-pooled client scoped to its namespace…"
+timestamp: "2026-07-22T09:30:00Z"
+okf_version: "0.1"
+sibyl_schema_version: "sibyl-memory-files-v1"
+sibyl_kind: "memory_note"
+sibyl_id: "pattern_a1b2c3d4"
+sibyl_entity_type: "pattern"
+sibyl_project_id: "project_05eb5c8c782a"
+---
+
+# Pool Surreal connections per org
+
+...full memory body...
+
+## Provenance
+
+- Sibyl id: `pattern_a1b2c3d4`
+- Entity type: `pattern`
+- Cite with: `sibyl cite pattern_a1b2c3d4`
+```
+
+This differs from `sibyld export okf`, which embeds a lossless JSON payload in frontmatter so an
+archive can round-trip back into a graph. That format is for backup and portability. This one is
+for reading, so it carries only the fields a reader needs.
+
+## Determinism
+
+Re-running against an unchanged graph rewrites **byte-identical files**. The directory is meant to
+live in git, and a projection that churned on every run would bury real changes in noise.
+
+Three rules make that hold:
+
+- **No wall-clock values.** Nothing samples `datetime.now()`. Timestamps in the output come from the
+  data. `manifest.json` carries a content digest instead of an export time.
+- **Whitelisted fields.** Retrieval counters, last-recalled stamps, embedding metadata, and internal
+  record handles all change when memory is merely *read*. None of them reach the files.
+- **Total ordering.** Records sort by id for file placement and by recency (id as tiebreak) for
+  reading order, so the order the server returned them in cannot leak into the bytes.
+
+Verify a materialized directory at any time:
+
+```bash
+sibyl export memory --output /tmp/check --json | jq -r .content_digest
+jq -r .content_digest .sibyl/memory/manifest.json
+```
+
+## Options
+
+| Option           | Short | Default          | Description                                            |
+| ---------------- | ----- | ---------------- | ------------------------------------------------------ |
+| `--project`      | `-p`  | linked project   | Project id or name to materialize                      |
+| `--output`       | `-o`  | `.sibyl/memory`  | Directory to write into                                |
+| `--notes`        | -     | `60`             | Maximum memories to include                            |
+| `--tasks`        | -     | `25`             | Maximum open tasks to include                          |
+| `--task-status`  | -     | `doing,blocked`  | Comma-separated task statuses to materialize           |
+| `--type`         | `-T`  | ten memory types | Memory entity type to include (repeatable)             |
+| `--hydrate`      | -     | true             | Refetch each entity for its full body                  |
+| `--writable`     | -     | false            | Leave files writable instead of read-only              |
+| `--json`         | `-j`  | false            | Print the export receipt as JSON                       |
+
+The note budget is spread across the requested types in round-robin rather than spent on whichever
+type the backend happens to order first, so a 40-item export covers decisions, patterns, procedures,
+claims, and the rest instead of forty decisions.
+
+`--hydrate` costs one extra request per memory. Turning it off is faster and yields
+500-character previews, which defeats the point for anything but a smoke test.
+
+## Reading the Result
+
+```bash
+# what does this project know about connection pooling?
+rg -i 'connection pool' .sibyl/memory/notes
+
+# every decision, by file
+rg -l 'type: "Sibyl Decision"' .sibyl/memory/notes
+
+# what is open right now?
+cat .sibyl/memory/tasks.md
+```
+
+Files are written read-only. Edit the graph, not the directory: the next export overwrites
+everything Sibyl manages. Files you add yourself are left alone.
+
+## Related Commands
+
+- [`sibyl context`](./context.md) - Live, goal-scoped context pack from the server
+- [`sibyl session`](./session.md) - Wake-up bundle for the current session
+- [`sibyl project`](./project.md) - Link a directory to a project

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -61,6 +61,7 @@ Capture knowledge and recall it back into agent context.
 | [`sibyl explore`](./explore.md)        | Graph traversal and exploration                     |
 | [`sibyl archive`](./archive.md)        | Browse raw quick captures                           |
 | [`sibyl session`](./session.md)        | Package a wake-up context bundle                    |
+| [`sibyl export`](./export.md)          | Materialize memory into `.sibyl/memory/` files      |
 | [`sibyl config context`](./context.md) | Manage named server, org, and project contexts      |
 
 ### Work tracking

--- a/packages/python/sibyl-core/src/sibyl_core/export/__init__.py
+++ b/packages/python/sibyl-core/src/sibyl_core/export/__init__.py
@@ -1,5 +1,23 @@
 """Portable export projections."""
 
+from sibyl_core.export.memory_files import (
+    HANDBOOK_PATH,
+    INDEX_PATH,
+    MANIFEST_PATH,
+    MEMORY_FILES_OKF_VERSION,
+    MEMORY_FILES_SCHEMA_VERSION,
+    NOTES_DIR,
+    README_PATH,
+    RECENT_PATH,
+    TASKS_PATH,
+    MemoryFilesBundle,
+    MemoryRecord,
+    MemorySnapshot,
+    build_memory_files_bundle,
+    memory_record_from_entity,
+    validate_memory_files_bundle,
+    write_memory_files_bundle,
+)
 from sibyl_core.export.okf import (
     OKF_VERSION,
     OkfBundle,
@@ -11,11 +29,27 @@ from sibyl_core.export.okf import (
 )
 
 __all__ = [
+    "HANDBOOK_PATH",
+    "INDEX_PATH",
+    "MANIFEST_PATH",
+    "MEMORY_FILES_OKF_VERSION",
+    "MEMORY_FILES_SCHEMA_VERSION",
+    "NOTES_DIR",
     "OKF_VERSION",
+    "README_PATH",
+    "RECENT_PATH",
+    "TASKS_PATH",
+    "MemoryFilesBundle",
+    "MemoryRecord",
+    "MemorySnapshot",
     "OkfBundle",
+    "build_memory_files_bundle",
     "build_okf_bundle_from_archive",
     "build_okf_bundle_from_graph_payload",
+    "memory_record_from_entity",
     "reconstruct_graph_payload_from_okf_bundle",
+    "validate_memory_files_bundle",
     "validate_okf_bundle",
+    "write_memory_files_bundle",
     "write_okf_bundle",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/export/_slug.py
+++ b/packages/python/sibyl-core/src/sibyl_core/export/_slug.py
@@ -1,0 +1,16 @@
+"""Filesystem-safe slugs shared by the export projections."""
+
+from __future__ import annotations
+
+import re
+
+_UNSAFE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+def safe_slug(value: str, *, fallback: str = "concept") -> str:
+    """Reduce arbitrary text to a lowercase filename-safe slug."""
+    slug = _UNSAFE.sub("-", value.strip()).strip(".-").lower()
+    return slug or fallback
+
+
+__all__ = ["safe_slug"]

--- a/packages/python/sibyl-core/src/sibyl_core/export/memory_files.py
+++ b/packages/python/sibyl-core/src/sibyl_core/export/memory_files.py
@@ -1,0 +1,660 @@
+"""Materialized memory-as-files projection for ``.sibyl/memory/``.
+
+The graph stays the governed source of truth; this module renders a curated,
+greppable slice of it into a directory an agent can read with the server down.
+
+Every function here is a pure transform over an explicit :class:`MemorySnapshot`.
+Nothing consults the clock, the network, or the package version, because the
+projection is meant to live in git: two runs over an unchanged graph must
+produce byte-identical files or every session emits a noise diff.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from sibyl_core.export._slug import safe_slug
+
+MEMORY_FILES_SCHEMA_VERSION = "sibyl-memory-files-v1"
+MEMORY_FILES_OKF_VERSION = "0.1"
+
+README_PATH = "README.md"
+INDEX_PATH = "index.md"
+RECENT_PATH = "recent.md"
+TASKS_PATH = "tasks.md"
+HANDBOOK_PATH = "handbook.md"
+MANIFEST_PATH = "manifest.json"
+NOTES_DIR = "notes"
+
+MANAGED_ROOT_FILES = (
+    README_PATH,
+    INDEX_PATH,
+    RECENT_PATH,
+    TASKS_PATH,
+    HANDBOOK_PATH,
+    MANIFEST_PATH,
+)
+MANAGED_DIRECTORIES = (NOTES_DIR,)
+
+RECENT_PREVIEW_CHARS = 320
+FRONTMATTER_TEXT_CHARS = 200
+
+# Usage counters, embedding bookkeeping, and Surreal record handles all mutate
+# when memory is merely *read*, so a whitelist rather than a blacklist is what
+# keeps a re-materialization byte-identical.
+_TASK_METADATA_FIELDS = ("status", "priority", "complexity", "feature", "epic_id")
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    """One durable memory item, stripped of volatile bookkeeping."""
+
+    id: str
+    entity_type: str
+    title: str
+    body: str = ""
+    updated_at: str | None = None
+    project_id: str | None = None
+    tags: tuple[str, ...] = ()
+    attributes: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class MemorySnapshot:
+    """Everything the projection is allowed to see."""
+
+    project_id: str
+    project_name: str | None = None
+    project_description: str | None = None
+    notes: tuple[MemoryRecord, ...] = ()
+    tasks: tuple[MemoryRecord, ...] = ()
+    handbook: str | None = None
+
+
+@dataclass(frozen=True)
+class MemoryFilesBundle:
+    """Deterministic ``.sibyl/memory/`` file tree, keyed by relative posix path."""
+
+    files: Mapping[str, str] = field(default_factory=dict)
+
+    @property
+    def content_digest(self) -> str:
+        return _digest_of_files(self.files)
+
+
+def memory_record_from_entity(payload: Mapping[str, Any]) -> MemoryRecord:
+    """Project a Sibyl entity envelope onto the whitelisted record shape."""
+    metadata = payload.get("metadata")
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+
+    record_id = _text(payload.get("id")) or _text(metadata.get("id")) or ""
+    entity_type = (
+        _text(payload.get("type")) or _text(metadata.get("entity_type")) or "entity"
+    ).lower()
+    title = (
+        _text(payload.get("name")) or _text(metadata.get("title")) or record_id or entity_type
+    ).strip()
+
+    # List responses truncate the top-level description; metadata carries the
+    # full text, so the longer of the two is the honest body.
+    candidates = [
+        _text(metadata.get("content")),
+        _text(metadata.get("description")),
+        _text(payload.get("content")),
+        _text(payload.get("description")),
+    ]
+    body = max((value for value in candidates if value), key=len, default="")
+
+    attributes = tuple(
+        (key, value)
+        for key in _TASK_METADATA_FIELDS
+        if (value := _text(metadata.get(key))) is not None
+    )
+
+    return MemoryRecord(
+        id=record_id,
+        entity_type=entity_type,
+        title=title,
+        body=body or "",
+        updated_at=_text(metadata.get("updated_at")) or _text(payload.get("updated_at")),
+        project_id=_text(metadata.get("project_id")) or _text(payload.get("project_id")),
+        tags=_string_tuple(metadata.get("tags")),
+        attributes=attributes,
+    )
+
+
+def build_memory_files_bundle(snapshot: MemorySnapshot) -> MemoryFilesBundle:
+    """Render a snapshot into the ``.sibyl/memory/`` file tree."""
+    notes = _canonical_records(snapshot.notes)
+    tasks = _canonical_records(snapshot.tasks)
+    note_paths = _note_paths(notes)
+
+    files: dict[str, str] = {
+        README_PATH: _readme_document(snapshot),
+        INDEX_PATH: _index_document(snapshot, notes, tasks, note_paths),
+        RECENT_PATH: _recent_document(snapshot, notes, note_paths),
+        TASKS_PATH: _tasks_document(snapshot, tasks),
+    }
+    if snapshot.handbook is not None:
+        files[HANDBOOK_PATH] = _handbook_document(snapshot, snapshot.handbook)
+    for record in notes:
+        files[note_paths[record.id]] = _note_document(snapshot, record)
+
+    files[MANIFEST_PATH] = _manifest_document(snapshot, files, notes=notes, tasks=tasks)
+    return MemoryFilesBundle(files={path: files[path] for path in sorted(files)})
+
+
+def write_memory_files_bundle(
+    bundle: MemoryFilesBundle,
+    root: Path,
+    *,
+    read_only: bool = True,
+) -> tuple[str, ...]:
+    """Write the bundle to ``root``, pruning stale managed files.
+
+    Returns the written paths. Only Sibyl-managed names are ever removed, so a
+    user file that happens to live alongside the projection survives.
+    """
+    if root.exists() and not root.is_dir():
+        msg = f"Memory files output path exists and is not a directory: {root}"
+        raise FileExistsError(msg)
+
+    root.mkdir(parents=True, exist_ok=True)
+    for stale in _stale_managed_paths(root, bundle.files):
+        stale.chmod(0o644)
+        stale.unlink()
+
+    for relative_path, content in bundle.files.items():
+        target = root / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            target.chmod(0o644)
+        target.write_text(content, encoding="utf-8")
+        target.chmod(0o444 if read_only else 0o644)
+
+    return tuple(bundle.files)
+
+
+def validate_memory_files_bundle(root: Path) -> list[str]:
+    """Check a materialized directory against the layout contract."""
+    errors: list[str] = []
+    manifest_path = root / MANIFEST_PATH
+    if not manifest_path.is_file():
+        return [f"missing {MANIFEST_PATH}"]
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"{MANIFEST_PATH}: not valid JSON: {exc}"]
+    if not isinstance(manifest, dict):
+        return [f"{MANIFEST_PATH}: must be an object"]
+    if manifest.get("schema_version") != MEMORY_FILES_SCHEMA_VERSION:
+        errors.append(
+            f"{MANIFEST_PATH}: unexpected schema_version {manifest.get('schema_version')}"
+        )
+
+    entries = manifest.get("files")
+    if not isinstance(entries, list) or not entries:
+        return [*errors, f"{MANIFEST_PATH}: files must be a non-empty array"]
+
+    listed: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            errors.append(f"{MANIFEST_PATH}: file entries must be objects")
+            continue
+        relative = str(entry.get("path") or "")
+        listed.add(relative)
+        target = root / relative
+        if not target.is_file():
+            errors.append(f"{relative}: listed in the manifest but missing on disk")
+            continue
+        content = target.read_text(encoding="utf-8")
+        if _digest_of_text(content) != entry.get("sha256"):
+            errors.append(f"{relative}: content does not match the manifest digest")
+
+    if INDEX_PATH not in listed:
+        errors.append(f"{MANIFEST_PATH}: missing {INDEX_PATH}")
+
+    for markdown in sorted(root.rglob("*.md")):
+        relative = markdown.relative_to(root).as_posix()
+        if relative not in listed:
+            continue
+        if not _frontmatter_type(markdown.read_text(encoding="utf-8")):
+            errors.append(f"{relative}: missing required OKF frontmatter type")
+
+    return errors
+
+
+def _stale_managed_paths(root: Path, files: Mapping[str, str]) -> list[Path]:
+    stale: list[Path] = []
+    for name in MANAGED_ROOT_FILES:
+        path = root / name
+        if path.is_file() and name not in files:
+            stale.append(path)
+    for name in MANAGED_DIRECTORIES:
+        directory = root / name
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*.md")):
+            if path.relative_to(root).as_posix() not in files:
+                stale.append(path)
+    return stale
+
+
+def _canonical_records(records: Iterable[MemoryRecord]) -> tuple[MemoryRecord, ...]:
+    return tuple(sorted(records, key=lambda record: (record.id, record.title)))
+
+
+def _note_paths(records: Sequence[MemoryRecord]) -> dict[str, str]:
+    """Assign one stable path per record.
+
+    A stem shared by several records disambiguates *every* one of them with its
+    id, so which file a record lands in depends only on the set and never on the
+    order it arrived in. Whoever sorts first does not get to keep the short name.
+    """
+    stems = {record.id: _note_stem(record) for record in records}
+    collisions = {stem for stem in stems.values() if list(stems.values()).count(stem) > 1}
+    return {
+        record_id: f"{NOTES_DIR}/{stem}-{safe_slug(record_id)}.md"
+        if stem in collisions
+        else f"{NOTES_DIR}/{stem}.md"
+        for record_id, stem in stems.items()
+    }
+
+
+def _note_stem(record: MemoryRecord) -> str:
+    return f"{safe_slug(record.entity_type, fallback='entity')}-{safe_slug(record.title)}"
+
+
+def _by_recency(records: Iterable[MemoryRecord]) -> list[MemoryRecord]:
+    """Newest first, id ascending as the tiebreak so equal timestamps never flip."""
+    by_id = sorted(records, key=lambda record: record.id)
+    return sorted(by_id, key=lambda record: record.updated_at or "", reverse=True)
+
+
+def _readme_document(snapshot: MemorySnapshot) -> str:
+    body = "\n".join(
+        [
+            "# Sibyl memory",
+            "",
+            f"Materialized memory for **{_project_label(snapshot)}**"
+            f" (`{snapshot.project_id}`), generated by `sibyl export memory`.",
+            "",
+            "Generated files. Edit the graph, not this directory: the next export",
+            "overwrites everything here. Files are written read-only as a reminder.",
+            "",
+            "## Reading order",
+            "",
+            f"1. `{HANDBOOK_PATH}` - distilled project handbook, when one has been built.",
+            f"2. `{INDEX_PATH}` - every materialized memory with its id and path.",
+            f"3. `{RECENT_PATH}` - the most recently updated memories, newest first.",
+            f"4. `{TASKS_PATH}` - open work with task ids.",
+            f"5. `{NOTES_DIR}/` - one file per memory, full text.",
+            "",
+            "## Grepping",
+            "",
+            "```sh",
+            f"rg 'surreal' .sibyl/memory/{NOTES_DIR}",
+            f"rg -l 'type: Sibyl Decision' .sibyl/memory/{NOTES_DIR}",
+            f"grep -n 'sibyl_id' .sibyl/memory/{INDEX_PATH}",
+            "```",
+            "",
+            "## Citing",
+            "",
+            "Reading a file records nothing. When a memory shapes the work, cite it",
+            "over the API so the usage signal stays honest:",
+            "",
+            "```sh",
+            "sibyl cite <sibyl_id>",
+            "```",
+            "",
+            f"`{MANIFEST_PATH}` carries a SHA-256 per file plus a `content_digest`",
+            "over the whole projection, so a hook can detect staleness without a refetch.",
+            "",
+        ]
+    )
+    return _document(
+        frontmatter=[
+            ("type", "Sibyl Memory Export"),
+            ("title", f"Sibyl memory for {_project_label(snapshot)}"),
+            ("description", "Read-only projection of Sibyl memory for this repository."),
+            ("okf_version", MEMORY_FILES_OKF_VERSION),
+            ("sibyl_schema_version", MEMORY_FILES_SCHEMA_VERSION),
+            ("sibyl_kind", "memory_export"),
+            ("sibyl_project_id", snapshot.project_id),
+        ],
+        body=body,
+    )
+
+
+def _index_document(
+    snapshot: MemorySnapshot,
+    notes: Sequence[MemoryRecord],
+    tasks: Sequence[MemoryRecord],
+    note_paths: Mapping[str, str],
+) -> str:
+    lines = [
+        f"# Memory index: {_project_label(snapshot)}",
+        "",
+        f"Project `{snapshot.project_id}` - {len(notes)} memories, {len(tasks)} open tasks.",
+        "",
+    ]
+    if snapshot.handbook is not None:
+        lines.extend([f"- Handbook: [{HANDBOOK_PATH}](./{HANDBOOK_PATH})", ""])
+    lines.extend(
+        [
+            f"- Recent: [{RECENT_PATH}](./{RECENT_PATH})",
+            f"- Tasks: [{TASKS_PATH}](./{TASKS_PATH})",
+            "",
+        ]
+    )
+
+    if not notes:
+        lines.extend(["## Memories", "", "No memories materialized for this project yet.", ""])
+        return _index_wrapper(snapshot, lines, notes, tasks)
+
+    lines.extend(["## Memories", ""])
+    for entity_type in sorted({record.entity_type for record in notes}):
+        lines.extend([f"### {_type_label(entity_type)}", ""])
+        for record in notes:
+            if record.entity_type != entity_type:
+                continue
+            lines.append(f"- [{record.title}](./{note_paths[record.id]}) - `{record.id}`")
+        lines.append("")
+    return _index_wrapper(snapshot, lines, notes, tasks)
+
+
+def _index_wrapper(
+    snapshot: MemorySnapshot,
+    lines: Sequence[str],
+    notes: Sequence[MemoryRecord],
+    tasks: Sequence[MemoryRecord],
+) -> str:
+    return _document(
+        frontmatter=[
+            ("type", "Sibyl Memory Index"),
+            ("title", f"Memory index for {_project_label(snapshot)}"),
+            ("description", "Inventory of every materialized Sibyl memory in this repository."),
+            ("okf_version", MEMORY_FILES_OKF_VERSION),
+            ("sibyl_schema_version", MEMORY_FILES_SCHEMA_VERSION),
+            ("sibyl_kind", "memory_index"),
+            ("sibyl_project_id", snapshot.project_id),
+            ("sibyl_note_count", len(notes)),
+            ("sibyl_task_count", len(tasks)),
+        ],
+        body="\n".join(lines),
+    )
+
+
+def _recent_document(
+    snapshot: MemorySnapshot,
+    notes: Sequence[MemoryRecord],
+    note_paths: Mapping[str, str],
+) -> str:
+    ordered = _by_recency(notes)
+    lines = [
+        f"# Recent memory: {_project_label(snapshot)}",
+        "",
+        "Most recently updated memories first.",
+        "",
+    ]
+    if not ordered:
+        lines.extend(["No memories materialized for this project yet.", ""])
+    for record in ordered:
+        lines.append(f"## {record.title}")
+        lines.append("")
+        lines.append(f"- id: `{record.id}`")
+        lines.append(f"- type: `{record.entity_type}`")
+        if record.updated_at:
+            lines.append(f"- updated: `{record.updated_at}`")
+        lines.append(f"- detail: [{note_paths[record.id]}](./{note_paths[record.id]})")
+        lines.append("")
+        if preview := _preview(record.body):
+            lines.extend([preview, ""])
+    return _document(
+        frontmatter=[
+            ("type", "Sibyl Memory Digest"),
+            ("title", f"Recent memory for {_project_label(snapshot)}"),
+            ("description", "Recency-ordered digest of materialized Sibyl memory."),
+            ("okf_version", MEMORY_FILES_OKF_VERSION),
+            ("sibyl_schema_version", MEMORY_FILES_SCHEMA_VERSION),
+            ("sibyl_kind", "memory_digest"),
+            ("sibyl_project_id", snapshot.project_id),
+            ("sibyl_note_count", len(ordered)),
+        ],
+        body="\n".join(lines),
+    )
+
+
+def _tasks_document(snapshot: MemorySnapshot, tasks: Sequence[MemoryRecord]) -> str:
+    ordered = _by_recency(tasks)
+    lines = [f"# Open work: {_project_label(snapshot)}", ""]
+    if not ordered:
+        lines.extend(["No open tasks materialized for this project.", ""])
+    for record in ordered:
+        attributes = dict(record.attributes)
+        status = attributes.get("status", "unknown")
+        priority = attributes.get("priority")
+        suffix = f" - priority `{priority}`" if priority else ""
+        lines.append(f"## [{status}] {record.title}")
+        lines.append("")
+        lines.append(f"- id: `{record.id}`{suffix}")
+        if record.updated_at:
+            lines.append(f"- updated: `{record.updated_at}`")
+        if record.tags:
+            lines.append(f"- tags: {', '.join(f'`{tag}`' for tag in record.tags)}")
+        lines.append("")
+        if preview := _preview(record.body):
+            lines.extend([preview, ""])
+    return _document(
+        frontmatter=[
+            ("type", "Sibyl Task Board"),
+            ("title", f"Open work for {_project_label(snapshot)}"),
+            ("description", "Materialized open Sibyl tasks with their ids."),
+            ("okf_version", MEMORY_FILES_OKF_VERSION),
+            ("sibyl_schema_version", MEMORY_FILES_SCHEMA_VERSION),
+            ("sibyl_kind", "task_board"),
+            ("sibyl_project_id", snapshot.project_id),
+            ("sibyl_task_count", len(ordered)),
+        ],
+        body="\n".join(lines),
+    )
+
+
+def _handbook_document(snapshot: MemorySnapshot, handbook: str) -> str:
+    body = handbook.strip()
+    return _document(
+        frontmatter=[
+            ("type", "Sibyl Handbook"),
+            ("title", f"Handbook for {_project_label(snapshot)}"),
+            ("description", "Distilled project handbook maintained by the Sibyl dream cycle."),
+            ("okf_version", MEMORY_FILES_OKF_VERSION),
+            ("sibyl_schema_version", MEMORY_FILES_SCHEMA_VERSION),
+            ("sibyl_kind", "handbook"),
+            ("sibyl_project_id", snapshot.project_id),
+        ],
+        body=f"{body}\n" if body else "",
+    )
+
+
+def _note_document(snapshot: MemorySnapshot, record: MemoryRecord) -> str:
+    frontmatter: list[tuple[str, Any]] = [
+        ("type", f"Sibyl {_type_label(record.entity_type)}"),
+        ("title", record.title),
+        ("description", _flatten(record.body or record.title)),
+        ("timestamp", record.updated_at),
+        ("okf_version", MEMORY_FILES_OKF_VERSION),
+        ("sibyl_schema_version", MEMORY_FILES_SCHEMA_VERSION),
+        ("sibyl_kind", "memory_note"),
+        ("sibyl_id", record.id),
+        ("sibyl_entity_type", record.entity_type),
+        ("sibyl_project_id", record.project_id or snapshot.project_id),
+    ]
+    if record.tags:
+        frontmatter.append(("sibyl_tags", list(record.tags)))
+    frontmatter.extend((f"sibyl_{key}", value) for key, value in record.attributes)
+
+    lines = [f"# {record.title}", ""]
+    if record.body:
+        lines.extend([record.body.strip(), ""])
+    lines.extend(
+        [
+            "## Provenance",
+            "",
+            f"- Sibyl id: `{record.id}`",
+            f"- Entity type: `{record.entity_type}`",
+            f"- Cite with: `sibyl cite {record.id}`",
+            "",
+        ]
+    )
+    return _document(frontmatter=frontmatter, body="\n".join(lines))
+
+
+def _manifest_document(
+    snapshot: MemorySnapshot,
+    files: Mapping[str, str],
+    *,
+    notes: Sequence[MemoryRecord],
+    tasks: Sequence[MemoryRecord],
+) -> str:
+    entries = [{"path": path, "sha256": _digest_of_text(files[path])} for path in sorted(files)]
+    manifest = {
+        "schema_version": MEMORY_FILES_SCHEMA_VERSION,
+        "okf_version": MEMORY_FILES_OKF_VERSION,
+        "project": {
+            "id": snapshot.project_id,
+            "name": snapshot.project_name,
+        },
+        "counts": {
+            "notes": len(notes),
+            "tasks": len(tasks),
+            "files": len(entries) + 1,
+        },
+        "handbook": snapshot.handbook is not None,
+        "content_digest": _digest_of_files(files),
+        "files": entries,
+    }
+    return json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+
+
+def _digest_of_text(content: str) -> str:
+    return sha256(content.encode("utf-8")).hexdigest()
+
+
+def _digest_of_files(files: Mapping[str, str]) -> str:
+    digest = sha256()
+    for path in sorted(files):
+        if path == MANIFEST_PATH:
+            continue
+        digest.update(path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(files[path].encode("utf-8"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _document(*, frontmatter: Sequence[tuple[str, Any]], body: str) -> str:
+    return f"---\n{_frontmatter_block(frontmatter)}---\n\n{body.rstrip()}\n"
+
+
+def _frontmatter_block(fields: Sequence[tuple[str, Any]]) -> str:
+    lines: list[str] = []
+    for key, value in fields:
+        if isinstance(value, list):
+            if not value:
+                lines.append(f"{key}: []")
+                continue
+            lines.append(f"{key}:")
+            lines.extend(f"  - {_yaml_scalar(item)}" for item in value)
+            continue
+        lines.append(f"{key}: {_yaml_scalar(value)}")
+    return "".join(f"{line}\n" for line in lines)
+
+
+def _yaml_scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    return _quote(str(value))
+
+
+def _quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    escaped = escaped.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    escaped = "".join(char for char in escaped if char >= " " or char == "\\")
+    return f'"{escaped}"'
+
+
+def _frontmatter_type(content: str) -> str | None:
+    if not content.startswith("---\n"):
+        return None
+    end = content.find("\n---\n", len("---\n"))
+    if end == -1:
+        return None
+    for line in content[len("---\n") : end].splitlines():
+        if line.startswith("type:"):
+            return line[len("type:") :].strip().strip('"') or None
+    return None
+
+
+def _preview(body: str) -> str:
+    flattened = _flatten(body, limit=RECENT_PREVIEW_CHARS)
+    return f"> {flattened}" if flattened else ""
+
+
+def _flatten(value: str, *, limit: int = FRONTMATTER_TEXT_CHARS) -> str:
+    collapsed = " ".join(value.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[: limit - 1].rstrip() + "\u2026"
+
+
+def _project_label(snapshot: MemorySnapshot) -> str:
+    return snapshot.project_name or snapshot.project_id
+
+
+def _type_label(entity_type: str) -> str:
+    return entity_type.replace("_", " ").title()
+
+
+def _text(value: object) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list | tuple):
+        return ()
+    return tuple(sorted({text for item in value if (text := _text(item)) is not None}))
+
+
+__all__ = [
+    "HANDBOOK_PATH",
+    "INDEX_PATH",
+    "MANAGED_DIRECTORIES",
+    "MANAGED_ROOT_FILES",
+    "MANIFEST_PATH",
+    "MEMORY_FILES_OKF_VERSION",
+    "MEMORY_FILES_SCHEMA_VERSION",
+    "NOTES_DIR",
+    "README_PATH",
+    "RECENT_PATH",
+    "TASKS_PATH",
+    "MemoryFilesBundle",
+    "MemoryRecord",
+    "MemorySnapshot",
+    "build_memory_files_bundle",
+    "memory_record_from_entity",
+    "validate_memory_files_bundle",
+    "write_memory_files_bundle",
+]

--- a/packages/python/sibyl-core/src/sibyl_core/export/memory_files.py
+++ b/packages/python/sibyl-core/src/sibyl_core/export/memory_files.py
@@ -31,17 +31,9 @@ HANDBOOK_PATH = "handbook.md"
 MANIFEST_PATH = "manifest.json"
 NOTES_DIR = "notes"
 
-MANAGED_ROOT_FILES = (
-    README_PATH,
-    INDEX_PATH,
-    RECENT_PATH,
-    TASKS_PATH,
-    HANDBOOK_PATH,
-    MANIFEST_PATH,
-)
-MANAGED_DIRECTORIES = (NOTES_DIR,)
-
 RECENT_PREVIEW_CHARS = 320
+NOTE_STEM_MAX_CHARS = 100
+NOTE_ID_SUFFIX_MAX_CHARS = 64
 FRONTMATTER_TEXT_CHARS = 200
 
 # Usage counters, embedding bookkeeping, and Surreal record handles all mutate
@@ -154,20 +146,34 @@ def write_memory_files_bundle(
     root: Path,
     *,
     read_only: bool = True,
+    force: bool = False,
 ) -> tuple[str, ...]:
-    """Write the bundle to ``root``, pruning stale managed files.
+    """Write the bundle to ``root``, pruning what a previous export wrote.
 
-    Returns the written paths. Only Sibyl-managed names are ever removed, so a
-    user file that happens to live alongside the projection survives.
+    Returns the written paths. The previous manifest is the only authority on
+    what Sibyl owns, so a file this exporter never wrote is never removed even
+    when it sits inside ``notes/``. A populated directory that is not already an
+    export is refused rather than overwritten: ``--output .`` in a repo root
+    would otherwise eat that repo's README.
     """
     if root.exists() and not root.is_dir():
         msg = f"Memory files output path exists and is not a directory: {root}"
         raise FileExistsError(msg)
 
+    previous = _previously_written(root)
+    if not force and previous is None and root.is_dir() and any(root.iterdir()):
+        msg = (
+            f"Refusing to overwrite {root}: it is not empty and holds no Sibyl "
+            f"{MANIFEST_PATH}. Pass force=True to write anyway."
+        )
+        raise FileExistsError(msg)
+
     root.mkdir(parents=True, exist_ok=True)
-    for stale in _stale_managed_paths(root, bundle.files):
-        stale.chmod(0o644)
-        stale.unlink()
+    for relative in sorted((previous or set()) - set(bundle.files)):
+        stale = root / relative
+        if stale.is_file():
+            stale.chmod(0o644)
+            stale.unlink()
 
     for relative_path, content in bundle.files.items():
         target = root / relative_path
@@ -178,6 +184,27 @@ def write_memory_files_bundle(
         target.chmod(0o444 if read_only else 0o644)
 
     return tuple(bundle.files)
+
+
+def _previously_written(root: Path) -> set[str] | None:
+    """Paths a previous export of this layout wrote, or None if there was none."""
+    manifest_path = root / MANIFEST_PATH
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != (
+        MEMORY_FILES_SCHEMA_VERSION
+    ):
+        return None
+    entries = manifest.get("files")
+    written = {MANIFEST_PATH}
+    for entry in entries if isinstance(entries, list) else []:
+        if isinstance(entry, dict) and (path := entry.get("path")):
+            written.add(str(path))
+    return written
 
 
 def validate_memory_files_bundle(root: Path) -> list[str]:
@@ -230,22 +257,6 @@ def validate_memory_files_bundle(root: Path) -> list[str]:
     return errors
 
 
-def _stale_managed_paths(root: Path, files: Mapping[str, str]) -> list[Path]:
-    stale: list[Path] = []
-    for name in MANAGED_ROOT_FILES:
-        path = root / name
-        if path.is_file() and name not in files:
-            stale.append(path)
-    for name in MANAGED_DIRECTORIES:
-        directory = root / name
-        if not directory.is_dir():
-            continue
-        for path in sorted(directory.rglob("*.md")):
-            if path.relative_to(root).as_posix() not in files:
-                stale.append(path)
-    return stale
-
-
 def _canonical_records(records: Iterable[MemoryRecord]) -> tuple[MemoryRecord, ...]:
     return tuple(sorted(records, key=lambda record: (record.id, record.title)))
 
@@ -260,15 +271,25 @@ def _note_paths(records: Sequence[MemoryRecord]) -> dict[str, str]:
     stems = {record.id: _note_stem(record) for record in records}
     collisions = {stem for stem in stems.values() if list(stems.values()).count(stem) > 1}
     return {
-        record_id: f"{NOTES_DIR}/{stem}-{safe_slug(record_id)}.md"
+        record_id: f"{NOTES_DIR}/{stem}-{_id_suffix(record_id)}.md"
         if stem in collisions
         else f"{NOTES_DIR}/{stem}.md"
         for record_id, stem in stems.items()
     }
 
 
+def _id_suffix(record_id: str) -> str:
+    return safe_slug(record_id)[:NOTE_ID_SUFFIX_MAX_CHARS]
+
+
 def _note_stem(record: MemoryRecord) -> str:
-    return f"{safe_slug(record.entity_type, fallback='entity')}-{safe_slug(record.title)}"
+    """Build the filename stem, capped so a long title cannot exceed NAME_MAX.
+
+    Memory titles are prose and run long; the id suffix and `.md` still have to
+    fit after the cap, or the write aborts partway through the tree.
+    """
+    stem = f"{safe_slug(record.entity_type, fallback='entity')}-{safe_slug(record.title)}"
+    return stem[:NOTE_STEM_MAX_CHARS].rstrip("-.") or safe_slug(record.id)
 
 
 def _by_recency(records: Iterable[MemoryRecord]) -> list[MemoryRecord]:
@@ -641,8 +662,6 @@ def _string_tuple(value: object) -> tuple[str, ...]:
 __all__ = [
     "HANDBOOK_PATH",
     "INDEX_PATH",
-    "MANAGED_DIRECTORIES",
-    "MANAGED_ROOT_FILES",
     "MANIFEST_PATH",
     "MEMORY_FILES_OKF_VERSION",
     "MEMORY_FILES_SCHEMA_VERSION",

--- a/packages/python/sibyl-core/src/sibyl_core/export/memory_files.py
+++ b/packages/python/sibyl-core/src/sibyl_core/export/memory_files.py
@@ -164,7 +164,7 @@ def write_memory_files_bundle(
     if not force and previous is None and root.is_dir() and any(root.iterdir()):
         msg = (
             f"Refusing to overwrite {root}: it is not empty and holds no Sibyl "
-            f"{MANIFEST_PATH}. Pass force=True to write anyway."
+            f"{MANIFEST_PATH}. Re-run with --force to write anyway."
         )
         raise FileExistsError(msg)
 

--- a/packages/python/sibyl-core/src/sibyl_core/export/okf.py
+++ b/packages/python/sibyl-core/src/sibyl_core/export/okf.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import json
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import rmtree
 from typing import Any
 
+from sibyl_core.export._slug import safe_slug
 from sibyl_core.migrate.archive import LoadedArchive, graph_payload_from_archive
 
 OKF_VERSION = "0.1"
@@ -200,7 +200,7 @@ def _concept_paths(graph_payload: dict[str, Any]) -> dict[tuple[str, int], str]:
     for kind, records in _iter_graph_records(graph_payload):
         for index, record in enumerate(records):
             record_id = _record_identifier(kind, record) or f"{kind}-{index + 1}"
-            slug = _safe_slug(record_id)
+            slug = safe_slug(record_id)
             path = f"{directories[kind]}/{slug}.md"
             if path in used:
                 path = f"{directories[kind]}/{slug}-{index + 1}.md"
@@ -391,11 +391,6 @@ def _relationship_type(record: dict[str, Any]) -> str:
         )
         or "related"
     )
-
-
-def _safe_slug(value: str) -> str:
-    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip(".-").lower()
-    return slug or "concept"
 
 
 def _optional_str(value: object) -> str | None:

--- a/packages/python/sibyl-core/tests/test_memory_files.py
+++ b/packages/python/sibyl-core/tests/test_memory_files.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import random
+import re
 import stat
 from pathlib import Path
 
@@ -21,6 +22,7 @@ from sibyl_core.export import (
     MemoryRecord,
     MemorySnapshot,
     build_memory_files_bundle,
+    memory_files,
     memory_record_from_entity,
     validate_memory_files_bundle,
     write_memory_files_bundle,
@@ -184,6 +186,25 @@ def test_no_wall_clock_value_leaks_into_the_projection() -> None:
     assert "exported_at" not in first.files[MANIFEST_PATH]
 
 
+def test_the_projection_module_cannot_reach_a_clock() -> None:
+    """Comparing two same-process builds misses a date-only leak.
+
+    `date.today()` returns the same value twice in a row, so the digest check
+    above passes while the files churn at midnight. The decisive property is
+    that the module has no clock to call in the first place.
+    """
+    source = Path(memory_files.__file__).read_text(encoding="utf-8")
+    imports = [
+        line
+        for line in source.splitlines()
+        if line.startswith(("import ", "from ")) and not line.startswith("from __future__")
+    ]
+
+    assert imports
+    for line in imports:
+        assert not re.search(r"\b(datetime|time|calendar|random|uuid|os)\b", line), line
+
+
 def test_manifest_digests_match_the_written_files(tmp_path: Path) -> None:
     bundle = build_memory_files_bundle(_snapshot())
     root = tmp_path / "memory"
@@ -226,8 +247,16 @@ def test_stale_notes_are_pruned_and_foreign_files_survive(tmp_path: Path) -> Non
     root = tmp_path / "memory"
     write_memory_files_bundle(build_memory_files_bundle(_snapshot()), root)
 
-    keeper = root / "OPERATOR_NOTES.md"
-    keeper.write_text("hand written, not ours\n", encoding="utf-8")
+    # A file this exporter never wrote is not ours to delete, wherever it sits.
+    keepers = {
+        root / "OPERATOR_NOTES.md": "hand written, not ours\n",
+        root / NOTES_DIR / "MY_OWN_NOTE.md": "also not ours\n",
+        root / NOTES_DIR / "sub" / "deep.md": "nested, still not ours\n",
+    }
+    for path, content in keepers.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
     dropped = root / NOTES_DIR / "decision-namespace-per-organization.md"
     assert dropped.is_file()
 
@@ -237,7 +266,66 @@ def test_stale_notes_are_pruned_and_foreign_files_survive(tmp_path: Path) -> Non
     write_memory_files_bundle(build_memory_files_bundle(trimmed), root)
 
     assert not dropped.exists()
-    assert keeper.read_text(encoding="utf-8") == "hand written, not ours\n"
+    for path, content in keepers.items():
+        assert path.read_text(encoding="utf-8") == content, path
+    assert validate_memory_files_bundle(root) == []
+
+
+def test_writing_into_a_populated_foreign_directory_is_refused(tmp_path: Path) -> None:
+    """`--output .` in a repo root would otherwise eat that repo's README."""
+    root = tmp_path / "someones-repo"
+    root.mkdir()
+    readme = root / "README.md"
+    readme.write_text("# Their project\n", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        write_memory_files_bundle(build_memory_files_bundle(_snapshot()), root)
+    assert readme.read_text(encoding="utf-8") == "# Their project\n"
+
+    write_memory_files_bundle(build_memory_files_bundle(_snapshot()), root, force=True)
+    assert validate_memory_files_bundle(root) == []
+
+
+def test_an_empty_or_missing_directory_needs_no_force(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    write_memory_files_bundle(build_memory_files_bundle(_snapshot()), empty)
+    assert validate_memory_files_bundle(empty) == []
+
+    fresh = tmp_path / "nested" / "fresh"
+    write_memory_files_bundle(build_memory_files_bundle(_snapshot()), fresh)
+    assert validate_memory_files_bundle(fresh) == []
+
+
+def test_a_long_title_still_produces_a_writable_filename(tmp_path: Path) -> None:
+    long_title = "Materialize " + "extraordinarily verbose memory " * 20
+    bundle = build_memory_files_bundle(
+        _snapshot(
+            notes=(_note("decision_long", long_title), _note("decision_long_two", long_title))
+        )
+    )
+
+    note_paths = [path for path in bundle.files if path.startswith(f"{NOTES_DIR}/")]
+    assert len(note_paths) == 2
+    for path in note_paths:
+        assert len(Path(path).name) < 255, path
+
+    root = tmp_path / "memory"
+    write_memory_files_bundle(bundle, root)
+    assert validate_memory_files_bundle(root) == []
+
+
+def test_a_body_containing_a_frontmatter_delimiter_stays_parseable(tmp_path: Path) -> None:
+    body = "Intro paragraph.\n\n---\n\nSection after a horizontal rule."
+    root = tmp_path / "memory"
+    write_memory_files_bundle(
+        build_memory_files_bundle(_snapshot(notes=(_note("decision_rule", "Ruled", body=body),))),
+        root,
+    )
+
+    note = (root / NOTES_DIR / "decision-ruled.md").read_text(encoding="utf-8")
+    assert note.startswith('---\ntype: "Sibyl Decision"')
+    assert "Section after a horizontal rule." in note
     assert validate_memory_files_bundle(root) == []
 
 
@@ -274,6 +362,20 @@ def test_recent_orders_by_recency_then_id() -> None:
     recent = bundle.files[RECENT_PATH]
 
     assert recent.index("Newer A") < recent.index("Newer B") < recent.index("Older")
+    # Reached through the builder the input is already id-sorted, so drive the
+    # tiebreak directly: equal timestamps must resolve by id, not arrival order.
+    ordered = memory_files._by_recency([newer_b, older, newer_a])
+    assert [record.id for record in ordered] == ["decision_a", "decision_b", "decision_z"]
+
+
+def test_note_files_carry_the_whole_body_not_a_preview() -> None:
+    body = "\n\n".join(f"Paragraph {index} of a memory that runs long." for index in range(40))
+    bundle = build_memory_files_bundle(_snapshot(notes=(_note("decision_big", "Big", body=body),)))
+
+    note = bundle.files[f"{NOTES_DIR}/decision-big.md"]
+    assert len(body) > 1000
+    assert body in note
+    assert "Paragraph 39 of a memory that runs long." in note
 
 
 @pytest.mark.parametrize(

--- a/packages/python/sibyl-core/tests/test_memory_files.py
+++ b/packages/python/sibyl-core/tests/test_memory_files.py
@@ -1,0 +1,321 @@
+"""Contract tests for the `.sibyl/memory/` materialized projection."""
+
+from __future__ import annotations
+
+import json
+import random
+import stat
+from pathlib import Path
+
+import pytest
+
+from sibyl_core.export import (
+    HANDBOOK_PATH,
+    INDEX_PATH,
+    MANIFEST_PATH,
+    MEMORY_FILES_SCHEMA_VERSION,
+    NOTES_DIR,
+    README_PATH,
+    RECENT_PATH,
+    TASKS_PATH,
+    MemoryRecord,
+    MemorySnapshot,
+    build_memory_files_bundle,
+    memory_record_from_entity,
+    validate_memory_files_bundle,
+    write_memory_files_bundle,
+)
+
+
+def _note(
+    record_id: str,
+    title: str,
+    entity_type: str = "decision",
+    *,
+    body: str | None = None,
+    updated_at: str = "2026-07-20T10:00:00Z",
+    tags: tuple[str, ...] = (),
+    attributes: tuple[tuple[str, str], ...] = (),
+) -> MemoryRecord:
+    return MemoryRecord(
+        id=record_id,
+        entity_type=entity_type,
+        title=title,
+        body=f"Body for {title}." if body is None else body,
+        updated_at=updated_at,
+        project_id="project_demo",
+        tags=tags,
+        attributes=attributes,
+    )
+
+
+def _snapshot(**overrides: object) -> MemorySnapshot:
+    base: dict[str, object] = {
+        "project_id": "project_demo",
+        "project_name": "Demo Project",
+        "project_description": "A project that keeps its memory in the repo.",
+        "notes": (
+            _note("decision_beta", "Namespace per organization"),
+            _note(
+                "pattern_alpha",
+                "Pool Surreal connections per org",
+                entity_type="pattern",
+                updated_at="2026-07-22T09:30:00Z",
+                tags=("surreal", "concurrency"),
+            ),
+        ),
+        "tasks": (
+            _note(
+                "task_gamma",
+                "Materialize memory as files",
+                entity_type="task",
+                updated_at="2026-07-24T08:00:00Z",
+                attributes=(("status", "doing"), ("priority", "high")),
+            ),
+        ),
+    }
+    base.update(overrides)
+    return MemorySnapshot(**base)  # type: ignore[arg-type]
+
+
+def _written_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_bundle_carries_the_documented_layout() -> None:
+    bundle = build_memory_files_bundle(_snapshot())
+
+    assert README_PATH in bundle.files
+    assert INDEX_PATH in bundle.files
+    assert RECENT_PATH in bundle.files
+    assert TASKS_PATH in bundle.files
+    assert MANIFEST_PATH in bundle.files
+    assert HANDBOOK_PATH not in bundle.files
+
+    note_paths = [path for path in bundle.files if path.startswith(f"{NOTES_DIR}/")]
+    assert note_paths == [
+        f"{NOTES_DIR}/decision-namespace-per-organization.md",
+        f"{NOTES_DIR}/pattern-pool-surreal-connections-per-org.md",
+    ]
+    assert list(bundle.files) == sorted(bundle.files)
+
+
+def test_every_markdown_file_declares_an_okf_type() -> None:
+    bundle = build_memory_files_bundle(_snapshot(handbook="# Handbook\n\nStart here."))
+
+    markdown = {path: content for path, content in bundle.files.items() if path.endswith(".md")}
+    assert markdown
+    for path, content in markdown.items():
+        assert content.startswith("---\n"), path
+        frontmatter = content[len("---\n") : content.find("\n---\n", len("---\n"))]
+        types = [line for line in frontmatter.splitlines() if line.startswith("type: ")]
+        assert types == [types[0]] and types[0] != 'type: ""', path
+
+
+def test_handbook_is_a_reserved_slot_that_fills_in_when_supplied() -> None:
+    without = build_memory_files_bundle(_snapshot())
+    with_handbook = build_memory_files_bundle(
+        _snapshot(handbook="# Demo handbook\n\nThe project is about memory.")
+    )
+
+    assert HANDBOOK_PATH not in without.files
+    assert HANDBOOK_PATH in with_handbook.files
+    assert "The project is about memory." in with_handbook.files[HANDBOOK_PATH]
+    assert f"./{HANDBOOK_PATH}" in with_handbook.files[INDEX_PATH]
+    assert f"./{HANDBOOK_PATH}" not in without.files[INDEX_PATH]
+    assert json.loads(with_handbook.files[MANIFEST_PATH])["handbook"] is True
+    assert json.loads(without.files[MANIFEST_PATH])["handbook"] is False
+
+
+def test_rebuilding_an_unchanged_snapshot_is_byte_identical() -> None:
+    snapshot = _snapshot()
+
+    assert build_memory_files_bundle(snapshot).files == build_memory_files_bundle(snapshot).files
+
+
+def test_input_ordering_does_not_change_a_single_byte() -> None:
+    snapshot = _snapshot()
+    canonical = build_memory_files_bundle(snapshot)
+
+    shuffler = random.Random(20260725)
+    for _ in range(8):
+        notes = list(snapshot.notes)
+        tasks = list(snapshot.tasks)
+        shuffler.shuffle(notes)
+        shuffler.shuffle(tasks)
+        reordered = build_memory_files_bundle(
+            MemorySnapshot(
+                project_id=snapshot.project_id,
+                project_name=snapshot.project_name,
+                project_description=snapshot.project_description,
+                notes=tuple(notes),
+                tasks=tuple(tasks),
+            )
+        )
+        assert reordered.files == canonical.files
+
+
+def test_rematerializing_produces_identical_bytes_on_disk(tmp_path: Path) -> None:
+    bundle = build_memory_files_bundle(_snapshot())
+    root = tmp_path / ".sibyl" / "memory"
+
+    write_memory_files_bundle(bundle, root)
+    first = _written_bytes(root)
+    write_memory_files_bundle(build_memory_files_bundle(_snapshot()), root)
+    second = _written_bytes(root)
+
+    assert first == second
+    assert validate_memory_files_bundle(root) == []
+
+
+def test_no_wall_clock_value_leaks_into_the_projection() -> None:
+    # The projection is a pure function of the snapshot, so a build taken at any
+    # later moment has to match. Anything sampled from `datetime.now` breaks this.
+    snapshot = _snapshot()
+    first = build_memory_files_bundle(snapshot)
+    second = build_memory_files_bundle(snapshot)
+
+    assert first.content_digest == second.content_digest
+    assert "generated_at" not in first.files[MANIFEST_PATH]
+    assert "exported_at" not in first.files[MANIFEST_PATH]
+
+
+def test_manifest_digests_match_the_written_files(tmp_path: Path) -> None:
+    bundle = build_memory_files_bundle(_snapshot())
+    root = tmp_path / "memory"
+    write_memory_files_bundle(bundle, root)
+
+    manifest = json.loads((root / MANIFEST_PATH).read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == MEMORY_FILES_SCHEMA_VERSION
+    assert manifest["project"]["id"] == "project_demo"
+    assert manifest["counts"] == {"notes": 2, "tasks": 1, "files": len(bundle.files)}
+
+    listed = {entry["path"] for entry in manifest["files"]}
+    assert listed == set(bundle.files) - {MANIFEST_PATH}
+    assert validate_memory_files_bundle(root) == []
+
+
+def test_validation_reports_content_edited_after_export(tmp_path: Path) -> None:
+    root = tmp_path / "memory"
+    write_memory_files_bundle(build_memory_files_bundle(_snapshot()), root)
+
+    index = root / INDEX_PATH
+    index.chmod(0o644)
+    index.write_text(index.read_text(encoding="utf-8") + "\nhand edit\n", encoding="utf-8")
+
+    errors = validate_memory_files_bundle(root)
+    assert errors == [f"{INDEX_PATH}: content does not match the manifest digest"]
+
+
+def test_files_are_written_read_only_by_default(tmp_path: Path) -> None:
+    root = tmp_path / "memory"
+    write_memory_files_bundle(build_memory_files_bundle(_snapshot()), root)
+
+    mode = stat.S_IMODE((root / INDEX_PATH).stat().st_mode)
+    assert mode == 0o444
+
+    write_memory_files_bundle(build_memory_files_bundle(_snapshot()), root, read_only=False)
+    assert stat.S_IMODE((root / INDEX_PATH).stat().st_mode) == 0o644
+
+
+def test_stale_notes_are_pruned_and_foreign_files_survive(tmp_path: Path) -> None:
+    root = tmp_path / "memory"
+    write_memory_files_bundle(build_memory_files_bundle(_snapshot()), root)
+
+    keeper = root / "OPERATOR_NOTES.md"
+    keeper.write_text("hand written, not ours\n", encoding="utf-8")
+    dropped = root / NOTES_DIR / "decision-namespace-per-organization.md"
+    assert dropped.is_file()
+
+    trimmed = _snapshot(
+        notes=(_note("pattern_alpha", "Pool Surreal connections per org", entity_type="pattern"),)
+    )
+    write_memory_files_bundle(build_memory_files_bundle(trimmed), root)
+
+    assert not dropped.exists()
+    assert keeper.read_text(encoding="utf-8") == "hand written, not ours\n"
+    assert validate_memory_files_bundle(root) == []
+
+
+def test_colliding_titles_both_disambiguate_regardless_of_order() -> None:
+    left = _note("decision_one", "Same title")
+    right = _note("decision_two", "Same title")
+
+    forward = build_memory_files_bundle(_snapshot(notes=(left, right)))
+    backward = build_memory_files_bundle(_snapshot(notes=(right, left)))
+
+    assert forward.files == backward.files
+    assert f"{NOTES_DIR}/decision-same-title.md" not in forward.files
+    assert f"{NOTES_DIR}/decision-same-title-decision_one.md" in forward.files
+    assert f"{NOTES_DIR}/decision-same-title-decision_two.md" in forward.files
+
+
+def test_ids_and_bodies_are_greppable_from_the_index_and_notes() -> None:
+    bundle = build_memory_files_bundle(_snapshot())
+
+    assert "`pattern_alpha`" in bundle.files[INDEX_PATH]
+    assert "`task_gamma`" in bundle.files[TASKS_PATH]
+    note = bundle.files[f"{NOTES_DIR}/pattern-pool-surreal-connections-per-org.md"]
+    assert 'sibyl_id: "pattern_alpha"' in note
+    assert "Body for Pool Surreal connections per org." in note
+    assert "sibyl cite pattern_alpha" in note
+
+
+def test_recent_orders_by_recency_then_id() -> None:
+    older = _note("decision_z", "Older", updated_at="2026-07-01T00:00:00Z")
+    newer_a = _note("decision_a", "Newer A", updated_at="2026-07-09T00:00:00Z")
+    newer_b = _note("decision_b", "Newer B", updated_at="2026-07-09T00:00:00Z")
+
+    bundle = build_memory_files_bundle(_snapshot(notes=(older, newer_b, newer_a)))
+    recent = bundle.files[RECENT_PATH]
+
+    assert recent.index("Newer A") < recent.index("Newer B") < recent.index("Older")
+
+
+@pytest.mark.parametrize(
+    "volatile_field",
+    ["retrieval_count", "last_recalled_at", "citation_count", "misled_count", "record_id"],
+)
+def test_volatile_bookkeeping_never_reaches_the_files(volatile_field: str) -> None:
+    payload = {
+        "id": "decision_live",
+        "type": "decision",
+        "name": "Live entity",
+        "description": "truncated preview",
+        "metadata": {
+            "description": "The full decision body lives in metadata.",
+            "updated_at": "2026-07-20T10:00:00Z",
+            "project_id": "project_demo",
+            "tags": ["surreal"],
+            volatile_field: "volatile-marker",
+            "embedding_metadata": {"model": "text-embedding-3-small"},
+        },
+    }
+    record = memory_record_from_entity(payload)
+    bundle = build_memory_files_bundle(_snapshot(notes=(record,), tasks=()))
+
+    assert record.body == "The full decision body lives in metadata."
+    assert record.tags == ("surreal",)
+    for content in bundle.files.values():
+        assert volatile_field not in content
+        assert "volatile-marker" not in content
+        assert "embedding_metadata" not in content
+
+
+def test_write_refuses_a_non_directory_target(tmp_path: Path) -> None:
+    blocker = tmp_path / "memory"
+    blocker.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        write_memory_files_bundle(build_memory_files_bundle(_snapshot()), blocker)
+
+
+def test_validation_reports_a_directory_that_was_never_exported(tmp_path: Path) -> None:
+    empty = tmp_path / "memory"
+    empty.mkdir()
+
+    assert validate_memory_files_bundle(empty) == [f"missing {MANIFEST_PATH}"]


### PR DESCRIPTION
# 🦋 Track B2: memory you can grep with the server down

First slice of B2. `sibyl export memory` writes a curated, deterministic projection of a project's memory into `.sibyl/memory/` as read-only files.

## 💡 Why now

Filesystem-native agents can grep this at zero marginal latency, and it survives the server being down — while the citation contract still routes usage back over the API when the server is up. Structured substrate, curated projection.

It is also the plan's most time-sensitive item after Track A. OpenAI (Agents SDK `memory_summary.md`, Codex `~/.codex/memories/`), Anthropic (Claude Code auto-memory), and Google (Gemini CLI) all shipped distilled-summary-plus-greppable-index memory in early 2026 — **each siloed to its own tool**. A repo-local `.sibyl/memory/` is readable by every one of them with zero integration work, and the window to become the cross-agent convention is ~6–12 months.

## 🔍 What already existed, and why the obvious reuse was wrong

**There was no `sibyl export`.** Export lives on `sibyld`, the server daemon. Since B2 is a user materializing files in their own repo, this adds `sibyl export memory` to the client CLI, talking to the API over HTTP.

**The existing OKF exporter turned out to be the wrong thing to point at a directory.** It is a *lossless archive* projection — it embeds the full JSON record in frontmatter so a graph can be reconstructed byte-for-byte. That is a backup format. Readability is the entire product here, so this is a genuinely new curated projection. What it does reuse: the frontmatter-with-`type` convention, the bundle/write/validate shape, and the filename slug rule, lifted into a shared `export/_slug.py` so both projections agree.

## 🗂️ Layout

\`\`\`
.sibyl/memory/
├── README.md      # orientation, how to cite
├── index.md       # every memory, grouped by type, with ids and paths
├── handbook.md    # B1 slot — written only when a handbook exists
├── recent.md      # recency-ordered digest with previews
├── tasks.md       # open work with task ids
├── notes/<type>-<title-slug>.md
└── manifest.json  # per-file SHA-256 plus a digest over the whole projection
\`\`\`

Three tiers on purpose: orient, grep the middle, open one detail file. **B1 slots in as `handbook.md` with no layout change** — the builder takes it from the snapshot, the index links it only when present, and it is simply absent today. B2 does not block on B1.

OKF-aligned where cheap: real YAML frontmatter, `type` on every file, `okf_version: 0.1`, Sibyl keys namespaced `sibyl_`. A small YAML subset is hand-serialized rather than taking a pyyaml dependency in core, which also guarantees byte determinism instead of trusting an emitter.

## 🔒 Determinism, proven

Two exports to separate directories against a live graph:

\`\`\`
digest 953bc7e9616ff97f
digest 953bc7e9616ff97f
diff -r v1 v2   → empty, exit 0
in-place rematerialize over 0444 → empty, exit 0
\`\`\`

Three rules buy it. Nothing in either module imports a clock — **with a test asserting the import list**, because comparing two same-process builds would miss a date-only leak. Fields are whitelisted rather than blacklisted, because `retrieval_count` and `last_recalled_at` mutate when memory is merely *read*. And ordering is total: ids place files, recency orders reading.

Anything less would make the directory useless in git and produce a noise diff on every export, so this is a gate requirement rather than a nicety.

## 🛡️ Three data-loss hazards caught in review and fixed

This command writes into people's repos, so these were fixed rather than filed:

- **Pruning deleted files it did not own.** It `rglob`'d `notes/` and removed any `.md` it had not written, so a user's own note filed there vanished on re-export. The previous manifest is now the sole authority on what Sibyl owns.
- **`--output .` in a repo root rewrote that repo's `README.md`** as a memory index. A populated directory with no Sibyl manifest is now refused, with `--force` for when it is meant.
- **No filename cap.** A long title produced a 412-char basename and `ENAMETOOLONG` partway through, leaving a half-written read-only tree that validation could not even report on. The live graph's longest name was already 186 chars. Capped at 100.

Verification also killed three tests by mutation — a date-only clock leak, body truncation at the render layer, and a never-exercised recency tiebreak all passed against broken code. Those are closed.

## 🧪 Validation

\`\`\`
moon run core:check cli:check api:check   (forced, uncached)
core 2010 passed / 14 skipped    cli 453 passed    api 2031 passed / 5 skipped
lint + typecheck green on all three
\`\`\`

Greps clean with no server in the loop:

\`\`\`
notes/pattern-surreal-driver-per-org-clone-fixes-lock-contention.md:36:
  Pair the clone with the existing namespace-per-org routing (org_<uuid_hex>)…
\`\`\`

## ⚠️ Two things the design brief got wrong

**A single multi-type query is not a curated projection.** The first live export of 40 memories came back as 40 decisions and nothing else — the backend spends the whole budget on whichever type it orders first. Notes are now fetched per type and merged round-robin; the same export now covers six types.

**"Recent context pack" cannot mean the semantic pack.** A goal-scoped pack is top-k over embeddings and is not reproducible against an unchanged graph, so it cannot satisfy the determinism gate. "Recent" is therefore recency-ordered, which is both deterministic and the honest reading. The live semantic pack stays where it belongs, over the API.

## 📌 Left for a follow-up

The session hook (explicitly out of scope for this pass) and the `files-projection-gate` receipt generator the plan names.

Two review findings judged not worth this pass: a project-less memory can be admitted by the project filter and stamped with the requested project's id (`record.project_id or snapshot.project_id`) — real, but not observed across 60 exported records; and the note budget's round-robin boundary was never partially exercised in live runs.

🔐 **Worth stating plainly:** this moves org-wide-visible rows from an API call into a git-committable file. That exposure is pre-existing explore behavior rather than something introduced here, but **committing the directory changes who can read it** — which matters for a product whose pitch is memory sovereignty. Users should decide deliberately whether `.sibyl/memory/` is committed or ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `sibyl export memory` to export project memory into deterministic, git-friendly `.sibyl/memory/` Markdown files.
  - Supports project selection, note and task limits, task filtering, hydration controls, custom output paths, writable files, overwrite protection, and JSON receipts.
  - Includes manifests, content digests, validation, and offline-readable note and task files.

- **Documentation**
  - Added CLI documentation, usage examples, layout details, options, and verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->