### PR TITLE
feat(retrieval): client-exposed bounded traversal verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,13 +249,15 @@ Connect Claude Code, Cursor, or any MCP client to Sibyl:
 }
 ```
 
-Sibyl exposes eleven MCP tools, organized by what they do:
+Sibyl exposes thirteen MCP tools, organized by what they do:
 
 | Tool               | Purpose                                                   |
 | ------------------ | --------------------------------------------------------- |
 | `search`           | Unified semantic search across graph and crawled docs     |
 | `context`          | Compile an agent context pack for a goal (intent + depth) |
 | `explore`          | Navigate the graph: list, related, traverse, dependencies |
+| `expand_neighbors` | Widen known memories into their bounded neighborhood      |
+| `fetch_slice`      | Read one memory at span granularity, citing its parent    |
 | `add`              | Create knowledge: episodes, patterns, tasks, projects     |
 | `remember`         | Capture durable memory: decisions, plans, ideas, claims   |
 | `reflect`          | Distill raw notes into reviewable memory candidates       |

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -23,8 +23,8 @@ moon run api:typecheck    # Type check
 
 ## What's Here
 
-- **MCP Server:** eleven tools for search, context packs, exploration, capture, memory, synthesis,
-  and management
+- **MCP Server:** thirteen tools for search, context packs, exploration, bounded traversal, capture,
+  memory, synthesis, and management
 - **REST API:** 31 routers covering entities, tasks, teams, projects, experience, memory, synthesis,
   sources, auth, settings, and admin
 - **Auth System:** JWT sessions, GitHub OAuth, OIDC enterprise SSO (see `docs/admin/`), API keys
@@ -39,7 +39,7 @@ moon run api:typecheck    # Type check
 Sibyl API (port 3334)
 ├── /api/*              → FastAPI REST endpoints
 ├── /api/openapi.json   → OpenAPI schema
-├── /mcp                → MCP server (streamable-http, 11 tools)
+├── /mcp                → MCP server (streamable-http, 13 tools)
 ├── /api/ws             → WebSocket for real-time updates
 └── Lifespan            → Background jobs + coordination broker
 ```

--- a/apps/api/src/sibyl/api/routes/search.py
+++ b/apps/api/src/sibyl/api/routes/search.py
@@ -446,6 +446,14 @@ async def expand_neighbors(
             duration_ms=elapsed_ms(started_at),
         )
         raise
+    except ValueError as e:
+        # Malformed input rather than an out-of-range budget, which is clamped.
+        telemetry_registry().record_search_operation(
+            surface="expand_neighbors",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         telemetry_registry().record_search_operation(
             surface="expand_neighbors",
@@ -508,6 +516,14 @@ async def fetch_slice(
             duration_ms=elapsed_ms(started_at),
         )
         raise HTTPException(status_code=404, detail="Entity not found") from e
+    except ValueError as e:
+        # Malformed input rather than an out-of-range window, which is clamped.
+        telemetry_registry().record_search_operation(
+            surface="fetch_slice",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         telemetry_registry().record_search_operation(
             surface="fetch_slice",

--- a/apps/api/src/sibyl/api/routes/search.py
+++ b/apps/api/src/sibyl/api/routes/search.py
@@ -14,8 +14,12 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from sibyl.api.decorators import handle_workflow_errors
 from sibyl.api.schemas import (
+    ExpandNeighborsRequest,
+    ExpandNeighborsResponse,
     ExploreRequest,
     ExploreResponse,
+    FetchSliceRequest,
+    FetchSliceResponse,
     SearchRequest,
     SearchResponse,
     TemporalEdgeSchema,
@@ -370,6 +374,148 @@ async def explore(
         )
         log.exception("explore_failed", mode=request.mode, error=str(e))
         raise HTTPException(status_code=500, detail="Explore failed. Please try again.") from e
+
+
+async def _resolve_traversal_scope(
+    *,
+    project: str | None,
+    ctx: AuthContext,
+) -> set[str] | None:
+    """Resolve the project set a bounded traversal may read.
+
+    The verified set has to reach the core even when one project was named: the
+    scope guard denies an unstamped project row when it gets None, so handing
+    None to a member whose access was just verified empties the walk.
+    """
+    if project:
+        await verify_entity_project_access(
+            None,
+            ctx,
+            project,
+            required_role=ProjectRole.VIEWER,
+            require_existing_project=True,
+        )
+        return {project}
+    return await list_accessible_project_graph_ids(ctx)
+
+
+@router.post("/expand", response_model=ExpandNeighborsResponse)
+async def expand_neighbors(
+    request: ExpandNeighborsRequest,
+    org: AuthOrganization = Depends(get_current_organization),
+    ctx: AuthContext = Depends(get_auth_context),
+) -> ExpandNeighborsResponse:
+    """Widen known memories into their bounded graph neighborhood.
+
+    Step two of an at-most-three-round retrieval loop: search or pack first,
+    widen here, then compose with the context pack. Every neighbor is authorized
+    for the caller, so a private memory stays unreachable by traversal.
+    """
+    started_at = time.perf_counter()
+    try:
+        from sibyl_core.tools.core import expand_neighbors as core_expand_neighbors
+
+        accessible_projects = await _resolve_traversal_scope(project=request.project, ctx=ctx)
+        scope_keys = ctx.api_key_memory_scope_keys
+        result = await core_expand_neighbors(
+            request.entity_ids,
+            organization_id=str(org.id),
+            relationship_types=request.relationship_types,
+            depth=request.depth,
+            limit=request.limit,
+            content_max_chars=request.content_max_chars,
+            include_incoming=request.include_incoming,
+            types=request.types,
+            principal_id=getattr(ctx, "user_id", None),
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=(set(scope_keys) if scope_keys is not None else None),
+        )
+        response = ExpandNeighborsResponse(**asdict(result))
+        telemetry_registry().record_search_operation(
+            surface="expand_neighbors",
+            status="ok",
+            duration_ms=elapsed_ms(started_at),
+            result_count=len(response.neighbors),
+        )
+        return response
+
+    except HTTPException:
+        telemetry_registry().record_search_operation(
+            surface="expand_neighbors",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+        )
+        raise
+    except Exception as e:
+        telemetry_registry().record_search_operation(
+            surface="expand_neighbors",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+        )
+        log.exception("expand_neighbors_failed", entity_ids=request.entity_ids, error=str(e))
+        raise HTTPException(status_code=500, detail="Expansion failed. Please try again.") from e
+
+
+@router.post("/slice", response_model=FetchSliceResponse)
+async def fetch_slice(
+    request: FetchSliceRequest,
+    org: AuthOrganization = Depends(get_current_organization),
+    ctx: AuthContext = Depends(get_auth_context),
+) -> FetchSliceResponse:
+    """Read one memory at span granularity, centered on the span named.
+
+    A memory too short to have been cut comes back whole with `sliced=false`.
+    Cite the parent the response names rather than a span id, because spans are
+    re-cut whenever their memory is edited.
+    """
+    started_at = time.perf_counter()
+    try:
+        from sibyl_core.tools.core import fetch_slice as core_fetch_slice
+
+        accessible_projects = await _resolve_traversal_scope(project=request.project, ctx=ctx)
+        scope_keys = ctx.api_key_memory_scope_keys
+        result = await core_fetch_slice(
+            request.entity_id,
+            organization_id=str(org.id),
+            window=request.window,
+            content_max_chars=request.content_max_chars,
+            principal_id=getattr(ctx, "user_id", None),
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=(set(scope_keys) if scope_keys is not None else None),
+        )
+        response = FetchSliceResponse(**asdict(result))
+        telemetry_registry().record_search_operation(
+            surface="fetch_slice",
+            status="ok",
+            duration_ms=elapsed_ms(started_at),
+            result_count=len(response.passages),
+        )
+        return response
+
+    except HTTPException:
+        telemetry_registry().record_search_operation(
+            surface="fetch_slice",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+        )
+        raise
+    except KeyError as e:
+        # Absent and unauthorized answer alike on purpose: telling them apart
+        # confirms a row the caller has no right to know exists.
+        telemetry_registry().record_search_operation(
+            surface="fetch_slice",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+        )
+        raise HTTPException(status_code=404, detail="Entity not found") from e
+    except Exception as e:
+        telemetry_registry().record_search_operation(
+            surface="fetch_slice",
+            status="error",
+            duration_ms=elapsed_ms(started_at),
+        )
+        log.exception("fetch_slice_failed", entity_id=request.entity_id, error=str(e))
+        raise HTTPException(status_code=500, detail="Slice fetch failed. Please try again.") from e
 
 
 @router.post("/temporal", response_model=TemporalResponse)

--- a/apps/api/src/sibyl/api/schemas/__init__.py
+++ b/apps/api/src/sibyl/api/schemas/__init__.py
@@ -200,6 +200,14 @@ from .temporal import (
     TemporalRequest,
     TemporalResponse,
 )
+from .traverse import (
+    ExpandNeighborsRequest,
+    ExpandNeighborsResponse,
+    FetchSliceRequest,
+    FetchSliceResponse,
+    NeighborEntityResponse,
+    SlicePassageResponse,
+)
 
 __all__ = [
     "AdminAuditEventResponse",
@@ -248,8 +256,12 @@ __all__ = [
     "EntityListResponse",
     "EntityResponse",
     "EntityUpdate",
+    "ExpandNeighborsRequest",
+    "ExpandNeighborsResponse",
     "ExploreRequest",
     "ExploreResponse",
+    "FetchSliceRequest",
+    "FetchSliceResponse",
     "FullPageResponse",
     "GraphData",
     "GraphEdge",
@@ -285,6 +297,7 @@ __all__ = [
     "MemorySpaceStateLiteral",
     "MemorySpaceUpdateRequest",
     "MutationReceipt",
+    "NeighborEntityResponse",
     "OrgMetricsResponse",
     "OperationalExperienceCaptureRequest",
     "OperationalExperienceCaptureResponse",
@@ -329,6 +342,7 @@ __all__ = [
     "SessionBundleResponse",
     "SessionMemorySummary",
     "SessionTaskSummary",
+    "SlicePassageResponse",
     "SourceAdapterListResponse",
     "SourceAdapterResponse",
     "SourceImportProgressResponse",

--- a/apps/api/src/sibyl/api/schemas/traverse.py
+++ b/apps/api/src/sibyl/api/schemas/traverse.py
@@ -1,8 +1,14 @@
 """Bounded traversal verb request/response models.
 
-The wire bounds are the core clamps, imported rather than restated, so a budget
-change lands in one place and cannot drift between the HTTP contract and the
-walk that honors it.
+The bounds are the core clamps, imported rather than restated, so a budget change
+lands in one place and cannot drift between the HTTP contract and the walk that
+honors it.
+
+They are documented rather than enforced as validation, because the MCP tools and
+these routes are one verb with one contract. A tool signature cannot express a
+range, so MCP clamps; rejecting here would mean the same request that succeeds
+for an agent 422s for a script. Both surfaces clamp, and every response reports
+the bound it actually applied.
 """
 
 from typing import Any, Literal
@@ -29,8 +35,10 @@ class ExpandNeighborsRequest(BaseModel):
     entity_ids: list[str] = Field(
         ...,
         min_length=1,
-        max_length=MAX_EXPAND_ORIGINS,
-        description="Seed entity IDs to expand from",
+        description=(
+            f"Seed entity IDs to expand from. At most {MAX_EXPAND_ORIGINS} are walked; "
+            "the remainder come back in `unresolved`."
+        ),
     )
     relationship_types: list[str] | None = Field(
         default=None,
@@ -41,21 +49,23 @@ class ExpandNeighborsRequest(BaseModel):
     )
     depth: int = Field(
         default=DEFAULT_TRAVERSAL_DEPTH,
-        ge=1,
-        le=MAX_TRAVERSAL_DEPTH,
-        description="Hops to walk from the seeds",
+        description=(
+            f"Hops to walk from the seeds, clamped to 1-{MAX_TRAVERSAL_DEPTH}. "
+            "The response reports the depth actually walked."
+        ),
     )
     limit: int = Field(
         default=DEFAULT_EXPAND_LIMIT,
-        ge=1,
-        le=MAX_EXPAND_LIMIT,
-        description="Maximum neighbors returned",
+        description=(
+            f"Maximum neighbors returned, clamped to 1-{MAX_EXPAND_LIMIT}. "
+            "The response reports the limit actually applied."
+        ),
     )
     content_max_chars: int = Field(
         default=DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS,
-        ge=0,
-        le=MAX_TRAVERSAL_CONTENT_MAX_CHARS,
-        description="Preview characters per neighbor",
+        description=(
+            f"Preview characters per neighbor, clamped to 0-{MAX_TRAVERSAL_CONTENT_MAX_CHARS}."
+        ),
     )
     include_incoming: bool = Field(
         default=True,
@@ -110,15 +120,17 @@ class FetchSliceRequest(BaseModel):
     )
     window: int = Field(
         default=DEFAULT_SLICE_WINDOW,
-        ge=1,
-        le=MAX_SLICE_WINDOW,
-        description="Adjacent spans to return",
+        description=(
+            f"Adjacent spans to return, clamped to 1-{MAX_SLICE_WINDOW}. "
+            "The response reports the window actually applied."
+        ),
     )
     content_max_chars: int = Field(
         default=DEFAULT_SLICE_CONTENT_MAX_CHARS,
-        ge=0,
-        le=MAX_TRAVERSAL_CONTENT_MAX_CHARS,
-        description="Character budget for the whole window",
+        description=(
+            "Character budget for the whole window, clamped to "
+            f"0-{MAX_TRAVERSAL_CONTENT_MAX_CHARS}."
+        ),
     )
     project: str | None = Field(
         default=None, description="Scope the read to one project the caller can read"

--- a/apps/api/src/sibyl/api/schemas/traverse.py
+++ b/apps/api/src/sibyl/api/schemas/traverse.py
@@ -1,0 +1,157 @@
+"""Bounded traversal verb request/response models.
+
+The wire bounds are the core clamps, imported rather than restated, so a budget
+change lands in one place and cannot drift between the HTTP contract and the
+walk that honors it.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from sibyl_core.tools.traverse import (
+    DEFAULT_EXPAND_LIMIT,
+    DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS,
+    DEFAULT_SLICE_CONTENT_MAX_CHARS,
+    DEFAULT_SLICE_WINDOW,
+    DEFAULT_TRAVERSAL_DEPTH,
+    MAX_EXPAND_LIMIT,
+    MAX_EXPAND_ORIGINS,
+    MAX_SLICE_WINDOW,
+    MAX_TRAVERSAL_CONTENT_MAX_CHARS,
+    MAX_TRAVERSAL_DEPTH,
+)
+
+
+class ExpandNeighborsRequest(BaseModel):
+    """One bounded neighbor-expansion step over the graph."""
+
+    entity_ids: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_EXPAND_ORIGINS,
+        description="Seed entity IDs to expand from",
+    )
+    relationship_types: list[str] | None = Field(
+        default=None,
+        description="Restrict hops to these relationship names (DEPENDS_ON, PART_OF, ...)",
+    )
+    types: list[str] | None = Field(
+        default=None, description="Restrict neighbors to these entity types"
+    )
+    depth: int = Field(
+        default=DEFAULT_TRAVERSAL_DEPTH,
+        ge=1,
+        le=MAX_TRAVERSAL_DEPTH,
+        description="Hops to walk from the seeds",
+    )
+    limit: int = Field(
+        default=DEFAULT_EXPAND_LIMIT,
+        ge=1,
+        le=MAX_EXPAND_LIMIT,
+        description="Maximum neighbors returned",
+    )
+    content_max_chars: int = Field(
+        default=DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS,
+        ge=0,
+        le=MAX_TRAVERSAL_CONTENT_MAX_CHARS,
+        description="Preview characters per neighbor",
+    )
+    include_incoming: bool = Field(
+        default=True,
+        description="Follow edges pointing at the seeds as well as away from them",
+    )
+    project: str | None = Field(
+        default=None, description="Scope the walk to one project the caller can read"
+    )
+
+
+class NeighborEntityResponse(BaseModel):
+    """One entity reached by a bounded traversal step."""
+
+    id: str
+    type: str
+    name: str
+    relationship: str
+    direction: Literal["outgoing", "incoming"]
+    distance: int = 1
+    score: float = 0.0
+    content: str = ""
+    project_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ExpandNeighborsResponse(BaseModel):
+    """Neighbors from one bounded expansion, highest path score first."""
+
+    origins: list[str]
+    neighbors: list[NeighborEntityResponse]
+    total: int
+    depth: int
+    limit: int
+    unresolved: list[str] = Field(
+        default_factory=list,
+        description="Seed IDs that resolved to nothing this reader may read",
+    )
+    truncated: bool = Field(
+        default=False, description="More neighbors existed than the limit returned"
+    )
+    filters: dict[str, Any] = Field(default_factory=dict)
+    usage_hint: str = ""
+
+
+class FetchSliceRequest(BaseModel):
+    """One span-window read of a memory."""
+
+    entity_id: str = Field(
+        ...,
+        min_length=1,
+        description="A passage entity ID, or the ID of the memory it was cut from",
+    )
+    window: int = Field(
+        default=DEFAULT_SLICE_WINDOW,
+        ge=1,
+        le=MAX_SLICE_WINDOW,
+        description="Adjacent spans to return",
+    )
+    content_max_chars: int = Field(
+        default=DEFAULT_SLICE_CONTENT_MAX_CHARS,
+        ge=0,
+        le=MAX_TRAVERSAL_CONTENT_MAX_CHARS,
+        description="Character budget for the whole window",
+    )
+    project: str | None = Field(
+        default=None, description="Scope the read to one project the caller can read"
+    )
+
+
+class SlicePassageResponse(BaseModel):
+    """One span of a sliced memory, or the whole memory when it was never cut."""
+
+    id: str
+    name: str
+    content: str
+    passage_index: int | None = None
+    passage_total: int | None = None
+    breadcrumb: str | None = None
+    truncated: bool = False
+
+
+class FetchSliceResponse(BaseModel):
+    """An ordered span window plus the parent a citation resolves to."""
+
+    entity_id: str
+    parent_id: str
+    parent_name: str
+    parent_type: str
+    passages: list[SlicePassageResponse]
+    window: int
+    sliced: bool = Field(..., description="False when the memory was never cut into spans")
+    total: int = 0
+    window_start: int | None = None
+    passage_total: int | None = None
+    covers_parent: bool = False
+    project_id: str | None = None
+    content_chars: int = 0
+    filters: dict[str, Any] = Field(default_factory=dict)
+    usage_hint: str = ""

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -2346,6 +2346,10 @@ def _register_tools(mcp: FastMCP) -> None:
         SKIP THIS VERB when the memory you found is already short enough to read.
         A result whose content was not truncated needs no widening.
 
+        COMPOSITION IS NOT YOURS. This verb hands back spans, not an answer.
+        `context` composes the final evidence, and it keeps control of ordering
+        and the reserved note lane whatever you gather here.
+
         CITE THE PARENT, NOT THE SPAN. The response names `parent_id`, and that
         is the id a later reader can resolve. Span ids are re-minted whenever the
         memory is edited, so a citation pointing at one goes stale silently.

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -1,8 +1,8 @@
 """MCP Server definition using FastMCP with streamable-http transport.
 
-Exposes 11 tools and 2 resources:
-- Tools: search, explore, context, remember, reflect, add, manage, logs,
-  synthesis_plan, synthesis_draft, synthesis_verify
+Exposes 13 tools and 2 resources:
+- Tools: search, explore, context, expand_neighbors, fetch_slice, remember,
+  reflect, add, manage, logs, synthesis_plan, synthesis_draft, synthesis_verify
 - Resources: sibyl://health, sibyl://stats
 """
 
@@ -54,6 +54,13 @@ from sibyl_core.services.surreal_content import (
     MemoryScope,
     get_raw_memory,
     get_raw_memory_by_source_id,
+)
+from sibyl_core.tools.traverse import (
+    DEFAULT_EXPAND_LIMIT,
+    DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS,
+    DEFAULT_SLICE_CONTENT_MAX_CHARS,
+    DEFAULT_SLICE_WINDOW,
+    DEFAULT_TRAVERSAL_DEPTH,
 )
 
 log = structlog.get_logger()
@@ -2234,7 +2241,157 @@ def _register_tools(mcp: FastMCP) -> None:
         return _to_dict(result)
 
     # =========================================================================
-    # TOOL 7: add
+    # TOOL 7: expand_neighbors
+    # =========================================================================
+
+    @mcp.tool()
+    async def expand_neighbors(
+        entity_ids: list[str],
+        relationship_types: list[str] | None = None,
+        types: list[str] | None = None,
+        depth: int = DEFAULT_TRAVERSAL_DEPTH,
+        limit: int = DEFAULT_EXPAND_LIMIT,
+        content_max_chars: int = DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS,
+        include_incoming: bool = True,
+        project: str | None = None,
+    ) -> dict[str, Any]:
+        """Widen memories you already found into their graph neighborhood.
+
+        TRAVERSAL CONTRACT (read this before calling):
+        This is a bounded step in a loop of AT MOST THREE ROUNDS. Round one is
+        `search` or `context`. Round two widens with `expand_neighbors` or
+        `fetch_slice`. Round three widens once more, and then you answer.
+        Two widening rounds capture nearly all of the available gain; a fourth
+        costs latency and buys noise.
+
+        SKIP THIS VERB when one hop answers the question. If you want "what do we
+        know about X", call `context` and read the pack it composed. Traversal is
+        for when you have specific memories in hand and need what sits next to
+        them: the tasks blocking this one, the decision a plan supersedes, the
+        spans of a memory a search only matched part of.
+
+        COMPOSITION IS NOT YOURS. This verb returns previews and adjacency so you
+        can choose what to gather. `context` still renders the evidence, and the
+        reserved note lane and evidence ordering stay under its control.
+
+        Every neighbor is authorized for you individually. A neighbor missing
+        from the result may exist and be someone else's private memory; that is
+        the system working, not a gap to route around.
+
+        Args:
+            entity_ids: Seed entity IDs, at most MAX_EXPAND_ORIGINS of them.
+                Seeds that resolve to nothing you may read come back in
+                `unresolved` without saying which reason applied.
+            relationship_types: Restrict hops to these relationship names, e.g.
+                ["DEPENDS_ON"] or ["PART_OF"]. Empty walks every relationship.
+            types: Restrict neighbors to these entity types.
+            depth: Hops to walk, 1-MAX_TRAVERSAL_DEPTH (default 1). Depth 1
+                first; deepen only when depth 1 came back thin.
+            limit: Neighbors returned, up to MAX_EXPAND_LIMIT.
+            content_max_chars: Preview characters per neighbor. These are
+                previews by design; widen a promising one with `fetch_slice`.
+            include_incoming: Follow edges pointing at the seeds too (default
+                True). Dependents and passages are only reachable inbound.
+            project: Scope the walk to one project you can read.
+
+        Returns:
+            Hop-tagged neighbors with relationship, direction, and distance,
+            highest path score first, plus `truncated` when more existed.
+
+        Examples:
+            expand_neighbors(["task_abc"], relationship_types=["DEPENDS_ON"])
+            expand_neighbors(["decision_1", "decision_2"], depth=2)
+        """
+        from sibyl_core.tools.core import expand_neighbors as _expand_neighbors
+
+        ctx = await _require_mcp_context()
+        accessible_projects = await _resolve_mcp_project_scope(ctx, project)
+        api_key_memory_scope_keys = ctx.api_key_memory_scope_keys
+        result = await _expand_neighbors(
+            entity_ids,
+            organization_id=ctx.org_id,
+            relationship_types=relationship_types,
+            types=types,
+            depth=depth,
+            limit=limit,
+            content_max_chars=content_max_chars,
+            include_incoming=include_incoming,
+            principal_id=getattr(ctx, "user_id", None),
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=(
+                set(api_key_memory_scope_keys) if api_key_memory_scope_keys is not None else None
+            ),
+        )
+        return _to_dict(result)
+
+    # =========================================================================
+    # TOOL 8: fetch_slice
+    # =========================================================================
+
+    @mcp.tool()
+    async def fetch_slice(
+        entity_id: str,
+        window: int = DEFAULT_SLICE_WINDOW,
+        content_max_chars: int = DEFAULT_SLICE_CONTENT_MAX_CHARS,
+        project: str | None = None,
+    ) -> dict[str, Any]:
+        """Read one memory at span granularity, centered where you point.
+
+        TRAVERSAL CONTRACT (read this before calling):
+        This is a bounded step in a loop of AT MOST THREE ROUNDS, the same budget
+        `expand_neighbors` spends from. Use it when a search hit is a passage, or
+        when a memory is long and you need the part around a match rather than
+        the whole body.
+
+        SKIP THIS VERB when the memory you found is already short enough to read.
+        A result whose content was not truncated needs no widening.
+
+        CITE THE PARENT, NOT THE SPAN. The response names `parent_id`, and that
+        is the id a later reader can resolve. Span ids are re-minted whenever the
+        memory is edited, so a citation pointing at one goes stale silently.
+
+        A memory short enough never to have been cut comes back whole with
+        `sliced=false`. That is the answer, not an error to retry.
+
+        Args:
+            entity_id: A passage entity ID, or the ID of the memory it came from.
+                Given a passage, the window is centered on it. Given a memory,
+                the window starts at its first span.
+            window: Adjacent spans to return, 1-MAX_SLICE_WINDOW. The default of
+                three is the measured adjacency: three spans reach the same
+                exposure as the whole memory, one span reaches noticeably less.
+            content_max_chars: Character budget for the whole window, spent in
+                span order. The span that exhausts it says `truncated`.
+            project: Scope the read to one project you can read.
+
+        Returns:
+            The ordered span window with per-span index and total, plus the
+            parent memory a citation resolves to.
+
+        Examples:
+            fetch_slice("passage_9f2c1b")
+            fetch_slice("decision_abc", window=5)
+        """
+        from sibyl_core.tools.core import fetch_slice as _fetch_slice
+
+        ctx = await _require_mcp_context()
+        accessible_projects = await _resolve_mcp_project_scope(ctx, project)
+        api_key_memory_scope_keys = ctx.api_key_memory_scope_keys
+        result = await _fetch_slice(
+            entity_id,
+            organization_id=ctx.org_id,
+            window=window,
+            content_max_chars=content_max_chars,
+            principal_id=getattr(ctx, "user_id", None),
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=(
+                set(api_key_memory_scope_keys) if api_key_memory_scope_keys is not None else None
+            ),
+        )
+        return _to_dict(result)
+
+    # =========================================================================
+    # TOOL 9: add
     # =========================================================================
 
     @mcp.tool()
@@ -2342,7 +2499,7 @@ def _register_tools(mcp: FastMCP) -> None:
         )
 
     # =========================================================================
-    # TOOL 8: remember
+    # TOOL 10: remember
     # =========================================================================
 
     @mcp.tool()
@@ -2384,7 +2541,7 @@ def _register_tools(mcp: FastMCP) -> None:
         )
 
     # =========================================================================
-    # TOOL 9: reflect
+    # TOOL 11: reflect
     # =========================================================================
 
     @mcp.tool()
@@ -2433,7 +2590,7 @@ def _register_tools(mcp: FastMCP) -> None:
         )
 
     # =========================================================================
-    # TOOL 10: manage
+    # TOOL 12: manage
     # =========================================================================
 
     @mcp.tool()
@@ -2510,7 +2667,7 @@ def _register_tools(mcp: FastMCP) -> None:
         )
 
     # =========================================================================
-    # TOOL 11: logs (Developer Introspection)
+    # TOOL 13: logs (Developer Introspection)
     # =========================================================================
 
     @mcp.tool()

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -2279,15 +2279,15 @@ def _register_tools(mcp: FastMCP) -> None:
         the system working, not a gap to route around.
 
         Args:
-            entity_ids: Seed entity IDs, at most MAX_EXPAND_ORIGINS of them.
+            entity_ids: Seed entity IDs, at most 8 of them.
                 Seeds that resolve to nothing you may read come back in
                 `unresolved` without saying which reason applied.
             relationship_types: Restrict hops to these relationship names, e.g.
                 ["DEPENDS_ON"] or ["PART_OF"]. Empty walks every relationship.
             types: Restrict neighbors to these entity types.
-            depth: Hops to walk, 1-MAX_TRAVERSAL_DEPTH (default 1). Depth 1
-                first; deepen only when depth 1 came back thin.
-            limit: Neighbors returned, up to MAX_EXPAND_LIMIT.
+            depth: Hops to walk, 1-3 (default 1). Depth 1 first; deepen only
+                when depth 1 came back thin.
+            limit: Neighbors returned, up to 24 (default 8).
             content_max_chars: Preview characters per neighbor. These are
                 previews by design; widen a promising one with `fetch_slice`.
             include_incoming: Follow edges pointing at the seeds too (default
@@ -2361,7 +2361,7 @@ def _register_tools(mcp: FastMCP) -> None:
             entity_id: A passage entity ID, or the ID of the memory it came from.
                 Given a passage, the window is centered on it. Given a memory,
                 the window starts at its first span.
-            window: Adjacent spans to return, 1-MAX_SLICE_WINDOW. The default of
+            window: Adjacent spans to return, 1-64. The default of
                 three is the measured adjacency: three spans reach the same
                 exposure as the whole memory, one span reaches noticeably less.
             content_max_chars: Character budget for the whole window, spent in

--- a/apps/api/tests/test_routes_traverse.py
+++ b/apps/api/tests/test_routes_traverse.py
@@ -480,3 +480,37 @@ class TestTraversalToolsAreRegistered:
             description = by_name[name].description or ""
             assert "THREE ROUNDS" in description
             assert "context" in description
+
+
+class TestAgentFacingBoundsAreNumbers:
+    """A docstring is the only place an agent can read a bound.
+
+    Writing the Python identifier there tells the model the name of a constant it
+    cannot resolve. These assert the literal numbers and that they still match the
+    constants, so the two cannot drift apart silently.
+    """
+
+    @pytest.mark.asyncio
+    async def test_docstrings_state_literal_bounds_matching_the_constants(self) -> None:
+        from sibyl.server import create_mcp_server
+        from sibyl_core.tools.traverse import (
+            MAX_EXPAND_LIMIT,
+            MAX_EXPAND_ORIGINS,
+            MAX_SLICE_WINDOW,
+            MAX_TRAVERSAL_DEPTH,
+        )
+
+        mcp = create_mcp_server()
+        by_name = {tool.name: tool.description or "" for tool in await mcp.list_tools()}
+        expand = by_name["expand_neighbors"]
+        slice_doc = by_name["fetch_slice"]
+
+        assert f"at most {MAX_EXPAND_ORIGINS} of them" in expand
+        assert f"1-{MAX_TRAVERSAL_DEPTH}" in expand
+        assert f"up to {MAX_EXPAND_LIMIT}" in expand
+        assert f"1-{MAX_SLICE_WINDOW}" in slice_doc
+
+        for text in (expand, slice_doc):
+            assert "MAX_EXPAND" not in text
+            assert "MAX_TRAVERSAL_DEPTH" not in text
+            assert "MAX_SLICE_WINDOW" not in text

--- a/apps/api/tests/test_routes_traverse.py
+++ b/apps/api/tests/test_routes_traverse.py
@@ -260,21 +260,60 @@ class TestExpandNeighborsRoute:
 
 
 class TestExpandNeighborsRequestBounds:
-    def test_seed_count_is_capped_at_the_core_budget(self) -> None:
-        from sibyl_core.tools.traverse import MAX_EXPAND_ORIGINS
+    """One verb, one contract: both surfaces clamp rather than one rejecting.
 
-        with pytest.raises(ValueError):
-            ExpandNeighborsRequest(
-                entity_ids=[f"seed_{index}" for index in range(MAX_EXPAND_ORIGINS + 1)]
-            )
+    A tool signature cannot express a range, so MCP clamps. Rejecting here would
+    mean the identical request succeeds for an agent and 422s for a script.
+    """
 
-    def test_depth_and_limit_reject_values_past_the_ceiling(self) -> None:
+    def test_out_of_range_budgets_are_accepted_and_clamped_by_the_core(self) -> None:
+        from sibyl_core.tools.traverse import (
+            MAX_EXPAND_LIMIT,
+            MAX_EXPAND_ORIGINS,
+            MAX_TRAVERSAL_DEPTH,
+        )
+
+        request = ExpandNeighborsRequest(
+            entity_ids=[f"seed_{index}" for index in range(MAX_EXPAND_ORIGINS + 5)],
+            depth=MAX_TRAVERSAL_DEPTH + 6,
+            limit=MAX_EXPAND_LIMIT + 100,
+        )
+        assert request.depth == MAX_TRAVERSAL_DEPTH + 6
+        assert len(request.entity_ids) == MAX_EXPAND_ORIGINS + 5
+
+    @pytest.mark.asyncio
+    async def test_the_response_reports_the_bound_it_actually_applied(self) -> None:
+        """Clamping is only honest if the caller can see the effective value."""
         from sibyl_core.tools.traverse import MAX_EXPAND_LIMIT, MAX_TRAVERSAL_DEPTH
 
-        with pytest.raises(ValueError):
-            ExpandNeighborsRequest(entity_ids=["seed"], depth=MAX_TRAVERSAL_DEPTH + 1)
-        with pytest.raises(ValueError):
-            ExpandNeighborsRequest(entity_ids=["seed"], limit=MAX_EXPAND_LIMIT + 1)
+        ctx = stub_auth_context()
+        clamped = _ExpandResult(
+            origins=["decision_seed"],
+            neighbors=[_Neighbor(id="decision_neighbor")],
+            total=1,
+            depth=MAX_TRAVERSAL_DEPTH,
+            limit=MAX_EXPAND_LIMIT,
+        )
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a"}),
+            ),
+            patch("sibyl_core.tools.core.expand_neighbors", AsyncMock(return_value=clamped)),
+        ):
+            response = await expand_neighbors(
+                request=ExpandNeighborsRequest(
+                    entity_ids=["decision_seed"],
+                    depth=99,
+                    limit=999,
+                ),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert response.depth == MAX_TRAVERSAL_DEPTH
+        assert response.limit == MAX_EXPAND_LIMIT
 
     def test_inbound_edges_are_followed_by_default(self) -> None:
         assert ExpandNeighborsRequest(entity_ids=["seed"]).include_incoming is True
@@ -386,15 +425,39 @@ class TestFetchSliceRequestBounds:
 
         assert FetchSliceRequest(entity_id="x").window == PASSAGE_WINDOW_UNITS
 
-    def test_window_rejects_values_past_the_span_cap(self) -> None:
+    def test_an_oversized_window_is_accepted_and_clamped_by_the_core(self) -> None:
         from sibyl_core.tools.traverse import MAX_SLICE_WINDOW
 
-        with pytest.raises(ValueError):
-            FetchSliceRequest(entity_id="x", window=MAX_SLICE_WINDOW + 1)
+        request = FetchSliceRequest(entity_id="x", window=MAX_SLICE_WINDOW + 40)
+        assert request.window == MAX_SLICE_WINDOW + 40
 
     def test_entity_id_cannot_be_empty(self) -> None:
+        """An absent required id is malformed input, not an out-of-range budget."""
         with pytest.raises(ValueError):
             FetchSliceRequest(entity_id="")
+
+    @pytest.mark.asyncio
+    async def test_malformed_input_is_a_400_rather_than_a_500(self) -> None:
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a"}),
+            ),
+            patch(
+                "sibyl_core.tools.core.fetch_slice",
+                AsyncMock(side_effect=ValueError("entity_id is required")),
+            ),
+            pytest.raises(HTTPException) as raised,
+        ):
+            await fetch_slice(
+                request=FetchSliceRequest(entity_id="   "),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert raised.value.status_code == 400
 
 
 class TestTraversalToolsAreRegistered:

--- a/apps/api/tests/test_routes_traverse.py
+++ b/apps/api/tests/test_routes_traverse.py
@@ -1,0 +1,419 @@
+"""Route contract for the bounded traversal verbs.
+
+The routes own one job the core cannot do for them: resolving which projects the
+caller may read and handing that set, the principal, and any API-key narrowing
+to the walk. A route that resolves the wrong set produces a correctly authorized
+walk over the wrong audience, so these assert the arguments that cross the seam.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from sibyl.api.routes.search import expand_neighbors, fetch_slice
+from sibyl.api.schemas import ExpandNeighborsRequest, FetchSliceRequest
+from sibyl.auth.errors import ProjectAccessDeniedError
+from sibyl_core.auth import OrganizationRole, ProjectRole
+from tests.harness.auth import stub_auth_context
+
+ORG = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+
+
+@dataclass
+class _Neighbor:
+    id: str
+    type: str = "decision"
+    name: str = "Neighbor"
+    relationship: str = "RELATED_TO"
+    direction: str = "outgoing"
+    distance: int = 1
+    score: float = 0.7
+    content: str = "preview"
+    project_id: str | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class _ExpandResult:
+    origins: list[str]
+    neighbors: list[_Neighbor]
+    total: int
+    depth: int
+    limit: int
+    unresolved: list[str] = field(default_factory=list)
+    truncated: bool = False
+    filters: dict[str, object] = field(default_factory=dict)
+    usage_hint: str = "bounded"
+
+
+@dataclass
+class _Passage:
+    id: str
+    name: str = "span"
+    content: str = "span body"
+    passage_index: int | None = 0
+    passage_total: int | None = 3
+    breadcrumb: str | None = None
+    truncated: bool = False
+
+
+@dataclass
+class _SliceResult:
+    entity_id: str
+    parent_id: str
+    parent_name: str
+    parent_type: str
+    passages: list[_Passage]
+    window: int
+    sliced: bool
+    total: int = 0
+    window_start: int | None = None
+    passage_total: int | None = None
+    covers_parent: bool = False
+    project_id: str | None = None
+    content_chars: int = 0
+    filters: dict[str, object] = field(default_factory=dict)
+    usage_hint: str = "bounded"
+
+
+def _expand_result() -> _ExpandResult:
+    return _ExpandResult(
+        origins=["decision_seed"],
+        neighbors=[_Neighbor(id="decision_neighbor")],
+        total=1,
+        depth=1,
+        limit=8,
+    )
+
+
+def _slice_result() -> _SliceResult:
+    return _SliceResult(
+        entity_id="decision_parent",
+        parent_id="decision_parent",
+        parent_name="Parent",
+        parent_type="decision",
+        passages=[_Passage(id="decision_parent_passage_0")],
+        window=3,
+        sliced=True,
+        total=1,
+    )
+
+
+class TestExpandNeighborsRoute:
+    @pytest.mark.asyncio
+    async def test_passes_the_readers_full_project_set_when_none_named(self) -> None:
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a", "proj_b"}),
+            ) as list_projects,
+            patch(
+                "sibyl_core.tools.core.expand_neighbors",
+                AsyncMock(return_value=_expand_result()),
+            ) as core_expand,
+        ):
+            response = await expand_neighbors(
+                request=ExpandNeighborsRequest(entity_ids=["decision_seed"]),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        list_projects.assert_awaited_once_with(ctx)
+        assert response.total == 1
+        assert response.neighbors[0].id == "decision_neighbor"
+        kwargs = core_expand.await_args.kwargs
+        assert kwargs["accessible_projects"] == {"proj_a", "proj_b"}
+        assert kwargs["principal_id"] == str(ctx.user_id)
+        assert kwargs["organization_id"] == str(ORG.id)
+
+    @pytest.mark.asyncio
+    async def test_named_project_is_verified_and_becomes_the_scope(self) -> None:
+        """None would empty the walk, so the verified project has to reach the core."""
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.verify_entity_project_access",
+                AsyncMock(return_value=None),
+            ) as verify,
+            patch(
+                "sibyl_core.tools.core.expand_neighbors",
+                AsyncMock(return_value=_expand_result()),
+            ) as core_expand,
+        ):
+            await expand_neighbors(
+                request=ExpandNeighborsRequest(entity_ids=["decision_seed"], project="proj_a"),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert verify.await_args.args[2] == "proj_a"
+        assert verify.await_args.kwargs["required_role"] == ProjectRole.VIEWER
+        assert core_expand.await_args.kwargs["accessible_projects"] == {"proj_a"}
+
+    @pytest.mark.asyncio
+    async def test_project_access_denial_propagates(self) -> None:
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.verify_entity_project_access",
+                AsyncMock(
+                    side_effect=ProjectAccessDeniedError(
+                        project_id="proj_forbidden",
+                        required_role="viewer",
+                    )
+                ),
+            ),
+            patch("sibyl_core.tools.core.expand_neighbors", AsyncMock()) as core_expand,
+            pytest.raises(ProjectAccessDeniedError),
+        ):
+            await expand_neighbors(
+                request=ExpandNeighborsRequest(
+                    entity_ids=["decision_seed"], project="proj_forbidden"
+                ),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        core_expand.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_api_key_memory_grants_reach_the_walk(self) -> None:
+        ctx = stub_auth_context(
+            org_role=OrganizationRole.MEMBER,
+            api_key_memory_scope_keys={"project:proj_a"},
+        )
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a"}),
+            ),
+            patch(
+                "sibyl_core.tools.core.expand_neighbors",
+                AsyncMock(return_value=_expand_result()),
+            ) as core_expand,
+        ):
+            await expand_neighbors(
+                request=ExpandNeighborsRequest(entity_ids=["decision_seed"]),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert core_expand.await_args.kwargs["allowed_memory_scope_keys"] == {"project:proj_a"}
+
+    @pytest.mark.asyncio
+    async def test_unnarrowed_session_sends_no_grant_restriction(self) -> None:
+        """None means unrestricted downstream, so it must not be a set of nothing."""
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a"}),
+            ),
+            patch(
+                "sibyl_core.tools.core.expand_neighbors",
+                AsyncMock(return_value=_expand_result()),
+            ) as core_expand,
+        ):
+            await expand_neighbors(
+                request=ExpandNeighborsRequest(entity_ids=["decision_seed"]),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert core_expand.await_args.kwargs["allowed_memory_scope_keys"] is None
+
+    @pytest.mark.asyncio
+    async def test_walk_failure_is_a_500_not_a_leak(self) -> None:
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a"}),
+            ),
+            patch(
+                "sibyl_core.tools.core.expand_neighbors",
+                AsyncMock(side_effect=RuntimeError("surreal exploded")),
+            ),
+            pytest.raises(HTTPException) as raised,
+        ):
+            await expand_neighbors(
+                request=ExpandNeighborsRequest(entity_ids=["decision_seed"]),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert raised.value.status_code == 500
+        assert "surreal exploded" not in str(raised.value.detail)
+
+
+class TestExpandNeighborsRequestBounds:
+    def test_seed_count_is_capped_at_the_core_budget(self) -> None:
+        from sibyl_core.tools.traverse import MAX_EXPAND_ORIGINS
+
+        with pytest.raises(ValueError):
+            ExpandNeighborsRequest(
+                entity_ids=[f"seed_{index}" for index in range(MAX_EXPAND_ORIGINS + 1)]
+            )
+
+    def test_depth_and_limit_reject_values_past_the_ceiling(self) -> None:
+        from sibyl_core.tools.traverse import MAX_EXPAND_LIMIT, MAX_TRAVERSAL_DEPTH
+
+        with pytest.raises(ValueError):
+            ExpandNeighborsRequest(entity_ids=["seed"], depth=MAX_TRAVERSAL_DEPTH + 1)
+        with pytest.raises(ValueError):
+            ExpandNeighborsRequest(entity_ids=["seed"], limit=MAX_EXPAND_LIMIT + 1)
+
+    def test_inbound_edges_are_followed_by_default(self) -> None:
+        assert ExpandNeighborsRequest(entity_ids=["seed"]).include_incoming is True
+
+
+class TestFetchSliceRoute:
+    @pytest.mark.asyncio
+    async def test_returns_the_window_and_the_parent_it_cites(self) -> None:
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a"}),
+            ),
+            patch(
+                "sibyl_core.tools.core.fetch_slice",
+                AsyncMock(return_value=_slice_result()),
+            ) as core_slice,
+        ):
+            response = await fetch_slice(
+                request=FetchSliceRequest(entity_id="decision_parent"),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert response.parent_id == "decision_parent"
+        assert response.sliced is True
+        assert len(response.passages) == 1
+        kwargs = core_slice.await_args.kwargs
+        assert kwargs["accessible_projects"] == {"proj_a"}
+        assert kwargs["principal_id"] == str(ctx.user_id)
+
+    @pytest.mark.asyncio
+    async def test_unreadable_or_absent_id_is_a_404(self) -> None:
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a"}),
+            ),
+            patch(
+                "sibyl_core.tools.core.fetch_slice",
+                AsyncMock(side_effect=KeyError("decision_secret")),
+            ),
+            pytest.raises(HTTPException) as raised,
+        ):
+            await fetch_slice(
+                request=FetchSliceRequest(entity_id="decision_secret"),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert raised.value.status_code == 404
+        # The id must not appear: a distinct message for a denied row confirms it.
+        assert "decision_secret" not in str(raised.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_named_project_is_verified_before_the_read(self) -> None:
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.verify_entity_project_access",
+                AsyncMock(return_value=None),
+            ) as verify,
+            patch(
+                "sibyl_core.tools.core.fetch_slice",
+                AsyncMock(return_value=_slice_result()),
+            ) as core_slice,
+        ):
+            await fetch_slice(
+                request=FetchSliceRequest(entity_id="decision_parent", project="proj_a"),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert verify.await_args.args[2] == "proj_a"
+        assert core_slice.await_args.kwargs["accessible_projects"] == {"proj_a"}
+
+    @pytest.mark.asyncio
+    async def test_read_failure_is_a_500(self) -> None:
+        ctx = stub_auth_context()
+
+        with (
+            patch(
+                "sibyl.api.routes.search.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_a"}),
+            ),
+            patch(
+                "sibyl_core.tools.core.fetch_slice",
+                AsyncMock(side_effect=RuntimeError("boom")),
+            ),
+            pytest.raises(HTTPException) as raised,
+        ):
+            await fetch_slice(
+                request=FetchSliceRequest(entity_id="decision_parent"),
+                org=ORG,
+                ctx=ctx,
+            )
+
+        assert raised.value.status_code == 500
+
+
+class TestFetchSliceRequestBounds:
+    def test_window_defaults_to_the_measured_adjacency(self) -> None:
+        from sibyl_core.retrieval.operational_sources import PASSAGE_WINDOW_UNITS
+
+        assert FetchSliceRequest(entity_id="x").window == PASSAGE_WINDOW_UNITS
+
+    def test_window_rejects_values_past_the_span_cap(self) -> None:
+        from sibyl_core.tools.traverse import MAX_SLICE_WINDOW
+
+        with pytest.raises(ValueError):
+            FetchSliceRequest(entity_id="x", window=MAX_SLICE_WINDOW + 1)
+
+    def test_entity_id_cannot_be_empty(self) -> None:
+        with pytest.raises(ValueError):
+            FetchSliceRequest(entity_id="")
+
+
+class TestTraversalToolsAreRegistered:
+    @pytest.mark.asyncio
+    async def test_mcp_exposes_both_verbs(self) -> None:
+        from sibyl.server import create_mcp_server
+
+        mcp = create_mcp_server()
+        tools = {tool.name for tool in await mcp.list_tools()}
+        assert {"expand_neighbors", "fetch_slice"} <= tools
+
+    @pytest.mark.asyncio
+    async def test_docstrings_state_the_round_budget(self) -> None:
+        """The docstring is the only place the bound is visible to an agent."""
+        from sibyl.server import create_mcp_server
+
+        mcp = create_mcp_server()
+        by_name = {tool.name: tool for tool in await mcp.list_tools()}
+        for name in ("expand_neighbors", "fetch_slice"):
+            description = by_name[name].description or ""
+            assert "THREE ROUNDS" in description
+            assert "context" in description

--- a/apps/cli/src/sibyl_cli/data/skill-packs/core.md
+++ b/apps/cli/src/sibyl_cli/data/skill-packs/core.md
@@ -1066,7 +1066,7 @@ sibyl auth status    # Check authentication
 
 ## MCP Tools (Programmatic Access)
 
-When used as an MCP server, Sibyl exposes 11 tools. These are different from CLI commands.
+When used as an MCP server, Sibyl exposes 13 tools. These are different from CLI commands.
 
 | MCP Tool           | Purpose                                                           |
 | ------------------ | ----------------------------------------------------------------- |
@@ -1076,6 +1076,8 @@ When used as an MCP server, Sibyl exposes 11 tools. These are different from CLI
 | `synthesis_draft`  | Draft + verify + optionally remember a synthesis artifact         |
 | `synthesis_verify` | Verify citation/freshness/hidden-context/gap coverage             |
 | `explore`          | Browse graph: list, related, traverse, deps                       |
+| `expand_neighbors` | Widen known memories into their bounded neighborhood              |
+| `fetch_slice`      | Read one memory at span granularity, citing its parent            |
 | `add`              | Add knowledge, tasks, or projects                                 |
 | `remember`         | Capture durable memory: decision/plan/idea/claim/artifact/session |
 | `reflect`          | Convert raw notes into reviewable memory candidates               |

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -213,6 +213,7 @@ export default defineConfig({
                         { text: 'search', link: '/api/mcp-search' },
                         { text: 'context', link: '/api/mcp-context' },
                         { text: 'explore', link: '/api/mcp-explore' },
+                        { text: 'traversal verbs', link: '/api/mcp-traverse' },
                         { text: 'add', link: '/api/mcp-add' },
                         { text: 'remember', link: '/api/mcp-remember' },
                         { text: 'reflect', link: '/api/mcp-reflect' },

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 # Sibyl API Reference
 
-Sibyl provides a dual-interface API: an eleven-tool MCP interface for assistant clients and
+Sibyl provides a dual-interface API: a thirteen-tool MCP interface for assistant clients and
 automation, plus a full REST API for applications and integrations. Both surfaces are served by the
 same daemon (`sibyld`) and share one SurrealDB-native runtime for graph, content, and auth.
 
@@ -9,7 +9,7 @@ same daemon (`sibyld`) and share one SurrealDB-native runtime for graph, content
 ```
 Sibyl Combined App (Starlette, port 3334)
 |-- /api/*    --> FastAPI REST endpoints (31 routers)
-|-- /mcp      --> MCP streamable-http transport (11 tools, 2 resources)
+|-- /mcp      --> MCP streamable-http transport (13 tools, 2 resources)
 |-- /ws       --> WebSocket for real-time updates
 '-- Lifespan  --> Coordination runtime + session management
 ```
@@ -28,8 +28,9 @@ multi-process or distributed worker deployments.
 
 ### MCP Tools (for Assistant Clients)
 
-The MCP interface exposes eleven tools that cover discovery, context, capture, synthesis, lifecycle
-operations, and introspection. Tools are registered in `apps/api/src/sibyl/server.py`.
+The MCP interface exposes thirteen tools that cover discovery, context, bounded traversal, capture,
+synthesis, lifecycle operations, and introspection. Tools are registered in
+`apps/api/src/sibyl/server.py`.
 
 | Tool               | Purpose                                                      | Documentation                          |
 | ------------------ | ------------------------------------------------------------ | -------------------------------------- |
@@ -39,6 +40,8 @@ operations, and introspection. Tools are registered in `apps/api/src/sibyl/serve
 | `synthesis_draft`  | Draft, verify, and optionally remember a synthesis artifact  | [mcp-synthesis.md](./mcp-synthesis.md) |
 | `synthesis_verify` | Verify citation, freshness, hidden-context, and gap coverage | [mcp-synthesis.md](./mcp-synthesis.md) |
 | `explore`          | Navigate and browse graph structure                          | [mcp-explore.md](./mcp-explore.md)     |
+| `expand_neighbors` | Widen known memories into their bounded graph neighborhood   | [mcp-traverse.md](./mcp-traverse.md)   |
+| `fetch_slice`      | Read one memory at span granularity, with parent citation    | [mcp-traverse.md](./mcp-traverse.md)   |
 | `add`              | Create new knowledge entities                                | [mcp-add.md](./mcp-add.md)             |
 | `remember`         | Capture durable memory with verbatim raw provenance          | [mcp-remember.md](./mcp-remember.md)   |
 | `reflect`          | Reflect raw notes into reviewable memory candidates          | [mcp-reflect.md](./mcp-reflect.md)     |
@@ -55,14 +58,14 @@ The MCP server also exposes two resources: `sibyl://health` (connectivity and en
 The REST API spans 31 routers. The pages below cover the most commonly used surfaces; the full
 contract is in the OpenAPI schema.
 
-| Category  | Endpoints                            | Documentation                            |
-| --------- | ------------------------------------ | ---------------------------------------- |
-| Entities  | `/api/entities/*`                    | [rest-entities.md](./rest-entities.md)   |
-| Tasks     | `/api/tasks/*`                       | [rest-tasks.md](./rest-tasks.md)         |
-| Projects  | `/api/entities?entity_type=project`  | [rest-projects.md](./rest-projects.md)   |
-| Search    | `/api/search`, `/api/search/explore` | [rest-search.md](./rest-search.md)       |
-| Memory    | `/api/memory/*`, `/api/context/*`    | [rest-memory.md](./rest-memory.md)       |
-| Synthesis | `/api/synthesis/*`                   | [rest-synthesis.md](./rest-synthesis.md) |
+| Category  | Endpoints                                                                       | Documentation                            |
+| --------- | ------------------------------------------------------------------------------- | ---------------------------------------- |
+| Entities  | `/api/entities/*`                                                               | [rest-entities.md](./rest-entities.md)   |
+| Tasks     | `/api/tasks/*`                                                                  | [rest-tasks.md](./rest-tasks.md)         |
+| Projects  | `/api/entities?entity_type=project`                                             | [rest-projects.md](./rest-projects.md)   |
+| Search    | `/api/search`, `/api/search/explore`, `/api/search/expand`, `/api/search/slice` | [rest-search.md](./rest-search.md)       |
+| Memory    | `/api/memory/*`, `/api/context/*`                                               | [rest-memory.md](./rest-memory.md)       |
+| Synthesis | `/api/synthesis/*`                                                              | [rest-synthesis.md](./rest-synthesis.md) |
 
 Additional routers not covered by dedicated pages include `auth`, `users`, `epics`, `experience`,
 `graph`, `crawler`, `ingestion`, `rag`, `resolve`, `jobs`, `backups`, `settings`, `ai_settings`,

--- a/docs/api/mcp-traverse.md
+++ b/docs/api/mcp-traverse.md
@@ -1,0 +1,164 @@
+# MCP Tools: expand_neighbors and fetch_slice
+
+Bounded traversal verbs for an agent that steers its own retrieval. `expand_neighbors` widens a set
+of known memories into their graph neighborhood; `fetch_slice` widens one memory into the span window
+it was cut into.
+
+## The traversal contract
+
+These verbs are steps in a loop of **at most three rounds**:
+
+1. `search` or `context` finds a starting set.
+2. `expand_neighbors` or `fetch_slice` widens it.
+3. One more widening round, then answer.
+
+Two retrieval iterations capture nearly all of the available gain, so a fourth round costs latency
+and buys noise. The verbs are stateless and bounded per call; the round budget lives in the tool
+docstrings rather than in server state, because there is no session to enforce it in.
+
+**Skip traversal entirely when one hop answers the question.** For "what do we know about X", call
+[`context`](./mcp-context.md) and read the pack it composed. Traversal is for when you hold specific
+memories and need what sits next to them: the tasks blocking this one, the decision a plan
+supersedes, the spans of a memory a search only matched part of.
+
+**Composition is not yours.** Both verbs return adjacency and previews so you can choose what to
+gather. `context` still renders the evidence and keeps control of ordering and the reserved note
+lane.
+
+## Authorization
+
+Every row either verb returns is authorized for the calling reader individually, not once per seed.
+Project membership does not authorize a private memory that happens to sit in that project, so a
+neighbor missing from a result may exist and belong to someone else.
+
+A seed that is absent and a seed the reader may not see are reported identically, and `fetch_slice`
+raises the same 404 for a denied entity as for one that does not exist. Distinguishing them would
+confirm the existence of a row the caller has no right to know about.
+
+## expand_neighbors
+
+### Input
+
+```typescript
+interface ExpandNeighborsInput {
+  entity_ids: string[]; // Seeds, at most 8
+  relationship_types?: string[]; // Restrict hops, e.g. ["DEPENDS_ON"]
+  types?: string[]; // Restrict neighbors to these entity types
+  depth?: number; // 1-3, default 1
+  limit?: number; // 1-24, default 8
+  content_max_chars?: number; // Preview characters per neighbor, default 500
+  include_incoming?: boolean; // default true
+  project?: string; // Scope the walk to one readable project
+}
+```
+
+`include_incoming` defaults to true because the interesting neighbors are usually on that side. The
+graph writes edges from span to memory and from dependent to dependency, so an outgoing-only walk
+reports those neighbors as absent.
+
+### Output
+
+```typescript
+interface ExpandNeighborsOutput {
+  origins: string[]; // Seeds that resolved for this reader
+  unresolved: string[]; // Seeds that did not, without saying why
+  neighbors: {
+    id: string;
+    type: string;
+    name: string;
+    relationship: string; // Edge name, or SHARES_COMMUNITY / MENTIONS
+    direction: "outgoing" | "incoming";
+    distance: number; // Hop count from the nearest seed
+    score: number; // Relationship weight with depth decay
+    content: string; // Preview, bounded by content_max_chars
+    project_id: string | null;
+    metadata: Record<string, unknown>;
+  }[];
+  total: number;
+  depth: number;
+  limit: number;
+  truncated: boolean; // More neighbors existed than the limit returned
+  filters: Record<string, unknown>;
+}
+```
+
+A neighbor that is itself a span carries `passage_index`, `parent_entity_id`, and
+`widen_with: "fetch_slice"`, naming the next move rather than making the caller infer it.
+
+### Examples
+
+```python
+expand_neighbors(["task_abc"], relationship_types=["DEPENDS_ON"])
+expand_neighbors(["decision_1", "decision_2"], depth=2, limit=16)
+expand_neighbors(["artifact_abc"], relationship_types=["PART_OF"])  # its spans
+```
+
+## fetch_slice
+
+### Input
+
+```typescript
+interface FetchSliceInput {
+  entity_id: string; // A passage ID, or the memory it was cut from
+  window?: number; // 1-64, default 3
+  content_max_chars?: number; // Budget for the whole window, default 18000
+  project?: string; // Scope the read to one readable project
+}
+```
+
+The default window of three is the measured adjacency: three adjacent spans reach the same answer
+exposure as sending the whole memory, where a lone span reaches noticeably less.
+
+Given a passage, the window centers on it. Given a memory, the window starts at its first span.
+
+### Output
+
+```typescript
+interface FetchSliceOutput {
+  entity_id: string; // What was asked for
+  parent_id: string; // What a citation resolves to
+  parent_name: string;
+  parent_type: string;
+  passages: {
+    id: string;
+    name: string;
+    content: string;
+    passage_index: number | null;
+    passage_total: number | null;
+    breadcrumb: string | null;
+    truncated: boolean;
+  }[];
+  window: number;
+  sliced: boolean; // false when the memory was never cut into spans
+  total: number;
+  window_start: number | null;
+  passage_total: number | null;
+  covers_parent: boolean; // Whether these spans account for the whole body
+  project_id: string | null;
+  content_chars: number;
+}
+```
+
+**Cite `parent_id`, not a span id.** Spans are re-minted whenever their memory is edited, so a
+citation pointing at one goes stale silently. `covers_parent` says whether the returned spans account
+for the whole body; when it is false, text lives only on the parent.
+
+A memory short enough never to have been cut comes back whole with `sliced: false`. That is the
+answer, not an error to retry.
+
+### Examples
+
+```python
+fetch_slice("passage_9f2c1b")            # window centered on this span
+fetch_slice("decision_abc", window=5)    # first five spans of this memory
+```
+
+## REST equivalents
+
+| Verb               | Endpoint               |
+| ------------------ | ---------------------- |
+| `expand_neighbors` | `POST /api/search/expand` |
+| `fetch_slice`      | `POST /api/search/slice`  |
+
+Both accept the same fields as the MCP tools and resolve the caller's readable projects from their
+session before the walk. See [rest-search.md](./rest-search.md) for the shared search surface.

--- a/docs/api/mcp-traverse.md
+++ b/docs/api/mcp-traverse.md
@@ -1,8 +1,8 @@
 # MCP Tools: expand_neighbors and fetch_slice
 
 Bounded traversal verbs for an agent that steers its own retrieval. `expand_neighbors` widens a set
-of known memories into their graph neighborhood; `fetch_slice` widens one memory into the span window
-it was cut into.
+of known memories into their graph neighborhood; `fetch_slice` widens one memory into the span
+window it was cut into.
 
 ## The traversal contract
 
@@ -140,8 +140,8 @@ interface FetchSliceOutput {
 ```
 
 **Cite `parent_id`, not a span id.** Spans are re-minted whenever their memory is edited, so a
-citation pointing at one goes stale silently. `covers_parent` says whether the returned spans account
-for the whole body; when it is false, text lives only on the parent.
+citation pointing at one goes stale silently. `covers_parent` says whether the returned spans
+account for the whole body; when it is false, text lives only on the parent.
 
 A memory short enough never to have been cut comes back whole with `sliced: false`. That is the
 answer, not an error to retry.
@@ -155,8 +155,8 @@ fetch_slice("decision_abc", window=5)    # first five spans of this memory
 
 ## REST equivalents
 
-| Verb               | Endpoint               |
-| ------------------ | ---------------------- |
+| Verb               | Endpoint                  |
+| ------------------ | ------------------------- |
 | `expand_neighbors` | `POST /api/search/expand` |
 | `fetch_slice`      | `POST /api/search/slice`  |
 

--- a/docs/api/mcp-traverse.md
+++ b/docs/api/mcp-traverse.md
@@ -31,6 +31,11 @@ Every row either verb returns is authorized for the calling reader individually,
 Project membership does not authorize a private memory that happens to sit in that project, so a
 neighbor missing from a result may exist and belong to someone else.
 
+The check gates the walk, not only its output. Only authorized rows join the next frontier, so an
+unreadable memory is not a route either: you will not receive a two-hop neighbor that is reachable
+only through someone else's private memory, because receiving it would tell you something sits
+between you and it.
+
 A seed that is absent and a seed the reader may not see are reported identically, and `fetch_slice`
 raises the same 404 for a denied entity as for one that does not exist. Distinguishing them would
 confirm the existence of a row the caller has no right to know about.

--- a/docs/api/mcp-traverse.md
+++ b/docs/api/mcp-traverse.md
@@ -52,7 +52,7 @@ confirm the existence of a row the caller has no right to know about.
 interface ExpandNeighborsInput {
   entity_ids: string[]; // Seeds, at most 8
   relationship_types?: string[]; // Restrict hops, e.g. ["DEPENDS_ON"]
-  types?: string[]; // Restrict neighbors to these entity types
+  types?: string[]; // Restrict the neighbors returned to these entity types
   depth?: number; // 1-3, default 1
   limit?: number; // 1-24, default 8
   content_max_chars?: number; // Preview characters per neighbor, default 500
@@ -64,6 +64,14 @@ interface ExpandNeighborsInput {
 `include_incoming` defaults to true because the interesting neighbors are usually on that side. The
 graph writes edges from span to memory and from dependent to dependency, so an outgoing-only walk
 reports those neighbors as absent.
+
+`types` narrows the answer, not the walk. A two-hop neighbor of the requested type stays reachable
+through a first hop of some other type, so asking for decisions will not hide a decision that sits
+behind a task.
+
+`covers_parent` reads a flag that only the prose passage projection writes, so spans cut from
+operational evidence report `false` even when the window is complete. That is conservative in the
+safe direction: it never claims coverage it does not have.
 
 `direction` describes the edge that reached a row from the node one hop closer, not from your seed.
 At `distance` 1 those are the same thing; at `distance` 2 and beyond, an `incoming` row points at

--- a/docs/api/mcp-traverse.md
+++ b/docs/api/mcp-traverse.md
@@ -36,6 +36,10 @@ unreadable memory is not a route either: you will not receive a two-hop neighbor
 only through someone else's private memory, because receiving it would tell you something sits
 between you and it.
 
+A span is never more readable than the memory it was cut from. `fetch_slice` authorizes the parent
+before serving a span, even when you name the span directly, because a span inherits its parent's
+scope once at write time and a later scope-only edit does not refresh it.
+
 A seed that is absent and a seed the reader may not see are reported identically, and `fetch_slice`
 raises the same 404 for a denied entity as for one that does not exist. Distinguishing them would
 confirm the existence of a row the caller has no right to know about.
@@ -60,6 +64,10 @@ interface ExpandNeighborsInput {
 `include_incoming` defaults to true because the interesting neighbors are usually on that side. The
 graph writes edges from span to memory and from dependent to dependency, so an outgoing-only walk
 reports those neighbors as absent.
+
+`direction` describes the edge that reached a row from the node one hop closer, not from your seed.
+At `distance` 1 those are the same thing; at `distance` 2 and beyond, an `incoming` row points at
+its own predecessor in the walk rather than at the seed you named.
 
 ### Output
 
@@ -157,6 +165,15 @@ answer, not an error to retry.
 fetch_slice("passage_9f2c1b")            # window centered on this span
 fetch_slice("decision_abc", window=5)    # first five spans of this memory
 ```
+
+## Bounds are clamped, not rejected
+
+Both surfaces clamp out-of-range budgets rather than refusing them, and every response reports the
+value it actually applied (`depth`, `limit`, `window`). A tool signature cannot express a range, so
+the MCP verbs clamp; rejecting on the REST side would mean the identical request succeeds for an
+agent and fails for a script. Seeds past the cap come back in `unresolved` rather than being walked
+silently. Malformed input, such as a blank `entity_id`, is a `400` and is a different thing from an
+out-of-range budget.
 
 ## REST equivalents
 

--- a/docs/guide/claude-code.md
+++ b/docs/guide/claude-code.md
@@ -28,6 +28,8 @@ tools and data sources. Sibyl exposes 11 MCP tools:
 | `synthesis_draft`  | Draft, verify, and optionally remember a synthesis artifact    |
 | `synthesis_verify` | Verify citation, freshness, redaction, and gap coverage        |
 | `explore`          | Navigate the graph: list, related, traverse, dependencies      |
+| `expand_neighbors` | Widen known memories into their bounded neighborhood           |
+| `fetch_slice`      | Read one memory at span granularity, citing its parent         |
 | `add`              | Create knowledge entries (episodes, patterns, tasks, projects) |
 | `remember`         | Capture durable memory (decision, plan, idea, claim, ...)      |
 | `reflect`          | Reflect raw notes into reviewable memory candidates            |
@@ -36,7 +38,9 @@ tools and data sources. Sibyl exposes 11 MCP tools:
 
 The four memory-loop tools (`context`, `remember`, `reflect`, and the `synthesis_*` family)
 implement the [memory loop](./memory-loop.md) for agents. `search`, `explore`, `add`, and `manage`
-cover retrieval and workflow.
+cover retrieval and workflow. `expand_neighbors` and `fetch_slice` are the bounded traversal verbs
+for an agent that wants to steer its own retrieval over at most three rounds; see
+[the traversal verbs](../api/mcp-traverse.md) for the contract they answer to.
 
 ## Connecting an Agent
 

--- a/docs/guide/mcp-configuration.md
+++ b/docs/guide/mcp-configuration.md
@@ -195,9 +195,10 @@ and is rejected by the production config validator.
 
 ### Tool Registration
 
-The MCP server is constructed in `server.py` and registers 11 tools: `search`, `context`,
-`synthesis_plan`, `synthesis_draft`, `synthesis_verify`, `explore`, `add`, `remember`, `reflect`,
-`manage`, and `logs`. See [Agents & MCP](./claude-code.md) for what each one does.
+The MCP server is constructed in `server.py` and registers 13 tools: `search`, `context`,
+`synthesis_plan`, `synthesis_draft`, `synthesis_verify`, `explore`, `expand_neighbors`,
+`fetch_slice`, `add`, `remember`, `reflect`, `manage`, and `logs`. See
+[Agents & MCP](./claude-code.md) for what each one does.
 
 ```python
 mcp = FastMCP(

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -97,6 +97,37 @@ def passage_entity_id(source_id: str, passage_index: int) -> str:
     return _generate_id("passage", "memory", source_id, str(passage_index))
 
 
+def spans_cover_parent(spans: Sequence[tuple[int | None, int | None, bool]]) -> bool:
+    """Whether this exact set of spans accounts for a whole parent body.
+
+    Takes ``(passage_index, passage_total, covers_parent_flag)`` per span.
+
+    Three things must hold, and the per-span flag is only the first of them. The
+    flag is a property of the projection, not of a subset of it, so a caller
+    holding two spans of four reads three trues and would wrongly conclude the
+    body is covered. That is the difference between a reader dropping a fat
+    parent safely and dropping half its text.
+
+    The projection has to have covered the whole body, the spans have to agree on
+    a single declared total, and their indices have to be exactly that total's
+    range. The middle condition matters because re-projecting a shortened memory
+    rewrites the leading spans in place while higher-index rows survive under
+    their old ids, so one parent can present spans from two generations that
+    count to the right number while missing the middle of the body.
+    """
+    if not spans:
+        return False
+    totals = {total for _index, total, _covers in spans}
+    if len(totals) != 1:
+        return False
+    total = next(iter(totals))
+    if not isinstance(total, int) or total <= 0:
+        return False
+    if not all(covers for _index, _total, covers in spans):
+        return False
+    return {index for index, _total, _covers in spans} == set(range(total))
+
+
 def should_project_passages(source: Entity) -> bool:
     """Whether this memory is the kind, and the size, worth cutting."""
     if source.entity_type not in PASSAGE_SOURCE_TYPES:
@@ -489,4 +520,5 @@ __all__ = [
     "reproject_entity_passages",
     "retire_entity_passages",
     "should_project_passages",
+    "spans_cover_parent",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -1821,6 +1821,7 @@ async def expand_neighbor_records(
     include_incoming: bool = True,
     search_filter: SearchFilter | None = None,
     row_allowed: Callable[[Mapping[str, object]], bool] | None = None,
+    row_included: Callable[[Mapping[str, object]], bool] | None = None,
 ) -> list[dict[str, object]]:
     """Walk one bounded neighborhood for a caller that steers its own retrieval.
 
@@ -1837,6 +1838,12 @@ async def expand_neighbor_records(
     the scored lanes read with, because a handful of unreadable rows outranking
     the readable ones would otherwise consume the whole budget and report a
     neighborhood as empty when it is not.
+
+    ``row_included`` narrows what the caller sees without narrowing where the walk
+    may go. The two are deliberately separate: authorization is about reachability,
+    while a presentational filter such as an entity-type restriction must not
+    silently sever a route, or asking for one type of neighbor would hide the
+    two-hop rows that are only reachable through another type.
     """
     limit = max(int(limit), 0)
     depth_budget = max(int(max_depth), 1)
@@ -1877,6 +1884,11 @@ async def expand_neighbor_records(
             if row_allowed is not None and not row_allowed(row):
                 # Unauthorized, so not a result and not a route either.
                 continue
+            # Authorized, so it is a route whatever the caller wants to see.
+            next_frontier.append(uuid)
+            if row_included is not None and not row_included(row):
+                # Filtered from the answer, but still walked through.
+                continue
             # The shared function reports every round as adjacent, because each
             # round is one hop from its own frontier. True distance from the
             # caller's seeds, and the decay it earns, are this walk's to state.
@@ -1886,7 +1898,6 @@ async def expand_neighbor_records(
             row["graph_expansion_score"] = score
             row["score"] = score
             collected[uuid] = row
-            next_frontier.append(uuid)
         frontier = next_frontier
 
     ordered = sorted(collected.values(), key=_record_score, reverse=True)

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -1453,7 +1453,13 @@ async def _node_bfs_records(
 
     wanted = {str(name).upper() for name in relationship_names if str(name).strip()}
     discovered: list[_GraphExpansionHop] = []
-    seen_discovered: set[str] = set()
+    # Origins are already in the caller's hand, so they are pre-marked as
+    # discovered rather than only as visited. Visiting stops an origin being
+    # walked from twice; it does not stop one being reported as its own
+    # neighbor, which is what a round trip does: with inbound hops enabled every
+    # A->B edge is a 2-cycle, so at depth 2 any seed with an edge finds itself and
+    # spends a result slot on a row the caller supplied.
+    seen_discovered = set(origin_uuids)
     visited_entities = set(origin_uuids)
     entity_frontier = _dedupe_strings(origin_uuids)
     episode_frontier = _dedupe_strings(episode_origin_uuids)
@@ -1821,24 +1827,67 @@ async def expand_neighbor_records(
 
     Hop-tagged entity rows, highest path score first, capped at ``limit``.
 
-    ``row_allowed`` is the reader's authorization check and runs before the cap,
-    so the walk is widened by the same headroom the scored lanes read with. A
-    filter applied after the cap would let a handful of unreadable rows consume
-    the caller's whole budget and report a neighborhood as empty when it is not.
+    ``row_allowed`` is the reader's authorization check, and it gates the walk
+    rather than only its output. The walk advances one hop at a time and only
+    authorized rows join the next frontier, so a row the reader may not see is
+    not merely withheld: it is not a route. Filtering only the final result would
+    still return a depth-two neighbor reachable exclusively through another
+    principal's private memory, which discloses that something sits between them.
+
+    The check runs before the cap, and each hop is widened by the same headroom
+    the scored lanes read with, because a handful of unreadable rows outranking
+    the readable ones would otherwise consume the whole budget and report a
+    neighborhood as empty when it is not.
     """
-    rows = await _node_bfs_records(
-        client=client,
-        origin_uuids=origin_uuids,
-        search_filter=search_filter if search_filter is not None else SearchFilter(),
-        group_id=group_id,
-        max_depth=max(int(max_depth), 1),
-        limit=_graph_expansion_fetch_limit(limit),
-        relationship_names=relationship_names,
-        include_incoming=include_incoming,
-    )
-    if row_allowed is not None:
-        rows = [row for row in rows if row_allowed(row)]
-    return rows[: max(int(limit), 0)]
+    limit = max(int(limit), 0)
+    depth_budget = max(int(max_depth), 1)
+    effective_filter = search_filter if search_filter is not None else SearchFilter()
+    if not limit:
+        return []
+
+    collected: dict[str, dict[str, object]] = {}
+    # Origins are the caller's own rows. Excluding them from results as well as
+    # from re-expansion is what stops a seed being returned as its own neighbor,
+    # which every inbound edge makes reachable at depth two.
+    seen = {str(uuid) for uuid in origin_uuids if str(uuid)}
+    frontier = _dedupe_strings(origin_uuids)
+
+    for depth in range(1, depth_budget + 1):
+        if not frontier or len(collected) >= limit:
+            break
+        hop_rows = await _node_bfs_records(
+            client=client,
+            origin_uuids=frontier,
+            search_filter=effective_filter,
+            group_id=group_id,
+            max_depth=1,
+            limit=_graph_expansion_fetch_limit(limit),
+            relationship_names=relationship_names,
+            include_incoming=include_incoming,
+        )
+        next_frontier: list[str] = []
+        for row in hop_rows:
+            uuid = _string_value(row.get("uuid"))
+            if not uuid or uuid in seen:
+                continue
+            seen.add(uuid)
+            if row_allowed is not None and not row_allowed(row):
+                # Unauthorized, so not a result and not a route either.
+                continue
+            # Each round walks one hop, so restate the true distance and re-apply
+            # the decay that distance earns rather than reporting every row as
+            # adjacent to the seed.
+            relationship = _string_value(row.get("graph_expansion_relationship")) or "RELATED_TO"
+            score = _graph_expansion_path_score(relationship, depth=depth)
+            row["graph_expansion_depth"] = depth
+            row["graph_expansion_score"] = score
+            row["score"] = score
+            collected[uuid] = row
+            next_frontier.append(uuid)
+        frontier = next_frontier
+
+    ordered = sorted(collected.values(), key=_record_score, reverse=True)
+    return ordered[:limit]
 
 
 async def _hydrate_entity_records(

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -1447,19 +1447,14 @@ async def _node_bfs_records(
     limit: int,
     relationship_names: Sequence[str] = (),
     include_incoming: bool = False,
+    include_community_hops: bool = True,
 ) -> list[dict[str, object]]:
     if (not origin_uuids and not episode_origin_uuids) or max_depth < 1:
         return []
 
     wanted = {str(name).upper() for name in relationship_names if str(name).strip()}
     discovered: list[_GraphExpansionHop] = []
-    # Origins are already in the caller's hand, so they are pre-marked as
-    # discovered rather than only as visited. Visiting stops an origin being
-    # walked from twice; it does not stop one being reported as its own
-    # neighbor, which is what a round trip does: with inbound hops enabled every
-    # A->B edge is a 2-cycle, so at depth 2 any seed with an edge finds itself and
-    # spends a result slot on a row the caller supplied.
-    seen_discovered = set(origin_uuids)
+    seen_discovered: set[str] = set()
     visited_entities = set(origin_uuids)
     entity_frontier = _dedupe_strings(origin_uuids)
     episode_frontier = _dedupe_strings(episode_origin_uuids)
@@ -1502,7 +1497,11 @@ async def _node_bfs_records(
                     relationship_names=sorted(wanted),
                 )
             )
-        if depth == 1 and _hop_relationship_wanted("SHARES_COMMUNITY", wanted):
+        if (
+            depth == 1
+            and include_community_hops
+            and _hop_relationship_wanted("SHARES_COMMUNITY", wanted)
+        ):
             next_hops.extend(
                 await _community_member_hops(
                     client=client,
@@ -1864,6 +1863,10 @@ async def expand_neighbor_records(
             limit=_graph_expansion_fetch_limit(limit),
             relationship_names=relationship_names,
             include_incoming=include_incoming,
+            # Every round is depth 1 as far as the shared function can tell, so
+            # the first-hop-only community lane would otherwise re-fire on each
+            # one and widen the neighborhood in a way the scored lane never does.
+            include_community_hops=depth == 1,
         )
         next_frontier: list[str] = []
         for row in hop_rows:
@@ -1874,9 +1877,9 @@ async def expand_neighbor_records(
             if row_allowed is not None and not row_allowed(row):
                 # Unauthorized, so not a result and not a route either.
                 continue
-            # Each round walks one hop, so restate the true distance and re-apply
-            # the decay that distance earns rather than reporting every row as
-            # adjacent to the seed.
+            # The shared function reports every round as adjacent, because each
+            # round is one hop from its own frontier. True distance from the
+            # caller's seeds, and the decay it earns, are this walk's to state.
             relationship = _string_value(row.get("graph_expansion_relationship")) or "RELATED_TO"
             score = _graph_expansion_path_score(relationship, depth=depth)
             row["graph_expansion_depth"] = depth

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -232,6 +232,7 @@ class _GraphExpansionHop:
     relationship: str
     score: float
     community_id: str | None = None
+    direction: str = "outgoing"
 
 
 def coerce_fusion_backend(
@@ -1444,10 +1445,13 @@ async def _node_bfs_records(
     group_id: str,
     max_depth: int,
     limit: int,
+    relationship_names: Sequence[str] = (),
+    include_incoming: bool = False,
 ) -> list[dict[str, object]]:
     if (not origin_uuids and not episode_origin_uuids) or max_depth < 1:
         return []
 
+    wanted = {str(name).upper() for name in relationship_names if str(name).strip()}
     discovered: list[_GraphExpansionHop] = []
     seen_discovered: set[str] = set()
     visited_entities = set(origin_uuids)
@@ -1461,7 +1465,7 @@ async def _node_bfs_records(
             break
         fetch_limit = _graph_expansion_fetch_limit(remaining)
         next_hops: list[_GraphExpansionHop] = []
-        if depth == 1:
+        if depth == 1 and _hop_relationship_wanted("MENTIONS", wanted):
             next_hops.extend(
                 await _mentioned_entity_hops(
                     client=client,
@@ -1478,9 +1482,21 @@ async def _node_bfs_records(
                 group_id=group_id,
                 depth=depth,
                 limit=fetch_limit,
+                relationship_names=sorted(wanted),
             )
         )
-        if depth == 1:
+        if include_incoming:
+            next_hops.extend(
+                await _relation_source_hops(
+                    client=client,
+                    target_uuids=entity_frontier,
+                    group_id=group_id,
+                    depth=depth,
+                    limit=fetch_limit,
+                    relationship_names=sorted(wanted),
+                )
+            )
+        if depth == 1 and _hop_relationship_wanted("SHARES_COMMUNITY", wanted):
             next_hops.extend(
                 await _community_member_hops(
                     client=client,
@@ -1561,6 +1577,16 @@ async def _mentioned_entity_hops(
     ]
 
 
+def _hop_relationship_wanted(relationship: str, wanted: set[str]) -> bool:
+    """Whether a synthesized hop label survives the caller's relationship filter.
+
+    ``MENTIONS`` and ``SHARES_COMMUNITY`` are labels the expanders mint rather
+    than edge names a query can filter on, so the filter is applied by skipping
+    the expander instead of narrowing its ``WHERE``.
+    """
+    return not wanted or relationship in wanted
+
+
 async def _relation_target_hops(
     *,
     client: Any,
@@ -1568,22 +1594,26 @@ async def _relation_target_hops(
     group_id: str,
     depth: int,
     limit: int,
+    relationship_names: Sequence[str] = (),
 ) -> list[_GraphExpansionHop]:
     if not source_uuids:
         return []
+    name_clause = "AND name IN $relationship_names" if relationship_names else ""
     rows = await _execute_query_records(
         client,
-        """
+        f"""
         SELECT target_id AS uuid, name AS relationship
         FROM relates_to
         WHERE source_id IN $source_uuids
           AND group_id = $group_id
           AND out.group_id = $group_id
+          {name_clause}
         LIMIT $limit;
         """,
         source_uuids=list(source_uuids),
         group_id=group_id,
         limit=max(int(limit), 1),
+        **({"relationship_names": list(relationship_names)} if relationship_names else {}),
     )
     hops: list[_GraphExpansionHop] = []
     for row in rows:
@@ -1597,6 +1627,60 @@ async def _relation_target_hops(
                 depth=depth,
                 relationship=relationship,
                 score=_graph_expansion_path_score(relationship, depth=depth),
+            )
+        )
+    return _dedupe_expansion_hops(hops)
+
+
+async def _relation_source_hops(
+    *,
+    client: Any,
+    target_uuids: Sequence[str],
+    group_id: str,
+    depth: int,
+    limit: int,
+    relationship_names: Sequence[str] = (),
+) -> list[_GraphExpansionHop]:
+    """Walk edges that point AT the frontier rather than away from it.
+
+    Retrieval's own expansion lane only follows outgoing edges, which is fine
+    when the seeds came from a scored search. A caller steering the walk itself
+    needs the other side too: the tasks that depend on this one and the passages
+    cut from this memory are all inbound, and an outgoing-only neighborhood
+    reports them as absent.
+    """
+    if not target_uuids:
+        return []
+    name_clause = "AND name IN $relationship_names" if relationship_names else ""
+    rows = await _execute_query_records(
+        client,
+        f"""
+        SELECT source_id AS uuid, name AS relationship
+        FROM relates_to
+        WHERE target_id IN $target_uuids
+          AND group_id = $group_id
+          AND in.group_id = $group_id
+          {name_clause}
+        LIMIT $limit;
+        """,
+        target_uuids=list(target_uuids),
+        group_id=group_id,
+        limit=max(int(limit), 1),
+        **({"relationship_names": list(relationship_names)} if relationship_names else {}),
+    )
+    hops: list[_GraphExpansionHop] = []
+    for row in rows:
+        uuid = _string_value(row.get("uuid"))
+        if not uuid:
+            continue
+        relationship = _string_value(row.get("relationship")) or "RELATED_TO"
+        hops.append(
+            _GraphExpansionHop(
+                uuid=uuid,
+                depth=depth,
+                relationship=relationship,
+                score=_graph_expansion_path_score(relationship, depth=depth),
+                direction="incoming",
             )
         )
     return _dedupe_expansion_hops(hops)
@@ -1710,11 +1794,51 @@ async def _hydrate_graph_expansion_records(
         record["graph_expansion_depth"] = hop.depth
         record["graph_expansion_relationship"] = hop.relationship
         record["graph_expansion_score"] = hop.score
+        # Not in _GRAPH_EXPANSION_METADATA_KEYS on purpose: the scored lanes copy
+        # only the listed keys onto a candidate, so direction reaches a caller
+        # that reads the record directly and stays out of search result metadata.
+        record["graph_expansion_direction"] = hop.direction
         if hop.community_id:
             record["graph_expansion_community_id"] = hop.community_id
         records.append(record)
     records.sort(key=_record_score, reverse=True)
     return records
+
+
+async def expand_neighbor_records(
+    *,
+    client: Any,
+    origin_uuids: Sequence[str],
+    group_id: str,
+    max_depth: int,
+    limit: int,
+    relationship_names: Sequence[str] = (),
+    include_incoming: bool = True,
+    search_filter: SearchFilter | None = None,
+    row_allowed: Callable[[Mapping[str, object]], bool] | None = None,
+) -> list[dict[str, object]]:
+    """Walk one bounded neighborhood for a caller that steers its own retrieval.
+
+    Hop-tagged entity rows, highest path score first, capped at ``limit``.
+
+    ``row_allowed`` is the reader's authorization check and runs before the cap,
+    so the walk is widened by the same headroom the scored lanes read with. A
+    filter applied after the cap would let a handful of unreadable rows consume
+    the caller's whole budget and report a neighborhood as empty when it is not.
+    """
+    rows = await _node_bfs_records(
+        client=client,
+        origin_uuids=origin_uuids,
+        search_filter=search_filter if search_filter is not None else SearchFilter(),
+        group_id=group_id,
+        max_depth=max(int(max_depth), 1),
+        limit=_graph_expansion_fetch_limit(limit),
+        relationship_names=relationship_names,
+        include_incoming=include_incoming,
+    )
+    if row_allowed is not None:
+        rows = [row for row in rows if row_allowed(row)]
+    return rows[: max(int(limit), 0)]
 
 
 async def _hydrate_entity_records(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/core.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/core.py
@@ -22,10 +22,14 @@ from sibyl_core.tools.responses import (
     AddResponse,
     DependencyNode,
     EntitySummary,
+    ExpandNeighborsResponse,
     ExploreResponse,
+    FetchSliceResponse,
+    NeighborEntity,
     RelatedEntity,
     SearchResponse,
     SearchResult,
+    SlicePassage,
 )
 
 
@@ -45,6 +49,18 @@ async def explore(*args: Any, **kwargs: Any) -> Any:
     from sibyl_core.tools.explore import explore as _explore
 
     return await _explore(*args, **kwargs)
+
+
+async def expand_neighbors(*args: Any, **kwargs: Any) -> Any:
+    from sibyl_core.tools.traverse import expand_neighbors as _expand_neighbors
+
+    return await _expand_neighbors(*args, **kwargs)
+
+
+async def fetch_slice(*args: Any, **kwargs: Any) -> Any:
+    from sibyl_core.tools.traverse import fetch_slice as _fetch_slice
+
+    return await _fetch_slice(*args, **kwargs)
 
 
 async def get_health(*args: Any, **kwargs: Any) -> Any:
@@ -110,10 +126,14 @@ __all__ = [
     "AddResponse",
     "DependencyNode",
     "EntitySummary",
+    "ExpandNeighborsResponse",
     "ExploreResponse",
+    "FetchSliceResponse",
+    "NeighborEntity",
     "RelatedEntity",
     "SearchResponse",
     "SearchResult",
+    "SlicePassage",
     "_auto_discover_links",
     "_build_entity_metadata",
     "_generate_id",
@@ -125,7 +145,9 @@ __all__ = [
     "compile_context",
     "context_pack_to_dict",
     "context_pack_to_markdown",
+    "expand_neighbors",
     "explore",
+    "fetch_slice",
     # Health/stats
     "get_health",
     "get_project_tags",

--- a/packages/python/sibyl-core/src/sibyl_core/tools/explore.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/explore.py
@@ -1,22 +1,18 @@
 """Explore tool for navigating the Sibyl knowledge graph."""
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
 
-from sibyl_core.auth.memory_policy import (
-    memory_metadata_read_allowed,
-    memory_row_project_id,
-    private_scope_granted_for,
-)
 from sibyl_core.models.entities import Entity, EntityType, RelationshipType
 from sibyl_core.tools.helpers import (
     VALID_ENTITY_TYPES,
+    ScopeGuard,
     _build_entity_metadata,
     _get_field,
     _project_id_for_policy,
     _serialize_enum,
+    memory_scope_guard,
 )
 from sibyl_core.tools.responses import (
     DependencyNode,
@@ -38,59 +34,6 @@ async def get_graph_runtime(group_id: str):
     from sibyl_core.services.graph import get_surreal_graph_runtime
 
     return await get_surreal_graph_runtime(group_id)
-
-
-ScopeGuard = Callable[[Any], bool]
-
-
-def _memory_scope_guard(
-    *,
-    principal_id: str | None,
-    accessible_projects: set[str] | None,
-    allowed_memory_scope_keys: set[str] | None,
-    enforce_memory_scope: bool,
-) -> ScopeGuard:
-    """Build the per-entity scope check graph navigation shares with search.
-
-    Project membership alone does not authorize a private memory, so browsing
-    and traversal answer to the same rule the retrieval candidate filter uses.
-    """
-    if not enforce_memory_scope:
-        return lambda _entity: True
-
-    # Enforcing against no reader denies every scoped row, so a caller that
-    # forgot to thread its principal gets an empty result that is
-    # indistinguishable from having found nothing. Say so the first time it
-    # actually costs a row; an operator browsing anonymously opts out through
-    # enforce_memory_scope instead.
-    unauthenticated = principal_id is None
-    reported = False
-
-    def allowed(entity: Any) -> bool:
-        nonlocal reported
-        decision = memory_metadata_read_allowed(
-            getattr(entity, "metadata", None),
-            principal_id=principal_id,
-            accessible_projects=accessible_projects,
-            allowed_memory_scope_keys=allowed_memory_scope_keys,
-            private_scope_granted=private_scope_granted_for(
-                allowed_memory_scope_keys, principal_id=principal_id
-            ),
-            row_project_id=memory_row_project_id(
-                getattr(entity, "metadata", None),
-                entity_type=getattr(getattr(entity, "entity_type", None), "value", None),
-                entity_id=getattr(entity, "id", None),
-            ),
-        )
-        if not decision and unauthenticated and not reported:
-            reported = True
-            log.warning(
-                "explore_scope_filtered_without_principal",
-                entity_id=getattr(entity, "id", None),
-            )
-        return decision
-
-    return allowed
 
 
 def _normalize_project_ids(
@@ -252,7 +195,7 @@ async def explore(
     if not organization_id:
         raise ValueError("organization_id is required - cannot access graph without org context")
 
-    scope_guard = _memory_scope_guard(
+    scope_guard = memory_scope_guard(
         principal_id=principal_id,
         accessible_projects=accessible_projects,
         allowed_memory_scope_keys=allowed_memory_scope_keys,

--- a/packages/python/sibyl-core/src/sibyl_core/tools/helpers.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/helpers.py
@@ -2,14 +2,21 @@
 
 import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any
 
 import structlog
 
+from sibyl_core.auth.memory_policy import (
+    memory_metadata_read_allowed,
+    memory_row_project_id,
+    private_scope_granted_for,
+)
 from sibyl_core.models.entities import EntityType
 
 log = structlog.get_logger()
+
+ScopeGuard = Callable[[Any], bool]
 
 VALID_ENTITY_TYPES = {t.value for t in EntityType}
 AUTO_LINK_ENTITY_TYPES = (
@@ -23,6 +30,57 @@ AUTO_LINK_ENTITY_TYPES = (
 # Validation constants
 MAX_TITLE_LENGTH = 200
 MAX_CONTENT_LENGTH = 50000
+
+
+def memory_scope_guard(
+    *,
+    principal_id: str | None,
+    accessible_projects: set[str] | None,
+    allowed_memory_scope_keys: set[str] | None,
+    enforce_memory_scope: bool = True,
+    surface: str = "explore",
+) -> ScopeGuard:
+    """Build the per-entity scope check graph navigation shares with search.
+
+    Project membership alone does not authorize a private memory, so browsing
+    and traversal answer to the same rule the retrieval candidate filter uses.
+    """
+    if not enforce_memory_scope:
+        return lambda _entity: True
+
+    # Enforcing against no reader denies every scoped row, so a caller that
+    # forgot to thread its principal gets an empty result that is
+    # indistinguishable from having found nothing. Say so the first time it
+    # actually costs a row; an operator browsing anonymously opts out through
+    # enforce_memory_scope instead.
+    unauthenticated = principal_id is None
+    reported = False
+
+    def allowed(entity: Any) -> bool:
+        nonlocal reported
+        decision = memory_metadata_read_allowed(
+            getattr(entity, "metadata", None),
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
+            private_scope_granted=private_scope_granted_for(
+                allowed_memory_scope_keys, principal_id=principal_id
+            ),
+            row_project_id=memory_row_project_id(
+                getattr(entity, "metadata", None),
+                entity_type=getattr(getattr(entity, "entity_type", None), "value", None),
+                entity_id=getattr(entity, "id", None),
+            ),
+        )
+        if not decision and unauthenticated and not reported:
+            reported = True
+            log.warning(
+                f"{surface}_scope_filtered_without_principal",
+                entity_id=getattr(entity, "id", None),
+            )
+        return decision
+
+    return allowed
 
 
 def _get_field(entity: Any, field: str, default: Any = None) -> Any:

--- a/packages/python/sibyl-core/src/sibyl_core/tools/responses.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/responses.py
@@ -76,6 +76,77 @@ class ExploreResponse:
 
 
 @dataclass
+class NeighborEntity:
+    """One entity reached by a bounded traversal step."""
+
+    id: str
+    type: str
+    name: str
+    relationship: str
+    direction: Literal["outgoing", "incoming"]
+    distance: int
+    score: float
+    content: str = ""
+    project_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ExpandNeighborsResponse:
+    """Response from one bounded neighbor expansion."""
+
+    origins: list[str]
+    neighbors: list[NeighborEntity]
+    total: int
+    depth: int
+    limit: int
+    unresolved: list[str] = field(default_factory=list)
+    truncated: bool = False
+    filters: dict[str, Any] = field(default_factory=dict)
+    usage_hint: str = (
+        "Bounded traversal step. Widen a hit with fetch_slice, then compose with context. "
+        "Stop after three rounds."
+    )
+
+
+@dataclass
+class SlicePassage:
+    """One span of a sliced memory, or the whole memory when it was never cut."""
+
+    id: str
+    name: str
+    content: str
+    passage_index: int | None = None
+    passage_total: int | None = None
+    breadcrumb: str | None = None
+    truncated: bool = False
+
+
+@dataclass
+class FetchSliceResponse:
+    """Response from one slice fetch, with the parent a citation resolves to."""
+
+    entity_id: str
+    parent_id: str
+    parent_name: str
+    parent_type: str
+    passages: list[SlicePassage]
+    window: int
+    sliced: bool
+    total: int = 0
+    window_start: int | None = None
+    passage_total: int | None = None
+    covers_parent: bool = False
+    project_id: str | None = None
+    content_chars: int = 0
+    filters: dict[str, Any] = field(default_factory=dict)
+    usage_hint: str = (
+        "Cite the parent memory, not the span. Compose the final answer with context. "
+        "Stop after three rounds."
+    )
+
+
+@dataclass
 class ConflictWarning:
     """A potential contradiction detected during ingest.
 

--- a/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
@@ -393,6 +393,9 @@ async def fetch_slice(
     enough never to have been cut comes back whole with `sliced=False`, which is
     the answer, not a failure.
 
+    Composition is not this verb's job either: it hands back spans, and `context`
+    still renders the evidence.
+
     Args:
         entity_id: A passage entity ID or the ID of the memory it was cut from.
         window: Adjacent spans to return, clamped to 1-MAX_SLICE_WINDOW. The

--- a/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
@@ -37,7 +37,6 @@ from sibyl_core.projection.passages import (
 from sibyl_core.retrieval.operational_sources import PASSAGE_WINDOW_UNITS
 from sibyl_core.retrieval.search import (
     DEFAULT_CANDIDATES_PER_SIGNAL,
-    SearchFilter,
     expand_neighbor_records,
 )
 from sibyl_core.tools.helpers import ScopeGuard, memory_scope_guard
@@ -209,7 +208,9 @@ async def expand_neighbors(
         content_max_chars: Preview characters per neighbor.
         include_incoming: Follow edges that point at the seeds as well as away
             from them. Inbound edges are how dependents and spans are reached.
-        types: Restrict neighbors to these entity types.
+        types: Restrict the neighbors returned to these entity types. The walk
+            still routes through other types, so a two-hop neighbor of the
+            requested type is reachable through one that is not.
         principal_id: Reader identity used to authorize scoped rows.
         accessible_projects: Projects this reader may read, or None when the
             caller could not resolve memberships (which denies project rows).
@@ -301,6 +302,12 @@ async def expand_neighbors(
         parsed[id(row)] = entity
         return True
 
+    def row_included(row: Mapping[str, object]) -> bool:
+        if not node_types:
+            return True
+        entity = parsed.get(id(row))
+        return entity is not None and entity.entity_type.value.lower() in node_types
+
     rows = await expand_neighbor_records(
         client=runtime.client,
         origin_uuids=origins,
@@ -310,8 +317,13 @@ async def expand_neighbors(
         limit=limit + 1,
         relationship_names=wanted_relationships,
         include_incoming=include_incoming,
-        search_filter=SearchFilter(node_types=node_types),
+        # Deliberately not a SearchFilter(node_types=...): that lands in the
+        # hydration WHERE, so a row of the wrong type is never read and therefore
+        # never walked through. A type restriction narrows the answer, not the
+        # routes, or asking for decisions would hide every decision that is only
+        # reachable through a task.
         row_allowed=row_allowed,
+        row_included=row_included,
     )
     truncated = len(rows) > limit
     neighbors = [

--- a/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
@@ -11,10 +11,14 @@ tool docstrings the agent reads, because there is no session to enforce it in
 and a limit an agent cannot see is not a limit.
 
 Every row either verb returns passes the same reader authorization the scored
-lanes apply. The walk is deliberately authorized per row rather than per seed:
-project membership is not permission to read a private memory that happens to
-sit in that project, and a traversal that skipped the row check would be a way
-to reach one by walking to it.
+lanes apply, per row rather than once per seed: project membership is not
+permission to read a private memory that happens to sit in that project, and a
+traversal that skipped the row check would be a way to reach one by walking to
+it.
+
+The check gates the walk and not merely its output. Only authorized rows join
+the next frontier, so an unreadable memory is not a route either, and a reader
+cannot infer that something sits between two rows by receiving the far one.
 """
 
 from __future__ import annotations
@@ -28,10 +32,11 @@ from sibyl_core.projection.passages import (
     MAX_PASSAGE_CONTENT_CHARS,
     MAX_PASSAGES_PER_SOURCE,
     PASSAGE_COVERS_PARENT_KEY,
+    spans_cover_parent,
 )
 from sibyl_core.retrieval.operational_sources import PASSAGE_WINDOW_UNITS
 from sibyl_core.retrieval.search import (
-    MAX_CANDIDATES_PER_SIGNAL,
+    DEFAULT_CANDIDATES_PER_SIGNAL,
     SearchFilter,
     expand_neighbor_records,
 )
@@ -41,6 +46,10 @@ from sibyl_core.tools.responses import (
     FetchSliceResponse,
     NeighborEntity,
     SlicePassage,
+)
+from sibyl_core.tools.search import (
+    DEFAULT_SEARCH_CONTENT_MAX_CHARS,
+    MAX_SEARCH_CONTENT_MAX_CHARS,
 )
 
 if TYPE_CHECKING:
@@ -60,16 +69,17 @@ DEFAULT_TRAVERSAL_DEPTH = 1
 # what a lane contributes and yields at most one lane's worth per hop it may
 # take. Both numbers are the scored budget rather than a new one, which is what
 # keeps an agent-steered walk from outspending the pass it is refining.
-MAX_EXPAND_ORIGINS = MAX_CANDIDATES_PER_SIGNAL
-DEFAULT_EXPAND_LIMIT = MAX_CANDIDATES_PER_SIGNAL
-MAX_EXPAND_LIMIT = MAX_CANDIDATES_PER_SIGNAL * MAX_TRAVERSAL_DEPTH
+MAX_EXPAND_ORIGINS = DEFAULT_CANDIDATES_PER_SIGNAL
+DEFAULT_EXPAND_LIMIT = DEFAULT_CANDIDATES_PER_SIGNAL
+MAX_EXPAND_LIMIT = DEFAULT_CANDIDATES_PER_SIGNAL * MAX_TRAVERSAL_DEPTH
 
 # Neighbors are a scan surface: the caller reads names and relationships to
-# decide where to widen, so previews are sized like search previews. Spans are
-# the read surface, and their budget is a whole window's worth of one span's
-# ceiling.
-DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS = 500
-MAX_TRAVERSAL_CONTENT_MAX_CHARS = 50_000
+# decide where to widen, so previews are sized exactly like search previews and
+# share their ceiling.
+DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS = DEFAULT_SEARCH_CONTENT_MAX_CHARS
+MAX_TRAVERSAL_CONTENT_MAX_CHARS = MAX_SEARCH_CONTENT_MAX_CHARS
+# Spans are the read surface rather than a scan surface, so a window's whole
+# budget is one worst-case span's ceiling.
 DEFAULT_SLICE_CONTENT_MAX_CHARS = MAX_PASSAGE_CONTENT_CHARS
 
 DEFAULT_SLICE_WINDOW = PASSAGE_WINDOW_UNITS
@@ -472,9 +482,32 @@ async def fetch_slice(
         )
 
     start = _window_start(spans, anchor_index=anchor_index, window=window)
+    if start is None:
+        # The named span exists and was authorized, but its parent's span set does
+        # not contain it: the discovery read hit its own ceiling, or the span
+        # belongs to a retired generation. Serve the span alone rather than a
+        # window that quietly omits it.
+        return _single_span_response(
+            requested,
+            window=window,
+            content_max_chars=content_max_chars,
+            anchor_index=anchor_index,
+        )
     selected = spans[start : start + window]
     passage_total = _passage_total(spans[0].metadata) or len(spans)
-    covers_parent = all(bool(span.metadata.get(PASSAGE_COVERS_PARENT_KEY)) for span in selected)
+    # A window is a subset by design, so the per-span flag alone would report a
+    # 3-of-4 window as covering the parent and invite the reader to drop a quarter
+    # of the body. Coverage is a property of the exact set returned.
+    covers_parent = spans_cover_parent(
+        [
+            (
+                _int_metadata(span.metadata, "passage_index"),
+                _passage_total(span.metadata),
+                bool(span.metadata.get(PASSAGE_COVERS_PARENT_KEY)),
+            )
+            for span in selected
+        ]
+    )
 
     passages: list[SlicePassage] = []
     remaining = content_max_chars
@@ -575,15 +608,20 @@ async def _authorized_spans(
     return authorized
 
 
-def _window_start(spans: Sequence[Entity], *, anchor_index: int | None, window: int) -> int:
-    """Center the window on the anchor, sliding it inside the available spans."""
+def _window_start(spans: Sequence[Entity], *, anchor_index: int | None, window: int) -> int | None:
+    """Center the window on the anchor, sliding it inside the available spans.
+
+    Returns None when the anchor is not among the spans, which the caller turns
+    into a single-span response rather than a window. Falling back to index zero
+    would serve a window that silently excludes the very span the caller named,
+    and a caller reading a coherent-looking window has no way to notice.
+    """
     if anchor_index is None:
         return 0
     positions = [_int_metadata(span.metadata, "passage_index") for span in spans]
-    try:
-        anchor_position = positions.index(anchor_index)
-    except ValueError:
-        return 0
+    if anchor_index not in positions:
+        return None
+    anchor_position = positions.index(anchor_index)
     start = anchor_position - (window - 1) // 2
     return max(0, min(start, max(len(spans) - window, 0)))
 

--- a/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
@@ -1,0 +1,674 @@
+"""Client-exposed bounded traversal verbs.
+
+Retrieval already walks the graph, but only inside one scored pass whose shape
+the caller cannot steer. These two verbs hand the steering wheel to the agent
+without handing over composition: `expand_neighbors` widens a neighborhood by a
+bounded number of hops, `fetch_slice` widens one hit into the span window it was
+cut into, and the deterministic evidence composer still renders the answer.
+
+Both verbs are stateless and bounded per call. The round budget lives in the
+tool docstrings the agent reads, because there is no session to enforce it in
+and a limit an agent cannot see is not a limit.
+
+Every row either verb returns passes the same reader authorization the scored
+lanes apply. The walk is deliberately authorized per row rather than per seed:
+project membership is not permission to read a private memory that happens to
+sit in that project, and a traversal that skipped the row check would be a way
+to reach one by walking to it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from sibyl_core.models.entities import EntityType, RelationshipType
+from sibyl_core.projection.passages import (
+    MAX_PASSAGE_CONTENT_CHARS,
+    MAX_PASSAGES_PER_SOURCE,
+    PASSAGE_COVERS_PARENT_KEY,
+)
+from sibyl_core.retrieval.operational_sources import PASSAGE_WINDOW_UNITS
+from sibyl_core.retrieval.search import (
+    MAX_CANDIDATES_PER_SIGNAL,
+    SearchFilter,
+    expand_neighbor_records,
+)
+from sibyl_core.tools.helpers import ScopeGuard, memory_scope_guard
+from sibyl_core.tools.responses import (
+    ExpandNeighborsResponse,
+    FetchSliceResponse,
+    NeighborEntity,
+    SlicePassage,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from sibyl_core.models.entities import Entity
+
+log = structlog.get_logger()
+
+# Two retrieval iterations capture most of the gain of five, so a walk that can
+# reach three hops can already overshoot what the measurement supports. The
+# ceiling matches the depth clamp graph browsing has always used.
+MAX_TRAVERSAL_DEPTH = 3
+DEFAULT_TRAVERSAL_DEPTH = 1
+
+# A traversal step is one lane of the retrieval budget, so it seeds from at most
+# what a lane contributes and yields at most one lane's worth per hop it may
+# take. Both numbers are the scored budget rather than a new one, which is what
+# keeps an agent-steered walk from outspending the pass it is refining.
+MAX_EXPAND_ORIGINS = MAX_CANDIDATES_PER_SIGNAL
+DEFAULT_EXPAND_LIMIT = MAX_CANDIDATES_PER_SIGNAL
+MAX_EXPAND_LIMIT = MAX_CANDIDATES_PER_SIGNAL * MAX_TRAVERSAL_DEPTH
+
+# Neighbors are a scan surface: the caller reads names and relationships to
+# decide where to widen, so previews are sized like search previews. Spans are
+# the read surface, and their budget is a whole window's worth of one span's
+# ceiling.
+DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS = 500
+MAX_TRAVERSAL_CONTENT_MAX_CHARS = 50_000
+DEFAULT_SLICE_CONTENT_MAX_CHARS = MAX_PASSAGE_CONTENT_CHARS
+
+DEFAULT_SLICE_WINDOW = PASSAGE_WINDOW_UNITS
+MAX_SLICE_WINDOW = MAX_PASSAGES_PER_SOURCE
+
+PASSAGE_ENTITY_TYPE = EntityType.PASSAGE.value
+
+# Both passage projections point a span at the memory it was cut from, but they
+# do not agree on the edge: prose memories write PART_OF, operational evidence
+# writes DERIVED_FROM. Asking for both is what makes one verb serve either.
+_PASSAGE_PARENT_RELATIONSHIPS = (RelationshipType.PART_OF, RelationshipType.DERIVED_FROM)
+
+_TRAVERSAL_ROUND_BUDGET = 3
+
+
+async def get_graph_runtime(group_id: str) -> Any:
+    from sibyl_core.services.graph import get_surreal_graph_runtime
+
+    return await get_surreal_graph_runtime(group_id)
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(int(value), high))
+
+
+def _entity_project_id(entity: Any) -> str | None:
+    metadata = getattr(entity, "metadata", None) or {}
+    value = getattr(entity, "project_id", None) or metadata.get("project_id")
+    return str(value) if value else None
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value.strip())
+    return None
+
+
+def _int_metadata(metadata: Mapping[str, Any], key: str) -> int | None:
+    return _coerce_int(metadata.get(key))
+
+
+def _coerce_float(value: object) -> float:
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _passage_total(metadata: Mapping[str, Any]) -> int | None:
+    # The prose projection stamps passage_total, the operational one stamps
+    # passage_count. Same number, two writers.
+    return _int_metadata(metadata, "passage_total") or _int_metadata(metadata, "passage_count")
+
+
+def _compact(value: str, max_chars: int) -> tuple[str, bool]:
+    """Bound one field's characters, reporting whether anything was dropped."""
+    text = value or ""
+    if max_chars <= 0:
+        return "", bool(text)
+    if len(text) <= max_chars:
+        return text, False
+    cutoff = text.rfind(" ", 0, max_chars + 1)
+    if cutoff < max_chars // 2:
+        cutoff = max_chars
+    return text[:cutoff].rstrip() + "...", True
+
+
+def _row_scope_entity(row: Mapping[str, object]) -> Entity:
+    """Parse a Surreal entity row, keeping the scope the column carries.
+
+    ``entity_from_surreal_row`` promotes denormalized columns into metadata but
+    not ``memory_scope``, and the read check treats an absent scope as
+    unscoped. The two representations are written in lockstep and agree on every
+    row in the live store today, so this overlay is a guard against a future
+    write that sets only the column rather than a repair of a known divergence:
+    it can only add a scope where metadata had none, never relax one.
+    """
+    from sibyl_core.services.graph import entity_from_surreal_row
+
+    entity = entity_from_surreal_row(row)
+    column_scope = row.get("memory_scope")
+    if not entity.metadata.get("memory_scope") and column_scope:
+        entity.metadata["memory_scope"] = str(column_scope)
+    return entity
+
+
+async def expand_neighbors(
+    entity_ids: Sequence[str],
+    *,
+    organization_id: str,
+    relationship_types: Sequence[str] | None = None,
+    depth: int = DEFAULT_TRAVERSAL_DEPTH,
+    limit: int = DEFAULT_EXPAND_LIMIT,
+    content_max_chars: int = DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS,
+    include_incoming: bool = True,
+    types: Sequence[str] | None = None,
+    principal_id: str | None = None,
+    accessible_projects: set[str] | None = None,
+    allowed_memory_scope_keys: set[str] | None = None,
+    enforce_memory_scope: bool = True,
+) -> ExpandNeighborsResponse:
+    """Widen a set of known memories into their bounded graph neighborhood.
+
+    ROUND BUDGET: this is step two of at most three. Round one is `search` or
+    `context`, round two widens with `expand_neighbors` or `fetch_slice`, round
+    three widens once more. A question answerable from one hop should skip this
+    verb entirely and read `context`, which composes the answer for you.
+
+    Composition is not this verb's job. It returns previews and adjacency so you
+    can decide what to gather; `context` still renders the evidence.
+
+    Args:
+        entity_ids: Seed entity IDs, capped at MAX_EXPAND_ORIGINS. Ids that
+            resolve to nothing you may read come back in `unresolved`.
+        relationship_types: Restrict hops to these relationship names, e.g.
+            DEPENDS_ON, PART_OF, SUPERSEDES. Empty walks every relationship.
+        depth: Hops to walk, clamped to 1-MAX_TRAVERSAL_DEPTH.
+        limit: Neighbors to return, clamped to 1-MAX_EXPAND_LIMIT.
+        content_max_chars: Preview characters per neighbor.
+        include_incoming: Follow edges that point at the seeds as well as away
+            from them. Inbound edges are how dependents and spans are reached.
+        types: Restrict neighbors to these entity types.
+        principal_id: Reader identity used to authorize scoped rows.
+        accessible_projects: Projects this reader may read, or None when the
+            caller could not resolve memberships (which denies project rows).
+        allowed_memory_scope_keys: API-key memory-space grants, when the caller
+            is a restricted credential.
+        enforce_memory_scope: Apply memory-scope filtering. Only an operator
+            tool dumping its own namespace turns this off.
+
+    Returns:
+        ExpandNeighborsResponse with hop-tagged neighbors, highest path score
+        first, plus the seeds that resolved and the ones that did not.
+    """
+    if not organization_id:
+        raise ValueError("organization_id is required - cannot traverse without org context")
+
+    depth = _clamp(depth, 1, MAX_TRAVERSAL_DEPTH)
+    limit = _clamp(limit, 1, MAX_EXPAND_LIMIT)
+    content_max_chars = _clamp(content_max_chars, 0, MAX_TRAVERSAL_CONTENT_MAX_CHARS)
+    requested_ids = list(dict.fromkeys(str(value) for value in entity_ids if str(value).strip()))
+    seed_ids = requested_ids[:MAX_EXPAND_ORIGINS]
+    dropped_ids = requested_ids[MAX_EXPAND_ORIGINS:]
+    wanted_relationships = [
+        str(name).upper() for name in (relationship_types or ()) if str(name).strip()
+    ]
+    node_types = tuple(str(value).lower() for value in (types or ()) if str(value).strip())
+
+    filters: dict[str, Any] = {
+        "depth": depth,
+        "limit": limit,
+        "include_incoming": include_incoming,
+        "round_budget": _TRAVERSAL_ROUND_BUDGET,
+    }
+    if wanted_relationships:
+        filters["relationship_types"] = wanted_relationships
+    if node_types:
+        filters["types"] = list(node_types)
+    if dropped_ids:
+        # Silently walking a prefix would make the response look complete.
+        filters["origin_limit"] = MAX_EXPAND_ORIGINS
+
+    if not seed_ids:
+        return ExpandNeighborsResponse(
+            origins=[],
+            neighbors=[],
+            total=0,
+            depth=depth,
+            limit=limit,
+            unresolved=dropped_ids,
+            filters=filters,
+        )
+
+    scope_guard = memory_scope_guard(
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
+        enforce_memory_scope=enforce_memory_scope,
+        surface="expand_neighbors",
+    )
+
+    runtime = await get_graph_runtime(organization_id)
+    seeds = await runtime.entity_manager.get_many(seed_ids)
+    authorized_seeds = [seed for seed in seeds if _seed_visible(seed, scope_guard)]
+    origins = [seed.id for seed in authorized_seeds]
+    # A seed the reader may not see and a seed that does not exist are reported
+    # the same way on purpose: telling them apart confirms the existence of a row
+    # the reader has no right to know about.
+    unresolved = [entity_id for entity_id in seed_ids if entity_id not in set(origins)]
+    unresolved.extend(dropped_ids)
+
+    if not origins:
+        return ExpandNeighborsResponse(
+            origins=[],
+            neighbors=[],
+            total=0,
+            depth=depth,
+            limit=limit,
+            unresolved=unresolved,
+            filters=filters,
+        )
+
+    # One parse per row, reused by the authorization check and the response, so a
+    # row is never read as two slightly different entities.
+    parsed: dict[int, Entity] = {}
+
+    def row_allowed(row: Mapping[str, object]) -> bool:
+        entity = _row_scope_entity(row)
+        if not scope_guard(entity):
+            return False
+        parsed[id(row)] = entity
+        return True
+
+    rows = await expand_neighbor_records(
+        client=runtime.client,
+        origin_uuids=origins,
+        group_id=organization_id,
+        max_depth=depth,
+        # One past the cap, so "there were more" is observed rather than assumed.
+        limit=limit + 1,
+        relationship_names=wanted_relationships,
+        include_incoming=include_incoming,
+        search_filter=SearchFilter(node_types=node_types),
+        row_allowed=row_allowed,
+    )
+    truncated = len(rows) > limit
+    neighbors = [
+        _neighbor_from_row(row, parsed[id(row)], content_max_chars=content_max_chars)
+        for row in rows[:limit]
+    ]
+
+    log.info(
+        "expand_neighbors",
+        origins=len(origins),
+        neighbors=len(neighbors),
+        depth=depth,
+        include_incoming=include_incoming,
+        relationship_types=wanted_relationships or None,
+    )
+    return ExpandNeighborsResponse(
+        origins=origins,
+        neighbors=neighbors,
+        total=len(neighbors),
+        depth=depth,
+        limit=limit,
+        unresolved=unresolved,
+        truncated=truncated,
+        filters=filters,
+    )
+
+
+def _seed_visible(seed: Any, scope_guard: ScopeGuard) -> bool:
+    return seed is not None and scope_guard(seed)
+
+
+def _neighbor_from_row(
+    row: Mapping[str, object],
+    entity: Entity,
+    *,
+    content_max_chars: int,
+) -> NeighborEntity:
+    relationship = str(row.get("graph_expansion_relationship") or RelationshipType.RELATED_TO.value)
+    direction = "incoming" if row.get("graph_expansion_direction") == "incoming" else "outgoing"
+    distance = _coerce_int(row.get("graph_expansion_depth"))
+    content, content_truncated = _compact(
+        entity.content or entity.description or "",
+        content_max_chars,
+    )
+    metadata: dict[str, Any] = {"content_truncated": content_truncated}
+    if community_id := row.get("graph_expansion_community_id"):
+        metadata["community_id"] = str(community_id)
+    passage_index = _int_metadata(entity.metadata, "passage_index")
+    if passage_index is not None:
+        # A span neighbor is only useful next to its siblings, so name the
+        # widening move rather than making the caller infer it.
+        metadata["passage_index"] = passage_index
+        metadata["parent_entity_id"] = entity.metadata.get("parent_entity_id")
+        metadata["widen_with"] = "fetch_slice"
+    return NeighborEntity(
+        id=entity.id,
+        type=entity.entity_type.value,
+        name=entity.name,
+        relationship=relationship,
+        direction=direction,
+        distance=distance if distance is not None else 1,
+        score=_coerce_float(row.get("graph_expansion_score") or row.get("score")),
+        content=content,
+        project_id=_entity_project_id(entity),
+        metadata=metadata,
+    )
+
+
+async def fetch_slice(
+    entity_id: str,
+    *,
+    organization_id: str,
+    window: int = DEFAULT_SLICE_WINDOW,
+    content_max_chars: int = DEFAULT_SLICE_CONTENT_MAX_CHARS,
+    principal_id: str | None = None,
+    accessible_projects: set[str] | None = None,
+    allowed_memory_scope_keys: set[str] | None = None,
+    enforce_memory_scope: bool = True,
+) -> FetchSliceResponse:
+    """Read one memory at span granularity, centered on the span you name.
+
+    ROUND BUDGET: this is step two of at most three, and it is the widening move
+    for a hit that is a span rather than a whole memory. Cite the parent memory
+    the response names, never the span id: the parent is what a reader can
+    resolve later, and spans are re-cut when their memory is edited.
+
+    Accepts either end of the relationship. Given a span, the window is centered
+    on it. Given a memory, the window starts at its first span. A memory short
+    enough never to have been cut comes back whole with `sliced=False`, which is
+    the answer, not a failure.
+
+    Args:
+        entity_id: A passage entity ID or the ID of the memory it was cut from.
+        window: Adjacent spans to return, clamped to 1-MAX_SLICE_WINDOW. The
+            default is the measured 3-adjacent window.
+        content_max_chars: Character budget for the whole window, spent in span
+            order. The span that exhausts it is truncated and says so.
+        principal_id: Reader identity used to authorize scoped rows.
+        accessible_projects: Projects this reader may read, or None when the
+            caller could not resolve memberships (which denies project rows).
+        allowed_memory_scope_keys: API-key memory-space grants, when the caller
+            is a restricted credential.
+        enforce_memory_scope: Apply memory-scope filtering. Only an operator
+            tool dumping its own namespace turns this off.
+
+    Returns:
+        FetchSliceResponse with the ordered window and the parent metadata a
+        citation resolves to.
+
+    Raises:
+        KeyError: The id does not resolve to a memory this reader may read.
+    """
+    if not organization_id:
+        raise ValueError("organization_id is required - cannot traverse without org context")
+    if not entity_id or not str(entity_id).strip():
+        raise ValueError("entity_id is required")
+
+    entity_id = str(entity_id).strip()
+    window = _clamp(window, 1, MAX_SLICE_WINDOW)
+    content_max_chars = _clamp(content_max_chars, 0, MAX_TRAVERSAL_CONTENT_MAX_CHARS)
+
+    scope_guard = memory_scope_guard(
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
+        enforce_memory_scope=enforce_memory_scope,
+        surface="fetch_slice",
+    )
+
+    runtime = await get_graph_runtime(organization_id)
+    requested = await _load_authorized(runtime.entity_manager, entity_id, scope_guard)
+    if requested is None:
+        # Same answer for absent and unauthorized, for the same reason the
+        # expansion verb conflates them.
+        raise KeyError(entity_id)
+
+    anchor_index: int | None = None
+    parent = requested
+    if requested.entity_type.value == PASSAGE_ENTITY_TYPE:
+        anchor_index = _int_metadata(requested.metadata, "passage_index")
+        parent_id = str(requested.metadata.get("parent_entity_id") or "")
+        resolved_parent = (
+            await _load_authorized(runtime.entity_manager, parent_id, scope_guard)
+            if parent_id
+            else None
+        )
+        if resolved_parent is None:
+            # An orphaned span, or one whose memory this reader cannot read. The
+            # span itself was authorized, so serve it alone rather than 404ing.
+            return _single_span_response(
+                requested,
+                window=window,
+                content_max_chars=content_max_chars,
+                anchor_index=anchor_index,
+            )
+        parent = resolved_parent
+
+    spans = await _authorized_spans(runtime, parent_id=parent.id, scope_guard=scope_guard)
+    if not spans:
+        return _unsliced_response(
+            parent,
+            requested_id=entity_id,
+            window=window,
+            content_max_chars=content_max_chars,
+        )
+
+    start = _window_start(spans, anchor_index=anchor_index, window=window)
+    selected = spans[start : start + window]
+    passage_total = _passage_total(spans[0].metadata) or len(spans)
+    covers_parent = all(bool(span.metadata.get(PASSAGE_COVERS_PARENT_KEY)) for span in selected)
+
+    passages: list[SlicePassage] = []
+    remaining = content_max_chars
+    for span in selected:
+        content, truncated = _compact(span.content or "", remaining)
+        remaining = max(remaining - len(content), 0)
+        passages.append(
+            SlicePassage(
+                id=span.id,
+                name=span.name,
+                content=content,
+                passage_index=_int_metadata(span.metadata, "passage_index"),
+                passage_total=_passage_total(span.metadata),
+                breadcrumb=(
+                    str(span.metadata.get("passage_breadcrumb"))
+                    if span.metadata.get("passage_breadcrumb")
+                    else None
+                ),
+                truncated=truncated,
+            )
+        )
+
+    window_start = _int_metadata(selected[0].metadata, "passage_index") if selected else None
+    log.info(
+        "fetch_slice",
+        entity_id=entity_id,
+        parent_id=parent.id,
+        spans=len(passages),
+        window=window,
+        sliced=True,
+    )
+    return FetchSliceResponse(
+        entity_id=entity_id,
+        parent_id=parent.id,
+        parent_name=parent.name,
+        parent_type=parent.entity_type.value,
+        passages=passages,
+        window=window,
+        sliced=True,
+        total=len(passages),
+        window_start=window_start,
+        passage_total=passage_total,
+        covers_parent=covers_parent,
+        project_id=_entity_project_id(parent),
+        content_chars=sum(len(passage.content) for passage in passages),
+        filters={"window": window, "round_budget": _TRAVERSAL_ROUND_BUDGET},
+    )
+
+
+async def _load_authorized(
+    entity_manager: Any,
+    entity_id: str,
+    scope_guard: ScopeGuard,
+) -> Entity | None:
+    if not entity_id:
+        return None
+    try:
+        entity = await entity_manager.get(entity_id)
+    except Exception:
+        return None
+    if entity is None or not scope_guard(entity):
+        return None
+    return entity
+
+
+async def _authorized_spans(
+    runtime: Any,
+    *,
+    parent_id: str,
+    scope_guard: ScopeGuard,
+) -> list[Entity]:
+    """The spans cut from one memory, ordered by position, reader-authorized.
+
+    Discovery goes through the edge rather than the deterministic span id: the
+    two projections mint ids differently but both write an edge from span to
+    memory, so the edge is the part that holds for either.
+    """
+    related = await runtime.relationship_manager.get_related_entities(
+        entity_id=parent_id,
+        relationship_types=list(_PASSAGE_PARENT_RELATIONSHIPS),
+        limit=MAX_PASSAGES_PER_SOURCE,
+    )
+    span_ids: list[str] = []
+    for entity, relationship in related:
+        if relationship.target_id != parent_id or entity.entity_type.value != PASSAGE_ENTITY_TYPE:
+            continue
+        if _int_metadata(entity.metadata, "passage_index") is None:
+            continue
+        span_ids.append(entity.id)
+    if not span_ids:
+        return []
+
+    # The related-entity projection omits content, so the spans are re-read whole
+    # once their ids are known.
+    spans = await runtime.entity_manager.get_many(span_ids)
+    authorized = [span for span in spans if scope_guard(span)]
+    authorized.sort(key=lambda span: _int_metadata(span.metadata, "passage_index") or 0)
+    return authorized
+
+
+def _window_start(spans: Sequence[Entity], *, anchor_index: int | None, window: int) -> int:
+    """Center the window on the anchor, sliding it inside the available spans."""
+    if anchor_index is None:
+        return 0
+    positions = [_int_metadata(span.metadata, "passage_index") for span in spans]
+    try:
+        anchor_position = positions.index(anchor_index)
+    except ValueError:
+        return 0
+    start = anchor_position - (window - 1) // 2
+    return max(0, min(start, max(len(spans) - window, 0)))
+
+
+def _single_span_response(
+    span: Entity,
+    *,
+    window: int,
+    content_max_chars: int,
+    anchor_index: int | None,
+) -> FetchSliceResponse:
+    content, truncated = _compact(span.content or "", content_max_chars)
+    parent_id = str(span.metadata.get("parent_entity_id") or span.id)
+    return FetchSliceResponse(
+        entity_id=span.id,
+        parent_id=parent_id,
+        parent_name=span.name,
+        parent_type=span.entity_type.value,
+        passages=[
+            SlicePassage(
+                id=span.id,
+                name=span.name,
+                content=content,
+                passage_index=anchor_index,
+                passage_total=_passage_total(span.metadata),
+                truncated=truncated,
+            )
+        ],
+        window=window,
+        sliced=True,
+        total=1,
+        window_start=anchor_index,
+        passage_total=_passage_total(span.metadata),
+        covers_parent=False,
+        project_id=_entity_project_id(span),
+        content_chars=len(content),
+        filters={
+            "window": window,
+            "round_budget": _TRAVERSAL_ROUND_BUDGET,
+            "parent_unreadable": True,
+        },
+    )
+
+
+def _unsliced_response(
+    parent: Entity,
+    *,
+    requested_id: str,
+    window: int,
+    content_max_chars: int,
+) -> FetchSliceResponse:
+    """Serve a memory that was never cut as its own single span."""
+    content, truncated = _compact(parent.content or parent.description or "", content_max_chars)
+    return FetchSliceResponse(
+        entity_id=requested_id,
+        parent_id=parent.id,
+        parent_name=parent.name,
+        parent_type=parent.entity_type.value,
+        passages=[
+            SlicePassage(
+                id=parent.id,
+                name=parent.name,
+                content=content,
+                truncated=truncated,
+            )
+        ],
+        window=window,
+        sliced=False,
+        total=1,
+        passage_total=None,
+        covers_parent=True,
+        project_id=_entity_project_id(parent),
+        content_chars=len(content),
+        filters={"window": window, "round_budget": _TRAVERSAL_ROUND_BUDGET},
+    )
+
+
+__all__ = [
+    "DEFAULT_EXPAND_LIMIT",
+    "DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS",
+    "DEFAULT_SLICE_CONTENT_MAX_CHARS",
+    "DEFAULT_SLICE_WINDOW",
+    "DEFAULT_TRAVERSAL_DEPTH",
+    "MAX_EXPAND_LIMIT",
+    "MAX_EXPAND_ORIGINS",
+    "MAX_SLICE_WINDOW",
+    "MAX_TRAVERSAL_CONTENT_MAX_CHARS",
+    "MAX_TRAVERSAL_DEPTH",
+    "expand_neighbors",
+    "fetch_slice",
+]

--- a/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py
@@ -462,14 +462,18 @@ async def fetch_slice(
             else None
         )
         if resolved_parent is None:
-            # An orphaned span, or one whose memory this reader cannot read. The
-            # span itself was authorized, so serve it alone rather than 404ing.
-            return _single_span_response(
-                requested,
-                window=window,
-                content_max_chars=content_max_chars,
-                anchor_index=anchor_index,
-            )
+            # A span is never more readable than the memory it was cut from, so an
+            # unreadable or missing parent denies the span too.
+            #
+            # This is the invariant and not merely a precaution. A span inherits
+            # its parent's scope once, at write time, and the reprojection that
+            # would refresh it runs only when the body changes: a scope-only edit
+            # tightening a memory to private leaves its spans carrying the old
+            # scope. Trusting the span's own stamp here would serve that memory's
+            # text through the span door while the parent correctly refused.
+            # Authorizing the parent makes the stale stamp unreachable rather than
+            # merely unlikely.
+            raise KeyError(entity_id)
         parent = resolved_parent
 
     spans = await _authorized_spans(runtime, parent_id=parent.id, scope_guard=scope_guard)
@@ -489,6 +493,7 @@ async def fetch_slice(
         # window that quietly omits it.
         return _single_span_response(
             requested,
+            parent=parent,
             window=window,
             content_max_chars=content_max_chars,
             anchor_index=anchor_index,
@@ -629,17 +634,22 @@ def _window_start(spans: Sequence[Entity], *, anchor_index: int | None, window: 
 def _single_span_response(
     span: Entity,
     *,
+    parent: Entity,
     window: int,
     content_max_chars: int,
     anchor_index: int | None,
 ) -> FetchSliceResponse:
+    """Serve one authorized span whose position its parent's span set does not hold.
+
+    Only reachable once the parent itself is authorized, so this is a
+    completeness gap rather than a way around the parent check.
+    """
     content, truncated = _compact(span.content or "", content_max_chars)
-    parent_id = str(span.metadata.get("parent_entity_id") or span.id)
     return FetchSliceResponse(
         entity_id=span.id,
-        parent_id=parent_id,
-        parent_name=span.name,
-        parent_type=span.entity_type.value,
+        parent_id=parent.id,
+        parent_name=parent.name,
+        parent_type=parent.entity_type.value,
         passages=[
             SlicePassage(
                 id=span.id,
@@ -656,12 +666,12 @@ def _single_span_response(
         window_start=anchor_index,
         passage_total=_passage_total(span.metadata),
         covers_parent=False,
-        project_id=_entity_project_id(span),
+        project_id=_entity_project_id(parent),
         content_chars=len(content),
         filters={
             "window": window,
             "round_budget": _TRAVERSAL_ROUND_BUDGET,
-            "parent_unreadable": True,
+            "anchor_outside_span_set": True,
         },
     )
 

--- a/packages/python/sibyl-core/tests/test_memory_policy.py
+++ b/packages/python/sibyl-core/tests/test_memory_policy.py
@@ -594,6 +594,10 @@ _SCOPE_READERS_THAT_DO_NOT_AUTHORIZE = {
     "tools/reflect.py::_persist_reflection_source_review": "passes an authorized scope to a write",
     "tools/search.py::_graph_candidate_metadata": "reports the scope on a candidate contract",
     "tools/search.py::search": "passes the scope through as a response filter",
+    "tools/traverse.py::_row_scope_entity": (
+        "normalizer: folds the column into metadata so the one read rule sees it; "
+        "can only add a scope where metadata had none, never relax one"
+    ),
 }
 
 

--- a/packages/python/sibyl-core/tests/test_tools.py
+++ b/packages/python/sibyl-core/tests/test_tools.py
@@ -4228,7 +4228,7 @@ class TestExploreMemoryScope:
                 "sibyl_core.tools.explore.get_graph_runtime",
                 AsyncMock(return_value=make_graph_runtime(entity_manager=entity_manager)),
             ),
-            patch.object(explore_module, "log", recorded_log),
+            patch("sibyl_core.tools.helpers.log", recorded_log),
         ):
             response = await explore_module.explore(
                 mode="list",
@@ -4253,7 +4253,7 @@ class TestExploreMemoryScope:
                 "sibyl_core.tools.explore.get_graph_runtime",
                 AsyncMock(return_value=make_graph_runtime(entity_manager=entity_manager)),
             ),
-            patch.object(explore_module, "log", recorded_log),
+            patch("sibyl_core.tools.helpers.log", recorded_log),
         ):
             await explore_module.explore(
                 mode="list",

--- a/packages/python/sibyl-core/tests/test_tools_traverse.py
+++ b/packages/python/sibyl-core/tests/test_tools_traverse.py
@@ -910,7 +910,8 @@ class TestFetchSliceAuthorization:
         assert [passage.passage_index for passage in response.passages] == [0, 2]
 
     @pytest.mark.asyncio
-    async def test_a_span_whose_parent_is_denied_still_serves_itself(self) -> None:
+    async def test_a_span_is_denied_when_its_parent_is(self) -> None:
+        """A span is never more readable than the memory it was cut from."""
         span = _span("decision_secret", 1, 3)
         runtime = _FakeRuntime(
             entity_manager=_FakeEntityManager(
@@ -919,16 +920,91 @@ class TestFetchSliceAuthorization:
             relationship_manager=_FakeRelationshipManager([]),
         )
 
-        with _runtime_patch(runtime):
-            response = await fetch_slice(
+        with _runtime_patch(runtime), pytest.raises(KeyError):
+            await fetch_slice(
                 span.id,
                 organization_id=ORG,
                 principal_id=OWNER,
                 accessible_projects=set(),
             )
 
-        assert response.total == 1
-        assert response.filters["parent_unreadable"] is True
+    @pytest.mark.asyncio
+    async def test_a_stale_span_scope_cannot_outlive_its_parents_tightening(self) -> None:
+        """The leak this closes, spelled out as data.
+
+        A span inherits its parent's scope once, at write time, and the
+        reprojection that would refresh it runs only when the body changes. So a
+        scope-only edit tightening a memory to private leaves its spans stamped
+        with the old, permissive scope. Trusting the span's own stamp would serve
+        the now-private memory's text through the span door while the parent
+        correctly refused.
+        """
+        parent = _private("decision_tightened", OWNER)
+        # Stale on purpose: still carrying the project scope it had before the edit.
+        stale_span = _entity(
+            "decision_tightened_passage_1",
+            entity_type=EntityType.PASSAGE,
+            content="text that is now private",
+            metadata={
+                "parent_entity_id": parent.id,
+                "passage_index": 1,
+                "passage_total": 3,
+                "memory_scope": "project",
+                "scope_key": "proj_a",
+                "project_id": "proj_a",
+                PASSAGE_COVERS_PARENT_KEY: True,
+            },
+        )
+        runtime = _FakeRuntime(
+            entity_manager=_FakeEntityManager({parent.id: parent, stale_span.id: stale_span}),
+            relationship_manager=_FakeRelationshipManager([]),
+        )
+
+        # The stranger is a member of the project the stale stamp still names, so
+        # the span's own scope would admit them.
+        with _runtime_patch(runtime), pytest.raises(KeyError):
+            await fetch_slice(
+                stale_span.id,
+                organization_id=ORG,
+                principal_id=OTHER,
+                accessible_projects={"proj_a"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_the_owner_still_reads_the_span_of_their_tightened_memory(self) -> None:
+        """The allow direction, so the deny above is not just a blanket refusal."""
+        parent = _private("decision_tightened", OWNER)
+        stale_span = _entity(
+            "decision_tightened_passage_1",
+            entity_type=EntityType.PASSAGE,
+            content="text that is now private",
+            metadata={
+                "parent_entity_id": parent.id,
+                "passage_index": 1,
+                "passage_total": 3,
+                "memory_scope": "project",
+                "scope_key": "proj_a",
+                "project_id": "proj_a",
+                PASSAGE_COVERS_PARENT_KEY: True,
+            },
+        )
+        runtime = _FakeRuntime(
+            entity_manager=_FakeEntityManager({parent.id: parent, stale_span.id: stale_span}),
+            relationship_manager=_FakeRelationshipManager(
+                [(stale_span, _part_of(stale_span, parent.id))]
+            ),
+        )
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                stale_span.id,
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects={"proj_a"},
+            )
+
+        assert response.parent_id == parent.id
+        assert [passage.id for passage in response.passages] == [stale_span.id]
 
     @pytest.mark.asyncio
     async def test_api_key_without_a_private_grant_cannot_read_its_own_rows(self) -> None:
@@ -1231,3 +1307,165 @@ class TestFetchSliceAnchorNotInSpanSet:
         assert [passage.id for passage in response.passages] == [anchor.id]
         assert response.passages[0].passage_index == 7
         assert response.covers_parent is False
+        # Named as its own condition rather than conflated with an unreadable
+        # parent: this path is only reachable once the parent is authorized.
+        assert response.filters["anchor_outside_span_set"] is True
+        assert response.parent_id == "decision_parent"
+
+
+class TestSteeredWalkMatchesTheScoredLane:
+    @pytest.mark.asyncio
+    async def test_first_hop_only_expanders_do_not_fire_on_later_hops(self) -> None:
+        """The steered walk takes one hop per round, so it must say how far it is.
+
+        `MENTIONS` and `SHARES_COMMUNITY` are first-hop-only in the scored lane.
+        A hop-at-a-time caller that restarted the depth counter every round would
+        re-run both at every level, quietly widening the neighborhood in a way the
+        scored lane never does.
+        """
+        client = _GraphClient(
+            edges=[
+                ("seed", "near", "RELATED_TO"),
+                ("near", "far", "RELATED_TO"),
+            ],
+            rows=[_entity_row("near"), _entity_row("far")],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                depth=3,
+                limit=8,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        community_reads = [query for query, _ in client.queries if "BELONGS_TO" in query]
+        assert len(community_reads) == 1, "community expansion is a first-hop-only lane"
+        assert {neighbor.distance for neighbor in response.neighbors} == {1, 2}
+
+    @pytest.mark.asyncio
+    async def test_depth_decay_is_applied_by_true_distance(self) -> None:
+        from sibyl_core.retrieval.search import _graph_expansion_path_score
+
+        client = _GraphClient(
+            edges=[
+                ("seed", "near", "RELATED_TO"),
+                ("near", "far", "RELATED_TO"),
+            ],
+            rows=[_entity_row("near"), _entity_row("far")],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                depth=2,
+                limit=8,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        by_id = {neighbor.id: neighbor for neighbor in response.neighbors}
+        assert by_id["near"].score == pytest.approx(
+            _graph_expansion_path_score("RELATED_TO", depth=1)
+        )
+        assert by_id["far"].score == pytest.approx(
+            _graph_expansion_path_score("RELATED_TO", depth=2)
+        )
+
+
+class TestSharedBfsContractAtDefaultArgs:
+    """The scored lane calls `_node_bfs_records` directly with default args.
+
+    Every parameter the traversal verbs added defaults to the pre-existing
+    behavior, so the benchmarked retrieval path is byte-identical. These pin that
+    rather than trusting it, because a shared-function edit that looks local to a
+    new caller is exactly how a pinned lane changes without anyone noticing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_seed_adjacent_to_another_seed_is_still_contributed(self) -> None:
+        """The case a seed-exclusion edit inside the shared function would break.
+
+        With origins ['a', 'b'] and an a->b edge, the expansion lane must still
+        contribute 'b'. Suppressing it there costs 'b' its graph-native signal
+        boost and an RRF rank term on the scored path.
+        """
+        from sibyl_core.retrieval.search import SearchFilter, _node_bfs_records
+
+        client = _GraphClient(
+            edges=[("entity_a", "entity_b", "RELATED_TO")],
+            rows=[_entity_row("entity_b")],
+        )
+
+        records = await _node_bfs_records(
+            client=client,
+            origin_uuids=["entity_a", "entity_b"],
+            search_filter=SearchFilter(),
+            group_id=ORG,
+            max_depth=1,
+            limit=8,
+        )
+
+        assert [record["uuid"] for record in records] == ["entity_b"]
+
+    @pytest.mark.asyncio
+    async def test_defaults_keep_inbound_off_and_community_on(self) -> None:
+        from sibyl_core.retrieval.search import SearchFilter, _node_bfs_records
+
+        client = _GraphClient(
+            edges=[("other", "seed", "RELATED_TO")],
+            rows=[_entity_row("other")],
+        )
+
+        records = await _node_bfs_records(
+            client=client,
+            origin_uuids=["seed"],
+            search_filter=SearchFilter(),
+            group_id=ORG,
+            max_depth=1,
+            limit=8,
+        )
+
+        # Inbound is opt-in, so the row pointing AT the seed is not returned.
+        assert records == []
+        assert not any("target_id IN $target_uuids" in query for query, _ in client.queries)
+        # The community lane is opt-out, so it still runs for the scored lane.
+        assert any("BELONGS_TO" in query for query, _ in client.queries)
+
+
+class TestSpansCoverParentRule:
+    """The rule itself, at the level the mutant survives."""
+
+    def test_disagreeing_totals_defeat_coverage_even_when_indices_look_complete(self) -> None:
+        """Pins the single-total guard rather than reaching False via the range check.
+
+        [(0, 2), (1, 2), (2, 3)] fails the range check anyway, so it passes with
+        the single-total guard deleted. [(0, 2), (1, 3)] is the discriminating
+        input: indices {0, 1} match range(2) under the smaller total, so only the
+        totals disagreement can reject it.
+        """
+        from sibyl_core.projection.passages import spans_cover_parent
+
+        assert spans_cover_parent([(0, 2, True), (1, 2, True)]) is True
+        assert spans_cover_parent([(0, 2, True), (1, 3, True)]) is False
+
+    def test_a_missing_flag_defeats_coverage(self) -> None:
+        from sibyl_core.projection.passages import spans_cover_parent
+
+        assert spans_cover_parent([(0, 2, True), (1, 2, False)]) is False
+
+    def test_a_gap_defeats_coverage(self) -> None:
+        from sibyl_core.projection.passages import spans_cover_parent
+
+        assert spans_cover_parent([(0, 3, True), (2, 3, True)]) is False

--- a/packages/python/sibyl-core/tests/test_tools_traverse.py
+++ b/packages/python/sibyl-core/tests/test_tools_traverse.py
@@ -14,7 +14,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from sibyl_core.auth.memory_policy import memory_scope_policy_key
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.models.memory_scope import MemoryScope
 from sibyl_core.projection.passages import PASSAGE_COVERS_PARENT_KEY
 from sibyl_core.retrieval.search import SearchFilter, expand_neighbor_records
 from sibyl_core.tools.traverse import (
@@ -29,6 +31,11 @@ from sibyl_core.tools.traverse import (
 ORG = "org_traverse"
 OWNER = "owner-principal"
 OTHER = "other-principal"
+
+# A real grant, built the way the API mints one. Spelling this as "project:proj_a"
+# denies every scope instead of just the private ones, which makes a deny test
+# pass without exercising the rule it names.
+PROJECT_GRANT = memory_scope_policy_key(MemoryScope.PROJECT, "proj_a")
 
 
 def _entity_row(
@@ -125,6 +132,48 @@ class _FakeClient:
         if "FROM entity" in query:
             wanted = params.get("uuids") or []
             return [self.rows[uuid] for uuid in wanted if uuid in self.rows]
+        return []
+
+
+class _GraphClient:
+    """A client backed by real adjacency, so multi-hop walks can be observed.
+
+    ``_FakeClient`` answers every frontier with one canned edge list, which is
+    enough for shape assertions and useless for anything about distance or about
+    which rows a walk routes through.
+    """
+
+    def __init__(
+        self,
+        *,
+        edges: list[tuple[str, str, str]],
+        rows: list[dict[str, Any]],
+    ) -> None:
+        self.edges = edges
+        self.rows = {row["uuid"]: row for row in rows}
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_query(self, query: str, **params: Any) -> list[dict[str, Any]]:
+        self.queries.append((query, params))
+        if "FROM mentions" in query or "BELONGS_TO" in query:
+            return []
+        if "FROM relates_to" in query:
+            if "target_id IN $target_uuids" in query:
+                wanted = set(params.get("target_uuids") or [])
+                return [
+                    {"uuid": source, "relationship": name}
+                    for source, target, name in self.edges
+                    if target in wanted
+                ]
+            wanted = set(params.get("source_uuids") or [])
+            return [
+                {"uuid": target, "relationship": name}
+                for source, target, name in self.edges
+                if source in wanted
+            ]
+        if "FROM entity" in query:
+            requested = params.get("uuids") or []
+            return [self.rows[uuid] for uuid in requested if uuid in self.rows]
         return []
 
 
@@ -897,10 +946,288 @@ class TestFetchSliceAuthorization:
                 organization_id=ORG,
                 principal_id=OWNER,
                 accessible_projects={"proj_a"},
-                allowed_memory_scope_keys={"project:proj_a"},
+                allowed_memory_scope_keys={PROJECT_GRANT},
             )
 
     @pytest.mark.asyncio
     async def test_entity_id_is_required(self) -> None:
         with pytest.raises(ValueError, match="entity_id"):
             await fetch_slice("  ", organization_id=ORG)
+
+
+class TestWalkAuthorizationGatesRoutes:
+    """A row the reader may not see must not be a route, only a non-result."""
+
+    @pytest.mark.asyncio
+    async def test_a_denied_row_is_not_a_route_to_its_own_neighbors(self) -> None:
+        """seed -> secret -> leaf, where secret belongs to another principal.
+
+        Withholding `secret` while still returning `leaf` would disclose that
+        something sits between them: a depth-2 row with no depth-1 parent in the
+        response is an admission of a hidden intermediate.
+        """
+        client = _GraphClient(
+            edges=[
+                ("seed", "secret", "RELATED_TO"),
+                ("secret", "leaf", "RELATED_TO"),
+            ],
+            rows=[
+                _entity_row("secret", memory_scope="private", principal_id=OTHER),
+                _entity_row("leaf"),
+            ],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                depth=2,
+                limit=8,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert [neighbor.id for neighbor in response.neighbors] == []
+
+    @pytest.mark.asyncio
+    async def test_the_same_route_is_walked_when_the_middle_row_is_readable(self) -> None:
+        """The allow direction of the same graph, so the deny is not vacuous."""
+        client = _GraphClient(
+            edges=[
+                ("seed", "middle", "RELATED_TO"),
+                ("middle", "leaf", "RELATED_TO"),
+            ],
+            rows=[_entity_row("middle"), _entity_row("leaf")],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                depth=2,
+                limit=8,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        by_id = {neighbor.id: neighbor for neighbor in response.neighbors}
+        assert set(by_id) == {"middle", "leaf"}
+        assert by_id["middle"].distance == 1
+        assert by_id["leaf"].distance == 2
+
+    @pytest.mark.asyncio
+    async def test_a_seed_is_never_returned_as_its_own_neighbor(self) -> None:
+        """Every inbound edge is a 2-cycle, so depth 2 rediscovers the seed."""
+        client = _GraphClient(
+            edges=[("seed", "neighbor", "RELATED_TO")],
+            rows=[_entity_row("seed"), _entity_row("neighbor")],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                depth=2,
+                limit=8,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert [neighbor.id for neighbor in response.neighbors] == ["neighbor"]
+        assert "seed" not in {neighbor.id for neighbor in response.neighbors}
+
+    @pytest.mark.asyncio
+    async def test_deeper_hops_score_below_adjacent_ones(self) -> None:
+        client = _GraphClient(
+            edges=[
+                ("seed", "near", "RELATED_TO"),
+                ("near", "far", "RELATED_TO"),
+            ],
+            rows=[_entity_row("near"), _entity_row("far")],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                depth=2,
+                limit=8,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        by_id = {neighbor.id: neighbor for neighbor in response.neighbors}
+        assert by_id["far"].score < by_id["near"].score
+
+    @pytest.mark.asyncio
+    async def test_api_key_without_a_private_grant_sees_no_private_neighbor(self) -> None:
+        """A key narrowed to a project does not inherit the principal's privates."""
+        rows = [
+            _entity_row("own_private", memory_scope="private", principal_id=OWNER),
+            _entity_row(
+                "project_row",
+                memory_scope="project",
+                scope_key="proj_a",
+                project_id="proj_a",
+            ),
+        ]
+        runtime = _FakeRuntime(
+            client=_FakeClient(
+                outgoing=[{"uuid": row["uuid"], "relationship": "RELATED_TO"} for row in rows],
+                rows=rows,
+            ),
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects={"proj_a"},
+                allowed_memory_scope_keys={PROJECT_GRANT},
+            )
+
+        assert [neighbor.id for neighbor in response.neighbors] == ["project_row"]
+
+
+class TestFetchSliceCoversParent:
+    """`covers_parent` is a claim a reader acts on by dropping the parent."""
+
+    @pytest.mark.asyncio
+    async def test_a_partial_window_does_not_claim_to_cover_the_parent(self) -> None:
+        """The bug this pins: 3 spans of 4 all carry the flag, but miss a quarter."""
+        parent = _entity("decision_parent")
+        spans = [_span("decision_parent", index, 4) for index in range(4)]
+        runtime = TestFetchSliceWindow._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_parent",
+                organization_id=ORG,
+                window=3,
+                principal_id=OWNER,
+            )
+
+        assert [passage.passage_index for passage in response.passages] == [0, 1, 2]
+        assert response.passage_total == 4
+        assert response.covers_parent is False
+
+    @pytest.mark.asyncio
+    async def test_a_complete_window_does_claim_to_cover_the_parent(self) -> None:
+        parent = _entity("decision_parent")
+        spans = [_span("decision_parent", index, 3) for index in range(3)]
+        runtime = TestFetchSliceWindow._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_parent",
+                organization_id=ORG,
+                window=3,
+                principal_id=OWNER,
+            )
+
+        assert [passage.passage_index for passage in response.passages] == [0, 1, 2]
+        assert response.covers_parent is True
+
+    @pytest.mark.asyncio
+    async def test_spans_from_two_generations_do_not_claim_coverage(self) -> None:
+        """A stale higher-index span can count to the right number and still lie."""
+        parent = _entity("decision_parent")
+        spans = [
+            _span("decision_parent", 0, 2),
+            _span("decision_parent", 1, 2),
+            _span("decision_parent", 2, 3),
+        ]
+        runtime = TestFetchSliceWindow._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_parent",
+                organization_id=ORG,
+                window=3,
+                principal_id=OWNER,
+            )
+
+        assert response.covers_parent is False
+
+    @pytest.mark.asyncio
+    async def test_a_denied_sibling_costs_the_window_its_coverage_claim(self) -> None:
+        parent = _entity(
+            "decision_parent",
+            metadata={"memory_scope": "project", "scope_key": "proj_a", "project_id": "proj_a"},
+        )
+        spans = [
+            _span("decision_parent", 0, 3),
+            _span("decision_parent", 1, 3, memory_scope="private", principal_id=OTHER),
+            _span("decision_parent", 2, 3),
+        ]
+        runtime = TestFetchSliceWindow._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_parent",
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects={"proj_a"},
+            )
+
+        assert [passage.passage_index for passage in response.passages] == [0, 2]
+        assert response.covers_parent is False
+
+    @pytest.mark.asyncio
+    async def test_an_unsliced_memory_covers_itself(self) -> None:
+        parent = _entity("decision_short", content="served whole")
+        runtime = _FakeRuntime(
+            entity_manager=_FakeEntityManager({parent.id: parent}),
+            relationship_manager=_FakeRelationshipManager([]),
+        )
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice("decision_short", organization_id=ORG, principal_id=OWNER)
+
+        assert response.sliced is False
+        assert response.covers_parent is True
+
+
+class TestFetchSliceAnchorNotInSpanSet:
+    @pytest.mark.asyncio
+    async def test_a_window_never_silently_omits_the_span_it_was_asked_for(self) -> None:
+        """The anchor is authorized but absent from its parent's discovered set."""
+        parent = _entity("decision_parent")
+        siblings = [_span("decision_parent", index, 9) for index in range(3)]
+        anchor = _span("decision_parent", 7, 9)
+        entities = {
+            parent.id: parent,
+            anchor.id: anchor,
+            **{span.id: span for span in siblings},
+        }
+        runtime = _FakeRuntime(
+            entity_manager=_FakeEntityManager(entities),
+            relationship_manager=_FakeRelationshipManager(
+                [(span, _part_of(span, parent.id)) for span in siblings]
+            ),
+        )
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(anchor.id, organization_id=ORG, principal_id=OWNER)
+
+        assert [passage.id for passage in response.passages] == [anchor.id]
+        assert response.passages[0].passage_index == 7
+        assert response.covers_parent is False

--- a/packages/python/sibyl-core/tests/test_tools_traverse.py
+++ b/packages/python/sibyl-core/tests/test_tools_traverse.py
@@ -173,7 +173,17 @@ class _GraphClient:
             ]
         if "FROM entity" in query:
             requested = params.get("uuids") or []
-            return [self.rows[uuid] for uuid in requested if uuid in self.rows]
+            rows = [self.rows[uuid] for uuid in requested if uuid in self.rows]
+            # Mirror the real hydration predicate. Without this a type filter
+            # pushed into the WHERE is invisible here, and a test asserting it is
+            # absent would pass whether or not it actually is.
+            node_types = params.get("node_types")
+            if node_types:
+                wanted_types = {str(value).lower() for value in node_types}
+                rows = [
+                    row for row in rows if str(row.get("entity_type", "")).lower() in wanted_types
+                ]
+            return rows
         return []
 
 
@@ -310,8 +320,12 @@ class TestExpandNeighborRecords:
         assert [record["graph_expansion_direction"] for record in records] == ["incoming"]
 
     @pytest.mark.asyncio
-    async def test_inbound_stays_off_for_the_scored_lane(self) -> None:
-        """The lane that seeds from a scored search must be unchanged."""
+    async def test_inbound_is_opt_in(self) -> None:
+        """Inbound expansion is off unless asked for, so no query is issued for it.
+
+        Named for what it checks. The scored lane's own contract is pinned in
+        TestSharedBfsContractAtDefaultArgs, which calls that lane's entry point.
+        """
         client = _FakeClient(
             incoming=[{"uuid": "task_dependent", "relationship": "DEPENDS_ON"}],
             rows=[_entity_row("task_dependent", entity_type="task")],
@@ -682,13 +696,16 @@ class TestExpandNeighborsBudget:
 
     @pytest.mark.asyncio
     async def test_no_seeds_returns_empty_without_touching_the_graph(self) -> None:
-        runtime = _FakeRuntime(client=_FakeClient(), entity_manager=_FakeEntityManager({}))
+        client = _FakeClient()
+        runtime = _FakeRuntime(client=client, entity_manager=_FakeEntityManager({}))
 
         with _runtime_patch(runtime):
             response = await expand_neighbors([], organization_id=ORG, principal_id=OWNER)
 
         assert response.total == 0
         assert response.neighbors == []
+        # The name promises this, so assert it rather than implying it.
+        assert client.queries == []
 
     @pytest.mark.asyncio
     async def test_organization_is_required(self) -> None:
@@ -1469,3 +1486,84 @@ class TestSpansCoverParentRule:
         from sibyl_core.projection.passages import spans_cover_parent
 
         assert spans_cover_parent([(0, 3, True), (2, 3, True)]) is False
+
+
+class TestTypeFilterNarrowsResultsNotRoutes:
+    @pytest.mark.asyncio
+    async def test_a_two_hop_neighbor_is_reachable_through_another_type(self) -> None:
+        """seed -> task_x -> decision_y, asking only for decisions.
+
+        Pushing the type filter into the hydration WHERE makes `task_x` unread and
+        therefore unwalkable, which hides `decision_y` entirely. The filter belongs
+        to the answer, not to the route.
+        """
+        client = _GraphClient(
+            edges=[
+                ("seed", "task_x", "RELATED_TO"),
+                ("task_x", "decision_y", "RELATED_TO"),
+            ],
+            rows=[
+                _entity_row("task_x", entity_type="task"),
+                _entity_row("decision_y", entity_type="decision"),
+            ],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                types=["decision"],
+                depth=2,
+                limit=8,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert [neighbor.id for neighbor in response.neighbors] == ["decision_y"]
+        assert response.neighbors[0].distance == 2
+        # Structural half of the same claim: the type restriction must never reach
+        # the hydration predicate, because a row it excludes there is never read
+        # and so can never be walked through.
+        hydration_params = [params for query, params in client.queries if "FROM entity" in query]
+        assert hydration_params
+        assert all("node_types" not in params for params in hydration_params)
+
+    @pytest.mark.asyncio
+    async def test_an_unauthorized_row_is_still_not_a_route(self) -> None:
+        """The type filter must not have relaxed the authorization gate."""
+        client = _GraphClient(
+            edges=[
+                ("seed", "secret_task", "RELATED_TO"),
+                ("secret_task", "decision_y", "RELATED_TO"),
+            ],
+            rows=[
+                _entity_row(
+                    "secret_task",
+                    entity_type="task",
+                    memory_scope="private",
+                    principal_id=OTHER,
+                ),
+                _entity_row("decision_y", entity_type="decision"),
+            ],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                types=["decision"],
+                depth=2,
+                limit=8,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert response.neighbors == []

--- a/packages/python/sibyl-core/tests/test_tools_traverse.py
+++ b/packages/python/sibyl-core/tests/test_tools_traverse.py
@@ -1,0 +1,912 @@
+"""Bounded traversal verbs: authorization, budgets, and window shape.
+
+Every verb here is a read surface, so each behavior is asserted as a pair: the
+row a reader is entitled to survives, and the row belonging to someone else does
+not. Testing only the deny direction is how a scope fix ships as an outage, and
+testing only the allow direction is how a leak ships as a feature.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.projection.passages import PASSAGE_COVERS_PARENT_KEY
+from sibyl_core.retrieval.search import SearchFilter, expand_neighbor_records
+from sibyl_core.tools.traverse import (
+    DEFAULT_SLICE_WINDOW,
+    MAX_EXPAND_LIMIT,
+    MAX_EXPAND_ORIGINS,
+    MAX_TRAVERSAL_DEPTH,
+    expand_neighbors,
+    fetch_slice,
+)
+
+ORG = "org_traverse"
+OWNER = "owner-principal"
+OTHER = "other-principal"
+
+
+def _entity_row(
+    uuid: str,
+    *,
+    entity_type: str = "decision",
+    name: str | None = None,
+    content: str = "row content",
+    memory_scope: str | None = None,
+    principal_id: str | None = None,
+    project_id: str | None = None,
+    scope_key: str | None = None,
+    extra_attributes: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """A Surreal entity row shaped the way the hydration query returns one."""
+    attributes: dict[str, Any] = {"description": "", "entity_type": entity_type}
+    if memory_scope is not None:
+        attributes["memory_scope"] = memory_scope
+    if principal_id is not None:
+        attributes["principal_id"] = principal_id
+    if project_id is not None:
+        attributes["project_id"] = project_id
+    if scope_key is not None:
+        attributes["scope_key"] = scope_key
+    attributes.update(extra_attributes or {})
+    return {
+        "uuid": uuid,
+        "name": name or uuid,
+        "entity_type": entity_type,
+        "content": content,
+        "summary": "",
+        "description": "",
+        "attributes": attributes,
+        "group_id": ORG,
+        "memory_scope": memory_scope,
+        "project_id": project_id,
+        "created_at": datetime(2026, 8, 1, tzinfo=UTC),
+        "updated_at": datetime(2026, 8, 1, tzinfo=UTC),
+        "revision": 1,
+    }
+
+
+def _entity(
+    entity_id: str,
+    *,
+    entity_type: EntityType = EntityType.DECISION,
+    content: str = "body",
+    metadata: dict[str, Any] | None = None,
+) -> Entity:
+    return Entity(
+        id=entity_id,
+        entity_type=entity_type,
+        name=entity_id,
+        description="",
+        content=content,
+        organization_id=ORG,
+        metadata=metadata or {},
+    )
+
+
+def _private(entity_id: str, owner: str, **kwargs: Any) -> Entity:
+    return _entity(
+        entity_id,
+        metadata={"memory_scope": "private", "principal_id": owner},
+        **kwargs,
+    )
+
+
+class _FakeClient:
+    """Answers the four query shapes the expansion BFS issues."""
+
+    def __init__(
+        self,
+        *,
+        outgoing: list[dict[str, Any]] | None = None,
+        incoming: list[dict[str, Any]] | None = None,
+        rows: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.outgoing = outgoing or []
+        self.incoming = incoming or []
+        self.rows = {row["uuid"]: row for row in (rows or [])}
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_query(self, query: str, **params: Any) -> list[dict[str, Any]]:
+        self.queries.append((query, params))
+        if "FROM mentions" in query:
+            return []
+        if "FROM relates_to" in query:
+            if "BELONGS_TO" in query:
+                return []
+            if "target_id IN $target_uuids" in query:
+                return list(self.incoming)
+            return list(self.outgoing)
+        if "FROM entity" in query:
+            wanted = params.get("uuids") or []
+            return [self.rows[uuid] for uuid in wanted if uuid in self.rows]
+        return []
+
+
+class _FakeEntityManager:
+    def __init__(self, entities: dict[str, Entity]) -> None:
+        self.entities = entities
+
+    async def get(self, entity_id: str) -> Entity:
+        if entity_id not in self.entities:
+            raise KeyError(entity_id)
+        return self.entities[entity_id]
+
+    async def get_many(self, entity_ids: Any) -> list[Entity]:
+        return [self.entities[value] for value in entity_ids if value in self.entities]
+
+
+class _FakeRelationshipManager:
+    def __init__(self, pairs: list[tuple[Entity, Relationship]]) -> None:
+        self.pairs = pairs
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_related_entities(
+        self,
+        entity_id: str,
+        relationship_types: Any = None,
+        max_depth: int = 1,
+        limit: int = 50,
+    ) -> list[tuple[Entity, Relationship]]:
+        self.calls.append(
+            {
+                "entity_id": entity_id,
+                "relationship_types": list(relationship_types or ()),
+                "limit": limit,
+            }
+        )
+        return list(self.pairs)
+
+
+class _FakeRuntime:
+    def __init__(
+        self,
+        *,
+        client: Any = None,
+        entity_manager: Any = None,
+        relationship_manager: Any = None,
+    ) -> None:
+        self.client = client
+        self.entity_manager = entity_manager
+        self.relationship_manager = relationship_manager
+
+
+def _runtime_patch(runtime: _FakeRuntime) -> Any:
+    return patch(
+        "sibyl_core.tools.traverse.get_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+
+
+def _span(
+    parent_id: str,
+    index: int,
+    total: int,
+    *,
+    memory_scope: str | None = None,
+    principal_id: str | None = None,
+    covers_parent: bool = True,
+) -> Entity:
+    metadata: dict[str, Any] = {
+        "parent_entity_id": parent_id,
+        "passage_index": index,
+        "passage_total": total,
+        "passage_breadcrumb": f"trail {index}",
+        PASSAGE_COVERS_PARENT_KEY: covers_parent,
+    }
+    if memory_scope is not None:
+        metadata["memory_scope"] = memory_scope
+    if principal_id is not None:
+        metadata["principal_id"] = principal_id
+    return _entity(
+        f"{parent_id}_passage_{index}",
+        entity_type=EntityType.PASSAGE,
+        content=f"span {index} body",
+        metadata=metadata,
+    )
+
+
+def _part_of(span: Entity, parent_id: str) -> Relationship:
+    return Relationship(
+        id=f"rel_{span.id}",
+        source_id=span.id,
+        target_id=parent_id,
+        relationship_type=RelationshipType.PART_OF,
+    )
+
+
+class TestExpandNeighborRecords:
+    """The primitive: hop tagging, authorization before the cap, and filters."""
+
+    @pytest.mark.asyncio
+    async def test_tags_hops_and_hydrates_rows(self) -> None:
+        client = _FakeClient(
+            outgoing=[{"uuid": "decision_b", "relationship": "SUPERSEDES"}],
+            rows=[_entity_row("decision_b")],
+        )
+
+        records = await expand_neighbor_records(
+            client=client,
+            origin_uuids=["decision_a"],
+            group_id=ORG,
+            max_depth=1,
+            limit=5,
+        )
+
+        assert [record["uuid"] for record in records] == ["decision_b"]
+        assert records[0]["graph_expansion_relationship"] == "SUPERSEDES"
+        assert records[0]["graph_expansion_depth"] == 1
+        assert records[0]["graph_expansion_direction"] == "outgoing"
+
+    @pytest.mark.asyncio
+    async def test_walks_inbound_edges_and_marks_direction(self) -> None:
+        client = _FakeClient(
+            incoming=[{"uuid": "task_dependent", "relationship": "DEPENDS_ON"}],
+            rows=[_entity_row("task_dependent", entity_type="task")],
+        )
+
+        records = await expand_neighbor_records(
+            client=client,
+            origin_uuids=["task_blocker"],
+            group_id=ORG,
+            max_depth=1,
+            limit=5,
+        )
+
+        assert [record["graph_expansion_direction"] for record in records] == ["incoming"]
+
+    @pytest.mark.asyncio
+    async def test_inbound_stays_off_for_the_scored_lane(self) -> None:
+        """The lane that seeds from a scored search must be unchanged."""
+        client = _FakeClient(
+            incoming=[{"uuid": "task_dependent", "relationship": "DEPENDS_ON"}],
+            rows=[_entity_row("task_dependent", entity_type="task")],
+        )
+
+        records = await expand_neighbor_records(
+            client=client,
+            origin_uuids=["task_blocker"],
+            group_id=ORG,
+            max_depth=1,
+            limit=5,
+            include_incoming=False,
+        )
+
+        assert records == []
+        assert not any("target_id IN $target_uuids" in query for query, _ in client.queries)
+
+    @pytest.mark.asyncio
+    async def test_relationship_filter_reaches_the_query(self) -> None:
+        client = _FakeClient(
+            outgoing=[{"uuid": "decision_b", "relationship": "DEPENDS_ON"}],
+            rows=[_entity_row("decision_b")],
+        )
+
+        await expand_neighbor_records(
+            client=client,
+            origin_uuids=["decision_a"],
+            group_id=ORG,
+            max_depth=1,
+            limit=5,
+            relationship_names=["DEPENDS_ON"],
+        )
+
+        edge_queries = [
+            params for query, params in client.queries if "FROM relates_to" in query
+        ]
+        assert edge_queries
+        assert all(params["relationship_names"] == ["DEPENDS_ON"] for params in edge_queries)
+
+    @pytest.mark.asyncio
+    async def test_authorization_runs_before_the_cap(self) -> None:
+        """A denied row must not consume the caller's budget.
+
+        Filtering after the cap is the bug this asserts against: two denied rows
+        ranked above one allowed row would fill a limit of two and report the
+        neighborhood as empty.
+        """
+        client = _FakeClient(
+            outgoing=[
+                {"uuid": "denied_1", "relationship": "DECIDES"},
+                {"uuid": "denied_2", "relationship": "DECIDES"},
+                {"uuid": "allowed", "relationship": "RELATED_TO"},
+            ],
+            rows=[
+                _entity_row("denied_1"),
+                _entity_row("denied_2"),
+                _entity_row("allowed"),
+            ],
+        )
+
+        records = await expand_neighbor_records(
+            client=client,
+            origin_uuids=["decision_a"],
+            group_id=ORG,
+            max_depth=1,
+            limit=2,
+            row_allowed=lambda row: not str(row.get("uuid", "")).startswith("denied"),
+        )
+
+        assert [record["uuid"] for record in records] == ["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_trims_to_the_requested_limit(self) -> None:
+        client = _FakeClient(
+            outgoing=[
+                {"uuid": f"decision_{index}", "relationship": "RELATED_TO"} for index in range(6)
+            ],
+            rows=[_entity_row(f"decision_{index}") for index in range(6)],
+        )
+
+        records = await expand_neighbor_records(
+            client=client,
+            origin_uuids=["decision_seed"],
+            group_id=ORG,
+            max_depth=1,
+            limit=3,
+            search_filter=SearchFilter(),
+        )
+
+        assert len(records) == 3
+
+
+class TestExpandNeighborsAuthorization:
+    """The allow and deny directions of the verb, asserted as a pair."""
+
+    @staticmethod
+    def _neighbors_runtime(rows: list[dict[str, Any]], seeds: dict[str, Entity]) -> _FakeRuntime:
+        return _FakeRuntime(
+            client=_FakeClient(
+                outgoing=[
+                    {"uuid": row["uuid"], "relationship": "RELATED_TO"} for row in rows
+                ],
+                rows=rows,
+            ),
+            entity_manager=_FakeEntityManager(seeds),
+        )
+
+    @pytest.mark.asyncio
+    async def test_reader_sees_own_private_and_project_neighbors(self) -> None:
+        runtime = self._neighbors_runtime(
+            [
+                _entity_row("own_private", memory_scope="private", principal_id=OWNER),
+                _entity_row(
+                    "project_row",
+                    memory_scope="project",
+                    scope_key="proj_a",
+                    project_id="proj_a",
+                ),
+            ],
+            {"seed": _entity("seed")},
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects={"proj_a"},
+            )
+
+        assert {neighbor.id for neighbor in response.neighbors} == {"own_private", "project_row"}
+        assert response.origins == ["seed"]
+
+    @pytest.mark.asyncio
+    async def test_another_principals_private_neighbor_is_absent(self) -> None:
+        runtime = self._neighbors_runtime(
+            [
+                _entity_row("own_private", memory_scope="private", principal_id=OWNER),
+                _entity_row("their_private", memory_scope="private", principal_id=OTHER),
+            ],
+            {"seed": _entity("seed")},
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert [neighbor.id for neighbor in response.neighbors] == ["own_private"]
+
+    @pytest.mark.asyncio
+    async def test_unrequested_projects_rows_drop(self) -> None:
+        runtime = self._neighbors_runtime(
+            [
+                _entity_row(
+                    "mine",
+                    memory_scope="project",
+                    scope_key="proj_a",
+                    project_id="proj_a",
+                ),
+                _entity_row(
+                    "theirs",
+                    memory_scope="project",
+                    scope_key="proj_b",
+                    project_id="proj_b",
+                ),
+            ],
+            {"seed": _entity("seed")},
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects={"proj_a"},
+            )
+
+        assert [neighbor.id for neighbor in response.neighbors] == ["mine"]
+
+    @pytest.mark.asyncio
+    async def test_unstamped_work_item_of_another_project_drops(self) -> None:
+        """A task carries its audience in project_id rather than a scope stamp."""
+        runtime = self._neighbors_runtime(
+            [
+                _entity_row("task_mine", entity_type="task", project_id="proj_a"),
+                _entity_row("task_theirs", entity_type="task", project_id="proj_b"),
+            ],
+            {"seed": _entity("seed")},
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects={"proj_a"},
+            )
+
+        assert [neighbor.id for neighbor in response.neighbors] == ["task_mine"]
+
+    @pytest.mark.asyncio
+    async def test_seed_the_reader_cannot_read_yields_no_walk(self) -> None:
+        """Expanding from an unreadable seed would leak its neighbor list."""
+        client = _FakeClient(
+            outgoing=[{"uuid": "neighbor", "relationship": "RELATED_TO"}],
+            rows=[_entity_row("neighbor")],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"secret": _private("secret", OTHER)}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["secret"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert response.origins == []
+        assert response.unresolved == ["secret"]
+        assert response.neighbors == []
+        assert client.queries == []
+
+    @pytest.mark.asyncio
+    async def test_owner_may_expand_from_their_own_private_seed(self) -> None:
+        client = _FakeClient(
+            outgoing=[{"uuid": "neighbor", "relationship": "RELATED_TO"}],
+            rows=[_entity_row("neighbor")],
+        )
+        runtime = _FakeRuntime(
+            client=client,
+            entity_manager=_FakeEntityManager({"secret": _private("secret", OWNER)}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["secret"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert response.origins == ["secret"]
+        assert [neighbor.id for neighbor in response.neighbors] == ["neighbor"]
+
+    @pytest.mark.asyncio
+    async def test_missing_and_denied_seeds_are_reported_alike(self) -> None:
+        runtime = _FakeRuntime(
+            client=_FakeClient(),
+            entity_manager=_FakeEntityManager({"secret": _private("secret", OTHER)}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["secret", "never_existed"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert sorted(response.unresolved) == ["never_existed", "secret"]
+
+
+class TestExpandNeighborsBudget:
+    @pytest.mark.asyncio
+    async def test_depth_and_limit_clamp_to_the_ceiling(self) -> None:
+        rows = [_entity_row(f"decision_{index}") for index in range(MAX_EXPAND_LIMIT + 4)]
+        runtime = _FakeRuntime(
+            client=_FakeClient(
+                outgoing=[{"uuid": row["uuid"], "relationship": "RELATED_TO"} for row in rows],
+                rows=rows,
+            ),
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                depth=99,
+                limit=999,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert response.depth == MAX_TRAVERSAL_DEPTH
+        assert response.limit == MAX_EXPAND_LIMIT
+        assert len(response.neighbors) == MAX_EXPAND_LIMIT
+        assert response.truncated is True
+
+    @pytest.mark.asyncio
+    async def test_seed_overflow_is_reported_rather_than_silently_dropped(self) -> None:
+        seed_ids = [f"seed_{index}" for index in range(MAX_EXPAND_ORIGINS + 2)]
+        runtime = _FakeRuntime(
+            client=_FakeClient(),
+            entity_manager=_FakeEntityManager(
+                {seed_id: _entity(seed_id) for seed_id in seed_ids}
+            ),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                seed_ids,
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert len(response.origins) == MAX_EXPAND_ORIGINS
+        assert response.unresolved == seed_ids[MAX_EXPAND_ORIGINS:]
+        assert response.filters["origin_limit"] == MAX_EXPAND_ORIGINS
+
+    @pytest.mark.asyncio
+    async def test_previews_are_bounded_and_flagged(self) -> None:
+        runtime = _FakeRuntime(
+            client=_FakeClient(
+                outgoing=[{"uuid": "long_row", "relationship": "RELATED_TO"}],
+                rows=[_entity_row("long_row", content="word " * 400)],
+            ),
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                content_max_chars=50,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        neighbor = response.neighbors[0]
+        assert len(neighbor.content) <= 53
+        assert neighbor.metadata["content_truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_passage_neighbor_names_its_widening_move(self) -> None:
+        runtime = _FakeRuntime(
+            client=_FakeClient(
+                outgoing=[{"uuid": "span_row", "relationship": "PART_OF"}],
+                rows=[
+                    _entity_row(
+                        "span_row",
+                        entity_type="passage",
+                        extra_attributes={
+                            "passage_index": 2,
+                            "passage_total": 5,
+                            "parent_entity_id": "decision_parent",
+                        },
+                    )
+                ],
+            ),
+            entity_manager=_FakeEntityManager({"seed": _entity("seed")}),
+        )
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors(
+                ["seed"],
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        metadata = response.neighbors[0].metadata
+        assert metadata["passage_index"] == 2
+        assert metadata["parent_entity_id"] == "decision_parent"
+        assert metadata["widen_with"] == "fetch_slice"
+
+    @pytest.mark.asyncio
+    async def test_no_seeds_returns_empty_without_touching_the_graph(self) -> None:
+        runtime = _FakeRuntime(client=_FakeClient(), entity_manager=_FakeEntityManager({}))
+
+        with _runtime_patch(runtime):
+            response = await expand_neighbors([], organization_id=ORG, principal_id=OWNER)
+
+        assert response.total == 0
+        assert response.neighbors == []
+
+    @pytest.mark.asyncio
+    async def test_organization_is_required(self) -> None:
+        with pytest.raises(ValueError, match="organization_id"):
+            await expand_neighbors(["seed"], organization_id="")
+
+
+class TestFetchSliceWindow:
+    @staticmethod
+    def _sliced_runtime(
+        parent: Entity,
+        spans: list[Entity],
+    ) -> _FakeRuntime:
+        entities = {parent.id: parent, **{span.id: span for span in spans}}
+        return _FakeRuntime(
+            entity_manager=_FakeEntityManager(entities),
+            relationship_manager=_FakeRelationshipManager(
+                [(span, _part_of(span, parent.id)) for span in spans]
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_window_centers_on_the_named_span(self) -> None:
+        parent = _entity("decision_parent", content="whole body")
+        spans = [_span("decision_parent", index, 5) for index in range(5)]
+        runtime = self._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                spans[2].id,
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert [passage.passage_index for passage in response.passages] == [1, 2, 3]
+        assert response.window == DEFAULT_SLICE_WINDOW
+        assert response.window_start == 1
+        assert response.parent_id == "decision_parent"
+        assert response.sliced is True
+
+    @pytest.mark.asyncio
+    async def test_window_slides_inside_the_available_spans(self) -> None:
+        parent = _entity("decision_parent")
+        spans = [_span("decision_parent", index, 4) for index in range(4)]
+        runtime = self._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            first = await fetch_slice(spans[0].id, organization_id=ORG, principal_id=OWNER)
+            last = await fetch_slice(spans[3].id, organization_id=ORG, principal_id=OWNER)
+
+        assert [passage.passage_index for passage in first.passages] == [0, 1, 2]
+        assert [passage.passage_index for passage in last.passages] == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_parent_id_starts_the_window_at_the_first_span(self) -> None:
+        parent = _entity("decision_parent")
+        spans = [_span("decision_parent", index, 5) for index in range(5)]
+        runtime = self._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_parent",
+                organization_id=ORG,
+                principal_id=OWNER,
+            )
+
+        assert [passage.passage_index for passage in response.passages] == [0, 1, 2]
+        assert response.passage_total == 5
+
+    @pytest.mark.asyncio
+    async def test_spans_come_back_in_index_order(self) -> None:
+        parent = _entity("decision_parent")
+        spans = [_span("decision_parent", index, 3) for index in range(3)]
+        runtime = self._sliced_runtime(parent, list(reversed(spans)))
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice("decision_parent", organization_id=ORG, principal_id=OWNER)
+
+        assert [passage.passage_index for passage in response.passages] == [0, 1, 2]
+
+    @pytest.mark.asyncio
+    async def test_unsliced_memory_returns_its_whole_body(self) -> None:
+        parent = _entity("decision_short", content="short enough to serve whole")
+        runtime = _FakeRuntime(
+            entity_manager=_FakeEntityManager({parent.id: parent}),
+            relationship_manager=_FakeRelationshipManager([]),
+        )
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice("decision_short", organization_id=ORG, principal_id=OWNER)
+
+        assert response.sliced is False
+        assert response.total == 1
+        assert response.passages[0].content == "short enough to serve whole"
+        assert response.passages[0].passage_index is None
+
+    @pytest.mark.asyncio
+    async def test_window_shares_one_character_budget(self) -> None:
+        parent = _entity("decision_parent")
+        spans = [_span("decision_parent", index, 3) for index in range(3)]
+        runtime = self._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_parent",
+                organization_id=ORG,
+                content_max_chars=12,
+                principal_id=OWNER,
+            )
+
+        assert response.content_chars <= 12 + len("...")
+        assert any(passage.truncated for passage in response.passages)
+
+    @pytest.mark.asyncio
+    async def test_partial_projection_does_not_claim_to_cover_the_parent(self) -> None:
+        parent = _entity("decision_parent")
+        spans = [
+            _span("decision_parent", 0, 2, covers_parent=True),
+            _span("decision_parent", 1, 2, covers_parent=False),
+        ]
+        runtime = self._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice("decision_parent", organization_id=ORG, principal_id=OWNER)
+
+        assert response.covers_parent is False
+
+    @pytest.mark.asyncio
+    async def test_window_clamps_below_one(self) -> None:
+        parent = _entity("decision_parent")
+        spans = [_span("decision_parent", index, 3) for index in range(3)]
+        runtime = self._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_parent",
+                organization_id=ORG,
+                window=0,
+                principal_id=OWNER,
+            )
+
+        assert response.window == 1
+        assert len(response.passages) == 1
+
+
+class TestFetchSliceAuthorization:
+    @pytest.mark.asyncio
+    async def test_owner_reads_the_window_of_their_private_memory(self) -> None:
+        parent = _private("decision_secret", OWNER)
+        spans = [
+            _span("decision_secret", index, 3, memory_scope="private", principal_id=OWNER)
+            for index in range(3)
+        ]
+        runtime = TestFetchSliceWindow._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_secret",
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert len(response.passages) == 3
+
+    @pytest.mark.asyncio
+    async def test_another_principals_private_memory_is_not_found(self) -> None:
+        parent = _private("decision_secret", OTHER)
+        spans = [
+            _span("decision_secret", index, 3, memory_scope="private", principal_id=OTHER)
+            for index in range(3)
+        ]
+        runtime = TestFetchSliceWindow._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime), pytest.raises(KeyError):
+            await fetch_slice(
+                "decision_secret",
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_absent_and_denied_ids_fail_identically(self) -> None:
+        runtime = _FakeRuntime(
+            entity_manager=_FakeEntityManager({"secret": _private("secret", OTHER)}),
+            relationship_manager=_FakeRelationshipManager([]),
+        )
+
+        with _runtime_patch(runtime):
+            with pytest.raises(KeyError):
+                await fetch_slice("secret", organization_id=ORG, principal_id=OWNER)
+            with pytest.raises(KeyError):
+                await fetch_slice("never_existed", organization_id=ORG, principal_id=OWNER)
+
+    @pytest.mark.asyncio
+    async def test_a_span_the_reader_may_not_read_leaves_the_window(self) -> None:
+        """A span carries its own scope, so one may be denied inside a readable parent."""
+        parent = _entity(
+            "decision_parent",
+            metadata={"memory_scope": "project", "scope_key": "proj_a", "project_id": "proj_a"},
+        )
+        spans = [
+            _span("decision_parent", 0, 3),
+            _span("decision_parent", 1, 3, memory_scope="private", principal_id=OTHER),
+            _span("decision_parent", 2, 3),
+        ]
+        runtime = TestFetchSliceWindow._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                "decision_parent",
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects={"proj_a"},
+            )
+
+        assert [passage.passage_index for passage in response.passages] == [0, 2]
+
+    @pytest.mark.asyncio
+    async def test_a_span_whose_parent_is_denied_still_serves_itself(self) -> None:
+        span = _span("decision_secret", 1, 3)
+        runtime = _FakeRuntime(
+            entity_manager=_FakeEntityManager(
+                {span.id: span, "decision_secret": _private("decision_secret", OTHER)}
+            ),
+            relationship_manager=_FakeRelationshipManager([]),
+        )
+
+        with _runtime_patch(runtime):
+            response = await fetch_slice(
+                span.id,
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects=set(),
+            )
+
+        assert response.total == 1
+        assert response.filters["parent_unreadable"] is True
+
+    @pytest.mark.asyncio
+    async def test_api_key_without_a_private_grant_cannot_read_its_own_rows(self) -> None:
+        """A key narrowed to a project does not inherit the principal's privates."""
+        parent = _private("decision_secret", OWNER)
+        spans = [
+            _span("decision_secret", index, 2, memory_scope="private", principal_id=OWNER)
+            for index in range(2)
+        ]
+        runtime = TestFetchSliceWindow._sliced_runtime(parent, spans)
+
+        with _runtime_patch(runtime), pytest.raises(KeyError):
+            await fetch_slice(
+                "decision_secret",
+                organization_id=ORG,
+                principal_id=OWNER,
+                accessible_projects={"proj_a"},
+                allowed_memory_scope_keys={"project:proj_a"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_entity_id_is_required(self) -> None:
+        with pytest.raises(ValueError, match="entity_id"):
+            await fetch_slice("  ", organization_id=ORG)

--- a/packages/python/sibyl-core/tests/test_tools_traverse.py
+++ b/packages/python/sibyl-core/tests/test_tools_traverse.py
@@ -296,9 +296,7 @@ class TestExpandNeighborRecords:
             relationship_names=["DEPENDS_ON"],
         )
 
-        edge_queries = [
-            params for query, params in client.queries if "FROM relates_to" in query
-        ]
+        edge_queries = [params for query, params in client.queries if "FROM relates_to" in query]
         assert edge_queries
         assert all(params["relationship_names"] == ["DEPENDS_ON"] for params in edge_queries)
 
@@ -362,9 +360,7 @@ class TestExpandNeighborsAuthorization:
     def _neighbors_runtime(rows: list[dict[str, Any]], seeds: dict[str, Entity]) -> _FakeRuntime:
         return _FakeRuntime(
             client=_FakeClient(
-                outgoing=[
-                    {"uuid": row["uuid"], "relationship": "RELATED_TO"} for row in rows
-                ],
+                outgoing=[{"uuid": row["uuid"], "relationship": "RELATED_TO"} for row in rows],
                 rows=rows,
             ),
             entity_manager=_FakeEntityManager(seeds),
@@ -564,9 +560,7 @@ class TestExpandNeighborsBudget:
         seed_ids = [f"seed_{index}" for index in range(MAX_EXPAND_ORIGINS + 2)]
         runtime = _FakeRuntime(
             client=_FakeClient(),
-            entity_manager=_FakeEntityManager(
-                {seed_id: _entity(seed_id) for seed_id in seed_ids}
-            ),
+            entity_manager=_FakeEntityManager({seed_id: _entity(seed_id) for seed_id in seed_ids}),
         )
 
         with _runtime_patch(runtime):

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -26,7 +26,7 @@ from tools.inventory.runtime_surface import (
 EXPECTED_ROUTER_COUNT = 31
 EXPECTED_HTTP_ROUTE_COUNT = 3
 EXPECTED_WEBSOCKET_ROUTE_COUNT = 1
-EXPECTED_MCP_TOOL_COUNT = 11
+EXPECTED_MCP_TOOL_COUNT = 13
 EXPECTED_MCP_RESOURCE_COUNT = 2
 EXPECTED_SQLMODEL_TABLE_COUNT = 0
 _GRAPHITI_PACKAGE = "graphiti" + "-core"
@@ -438,6 +438,8 @@ def test_runtime_surface_finds_known_contracts() -> None:
     assert {record.name for record in surface.mcp_tools} >= {
         "search",
         "explore",
+        "expand_neighbors",
+        "fetch_slice",
         "add",
         "synthesis_plan",
         "synthesis_draft",


### PR DESCRIPTION
## 🔮 Why

The 1.2 plan's A3 fork asks whether multi-step retrieval should be a smarter
one-shot pass or a bounded loop the model steers. This resolves it toward the
loop, and only the loop: retrieval already walks the graph, but only inside one
scored pass whose shape the caller cannot change. An agent holding a specific
memory has no way to ask what sits next to it, and an agent whose search matched
one span of a long memory has no way to widen to the spans around it.

Two verbs close that, and nothing else moves. `expand_neighbors` widens a seed
set by a bounded number of hops. `fetch_slice` widens one hit into the span
window it was cut into. Composition stays exactly where it was: both verbs hand
back adjacency and previews, and `context` still renders the evidence with its
ordering and reserved note lane intact.

The budget comes from the measurement, not from taste. Two retrieval iterations
capture nearly all the gain of five, so the contract is at most three rounds:
search or pack, widen, widen once more, answer. The slice window defaults to
three adjacent spans because that is where the exposure measurement lands (95.5%
enterprise / 100% web for a 3-adjacent window against the same figures for the
whole state, where a lone span reaches only 93.2% / 97.9%).

## ⚡ What

**Core** (`packages/python/sibyl-core/src/sibyl_core/tools/traverse.py`)

- `expand_neighbors(entity_ids, ...)` returns hop-tagged neighbors with
  relationship, direction, and distance, highest path score first.
- `fetch_slice(entity_id, ...)` accepts either end of the relationship. Given a
  span the window centers on it; given a memory it starts at the first span. A
  memory too short to have been cut comes back whole with `sliced=False`.

**Primitive** (`retrieval/search.py`)

The walk reuses the existing expansion BFS rather than adding a second one. Two
additions, both defaulted off so the scored lane is unchanged: a
relationship-name filter, and inbound hops.

Inbound is the load-bearing one. The graph writes edges from span to memory and
from dependent to dependency, so an outgoing-only walk reports the interesting
neighbors as absent. Live proof, from the probe below: expanding off a sliced
artifact returns 4 spans with `include_incoming=True` and 0 without.

**Surfaces**

`POST /search/expand` and `POST /search/slice` sit beside `/search` and
`/search/explore`; `expand_neighbors` and `fetch_slice` register as MCP tools.
The wire bounds import the core clamps rather than restating them, so a budget
change cannot drift between the HTTP contract and the walk that honors it.

The MCP docstrings carry the round budget, because there is no session to
enforce it in and a bound invisible to the model is not a bound. They also tell
the agent when to skip traversal entirely (one hop answers it, read `context`),
that composition is not theirs, and that a citation goes on the parent rather
than the span, since span ids are re-minted whenever a memory is edited.

**Docs**

`docs/api/mcp-traverse.md` is the reference page: the round budget, when to skip
traversal, why inbound edges are followed by default, both input and output
shapes, and the two rules a caller gets wrong first. Six surfaces asserted that
Sibyl exposes eleven MCP tools and listed them by name, including the CLI skill
pack an agent reads, so the count moves to thirteen everywhere it appears.

## 💎 How the authorization works

Every row either verb returns passes `memory_metadata_read_allowed`
individually, not once per seed. Project membership is not permission to read a
private memory that happens to sit in that project, and a traversal that
authorized only its seeds would be a way to reach one by walking to it.

Three details worth a reviewer's attention:

**The check gates the walk, not just its output.** The walk advances one hop at a
time and only authorized rows join the next frontier, so an unreadable memory is
not a result and not a route. Filtering only the final result set still returns a
depth-two neighbor reachable exclusively through another principal's private
memory, and receiving that row tells the reader something sits between them.

**Authorization runs before the cap.** Each hop is widened by the headroom the
scored lanes already read with, filtered, then trimmed. Filter after the cap and
two denied rows ranked above one allowed row fill a limit of two and report the
neighborhood as empty.

**Absent and unauthorized answer identically.** An unreadable seed lands in
`unresolved` with no reason attached, and `fetch_slice` raises the same 404 for
a denied row as for one that does not exist. Distinguishing them confirms a row
the caller has no right to know exists.

**The scope column is folded into metadata before the check.**
`entity_from_surreal_row` promotes denormalized columns into metadata but not
`memory_scope`, and the read rule treats an absent scope as unscoped. The two
representations are written in lockstep and agree on every scoped row in the dev
store (8071 rows, 0 divergence in both directions), so this is a guard against a
future write that sets only the column, not a repair. It can only add a scope
where metadata had none, never relax one, and it is registered in the
scope-reader inventory with that reason.

The scope guard graph browsing already used moves to `tools/helpers.py`, so both
verbs and `explore` answer to one rule rather than three copies of it.

## 🧪 Verification

Unit and route tests assert every read behavior as a pair, because testing only
the deny direction is how a scope fix ships as an outage and testing only the
allow direction is how a leak ships as a feature.

```
core:test    2186 passed, 14 skipped
api:test     2056 passed, 5 skipped
```

New: 56 core tests (`test_tools_traverse.py`), 20 route tests
(`test_routes_traverse.py`).

The docstring assertion earned its place on the first run: it failed because
`fetch_slice` never told the agent that composition belongs to `context`.

### Live probe, read-only against the dev store

Units drive the primitive through a fake client, so the new SurrealQL had never
executed. The probe ran the branch's own `sibyl_core` against dev SurrealDB
(10,926 entities, 61 passages, 24,544 edges), read-only, no schema preparation.
Each arm was built so a broken build and a working one produce different output.

| Arm | Result |
| --- | --- |
| Inbound hops off a sliced memory | 4 incoming `PART_OF` spans, `d1`, score 0.64 |
| Same seed, `include_incoming=False` | 0, so the flag is not decoration |
| Relationship filter, depth 2 | unfiltered `[BELONGS_TO, RELATED_TO]` narrows to `[BELONGS_TO]` |
| Depth 1 vs 2 | 4 neighbors at distance `[1]` vs 24 at `[1, 2]` |
| Window centered on span 2 of 4 | `[1, 2, 3]`, ordered, 2687 chars, `covers_parent=True` |
| Same memory by parent id | `[0, 1, 2]`, `passage_total=4` |
| Memory with no spans | `sliced=False`, whole 354-char body served |

The deny arms hold the project grant fixed and vary only the principal, so a
withheld row is attributable to identity rather than to membership.

| Deny arm | Owner | Stranger |
| --- | --- | --- |
| Slice a private memory | 3 spans, 2687 chars | `KeyError`, same as absent |
| Expand a seed with private neighbors | 4 neighbors | 2, exactly the two private rows withheld, project rows intact |
| Expand from a private seed | walks | `origins=[]`, `unresolved=[seed]`, no query issued |
| Slice an ungranted project's memory | 1 span with the grant | `KeyError` without it |

The allow direction is asserted alongside every deny, which is the check the
1.1.3 regression would have failed.

## 🎯 Blast radius

The scored retrieval lane keeps its behavior: both BFS additions default off, the
per-hop authorized walk lives in the traversal wrapper rather than in the shared
BFS, and the direction tag is deliberately left out of
`_GRAPH_EXPANSION_METADATA_KEYS` so it reaches a direct reader and stays out of
search result metadata. Every parameter added to the shared BFS
defaults to the pre-existing behavior, and two tests call that lane's own entry
point at default arguments to pin it. The evidence composer, `TYPED_NOTE_RESERVATION_ITEMS`, and
context pack rendering are untouched.

Two structural guards were updated rather than worked around: the scope-reader
inventory gains the normalizer with its reason, and the runtime surface tool
count moves 11 to 13.

Not done, and not blocking: no CLI subcommand for either verb (REST and MCP were
the scope), no ranking or exposure changes, and no benchmark arm. Whether
agent-steered traversal actually beats the one-shot pass is a measurement this
enables rather than one it makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🔍 Review rounds

An independent adversarial review returned FAIL on five counts. Every one is
fixed with a test that fails without the fix.

The caps anchored to `MAX_CANDIDATES_PER_SIGNAL`, which main deleted in favour of
`DEFAULT_CANDIDATES_PER_SIGNAL` while this branch was open. Git merged both sides
with no conflict, so the merge imported a name that no longer existed, and because
the API schemas and the MCP server import this module at import time the API would
not have started at all. That single cause is what had `E2E`, `Package Tests`, and
`LongMemEval Local Embedding Smoke` red; all three pass now.

Authorization gated emitted rows but not the frontier, so a depth-two neighbor
reachable only through another principal's private memory still came back. No
content leaked, but the module claimed a stronger guarantee than it provided. The
walk is now authorized hop by hop and the docstring matches it.

`covers_parent` was computed from the per-span flag alone, which every span of a
complete projection carries, so a three-of-four window claimed to cover its
parent and invited a reader to drop a quarter of the body. The rule now lives
beside the flag in `projection/passages.py` and requires a single declared total
and an exact index range.

Two smaller ones: a seed came back as its own neighbor at depth two, because
inbound hops make every edge a two-cycle; and a window whose anchor was missing
from its parent's span set silently served a different window.

The review also caught a defect in the tests rather than the code. API-key grant
keys are `\x1f`-separated, so a grant spelled `"project:proj_a"` denies every
scope, and a deny test using it passed without exercising the rule it named. Both
grant tests now build the key with `memory_scope_policy_key`.

### Round 2

Adversarial review returned FAIL on the first remediation, then found three more
on the second pass. All are fixed, each with a test that fails without the fix.

A span could serve text its own parent refuses. Spans inherit scope once at write
time, and the reprojection that refreshes them runs only when the body changes, so
a scope-only edit tightening a memory to private leaves its spans readable, and
`fetch_slice` takes a span id directly. It now authorizes the parent before
serving any span: a span is never more readable than the memory it was cut from.
Nothing in the live store currently disagrees on scope, so this was reachable in
code rather than exploitable in data.

The seed-exclusion fix had been placed inside the shared BFS, which changed the
scored lane: a seed adjacent to another seed stopped being contributed by the
expansion lane, costing it a signal boost and an RRF rank term on the benchmarked
path. It was also redundant, since the traversal wrapper's own bookkeeping already
excludes seeds. Reverted, and the scored lane's contract is now pinned by tests
that call it directly at default arguments.

The `types` parameter narrowed the walk instead of the answer. Passing it as a
`SearchFilter` put the type test in the hydration predicate, so a row of an
unwanted type was never read and never walked through, hiding every requested-type
neighbor that sat two hops out behind another type. Results and routes are now
gated separately.

Both surfaces also disagreed on out-of-range input, REST rejecting what MCP
clamped, so one verb answered differently depending on how it was called. Both
clamp now and every response reports the bound it applied.

Two smaller ones: the agent-facing bounds in the MCP docstrings were Python
identifiers rather than numbers, and two test names promised more than their bodies
checked.
