### PR TITLE
feat(trust): machine-generate the team-scope trust receipt

### DIFF
--- a/benchmarks/results/ai-memory/manifest.json
+++ b/benchmarks/results/ai-memory/manifest.json
@@ -526,6 +526,18 @@
           ]
         },
         {
+          "metric": "stamped_scope_mismatch_count",
+          "mode": "receipt",
+          "required_receipt": "team-scope-trust-receipt.json",
+          "receipt_schema": "sibyl-team-scope-trust-receipt-v1",
+          "direction": "lower",
+          "threshold": 0,
+          "require_receipt_checks": true,
+          "required_surfaces": [
+            "private source isolation"
+          ]
+        },
+        {
           "metric": "promotion_attribution_coverage",
           "mode": "receipt",
           "required_receipt": "team-scope-trust-receipt.json",

--- a/benchmarks/results/ai-memory/manifest.json
+++ b/benchmarks/results/ai-memory/manifest.json
@@ -490,6 +490,42 @@
           ]
         },
         {
+          "metric": "surface_disagreement_count",
+          "mode": "receipt",
+          "required_receipt": "team-scope-trust-receipt.json",
+          "receipt_schema": "sibyl-team-scope-trust-receipt-v1",
+          "direction": "lower",
+          "threshold": 0,
+          "require_receipt_checks": true,
+          "required_surfaces": [
+            "team scope service recall"
+          ]
+        },
+        {
+          "metric": "owner_forgery_surviving_count",
+          "mode": "receipt",
+          "required_receipt": "team-scope-trust-receipt.json",
+          "receipt_schema": "sibyl-team-scope-trust-receipt-v1",
+          "direction": "lower",
+          "threshold": 0,
+          "require_receipt_checks": true,
+          "required_surfaces": [
+            "private source isolation"
+          ]
+        },
+        {
+          "metric": "membership_resolution_mismatch_count",
+          "mode": "receipt",
+          "required_receipt": "team-scope-trust-receipt.json",
+          "receipt_schema": "sibyl-team-scope-trust-receipt-v1",
+          "direction": "lower",
+          "threshold": 0,
+          "require_receipt_checks": true,
+          "required_surfaces": [
+            "team membership lookup"
+          ]
+        },
+        {
           "metric": "promotion_attribution_coverage",
           "mode": "receipt",
           "required_receipt": "team-scope-trust-receipt.json",

--- a/benchmarks/results/ai-memory/manifest.json
+++ b/benchmarks/results/ai-memory/manifest.json
@@ -476,6 +476,20 @@
           ]
         },
         {
+          "metric": "allow_failure_count",
+          "mode": "receipt",
+          "required_receipt": "team-scope-trust-receipt.json",
+          "receipt_schema": "sibyl-team-scope-trust-receipt-v1",
+          "direction": "lower",
+          "threshold": 0,
+          "require_receipt_checks": true,
+          "required_surfaces": [
+            "team scope service recall",
+            "graph metadata read filter",
+            "retrieval candidate filter"
+          ]
+        },
+        {
           "metric": "promotion_attribution_coverage",
           "mode": "receipt",
           "required_receipt": "team-scope-trust-receipt.json",

--- a/benchmarks/results/ai-memory/team-scope-trust-receipt.json
+++ b/benchmarks/results/ai-memory/team-scope-trust-receipt.json
@@ -5,14 +5,16 @@
   ],
   "budgets": {
     "allow_failure_count": 0,
-    "allow_probe_count": 12,
-    "deny_probe_count": 23,
+    "allow_probe_count": 13,
+    "deny_probe_count": 31,
     "leak_count": 0,
-    "owner_forgery_offered_count": 3,
+    "membership_resolution_mismatch_count": 0,
+    "owner_forgery_offered_count": 5,
     "owner_forgery_surviving_count": 0,
     "promotion_attribution_coverage": 1,
     "promotion_preview_coverage": 1,
-    "surface_count": 5
+    "surface_count": 6,
+    "surface_disagreement_count": 0
   },
   "checks": [
     {
@@ -86,6 +88,7 @@
   ],
   "claim_boundary": "Machine-generated from an ephemeral embedded auth and content store. Memberships are resolved by the real team and project lookups, scope metadata is stamped by the real capture path, and every probe reads through a real read surface in both the deny and the allow direction.",
   "fixture": "team-scope-isolation-v1",
+  "membership_mismatches": [],
   "memories": [
     {
       "label": "delegated-oncall",
@@ -109,7 +112,9 @@
       "label": "private-member",
       "offered_owner_forgeries": [
         "memory_scope",
-        "principal_id"
+        "principal_id",
+        "scope_backfill_prior",
+        "scope_backfill_source"
       ],
       "owner": "member",
       "requested_scope": "private",
@@ -167,16 +172,18 @@
   ],
   "metrics": {
     "allow_failure_count": 0,
-    "allow_probe_count": 12,
-    "deny_probe_count": 23,
+    "allow_probe_count": 13,
+    "deny_probe_count": 31,
     "graph_team_membership_forwarded": 0,
     "leak_count": 0,
-    "owner_forgery_offered_count": 3,
+    "membership_resolution_mismatch_count": 0,
+    "owner_forgery_offered_count": 5,
     "owner_forgery_surviving_count": 0,
-    "probe_count": 35,
+    "probe_count": 44,
     "promotion_attribution_coverage": 1.0,
     "promotion_preview_coverage": 1.0,
-    "surface_count": 5
+    "surface_count": 6,
+    "surface_disagreement_count": 0
   },
   "principals": [
     {
@@ -195,7 +202,9 @@
     {
       "label": "outsider",
       "resolved_delegations": [],
-      "resolved_projects": [],
+      "resolved_projects": [
+        "64f905d3-0b0b-50ca-83ab-95f541a79964"
+      ],
       "resolved_teams": [
         "cc7ec25b-56e3-51cc-b5e6-83e8564db96b"
       ],
@@ -213,7 +222,8 @@
       "reader": "member",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
-      "surface": "graph_metadata_read"
+      "surface": "graph_metadata_read",
+      "surface_disagreement": false
     },
     {
       "detail": "stamped_scope=delegated owner_is_reader=False",
@@ -223,7 +233,8 @@
       "reader": "outsider",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
-      "surface": "graph_metadata_read"
+      "surface": "graph_metadata_read",
+      "surface_disagreement": false
     },
     {
       "detail": "stamped_scope=private owner_is_reader=True",
@@ -233,7 +244,8 @@
       "reader": "member",
       "requested_scope_key": null,
       "status": "PASS",
-      "surface": "graph_metadata_read"
+      "surface": "graph_metadata_read",
+      "surface_disagreement": false
     },
     {
       "detail": "stamped_scope=private owner_is_reader=False",
@@ -243,7 +255,8 @@
       "reader": "outsider",
       "requested_scope_key": null,
       "status": "PASS",
-      "surface": "graph_metadata_read"
+      "surface": "graph_metadata_read",
+      "surface_disagreement": false
     },
     {
       "detail": "stamped_scope=project owner_is_reader=True",
@@ -253,7 +266,8 @@
       "reader": "member",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "graph_metadata_read"
+      "surface": "graph_metadata_read",
+      "surface_disagreement": false
     },
     {
       "detail": "stamped_scope=project owner_is_reader=False",
@@ -263,7 +277,8 @@
       "reader": "outsider",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "graph_metadata_read"
+      "surface": "graph_metadata_read",
+      "surface_disagreement": false
     },
     {
       "boundary": "graph read helper forwards no team or delegation membership",
@@ -274,7 +289,8 @@
       "reader": "member",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "graph_metadata_read"
+      "surface": "graph_metadata_read",
+      "surface_disagreement": false
     },
     {
       "detail": "stamped_scope=team owner_is_reader=False",
@@ -284,7 +300,97 @@
       "reader": "outsider",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "graph_metadata_read"
+      "surface": "graph_metadata_read",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "granted_spaces=1 row_space=delegated\u001f02fa694a-f5d1-5213-9166-34a434e6323c",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "granted_spaces=1 row_space=delegated\u001f02fa694a-f5d1-5213-9166-34a434e6323c",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "granted_spaces=1 row_space=private\u001f",
+      "expected": "deny",
+      "memory": "private-member",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "granted_spaces=1 row_space=private\u001f",
+      "expected": "deny",
+      "memory": "private-member",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "granted_spaces=1 row_space=project\u001f3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "expected": "allow",
+      "memory": "project-lumen",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "granted_spaces=1 row_space=project\u001f3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "expected": "deny",
+      "memory": "project-lumen",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
+    },
+    {
+      "boundary": "graph read helper forwards no team or delegation membership",
+      "detail": "granted_spaces=1 row_space=team\u001fb63cfc01-0255-597d-83b5-8fca205cbc64",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "granted_spaces=1 row_space=team\u001fb63cfc01-0255-597d-83b5-8fca205cbc64",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=private_principal_bound listed=True recalled=True rows_listed=1 rows_recalled=1",
@@ -294,7 +400,8 @@
       "reader": "member",
       "requested_scope_key": null,
       "status": "PASS",
-      "surface": "raw_own_scope_read"
+      "surface": "raw_own_scope_read",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=private_principal_bound listed=False recalled=False rows_listed=0 rows_recalled=0",
@@ -304,7 +411,8 @@
       "reader": "outsider",
       "requested_scope_key": null,
       "status": "PASS",
-      "surface": "raw_own_scope_read"
+      "surface": "raw_own_scope_read",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=project_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
@@ -314,7 +422,19 @@
       "reader": "member",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "raw_own_scope_read"
+      "surface": "raw_own_scope_read",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "reason=project_access_verified listed=False recalled=False rows_listed=0 rows_recalled=0",
+      "expected": "deny",
+      "memory": "project-lumen",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "64f905d3-0b0b-50ca-83ab-95f541a79964",
+      "status": "PASS",
+      "surface": "raw_own_scope_read",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=team_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
@@ -324,7 +444,8 @@
       "reader": "member",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "raw_own_scope_read"
+      "surface": "raw_own_scope_read",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=team_access_verified listed=False recalled=False rows_listed=0 rows_recalled=0",
@@ -334,7 +455,8 @@
       "reader": "outsider",
       "requested_scope_key": "cc7ec25b-56e3-51cc-b5e6-83e8564db96b",
       "status": "PASS",
-      "surface": "raw_own_scope_read"
+      "surface": "raw_own_scope_read",
+      "surface_disagreement": false
     },
     {
       "boundary": "no resolver grants a delegation, so no principal can hold one",
@@ -345,7 +467,8 @@
       "reader": "member",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
-      "surface": "raw_targeted_read"
+      "surface": "raw_targeted_read",
+      "surface_disagreement": false
     },
     {
       "boundary": "no resolver grants a delegation, so no principal can hold one",
@@ -356,7 +479,8 @@
       "reader": "outsider",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
-      "surface": "raw_targeted_read"
+      "surface": "raw_targeted_read",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=private_principal_bound listed=True recalled=True rows_listed=1 rows_recalled=1",
@@ -366,7 +490,8 @@
       "reader": "member",
       "requested_scope_key": null,
       "status": "PASS",
-      "surface": "raw_targeted_read"
+      "surface": "raw_targeted_read",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=private_principal_bound listed=False recalled=False rows_listed=0 rows_recalled=0",
@@ -376,7 +501,8 @@
       "reader": "outsider",
       "requested_scope_key": null,
       "status": "PASS",
-      "surface": "raw_targeted_read"
+      "surface": "raw_targeted_read",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=project_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
@@ -386,7 +512,8 @@
       "reader": "member",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "raw_targeted_read"
+      "surface": "raw_targeted_read",
+      "surface_disagreement": false
     },
     {
       "detail": "denied_at=authorization reason=unverified_membership",
@@ -396,7 +523,8 @@
       "reader": "outsider",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "raw_targeted_read"
+      "surface": "raw_targeted_read",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=team_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
@@ -406,7 +534,8 @@
       "reader": "member",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "raw_targeted_read"
+      "surface": "raw_targeted_read",
+      "surface_disagreement": false
     },
     {
       "detail": "denied_at=authorization reason=unverified_membership",
@@ -416,7 +545,8 @@
       "reader": "outsider",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "raw_targeted_read"
+      "surface": "raw_targeted_read",
+      "surface_disagreement": false
     },
     {
       "detail": "plan_scopes=private,project",
@@ -426,17 +556,19 @@
       "reader": "member",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
-      "surface": "retrieval_candidate_filter"
+      "surface": "retrieval_candidate_filter",
+      "surface_disagreement": false
     },
     {
-      "detail": "plan_scopes=private",
+      "detail": "plan_scopes=private,project",
       "expected": "deny",
       "memory": "delegated-oncall",
       "observed": "deny",
       "reader": "outsider",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
-      "surface": "retrieval_candidate_filter"
+      "surface": "retrieval_candidate_filter",
+      "surface_disagreement": false
     },
     {
       "detail": "plan_scopes=private,project",
@@ -446,17 +578,19 @@
       "reader": "member",
       "requested_scope_key": null,
       "status": "PASS",
-      "surface": "retrieval_candidate_filter"
+      "surface": "retrieval_candidate_filter",
+      "surface_disagreement": false
     },
     {
-      "detail": "plan_scopes=private",
+      "detail": "plan_scopes=private,project",
       "expected": "deny",
       "memory": "private-member",
       "observed": "deny",
       "reader": "outsider",
       "requested_scope_key": null,
       "status": "PASS",
-      "surface": "retrieval_candidate_filter"
+      "surface": "retrieval_candidate_filter",
+      "surface_disagreement": false
     },
     {
       "detail": "plan_scopes=private,project",
@@ -466,17 +600,19 @@
       "reader": "member",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "retrieval_candidate_filter"
+      "surface": "retrieval_candidate_filter",
+      "surface_disagreement": false
     },
     {
-      "detail": "plan_scopes=private",
+      "detail": "plan_scopes=private,project",
       "expected": "deny",
       "memory": "project-lumen",
       "observed": "deny",
       "reader": "outsider",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "retrieval_candidate_filter"
+      "surface": "retrieval_candidate_filter",
+      "surface_disagreement": false
     },
     {
       "boundary": "graph read helper forwards no team or delegation membership",
@@ -487,17 +623,19 @@
       "reader": "member",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "retrieval_candidate_filter"
+      "surface": "retrieval_candidate_filter",
+      "surface_disagreement": false
     },
     {
-      "detail": "plan_scopes=private",
+      "detail": "plan_scopes=private,project",
       "expected": "deny",
       "memory": "team-alpha",
       "observed": "deny",
       "reader": "outsider",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "retrieval_candidate_filter"
+      "surface": "retrieval_candidate_filter",
+      "surface_disagreement": false
     },
     {
       "boundary": "no resolver grants a delegation, so no principal can hold one",
@@ -508,7 +646,8 @@
       "reader": "member",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
-      "surface": "scope_authorization"
+      "surface": "scope_authorization",
+      "surface_disagreement": false
     },
     {
       "boundary": "no resolver grants a delegation, so no principal can hold one",
@@ -519,7 +658,8 @@
       "reader": "outsider",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
-      "surface": "scope_authorization"
+      "surface": "scope_authorization",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=project_access_verified",
@@ -529,7 +669,8 @@
       "reader": "member",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "scope_authorization"
+      "surface": "scope_authorization",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=unverified_membership",
@@ -539,7 +680,8 @@
       "reader": "outsider",
       "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
       "status": "PASS",
-      "surface": "scope_authorization"
+      "surface": "scope_authorization",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=team_access_verified",
@@ -549,7 +691,8 @@
       "reader": "member",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "scope_authorization"
+      "surface": "scope_authorization",
+      "surface_disagreement": false
     },
     {
       "detail": "reason=unverified_membership",
@@ -559,13 +702,15 @@
       "reader": "outsider",
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
-      "surface": "scope_authorization"
+      "surface": "scope_authorization",
+      "surface_disagreement": false
     }
   ],
   "release_scope": "v1.2 Track C team-scope trust receipt",
   "schema_version": "sibyl-team-scope-trust-receipt-v1",
   "surfaces": [
     "graph_metadata_read",
+    "graph_metadata_read_narrowed",
     "raw_own_scope_read",
     "raw_targeted_read",
     "retrieval_candidate_filter",

--- a/benchmarks/results/ai-memory/team-scope-trust-receipt.json
+++ b/benchmarks/results/ai-memory/team-scope-trust-receipt.json
@@ -1,18 +1,18 @@
 {
   "boundaries": [
-    "graph read helper forwards no team or delegation membership",
-    "no resolver grants a delegation, so no principal can hold one"
+    "graph read helper forwards no team or delegation membership"
   ],
   "budgets": {
     "allow_failure_count": 0,
-    "allow_probe_count": 13,
-    "deny_probe_count": 31,
+    "allow_probe_count": 16,
+    "deny_probe_count": 29,
     "leak_count": 0,
     "membership_resolution_mismatch_count": 0,
     "owner_forgery_offered_count": 5,
     "owner_forgery_surviving_count": 0,
     "promotion_attribution_coverage": 1,
     "promotion_preview_coverage": 1,
+    "stamped_scope_mismatch_count": 0,
     "surface_count": 6,
     "surface_disagreement_count": 0
   },
@@ -50,15 +50,7 @@
       "status": "PASS",
       "surfaces": [
         "team scope REST recall",
-        "unverified team denial"
-      ]
-    },
-    {
-      "command": "moon run api:memory-trust-rest-test",
-      "exit_code": 0,
-      "name": "share-promotion-apply",
-      "status": "PASS",
-      "surfaces": [
+        "unverified team denial",
         "promotion attribution",
         "promotion preview",
         "audit receipt",
@@ -172,23 +164,26 @@
   ],
   "metrics": {
     "allow_failure_count": 0,
-    "allow_probe_count": 13,
-    "deny_probe_count": 31,
+    "allow_probe_count": 16,
+    "deny_probe_count": 29,
     "graph_team_membership_forwarded": 0,
     "leak_count": 0,
     "membership_resolution_mismatch_count": 0,
     "owner_forgery_offered_count": 5,
     "owner_forgery_surviving_count": 0,
-    "probe_count": 44,
+    "probe_count": 45,
     "promotion_attribution_coverage": 1.0,
     "promotion_preview_coverage": 1.0,
+    "stamped_scope_mismatch_count": 0,
     "surface_count": 6,
     "surface_disagreement_count": 0
   },
   "principals": [
     {
       "label": "member",
-      "resolved_delegations": [],
+      "resolved_delegations": [
+        "02fa694a-f5d1-5213-9166-34a434e6323c"
+      ],
       "resolved_projects": [
         "3b1965c7-246a-5b6b-b32a-ce747c41cdc8"
       ],
@@ -215,6 +210,7 @@
   ],
   "probes": [
     {
+      "boundary": "graph read helper forwards no team or delegation membership",
       "detail": "stamped_scope=delegated owner_is_reader=True",
       "expected": "deny",
       "memory": "delegated-oncall",
@@ -304,6 +300,7 @@
       "surface_disagreement": false
     },
     {
+      "boundary": "graph read helper forwards no team or delegation membership",
       "detail": "granted_spaces=1 row_space=delegated\u001f02fa694a-f5d1-5213-9166-34a434e6323c",
       "expected": "deny",
       "memory": "delegated-oncall",
@@ -390,6 +387,17 @@
       "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
       "status": "PASS",
       "surface": "graph_metadata_read_narrowed",
+      "surface_disagreement": false
+    },
+    {
+      "detail": "reason=delegated_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
+      "expected": "allow",
+      "memory": "delegated-oncall",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "raw_own_scope_read",
       "surface_disagreement": false
     },
     {
@@ -459,11 +467,10 @@
       "surface_disagreement": false
     },
     {
-      "boundary": "no resolver grants a delegation, so no principal can hold one",
-      "detail": "denied_at=authorization reason=unverified_membership",
-      "expected": "deny",
+      "detail": "reason=delegated_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
+      "expected": "allow",
       "memory": "delegated-oncall",
-      "observed": "deny",
+      "observed": "allow",
       "reader": "member",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
@@ -471,7 +478,6 @@
       "surface_disagreement": false
     },
     {
-      "boundary": "no resolver grants a delegation, so no principal can hold one",
       "detail": "denied_at=authorization reason=unverified_membership",
       "expected": "deny",
       "memory": "delegated-oncall",
@@ -549,6 +555,7 @@
       "surface_disagreement": false
     },
     {
+      "boundary": "graph read helper forwards no team or delegation membership",
       "detail": "plan_scopes=private,project",
       "expected": "deny",
       "memory": "delegated-oncall",
@@ -638,11 +645,10 @@
       "surface_disagreement": false
     },
     {
-      "boundary": "no resolver grants a delegation, so no principal can hold one",
-      "detail": "reason=unverified_membership",
-      "expected": "deny",
+      "detail": "reason=delegated_access_verified",
+      "expected": "allow",
       "memory": "delegated-oncall",
-      "observed": "deny",
+      "observed": "allow",
       "reader": "member",
       "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
       "status": "PASS",
@@ -650,7 +656,6 @@
       "surface_disagreement": false
     },
     {
-      "boundary": "no resolver grants a delegation, so no principal can hold one",
       "detail": "reason=unverified_membership",
       "expected": "deny",
       "memory": "delegated-oncall",
@@ -708,6 +713,7 @@
   ],
   "release_scope": "v1.2 Track C team-scope trust receipt",
   "schema_version": "sibyl-team-scope-trust-receipt-v1",
+  "stamp_mismatches": [],
   "surfaces": [
     "graph_metadata_read",
     "graph_metadata_read_narrowed",

--- a/benchmarks/results/ai-memory/team-scope-trust-receipt.json
+++ b/benchmarks/results/ai-memory/team-scope-trust-receipt.json
@@ -1,38 +1,61 @@
 {
-  "schema_version": "sibyl-team-scope-trust-receipt-v1",
-  "generated_at": "2026-07-03T22:30:00Z",
-  "release_scope": "v1.1 W8 team-memory foundation",
-  "claim_boundary": "Static receipt for committed unit and route fixtures covering team-scope isolation, promotion attribution, and preview coverage.",
-  "metrics": {
+  "boundaries": [
+    "graph read helper forwards no team or delegation membership",
+    "no resolver grants a delegation, so no principal can hold one"
+  ],
+  "budgets": {
+    "allow_failure_count": 0,
+    "allow_probe_count": 12,
+    "deny_probe_count": 23,
     "leak_count": 0,
+    "owner_forgery_offered_count": 3,
+    "owner_forgery_surviving_count": 0,
     "promotion_attribution_coverage": 1,
-    "promotion_preview_coverage": 1
+    "promotion_preview_coverage": 1,
+    "surface_count": 5
   },
   "checks": [
     {
-      "name": "team-target-preview-redaction",
+      "command": "moon run team-scope-gate",
+      "name": "team-scope-read-isolation",
       "status": "PASS",
-      "command": "moon run core:test -- tests/test_memory.py -k \"share_memory or share_preview\"",
       "surfaces": [
-        "team target redaction",
         "private source isolation",
         "delegated source isolation",
-        "project source isolation"
+        "project source isolation",
+        "unverified team denial",
+        "team membership lookup",
+        "canonical team memory space",
+        "team scope service recall",
+        "graph metadata read filter",
+        "retrieval candidate filter"
       ]
     },
     {
+      "command": "moon run core:test -- tests/test_memory.py -k 'share_memory or share_preview'",
+      "exit_code": 0,
+      "name": "team-target-preview-redaction",
+      "status": "PASS",
+      "surfaces": [
+        "team target redaction",
+        "private source isolation"
+      ]
+    },
+    {
+      "command": "moon run api:memory-trust-rest-test",
+      "exit_code": 0,
       "name": "team-scope-rest-policy",
       "status": "PASS",
-      "command": "moon run api:memory-trust-rest-test",
       "surfaces": [
         "team scope REST recall",
         "unverified team denial"
       ]
     },
     {
+      "command": "moon run api:memory-trust-rest-test",
+      "exit_code": 0,
       "name": "share-promotion-apply",
       "status": "PASS",
-      "command": "moon run api:memory-trust-rest-test",
       "surfaces": [
         "promotion attribution",
         "promotion preview",
@@ -41,13 +64,511 @@
       ]
     },
     {
+      "command": "moon run api:trust-control-auth-test",
+      "exit_code": 0,
       "name": "team-control-plane-auth",
       "status": "PASS",
-      "command": "moon run api:trust-control-auth-test",
       "surfaces": [
         "team membership lookup",
         "canonical team memory space"
       ]
+    },
+    {
+      "command": "moon run bench-gate",
+      "exit_code": 0,
+      "name": "ai-memory-contracts",
+      "status": "PASS",
+      "surfaces": [
+        "manifest",
+        "release contract"
+      ]
     }
+  ],
+  "claim_boundary": "Machine-generated from an ephemeral embedded auth and content store. Memberships are resolved by the real team and project lookups, scope metadata is stamped by the real capture path, and every probe reads through a real read surface in both the deny and the allow direction.",
+  "fixture": "team-scope-isolation-v1",
+  "memories": [
+    {
+      "label": "delegated-oncall",
+      "offered_owner_forgeries": [],
+      "owner": "member",
+      "requested_scope": "delegated",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "stamped_memory_scope": "delegated",
+      "stamped_metadata_keys": [
+        "memory_scope",
+        "principal_id",
+        "raw_memory_id",
+        "raw_source_id",
+        "scope_key"
+      ],
+      "stamped_principal_id": "67d560eb-44c3-5c8c-b3e0-64556dc748bc",
+      "stamped_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "surviving_owner_forgeries": []
+    },
+    {
+      "label": "private-member",
+      "offered_owner_forgeries": [
+        "memory_scope",
+        "principal_id"
+      ],
+      "owner": "member",
+      "requested_scope": "private",
+      "requested_scope_key": null,
+      "stamped_memory_scope": "private",
+      "stamped_metadata_keys": [
+        "memory_scope",
+        "principal_id",
+        "raw_memory_id",
+        "raw_source_id"
+      ],
+      "stamped_principal_id": "67d560eb-44c3-5c8c-b3e0-64556dc748bc",
+      "stamped_scope_key": null,
+      "surviving_owner_forgeries": []
+    },
+    {
+      "label": "project-lumen",
+      "offered_owner_forgeries": [],
+      "owner": "member",
+      "requested_scope": "project",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "stamped_memory_scope": "project",
+      "stamped_metadata_keys": [
+        "memory_scope",
+        "principal_id",
+        "project_id",
+        "raw_memory_id",
+        "raw_source_id",
+        "scope_key"
+      ],
+      "stamped_principal_id": "67d560eb-44c3-5c8c-b3e0-64556dc748bc",
+      "stamped_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "surviving_owner_forgeries": []
+    },
+    {
+      "label": "team-alpha",
+      "offered_owner_forgeries": [
+        "scope_key"
+      ],
+      "owner": "member",
+      "requested_scope": "team",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "stamped_memory_scope": "team",
+      "stamped_metadata_keys": [
+        "memory_scope",
+        "principal_id",
+        "raw_memory_id",
+        "raw_source_id",
+        "scope_key"
+      ],
+      "stamped_principal_id": "67d560eb-44c3-5c8c-b3e0-64556dc748bc",
+      "stamped_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "surviving_owner_forgeries": []
+    }
+  ],
+  "metrics": {
+    "allow_failure_count": 0,
+    "allow_probe_count": 12,
+    "deny_probe_count": 23,
+    "graph_team_membership_forwarded": 0,
+    "leak_count": 0,
+    "owner_forgery_offered_count": 3,
+    "owner_forgery_surviving_count": 0,
+    "probe_count": 35,
+    "promotion_attribution_coverage": 1.0,
+    "promotion_preview_coverage": 1.0,
+    "surface_count": 5
+  },
+  "principals": [
+    {
+      "label": "member",
+      "resolved_delegations": [],
+      "resolved_projects": [
+        "3b1965c7-246a-5b6b-b32a-ce747c41cdc8"
+      ],
+      "resolved_teams": [
+        "b63cfc01-0255-597d-83b5-8fca205cbc64"
+      ],
+      "team_memory_space": [
+        "team\u001fb63cfc01-0255-597d-83b5-8fca205cbc64"
+      ]
+    },
+    {
+      "label": "outsider",
+      "resolved_delegations": [],
+      "resolved_projects": [],
+      "resolved_teams": [
+        "cc7ec25b-56e3-51cc-b5e6-83e8564db96b"
+      ],
+      "team_memory_space": [
+        "team\u001fcc7ec25b-56e3-51cc-b5e6-83e8564db96b"
+      ]
+    }
+  ],
+  "probes": [
+    {
+      "detail": "stamped_scope=delegated owner_is_reader=True",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "graph_metadata_read"
+    },
+    {
+      "detail": "stamped_scope=delegated owner_is_reader=False",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "graph_metadata_read"
+    },
+    {
+      "detail": "stamped_scope=private owner_is_reader=True",
+      "expected": "allow",
+      "memory": "private-member",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "graph_metadata_read"
+    },
+    {
+      "detail": "stamped_scope=private owner_is_reader=False",
+      "expected": "deny",
+      "memory": "private-member",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "graph_metadata_read"
+    },
+    {
+      "detail": "stamped_scope=project owner_is_reader=True",
+      "expected": "allow",
+      "memory": "project-lumen",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "graph_metadata_read"
+    },
+    {
+      "detail": "stamped_scope=project owner_is_reader=False",
+      "expected": "deny",
+      "memory": "project-lumen",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "graph_metadata_read"
+    },
+    {
+      "boundary": "graph read helper forwards no team or delegation membership",
+      "detail": "stamped_scope=team owner_is_reader=True",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "graph_metadata_read"
+    },
+    {
+      "detail": "stamped_scope=team owner_is_reader=False",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "graph_metadata_read"
+    },
+    {
+      "detail": "reason=private_principal_bound listed=True recalled=True rows_listed=1 rows_recalled=1",
+      "expected": "allow",
+      "memory": "private-member",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "raw_own_scope_read"
+    },
+    {
+      "detail": "reason=private_principal_bound listed=False recalled=False rows_listed=0 rows_recalled=0",
+      "expected": "deny",
+      "memory": "private-member",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "raw_own_scope_read"
+    },
+    {
+      "detail": "reason=project_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
+      "expected": "allow",
+      "memory": "project-lumen",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "raw_own_scope_read"
+    },
+    {
+      "detail": "reason=team_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
+      "expected": "allow",
+      "memory": "team-alpha",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "raw_own_scope_read"
+    },
+    {
+      "detail": "reason=team_access_verified listed=False recalled=False rows_listed=0 rows_recalled=0",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "cc7ec25b-56e3-51cc-b5e6-83e8564db96b",
+      "status": "PASS",
+      "surface": "raw_own_scope_read"
+    },
+    {
+      "boundary": "no resolver grants a delegation, so no principal can hold one",
+      "detail": "denied_at=authorization reason=unverified_membership",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "raw_targeted_read"
+    },
+    {
+      "boundary": "no resolver grants a delegation, so no principal can hold one",
+      "detail": "denied_at=authorization reason=unverified_membership",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "raw_targeted_read"
+    },
+    {
+      "detail": "reason=private_principal_bound listed=True recalled=True rows_listed=1 rows_recalled=1",
+      "expected": "allow",
+      "memory": "private-member",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "raw_targeted_read"
+    },
+    {
+      "detail": "reason=private_principal_bound listed=False recalled=False rows_listed=0 rows_recalled=0",
+      "expected": "deny",
+      "memory": "private-member",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "raw_targeted_read"
+    },
+    {
+      "detail": "reason=project_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
+      "expected": "allow",
+      "memory": "project-lumen",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "raw_targeted_read"
+    },
+    {
+      "detail": "denied_at=authorization reason=unverified_membership",
+      "expected": "deny",
+      "memory": "project-lumen",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "raw_targeted_read"
+    },
+    {
+      "detail": "reason=team_access_verified listed=True recalled=True rows_listed=1 rows_recalled=1",
+      "expected": "allow",
+      "memory": "team-alpha",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "raw_targeted_read"
+    },
+    {
+      "detail": "denied_at=authorization reason=unverified_membership",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "raw_targeted_read"
+    },
+    {
+      "detail": "plan_scopes=private,project",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "retrieval_candidate_filter"
+    },
+    {
+      "detail": "plan_scopes=private",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "retrieval_candidate_filter"
+    },
+    {
+      "detail": "plan_scopes=private,project",
+      "expected": "allow",
+      "memory": "private-member",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "retrieval_candidate_filter"
+    },
+    {
+      "detail": "plan_scopes=private",
+      "expected": "deny",
+      "memory": "private-member",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": null,
+      "status": "PASS",
+      "surface": "retrieval_candidate_filter"
+    },
+    {
+      "detail": "plan_scopes=private,project",
+      "expected": "allow",
+      "memory": "project-lumen",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "retrieval_candidate_filter"
+    },
+    {
+      "detail": "plan_scopes=private",
+      "expected": "deny",
+      "memory": "project-lumen",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "retrieval_candidate_filter"
+    },
+    {
+      "boundary": "graph read helper forwards no team or delegation membership",
+      "detail": "plan_scopes=private,project",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "retrieval_candidate_filter"
+    },
+    {
+      "detail": "plan_scopes=private",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "retrieval_candidate_filter"
+    },
+    {
+      "boundary": "no resolver grants a delegation, so no principal can hold one",
+      "detail": "reason=unverified_membership",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "member",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "scope_authorization"
+    },
+    {
+      "boundary": "no resolver grants a delegation, so no principal can hold one",
+      "detail": "reason=unverified_membership",
+      "expected": "deny",
+      "memory": "delegated-oncall",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "02fa694a-f5d1-5213-9166-34a434e6323c",
+      "status": "PASS",
+      "surface": "scope_authorization"
+    },
+    {
+      "detail": "reason=project_access_verified",
+      "expected": "allow",
+      "memory": "project-lumen",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "scope_authorization"
+    },
+    {
+      "detail": "reason=unverified_membership",
+      "expected": "deny",
+      "memory": "project-lumen",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "3b1965c7-246a-5b6b-b32a-ce747c41cdc8",
+      "status": "PASS",
+      "surface": "scope_authorization"
+    },
+    {
+      "detail": "reason=team_access_verified",
+      "expected": "allow",
+      "memory": "team-alpha",
+      "observed": "allow",
+      "reader": "member",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "scope_authorization"
+    },
+    {
+      "detail": "reason=unverified_membership",
+      "expected": "deny",
+      "memory": "team-alpha",
+      "observed": "deny",
+      "reader": "outsider",
+      "requested_scope_key": "b63cfc01-0255-597d-83b5-8fca205cbc64",
+      "status": "PASS",
+      "surface": "scope_authorization"
+    }
+  ],
+  "release_scope": "v1.2 Track C team-scope trust receipt",
+  "schema_version": "sibyl-team-scope-trust-receipt-v1",
+  "surfaces": [
+    "graph_metadata_read",
+    "raw_own_scope_read",
+    "raw_targeted_read",
+    "retrieval_candidate_filter",
+    "scope_authorization"
   ]
 }

--- a/moon.yml
+++ b/moon.yml
@@ -233,6 +233,7 @@ tasks:
       - ~:reflection-quality-gate-test
       - ~:forgetting-gate-test
       - ~:write-path-integrity-gate-test
+      - ~:team-scope-gate-test
       - ~:auth-session-gate-test
       - ~:overview-perf-gate-test
       - ~:synthesis-gate-test
@@ -271,6 +272,7 @@ tasks:
       - ~:reflection-quality-gate-test
       - ~:forgetting-gate-test
       - ~:write-path-integrity-gate-test
+      - ~:team-scope-gate-test
       - ~:auth-session-gate-test
       - ~:overview-perf-gate-test
       - ~:synthesis-gate-test
@@ -1003,6 +1005,30 @@ tasks:
       - tools/trust/**/*.py
       - tools/tests/conftest.py
       - tools/tests/test_write_path_integrity_gate.py
+      - pyproject.toml
+      - moon.yml
+      - apps/api/moon.yml
+      - packages/python/sibyl-core/moon.yml
+
+  team-scope-gate:
+    command: uv run python -m tools.trust.team_scope_gate
+    options:
+      cache: false
+
+  team-scope-gate-observe:
+    command: uv run python -m tools.trust.team_scope_gate --observe-only
+    options:
+      cache: false
+
+  team-scope-gate-test:
+    command: uv run pytest tools/tests/test_team_scope_gate.py -v
+    inputs:
+      - tools/trust/**/*.py
+      - tools/tests/conftest.py
+      - tools/tests/test_team_scope_gate.py
+      - packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
+      - packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py
+      - packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
       - pyproject.toml
       - moon.yml
       - apps/api/moon.yml

--- a/moon.yml
+++ b/moon.yml
@@ -1029,6 +1029,10 @@ tasks:
       - packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
       - packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py
       - packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+      - packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
+      - apps/api/src/sibyl/persistence/surreal/auth_runtime/projects.py
+      - benchmarks/results/ai-memory/manifest.json
+      - benchmarks/results/ai-memory/team-scope-trust-receipt.json
       - pyproject.toml
       - moon.yml
       - apps/api/moon.yml

--- a/tools/tests/test_team_scope_gate.py
+++ b/tools/tests/test_team_scope_gate.py
@@ -12,7 +12,7 @@ import pytest
 from tools.trust import team_scope_gate
 
 MISSING_SURFACE_EXIT_CODE = 2
-GRAPH_TEAM_DENIAL_SURFACE_COUNT = 2
+GRAPH_TEAM_DENIAL_SURFACE_COUNT = 3
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMMITTED_RECEIPT = team_scope_gate.DEFAULT_RECEIPT_PATH
 MANIFEST_PATH = REPO_ROOT / "benchmarks" / "results" / "ai-memory" / "manifest.json"
@@ -105,7 +105,9 @@ class TestObservedReceipt:
         assert by_label["member"]["resolved_teams"] == [team_scope_gate.TEAM_ID]
         assert by_label["member"]["resolved_projects"] == [team_scope_gate.PROJECT_ID]
         assert by_label["outsider"]["resolved_teams"] == [team_scope_gate.OTHER_TEAM_ID]
-        assert by_label["outsider"]["resolved_projects"] == []
+        # The outsider holds a different project so the row-selection clause gets
+        # probed on the project surface too, not just the membership check.
+        assert by_label["outsider"]["resolved_projects"] == [team_scope_gate.OTHER_PROJECT_ID]
 
     def test_write_path_drops_every_forged_owner_field(
         self,
@@ -120,7 +122,16 @@ class TestObservedReceipt:
             for entry in observed_receipt["memories"]
         }
 
-        assert offered["private-member"] == ["memory_scope", "principal_id"]
+        # The two backfill-provenance keys are the pair that matters: the
+        # authorized path never rewrites them, so they survive if the write
+        # path's drop filter is removed, while the scope and owner keys would be
+        # overwritten anyway and cannot prove the filter runs.
+        assert offered["private-member"] == [
+            "memory_scope",
+            "principal_id",
+            "scope_backfill_prior",
+            "scope_backfill_source",
+        ]
         assert offered["team-alpha"] == ["scope_key"]
         assert all(not fields for fields in surviving.values())
 
@@ -237,15 +248,66 @@ class TestValidationCatchesRegressions:
         receipt["probes"] = [
             probe for probe in receipt["probes"] if probe["surface"] != "graph_metadata_read"
         ]
+        receipt["surfaces"] = [
+            surface for surface in receipt["surfaces"] if surface != "graph_metadata_read"
+        ]
         receipt["metrics"]["deny_probe_count"] = 0
         receipt["metrics"]["allow_probe_count"] = 0
-        receipt["metrics"]["surface_count"] = 4
+        receipt["metrics"]["surface_count"] = 5
 
         failures = team_scope_gate.validate_team_scope_receipt(receipt)
 
         assert any("deny_probe_count" in failure for failure in failures)
         assert any("allow_probe_count" in failure for failure in failures)
         assert any("surface_count" in failure for failure in failures)
+        assert any("'graph_metadata_read' never ran" in failure for failure in failures)
+
+    def test_rejects_a_silent_read_surface(self, observed_receipt: dict[str, Any]) -> None:
+        """A recall surface that stops answering must not pass on the listing's word."""
+        receipt = _full_receipt(observed_receipt)
+        allowed = next(
+            index
+            for index, probe in enumerate(receipt["probes"])
+            if probe["expected"] == team_scope_gate.ALLOW
+        )
+        receipt["probes"][allowed] = {
+            **receipt["probes"][allowed],
+            "surface_disagreement": True,
+        }
+        receipt["metrics"]["surface_disagreement_count"] = 1
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("surface_disagreement_count" in failure for failure in failures)
+        assert any("stopped filtering" in failure for failure in failures)
+
+    def test_counts_a_disagreement_as_a_probe_failure(self) -> None:
+        probe = team_scope_gate.ScopeProbe(
+            surface="raw_targeted_read",
+            reader_label="member",
+            memory_label="team-alpha",
+            expectation=team_scope_gate.ALLOW,
+        )
+        observation = team_scope_gate.ProbeObservation(
+            probe=probe,
+            observed=team_scope_gate.ALLOW,
+            detail="listed=True recalled=False",
+            disagreement=True,
+        )
+
+        # The expectation matches, so only the disagreement can fail it.
+        assert observation.leaked is False
+        assert observation.allow_failed is False
+        assert observation.passed is False
+        assert observation.as_receipt_entry()["status"] == "FAIL"
+
+    def test_rejects_an_unknown_probe_surface(self, observed_receipt: dict[str, Any]) -> None:
+        receipt = _full_receipt(observed_receipt)
+        receipt["surfaces"] = [*receipt["surfaces"], "invented_surface"]
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("invented_surface" in failure for failure in failures)
 
     def test_rejects_an_empty_probe_list(self, observed_receipt: dict[str, Any]) -> None:
         receipt = _full_receipt(observed_receipt)
@@ -307,7 +369,12 @@ class TestBoundaryProbe:
             for probe in observed_receipt["probes"]
             if probe["memory"] == "team-alpha"
             and probe["reader"] == "member"
-            and probe["surface"] in {"graph_metadata_read", "retrieval_candidate_filter"}
+            and probe["surface"]
+            in {
+                "graph_metadata_read",
+                "graph_metadata_read_narrowed",
+                "retrieval_candidate_filter",
+            }
         ]
 
         assert len(entitled_team_denials) == GRAPH_TEAM_DENIAL_SURFACE_COUNT
@@ -444,6 +511,28 @@ class TestRunGate:
         assert exit_code == MISSING_SURFACE_EXIT_CODE
         assert "Team scope gate is missing required surfaces:" in messages
         assert "- team target redaction" in messages
+
+    def test_observe_only_enforces_the_anti_vacuity_floors(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        """`--observe-only` is a gate, so a shrunken probe set has to fail it there too."""
+        starved = deepcopy(observed_receipt)
+        starved["probes"] = starved["probes"][:1]
+        starved["surfaces"] = [starved["probes"][0]["surface"]]
+        starved["metrics"]["deny_probe_count"] = 1
+        starved["metrics"]["allow_probe_count"] = 0
+        starved["metrics"]["surface_count"] = 1
+        messages: list[str] = []
+
+        exit_code = team_scope_gate.run_observations(
+            echo=messages.append,
+            receipt_path=None,
+            receipt_builder=lambda: starved,
+        )
+
+        assert exit_code == 1
+        assert any("allow_probe_count" in message for message in messages)
 
     def test_observe_only_never_writes_without_a_path(
         self,

--- a/tools/tests/test_team_scope_gate.py
+++ b/tools/tests/test_team_scope_gate.py
@@ -108,6 +108,10 @@ class TestObservedReceipt:
         # The outsider holds a different project so the row-selection clause gets
         # probed on the project surface too, not just the membership check.
         assert by_label["outsider"]["resolved_projects"] == [team_scope_gate.OTHER_PROJECT_ID]
+        # The delegation resolver reads memory_spaces and memory_space_members, so
+        # the delegated scope has a real serving direction rather than a boundary.
+        assert by_label["member"]["resolved_delegations"] == [team_scope_gate.DELEGATION_ID]
+        assert by_label["outsider"]["resolved_delegations"] == []
 
     def test_write_path_drops_every_forged_owner_field(
         self,
@@ -317,6 +321,31 @@ class TestValidationCatchesRegressions:
 
         assert "receipt probes must be a non-empty list" in failures
 
+    def test_rejects_a_read_neutral_mis_stamp(self, observed_receipt: dict[str, Any]) -> None:
+        """A row stamped for the wrong audience moves no read outcome at all."""
+        receipt = _full_receipt(observed_receipt)
+        receipt["metrics"]["stamped_scope_mismatch_count"] = 1
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("stamped_scope_mismatch_count" in failure for failure in failures)
+        assert any("not captured for" in failure for failure in failures)
+
+    def test_stamp_mismatch_is_detected_from_the_stamped_metadata(self) -> None:
+        memory = team_scope_gate.SeededMemory(
+            label="team-alpha",
+            memory_scope="team",
+            scope_key="team-1",
+            owner_label="member",
+            title="t",
+            content="c",
+            raw_memory_id="r",
+            graph_metadata={"memory_scope": "project", "scope_key": "team-1"},
+            requested_metadata={},
+        )
+
+        assert memory.stamp_mismatches == ("team-alpha captured as team but stamped project",)
+
     def test_rejects_a_surviving_owner_forgery(self, observed_receipt: dict[str, Any]) -> None:
         receipt = _full_receipt(observed_receipt)
         receipt["metrics"]["owner_forgery_surviving_count"] = 1
@@ -382,11 +411,24 @@ class TestBoundaryProbe:
             assert probe["expected"] == team_scope_gate.DENY
             assert probe["boundary"] == team_scope_gate.GRAPH_MEMBERSHIP_BOUNDARY
 
-    def test_records_both_boundaries(self, observed_receipt: dict[str, Any]) -> None:
-        assert observed_receipt["boundaries"] == [
-            team_scope_gate.GRAPH_MEMBERSHIP_BOUNDARY,
-            team_scope_gate.DELEGATION_RESOLVER_BOUNDARY,
-        ]
+    def test_records_only_the_graph_membership_boundary(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        assert observed_receipt["boundaries"] == [team_scope_gate.GRAPH_MEMBERSHIP_BOUNDARY]
+
+    def test_delegated_scope_is_probed_in_both_directions(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        """A boundary asserting nobody can hold a delegation would be unfalsifiable."""
+        directions = {
+            probe["expected"]
+            for probe in observed_receipt["probes"]
+            if probe["memory"] == "delegated-oncall"
+        }
+
+        assert directions == {team_scope_gate.ALLOW, team_scope_gate.DENY}
 
 
 class TestPromotionCoverage:
@@ -406,7 +448,7 @@ class TestPromotionCoverage:
         results = [
             team_scope_gate.GateResult(
                 check=check,
-                exit_code=1 if check.name == "share-promotion-apply" else 0,
+                exit_code=1 if check.name == "team-scope-rest-policy" else 0,
                 elapsed_seconds=0.0,
             )
             for check in team_scope_gate.GATE_CHECKS

--- a/tools/tests/test_team_scope_gate.py
+++ b/tools/tests/test_team_scope_gate.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+from shutil import which
+from typing import Any, NotRequired, TypedDict, cast
+
+import pytest
+from tools.trust import team_scope_gate
+
+MISSING_SURFACE_EXIT_CODE = 2
+GRAPH_TEAM_DENIAL_SURFACE_COUNT = 2
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMITTED_RECEIPT = team_scope_gate.DEFAULT_RECEIPT_PATH
+MANIFEST_PATH = REPO_ROOT / "benchmarks" / "results" / "ai-memory" / "manifest.json"
+
+
+class MoonTask(TypedDict):
+    command: str
+    args: NotRequired[list[str]]
+    target: str
+
+
+class MoonTaskQuery(TypedDict):
+    tasks: dict[str, dict[str, MoonTask]]
+
+
+def _root_moon_tasks() -> dict[str, MoonTask]:
+    moon = which("moon")
+    assert moon is not None
+
+    result = subprocess.run(  # noqa: S603
+        [moon, "query", "tasks", "--project", "root"],
+        cwd=REPO_ROOT,
+        env={**os.environ, "MOON_COLOR": "false"},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = cast(MoonTaskQuery, json.loads(result.stdout))
+    return payload["tasks"]["root"]
+
+
+@pytest.fixture(scope="module")
+def observed_receipt() -> dict[str, Any]:
+    """One real fixture-store run, shared by every test that reads observations."""
+    return team_scope_gate.build_observed_team_scope_receipt()
+
+
+@pytest.fixture(scope="module")
+def committed_receipt() -> dict[str, Any]:
+    return cast("dict[str, Any]", json.loads(COMMITTED_RECEIPT.read_text(encoding="utf-8")))
+
+
+def _passing_results() -> list[team_scope_gate.GateResult]:
+    return [
+        team_scope_gate.GateResult(check=check, exit_code=0, elapsed_seconds=0.0)
+        for check in team_scope_gate.GATE_CHECKS
+    ]
+
+
+def _full_receipt(observed: dict[str, Any]) -> dict[str, Any]:
+    results = _passing_results()
+    return team_scope_gate.with_check_results(
+        team_scope_gate.with_promotion_coverage(deepcopy(observed), results),
+        results,
+    )
+
+
+class TestObservedReceipt:
+    def test_reports_no_leak_and_no_allow_failure(self, observed_receipt: dict[str, Any]) -> None:
+        metrics = observed_receipt["metrics"]
+
+        assert metrics["leak_count"] == 0
+        assert metrics["allow_failure_count"] == 0
+        assert observed_receipt["schema_version"] == team_scope_gate.RECEIPT_SCHEMA_VERSION
+
+    def test_probes_both_directions_on_every_surface(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        directions: dict[str, set[str]] = {}
+        for probe in observed_receipt["probes"]:
+            directions.setdefault(probe["surface"], set()).add(probe["expected"])
+
+        assert directions, "receipt recorded no probes"
+        deny_only = sorted(
+            surface for surface, seen in directions.items() if seen == {team_scope_gate.DENY}
+        )
+        # Only the surfaces that cannot serve a team row at all may be deny-only,
+        # and they have to say so through a declared boundary.
+        assert deny_only == [], f"surfaces probed in one direction only: {deny_only}"
+
+    def test_resolves_membership_from_the_auth_store(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        by_label = {entry["label"]: entry for entry in observed_receipt["principals"]}
+
+        assert by_label["member"]["resolved_teams"] == [team_scope_gate.TEAM_ID]
+        assert by_label["member"]["resolved_projects"] == [team_scope_gate.PROJECT_ID]
+        assert by_label["outsider"]["resolved_teams"] == [team_scope_gate.OTHER_TEAM_ID]
+        assert by_label["outsider"]["resolved_projects"] == []
+
+    def test_write_path_drops_every_forged_owner_field(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        offered = {
+            entry["label"]: entry["offered_owner_forgeries"]
+            for entry in observed_receipt["memories"]
+        }
+        surviving = {
+            entry["label"]: entry["surviving_owner_forgeries"]
+            for entry in observed_receipt["memories"]
+        }
+
+        assert offered["private-member"] == ["memory_scope", "principal_id"]
+        assert offered["team-alpha"] == ["scope_key"]
+        assert all(not fields for fields in surviving.values())
+
+    def test_team_row_is_stamped_with_the_authorized_key(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        team_row = next(
+            entry for entry in observed_receipt["memories"] if entry["label"] == "team-alpha"
+        )
+
+        assert team_row["stamped_memory_scope"] == "team"
+        assert team_row["stamped_scope_key"] == team_scope_gate.TEAM_ID
+        assert team_row["stamped_principal_id"] == team_scope_gate.PRINCIPAL_IDS["member"]
+
+    def test_is_byte_deterministic(self, observed_receipt: dict[str, Any]) -> None:
+        rebuilt = team_scope_gate.build_observed_team_scope_receipt()
+
+        assert json.dumps(rebuilt, sort_keys=True) == json.dumps(
+            observed_receipt,
+            sort_keys=True,
+        )
+
+    def test_validates_once_evidence_checks_pass(self, observed_receipt: dict[str, Any]) -> None:
+        assert team_scope_gate.validate_team_scope_receipt(_full_receipt(observed_receipt)) == []
+
+
+class TestCommittedReceipt:
+    def test_matches_a_fresh_observation(
+        self,
+        committed_receipt: dict[str, Any],
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        """The committed receipt has to be regenerable, or it is hand-typed again."""
+        assert team_scope_gate.observed_receipt_fields(
+            committed_receipt
+        ) == team_scope_gate.observed_receipt_fields(observed_receipt)
+
+    def test_carries_no_wall_clock_field(self, committed_receipt: dict[str, Any]) -> None:
+        assert "generated_at" not in committed_receipt
+
+    def test_satisfies_its_own_validator(self, committed_receipt: dict[str, Any]) -> None:
+        assert team_scope_gate.validate_team_scope_receipt(committed_receipt) == []
+
+    def test_covers_every_manifest_required_surface(
+        self,
+        committed_receipt: dict[str, Any],
+    ) -> None:
+        manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        contract = next(
+            entry
+            for entry in manifest["gate_contracts"]
+            if entry["name"] == "team-scope-trust-gate"
+        )
+        covered = {
+            surface for check in committed_receipt["checks"] for surface in check["surfaces"]
+        }
+
+        for metric_contract in contract["metric_contracts"]:
+            assert metric_contract["receipt_schema"] == team_scope_gate.RECEIPT_SCHEMA_VERSION
+            assert metric_contract["metric"] in committed_receipt["metrics"]
+            for surface in metric_contract.get("required_surfaces", []):
+                assert surface in covered, f"{surface} is required but uncovered"
+
+    def test_manifest_gates_the_allow_direction(self) -> None:
+        manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        contract = next(
+            entry
+            for entry in manifest["gate_contracts"]
+            if entry["name"] == "team-scope-trust-gate"
+        )
+        allow_contract = next(
+            entry
+            for entry in contract["metric_contracts"]
+            if entry["metric"] == "allow_failure_count"
+        )
+
+        assert allow_contract["direction"] == "lower"
+        assert allow_contract["threshold"] == 0
+        assert allow_contract["require_receipt_checks"] is True
+
+
+class TestValidationCatchesRegressions:
+    def test_rejects_a_leak(self, observed_receipt: dict[str, Any]) -> None:
+        receipt = _full_receipt(observed_receipt)
+        receipt["metrics"]["leak_count"] = 1
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("leak_count" in failure for failure in failures)
+
+    def test_rejects_an_allow_failure(self, observed_receipt: dict[str, Any]) -> None:
+        receipt = _full_receipt(observed_receipt)
+        receipt["metrics"]["allow_failure_count"] = 2
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("allow_failure_count" in failure for failure in failures)
+
+    def test_rejects_a_failing_probe_even_when_metrics_read_clean(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        receipt = _full_receipt(observed_receipt)
+        receipt["probes"][0] = {**receipt["probes"][0], "status": "FAIL", "observed": "allow"}
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("expected" in failure for failure in failures)
+
+    def test_rejects_a_dropped_probe_family(self, observed_receipt: dict[str, Any]) -> None:
+        """A gate that stops probing must not read as a gate that found nothing."""
+        receipt = _full_receipt(observed_receipt)
+        receipt["probes"] = [
+            probe for probe in receipt["probes"] if probe["surface"] != "graph_metadata_read"
+        ]
+        receipt["metrics"]["deny_probe_count"] = 0
+        receipt["metrics"]["allow_probe_count"] = 0
+        receipt["metrics"]["surface_count"] = 4
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("deny_probe_count" in failure for failure in failures)
+        assert any("allow_probe_count" in failure for failure in failures)
+        assert any("surface_count" in failure for failure in failures)
+
+    def test_rejects_an_empty_probe_list(self, observed_receipt: dict[str, Any]) -> None:
+        receipt = _full_receipt(observed_receipt)
+        receipt["probes"] = []
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert "receipt probes must be a non-empty list" in failures
+
+    def test_rejects_a_surviving_owner_forgery(self, observed_receipt: dict[str, Any]) -> None:
+        receipt = _full_receipt(observed_receipt)
+        receipt["metrics"]["owner_forgery_surviving_count"] = 1
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("owner_forgery_surviving_count" in failure for failure in failures)
+
+    def test_rejects_a_receipt_that_offered_no_forgery(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        receipt = _full_receipt(observed_receipt)
+        receipt["metrics"]["owner_forgery_offered_count"] = 0
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("owner_forgery_offered_count" in failure for failure in failures)
+
+    def test_rejects_a_stale_graph_membership_boundary(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        """Fixing the graph read helper must force the boundary to be retired."""
+        receipt = _full_receipt(observed_receipt)
+        receipt["metrics"]["graph_team_membership_forwarded"] = 1
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("retire the" in failure for failure in failures)
+
+    def test_rejects_a_missing_promotion_coverage(self, observed_receipt: dict[str, Any]) -> None:
+        receipt = team_scope_gate.with_check_results(deepcopy(observed_receipt), [])
+
+        failures = team_scope_gate.validate_team_scope_receipt(receipt)
+
+        assert any("promotion_attribution_coverage" in failure for failure in failures)
+
+
+class TestBoundaryProbe:
+    def test_reports_the_current_read_helper_signature(self) -> None:
+        assert team_scope_gate.graph_team_membership_forwarded() is False
+
+    def test_declares_the_boundary_on_entitled_team_denials(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        entitled_team_denials = [
+            probe
+            for probe in observed_receipt["probes"]
+            if probe["memory"] == "team-alpha"
+            and probe["reader"] == "member"
+            and probe["surface"] in {"graph_metadata_read", "retrieval_candidate_filter"}
+        ]
+
+        assert len(entitled_team_denials) == GRAPH_TEAM_DENIAL_SURFACE_COUNT
+        for probe in entitled_team_denials:
+            assert probe["expected"] == team_scope_gate.DENY
+            assert probe["boundary"] == team_scope_gate.GRAPH_MEMBERSHIP_BOUNDARY
+
+    def test_records_both_boundaries(self, observed_receipt: dict[str, Any]) -> None:
+        assert observed_receipt["boundaries"] == [
+            team_scope_gate.GRAPH_MEMBERSHIP_BOUNDARY,
+            team_scope_gate.DELEGATION_RESOLVER_BOUNDARY,
+        ]
+
+
+class TestPromotionCoverage:
+    def test_is_one_when_every_promotion_check_passes(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        receipt = team_scope_gate.with_promotion_coverage(
+            deepcopy(observed_receipt),
+            _passing_results(),
+        )
+
+        assert receipt["metrics"]["promotion_attribution_coverage"] == 1
+        assert receipt["metrics"]["promotion_preview_coverage"] == 1
+
+    def test_drops_when_a_promotion_check_fails(self, observed_receipt: dict[str, Any]) -> None:
+        results = [
+            team_scope_gate.GateResult(
+                check=check,
+                exit_code=1 if check.name == "share-promotion-apply" else 0,
+                elapsed_seconds=0.0,
+            )
+            for check in team_scope_gate.GATE_CHECKS
+        ]
+
+        receipt = team_scope_gate.with_promotion_coverage(deepcopy(observed_receipt), results)
+
+        assert receipt["metrics"]["promotion_attribution_coverage"] < 1
+        assert receipt["metrics"]["promotion_preview_coverage"] < 1
+
+    def test_is_zero_when_the_checks_never_ran(self, observed_receipt: dict[str, Any]) -> None:
+        receipt = team_scope_gate.with_promotion_coverage(deepcopy(observed_receipt), [])
+
+        assert receipt["metrics"]["promotion_attribution_coverage"] == 0
+        assert receipt["metrics"]["promotion_preview_coverage"] == 0
+
+
+class TestRunGate:
+    def test_executes_every_check_and_writes_a_receipt(
+        self,
+        observed_receipt: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        commands: list[tuple[str, ...]] = []
+        receipt_path = tmp_path / "receipt.json"
+
+        exit_code = team_scope_gate.run_gate(
+            runner=lambda command: commands.append(command) or 0,
+            echo=lambda _: None,
+            receipt_path=receipt_path,
+            receipt_builder=lambda: deepcopy(observed_receipt),
+        )
+
+        assert exit_code == 0
+        assert commands == [check.command for check in team_scope_gate.GATE_CHECKS]
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        assert receipt["metrics"]["leak_count"] == 0
+        assert receipt["metrics"]["promotion_attribution_coverage"] == 1
+
+    def test_fails_and_still_writes_a_receipt_when_a_check_fails(
+        self,
+        observed_receipt: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        failing = team_scope_gate.GATE_CHECKS[1]
+        receipt_path = tmp_path / "receipt.json"
+        messages: list[str] = []
+
+        exit_code = team_scope_gate.run_gate(
+            runner=lambda command: 1 if command == failing.command else 0,
+            echo=messages.append,
+            receipt_path=receipt_path,
+            receipt_builder=lambda: deepcopy(observed_receipt),
+        )
+
+        assert exit_code == 1
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        statuses = {check["name"]: check["status"] for check in receipt["checks"]}
+        assert statuses[failing.name] == "FAIL"
+
+    def test_reports_a_leak_without_running_evidence_checks(
+        self,
+        observed_receipt: dict[str, Any],
+        tmp_path: Path,
+    ) -> None:
+        leaked = deepcopy(observed_receipt)
+        leaked["metrics"]["leak_count"] = 1
+        leaked["probes"][0] = {
+            **leaked["probes"][0],
+            "status": "FAIL",
+            "expected": team_scope_gate.DENY,
+            "observed": team_scope_gate.ALLOW,
+        }
+        messages: list[str] = []
+
+        exit_code = team_scope_gate.run_gate(
+            runner=lambda _: 0,
+            echo=messages.append,
+            receipt_path=tmp_path / "receipt.json",
+            receipt_builder=lambda: leaked,
+        )
+
+        assert exit_code == 1
+        assert any("leak_count: 1" in message for message in messages)
+
+    def test_rejects_missing_required_surface(self) -> None:
+        check = team_scope_gate.GateCheck(
+            name="partial",
+            description="partial coverage",
+            surfaces=("manifest",),
+            command=("moon", "run", "bench-gate"),
+        )
+        messages: list[str] = []
+
+        exit_code = team_scope_gate.run_gate(
+            [check],
+            runner=lambda _: 0,
+            echo=messages.append,
+            receipt_path=None,
+        )
+
+        assert exit_code == MISSING_SURFACE_EXIT_CODE
+        assert "Team scope gate is missing required surfaces:" in messages
+        assert "- team target redaction" in messages
+
+    def test_observe_only_never_writes_without_a_path(
+        self,
+        observed_receipt: dict[str, Any],
+    ) -> None:
+        messages: list[str] = []
+
+        exit_code = team_scope_gate.run_observations(
+            echo=messages.append,
+            receipt_path=None,
+            receipt_builder=lambda: deepcopy(observed_receipt),
+        )
+
+        assert exit_code == 0
+        assert not any("receipt:" in message for message in messages)
+
+
+class TestCommandLine:
+    def test_lists_gate_checks(self, capsys: pytest.CaptureFixture[str]) -> None:
+        exit_code = team_scope_gate.main(["--list"])
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "team-scope-rest-policy: moon run api:memory-trust-rest-test" in captured.out
+        assert "ai-memory-contracts: moon run bench-gate" in captured.out
+
+    def test_root_moon_tasks_expose_the_gate(self) -> None:
+        tasks = _root_moon_tasks()
+
+        gate = tasks["team-scope-gate"]
+        assert gate["target"] == "root:team-scope-gate"
+        assert gate["command"] == "uv"
+        assert gate["args"] == ["run", "python", "-m", "tools.trust.team_scope_gate"]
+
+        observe = tasks["team-scope-gate-observe"]
+        assert observe["args"] == [
+            "run",
+            "python",
+            "-m",
+            "tools.trust.team_scope_gate",
+            "--observe-only",
+        ]
+
+        test_task = tasks["team-scope-gate-test"]
+        assert test_task["target"] == "root:team-scope-gate-test"
+        assert test_task["args"] == [
+            "run",
+            "pytest",
+            "tools/tests/test_team_scope_gate.py",
+            "-v",
+        ]

--- a/tools/trust/team_scope_gate.py
+++ b/tools/trust/team_scope_gate.py
@@ -75,8 +75,8 @@ TEAM_SCOPE_BUDGETS: dict[str, float] = {
     # A gate that probes nothing reports zero leaks. These floors are what stop a
     # vacuous receipt from reading as a clean one, so they are budgets rather
     # than commentary: dropping a probe class fails the gate.
-    "deny_probe_count": 31,
-    "allow_probe_count": 13,
+    "deny_probe_count": 29,
+    "allow_probe_count": 16,
     "surface_count": 6,
     # Five forged owner fields, and the two backfill-provenance keys matter most:
     # nothing downstream rewrites them, so they are the pair that proves the
@@ -90,6 +90,11 @@ TEAM_SCOPE_BUDGETS: dict[str, float] = {
     # over-broad resolver could move them together and stay green. The rows this
     # gate provisions are the independent ground truth that check sits against.
     "membership_resolution_mismatch_count": 0,
+    # A row stamped with the wrong scope can still be served and refused to
+    # exactly the right readers, so no read outcome moves and every counter
+    # above stays zero. Only comparing the stamp against the captured scope
+    # catches it, which makes this the one check with no probe behind it.
+    "stamped_scope_mismatch_count": 0,
 }
 LOWER_IS_BETTER_METRICS = frozenset(
     (
@@ -99,6 +104,7 @@ LOWER_IS_BETTER_METRICS = frozenset(
         "owner_forgery_surviving_count",
         "surface_disagreement_count",
         "membership_resolution_mismatch_count",
+        "stamped_scope_mismatch_count",
     )
 )
 
@@ -156,6 +162,10 @@ PROVISIONED_TEAMS: Mapping[str, frozenset[str]] = {
 PROVISIONED_PROJECTS: Mapping[str, frozenset[str]] = {
     "member": frozenset({PROJECT_ID}),
     "outsider": frozenset({OTHER_PROJECT_ID}),
+}
+PROVISIONED_DELEGATIONS: Mapping[str, frozenset[str]] = {
+    "member": frozenset({DELEGATION_ID}),
+    "outsider": frozenset(),
 }
 
 ALLOW = "allow"
@@ -220,6 +230,28 @@ class SeededMemory:
     raw_memory_id: str
     graph_metadata: Mapping[str, Any]
     requested_metadata: Mapping[str, Any]
+
+    @property
+    def stamp_mismatches(self) -> tuple[str, ...]:
+        """Where the stamped audience differs from the one capture was asked for.
+
+        A private row deliberately carries no scope key, since its owner resolves
+        from principal_id; every other scope must carry the key it was captured
+        with or it is addressed to the wrong audience.
+        """
+        stamped_scope = self.graph_metadata.get("memory_scope")
+        stamped_key = self.graph_metadata.get("scope_key")
+        expected_key = None if self.memory_scope == MemoryScope.PRIVATE.value else self.scope_key
+        mismatches: list[str] = []
+        if stamped_scope != self.memory_scope:
+            mismatches.append(
+                f"{self.label} captured as {self.memory_scope} but stamped {stamped_scope}"
+            )
+        if stamped_key != expected_key:
+            mismatches.append(
+                f"{self.label} captured for key {expected_key} but stamped {stamped_key}"
+            )
+        return tuple(mismatches)
 
     @property
     def offered_owner_forgeries(self) -> tuple[str, ...]:
@@ -332,16 +364,18 @@ GATE_CHECKS: tuple[GateCheck, ...] = (
             "share_memory or share_preview",
         ),
     ),
+    # One command, one row. Naming it twice made promotion coverage read as two
+    # executions when the second was a cache hit of the first, so the surfaces
+    # both rows claimed are carried by the single run that actually proves them.
     GateCheck(
         name="team-scope-rest-policy",
-        description="REST recall serves a verified team and denies an unverified one",
-        surfaces=("team scope REST recall", "unverified team denial"),
-        command=("moon", "run", "api:memory-trust-rest-test"),
-    ),
-    GateCheck(
-        name="share-promotion-apply",
-        description="promotion to a team target records attribution and an audit receipt",
+        description=(
+            "REST recall serves a verified team, denies an unverified one, and "
+            "records promotion attribution with an audit receipt"
+        ),
         surfaces=(
+            "team scope REST recall",
+            "unverified team denial",
             "promotion attribution",
             "promotion preview",
             "audit receipt",
@@ -483,12 +517,25 @@ async def _provision_principals(client: SurrealAuthClient) -> dict[str, Principa
             uuid: $other_project_membership, organization_id: $organization,
             project_id: $other_project, user_id: $outsider
         };
+        CREATE memory_spaces CONTENT {
+            uuid: $delegation_space, organization_id: $organization,
+            memory_scope: 'delegated', scope_key: $delegation, name: 'Oncall',
+            state: 'active', created_by_user_id: $member
+        };
+        CREATE memory_space_members CONTENT {
+            uuid: $delegation_membership, organization_id: $organization,
+            space_id: $delegation_space, principal_type: 'user',
+            principal_id: $member, created_by_user_id: $member
+        };
         """,
         organization=ORGANIZATION_ID,
         team=TEAM_ID,
         other_team=OTHER_TEAM_ID,
         project=PROJECT_ID,
         other_project=OTHER_PROJECT_ID,
+        delegation=DELEGATION_ID,
+        delegation_space=_fixture_id("memory-space-oncall"),
+        delegation_membership=_fixture_id("membership-member-oncall"),
         member=PRINCIPAL_IDS["member"],
         outsider=PRINCIPAL_IDS["outsider"],
         membership=_fixture_id("membership-member-alpha"),
@@ -509,14 +556,13 @@ async def _provision_principals(client: SurrealAuthClient) -> dict[str, Principa
             context = _auth_context(user_id)
             teams = await projects_runtime.list_accessible_team_scope_keys(context)
             projects = await projects_runtime.list_accessible_project_graph_ids(context)
+            delegations = await projects_runtime.list_accessible_delegated_scope_keys(context)
             principals[label] = Principal(
                 label=label,
                 user_id=user_id,
                 teams=frozenset(str(value) for value in teams),
                 projects=frozenset(str(value) for value in projects),
-                # No delegation is granted to anyone, so the delegated row's
-                # isolation is observed rather than assumed away.
-                delegations=frozenset(),
+                delegations=frozenset(str(value) for value in delegations),
             )
     finally:
         projects_runtime._auth_client_scope = previous_scope
@@ -665,7 +711,6 @@ _GRAPH_SERVABLE_SCOPES = frozenset(
     (MemoryScope.PRIVATE.value, MemoryScope.PROJECT.value),
 )
 GRAPH_MEMBERSHIP_BOUNDARY = "graph read helper forwards no team or delegation membership"
-DELEGATION_RESOLVER_BOUNDARY = "no resolver grants a delegation, so no principal can hold one"
 
 
 def _expected_probes(
@@ -684,9 +729,6 @@ def _expected_probes(
         for label in sorted(principals):
             principal = principals[label]
             entitled = _reader_grants(principal, memory)
-            delegated_unreachable = (
-                memory.memory_scope == MemoryScope.DELEGATED.value and not principal.delegations
-            )
 
             # Reaching for the row's own audience: the membership check answers.
             probes.append(
@@ -696,7 +738,6 @@ def _expected_probes(
                     memory_label=memory.label,
                     expectation=ALLOW if entitled else DENY,
                     requested_scope_key=memory.scope_key,
-                    boundary=DELEGATION_RESOLVER_BOUNDARY if delegated_unreachable else None,
                 )
             )
             if memory.memory_scope != MemoryScope.PRIVATE.value:
@@ -707,7 +748,6 @@ def _expected_probes(
                         memory_label=memory.label,
                         expectation=ALLOW if entitled else DENY,
                         requested_scope_key=memory.scope_key,
-                        boundary=DELEGATION_RESOLVER_BOUNDARY if delegated_unreachable else None,
                     )
                 )
 
@@ -776,6 +816,11 @@ def membership_resolution_mismatches(
         for kind, resolved, provisioned in (
             ("teams", principal.teams, PROVISIONED_TEAMS.get(label, frozenset())),
             ("projects", principal.projects, PROVISIONED_PROJECTS.get(label, frozenset())),
+            (
+                "delegations",
+                principal.delegations,
+                PROVISIONED_DELEGATIONS.get(label, frozenset()),
+            ),
         ):
             if resolved != provisioned:
                 mismatches.append(
@@ -1069,6 +1114,7 @@ def build_team_scope_receipt(
         "owner_forgery_offered_count": sum(
             len(memory.offered_owner_forgeries) for memory in memories
         ),
+        "stamped_scope_mismatch_count": sum(len(memory.stamp_mismatches) for memory in memories),
         "owner_forgery_surviving_count": sum(
             len(memory.surviving_owner_forgeries) for memory in memories
         ),
@@ -1091,6 +1137,9 @@ def build_team_scope_receipt(
         "metrics": metrics,
         "boundaries": boundaries,
         "membership_mismatches": mismatches,
+        "stamp_mismatches": [
+            mismatch for memory in memories for mismatch in memory.stamp_mismatches
+        ],
         "principals": [_principal_entry(principals[label]) for label in sorted(principals)],
         "memories": [_memory_entry(memory) for memory in memories],
         "probes": [observation.as_receipt_entry() for observation in ordered],
@@ -1103,6 +1152,7 @@ OBSERVED_RECEIPT_FIELDS: tuple[str, ...] = (
     "fixture",
     "boundaries",
     "membership_mismatches",
+    "stamp_mismatches",
     "principals",
     "memories",
     "probes",
@@ -1231,6 +1281,16 @@ def _validate_receipt_metrics(
                 failures.append(f"metric {metric!r} exceeds budget {budget}: {value}")
         elif float(value) < float(budget):
             failures.append(f"metric {metric!r} below budget {budget}: {value}")
+    stamp_mismatch = metrics.get("stamped_scope_mismatch_count")
+    if (
+        isinstance(stamp_mismatch, int | float)
+        and not isinstance(stamp_mismatch, bool)
+        and stamp_mismatch
+    ):
+        failures.append(
+            "a captured row was stamped with an audience it was not captured for, "
+            "which every read probe can still agree with"
+        )
     mismatch = metrics.get("membership_resolution_mismatch_count")
     if isinstance(mismatch, int | float) and not isinstance(mismatch, bool) and mismatch:
         failures.append(
@@ -1371,6 +1431,8 @@ def _print_observations(receipt: Mapping[str, Any], *, echo: Echo) -> None:
     echo(f"leak_count: {metrics['leak_count']}")
     echo(f"allow_failure_count: {metrics['allow_failure_count']}")
     echo(f"surface_disagreement_count: {metrics['surface_disagreement_count']}")
+    for mismatch in receipt.get("stamp_mismatches", []):
+        echo(f"stamp mismatch: {mismatch}")
     for mismatch in receipt.get("membership_mismatches", []):
         echo(f"membership mismatch: {mismatch}")
     for boundary in receipt.get("boundaries", []):

--- a/tools/trust/team_scope_gate.py
+++ b/tools/trust/team_scope_gate.py
@@ -1,0 +1,1292 @@
+#!/usr/bin/env python3
+"""Run the focused release gate for team-scope memory isolation.
+
+The receipt this writes used to be hand-maintained, which made its
+``leak_count: 0`` an assertion typed by a human rather than an observation. Every
+number here is now produced by writing scoped memories through the real capture
+path and reading them back through the real read surfaces as two principals whose
+memberships were resolved from real ``teams``/``team_members`` rows.
+
+Two failure modes shaped the design. The original scope leak shipped because the
+only test of the filter hand-injected the very field whose absence was the bug,
+so no fixture here supplies scope metadata directly: the write path stamps it.
+The 1.1.3 patch then regressed in the opposite direction by hiding rows a member
+was entitled to, so every probe declares an expected direction and the receipt
+counts allow failures beside leaks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import inspect
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from shutil import which
+from typing import Any, cast
+from uuid import NAMESPACE_URL, uuid5
+
+from sibyl.persistence.surreal.auth_runtime import projects as projects_runtime
+from sibyl_core.auth.context import AuthContext
+from sibyl_core.auth.memory_policy import (
+    MEMORY_OWNER_METADATA_KEYS,
+    authorize_memory_read,
+    memory_metadata_read_allowed,
+    memory_scope_policy_key,
+)
+from sibyl_core.auth.models import AuthOrganization, AuthUser, OrganizationRole
+from sibyl_core.backends.surreal.auth_client import SurrealAuthClient
+from sibyl_core.backends.surreal.auth_schema import bootstrap_auth_schema
+from sibyl_core.backends.surreal.content_client import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.config import settings
+from sibyl_core.memory_pipeline.capture import MemoryCaptureRequest, MemoryCaptureService
+from sibyl_core.models.memory_scope import MemoryScope
+from sibyl_core.retrieval.candidates import RetrievalCandidate
+from sibyl_core.retrieval.search import _candidate_scope_allowed, build_context_retrieval_plan
+from sibyl_core.services import surreal_content as content_service
+from sibyl_core.tools.context import ContextFacet
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RECEIPT_SCHEMA_VERSION = "sibyl-team-scope-trust-receipt-v1"
+DEFAULT_RECEIPT_PATH = (
+    REPO_ROOT / "benchmarks" / "results" / "ai-memory" / "team-scope-trust-receipt.json"
+)
+FIXTURE_NAME = "team-scope-isolation-v1"
+RELEASE_SCOPE = "v1.2 Track C team-scope trust receipt"
+
+Runner = Callable[[tuple[str, ...]], int]
+Echo = Callable[[str], None]
+
+TEAM_SCOPE_BUDGETS: dict[str, float] = {
+    "leak_count": 0,
+    "allow_failure_count": 0,
+    "promotion_attribution_coverage": 1,
+    "promotion_preview_coverage": 1,
+    # A gate that probes nothing reports zero leaks. These floors are what stop a
+    # vacuous receipt from reading as a clean one, so they are budgets rather
+    # than commentary: dropping a probe class fails the gate.
+    "deny_probe_count": 23,
+    "allow_probe_count": 12,
+    "surface_count": 5,
+    "owner_forgery_offered_count": 3,
+    "owner_forgery_surviving_count": 0,
+}
+LOWER_IS_BETTER_METRICS = frozenset(
+    (
+        "leak_count",
+        "allow_failure_count",
+        "graph_team_membership_forwarded",
+        "owner_forgery_surviving_count",
+    )
+)
+
+PROMOTION_ATTRIBUTION_SURFACES: tuple[str, ...] = (
+    "promotion attribution",
+    "audit receipt",
+    "team target promotion",
+)
+PROMOTION_PREVIEW_SURFACES: tuple[str, ...] = (
+    "promotion preview",
+    "team target redaction",
+)
+
+# Deterministic identity: the receipt is a function of the code under test, not
+# of the clock or a random generator, so a rerun that changes bytes means the
+# behaviour changed.
+_ID_NAMESPACE = uuid5(NAMESPACE_URL, "https://sibyl.ist/gates/team-scope")
+
+
+def _fixture_id(name: str) -> str:
+    return str(uuid5(_ID_NAMESPACE, name))
+
+
+ORGANIZATION_ID = _fixture_id("organization")
+TEAM_ID = _fixture_id("team-alpha")
+OTHER_TEAM_ID = _fixture_id("team-beta")
+PROJECT_ID = _fixture_id("project-lumen")
+DELEGATION_ID = _fixture_id("delegation-oncall")
+PRINCIPAL_IDS: Mapping[str, str] = {
+    "member": _fixture_id("principal-member"),
+    "outsider": _fixture_id("principal-outsider"),
+}
+
+ALLOW = "allow"
+DENY = "deny"
+
+
+@dataclass(frozen=True)
+class GateCheck:
+    name: str
+    description: str
+    surfaces: tuple[str, ...]
+    command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GateResult:
+    check: GateCheck
+    exit_code: int
+    elapsed_seconds: float
+    error: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return self.exit_code == 0
+
+
+@dataclass(frozen=True)
+class Principal:
+    """A reader whose memberships came out of the auth store, not a literal.
+
+    ``teams`` and ``projects`` are resolved by the same functions the REST layer
+    calls. Declaring them inline would reproduce the defect this gate exists to
+    catch: a fixture that supplies the authorization input under test.
+    """
+
+    label: str
+    user_id: str
+    teams: frozenset[str]
+    projects: frozenset[str]
+    delegations: frozenset[str]
+
+
+@dataclass(frozen=True)
+class SeededMemory:
+    label: str
+    memory_scope: str
+    scope_key: str | None
+    owner_label: str
+    title: str
+    content: str
+    raw_memory_id: str
+    graph_metadata: Mapping[str, Any]
+    requested_metadata: Mapping[str, Any]
+
+    @property
+    def offered_owner_forgeries(self) -> tuple[str, ...]:
+        """Owner fields the payload tried to name for itself."""
+        return tuple(sorted(set(self.requested_metadata) & MEMORY_OWNER_METADATA_KEYS))
+
+    @property
+    def surviving_owner_forgeries(self) -> tuple[str, ...]:
+        """Forged owner fields the write path failed to overwrite.
+
+        The read filter reads a row's audience out of these fields, so one
+        surviving forgery lets a payload nominate its own readers and every
+        downstream isolation probe becomes meaningless.
+        """
+        return tuple(
+            field
+            for field in self.offered_owner_forgeries
+            if self.graph_metadata.get(field) == self.requested_metadata.get(field)
+        )
+
+
+@dataclass(frozen=True)
+class ScopeProbe:
+    """One authorization question with a declared direction.
+
+    ``requested_scope_key`` is what the reader asked for, which is not always the
+    row's own key: a reader querying the scope key they legitimately hold is how
+    the row-selection clause gets tested, while a reader naming someone else's
+    key is how the membership check gets tested.
+
+    ``boundary`` names a structural limit of the surface when the expectation is
+    a denial the scope model would otherwise allow, so a receipt reader can tell
+    "isolation held" apart from "this surface cannot serve this scope at all".
+    """
+
+    surface: str
+    reader_label: str
+    memory_label: str
+    expectation: str
+    requested_scope_key: str | None = None
+    boundary: str | None = None
+
+    @property
+    def key(self) -> tuple[str, str, str, str]:
+        return (
+            self.surface,
+            self.memory_label,
+            self.reader_label,
+            self.requested_scope_key or "",
+        )
+
+
+@dataclass(frozen=True)
+class ProbeObservation:
+    probe: ScopeProbe
+    observed: str
+    detail: str
+
+    @property
+    def leaked(self) -> bool:
+        return self.probe.expectation == DENY and self.observed == ALLOW
+
+    @property
+    def allow_failed(self) -> bool:
+        return self.probe.expectation == ALLOW and self.observed == DENY
+
+    def as_receipt_entry(self) -> dict[str, Any]:
+        entry: dict[str, Any] = {
+            "surface": self.probe.surface,
+            "memory": self.probe.memory_label,
+            "reader": self.probe.reader_label,
+            "requested_scope_key": self.probe.requested_scope_key,
+            "expected": self.probe.expectation,
+            "observed": self.observed,
+            "status": "PASS" if self.observed == self.probe.expectation else "FAIL",
+            "detail": self.detail,
+        }
+        if self.probe.boundary is not None:
+            entry["boundary"] = self.probe.boundary
+        return entry
+
+
+GATE_CHECKS: tuple[GateCheck, ...] = (
+    GateCheck(
+        name="team-target-preview-redaction",
+        description="share preview redacts a team target's private and delegated sources",
+        surfaces=("team target redaction", "private source isolation"),
+        command=(
+            "moon",
+            "run",
+            "core:test",
+            "--",
+            "tests/test_memory.py",
+            "-k",
+            "share_memory or share_preview",
+        ),
+    ),
+    GateCheck(
+        name="team-scope-rest-policy",
+        description="REST recall serves a verified team and denies an unverified one",
+        surfaces=("team scope REST recall", "unverified team denial"),
+        command=("moon", "run", "api:memory-trust-rest-test"),
+    ),
+    GateCheck(
+        name="share-promotion-apply",
+        description="promotion to a team target records attribution and an audit receipt",
+        surfaces=(
+            "promotion attribution",
+            "promotion preview",
+            "audit receipt",
+            "team target promotion",
+        ),
+        command=("moon", "run", "api:memory-trust-rest-test"),
+    ),
+    GateCheck(
+        name="team-control-plane-auth",
+        description="team membership lookup resolves the canonical team memory space",
+        surfaces=("team membership lookup", "canonical team memory space"),
+        command=("moon", "run", "api:trust-control-auth-test"),
+    ),
+    GateCheck(
+        name="ai-memory-contracts",
+        description="committed AI-memory manifest carries the team-scope receipt contract",
+        surfaces=("manifest", "release contract"),
+        command=("moon", "run", "bench-gate"),
+    ),
+)
+
+OBSERVED_CHECK_NAME = "team-scope-read-isolation"
+OBSERVED_CHECK_SURFACES: tuple[str, ...] = (
+    "private source isolation",
+    "delegated source isolation",
+    "project source isolation",
+    "unverified team denial",
+    "team membership lookup",
+    "canonical team memory space",
+    "team scope service recall",
+    "graph metadata read filter",
+    "retrieval candidate filter",
+)
+CONTRACT_CHECK_NAMES = frozenset(("ai-memory-contracts",))
+
+REQUIRED_SURFACES: tuple[str, ...] = (
+    "team target redaction",
+    "private source isolation",
+    "delegated source isolation",
+    "project source isolation",
+    "team scope REST recall",
+    "unverified team denial",
+    "promotion attribution",
+    "promotion preview",
+    "audit receipt",
+    "team target promotion",
+    "team membership lookup",
+    "canonical team memory space",
+    "manifest",
+    "release contract",
+)
+
+
+def covered_surfaces(checks: Iterable[GateCheck] = GATE_CHECKS) -> set[str]:
+    covered = {surface for check in checks for surface in check.surfaces}
+    covered.update(OBSERVED_CHECK_SURFACES)
+    return covered
+
+
+def missing_required_surfaces(checks: Sequence[GateCheck] = GATE_CHECKS) -> list[str]:
+    covered = covered_surfaces(checks)
+    return [surface for surface in REQUIRED_SURFACES if surface not in covered]
+
+
+def graph_team_membership_forwarded() -> bool:
+    """Whether the shared graph read helper can be told about team membership.
+
+    ``memory_metadata_read_allowed`` accepts no team or delegation membership
+    today, so a team-scoped graph row is denied to members and non-members
+    alike, and the scope backfill deliberately refuses to stamp one. That is a
+    real boundary rather than a passing isolation claim, so the receipt records
+    it and this probe fails the gate the moment the signature grows the
+    parameter: the boundary then needs retiring, not carrying forward.
+    """
+    parameters = inspect.signature(memory_metadata_read_allowed).parameters
+    return "accessible_teams" in parameters or "accessible_delegations" in parameters
+
+
+def _auth_context(user_id: str) -> AuthContext:
+    return AuthContext(
+        user=AuthUser(id=user_id, email=None, name="team-scope-gate"),
+        organization=AuthOrganization(
+            id=ORGANIZATION_ID,
+            name="team-scope-gate",
+            slug="team-scope-gate",
+        ),
+        # A plain member, so team access has to come from a membership row rather
+        # than from an org-admin shortcut that returns every team in the org.
+        org_role=OrganizationRole.MEMBER,
+    )
+
+
+@asynccontextmanager
+async def _embedded_surreal_url():
+    """Pin scope queries to the embedded SQL dialect for this run.
+
+    The content service picks embedded or server function names off the resolved
+    URL, and the fixture store is always embedded. A developer whose environment
+    points at the shared dev stack would otherwise render server-side names
+    against an in-process engine.
+    """
+    previous = settings.surreal_url
+    settings.surreal_url = "memory://"
+    try:
+        yield
+    finally:
+        settings.surreal_url = previous
+
+
+async def _provision_principals(client: SurrealAuthClient) -> dict[str, Principal]:
+    await bootstrap_auth_schema(client)
+    await client.execute_query(
+        """
+        CREATE teams CONTENT {
+            uuid: $team, organization_id: $organization, name: 'Alpha', slug: 'alpha'
+        };
+        CREATE teams CONTENT {
+            uuid: $other_team, organization_id: $organization, name: 'Beta', slug: 'beta'
+        };
+        CREATE team_members CONTENT {
+            uuid: $membership, team_id: $team, user_id: $member
+        };
+        CREATE team_members CONTENT {
+            uuid: $other_membership, team_id: $other_team, user_id: $outsider
+        };
+        CREATE projects CONTENT {
+            uuid: $project, organization_id: $organization, name: 'Lumen', slug: 'lumen',
+            graph_project_id: $project, visibility: 'private'
+        };
+        CREATE project_members CONTENT {
+            uuid: $project_membership, organization_id: $organization,
+            project_id: $project, user_id: $member
+        };
+        """,
+        organization=ORGANIZATION_ID,
+        team=TEAM_ID,
+        other_team=OTHER_TEAM_ID,
+        project=PROJECT_ID,
+        member=PRINCIPAL_IDS["member"],
+        outsider=PRINCIPAL_IDS["outsider"],
+        membership=_fixture_id("membership-member-alpha"),
+        other_membership=_fixture_id("membership-outsider-beta"),
+        project_membership=_fixture_id("membership-member-lumen"),
+    )
+
+    @asynccontextmanager
+    async def fixture_auth_scope():
+        yield client
+
+    previous_scope = projects_runtime._auth_client_scope
+    projects_runtime._auth_client_scope = cast(Any, fixture_auth_scope)
+    try:
+        principals: dict[str, Principal] = {}
+        for label, user_id in PRINCIPAL_IDS.items():
+            context = _auth_context(user_id)
+            teams = await projects_runtime.list_accessible_team_scope_keys(context)
+            projects = await projects_runtime.list_accessible_project_graph_ids(context)
+            principals[label] = Principal(
+                label=label,
+                user_id=user_id,
+                teams=frozenset(str(value) for value in teams),
+                projects=frozenset(str(value) for value in projects),
+                # No delegation is granted to anyone, so the delegated row's
+                # isolation is observed rather than assumed away.
+                delegations=frozenset(),
+            )
+    finally:
+        projects_runtime._auth_client_scope = previous_scope
+    return principals
+
+
+def _seed_requests() -> tuple[MemoryCaptureRequest, ...]:
+    member = PRINCIPAL_IDS["member"]
+    return (
+        MemoryCaptureRequest(
+            title="private rotation notes",
+            content="rotate the staging signing key before the lumen cutover",
+            entity_type="episode",
+            memory_scope=MemoryScope.PRIVATE.value,
+            scope_key=None,
+            principal_id=member,
+            source_id="team-scope-gate:private",
+            # A payload that names its own owner is the exact forgery the write
+            # path is supposed to drop, so every seed offers one.
+            metadata={"principal_id": PRINCIPAL_IDS["outsider"], "memory_scope": "organization"},
+        ),
+        MemoryCaptureRequest(
+            title="team deploy runbook",
+            content="alpha owns the lumen deploy runbook and the rollback switch",
+            entity_type="episode",
+            memory_scope=MemoryScope.TEAM.value,
+            scope_key=TEAM_ID,
+            principal_id=member,
+            source_id="team-scope-gate:team",
+            metadata={"scope_key": OTHER_TEAM_ID},
+        ),
+        MemoryCaptureRequest(
+            title="project retrieval decision",
+            content="lumen retrieval uses surreal native rrf for graph fusion",
+            entity_type="episode",
+            memory_scope=MemoryScope.PROJECT.value,
+            scope_key=PROJECT_ID,
+            principal_id=member,
+            source_id="team-scope-gate:project",
+            project_id=PROJECT_ID,
+            metadata={"project_id": PROJECT_ID},
+        ),
+        MemoryCaptureRequest(
+            title="delegated oncall handoff",
+            content="oncall delegation covers the lumen pager rotation this week",
+            entity_type="episode",
+            memory_scope=MemoryScope.DELEGATED.value,
+            scope_key=DELEGATION_ID,
+            principal_id=member,
+            source_id="team-scope-gate:delegated",
+            metadata={},
+        ),
+    )
+
+
+_SEED_LABELS: Mapping[str, str] = {
+    "team-scope-gate:private": "private-member",
+    "team-scope-gate:team": "team-alpha",
+    "team-scope-gate:project": "project-lumen",
+    "team-scope-gate:delegated": "delegated-oncall",
+}
+
+
+async def _seed_memories(requests: Sequence[MemoryCaptureRequest]) -> list[SeededMemory]:
+    """Write each scope through the real capture service and keep what it stamped."""
+    stamped: dict[str, Mapping[str, Any]] = {}
+
+    async def write_raw(request: MemoryCaptureRequest) -> Mapping[str, Any]:
+        memory = await content_service.remember_raw_memory(
+            organization_id=ORGANIZATION_ID,
+            principal_id=request.principal_id or "",
+            source_id=request.source_id or request.title,
+            raw_content=request.content,
+            title=request.title,
+            memory_scope=request.memory_scope,
+            scope_key=request.scope_key,
+            metadata=dict(request.metadata),
+            capture_surface=request.capture_surface,
+            embedding_provider=None,
+        )
+        return {"id": memory.id, "source_id": memory.source_id}
+
+    async def write_graph(
+        request: MemoryCaptureRequest,
+        metadata: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        stamped[str(request.source_id)] = dict(metadata)
+        return {"id": _fixture_id(f"graph:{request.source_id}")}
+
+    service = MemoryCaptureService(
+        remember_raw_memory=write_raw,
+        create_graph_entity=write_graph,
+    )
+    seeded: list[SeededMemory] = []
+    for request in requests:
+        result = await service.capture(request)
+        source_id = str(request.source_id)
+        seeded.append(
+            SeededMemory(
+                label=_SEED_LABELS[source_id],
+                memory_scope=request.memory_scope,
+                scope_key=request.scope_key,
+                owner_label="member",
+                title=request.title,
+                content=request.content,
+                raw_memory_id=str(result.raw_memory_id),
+                graph_metadata=stamped[source_id],
+                requested_metadata=dict(request.metadata),
+            )
+        )
+    return sorted(seeded, key=lambda memory: memory.label)
+
+
+def _reader_keys(principal: Principal, memory_scope: str) -> frozenset[str]:
+    """The scope keys this reader's resolved memberships let them address."""
+    if memory_scope == MemoryScope.TEAM.value:
+        return principal.teams
+    if memory_scope == MemoryScope.PROJECT.value:
+        return principal.projects
+    if memory_scope == MemoryScope.DELEGATED.value:
+        return principal.delegations
+    return frozenset()
+
+
+def _reader_grants(principal: Principal, memory: SeededMemory) -> bool:
+    """Whether this reader's resolved memberships satisfy the row's audience."""
+    if memory.memory_scope == MemoryScope.PRIVATE.value:
+        return principal.label == memory.owner_label
+    return memory.scope_key is not None and memory.scope_key in _reader_keys(
+        principal,
+        memory.memory_scope,
+    )
+
+
+_GRAPH_SERVABLE_SCOPES = frozenset(
+    (MemoryScope.PRIVATE.value, MemoryScope.PROJECT.value),
+)
+GRAPH_MEMBERSHIP_BOUNDARY = "graph read helper forwards no team or delegation membership"
+DELEGATION_RESOLVER_BOUNDARY = "no resolver grants a delegation, so no principal can hold one"
+
+
+def _expected_probes(
+    principals: Mapping[str, Principal],
+    memories: Sequence[SeededMemory],
+) -> list[ScopeProbe]:
+    """Enumerate one probe per read decision the surfaces can actually make.
+
+    Every expectation is derived from resolved memberships plus what the surface
+    is structurally able to serve, never from a per-case judgement, so a probe
+    cannot be quietly tuned to match whatever the code happens to do.
+    """
+    graph_boundary = None if graph_team_membership_forwarded() else GRAPH_MEMBERSHIP_BOUNDARY
+    probes: list[ScopeProbe] = []
+    for memory in memories:
+        for label in sorted(principals):
+            principal = principals[label]
+            entitled = _reader_grants(principal, memory)
+            delegated_unreachable = (
+                memory.memory_scope == MemoryScope.DELEGATED.value and not principal.delegations
+            )
+
+            # Reaching for the row's own audience: the membership check answers.
+            probes.append(
+                ScopeProbe(
+                    surface="raw_targeted_read",
+                    reader_label=label,
+                    memory_label=memory.label,
+                    expectation=ALLOW if entitled else DENY,
+                    requested_scope_key=memory.scope_key,
+                    boundary=DELEGATION_RESOLVER_BOUNDARY if delegated_unreachable else None,
+                )
+            )
+            if memory.memory_scope != MemoryScope.PRIVATE.value:
+                probes.append(
+                    ScopeProbe(
+                        surface="scope_authorization",
+                        reader_label=label,
+                        memory_label=memory.label,
+                        expectation=ALLOW if entitled else DENY,
+                        requested_scope_key=memory.scope_key,
+                        boundary=DELEGATION_RESOLVER_BOUNDARY if delegated_unreachable else None,
+                    )
+                )
+
+            # Reading the reader's own audience: the row-selection clause answers,
+            # which is the only way a dropped scope_key filter shows up.
+            own_keys: tuple[str | None, ...]
+            if memory.memory_scope == MemoryScope.PRIVATE.value:
+                own_keys = (None,)
+            else:
+                own_keys = tuple(sorted(_reader_keys(principal, memory.memory_scope)))
+            for own_key in own_keys:
+                probes.append(
+                    ScopeProbe(
+                        surface="raw_own_scope_read",
+                        reader_label=label,
+                        memory_label=memory.label,
+                        expectation=ALLOW if (entitled and own_key == memory.scope_key) else DENY,
+                        requested_scope_key=own_key,
+                    )
+                )
+
+            graph_servable = memory.memory_scope in _GRAPH_SERVABLE_SCOPES
+            graph_expectation = ALLOW if (entitled and graph_servable) else DENY
+            boundary = graph_boundary if entitled and not graph_servable else None
+            for surface in ("graph_metadata_read", "retrieval_candidate_filter"):
+                probes.append(
+                    ScopeProbe(
+                        surface=surface,
+                        reader_label=label,
+                        memory_label=memory.label,
+                        expectation=graph_expectation,
+                        requested_scope_key=memory.scope_key,
+                        boundary=boundary,
+                    )
+                )
+    return sorted(probes, key=lambda probe: probe.key)
+
+
+def _authorize_raw_read(
+    principal: Principal,
+    memory: SeededMemory,
+    scope_key: str | None,
+) -> Any:
+    return authorize_memory_read(
+        principal_id=principal.user_id,
+        memory_scope=memory.memory_scope,
+        scope_key=scope_key,
+        accessible_projects=principal.projects,
+        accessible_teams=principal.teams,
+        accessible_delegations=principal.delegations,
+    )
+
+
+async def _observe_raw_read(
+    principal: Principal,
+    memory: SeededMemory,
+    scope_key: str | None,
+) -> tuple[str, str]:
+    """Run a raw read the way a route runs one: authorize, then query.
+
+    The content query builder trusts an already-authorized scope key, so probing
+    it alone would report a membership check that lives a layer up. Composing the
+    two is the only shape that measures what a caller actually gets.
+    """
+    decision = _authorize_raw_read(principal, memory, scope_key)
+    if not decision.allowed:
+        return (DENY, f"denied_at=authorization reason={decision.reason}")
+    listed = await content_service.list_raw_memories_for_scope(
+        organization_id=ORGANIZATION_ID,
+        principal_id=principal.user_id,
+        memory_scope=memory.memory_scope,
+        scope_key=scope_key,
+        limit=25,
+    )
+    recalled = await content_service.recall_raw_memory(
+        organization_id=ORGANIZATION_ID,
+        principal_id=principal.user_id,
+        query=memory.content,
+        memory_scope=memory.memory_scope,
+        scope_key=scope_key,
+        limit=25,
+    )
+    in_listing = any(row.id == memory.raw_memory_id for row in listed)
+    in_recall = any(row.id == memory.raw_memory_id for row in recalled)
+    detail = (
+        f"reason={decision.reason} listed={in_listing} recalled={in_recall} "
+        f"rows_listed={len(listed)} rows_recalled={len(recalled)}"
+    )
+    if in_listing != in_recall:
+        # Listing and recall disagreeing about one row means one of them is not
+        # applying the scope clause, which is a leak whichever way it points.
+        return (ALLOW, f"{detail} surface_disagreement=True")
+    return (ALLOW if in_listing else DENY, detail)
+
+
+def _observe_scope_authorization(
+    principal: Principal,
+    memory: SeededMemory,
+    scope_key: str | None,
+) -> tuple[str, str]:
+    decision = _authorize_raw_read(principal, memory, scope_key)
+    return (ALLOW if decision.allowed else DENY, f"reason={decision.reason}")
+
+
+def _observe_graph_metadata_read(principal: Principal, memory: SeededMemory) -> tuple[str, str]:
+    allowed = memory_metadata_read_allowed(
+        memory.graph_metadata,
+        principal_id=principal.user_id,
+        private_scope_granted=True,
+        accessible_projects=principal.projects,
+        project_id=None,
+    )
+    stamped_scope = memory.graph_metadata.get("memory_scope")
+    stamped_owner = memory.graph_metadata.get("principal_id")
+    return (
+        ALLOW if allowed else DENY,
+        f"stamped_scope={stamped_scope} owner_is_reader={stamped_owner == principal.user_id}",
+    )
+
+
+def _observe_retrieval_filter(principal: Principal, memory: SeededMemory) -> tuple[str, str]:
+    plan = build_context_retrieval_plan(
+        query=memory.content,
+        organization_id=ORGANIZATION_ID,
+        facets=(ContextFacet.RECENT_MEMORY,),
+        facet_types={ContextFacet.RECENT_MEMORY: ("episode",)},
+        principal_id=principal.user_id,
+        project=None,
+        accessible_projects=principal.projects,
+    )
+    candidate = RetrievalCandidate(
+        id=_fixture_id(f"candidate:{memory.label}"),
+        type="episode",
+        name=memory.title,
+        content=memory.content,
+        score=1.0,
+        source="team-scope-gate",
+        metadata=dict(memory.graph_metadata),
+        project_id=memory.scope_key if memory.memory_scope == MemoryScope.PROJECT.value else None,
+    )
+    allowed = _candidate_scope_allowed(candidate, plan)
+    return (
+        ALLOW if allowed else DENY,
+        f"plan_scopes={','.join(sorted(scope.memory_scope.value for scope in plan.scopes))}",
+    )
+
+
+async def _observe_probe(
+    probe: ScopeProbe,
+    *,
+    principals: Mapping[str, Principal],
+    memories: Mapping[str, SeededMemory],
+) -> ProbeObservation:
+    principal = principals[probe.reader_label]
+    memory = memories[probe.memory_label]
+    if probe.surface in {"raw_targeted_read", "raw_own_scope_read"}:
+        observed, detail = await _observe_raw_read(principal, memory, probe.requested_scope_key)
+    elif probe.surface == "scope_authorization":
+        observed, detail = _observe_scope_authorization(
+            principal,
+            memory,
+            probe.requested_scope_key,
+        )
+    elif probe.surface == "graph_metadata_read":
+        observed, detail = _observe_graph_metadata_read(principal, memory)
+    elif probe.surface == "retrieval_candidate_filter":
+        observed, detail = _observe_retrieval_filter(principal, memory)
+    else:  # pragma: no cover - guarded by _expected_probes
+        msg = f"unknown probe surface {probe.surface!r}"
+        raise AssertionError(msg)
+    return ProbeObservation(probe=probe, observed=observed, detail=detail)
+
+
+async def collect_team_scope_observations() -> dict[str, Any]:
+    auth_client = SurrealAuthClient(url="memory://")
+    content_client = SurrealContentClient(url="memory://")
+
+    @asynccontextmanager
+    async def fixture_content_scope():
+        yield content_client
+
+    previous_content_scope = content_service.surreal_content_client
+    try:
+        async with _embedded_surreal_url():
+            principals = await _provision_principals(auth_client)
+            await bootstrap_content_schema(content_client)
+            content_service.surreal_content_client = cast(Any, fixture_content_scope)
+            memories = await _seed_memories(_seed_requests())
+            memories_by_label = {memory.label: memory for memory in memories}
+            probes = _expected_probes(principals, memories)
+            observations = [
+                await _observe_probe(
+                    probe,
+                    principals=principals,
+                    memories=memories_by_label,
+                )
+                for probe in probes
+            ]
+    finally:
+        content_service.surreal_content_client = previous_content_scope
+        await content_client.close()
+        await auth_client.close()
+
+    return build_team_scope_receipt(
+        principals=principals,
+        memories=memories,
+        observations=observations,
+    )
+
+
+def build_observed_team_scope_receipt() -> dict[str, Any]:
+    return asyncio.run(collect_team_scope_observations())
+
+
+def _principal_entry(principal: Principal) -> dict[str, Any]:
+    return {
+        "label": principal.label,
+        "resolved_teams": sorted(principal.teams),
+        "resolved_projects": sorted(principal.projects),
+        "resolved_delegations": sorted(principal.delegations),
+        "team_memory_space": sorted(
+            memory_scope_policy_key(MemoryScope.TEAM, team) for team in principal.teams
+        ),
+    }
+
+
+def _memory_entry(memory: SeededMemory) -> dict[str, Any]:
+    metadata = dict(memory.graph_metadata)
+    return {
+        "label": memory.label,
+        "requested_scope": memory.memory_scope,
+        "requested_scope_key": memory.scope_key,
+        "owner": memory.owner_label,
+        "stamped_memory_scope": metadata.get("memory_scope"),
+        "stamped_scope_key": metadata.get("scope_key"),
+        "stamped_principal_id": metadata.get("principal_id"),
+        "stamped_metadata_keys": sorted(metadata),
+        "offered_owner_forgeries": list(memory.offered_owner_forgeries),
+        "surviving_owner_forgeries": list(memory.surviving_owner_forgeries),
+    }
+
+
+def build_team_scope_receipt(
+    *,
+    principals: Mapping[str, Principal],
+    memories: Sequence[SeededMemory],
+    observations: Sequence[ProbeObservation],
+) -> dict[str, Any]:
+    ordered = sorted(observations, key=lambda observation: observation.probe.key)
+    leaks = [observation for observation in ordered if observation.leaked]
+    allow_failures = [observation for observation in ordered if observation.allow_failed]
+    deny_probes = [observation for observation in ordered if observation.probe.expectation == DENY]
+    allow_probes = [
+        observation for observation in ordered if observation.probe.expectation == ALLOW
+    ]
+    surfaces = sorted({observation.probe.surface for observation in ordered})
+    boundaries = sorted(
+        {
+            observation.probe.boundary
+            for observation in ordered
+            if observation.probe.boundary is not None
+        }
+    )
+    metrics: dict[str, Any] = {
+        "leak_count": len(leaks),
+        "allow_failure_count": len(allow_failures),
+        "probe_count": len(ordered),
+        "deny_probe_count": len(deny_probes),
+        "allow_probe_count": len(allow_probes),
+        "surface_count": len(surfaces),
+        "graph_team_membership_forwarded": int(graph_team_membership_forwarded()),
+        "owner_forgery_offered_count": sum(
+            len(memory.offered_owner_forgeries) for memory in memories
+        ),
+        "owner_forgery_surviving_count": sum(
+            len(memory.surviving_owner_forgeries) for memory in memories
+        ),
+        # Promotion coverage is observed from the evidence checks, so a receipt
+        # built without them reports zero rather than an aspirational one.
+        "promotion_attribution_coverage": 0,
+        "promotion_preview_coverage": 0,
+    }
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "fixture": FIXTURE_NAME,
+        "release_scope": RELEASE_SCOPE,
+        "claim_boundary": (
+            "Machine-generated from an ephemeral embedded auth and content store. "
+            "Memberships are resolved by the real team and project lookups, scope "
+            "metadata is stamped by the real capture path, and every probe reads "
+            "through a real read surface in both the deny and the allow direction."
+        ),
+        "budgets": dict(TEAM_SCOPE_BUDGETS),
+        "metrics": metrics,
+        "boundaries": boundaries,
+        "principals": [_principal_entry(principals[label]) for label in sorted(principals)],
+        "memories": [_memory_entry(memory) for memory in memories],
+        "probes": [observation.as_receipt_entry() for observation in ordered],
+        "surfaces": surfaces,
+    }
+
+
+OBSERVED_RECEIPT_FIELDS: tuple[str, ...] = (
+    "schema_version",
+    "fixture",
+    "boundaries",
+    "principals",
+    "memories",
+    "probes",
+    "surfaces",
+)
+DERIVED_METRICS: frozenset[str] = frozenset(
+    ("promotion_attribution_coverage", "promotion_preview_coverage"),
+)
+
+
+def observed_receipt_fields(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """The part of a receipt that a rerun has to reproduce exactly.
+
+    Promotion coverage and the check list come from subprocess evidence, so they
+    are excluded. Everything else is a direct observation of the code under test,
+    which is what makes a committed receipt checkable against a fresh run instead
+    of being taken on trust.
+    """
+    fields = {field: receipt.get(field) for field in OBSERVED_RECEIPT_FIELDS}
+    metrics = receipt.get("metrics")
+    fields["metrics"] = (
+        {metric: value for metric, value in metrics.items() if metric not in DERIVED_METRICS}
+        if isinstance(metrics, Mapping)
+        else metrics
+    )
+    return fields
+
+
+def with_promotion_coverage(
+    receipt: Mapping[str, Any],
+    results: Sequence[GateResult],
+) -> dict[str, Any]:
+    """Derive the promotion coverage metrics from checks that actually ran."""
+    passed_surfaces = {
+        surface for result in results if result.passed for surface in result.check.surfaces
+    }
+    attempted_surfaces = {surface for result in results for surface in result.check.surfaces}
+
+    def coverage(required: tuple[str, ...]) -> float:
+        expected = [surface for surface in required if surface in attempted_surfaces]
+        if len(expected) != len(required):
+            return 0.0
+        covered = sum(1 for surface in required if surface in passed_surfaces)
+        return covered / len(required)
+
+    metrics = {
+        **dict(receipt["metrics"]),
+        "promotion_attribution_coverage": coverage(PROMOTION_ATTRIBUTION_SURFACES),
+        "promotion_preview_coverage": coverage(PROMOTION_PREVIEW_SURFACES),
+    }
+    return {**dict(receipt), "metrics": metrics}
+
+
+def with_check_results(
+    receipt: Mapping[str, Any],
+    results: Sequence[GateResult],
+) -> dict[str, Any]:
+    observed_status = "PASS"
+    metrics = receipt.get("metrics", {})
+    if metrics.get("leak_count") or metrics.get("allow_failure_count"):
+        observed_status = "FAIL"
+    checks: list[dict[str, Any]] = [
+        {
+            "name": OBSERVED_CHECK_NAME,
+            "status": observed_status,
+            "command": format_command(("moon", "run", "team-scope-gate")),
+            "surfaces": list(OBSERVED_CHECK_SURFACES),
+        }
+    ]
+    checks.extend(
+        {
+            "name": result.check.name,
+            "status": "PASS" if result.passed else "FAIL",
+            "exit_code": result.exit_code,
+            "command": format_command(result.check.command),
+            "surfaces": list(result.check.surfaces),
+        }
+        for result in results
+    )
+    return {**dict(receipt), "checks": checks}
+
+
+def validate_team_scope_receipt(receipt: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if receipt.get("schema_version") != RECEIPT_SCHEMA_VERSION:
+        failures.append(f"receipt schema_version must be {RECEIPT_SCHEMA_VERSION}")
+    metrics = receipt.get("metrics")
+    if not isinstance(metrics, dict):
+        return [*failures, "receipt metrics must be an object"]
+    failures.extend(_validate_receipt_metrics(metrics))
+    failures.extend(_validate_receipt_probes(receipt.get("probes")))
+    failures.extend(_validate_receipt_checks(receipt.get("checks")))
+    return failures
+
+
+def _validate_receipt_metrics(metrics: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    for metric, budget in TEAM_SCOPE_BUDGETS.items():
+        value = metrics.get(metric)
+        if not isinstance(value, int | float) or isinstance(value, bool):
+            failures.append(f"metric {metric!r} must be numeric")
+            continue
+        if metric in LOWER_IS_BETTER_METRICS:
+            if float(value) > float(budget):
+                failures.append(f"metric {metric!r} exceeds budget {budget}: {value}")
+        elif float(value) < float(budget):
+            failures.append(f"metric {metric!r} below budget {budget}: {value}")
+    forwarded = metrics.get("graph_team_membership_forwarded")
+    if isinstance(forwarded, int | float) and not isinstance(forwarded, bool) and forwarded:
+        failures.append(
+            "graph read helper now forwards team membership: retire the "
+            "'graph read helper forwards no team or delegation membership' boundary "
+            "and add team allow probes on the graph surfaces"
+        )
+    return failures
+
+
+def _validate_receipt_probes(probes: Any) -> list[str]:
+    if not isinstance(probes, list) or not probes:
+        return ["receipt probes must be a non-empty list"]
+    failures: list[str] = []
+    for index, probe in enumerate(probes):
+        if not isinstance(probe, dict):
+            failures.append(f"receipt probes[{index}] must be an object")
+            continue
+        if probe.get("status") != "PASS":
+            failures.append(
+                f"receipt probes[{index}] {probe.get('surface')} "
+                f"{probe.get('memory')} as {probe.get('reader')} "
+                f"expected {probe.get('expected')} but observed {probe.get('observed')}"
+            )
+    return failures
+
+
+def _validate_receipt_checks(checks: Any) -> list[str]:
+    if checks is None:
+        return []
+    if not isinstance(checks, list):
+        return ["receipt checks must be a list"]
+    failures: list[str] = []
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(f"receipt checks[{index}] must be an object")
+            continue
+        if check.get("status") != "PASS":
+            failures.append(f"receipt checks[{index}] {check.get('name')} did not pass")
+    return failures
+
+
+def format_command(command: Sequence[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def write_receipt(receipt: Mapping[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{json.dumps(receipt, indent=2, sort_keys=True)}\n", encoding="utf-8")
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _echo(message: str = "") -> None:
+    sys.stdout.write(f"{message}\n")
+
+
+def _real_runner(command: tuple[str, ...]) -> int:
+    executable = which(command[0])
+    if executable is None:
+        msg = f"Required executable not found on PATH: {command[0]}"
+        raise RuntimeError(msg)
+    env = dict(os.environ)
+    env.setdefault("MOON_COLOR", "false")
+    completed = subprocess.run(  # noqa: S603
+        (executable, *command[1:]),
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+    )
+    return completed.returncode
+
+
+def _run_check(check: GateCheck, *, runner: Runner, echo: Echo) -> GateResult:
+    echo("")
+    echo(f"[{check.name}] {check.description}")
+    echo(f"surfaces: {', '.join(check.surfaces)}")
+    echo(f"command: {format_command(check.command)}")
+
+    started = time.perf_counter()
+    error: str | None = None
+    try:
+        exit_code = runner(check.command)
+    except Exception as exc:
+        exit_code = 1
+        error = f"{type(exc).__name__}: {exc}"
+    elapsed = time.perf_counter() - started
+
+    status = "PASS" if exit_code == 0 else f"FAIL exit={exit_code}"
+    if error is not None:
+        status = f"{status} error={error}"
+    echo(f"result: {status} in {elapsed:.2f}s")
+    return GateResult(check=check, exit_code=exit_code, elapsed_seconds=elapsed, error=error)
+
+
+def _print_observations(receipt: Mapping[str, Any], *, echo: Echo) -> None:
+    metrics = receipt["metrics"]
+    echo("")
+    echo("Team Scope Read Isolation")
+    echo(
+        f"probes: {metrics['probe_count']} "
+        f"({metrics['deny_probe_count']} deny, {metrics['allow_probe_count']} allow) "
+        f"across {metrics['surface_count']} surfaces"
+    )
+    echo(f"leak_count: {metrics['leak_count']}")
+    echo(f"allow_failure_count: {metrics['allow_failure_count']}")
+    for boundary in receipt.get("boundaries", []):
+        echo(f"boundary: {boundary}")
+    for probe in receipt["probes"]:
+        if probe["status"] != "PASS":
+            echo(
+                f"- FAIL {probe['surface']} {probe['memory']} as {probe['reader']}: "
+                f"expected {probe['expected']} observed {probe['observed']} ({probe['detail']})"
+            )
+
+
+def _print_receipt(
+    receipt: Mapping[str, Any],
+    results: Sequence[GateResult],
+    *,
+    echo: Echo,
+) -> None:
+    passed = [result for result in results if result.passed]
+    failed = [result for result in results if not result.passed]
+    metrics = receipt["metrics"]
+    status = "PASS" if not failed and not validate_team_scope_receipt(receipt) else "FAIL"
+
+    echo("")
+    echo("Team Scope Trust Gate Receipt")
+    echo(f"status: {status}")
+    echo(f"checks: {len(passed)} passed, {len(failed)} failed")
+    echo("metrics: " + ", ".join(f"{metric}={value}" for metric, value in metrics.items()))
+    echo(f"surfaces: {', '.join(sorted(covered_surfaces()))}")
+    for result in results:
+        check_status = "PASS" if result.passed else f"FAIL exit={result.exit_code}"
+        error = f"; error={result.error}" if result.error is not None else ""
+        echo(f"- {check_status} {result.check.name} ({result.elapsed_seconds:.2f}s){error}")
+
+
+def run_observations(
+    *,
+    echo: Echo = _echo,
+    receipt_path: Path | None = None,
+    receipt_builder: Callable[[], dict[str, Any]] = build_observed_team_scope_receipt,
+) -> int:
+    receipt = receipt_builder()
+    _print_observations(receipt, echo=echo)
+    if receipt_path is not None:
+        write_receipt(receipt, receipt_path)
+        echo(f"receipt: {display_path(receipt_path)}")
+    metrics = receipt["metrics"]
+    failures = _validate_receipt_probes(receipt.get("probes"))
+    if metrics["leak_count"] or metrics["allow_failure_count"] or failures:
+        return 1
+    return 0
+
+
+def run_gate(
+    checks: Sequence[GateCheck] = GATE_CHECKS,
+    *,
+    runner: Runner | None = None,
+    echo: Echo = _echo,
+    receipt_path: Path | None = DEFAULT_RECEIPT_PATH,
+    receipt_builder: Callable[[], dict[str, Any]] = build_observed_team_scope_receipt,
+) -> int:
+    missing = missing_required_surfaces(checks)
+    if missing:
+        echo("Team scope gate is missing required surfaces:")
+        for surface in missing:
+            echo(f"- {surface}")
+        return 2
+
+    echo("Team Scope Trust Gate")
+    echo(f"checks: {len(checks)}")
+    echo(f"receipt_schema: {RECEIPT_SCHEMA_VERSION}")
+    if receipt_path is not None:
+        echo(f"receipt: {display_path(receipt_path)}")
+
+    try:
+        receipt = receipt_builder()
+    except Exception as exc:
+        echo(f"Team scope observations failed: {type(exc).__name__}: {exc}")
+        return 1
+    _print_observations(receipt, echo=echo)
+
+    active_runner = runner or _real_runner
+    evidence_checks = [check for check in checks if check.name not in CONTRACT_CHECK_NAMES]
+    contract_checks = [check for check in checks if check.name in CONTRACT_CHECK_NAMES]
+    results = [_run_check(check, runner=active_runner, echo=echo) for check in evidence_checks]
+
+    evidence_receipt = with_check_results(
+        with_promotion_coverage(receipt, results),
+        results,
+    )
+    failures = validate_team_scope_receipt(evidence_receipt)
+    if receipt_path is not None:
+        write_receipt(evidence_receipt, receipt_path)
+    if failures:
+        echo("Team scope receipt failed:")
+        for failure in failures:
+            echo(f"- {failure}")
+        _print_receipt(evidence_receipt, results, echo=echo)
+        return 1
+
+    results.extend(_run_check(check, runner=active_runner, echo=echo) for check in contract_checks)
+    final_receipt = with_check_results(
+        with_promotion_coverage(receipt, results),
+        results,
+    )
+    if receipt_path is not None:
+        write_receipt(final_receipt, receipt_path)
+    _print_receipt(final_receipt, results, echo=echo)
+    if validate_team_scope_receipt(final_receipt):
+        return 1
+    return 0 if all(result.passed for result in results) else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run focused team-scope isolation release-gate checks.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List checks and exit without running them.",
+    )
+    parser.add_argument(
+        "--observe-only",
+        action="store_true",
+        help="Run the in-process scope probes without the moon evidence checks.",
+    )
+    parser.add_argument(
+        "--receipt",
+        type=Path,
+        help="Receipt path. Defaults to the committed receipt, or nowhere with --observe-only.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list:
+        for check in GATE_CHECKS:
+            _echo(f"{check.name}: {format_command(check.command)}")
+        return 0
+    if args.observe_only:
+        return run_observations(receipt_path=args.receipt)
+    return run_gate(receipt_path=args.receipt or DEFAULT_RECEIPT_PATH)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/trust/team_scope_gate.py
+++ b/tools/trust/team_scope_gate.py
@@ -41,6 +41,7 @@ from sibyl_core.auth.memory_policy import (
     authorize_memory_read,
     memory_metadata_read_allowed,
     memory_scope_policy_key,
+    private_scope_granted_for,
 )
 from sibyl_core.auth.models import AuthOrganization, AuthUser, OrganizationRole
 from sibyl_core.backends.surreal.auth_client import SurrealAuthClient
@@ -74,11 +75,21 @@ TEAM_SCOPE_BUDGETS: dict[str, float] = {
     # A gate that probes nothing reports zero leaks. These floors are what stop a
     # vacuous receipt from reading as a clean one, so they are budgets rather
     # than commentary: dropping a probe class fails the gate.
-    "deny_probe_count": 23,
-    "allow_probe_count": 12,
-    "surface_count": 5,
-    "owner_forgery_offered_count": 3,
+    "deny_probe_count": 31,
+    "allow_probe_count": 13,
+    "surface_count": 6,
+    # Five forged owner fields, and the two backfill-provenance keys matter most:
+    # nothing downstream rewrites them, so they are the pair that proves the
+    # write path's drop filter is load bearing rather than belt and braces.
+    "owner_forgery_offered_count": 5,
     "owner_forgery_surviving_count": 0,
+    # A read surface that stops answering agrees with every denial, so its
+    # silence has to be counted rather than inferred from a direction.
+    "surface_disagreement_count": 0,
+    # Probe expectations and probe observations both read the resolver, so an
+    # over-broad resolver could move them together and stay green. The rows this
+    # gate provisions are the independent ground truth that check sits against.
+    "membership_resolution_mismatch_count": 0,
 }
 LOWER_IS_BETTER_METRICS = frozenset(
     (
@@ -86,6 +97,20 @@ LOWER_IS_BETTER_METRICS = frozenset(
         "allow_failure_count",
         "graph_team_membership_forwarded",
         "owner_forgery_surviving_count",
+        "surface_disagreement_count",
+        "membership_resolution_mismatch_count",
+    )
+)
+
+
+EXPECTED_PROBE_SURFACES: frozenset[str] = frozenset(
+    (
+        "raw_targeted_read",
+        "raw_own_scope_read",
+        "scope_authorization",
+        "graph_metadata_read",
+        "graph_metadata_read_narrowed",
+        "retrieval_candidate_filter",
     )
 )
 
@@ -113,10 +138,24 @@ ORGANIZATION_ID = _fixture_id("organization")
 TEAM_ID = _fixture_id("team-alpha")
 OTHER_TEAM_ID = _fixture_id("team-beta")
 PROJECT_ID = _fixture_id("project-lumen")
+OTHER_PROJECT_ID = _fixture_id("project-mercury")
 DELEGATION_ID = _fixture_id("delegation-oncall")
 PRINCIPAL_IDS: Mapping[str, str] = {
     "member": _fixture_id("principal-member"),
     "outsider": _fixture_id("principal-outsider"),
+}
+
+# Ground truth for the membership resolvers: exactly the rows _provision_principals
+# writes. Comparing the resolvers against this is not the same as handing the
+# probes their memberships, which still come from the resolvers; it is the one
+# check that fails when a resolver stops agreeing with the store.
+PROVISIONED_TEAMS: Mapping[str, frozenset[str]] = {
+    "member": frozenset({TEAM_ID}),
+    "outsider": frozenset({OTHER_TEAM_ID}),
+}
+PROVISIONED_PROJECTS: Mapping[str, frozenset[str]] = {
+    "member": frozenset({PROJECT_ID}),
+    "outsider": frozenset({OTHER_PROJECT_ID}),
 }
 
 ALLOW = "allow"
@@ -158,6 +197,17 @@ class Principal:
     projects: frozenset[str]
     delegations: frozenset[str]
 
+    @property
+    def granted_memory_scope_keys(self) -> frozenset[str]:
+        """The memory spaces an API key narrowed to this reader's projects holds.
+
+        Derived from resolved project membership rather than declared, so the
+        narrowing under test is the same key format the API mints.
+        """
+        return frozenset(
+            memory_scope_policy_key(MemoryScope.PROJECT, project) for project in self.projects
+        )
+
 
 @dataclass(frozen=True)
 class SeededMemory:
@@ -189,6 +239,15 @@ class SeededMemory:
             for field in self.offered_owner_forgeries
             if self.graph_metadata.get(field) == self.requested_metadata.get(field)
         )
+
+
+@dataclass(frozen=True)
+class SurfaceReading:
+    """What one read surface answered, and whether it answered coherently."""
+
+    observed: str
+    detail: str
+    disagreement: bool = False
 
 
 @dataclass(frozen=True)
@@ -227,6 +286,7 @@ class ProbeObservation:
     probe: ScopeProbe
     observed: str
     detail: str
+    disagreement: bool = False
 
     @property
     def leaked(self) -> bool:
@@ -236,6 +296,10 @@ class ProbeObservation:
     def allow_failed(self) -> bool:
         return self.probe.expectation == ALLOW and self.observed == DENY
 
+    @property
+    def passed(self) -> bool:
+        return self.observed == self.probe.expectation and not self.disagreement
+
     def as_receipt_entry(self) -> dict[str, Any]:
         entry: dict[str, Any] = {
             "surface": self.probe.surface,
@@ -244,8 +308,9 @@ class ProbeObservation:
             "requested_scope_key": self.probe.requested_scope_key,
             "expected": self.probe.expectation,
             "observed": self.observed,
-            "status": "PASS" if self.observed == self.probe.expectation else "FAIL",
+            "status": "PASS" if self.passed else "FAIL",
             "detail": self.detail,
+            "surface_disagreement": self.disagreement,
         }
         if self.probe.boundary is not None:
             entry["boundary"] = self.probe.boundary
@@ -406,20 +471,30 @@ async def _provision_principals(client: SurrealAuthClient) -> dict[str, Principa
             uuid: $project, organization_id: $organization, name: 'Lumen', slug: 'lumen',
             graph_project_id: $project, visibility: 'private'
         };
+        CREATE projects CONTENT {
+            uuid: $other_project, organization_id: $organization, name: 'Mercury',
+            slug: 'mercury', graph_project_id: $other_project, visibility: 'private'
+        };
         CREATE project_members CONTENT {
             uuid: $project_membership, organization_id: $organization,
             project_id: $project, user_id: $member
+        };
+        CREATE project_members CONTENT {
+            uuid: $other_project_membership, organization_id: $organization,
+            project_id: $other_project, user_id: $outsider
         };
         """,
         organization=ORGANIZATION_ID,
         team=TEAM_ID,
         other_team=OTHER_TEAM_ID,
         project=PROJECT_ID,
+        other_project=OTHER_PROJECT_ID,
         member=PRINCIPAL_IDS["member"],
         outsider=PRINCIPAL_IDS["outsider"],
         membership=_fixture_id("membership-member-alpha"),
         other_membership=_fixture_id("membership-outsider-beta"),
         project_membership=_fixture_id("membership-member-lumen"),
+        other_project_membership=_fixture_id("membership-outsider-mercury"),
     )
 
     @asynccontextmanager
@@ -460,8 +535,18 @@ def _seed_requests() -> tuple[MemoryCaptureRequest, ...]:
             principal_id=member,
             source_id="team-scope-gate:private",
             # A payload that names its own owner is the exact forgery the write
-            # path is supposed to drop, so every seed offers one.
-            metadata={"principal_id": PRINCIPAL_IDS["outsider"], "memory_scope": "organization"},
+            # path is supposed to drop. The scope and owner keys are also
+            # rewritten from authorized values further down that function, so
+            # they alone cannot prove the drop filter runs; the two backfill
+            # provenance keys are never rewritten, which makes them the pair
+            # that fails loudly if the filter is removed. Forging them nominates
+            # the row for a rollback that strips its scope to the fail-open.
+            metadata={
+                "principal_id": PRINCIPAL_IDS["outsider"],
+                "memory_scope": "organization",
+                "scope_backfill_source": "raw_capture",
+                "scope_backfill_prior": {"touched": ["memory_scope"], "prior": {}},
+            },
         ),
         MemoryCaptureRequest(
             title="team deploy runbook",
@@ -471,7 +556,7 @@ def _seed_requests() -> tuple[MemoryCaptureRequest, ...]:
             scope_key=TEAM_ID,
             principal_id=member,
             source_id="team-scope-gate:team",
-            metadata={"scope_key": OTHER_TEAM_ID},
+            metadata={"scope_key": OTHER_TEAM_ID},  # claims another team's audience
         ),
         MemoryCaptureRequest(
             title="project retrieval decision",
@@ -658,7 +743,50 @@ def _expected_probes(
                         boundary=boundary,
                     )
                 )
+
+            # Same row, same reader, but through a credential narrowed to the
+            # reader's project memory spaces. A row whose canonical space the key
+            # does not hold must be refused even when the reader owns it, so the
+            # private row is denied to its own author here.
+            probes.append(
+                ScopeProbe(
+                    surface="graph_metadata_read_narrowed",
+                    reader_label=label,
+                    memory_label=memory.label,
+                    expectation=ALLOW
+                    if (
+                        graph_expectation == ALLOW
+                        and _memory_space_key(memory) in principal.granted_memory_scope_keys
+                    )
+                    else DENY,
+                    requested_scope_key=memory.scope_key,
+                    boundary=boundary,
+                )
+            )
     return sorted(probes, key=lambda probe: probe.key)
+
+
+def membership_resolution_mismatches(
+    principals: Mapping[str, Principal],
+) -> list[str]:
+    """Where a resolver disagrees with the membership rows this gate wrote."""
+    mismatches: list[str] = []
+    for label in sorted(principals):
+        principal = principals[label]
+        for kind, resolved, provisioned in (
+            ("teams", principal.teams, PROVISIONED_TEAMS.get(label, frozenset())),
+            ("projects", principal.projects, PROVISIONED_PROJECTS.get(label, frozenset())),
+        ):
+            if resolved != provisioned:
+                mismatches.append(
+                    f"{label} resolved {kind} {sorted(resolved)} "
+                    f"but was provisioned {sorted(provisioned)}"
+                )
+    return mismatches
+
+
+def _memory_space_key(memory: SeededMemory) -> str:
+    return memory_scope_policy_key(memory.memory_scope, memory.scope_key)
 
 
 def _authorize_raw_read(
@@ -680,7 +808,7 @@ async def _observe_raw_read(
     principal: Principal,
     memory: SeededMemory,
     scope_key: str | None,
-) -> tuple[str, str]:
+) -> SurfaceReading:
     """Run a raw read the way a route runs one: authorize, then query.
 
     The content query builder trusts an already-authorized scope key, so probing
@@ -689,7 +817,7 @@ async def _observe_raw_read(
     """
     decision = _authorize_raw_read(principal, memory, scope_key)
     if not decision.allowed:
-        return (DENY, f"denied_at=authorization reason={decision.reason}")
+        return SurfaceReading(DENY, f"denied_at=authorization reason={decision.reason}")
     listed = await content_service.list_raw_memories_for_scope(
         organization_id=ORGANIZATION_ID,
         principal_id=principal.user_id,
@@ -711,23 +839,32 @@ async def _observe_raw_read(
         f"reason={decision.reason} listed={in_listing} recalled={in_recall} "
         f"rows_listed={len(listed)} rows_recalled={len(recalled)}"
     )
-    if in_listing != in_recall:
-        # Listing and recall disagreeing about one row means one of them is not
-        # applying the scope clause, which is a leak whichever way it points.
-        return (ALLOW, f"{detail} surface_disagreement=True")
-    return (ALLOW if in_listing else DENY, detail)
+    # Two reads of one row that disagree mean one of them stopped applying the
+    # scope clause, and the direction does not make it benign: a recall surface
+    # that returns nothing at all agrees with every denial and would otherwise
+    # pass its allow probes on the listing's answer alone. So the disagreement
+    # is carried as its own counted fact rather than folded into allow or deny,
+    # where an expectation could absorb it.
+    return SurfaceReading(
+        ALLOW if in_listing else DENY,
+        detail,
+        disagreement=in_listing != in_recall,
+    )
 
 
 def _observe_scope_authorization(
     principal: Principal,
     memory: SeededMemory,
     scope_key: str | None,
-) -> tuple[str, str]:
+) -> SurfaceReading:
     decision = _authorize_raw_read(principal, memory, scope_key)
-    return (ALLOW if decision.allowed else DENY, f"reason={decision.reason}")
+    return SurfaceReading(ALLOW if decision.allowed else DENY, f"reason={decision.reason}")
 
 
-def _observe_graph_metadata_read(principal: Principal, memory: SeededMemory) -> tuple[str, str]:
+def _observe_graph_metadata_read(
+    principal: Principal,
+    memory: SeededMemory,
+) -> SurfaceReading:
     allowed = memory_metadata_read_allowed(
         memory.graph_metadata,
         principal_id=principal.user_id,
@@ -737,13 +874,41 @@ def _observe_graph_metadata_read(principal: Principal, memory: SeededMemory) -> 
     )
     stamped_scope = memory.graph_metadata.get("memory_scope")
     stamped_owner = memory.graph_metadata.get("principal_id")
-    return (
+    return SurfaceReading(
         ALLOW if allowed else DENY,
         f"stamped_scope={stamped_scope} owner_is_reader={stamped_owner == principal.user_id}",
     )
 
 
-def _observe_retrieval_filter(principal: Principal, memory: SeededMemory) -> tuple[str, str]:
+def _observe_graph_metadata_read_narrowed(
+    principal: Principal,
+    memory: SeededMemory,
+) -> SurfaceReading:
+    """Read as an API key narrowed to this reader's project memory space.
+
+    A credential narrowed to a project must not reach the principal's own private
+    rows just because the principal owns them, so this is the surface where the
+    canonical memory-space key is the authorization input rather than a label.
+    """
+    granted = principal.granted_memory_scope_keys
+    allowed = memory_metadata_read_allowed(
+        memory.graph_metadata,
+        principal_id=principal.user_id,
+        private_scope_granted=private_scope_granted_for(
+            granted,
+            principal_id=principal.user_id,
+        ),
+        accessible_projects=principal.projects,
+        project_id=None,
+        allowed_memory_scope_keys=granted,
+    )
+    return SurfaceReading(
+        ALLOW if allowed else DENY,
+        f"granted_spaces={len(granted)} row_space={_memory_space_key(memory)}",
+    )
+
+
+def _observe_retrieval_filter(principal: Principal, memory: SeededMemory) -> SurfaceReading:
     plan = build_context_retrieval_plan(
         query=memory.content,
         organization_id=ORGANIZATION_ID,
@@ -764,7 +929,7 @@ def _observe_retrieval_filter(principal: Principal, memory: SeededMemory) -> tup
         project_id=memory.scope_key if memory.memory_scope == MemoryScope.PROJECT.value else None,
     )
     allowed = _candidate_scope_allowed(candidate, plan)
-    return (
+    return SurfaceReading(
         ALLOW if allowed else DENY,
         f"plan_scopes={','.join(sorted(scope.memory_scope.value for scope in plan.scopes))}",
     )
@@ -779,21 +944,24 @@ async def _observe_probe(
     principal = principals[probe.reader_label]
     memory = memories[probe.memory_label]
     if probe.surface in {"raw_targeted_read", "raw_own_scope_read"}:
-        observed, detail = await _observe_raw_read(principal, memory, probe.requested_scope_key)
+        reading = await _observe_raw_read(principal, memory, probe.requested_scope_key)
     elif probe.surface == "scope_authorization":
-        observed, detail = _observe_scope_authorization(
-            principal,
-            memory,
-            probe.requested_scope_key,
-        )
+        reading = _observe_scope_authorization(principal, memory, probe.requested_scope_key)
     elif probe.surface == "graph_metadata_read":
-        observed, detail = _observe_graph_metadata_read(principal, memory)
+        reading = _observe_graph_metadata_read(principal, memory)
+    elif probe.surface == "graph_metadata_read_narrowed":
+        reading = _observe_graph_metadata_read_narrowed(principal, memory)
     elif probe.surface == "retrieval_candidate_filter":
-        observed, detail = _observe_retrieval_filter(principal, memory)
+        reading = _observe_retrieval_filter(principal, memory)
     else:  # pragma: no cover - guarded by _expected_probes
         msg = f"unknown probe surface {probe.surface!r}"
         raise AssertionError(msg)
-    return ProbeObservation(probe=probe, observed=observed, detail=detail)
+    return ProbeObservation(
+        probe=probe,
+        observed=reading.observed,
+        detail=reading.detail,
+        disagreement=reading.disagreement,
+    )
 
 
 async def collect_team_scope_observations() -> dict[str, Any]:
@@ -871,6 +1039,7 @@ def build_team_scope_receipt(
     memories: Sequence[SeededMemory],
     observations: Sequence[ProbeObservation],
 ) -> dict[str, Any]:
+    mismatches = membership_resolution_mismatches(principals)
     ordered = sorted(observations, key=lambda observation: observation.probe.key)
     leaks = [observation for observation in ordered if observation.leaked]
     allow_failures = [observation for observation in ordered if observation.allow_failed]
@@ -886,14 +1055,17 @@ def build_team_scope_receipt(
             if observation.probe.boundary is not None
         }
     )
+    disagreements = [observation for observation in ordered if observation.disagreement]
     metrics: dict[str, Any] = {
         "leak_count": len(leaks),
         "allow_failure_count": len(allow_failures),
+        "surface_disagreement_count": len(disagreements),
         "probe_count": len(ordered),
         "deny_probe_count": len(deny_probes),
         "allow_probe_count": len(allow_probes),
         "surface_count": len(surfaces),
         "graph_team_membership_forwarded": int(graph_team_membership_forwarded()),
+        "membership_resolution_mismatch_count": len(mismatches),
         "owner_forgery_offered_count": sum(
             len(memory.offered_owner_forgeries) for memory in memories
         ),
@@ -918,6 +1090,7 @@ def build_team_scope_receipt(
         "budgets": dict(TEAM_SCOPE_BUDGETS),
         "metrics": metrics,
         "boundaries": boundaries,
+        "membership_mismatches": mismatches,
         "principals": [_principal_entry(principals[label]) for label in sorted(principals)],
         "memories": [_memory_entry(memory) for memory in memories],
         "probes": [observation.as_receipt_entry() for observation in ordered],
@@ -929,6 +1102,7 @@ OBSERVED_RECEIPT_FIELDS: tuple[str, ...] = (
     "schema_version",
     "fixture",
     "boundaries",
+    "membership_mismatches",
     "principals",
     "memories",
     "probes",
@@ -988,7 +1162,11 @@ def with_check_results(
 ) -> dict[str, Any]:
     observed_status = "PASS"
     metrics = receipt.get("metrics", {})
-    if metrics.get("leak_count") or metrics.get("allow_failure_count"):
+    if (
+        metrics.get("leak_count")
+        or metrics.get("allow_failure_count")
+        or metrics.get("surface_disagreement_count")
+    ):
         observed_status = "FAIL"
     checks: list[dict[str, Any]] = [
         {
@@ -1020,13 +1198,30 @@ def validate_team_scope_receipt(receipt: Mapping[str, Any]) -> list[str]:
         return [*failures, "receipt metrics must be an object"]
     failures.extend(_validate_receipt_metrics(metrics))
     failures.extend(_validate_receipt_probes(receipt.get("probes")))
+    failures.extend(_validate_receipt_surfaces(receipt.get("surfaces")))
     failures.extend(_validate_receipt_checks(receipt.get("checks")))
     return failures
 
 
-def _validate_receipt_metrics(metrics: Mapping[str, Any]) -> list[str]:
+def _validate_observed_metrics(metrics: Mapping[str, Any]) -> list[str]:
+    """Budgets that hold without the subprocess evidence checks having run.
+
+    Only the two promotion coverage metrics need those checks, so observe-only
+    runs enforce everything else. Skipping the floors there would make
+    ``--observe-only`` look like a gate while accepting an empty probe set.
+    """
+    return _validate_receipt_metrics(metrics, skip=DERIVED_METRICS)
+
+
+def _validate_receipt_metrics(
+    metrics: Mapping[str, Any],
+    *,
+    skip: frozenset[str] = frozenset(),
+) -> list[str]:
     failures: list[str] = []
     for metric, budget in TEAM_SCOPE_BUDGETS.items():
+        if metric in skip:
+            continue
         value = metrics.get(metric)
         if not isinstance(value, int | float) or isinstance(value, bool):
             failures.append(f"metric {metric!r} must be numeric")
@@ -1036,6 +1231,12 @@ def _validate_receipt_metrics(metrics: Mapping[str, Any]) -> list[str]:
                 failures.append(f"metric {metric!r} exceeds budget {budget}: {value}")
         elif float(value) < float(budget):
             failures.append(f"metric {metric!r} below budget {budget}: {value}")
+    mismatch = metrics.get("membership_resolution_mismatch_count")
+    if isinstance(mismatch, int | float) and not isinstance(mismatch, bool) and mismatch:
+        failures.append(
+            "a membership resolver no longer agrees with the provisioned rows, so "
+            "probe expectations and probe observations are no longer independent"
+        )
     forwarded = metrics.get("graph_team_membership_forwarded")
     if isinstance(forwarded, int | float) and not isinstance(forwarded, bool) and forwarded:
         failures.append(
@@ -1043,6 +1244,22 @@ def _validate_receipt_metrics(metrics: Mapping[str, Any]) -> list[str]:
             "'graph read helper forwards no team or delegation membership' boundary "
             "and add team allow probes on the graph surfaces"
         )
+    return failures
+
+
+def _validate_receipt_surfaces(surfaces: Any) -> list[str]:
+    """Every declared probe surface has to have actually run.
+
+    A count floor catches a shrunken probe set but not a renamed or silently
+    dropped surface, so the surface names are pinned too.
+    """
+    if not isinstance(surfaces, list):
+        return ["receipt surfaces must be a list"]
+    observed = {str(surface) for surface in surfaces}
+    missing = sorted(EXPECTED_PROBE_SURFACES - observed)
+    unexpected = sorted(observed - EXPECTED_PROBE_SURFACES)
+    failures = [f"probe surface {surface!r} never ran" for surface in missing]
+    failures.extend(f"receipt reports unknown probe surface {surface!r}" for surface in unexpected)
     return failures
 
 
@@ -1054,7 +1271,13 @@ def _validate_receipt_probes(probes: Any) -> list[str]:
         if not isinstance(probe, dict):
             failures.append(f"receipt probes[{index}] must be an object")
             continue
-        if probe.get("status") != "PASS":
+        if probe.get("surface_disagreement"):
+            failures.append(
+                f"receipt probes[{index}] {probe.get('surface')} "
+                f"{probe.get('memory')} as {probe.get('reader')}: "
+                "listing and recall disagreed, so one of them stopped filtering"
+            )
+        if probe.get("status") != "PASS" and probe.get("expected") != probe.get("observed"):
             failures.append(
                 f"receipt probes[{index}] {probe.get('surface')} "
                 f"{probe.get('memory')} as {probe.get('reader')} "
@@ -1147,6 +1370,9 @@ def _print_observations(receipt: Mapping[str, Any], *, echo: Echo) -> None:
     )
     echo(f"leak_count: {metrics['leak_count']}")
     echo(f"allow_failure_count: {metrics['allow_failure_count']}")
+    echo(f"surface_disagreement_count: {metrics['surface_disagreement_count']}")
+    for mismatch in receipt.get("membership_mismatches", []):
+        echo(f"membership mismatch: {mismatch}")
     for boundary in receipt.get("boundaries", []):
         echo(f"boundary: {boundary}")
     for probe in receipt["probes"]:
@@ -1191,11 +1417,14 @@ def run_observations(
     if receipt_path is not None:
         write_receipt(receipt, receipt_path)
         echo(f"receipt: {display_path(receipt_path)}")
-    metrics = receipt["metrics"]
-    failures = _validate_receipt_probes(receipt.get("probes"))
-    if metrics["leak_count"] or metrics["allow_failure_count"] or failures:
-        return 1
-    return 0
+    failures = [
+        *_validate_observed_metrics(receipt["metrics"]),
+        *_validate_receipt_probes(receipt.get("probes")),
+        *_validate_receipt_surfaces(receipt.get("surfaces")),
+    ]
+    for failure in failures:
+        echo(f"- {failure}")
+    return 1 if failures else 0
 
 
 def run_gate(


### PR DESCRIPTION
# 🎯 A team-scope trust receipt that can actually fail

> Track C item 2 of the 1.2 plan (sibyl task `63d6d85f`). Replaces the last hand-maintained blocking receipt in `benchmarks/results/ai-memory/` with a generator, and gates five zero-budget properties the old contract could not see.

## 💡 What this is

`benchmarks/results/ai-memory/team-scope-trust-receipt.json` is a blocking gate contract asserting `leak_count: 0` across private, team, project, and delegated memory isolation. Until this PR it was a static file with no generator anywhere in the repo, which means its zero was typed by a human and reported the same green whether the scope filter worked or had been deleted.

A new gate (`tools/trust/team_scope_gate.py`) generates that receipt from observation. It stands up an ephemeral embedded auth store and content store, provisions two principals in one organization where each belongs to a different team and a different project, writes a private, team, project, and delegated memory through the real capture path, then reads each row back as each principal through six real read surfaces and counts what happened. Forty-five probes, twenty-nine expecting a denial and sixteen expecting to be served.

The naive version of this gate is the trap worth naming: assert the read filter denies a row whose metadata the test wrote itself. That is precisely how the original scope leak shipped, because the only unit test of the filter hand-injected the very field whose absence was the bug. No fixture here supplies a scope field or a membership set.

## 🤔 Why we need it & what it replaces

The old receipt named four `checks` whose `command` strings pointed at moon tasks, so a reader could believe the numbers came from those commands. They did not: nothing re-derived `leak_count` from a run, and editing the file was enough to move it.

Two failure modes shaped the replacement, and both are real history in this repo:

- **The leak direction.** The original scope leak passed its unit test because the test supplied the metadata field under test. Any gate whose fixture provides the authorization input is unfalsifiable by construction.
- **The serving direction.** The 1.1.3 scope patch regressed by hiding rows a team member was entitled to read. A leak-only contract reports that as a clean run, and the old contract was leak-only.

What is deliberately not built: this gate does not talk to the shared dev stack, and it does not reuse a developer's configured SurrealDB. Both stores are `memory://`, created and closed inside the process, so the gate cannot read or mutate real data. The gate also pins `settings.surreal_url` to `memory://` for its own duration, because the content service picks embedded or server-side SQL function names off the resolved URL and a developer pointed at the dev stack would otherwise render server names against an in-process engine.

## 🎯 The invariant

Anchor the review on one property: **no number in this receipt can be satisfied by the fixture instead of the code.**

Five mechanisms carry it, and each has a zero-budget metric so a regression fails rather than degrades quietly:

- **Membership is resolved, not declared.** `list_accessible_team_scope_keys()`, `list_accessible_project_graph_ids()`, and `list_accessible_delegated_scope_keys()` read real `teams`, `team_members`, `projects`, `project_members`, `memory_spaces`, and `memory_space_members` rows. The gate never sets a membership set inline, which is what gives every scope including delegated a serving direction rather than a claim that nobody can reach it.
- **Membership resolution is independently cross-checked.** Probe expectations and probe observations both consume that resolver, so an over-broad resolver could move both together and stay green. The rows the gate provisions are independent ground truth, and `membership_resolution_mismatch_count` fails when a resolver stops agreeing with them.
- **Scope metadata is stamped by the write path.** `MemoryCaptureService.capture()` calls the real `stamp_memory_scope_metadata()`. Each seed's payload forges owner fields, and `owner_forgery_surviving_count` counts what survived. The private seed forges `scope_backfill_source` and `scope_backfill_prior` specifically: the authorized path rewrites scope, owner, and scope key anyway, so only the two provenance keys can prove the drop filter runs at all. Forging them nominates a row for a rollback that strips its scope to the fail-open, which is the vector commit `fe325f9a` closed.
- **The stamped audience is checked against the captured one.** A row stamped for the wrong scope is served to and withheld from exactly the readers it was before, so no probe disagrees and every counter stays zero. `stamped_scope_mismatch_count` is the one check with no probe behind it, because no probe can have one.
- **A silent surface is a failure, not an agreement.** A read surface that returns nothing agrees with every denial, so `surface_disagreement_count` records a listing and recall that disagree about one row, and it fails a probe in either direction rather than letting an expectation absorb it.

## 🛠️ How it works

### 1. Provisioning (`_provision_principals`)

`SurrealAuthClient(url="memory://")` plus the real `bootstrap_auth_schema()`, then `teams`/`team_members`/`projects`/`project_members` rows: the member joins team Alpha, project Lumen, and a delegated memory space, and the outsider joins team Beta and project Mercury. Both principals carry `OrganizationRole.MEMBER`, so team access has to come from a membership row rather than the org-admin branch that returns every team in the organization.

Giving the outsider their own team and project is what makes the row-selection clause testable. A reader who holds nothing can only ever be refused at the membership check, which leaves the query's own filtering unobserved.

### 2. Seeding (`_seed_memories`)

`SurrealContentClient(url="memory://")` plus the real `bootstrap_content_schema()` gives the actual `raw_captures` schema, including the `memory_scope`, `scope_key`, and `principal_id` columns the read clauses filter on. The gate then drives `MemoryCaptureService.capture()` with a raw writer that calls the real `remember_raw_memory()` and a graph writer that captures the metadata the service stamped.

### 3. Probing (`_expected_probes`, `_observe_probe`)

| Surface | What answers | Function |
| --- | --- | --- |
| `raw_targeted_read` | membership check, then engine query | `authorize_memory_read` + `list_raw_memories_for_scope` + `recall_raw_memory` |
| `raw_own_scope_read` | the row-selection clause | same composite, reader asks for a key they hold |
| `scope_authorization` | membership alone, keyed scopes | `authorize_memory_read` |
| `graph_metadata_read` | the shared graph read helper | `memory_metadata_read_allowed` |
| `graph_metadata_read_narrowed` | the same helper under a narrowed credential | `memory_metadata_read_allowed` + `private_scope_granted_for` |
| `retrieval_candidate_filter` | the retrieval filter on a real plan | `_candidate_scope_allowed` + `build_context_retrieval_plan` |

The split between the first two surfaces matters and is not redundant. The content query builder trusts an already-authorized scope key, so probing it alone would report a membership check that lives one layer up. `raw_targeted_read` has the reader name the row's own key, which the membership check answers. `raw_own_scope_read` has the reader name a key they legitimately hold, which is the only way a dropped `scope_key` clause becomes visible: the outsider queries team Beta, authorization allows it, and the engine must still exclude Alpha's row.

`graph_metadata_read_narrowed` reads as an API key narrowed to the reader's project memory spaces, derived through `memory_scope_policy_key` from resolved project membership. A credential holding only a project grant is refused the principal's own private row, which is the surface where the canonical memory-space key is an authorization input rather than a label.

Expectations derive from resolved memberships plus what each surface can structurally serve, never from a per-case judgement, so a probe cannot be quietly tuned to match whatever the code happens to do.

### 4. Counting

`leak_count` counts deny expectations that observed allow, `allow_failure_count` counts allow expectations that observed deny, and the three cross-check metrics above cover what a direction alone cannot express. Probe-count floors (`deny_probe_count: 29`, `allow_probe_count: 16`, `surface_count: 6`) plus a pinned surface-name set are budgets rather than commentary, because a gate that stops probing must not read as a gate that found nothing. `--observe-only` enforces every budget that does not depend on the subprocess checks, so that path cannot look like a gate while accepting a starved probe set.

The two promotion coverage metrics the manifest already required now derive from subprocess exit codes: a coverage of 1 means the checks carrying those surfaces actually passed, and a receipt built without running them reports 0 rather than an aspirational 1.

## 🚧 The one boundary the receipt states out loud

It is not introduced here, and it would have been invisible in a hand-typed receipt.

**The graph read helper forwards no team or delegation membership.** `memory_metadata_read_allowed` accepts `accessible_projects` but has no `accessible_teams` or `accessible_delegations` parameter, and none of its roughly twenty callers can pass one. A team-scoped graph row is therefore denied to members and non-members alike. The scope backfill already documents and relies on this (`migrate/scope_backfill.py`, `_readable_scope`) by refusing to stamp a scope no reader could satisfy.

Recording that as a passing team isolation claim would launder a defect into a green, so the receipt names it as a boundary on exactly the probes it affects, and `graph_team_membership_forwarded` fails the gate the moment the helper's signature grows either parameter. Fixing the helper forces the boundary to be retired and team allow probes added, rather than letting a stale exemption ride.

## 🚦 The manifest contract change

The `team-scope-trust-gate` contract previously bound only metrics that fail when isolation breaks open. Five blocking metrics with a threshold of 0 now join it, because each catches a failure the existing three cannot see:

| Metric | Catches |
| --- | --- |
| `allow_failure_count` | isolation closing too far, the direction 1.1.3 regressed in |
| `surface_disagreement_count` | a read surface going silent while its twin still answers |
| `owner_forgery_surviving_count` | a payload naming the audience its own row reads as |
| `membership_resolution_mismatch_count` | a resolver drifting from the store it is supposed to reflect |
| `stamped_scope_mismatch_count` | a row stamped for an audience it was not captured for |

The gate emits all five. This only decides that each blocks a release the way a leak does.

## 🧪 Validation

All receipts below are against head `68650e59`, rebased onto current `main`. The rebase pulled in a retrieval change to `build_context_retrieval_plan` (`89684d05`, per-lane seed budget), which the gate calls: rerunning after the rebase produced a byte-identical receipt (`sha256 ad298421…` before and after), so that change does not move any observation here.

- `uv run python -m tools.trust.team_scope_gate` → exit 0. Observed: 45 probes (29 deny, 16 allow) across 6 surfaces; every zero-budget counter at 0 (`leak_count`, `allow_failure_count`, `surface_disagreement_count`, `owner_forgery_surviving_count`, `membership_resolution_mismatch_count`, `stamped_scope_mismatch_count`) with `owner_forgery_offered_count=5`. All 4 evidence checks PASS (`core:test` share slice, `api:memory-trust-rest-test`, `api:trust-control-auth-test`, `bench-gate`).
- `uv run pytest tools/tests/test_team_scope_gate.py -q` → **41 passed**.
- `moon run :check` → **56 tasks completed**, exit 0.
- `moon run bench-gate` → `Gate passed`, exit 0, so the regenerated receipt satisfies the contract with all four new metrics.
- `uv run ruff check` and `ruff format --check` clean on both new files; `uv run ty check` → `All checks passed!`.

**Tamper matrix.** A gate that cannot fail is the defect this lane exists to kill, so breakage was induced across five distinct functions. Every tamper was an uncommitted local edit, reverted from a byte backup, never committed.

| Tamper | Function | Result |
| --- | --- | --- |
| Graph read helper returns True unconditionally | `memory_metadata_read_allowed` | `leak_count: 19`, exit 1 |
| Team branch always denies | `authorize_memory_read` | `allow_failure_count: 3`, `leak_count: 0`, exit 1 |
| Keyed-scope row filter dropped | `_memory_scope_where` | `leak_count: 2`, exit 1 |
| Private owner filter dropped | `_memory_scope_where` | `leak_count: 2`, exit 1 |
| Retrieval filter returns True | `_candidate_scope_allowed` | `leak_count: 6`, exit 1 |
| Owner-field drop filter removed | `stamp_memory_scope_metadata` | `owner_forgery_surviving_count: 2`, exit 1 |
| Recall surface returns nothing | `recall_raw_memory` | `surface_disagreement_count: 6`, exit 1 |
| Team resolver returns the whole org | `list_accessible_team_scope_keys` | `membership_resolution_mismatch_count: 2`, exit 1 |
| Team rows stamped as `project` | `stamp_memory_scope_metadata` | `stamped_scope_mismatch_count: 1`, exit 1 |
| Read helper gains an `accessible_teams` kwarg | `memory_metadata_read_allowed` | fails with the retire-the-boundary message |

Four of those rows are the reason the third and fourth commits exist. Each leaves `leak_count` at 0, so a leak-only receipt calls all four clean: a dead recall surface, a payload forging its own audience, a resolver handing every team to everyone, and a row stamped for an audience it was never captured for.

**Determinism.** Two consecutive runs produce byte-identical receipts (`diff` empty). The receipt carries no wall-clock field and derives every identifier from a fixed UUID5 namespace, so a byte change means behaviour changed. `TestCommittedReceipt::test_matches_a_fresh_observation` compares the committed file against a fresh observation, which is what stops it from being hand-edited back. That test has teeth: hand-editing one probe into a self-consistent clean state fails it while the receipt's own validator still passes, which is why the drift test exists alongside the validator.

**Cache correctness.** `team-scope-gate-test` is the task wired into the root `check` and `test` aggregates, and its `inputs` now name the content service and the auth runtime alongside the policy, capture, and retrieval modules. Without those two, moon replays a cached pass while either one is actively leaking.

⚠️ One failure not explained. An early `moon run :check` failed `root:write-path-integrity-gate-test`, a sibling gate this PR does not modify, and its output was not captured. Every subsequent run is green, including two full `:check` runs and that task standalone under both `pytest` and `moon`. The leading hypothesis is contention in the nested `moon query tasks` subprocess those tests shell out to, a pattern that pre-exists in five sibling gate tests and that this PR adds a sixth instance of. It is unproven, so treat it as an observed one-off rather than a diagnosis.

## 🔍 What reviewers should focus on

- **The expectation rule** in `_expected_probes`. It is the part that could hide a defect by construction. Every expectation should trace to resolved memberships plus a surface's structural capability, with no per-case special casing.
- **The membership cross-check** in `membership_resolution_mismatches`. It compares resolvers against the rows the gate provisions, which is the only place the gate holds an opinion of its own about who belongs where. If that ground truth drifts from `_provision_principals`, the check becomes theatre.
- **The two boundaries.** Is recording the graph-surface team denial as a declared boundary the right call, or should this PR instead thread `accessible_teams` through `memory_metadata_read_allowed` and its callers? Threading it is a roughly twenty-call-site change and reads as its own PR to me, but the argument that a trust receipt should not ship with a named hole is a fair one.
- **The five new blocking metrics.** Each raises the bar for every future release. All five currently report 0, and the tamper matrix shows what moves each one.
- **Out of scope:** the promotion and share surfaces stay evidence-check driven (real moon commands, PASS recorded from exit codes) rather than probed in process. Those surfaces need a graph runtime, and the coverage metrics now derive from commands that genuinely ran.

## 📌 Follow-ups

- Threading team and delegation membership through `memory_metadata_read_allowed` would retire the graph-surface boundary and let the scope backfill stamp team rows. The gate is already wired to fail when that lands, so the boundary cannot rot.
- Probing a second delegated space would test the delegated row-selection clause the way team Beta tests the team one. Today the delegated scope has one space, so its denials come from the membership check alone.
- The probe-count floors are hand-maintained constants that have to be raised whenever a probe is legitimately added, and a raise made for the wrong reason retires the detection it provides. The pinned surface-name set covers the dropped-surface case; deriving the counts from the fixture shape would cover the rest.
- `share-promotion-apply` and `team-scope-rest-policy` name the same moon command, inherited from the old receipt's check list. Both surface sets are genuinely covered by `apps/api/tests/test_routes_memory.py` (`test_share_memory_applies_promotions_and_returns_audit_receipt`, `test_share_memory_applies_team_promotions_with_membership_scope`, `test_preview_memory_share_returns_disabled_contract_and_audit`), so the claims hold, but splitting them into distinct test slices would make the coverage arithmetic sharper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a team-scope trust gate that verifies membership, authorization, retrieval filtering, scope stamping, and forged-owner protection.
  * Added observation-only execution, configurable receipt output, check listing, and detailed failure reporting.
  * Added expanded trust receipts covering 45 access probes and promotion coverage.

* **Bug Fixes**
  * Detects leaks, unexpected denials, scope mismatches, membership inconsistencies, and surface disagreements.

* **Tests**
  * Added comprehensive coverage for gate execution, receipt validation, CLI behavior, regression detection, and task integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->