### PR TITLE
fix(retrieval): serve stored content instead of its derived blurb

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -1913,10 +1913,15 @@ def _content_for_record(
     row: Mapping[str, object],
     attributes: Mapping[str, Any],
 ) -> str:
+    # For memory-shaped rows the description is a derived blurb: often
+    # content[:500], and for passages one shared summary across every span of an
+    # observation. Either way it cannot stand in for content, so the full-text
+    # carriers are exhausted first. Tasks invert this and are resolved by the
+    # active-work path in tools/context.py rather than here.
     for value in (
+        row.get("content"),
         attributes.get("content"),
         attributes.get("description"),
-        row.get("content"),
         row.get("description"),
         row.get("summary"),
     ):
@@ -2188,10 +2193,12 @@ def _labels_without_entity(node: Any) -> list[str]:
 
 
 def _content_for_node(node: Any, attributes: Mapping[str, Any]) -> str:
+    # Mirrors _content_for_record: full content outranks the truncated
+    # description/summary copies regardless of which carrier holds it.
     for value in (
+        getattr(node, "content", None),
         attributes.get("content"),
         attributes.get("description"),
-        getattr(node, "content", None),
         getattr(node, "description", None),
         getattr(node, "summary", None),
     ):

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -615,6 +615,20 @@ def _lean_item_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     return lean
 
 
+def _description_adds_nothing(description: str, content: str | None) -> bool:
+    """Report whether a description is wholly contained in the content already served.
+
+    Writers store description as a hard prefix of content, so equality only holds
+    while the reader is served that same prefix; once the full body is served the
+    description is still redundant, just no longer identical.
+    """
+    trimmed = description.strip()
+    body = (content or "").strip()
+    if not trimmed:
+        return not body
+    return body.startswith(trimmed)
+
+
 def _item_from_result(
     result: SearchResult,
     facet: ContextFacet,
@@ -633,7 +647,7 @@ def _item_from_result(
             content = learnings.strip()
     if not audit:
         description = metadata.get("description")
-        if isinstance(description, str) and description.strip() == (content or "").strip():
+        if isinstance(description, str) and _description_adds_nothing(description, content):
             metadata.pop("description", None)
     kwargs: dict[str, Any] = {
         "id": result.id,
@@ -1212,6 +1226,10 @@ def _item_from_active_entity(entity: Any) -> ContextItem:
         "status": status,
         "priority": _enum_value(getattr(entity, "priority", "") or ""),
     }
+    # Tasks invert the usual relationship: Task.set_entity_fields seeds content
+    # from description at creation and the update path never rewrites it, so
+    # content is a frozen create-time snapshot and description is the live text.
+    # Reading content first here would serve prose the author already replaced.
     content = str(getattr(entity, "description", "") or getattr(entity, "content", "") or "")
     reason = "task is currently in progress for this project"
     if status == "blocked":

--- a/packages/python/sibyl-core/tests/test_context_pack.py
+++ b/packages/python/sibyl-core/tests/test_context_pack.py
@@ -1925,6 +1925,84 @@ async def test_lean_metadata_drops_description_equal_to_content(
 
 
 @pytest.mark.asyncio
+async def test_lean_metadata_drops_description_that_only_prefixes_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Serving the full body must not resurrect the truncated copy of it.
+
+    Writers store description as content[:500]. Once retrieval serves the whole
+    body the two stop being equal, so an equality-only check would ship the
+    prefix again as redundant metadata on every item.
+    """
+    full_content = "Full decision body. " * 100
+    responses = {
+        ContextFacet.DECISIONS: [
+            SearchResult(
+                id="decision-1",
+                type="decision",
+                name="Decision",
+                content=full_content,
+                score=0.8,
+                metadata={"entity_type": "decision", "description": full_content[:500]},
+            ),
+            SearchResult(
+                id="decision-2",
+                type="decision",
+                name="Other",
+                content=full_content,
+                score=0.7,
+                metadata={"entity_type": "decision", "description": "An unrelated summary"},
+            ),
+        ],
+    }
+    monkeypatch.setattr(context_module, "context_search", _facet_native_search(responses))
+
+    pack = await compile_context("ship", intent="decide", organization_id="org-123")
+
+    by_id = {item.id: item for item in pack.items}
+    assert by_id["decision-1"].content == full_content
+    assert "description" not in by_id["decision-1"].metadata
+    assert by_id["decision-2"].metadata["description"] == "An unrelated summary"
+
+
+def test_active_work_item_serves_live_description_over_stale_content() -> None:
+    """Tasks invert the usual content/description relationship.
+
+    Task.set_entity_fields (models/tasks.py:110-118) seeds content from
+    description at creation, and _build_update_data (routes/tasks.py:765-780)
+    carries no content key, so every description edit leaves content frozen at
+    the create-time text. Reading content first would serve the stale copy.
+    """
+    entity = SimpleNamespace(
+        id="task-1",
+        name="Ship the fix",
+        status="doing",
+        entity_type="task",
+        description="CORRECTED: the real cause is the error sanitizer.",
+        content="Original premise, frozen at create time and since retracted.",
+    )
+
+    item = context_module._item_from_active_entity(entity)
+
+    assert item.content == "CORRECTED: the real cause is the error sanitizer."
+    assert item.facet is ContextFacet.ACTIVE_WORK
+
+
+def test_active_work_item_falls_back_to_content_without_description() -> None:
+    """The create-time snapshot is still the only text when description is gone."""
+    entity = SimpleNamespace(
+        id="task-2",
+        name="Plan the work",
+        status="blocked",
+        entity_type="task",
+        description="",
+        content="Only a content snapshot",
+    )
+
+    assert context_module._item_from_active_entity(entity).content == "Only a content snapshot"
+
+
+@pytest.mark.asyncio
 async def test_completed_epics_route_to_prior_art(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/python/sibyl-core/tests/test_search.py
+++ b/packages/python/sibyl-core/tests/test_search.py
@@ -3214,3 +3214,129 @@ def test_query_coverage_refinement_reuses_candidate_text() -> None:
     )
 
     assert calls == ["weak", "strong"]
+
+
+def _truncated_description(content: str) -> str:
+    """Mirror how writers derive a description: a hard prefix of the content."""
+    return content[:500]
+
+
+def test_record_content_outranks_truncated_attribute_description() -> None:
+    """The stored description is a 500-char prefix and must not shadow the row.
+
+    Writers persist ``description`` as ``content[:500]`` while the full text
+    lives in the ``content`` column, so resolving the description first serves a
+    mid-word fragment and makes the rest of the record unreachable.
+    """
+    full_content = "Full decision body. " * 100
+    row = {
+        "uuid": "decision_1",
+        "name": "Decision",
+        "content": full_content,
+        "description": _truncated_description(full_content),
+        "summary": _truncated_description(full_content),
+        "attributes": {"description": _truncated_description(full_content)},
+    }
+
+    resolved = search_module._content_for_record(row, row["attributes"])
+
+    assert resolved == full_content
+    assert len(resolved) > 500
+
+
+def test_node_content_outranks_truncated_attribute_description() -> None:
+    full_content = "Full decision body. " * 100
+    attributes = {"description": _truncated_description(full_content)}
+    node = SimpleNamespace(
+        uuid="decision_1",
+        name="Decision",
+        content=full_content,
+        description=_truncated_description(full_content),
+        summary=_truncated_description(full_content),
+        attributes=attributes,
+    )
+
+    resolved = search_module._content_for_node(node, attributes)
+
+    assert resolved == full_content
+    assert len(resolved) > 500
+
+
+def test_node_record_candidate_serves_full_content_over_description() -> None:
+    """The reorder has to survive the projection, not just the helper."""
+    full_content = "Full decision body. " * 100
+    candidate = search_module._candidate_from_node_record(
+        {
+            "uuid": "decision_1",
+            "name": "Decision",
+            "entity_type": "decision",
+            "group_id": "org-123",
+            "content": full_content,
+            "description": _truncated_description(full_content),
+            "attributes": {"description": _truncated_description(full_content)},
+        },
+        signal=RetrievalSignal.NODE_FULLTEXT,
+        score=0.9,
+    )
+
+    assert candidate.content == full_content
+
+
+def test_record_content_resolution_falls_back_through_every_carrier() -> None:
+    """Preferring content must not break the rows that only have a fallback."""
+    cases: list[tuple[dict[str, object], dict[str, object], str]] = [
+        ({"content": "row content"}, {}, "row content"),
+        ({}, {"content": "attribute content"}, "attribute content"),
+        ({}, {"description": "attribute description"}, "attribute description"),
+        ({"description": "row description"}, {}, "row description"),
+        ({"summary": "row summary"}, {}, "row summary"),
+        ({}, {}, ""),
+    ]
+    for row, attributes, expected in cases:
+        assert search_module._content_for_record({**row, "attributes": attributes}, attributes) == (
+            expected
+        )
+
+
+def test_record_content_resolution_skips_empty_carriers() -> None:
+    """Empty strings are absent values, not a reason to stop resolving."""
+    row = {"content": "", "description": "", "summary": "row summary"}
+    attributes: dict[str, object] = {"content": "", "description": ""}
+
+    assert search_module._content_for_record({**row, "attributes": attributes}, attributes) == (
+        "row summary"
+    )
+
+
+def test_node_content_resolution_falls_back_through_every_carrier() -> None:
+    cases: list[tuple[dict[str, object], dict[str, object], str]] = [
+        ({"content": "node content"}, {}, "node content"),
+        ({}, {"content": "attribute content"}, "attribute content"),
+        ({}, {"description": "attribute description"}, "attribute description"),
+        ({"description": "node description"}, {}, "node description"),
+        ({"summary": "node summary"}, {}, "node summary"),
+        ({}, {}, ""),
+    ]
+    for fields, attributes, expected in cases:
+        node = SimpleNamespace(attributes=attributes, **fields)
+        assert search_module._content_for_node(node, attributes) == expected
+
+
+def test_record_content_column_outranks_attribute_content_copy() -> None:
+    """Pin which content carrier wins when a row and its attributes disagree.
+
+    Storage resolves this the same way: entity hydration coalesces the column
+    first and the schema maintenance pass writes content ?? attributes.content,
+    so free-form metadata must not override the canonical column.
+    """
+    attributes = {"content": "attribute copy"}
+    row = {"uuid": "entity_1", "content": "canonical column", "attributes": attributes}
+
+    assert search_module._content_for_record(row, attributes) == "canonical column"
+
+
+def test_node_content_resolution_skips_empty_carriers() -> None:
+    node = SimpleNamespace(content="", description="", summary="node summary")
+    attributes: dict[str, object] = {"content": "", "description": ""}
+
+    assert search_module._content_for_node(node, attributes) == "node summary"


### PR DESCRIPTION
# 🩹 Sibyl has been serving a derived blurb instead of what it stored

A memory system's core promise is that what you put in comes back out. On the graph-entity path, it hasn't been.

## 💡 The defect

Two retrieval resolvers checked a **derived description before the content it was derived from**. Wherever `attributes["content"]` was absent, that blurb shadowed the full `content` column, which became unreachable.

That the resolver checked `attributes["content"]` first is the tell: content-first was always the intent, and the column-level fallback had been dead code behind the blurb.

| site | defect |
| --- | --- |
| `retrieval/search.py:1912` `_content_for_record` | `attributes.description` shadowed `row.content` |
| `retrieval/search.py:2190` `_content_for_node` | same, node carrier (no production callers today) |

The blurb is usually `content[:500]` (`tools/add.py:505,517,534`), but **"truncated copy" is not a universal claim** — the passage case below is the counterexample that matters, and the code comment was softened accordingly.

## 🧬 The sharpest case is passages, not truncation

Experience projection writes **one shared description per observation** and puts each span in `content`. At `projection/experience.py:451` the blurb is computed once, *outside* the slice loop; each passage entity then gets that same blurb plus its own `render_slice(...)` span.

Under the old ordering, **every passage of an observation served the identical blurb and the spans were structurally unreachable.** The A1 slice substrate would have minted correctly, ranked correctly, and then served the same text for every slice — the whole slice-granular thesis measuring as a failure for a reason that had nothing to do with slicing.

No passage entities exist yet, so this is a **correctness precondition for A1**, not a repair of live data.

## 🎯 Impact, measured read-only against the live graph

**5,220 of 10,686 entities (48.9%) change what they serve.** Median recovery **3.25×** (the 37× mean is skewed by a 50K-char tail entity).

One real context pack: graph entities go **1,500 → 11,213 chars (7.48×)**. `decision_d8c92a05218d` 500 → 1,487. `artifact_37488c344e9d` 500 → 6,272.

This is the **JSON** surface — `sibyl context --json`, the web UI, `required_terms` matching — not just the human markdown render.

## 🔁 Collateral damage, caught and fixed

The reorder broke something subtle. `context.py:634`'s metadata dedupe dropped a redundant `description` by **exact equality**, which only ever held *because* content was the description. Confirmed on a live pack that this dedupe fires today for every graph entity — so without a fix, all 5,220 affected entities would have shipped a redundant duplicate on the very JSON surface this change exists to repair. `_description_adds_nothing()` now recognizes the prefix relationship.

## 🔀 Active work is excluded on purpose

The two resolvers now disagree, deliberately. **Tasks invert the write-side relationship:** `Task.set_entity_fields` (`models/tasks.py:110-118`) seeds `content` from `description` at creation, and `_build_update_data` (`routes/tasks.py:765-780`) carries **no `content` key** — so `content` is a frozen create-time snapshot while `description` is the live field.

The measurement that settles it: of **1,876** task/epic rows holding both fields, **1,844 are byte-identical** because nobody ever edited the description, and the **32 that diverged are exactly the rows someone updated**. Ordering content first there would serve prose the author already replaced.

An earlier revision of this PR "fixed" `_item_from_active_entity` the same way as the search resolvers. That was wrong and has been reverted — the line is now byte-identical to `main`, carrying only an explanatory comment. Two tests pin the correct order so a re-swap fails.

## 🚨 Known residual that ships with this PR

**32 diverged task rows will serve stale-but-complete content through `_content_for_record` until Sibyl task `f200cd80` lands.**

Updates rewrite `row.description` *and* `attributes.description` but never `row.content`. So for those rows the old order reached `attributes.description` (live) while the new order takes `row.content` (stale) first. Verified: `attributes.description` tracks the live text in **32 of 32** cases. That is **0.30% of entities, 1.7% of task rows**.

Shipping it is deliberate, for two reasons:

- **The harms are not the same kind.** On memory-shaped rows the reorder recovers text that is genuinely *absent* — the reader never sees it. On these 32 rows the reader gets text that is *stale but complete*: an older version, not a truncated one. Older-but-whole is materially smaller harm than missing.
- **The resolver cannot be right for both shapes**, because one order is being asked to serve two inverted write-side conventions. Any reader-side rule is a patch over a write-side defect, and a type-aware resolver would spread the inconsistency to a third site instead of retiring it.

The durable repair is task **f200cd80-4359-4a32-8cfe-ca3ea3a313d4** — task description updates should write `content` too, which fixes every reader at once and also retires the hydration fallback to `summary`.

## 📐 Why the content column outranks `attributes["content"]`

Final order: **`content` carrier → `attributes.content` → `attributes.description` → `description` → `summary`.**

Putting the column first rests on four converging pieces of evidence: the writer (`graph.py:2804-2838`) puts full text in the column, always overwrites `attributes["description"]`, and never writes `attributes["content"]`; hydration at `graph.py:1929` already coalesces column-first; storage at `schema.py:129` writes `content ?? attributes.content`; and zero live entities have both non-empty *and* differing, so the choice is inert on real data.

## ✅ No consumer wanted the short form

Checked explicitly, because a reorder is only safe if nothing depended on the truncation. Every LLM prompt path re-truncates independently — synthesis at 320, reranking at 512 and 2000, crawler at 4000, the search tool at `content_max_chars`. Nothing relied on the resolver to keep payloads small.

## 🧪 Validation

```
core 1994 passed / 14 skipped     api 2031 passed / 5 skipped
lint + typecheck: All checks passed! (4/4)     exit 0
```

**No pre-existing test failed — nothing pinned the old order**, which is itself worth noting: this behavior was never intentional enough to be tested. 11 tests added, each falsified against the code it pins; the single-carrier fallback guards are non-discriminating by construction and correct for their purpose.

A sweep for further instances was redone with the **AST** rather than regex, after the original regex sweep was found to have a `getattr(x, "description")` blind spot. It matched every access shape — attribute, `getattr`, `.get()`, subscript, `attrgetter`, `itemgetter` — across `or`-chains and tuple fallbacks. Seven candidates surfaced; six are joins or return tuples, and the one real fallback (`tools/search.py:612` `memory.snippet or memory.raw_content`) is correct, since `snippet` is a match-centered highlight with `<mark>` tags, not a prefix.

No writes to the live store during measurement: `last_recalled_at` on the receipt entities still reads ~21h before the read.

## 🚧 Scope

**The render cap is untouched** — `tools/context.py` `max_content_chars = 280` is absent from this diff entirely. That is a budget decision needing its own reader-holdout measurement, and conflating it with a correctness fix would make both unreviewable. Expect only ~+1.3% on the markdown surface; the value is on the JSON surface.

## 📌 One pre-existing follow-up, filed not fixed

The degraded fallback path in `context.py` passes no `content_max_chars`, so it takes the 500 default while the native path now returns full content — same family as the render cap, wanting its own measurement.

*(An earlier revision listed `services/synthesis.py:166` as a second follow-up. Retracted: `EntitySummary` (`tools/responses.py:42-49`) has no `content` field, so that read is structurally forced, not a defect.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
