### PR TITLE
fix(ai): type the validation probe agent

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/ai/validation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/validation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from typing import Literal, cast
+from typing import Literal
 
 from pydantic import BaseModel, Field, SecretStr
 from pydantic_ai import Agent
@@ -181,7 +181,7 @@ async def test_surface_config(
     config = resolved.to_llm_config()
     started_at = time.perf_counter()
     try:
-        agent = Agent(
+        agent = Agent[object, _SurfaceProbe](
             build_model(config),
             output_type=_SurfaceProbe,
             retries=output_retry_budget(1),
@@ -206,7 +206,7 @@ async def test_surface_config(
             status="valid",
             valid=True,
             latency_ms=latency_ms,
-            parsed_output=cast(_SurfaceProbe, result.output).model_dump(),
+            parsed_output=result.output.model_dump(),
             input_tokens=_input_tokens(result),
             output_tokens=_output_tokens(result),
         )


### PR DESCRIPTION
## 💡 What this is

The validation probe now carries `_SurfaceProbe` as the `Agent` output type at construction. The explicit generic keeps ty 0.0.63 and 0.0.65 aligned without a call-site cast that one version requires and the other rejects.

## 🎯 The invariant

`AgentRunResult.output` remains `_SurfaceProbe` from construction through serialization. The type is explicit at its source, with no runtime assertion or suppression.

## 🧪 Validation

- `proto run moon -- run core:typecheck --force` on ty 0.0.63 → `All checks passed!`
- The integration tree with Dependabot PR #324 and ty 0.0.65 ran `proto run moon -- run core:lint core:typecheck --force` → `2 completed`
- The same integration tree ran `proto run moon -- run core:test --force -- -k test_surface_config` → `1 passed, 2128 deselected`

## 🔍 What reviewers should focus on

Anchor on the explicit `Agent[object, _SurfaceProbe]` construction. The change removes the cast without changing probe behavior.
