### PR TITLE
feat(retrieval): scale the per-lane seed budget with the request

### DIFF
--- a/benchmarks/longmemeval_v2_chunk_geometry/README.md
+++ b/benchmarks/longmemeval_v2_chunk_geometry/README.md
@@ -220,7 +220,7 @@ arm); the third is the one that actually binds.
   sends the field and nothing reads it. The knob's one live enforcement is the
   eval adapter's `_select_diverse_results`, which **drops** over-cap rows where
   the server would have deferred and backfilled them.
-- **`MAX_CANDIDATES_PER_SIGNAL` cannot reach a passage.** It bounds
+- **The plan's per-lane seed budget cannot reach a passage.** It bounds
   `CandidateLimits` for `build_context_retrieval_plan` / `context_search`, whose
   only non-test caller is `sibyl_core/tools/context.py` serving context-pack
   *facet sections*. The evidence lane goes `execute_search_request` ->

--- a/benchmarks/longmemeval_v2_chunk_geometry/stage2.py
+++ b/benchmarks/longmemeval_v2_chunk_geometry/stage2.py
@@ -16,7 +16,7 @@ measurement.** Three code reads over the eight-PR A1 stack say:
     live enforcement is the eval adapter's `_select_diverse_results`, which
     drops over-cap rows outright with no backfill, unlike the server's
     defer-then-backfill.
-  * `MAX_CANDIDATES_PER_SIGNAL` bounds `build_context_retrieval_plan`, which
+  * `seed_candidates_per_signal` bounds `build_context_retrieval_plan`, which
     serves the **context-pack facet sections**. The evidence lane does not go
     that way: `/context/pack` builds a `SearchRequest` and runs
     `execute_search_request` -> `tools.search.search` -> `hybrid_search`, where
@@ -30,7 +30,7 @@ measurement.** Three code reads over the eight-PR A1 stack say:
     ceiling on how many passages exist to be capped, composed, or read.
 
 So the sweep is `max_chunks_per_trajectory` x **evidence-lane depth**, and the
-`MAX_CANDIDATES_PER_SIGNAL` result is a null one recorded against the code.
+per-lane seed-budget result is a null one recorded against the code.
 
 Two arms, because a cap and a ranker fail differently:
 
@@ -74,7 +74,7 @@ GATE_CHAR_BUDGET = 48_000
 TRAJECTORY_CAPS: tuple[int | None, ...] = (1, 2, 4, 8, 16, None)
 
 # Evidence-lane depth: the `limit` the pack request carries, which is what
-# `MAX_CANDIDATES_PER_SIGNAL` was believed to be. 28 is the staged geometry
+# the per-lane seed budget was believed to be. 28 is the staged geometry
 # (`max_context_items` beats the default `search_limit` of 12); 50 is the
 # schema maximum, reachable with `--search-limit 50`.
 POOL_DEPTHS = (8, 16, 24, 28, 50)

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -59,14 +59,23 @@ type RawMemoryRecallFn = Callable[..., Awaitable[list[RawMemory] | RawMemoryReca
 DEFAULT_FILTER_SELECTIVITY_THRESHOLD = 0.1
 EDGE_FULLTEXT_MATCH_HEADROOM = 8
 EDGE_FULLTEXT_MIN_MATCH_LIMIT = 32
-# Ceiling on candidates any one lane contributes, however large the caller's
-# `limit` is. This is a seed-diversity budget rather than a payload budget: on a
-# whole-state substrate each candidate is a distinct state, while on a passage
-# substrate several candidates can be cuts of one state, so the distinct sources
-# a lane can reach shrinks as the retrieval unit shrinks. Raising it widens the
-# fulltext and HNSW read on every lane for every caller, so it belongs to a
-# measured arm rather than to whichever substrate landed most recently.
-MAX_CANDIDATES_PER_SIGNAL = 8
+# Seed budget: how many candidates one lane may contribute before fusion. It is
+# a seed-diversity budget rather than a payload budget, because several
+# candidates can be cuts of one source once the retrieval unit is a passage
+# rather than a whole memory, so a lane needs more rows to reach the same number
+# of distinct sources. The bound is therefore the caller's own `limit`: no lane
+# may propose more rows than the whole answer holds, and a caller that asks for
+# a wider answer is the caller that pays for the wider fulltext and HNSW read.
+# A single flat ceiling cannot express that, since it pins a 50-item request to
+# the same lane depth as an 8-item one.
+MIN_CANDIDATES_PER_SIGNAL = 2
+MAX_RETRIEVAL_LIMIT = 50
+# Lane depth for a plan built without a limit, equal to what the rule above
+# yields at the narrowest layer a pack can ask for (`ContextLayer.WAKE`).
+DEFAULT_CANDIDATES_PER_SIGNAL = 8
+# The raw-memory lane reads whole memories rather than passages, so it takes a
+# share of the seed budget instead of the whole of it.
+RAW_LEXICAL_LIMIT_DIVISOR = 4
 _ACTIVE_TASK_STATUSES = {"doing", "in_progress", "review"}
 _RAW_MEMORY_CONTEXT_TYPES = {"raw_memory", "session", "episode", "note"}
 _EDGE_CONTEXT_TYPES = {"claim", "relationship"}
@@ -161,12 +170,12 @@ class RetrievalWeights:
 @dataclass(frozen=True, slots=True)
 class CandidateLimits:
     raw_lexical: int = 4
-    node_fulltext: int = MAX_CANDIDATES_PER_SIGNAL
-    episode_fulltext: int = MAX_CANDIDATES_PER_SIGNAL
-    edge_fulltext: int = MAX_CANDIDATES_PER_SIGNAL
-    node_vector: int = MAX_CANDIDATES_PER_SIGNAL
-    edge_vector: int = MAX_CANDIDATES_PER_SIGNAL
-    graph_expansion: int = MAX_CANDIDATES_PER_SIGNAL
+    node_fulltext: int = DEFAULT_CANDIDATES_PER_SIGNAL
+    episode_fulltext: int = DEFAULT_CANDIDATES_PER_SIGNAL
+    edge_fulltext: int = DEFAULT_CANDIDATES_PER_SIGNAL
+    node_vector: int = DEFAULT_CANDIDATES_PER_SIGNAL
+    edge_vector: int = DEFAULT_CANDIDATES_PER_SIGNAL
+    graph_expansion: int = DEFAULT_CANDIDATES_PER_SIGNAL
 
 
 @dataclass(frozen=True, slots=True)
@@ -244,6 +253,12 @@ def fusion_backend_from_env(
     return coerce_fusion_backend(source.get("SIBYL_FUSION_BACKEND"))
 
 
+def seed_candidates_per_signal(limit: int) -> int:
+    """Candidates one lane may seed for a caller asking for `limit` results."""
+
+    return max(MIN_CANDIDATES_PER_SIGNAL, min(int(limit), MAX_RETRIEVAL_LIMIT))
+
+
 def build_context_retrieval_plan(
     *,
     query: str,
@@ -308,7 +323,7 @@ def build_context_retrieval_plan(
             )
         )
 
-    per_signal_limit = max(2, min(MAX_CANDIDATES_PER_SIGNAL, limit))
+    per_signal_limit = seed_candidates_per_signal(limit)
     facet_types_by_facet = {facet: tuple(facet_types.get(facet, ())) for facet in facets}
     return RetrievalPlan(
         query=query,
@@ -318,7 +333,7 @@ def build_context_retrieval_plan(
         scopes=tuple(scopes),
         denied_scopes=tuple(denied_scopes),
         candidate_limits=CandidateLimits(
-            raw_lexical=max(1, min(MAX_CANDIDATES_PER_SIGNAL, limit // 4 or 1)),
+            raw_lexical=max(1, min(per_signal_limit, limit // RAW_LEXICAL_LIMIT_DIVISOR or 1)),
             node_fulltext=per_signal_limit,
             episode_fulltext=per_signal_limit,
             edge_fulltext=per_signal_limit,
@@ -349,7 +364,7 @@ async def context_search(
     search_started_at = time.perf_counter()
     stage_timings_ms: dict[str, float] = {}
     stage_started_at = time.perf_counter()
-    limit = max(1, min(limit, 50))
+    limit = max(1, min(limit, MAX_RETRIEVAL_LIMIT))
     search_plan = replace(
         plan,
         candidate_limits=_candidate_limits_for_limit(plan.candidate_limits, limit),
@@ -754,7 +769,11 @@ def _candidate_limits_for_limit(
     candidate_limits: CandidateLimits,
     limit: int,
 ) -> CandidateLimits:
-    source_limit = max(1, min(int(limit), 50))
+    # Narrows only. A plan is built from the caller's `limit`, so a query-time
+    # limit below it must not leave a lane reading deeper than the answer, while
+    # a query-time limit above it must not widen a plan the caller never asked
+    # to widen.
+    source_limit = max(1, min(int(limit), MAX_RETRIEVAL_LIMIT))
     return CandidateLimits(
         raw_lexical=max(1, min(candidate_limits.raw_lexical, source_limit)),
         node_fulltext=max(1, min(candidate_limits.node_fulltext, source_limit)),

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -70,8 +70,9 @@ EDGE_FULLTEXT_MIN_MATCH_LIMIT = 32
 # the same lane depth as an 8-item one.
 MIN_CANDIDATES_PER_SIGNAL = 2
 MAX_RETRIEVAL_LIMIT = 50
-# Lane depth for a plan built without a limit, equal to what the rule above
-# yields at the narrowest layer a pack can ask for (`ContextLayer.WAKE`).
+# Lane depth for a bare `CandidateLimits()`, which is the fallback for a plan
+# assembled without lane budgets rather than for a plan without a limit: the
+# builder has its own default `limit` and derives every field from it.
 DEFAULT_CANDIDATES_PER_SIGNAL = 8
 # The raw-memory lane reads whole memories rather than passages, so it takes a
 # share of the seed budget instead of the whole of it.
@@ -853,8 +854,13 @@ def _project_filter_selectivity(
     return 1.0 / len(accessible_projects)
 
 
-def _graph_knn_effort() -> int:
-    return max(1, int(core_config.graph_knn_ef))
+def _graph_knn_effort(candidate_limit: int) -> int:
+    # An HNSW search keeps at most `ef` nodes in flight, so an effort below the
+    # requested `k` truncates the read to `ef` rows and no error is raised. The
+    # configured effort is a floor on search quality, never a ceiling on the
+    # candidates a lane was budgeted, so `k` raises it when the seed budget runs
+    # deeper than the configuration.
+    return max(1, int(core_config.graph_knn_ef), int(candidate_limit))
 
 
 def _explicit_project_denied(plan: RetrievalPlan) -> bool:
@@ -1221,7 +1227,7 @@ async def _node_vector_candidates(
         return []
     filter_clauses, filter_params = _node_filter_clause(search_filter)
     candidate_limit = max(int(limit), 1)
-    knn_effort = _graph_knn_effort()
+    knn_effort = _graph_knn_effort(candidate_limit)
     rows = await _execute_query_records(
         client,
         """
@@ -1269,7 +1275,7 @@ async def _edge_vector_candidates(
         return []
     filter_clauses, filter_params = _edge_filter_clause(search_filter)
     candidate_limit = max(int(limit), 1)
-    knn_effort = _graph_knn_effort()
+    knn_effort = _graph_knn_effort(candidate_limit)
     rows = await _execute_query_records(
         client,
         "SELECT * FROM ("

--- a/packages/python/sibyl-core/tests/test_search.py
+++ b/packages/python/sibyl-core/tests/test_search.py
@@ -2555,6 +2555,49 @@ async def test_vector_candidate_sources_use_configured_knn_effort(
     assert f"fact_embedding <|{edge_knn}, 96|> $query_embedding" in edge_query
 
 
+@pytest.mark.asyncio
+async def test_vector_lanes_raise_knn_effort_to_the_seed_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An HNSW read returns at most `ef` rows, so a deep-search plan whose seed
+    # budget outruns the configured effort would silently come back short.
+    monkeypatch.setattr(search_module.core_config, "graph_knn_ef", 40)
+    plan = build_context_retrieval_plan(
+        query="deep search vectors",
+        organization_id="org-123",
+        facets=[ContextFacet.ACTIVE_WORK],
+        facet_types={ContextFacet.ACTIVE_WORK: ["task"]},
+        principal_id="user-123",
+        project="project_123",
+        accessible_projects={"project_123"},
+        limit=MAX_RETRIEVAL_LIMIT,
+    )
+    provider = DeterministicEmbeddingProvider(
+        EmbeddingMetadata(
+            provider="deterministic",
+            model="unit-test",
+            dimensions=4,
+            cache_namespace="retrieval-test",
+            tokenizer_estimate_method="utf8-byte-length",
+        )
+    )
+    client = _VectorClient()
+
+    await search_module._vector_candidate_sources(
+        client=client,
+        plan=plan,
+        search_filter=search_module.SearchFilter(project_ids=("project_123",)),
+        embedding_provider=provider,
+    )
+
+    node_query = next(call for call in client.calls if "name_embedding" in call[0])[0]
+    edge_query = next(call for call in client.calls if "fact_embedding" in call[0])[0]
+    assert plan.candidate_limits.node_vector == MAX_RETRIEVAL_LIMIT
+    assert f"name_embedding <|{MAX_RETRIEVAL_LIMIT}, {MAX_RETRIEVAL_LIMIT}|>" in node_query
+    assert f"fact_embedding <|{MAX_RETRIEVAL_LIMIT}, {MAX_RETRIEVAL_LIMIT}|>" in edge_query
+    assert search_module._graph_knn_effort(8) == 40
+
+
 def test_node_record_candidates_keep_top_level_provenance_metadata() -> None:
     candidate = search_module._candidate_from_node_record(
         {

--- a/packages/python/sibyl-core/tests/test_search.py
+++ b/packages/python/sibyl-core/tests/test_search.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-from dataclasses import replace
+from dataclasses import asdict, replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -30,6 +30,9 @@ from sibyl_core.models.context import ContextFacet
 from sibyl_core.retrieval.candidates import CandidateKind, CandidateScope
 from sibyl_core.retrieval.search import (
     DEFAULT_FILTER_SELECTIVITY_THRESHOLD,
+    MAX_RETRIEVAL_LIMIT,
+    MIN_CANDIDATES_PER_SIGNAL,
+    CandidateLimits,
     FusionBackend,
     RetrievalCandidate,
     RetrievalSignal,
@@ -37,6 +40,7 @@ from sibyl_core.retrieval.search import (
     build_context_retrieval_plan,
     coerce_fusion_backend,
     fusion_backend_from_env,
+    seed_candidates_per_signal,
 )
 from sibyl_core.services.surreal_content import MemoryScope, RawMemory, RawMemoryRecallResult
 
@@ -276,6 +280,106 @@ def test_build_context_retrieval_plan_records_scopes_and_weights() -> None:
     assert RetrievalSignal.RAW_LEXICAL in plan.signals
     assert RetrievalSignal.GRAPH_EXPANSION in plan.signals
     assert plan.filter_selectivity == 1.0
+
+
+def _plan_lane_limits(limit: int) -> dict[str, int]:
+    plan = build_context_retrieval_plan(
+        query="seed budget",
+        organization_id="org-123",
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["session", "episode", "note"]},
+        principal_id="user-123",
+        project=None,
+        accessible_projects=None,
+        limit=limit,
+    )
+    return asdict(plan.candidate_limits)
+
+
+def _flat_cap_lane_limits(limit: int) -> dict[str, int]:
+    """The flat-cap rule, restated so the derived rule cannot silently move it.
+
+    A literal copy rather than a call into the module: the point of the range
+    below is that the configuration Sibyl ships today survives the derivation,
+    and a check that reuses the derivation cannot show that.
+    """
+    per_signal = max(2, min(8, limit))
+    return {
+        "raw_lexical": max(1, min(8, limit // 4 or 1)),
+        "node_fulltext": per_signal,
+        "episode_fulltext": per_signal,
+        "edge_fulltext": per_signal,
+        "node_vector": per_signal,
+        "edge_vector": per_signal,
+        "graph_expansion": per_signal,
+    }
+
+
+@pytest.mark.parametrize("limit", range(1, 9))
+def test_seed_budget_keeps_narrow_limits_identical_to_the_flat_cap(limit: int) -> None:
+    assert _plan_lane_limits(limit) == _flat_cap_lane_limits(limit)
+
+
+@pytest.mark.parametrize(("limit", "per_signal", "raw_lexical"), [(24, 24, 6), (28, 28, 7)])
+def test_seed_budget_widens_lanes_at_slice_scale_limits(
+    limit: int,
+    per_signal: int,
+    raw_lexical: int,
+) -> None:
+    lane_limits = _plan_lane_limits(limit)
+
+    assert lane_limits == {
+        "raw_lexical": raw_lexical,
+        "node_fulltext": per_signal,
+        "episode_fulltext": per_signal,
+        "edge_fulltext": per_signal,
+        "node_vector": per_signal,
+        "edge_vector": per_signal,
+        "graph_expansion": per_signal,
+    }
+    assert lane_limits["node_fulltext"] > _flat_cap_lane_limits(limit)["node_fulltext"]
+
+
+def test_seed_budget_stops_at_the_deepest_read_context_search_accepts() -> None:
+    assert seed_candidates_per_signal(MAX_RETRIEVAL_LIMIT) == MAX_RETRIEVAL_LIMIT
+    assert seed_candidates_per_signal(MAX_RETRIEVAL_LIMIT * 4) == MAX_RETRIEVAL_LIMIT
+    assert _plan_lane_limits(MAX_RETRIEVAL_LIMIT * 4)["node_fulltext"] == MAX_RETRIEVAL_LIMIT
+
+
+def test_seed_budget_floors_every_lane_at_a_rankable_pair() -> None:
+    assert seed_candidates_per_signal(0) == MIN_CANDIDATES_PER_SIGNAL
+    assert seed_candidates_per_signal(1) == MIN_CANDIDATES_PER_SIGNAL
+    assert _plan_lane_limits(1)["node_fulltext"] == MIN_CANDIDATES_PER_SIGNAL
+
+
+def test_seed_budget_rises_monotonically_with_the_requested_limit() -> None:
+    widths = [seed_candidates_per_signal(limit) for limit in range(1, MAX_RETRIEVAL_LIMIT + 1)]
+
+    assert widths == sorted(widths)
+    assert widths[-1] > widths[0]
+
+
+def test_query_time_limits_narrow_lanes_but_never_widen_them() -> None:
+    limits = CandidateLimits(
+        raw_lexical=7,
+        node_fulltext=28,
+        episode_fulltext=28,
+        edge_fulltext=28,
+        node_vector=28,
+        edge_vector=28,
+        graph_expansion=28,
+    )
+
+    narrowed = search_module._candidate_limits_for_limit(limits, 4)
+    widened = search_module._candidate_limits_for_limit(limits, MAX_RETRIEVAL_LIMIT * 2)
+
+    assert narrowed.node_fulltext == 4
+    assert narrowed.raw_lexical == 4
+    assert widened == limits
+    # A plan built at the narrowest layer stays narrow however deep the pack
+    # composer's own search limit runs.
+    narrow_plan = CandidateLimits(**_flat_cap_lane_limits(8))
+    assert search_module._candidate_limits_for_limit(narrow_plan, 50) == narrow_plan
 
 
 def test_search_filter_for_plan_carries_requested_entity_types() -> None:
@@ -2272,8 +2376,10 @@ async def test_vector_candidate_sources_use_embedding_contract() -> None:
     assert edge_candidates[0].metadata["embedding_metadata"] == provider.metadata.to_dict()
     node_query, node_params = next(call for call in client.calls if "name_embedding" in call[0])
     edge_query, edge_params = next(call for call in client.calls if "fact_embedding" in call[0])
-    assert "name_embedding <|8, 40|> $query_embedding" in node_query
-    assert "fact_embedding <|8, 40|> $query_embedding" in edge_query
+    node_knn = plan.candidate_limits.node_vector
+    edge_knn = plan.candidate_limits.edge_vector
+    assert f"name_embedding <|{node_knn}, 40|> $query_embedding" in node_query
+    assert f"fact_embedding <|{edge_knn}, 40|> $query_embedding" in edge_query
     assert len(node_params["query_embedding"]) == 4
     assert len(edge_params["query_embedding"]) == 4
     assert node_params["project_ids"] == ["project_123"]
@@ -2443,8 +2549,10 @@ async def test_vector_candidate_sources_use_configured_knn_effort(
 
     node_query = next(call for call in client.calls if "name_embedding" in call[0])[0]
     edge_query = next(call for call in client.calls if "fact_embedding" in call[0])[0]
-    assert "name_embedding <|8, 96|> $query_embedding" in node_query
-    assert "fact_embedding <|8, 96|> $query_embedding" in edge_query
+    node_knn = plan.candidate_limits.node_vector
+    edge_knn = plan.candidate_limits.edge_vector
+    assert f"name_embedding <|{node_knn}, 96|> $query_embedding" in node_query
+    assert f"fact_embedding <|{edge_knn}, 96|> $query_embedding" in edge_query
 
 
 def test_node_record_candidates_keep_top_level_provenance_metadata() -> None:


### PR DESCRIPTION
# ⚡ A per-lane seed budget that scales with the request

> Retrieval planning in `sibyl-core`, one file of behavior plus its tests. This is the seed-diversity half of the 1.2 passage substrate work: the slice projection already landed, and this removes the cap that would have starved it.

## 💡 What this is

Context retrieval fans out over seven lanes (raw lexical, node fulltext, episode fulltext, edge fulltext, node vector, edge vector, graph expansion) and fuses the results with reciprocal rank fusion. Each lane was allowed at most 8 candidates no matter how many results the caller asked for. The natural reading of that number is "a payload budget, so the pack does not get too big", and that reading is wrong: the pack size is bounded separately, by the fused `limit` and by the composer's character budget. What the 8 actually bounded was seed diversity, the number of distinct sources a single lane could put in front of fusion.

The bound is now the caller's own `limit`. A caller asking for 8 results still gets lanes of 8; a caller asking for 28 gets lanes of 28.

## 🤔 Why we need it and what it replaces

The number 8 was chosen when one retrieval unit was one whole memory of roughly 12,000 characters, where 8 rows from a lane meant 8 distinct sources. Sibyl 1.2 cut those memories into passages of 600 to 1,200 characters (`packages/python/sibyl-core/src/sibyl_core/projection/slicing.py`, `TARGET_LO` through `HARD_MAX`), an eleven-fold drop in unit size. Several rows from one lane can now be cuts of the same source, so the same 8 rows reach materially fewer distinct sources, and nothing inside the plan reports that shortfall.

The effect is visible from outside, though. Against the dev graph at `limit=28`, the old rule fused from 48 unique candidates across all seven lanes and returned 19 results for a 28-result request. The request could not be filled because there were not enough candidates in the pool to fill it.

What this deliberately does not do is pick a bigger flat number. A cap of 24 or 32 would have been a value chosen by taste, and it would still pin a 50-item deep search to the same lane depth as an 8-item wake-layer pack. It also does not widen the composer, the character budgets, or the typed-note reservation, all of which keep bounding the pack exactly as before.

## 🎯 The invariant

Anchor the review on one property: **at `limit <= 8` the composed plan is identical to what Sibyl ships today, field for field.** That range covers `ContextLayer.WAKE` and every caller that asks for a narrow pack, so if it holds, this change cannot regress the shipped configuration; it can only widen requests that were previously silently narrowed. The test that pins it restates the old formula literally rather than calling the new one, because a check that reuses the derivation cannot show that the derivation preserved anything.

## 🛠️ How it works

Everything lives in `packages/python/sibyl-core/src/sibyl_core/retrieval/search.py`.

**1. The derivation.** `seed_candidates_per_signal(limit)` returns `max(MIN_CANDIDATES_PER_SIGNAL, min(limit, MAX_RETRIEVAL_LIMIT))`, and `build_context_retrieval_plan` uses it for all six graph lanes. No new value is introduced by either constant:

| Name | Value | Where it already existed |
| --- | --- | --- |
| `MIN_CANDIDATES_PER_SIGNAL` | 2 | the `max(2, ...)` floor in the old `per_signal_limit` expression |
| `MAX_RETRIEVAL_LIMIT` | 50 | the two `min(limit, 50)` clips in `context_search` and `_candidate_limits_for_limit`, and `LAYER_LIMITS[ContextLayer.DEEP_SEARCH]` |
| `RAW_LEXICAL_LIMIT_DIVISOR` | 4 | the `limit // 4` share the raw-memory lane already took |
| `DEFAULT_CANDIDATES_PER_SIGNAL` | 8 | the old cap, now only the `CandidateLimits` field default for a plan built without a limit |

Both literal `50`s are gone, replaced by the named ceiling, so the plan's widest lane and the deepest read `context_search` accepts can no longer drift apart.

**2. The raw-memory lane keeps its share.** `raw_lexical` reads whole memories rather than passages, so it stays at `limit // RAW_LEXICAL_LIMIT_DIVISOR` and is clamped by the seed budget instead of by the old flat 8. The clamp binds only past the ceiling, where a quarter of the request would exceed `MAX_RETRIEVAL_LIMIT`. Below it, the change to this lane is confined to requests above `limit=32`, where the old flat 8 used to bind and the quarter share now runs to 12 at `limit=50`.

**3. The HNSW effort follows the budget.** An HNSW search keeps at most `ef` nodes in flight, so asking for more neighbours than the configured effort returns fewer rows than requested and raises nothing. With every lane capped at 8 that could not happen, since 8 sits well under the default `graph_knn_ef` of 40. A budget derived from the caller's limit reaches 50 at the deep-search layer and crosses it, so `_graph_knn_effort(candidate_limit)` now floors the effort at `k`. Measured on the dev graph at `limit=50` with the floor removed, both vector lanes were handed 50 and returned 40 while the four non-vector lanes returned 50 each; the floor recovers those rows and takes the pre-fusion pool from 276 to 296. Narrower reads are untouched, so `limit=8` still queries at effort 40.

**4. Query-time limits narrow, never widen.** `_candidate_limits_for_limit` is called from `context_search` with whatever limit the query carries, and it still takes the minimum with the plan's own lane budgets. That direction matters, because `tools/context.py` derives its `search_limit` as `min(50, max(limit, per_facet_limit * len(facets)))`, which can exceed the limit the plan was built from. Narrowing only means a wake-layer plan stays narrow however that arithmetic lands.

**5. The rationale comment says what the rule is.** The old comment argued for holding the cap at 8 pending a measured arm. That argument is now spent, so the comment states the current rule and why the bound is the caller's limit.

## 🧪 Validation

**Unit gates.**

- `moon run core:check` → `core:test` 2129 passed, 14 skipped in 40.29s; `core:lint` "All checks passed!" plus 269 files already formatted; `core:typecheck` clean.
- `moon run :check` at the repo root → `Tasks: 55 completed`, no failures. The root fans out to every lint, typecheck, and gate suite; the per-package check covers about a quarter of it.
- 15 of those tests are new: the 1 through 8 identity range (8 cases), slice-scale widening at 24 and 28, the ceiling at four times `MAX_RETRIEVAL_LIMIT`, the floor at `limit` 0 and 1, monotonicity across 1 through 50, the narrow-only direction of `_candidate_limits_for_limit`, and the HNSW effort floor at `limit=50` with the configured effort left at 40.

**Live probe.** A read-only probe ran `context_search` against the shared dev SurrealDB (10,926 entities, 24,544 edges, real 1024-dimension HNSW indexes) on the pre-change and post-change builds, instrumenting each lane for the limit it was handed, the candidates it returned, and its wall clock. Median of 7 runs after one warm-up, `limit=8` and `limit=28`. The raw-memory lane is stubbed so the probe writes nothing to the content store, and the query embedding comes from the deterministic mock provider, so the vector lanes measure real KNN cost at the real index width against an arbitrary query point.

At `limit=8`, nothing moves, which is what the invariant demands:

| Lane | Before (limit/count/ms) | After (limit/count/ms) |
| --- | --- | --- |
| node fulltext | 8 / 8 / 514.5 | 8 / 8 / 508.9 |
| edge fulltext | 8 / 8 / 112.3 | 8 / 8 / 103.8 |
| episode fulltext | 8 / 8 / 6.2 | 8 / 8 / 8.5 |
| node vector | 8 / 8 / 13.9 | 8 / 8 / 14.2 |
| edge vector | 8 / 8 / 10.8 | 8 / 8 / 11.0 |
| graph expansion | 8 / 8 / 90.5 | 8 / 8 / 88.2 |
| **total** | **619.1 ms**, 48 unique candidates, 8 results | **616.7 ms**, 48 unique candidates, 8 results |

At `limit=28`, the lanes open up and the request becomes fillable:

| Lane | Before (limit/count/ms) | After (limit/count/ms) |
| --- | --- | --- |
| node fulltext | 8 / 8 / 513.6 | 28 / 28 / 520.5 |
| edge fulltext | 8 / 8 / 107.9 | 28 / 28 / 175.2 |
| episode fulltext | 8 / 8 / 8.6 | 28 / 28 / 6.0 |
| node vector | 8 / 8 / 13.9 | 28 / 28 / 28.7 |
| edge vector | 8 / 8 / 11.0 | 28 / 28 / 19.7 |
| graph expansion | 8 / 8 / 89.3 | 28 / 28 / 104.4 |
| **total** | **631.0 ms**, 48 unique candidates, **19 results** | **668.5 ms**, **165 unique candidates**, **28 results** |

Seed diversity goes up 3.4 times and the 28-result request fills for 37.5 ms, about 6 percent. The deeper lanes each cost more (edge fulltext plus 67 ms, both vector lanes plus 24 ms together, graph expansion plus 15 ms) and the total rises by much less than their sum, because the lanes run concurrently behind a node fulltext read that takes roughly 515 ms on its own.

At `limit=50`, the deep-search layer, the candidate counts move the same way. Every lane goes from 8 to 50, the pre-fusion pool goes from 48 unique candidates to 296, and the request returns 50 results where it previously returned 19. Those counts are deterministic and independent of machine load; the timings for this arm are not reported, because the box was running at load average 47 when it was measured and even the `limit=8` control arm inflated fourfold.

⚠️ Three limits on what these numbers prove. Timings are only readable within a session: one probe session measured 718.7 ms at `limit=8` where the plan is provably identical, so a cross-session delta under 100 ms says nothing, and the two tables above are the sessions that ran adjacent in time. The `limit=50` timings are missing for the reason given above, and the counts are what stand in for them. And the dev graph holds 61 passages rather than a passage-dominated corpus, so this probe proves the seed pool and the query cost, not retrieval quality on slices. Quality is what the slice substrate gate measures next, which is the reason this landed before it.

## 🔍 What reviewers should focus on

- **The identity claim at `limit <= 8`.** `_flat_cap_lane_limits` in `tests/test_search.py` is a deliberate copy of the deleted formula. If you think the copy is wrong, that is the finding that matters most.
- **`edge_fulltext` amplification.** The lane multiplies its own budget: `match_limit = max(result_limit * EDGE_FULLTEXT_MATCH_HEADROOM, EDGE_FULLTEXT_MIN_MATCH_LIMIT)` at `search.py:1006`, so its inner `ORDER BY` now covers up to 400 matched edges at `limit=50` where it covered 64 before. The probe's plus 67 ms at `limit=28` is that multiplier, and it is the one lane whose cost grows faster than its seed budget.
- **Graph expansion depth.** `_graph_expansion_fetch_limit` multiplies by `_GRAPH_EXPANSION_FETCH_HEADROOM`, and the lane's seed set is now every candidate the fulltext and vector lanes found, so its input grows with the budget as well as its own fetch.
- **The HNSW effort floor.** `_graph_knn_effort(candidate_limit)` at `search.py:856` now takes the maximum of the configured `graph_knn_ef` and `k`. An operator who lowered the effort deliberately for speed will see it overridden whenever the seed budget runs deeper, which is the choice this makes: an effort below `k` cannot answer the query that was asked, so it is a broken read rather than a cheaper one.
- **The two vector-contract tests.** `test_vector_candidate_sources_use_embedding_contract` and `test_vector_candidate_sources_use_configured_knn_effort` now read the KNN width off the plan they build instead of asserting a literal 8. They were pinning the cap incidentally while testing the embedding contract and the configured HNSW effort, and the new seed-budget tests pin the width itself.
- **Out of scope on purpose:** the composer's character budgets, `TYPED_NOTE_RESERVATION_ITEMS`, the evidence lane (`hybrid_search` reads candidates at `limit * 3` and constructs no `CandidateLimits`, so it never saw this cap), and the `raw_lexical` field default of 4 on `CandidateLimits`, which is inconsistent with the 2 the derivation yields at `limit=8` and predates this change.

## 📌 Follow-ups

- The chunk-geometry benchmark's stage-2 notes and README recorded a null result against this budget by name. The second commit renames those prose references to the live symbol; the recorded finding still holds, since the evidence lane builds no `CandidateLimits` and no `FACET_TYPES` entry names a passage, so the budget cannot reach a passage whatever its value.
- Retrieval quality on a passage-dominated corpus is the slice substrate gate's job, not this PR's. A regression there can now be attributed to slicing rather than to a cap that predated it.
- The `raw_lexical` field default of 4 on `CandidateLimits` disagrees with the 2 the derivation yields at `limit=8`. It predates this change, only a bare `CandidateLimits()` reaches it, and no production path constructs one, so reconciling it is a separate decision about what a plan without lane budgets should mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
