### PR TITLE
feat(memory): agent-authored spans, atomic memories, and probe-carrying writes

### DIFF
--- a/apps/api/src/sibyl/api/errors.py
+++ b/apps/api/src/sibyl/api/errors.py
@@ -182,6 +182,30 @@ def constraint_violation(
     )
 
 
+def unprocessable_entity(
+    message: str,
+    *,
+    field: str | None = None,
+    remediation: str | None = None,
+) -> HTTPException:
+    """Create a 422 for a well-formed request whose contents cannot be honored.
+
+    Unlike most factories here the message reaches the client verbatim, because
+    the caller is an agent that has to correct a specific payload and a generic
+    "invalid request" leaves it guessing which of its offsets was wrong.
+    Sanitization still applies, so the message must stay short and name no paths.
+    """
+    return HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=safe_error_payload(
+            error="validation_error",
+            message=message,
+            remediation=remediation,
+            details={"field": field} if field else None,
+        ),
+    )
+
+
 def internal_error(error_id: str | None = None) -> HTTPException:
     """Create a 500 exception with optional error reference.
 

--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -225,7 +225,12 @@ def _resolved_update_structure(
         MemoryStructureError,
         agent_atomic_from_metadata,
     )
-    from sibyl_core.memory_pipeline.structure import build_memory_structure, structure_metadata
+    from sibyl_core.memory_pipeline.structure import (
+        PROBE_LAST_REPLAY_METADATA_KEY,
+        PROBE_REHEARSAL_METADATA_KEY,
+        build_memory_structure,
+        structure_metadata,
+    )
 
     existing_metadata = getattr(existing, "metadata", {}) or {}
     stored_content = (getattr(existing, "content", "") or "").strip()
@@ -258,7 +263,13 @@ def _resolved_update_structure(
             remediation="Recompute the declared structure against the updated content.",
         ) from exc
 
-    declaration_keys = (AGENT_SPANS_METADATA_KEY, AGENT_ATOMIC_METADATA_KEY)
+    declaration_keys = [AGENT_SPANS_METADATA_KEY, AGENT_ATOMIC_METADATA_KEY]
+    if content_changed:
+        # A receipt describes whether a particular body could be found. Once that
+        # body is rewritten the verdict is about text that no longer exists, and a
+        # stale pass is worse than no receipt: the probes survive, so the replay
+        # job produces an honest one on its next run.
+        declaration_keys += [PROBE_REHEARSAL_METADATA_KEY, PROBE_LAST_REPLAY_METADATA_KEY]
     resolved = {key: value for key, value in base_metadata.items() if key not in declaration_keys}
     stamped = structure_metadata(structure)
     # The entity update lands as `UPDATE entity MERGE $patch`, and a MERGE cannot
@@ -368,8 +379,6 @@ def _bulk_create_metadata(
     now: datetime,
     principal_id: str | None,
 ) -> dict[str, Any]:
-    from sibyl_core.memory_pipeline.structure import structure_metadata
-
     request_metadata = strip_structure_metadata(entity.metadata)
     project_id = str(request_metadata.get("project_id") or "").strip()
     return {
@@ -383,15 +392,18 @@ def _bulk_create_metadata(
             principal_id=principal_id,
             verified_project_id=project_id or None,
         ),
-        # Declared through the typed fields and validated, never carried over from
-        # the payload bag: this batch path writes rows directly rather than
-        # through the graph writer that owns those keys everywhere else.
-        **structure_metadata(_bulk_create_structure(entity)),
     }
 
 
 def _reject_unsupported_bulk_entry(entity: EntityCreate) -> None:
-    """Fault a batch entry the direct-write path cannot honor."""
+    """Fault a batch entry the direct-write path cannot honor.
+
+    All three structure fields are refused rather than accepted and ignored. This
+    path writes rows itself and enqueues ``project_memory_batch``, which extracts
+    memory entities and never mints passages, so there is no cutter here to honor
+    a declared plan and nothing searchable to rehearse a probe against. Storing a
+    validated plan no cutter reads would be a promise with no keeper.
+    """
     if entity.entity_type in BULK_UNSUPPORTED_TYPES:
         raise HTTPException(
             status_code=400,
@@ -405,38 +417,21 @@ def _reject_unsupported_bulk_entry(entity: EntityCreate) -> None:
                 "use POST /entities for conflict detection"
             ),
         )
-    if entity.probes:
-        # Rehearsal has to observe the row it asks about, and this path writes a
-        # whole batch without waiting on a searchable write per entry. Accepting
-        # the field and never rehearsing would ship a receipt-shaped promise
-        # nothing keeps.
-        raise unprocessable_entity(
-            "probes are not supported on bulk create; write the memory through "
-            "POST /entities to get a rehearsal receipt",
-            field="probes",
+    declared = [
+        name
+        for name, sent in (
+            ("spans", entity.spans is not None),
+            ("atomic", entity.atomic),
+            ("probes", bool(entity.probes)),
         )
-
-
-def _bulk_create_structure(entity: EntityCreate) -> Any:
-    """Validate one batch entry's declared structure against its own body."""
-    from sibyl_core.memory_pipeline.spans import MemoryStructureError
-    from sibyl_core.memory_pipeline.structure import build_memory_structure
-
-    content = (entity.content or entity.description or entity.name).strip()
-    try:
-        return build_memory_structure(
-            content,
-            spans=[span.model_dump(exclude_none=True) for span in entity.spans]
-            if entity.spans is not None
-            else None,
-            atomic=entity.atomic,
-        )
-    except MemoryStructureError as exc:
+        if sent
+    ]
+    if declared:
         raise unprocessable_entity(
-            str(exc),
-            field=exc.field,
-            remediation="Recompute the declared structure against the entry's own content.",
-        ) from exc
+            f"{', '.join(declared)} not supported on bulk create; "
+            "write the memory through POST /entities",
+            field=declared[0],
+        )
 
 
 def _entity_from_bulk_create(
@@ -2365,7 +2360,12 @@ async def update_entity(
             if update.description is not None:
                 update_data["description"] = update.description
             if update.content is not None:
-                update_data["content"] = update.content
+                # Stripped, because the graph writer strips on create and the
+                # declared span offsets are validated against the stripped body.
+                # Storing the padded string would put the plan one place at
+                # validation and another at projection, so an accepted plan would
+                # be quietly abandoned for the mechanical cutter.
+                update_data["content"] = update.content.strip()
             if update.category is not None:
                 update_data["category"] = update.category
             if update.languages is not None:

--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -200,8 +200,13 @@ def _resolved_update_structure(
     existing: Any,
     update: Any,
     new_content: str | None,
+    base_metadata: dict[str, Any],
 ) -> dict[str, Any]:
-    """Work out what structure metadata an update leaves on the row.
+    """Return the complete metadata an update leaves on the row.
+
+    Complete rather than a patch: dropping a stored plan means the key must be
+    absent from what gets written, and spreading a partial dict over the stored
+    metadata can add keys but never remove them.
 
     Offsets belong to the text they were computed over, so a rewritten body
     invalidates a stored plan outright: without fresh spans the plan is dropped
@@ -253,12 +258,15 @@ def _resolved_update_structure(
             remediation="Recompute the declared structure against the updated content.",
         ) from exc
 
-    resolved = {
-        key: value
-        for key, value in existing_metadata.items()
-        if key not in {AGENT_SPANS_METADATA_KEY, AGENT_ATOMIC_METADATA_KEY}
-    }
-    resolved.update(structure_metadata(structure))
+    declaration_keys = (AGENT_SPANS_METADATA_KEY, AGENT_ATOMIC_METADATA_KEY)
+    resolved = {key: value for key, value in base_metadata.items() if key not in declaration_keys}
+    stamped = structure_metadata(structure)
+    # The entity update lands as `UPDATE entity MERGE $patch`, and a MERGE cannot
+    # remove a key: one omitted from the patch keeps whatever the row already
+    # held. So a withdrawn declaration is written as an explicit null, which the
+    # readers treat as absent, rather than left out and silently preserved.
+    for key in declaration_keys:
+        resolved[key] = stamped.get(key)
     return resolved
 
 
@@ -2337,15 +2345,14 @@ async def update_entity(
                 update.spans is not None or update.atomic is not None or update.content is not None
             )
             if structure_metadata_changed:
-                resolved_structure = _resolved_update_structure(
+                update_data["metadata"] = _resolved_update_structure(
                     existing=existing,
                     update=update,
                     new_content=update.content,
+                    base_metadata=update_data.get(
+                        "metadata", dict(getattr(existing, "metadata", {}) or {})
+                    ),
                 )
-                update_data["metadata"] = {
-                    **update_data.get("metadata", getattr(existing, "metadata", {}) or {}),
-                    **resolved_structure,
-                }
 
             # Update timestamp
             update_data["updated_at"] = datetime.now(UTC)

--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from sibyl.api.decorators import handle_workflow_errors
 from sibyl.api.dependencies import get_knowledge_read_service
-from sibyl.api.errors import constraint_violation, sanitize_error_text
+from sibyl.api.errors import constraint_violation, sanitize_error_text, unprocessable_entity
 from sibyl.api.event_types import WSEvent
 from sibyl.api.idempotency import (
     replay_idempotent_response,
@@ -69,10 +69,12 @@ from sibyl_core.auth.memory_policy import (
     private_scope_granted_for,
     stamp_memory_scope_metadata,
 )
+from sibyl_core.memory_pipeline.structure import strip_structure_metadata
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.projection import (
     MANIFEST_STATE_COMPLETE,
     extract_projected_memory_entities,
+    reproject_entity_passages,
     retire_entity_passages,
 )
 from sibyl_core.services import KnowledgeReadService
@@ -171,6 +173,93 @@ def _scoped_graph_metadata(
         scope_key=verified_project_id,
         principal_id=principal_id,
     )
+
+
+async def _add_with_structure(**kwargs: Any) -> Any:
+    """Call the graph writer, turning a refused cut plan into a 422.
+
+    The message reaches the caller intact on purpose. A writing agent that got
+    its offsets wrong has to know which span was out of bounds or where the gap
+    was, and a generic rejection would leave it re-guessing the whole plan.
+    """
+    from sibyl_core.memory_pipeline.structure import MemoryStructureError
+    from sibyl_core.tools.core import add
+
+    try:
+        return await add(**kwargs)
+    except MemoryStructureError as exc:
+        raise unprocessable_entity(
+            str(exc),
+            field=exc.field,
+            remediation="Recompute the declared structure against the stored content.",
+        ) from exc
+
+
+def _resolved_update_structure(
+    *,
+    existing: Any,
+    update: Any,
+    new_content: str | None,
+) -> dict[str, Any]:
+    """Work out what structure metadata an update leaves on the row.
+
+    Offsets belong to the text they were computed over, so a rewritten body
+    invalidates a stored plan outright: without fresh spans the plan is dropped
+    and the body goes back to the mechanical cutter. Refusing the update instead
+    would make a plain content edit impossible for any memory that was ever
+    spanned, and keeping the stale plan would cut the new body on the old seams.
+
+    The atomic claim is about the memory rather than about offsets, so it
+    survives a content change untouched unless the caller restates it. It is
+    re-validated against whatever body ends up stored, since a rewrite can push
+    a previously-atomic memory past the ceiling one passage row can hold.
+    """
+    from sibyl_core.memory_pipeline.spans import (
+        AGENT_ATOMIC_METADATA_KEY,
+        AGENT_SPANS_METADATA_KEY,
+        MemoryStructureError,
+        agent_atomic_from_metadata,
+    )
+    from sibyl_core.memory_pipeline.structure import build_memory_structure, structure_metadata
+
+    existing_metadata = getattr(existing, "metadata", {}) or {}
+    stored_content = (getattr(existing, "content", "") or "").strip()
+    content = new_content.strip() if new_content is not None else stored_content
+    content_changed = new_content is not None and content != stored_content
+
+    spans: list[dict[str, Any]] | None
+    if update.spans is not None:
+        # A fresh plan is the most specific instruction in the request, so it
+        # withdraws a stored atomic claim rather than colliding with it.
+        spans = [span.model_dump(exclude_none=True) for span in update.spans]
+        atomic = bool(update.atomic)
+    elif update.atomic:
+        spans = None
+        atomic = True
+    else:
+        spans = (
+            None
+            if content_changed
+            else list(existing_metadata.get(AGENT_SPANS_METADATA_KEY) or ()) or None
+        )
+        atomic = False if update.atomic is False else agent_atomic_from_metadata(existing_metadata)
+
+    try:
+        structure = build_memory_structure(content, spans=spans, atomic=atomic)
+    except MemoryStructureError as exc:
+        raise unprocessable_entity(
+            str(exc),
+            field=exc.field,
+            remediation="Recompute the declared structure against the updated content.",
+        ) from exc
+
+    resolved = {
+        key: value
+        for key, value in existing_metadata.items()
+        if key not in {AGENT_SPANS_METADATA_KEY, AGENT_ATOMIC_METADATA_KEY}
+    }
+    resolved.update(structure_metadata(structure))
+    return resolved
 
 
 # =============================================================================
@@ -1940,7 +2029,6 @@ async def create_entity(
     Set sync=true to wait for creation to complete (useful for tasks that need
     immediate workflow operations like start/complete).
     """
-    from sibyl_core.tools.core import add
 
     group_id = str(org.id)
 
@@ -2002,9 +2090,12 @@ async def create_entity(
 
     # Projects are always sync (foundational - tasks depend on them existing)
     # Other entities can be async unless caller explicitly requests sync
-    is_sync = entity.entity_type.value == "project" or sync
+    # Probes force a synchronous write in the writer too, but the route decides
+    # which response shape it returns, so both have to agree: a pending response
+    # would drop the rehearsal receipt the caller asked for.
+    is_sync = entity.entity_type.value == "project" or sync or bool(entity.probes)
 
-    result = await add(
+    result = await _add_with_structure(
         title=entity.name,
         content=content,
         entity_type=entity.entity_type.value,
@@ -2027,6 +2118,11 @@ async def create_entity(
         memory_scope=str(declared_memory_scope) if declared_memory_scope is not None else None,
         scope_key=authorized_scope_key,
         principal_id=authorized_principal_id,
+        spans=[span.model_dump(exclude_none=True) for span in entity.spans]
+        if entity.spans is not None
+        else None,
+        atomic=entity.atomic,
+        probes=list(entity.probes) if entity.probes is not None else None,
     )
 
     if not result.success or not result.id:
@@ -2109,6 +2205,7 @@ async def create_entity(
         languages=entity.languages or [],
         tags=entity.tags or [],
         metadata=merged_metadata,
+        probe_rehearsal=getattr(result, "probe_rehearsal", None),
         source_file=None,
         created_at=response_timestamp,
         updated_at=response_timestamp,
@@ -2224,14 +2321,30 @@ async def update_entity(
             if update.metadata is not None:
                 # Merge metadata, keeping the stored owner channels: reassigning
                 # them would hand the row to a different principal or project.
+                # The structure keys go the same way, so a forwarded body cannot
+                # plant a plan the server never validated.
                 existing_meta = getattr(existing, "metadata", {}) or {}
                 update_data["metadata"] = {
                     **existing_meta,
                     **{
                         key: value
-                        for key, value in update.metadata.items()
+                        for key, value in strip_structure_metadata(update.metadata).items()
                         if key not in MEMORY_OWNER_METADATA_KEYS
                     },
+                }
+
+            structure_metadata_changed = (
+                update.spans is not None or update.atomic is not None or update.content is not None
+            )
+            if structure_metadata_changed:
+                resolved_structure = _resolved_update_structure(
+                    existing=existing,
+                    update=update,
+                    new_content=update.content,
+                )
+                update_data["metadata"] = {
+                    **update_data.get("metadata", getattr(existing, "metadata", {}) or {}),
+                    **resolved_structure,
                 }
 
             # Update timestamp
@@ -2241,6 +2354,27 @@ async def update_entity(
             updated = await runtime.entity_manager.update(entity_id, update_data)
             if not updated:
                 raise HTTPException(status_code=500, detail="Update failed")
+
+            if update.content is not None or update.spans is not None or update.atomic is not None:
+                # A rewritten body invalidates every span cut from the old one,
+                # and a re-declared plan changes where the seams belong. Either
+                # way the stored spans keep serving the previous revision until
+                # they are replaced, so the re-cut happens on the request path:
+                # the only other caller of the reprojection is an arq job nothing
+                # enqueues, which is why this rule was inert before.
+                passage_result = await reproject_entity_passages(
+                    entity_manager=runtime.entity_manager,
+                    relationship_manager=runtime.relationship_manager,
+                    source=updated,
+                    group_id=group_id,
+                    created_source_id=entity_id,
+                )
+                if passage_result.errors:
+                    log.warning(
+                        "update_entity_passage_reprojection_failed",
+                        entity_id=entity_id,
+                        errors=passage_result.errors,
+                    )
 
             response = EntityResponse(
                 id=updated.id,

--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -368,7 +368,9 @@ def _bulk_create_metadata(
     now: datetime,
     principal_id: str | None,
 ) -> dict[str, Any]:
-    request_metadata = dict(entity.metadata or {})
+    from sibyl_core.memory_pipeline.structure import structure_metadata
+
+    request_metadata = strip_structure_metadata(entity.metadata)
     project_id = str(request_metadata.get("project_id") or "").strip()
     return {
         "category": entity.category,
@@ -381,7 +383,60 @@ def _bulk_create_metadata(
             principal_id=principal_id,
             verified_project_id=project_id or None,
         ),
+        # Declared through the typed fields and validated, never carried over from
+        # the payload bag: this batch path writes rows directly rather than
+        # through the graph writer that owns those keys everywhere else.
+        **structure_metadata(_bulk_create_structure(entity)),
     }
+
+
+def _reject_unsupported_bulk_entry(entity: EntityCreate) -> None:
+    """Fault a batch entry the direct-write path cannot honor."""
+    if entity.entity_type in BULK_UNSUPPORTED_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{entity.entity_type.value} entities are not supported by bulk create",
+        )
+    if not entity.skip_conflicts:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "bulk create requires skip_conflicts=true; "
+                "use POST /entities for conflict detection"
+            ),
+        )
+    if entity.probes:
+        # Rehearsal has to observe the row it asks about, and this path writes a
+        # whole batch without waiting on a searchable write per entry. Accepting
+        # the field and never rehearsing would ship a receipt-shaped promise
+        # nothing keeps.
+        raise unprocessable_entity(
+            "probes are not supported on bulk create; write the memory through "
+            "POST /entities to get a rehearsal receipt",
+            field="probes",
+        )
+
+
+def _bulk_create_structure(entity: EntityCreate) -> Any:
+    """Validate one batch entry's declared structure against its own body."""
+    from sibyl_core.memory_pipeline.spans import MemoryStructureError
+    from sibyl_core.memory_pipeline.structure import build_memory_structure
+
+    content = (entity.content or entity.description or entity.name).strip()
+    try:
+        return build_memory_structure(
+            content,
+            spans=[span.model_dump(exclude_none=True) for span in entity.spans]
+            if entity.spans is not None
+            else None,
+            atomic=entity.atomic,
+        )
+    except MemoryStructureError as exc:
+        raise unprocessable_entity(
+            str(exc),
+            field=exc.field,
+            remediation="Recompute the declared structure against the entry's own content.",
+        ) from exc
 
 
 def _entity_from_bulk_create(
@@ -1601,16 +1656,7 @@ async def create_entities_bulk(
     verified_project_ids: set[str] = set()
 
     for entity in batch.entities:
-        if entity.entity_type in BULK_UNSUPPORTED_TYPES:
-            raise HTTPException(
-                status_code=400,
-                detail=f"{entity.entity_type.value} entities are not supported by bulk create",
-            )
-        if not entity.skip_conflicts:
-            raise HTTPException(
-                status_code=400,
-                detail="bulk create requires skip_conflicts=true; use POST /entities for conflict detection",
-            )
+        _reject_unsupported_bulk_entry(entity)
         project = entity.metadata.get("project_id") if entity.metadata else None
         project_id = str(project) if project else None
         if project_id and project_id not in verified_project_ids:

--- a/apps/api/src/sibyl/api/schemas/entities.py
+++ b/apps/api/src/sibyl/api/schemas/entities.py
@@ -1,11 +1,48 @@
 """Entity and raw-capture request/response models."""
 
 from datetime import datetime
-from typing import Any, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, StringConstraints, model_validator
 
+from sibyl_core.memory_pipeline.spans import MAX_AGENT_SPANS, MAX_SPAN_LABEL_CHARS
+from sibyl_core.memory_pipeline.structure import MAX_PROBE_CHARS, MAX_PROBES_PER_MEMORY
 from sibyl_core.models.entities import EntityType
+
+
+class MemorySpan(BaseModel):
+    """One half-open cut into the stored body, authored by the writing agent."""
+
+    start: int = Field(..., ge=0, description="First character of the span, inclusive")
+    end: int = Field(..., ge=1, description="Character after the span, exclusive")
+    label: str | None = Field(
+        default=None,
+        max_length=MAX_SPAN_LABEL_CHARS,
+        description="Section name rendered into the passage body and indexed with it",
+    )
+
+
+class MemoryStructureFields(BaseModel):
+    """The structure a write may declare for the memory it stores.
+
+    The tiling rules (ordered, gap-free, non-overlapping, whole-body) are checked
+    against the stored content by the server, not here: this schema only fixes
+    the shape and the counts, because the body a span addresses is not known
+    until the route has resolved content, description, and name fallbacks.
+    """
+
+    spans: list[MemorySpan] | None = Field(
+        default=None,
+        max_length=MAX_AGENT_SPANS,
+        description=(
+            "Agent-authored cut plan over the stored content. Offsets must tile the "
+            "whole body with no gap and no overlap; passages carry the exact span text."
+        ),
+    )
+    atomic: bool = Field(
+        default=False,
+        description="Declare the body one retrievable unit that must not be cut into passages",
+    )
 
 
 class EntityBase(BaseModel):
@@ -20,10 +57,19 @@ class EntityBase(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 
 
-class EntityCreate(EntityBase):
+class EntityCreate(EntityBase, MemoryStructureFields):
     """Schema for creating a new entity."""
 
     entity_type: EntityType = Field(default=EntityType.EPISODE, description="Type of entity")
+    probes: list[Annotated[str, StringConstraints(max_length=MAX_PROBE_CHARS)]] | None = Field(
+        default=None,
+        max_length=MAX_PROBES_PER_MEMORY,
+        description=(
+            "Questions this memory must answer later. Each is run through the live "
+            "search path once the write lands and the ranks come back in the response. "
+            "Supplying probes forces a synchronous write."
+        ),
+    )
     skip_conflicts: bool = Field(
         default=False,
         description="Skip semantic duplicate/conflict detection for latency-sensitive captures",
@@ -54,7 +100,13 @@ class EntityBulkCreateRequest(BaseModel):
 
 
 class EntityUpdate(BaseModel):
-    """Schema for updating an entity (all fields optional)."""
+    """Schema for updating an entity (all fields optional).
+
+    ``spans`` re-declares the cut plan for the body this update stores. A content
+    change without fresh spans drops any stored plan and hands the body back to
+    the mechanical cutter, because offsets are only meaningful against the text
+    they were computed over.
+    """
 
     name: str | None = Field(default=None, max_length=200)
     description: str | None = None
@@ -63,6 +115,18 @@ class EntityUpdate(BaseModel):
     languages: list[str] | None = None
     tags: list[str] | None = None
     metadata: dict[str, Any] | None = None
+    spans: list[MemorySpan] | None = Field(
+        default=None,
+        max_length=MAX_AGENT_SPANS,
+        description="Cut plan for the body this update stores, tiling it exactly",
+    )
+    atomic: bool | None = Field(
+        default=None,
+        description=(
+            "Re-declare (or with false, withdraw) the claim that this body is one "
+            "retrievable unit. Omitted leaves any stored claim in place."
+        ),
+    )
 
 
 class RelatedEntitySummary(BaseModel):
@@ -87,6 +151,10 @@ class EntityResponse(EntityBase):
         default=None, description="Related entities (when requested via related_limit)"
     )
     background_jobs: dict[str, Any] = Field(default_factory=dict)
+    probe_rehearsal: dict[str, Any] | None = Field(
+        default=None,
+        description="Per-probe rank-or-absent from the write-time rehearsal, when probes were sent",
+    )
 
     model_config = {"from_attributes": True}
 

--- a/apps/api/src/sibyl/coordination/_local/broker.py
+++ b/apps/api/src/sibyl/coordination/_local/broker.py
@@ -671,6 +671,23 @@ class LocalQueueBroker:
         )
         return result.job_id
 
+    async def enqueue_probe_replay(
+        self,
+        group_id: str,
+        *,
+        window_hours: int = 168,
+        max_memories: int = 200,
+    ) -> str:
+        result = await self._enqueue_unique(
+            "replay_memory_probes",
+            group_id,
+            job_id=f"replay_memory_probes:{group_id}",
+            clear_result=True,
+            window_hours=window_hours,
+            max_memories=max_memories,
+        )
+        return result.job_id
+
     async def enqueue_reflection_dream_cycle(
         self,
         group_id: str,

--- a/apps/api/src/sibyl/coordination/_redis/broker.py
+++ b/apps/api/src/sibyl/coordination/_redis/broker.py
@@ -865,6 +865,37 @@ class RedisQueueBroker:
         )
         return result.job_id
 
+    async def enqueue_probe_replay(
+        self,
+        group_id: str,
+        *,
+        window_hours: int = 168,
+        max_memories: int = 200,
+    ) -> str:
+        """Enqueue an org-scoped probe replay."""
+        job_id = f"replay_memory_probes:{group_id}"
+        result = await self._enqueue_unique(
+            "replay_memory_probes",
+            group_id,
+            job_id=job_id,
+            clear_result=True,
+            window_hours=window_hours,
+            max_memories=max_memories,
+        )
+
+        if not result.created:
+            log.info("Probe replay job already running", job_id=job_id, group_id=group_id)
+            return result.job_id
+
+        log.info(
+            "Enqueued probe replay job",
+            job_id=result.job_id,
+            group_id=group_id,
+            window_hours=window_hours,
+            max_memories=max_memories,
+        )
+        return result.job_id
+
     async def enqueue_reflection_dream_cycle(
         self,
         group_id: str,

--- a/apps/api/src/sibyl/coordination/broker.py
+++ b/apps/api/src/sibyl/coordination/broker.py
@@ -382,6 +382,14 @@ class QueueBroker(Protocol):
         max_archives_per_run: int = 100,
     ) -> str: ...
 
+    async def enqueue_probe_replay(
+        self,
+        group_id: str,
+        *,
+        window_hours: int = 168,
+        max_memories: int = 200,
+    ) -> str: ...
+
     async def enqueue_reflection_dream_cycle(
         self,
         group_id: str,

--- a/apps/api/src/sibyl/jobs/__init__.py
+++ b/apps/api/src/sibyl/jobs/__init__.py
@@ -40,6 +40,7 @@ from sibyl.jobs.pending import (
     process_pending_operations,
     queue_pending_operation,
 )
+from sibyl.jobs.probes import replay_memory_probes, replay_memory_probes_all_orgs
 from sibyl.jobs.queue import (
     JobStatus,
     enqueue_backup,
@@ -54,6 +55,7 @@ from sibyl.jobs.queue import (
     enqueue_memory_projection,
     enqueue_operational_note_distillation,
     enqueue_priority_decay,
+    enqueue_probe_replay,
     enqueue_raw_capture_changefeed_poll,
     enqueue_raw_promotion,
     enqueue_reflection_dream_cycle,
@@ -108,6 +110,7 @@ __all__ = [
     "enqueue_backup_cleanup",
     "enqueue_consolidation",
     "enqueue_priority_decay",
+    "enqueue_probe_replay",
     "enqueue_raw_capture_changefeed_poll",
     "enqueue_raw_promotion",
     "enqueue_reflection_dream_cycle",
@@ -119,6 +122,8 @@ __all__ = [
     "drain_source_import",
     "import_source_archive",
     "promote_raw_captures",
+    "replay_memory_probes",
+    "replay_memory_probes_all_orgs",
     "poll_all_raw_capture_changefeeds",
     "poll_raw_capture_changefeed",
     "create_entity",

--- a/apps/api/src/sibyl/jobs/probes.py
+++ b/apps/api/src/sibyl/jobs/probes.py
@@ -34,9 +34,15 @@ log = structlog.get_logger()
 DEFAULT_REPLAY_WINDOW_HOURS = 168
 DEFAULT_MAX_MEMORIES_PER_RUN = 200
 
+# Three column names are load-bearing and none of them is the obvious one. The
+# model's ``metadata`` is stored in the ``attributes`` column. The logical id an
+# entity is addressed by is ``uuid``; the ``id`` column holds a Surreal record id
+# that ``EntityManager.update`` (which matches ``WHERE uuid = $uuid``) and search
+# results do not speak. And ``created_at`` has to appear in a non-star projection
+# for 3.x to accept ordering on it.
 _CANDIDATE_QUERY = """
-SELECT id, metadata, created_at FROM entity
-WHERE metadata.memory_probes != NONE
+SELECT uuid, attributes, created_at FROM entity
+WHERE attributes.memory_probes != NONE
   AND created_at > $since
 ORDER BY created_at DESC
 LIMIT $limit;
@@ -45,8 +51,8 @@ LIMIT $limit;
 # One query for the whole batch rather than one per parent: a passage counts as
 # finding its memory, so the targets have to be known before any probe runs.
 _PASSAGE_QUERY = """
-SELECT id, metadata.parent_entity_id AS parent_entity_id FROM entity
-WHERE metadata.parent_entity_id IN $parents;
+SELECT uuid, attributes.parent_entity_id AS parent_entity_id FROM entity
+WHERE attributes.parent_entity_id IN $parents;
 """
 
 
@@ -90,16 +96,18 @@ async def replay_memory_probes(
 
     since = datetime.now(UTC) - timedelta(hours=max(int(window_hours), 1))
     rows = normalize_records(
-        await client.query(
+        await client.execute_query(
             _CANDIDATE_QUERY,
-            {"since": since, "limit": max(int(max_memories), 1)},
+            since=since,
+            limit=max(int(max_memories), 1),
+            _query_label="probes.replay.candidates",
         )
     )
     candidates = [
         (entity_id, metadata, probes)
         for row in rows
-        if (entity_id := str(row.get("id") or ""))
-        and isinstance(metadata := row.get("metadata"), dict)
+        if (entity_id := str(row.get("uuid") or ""))
+        and isinstance(metadata := row.get("attributes"), dict)
         and (probes := probes_from_metadata(metadata))
     ]
     if not candidates:
@@ -158,10 +166,20 @@ async def replay_memory_probes(
         probes_total += int(receipt.get("total") or 0)
         probes_retrievable += int(receipt.get("retrievable") or 0)
         try:
-            await entity_manager.update(
+            written = await entity_manager.update(
                 entity_id,
                 {"metadata": {**metadata, PROBE_LAST_REPLAY_METADATA_KEY: receipt}},
             )
+            if written is None:
+                # The update matches on the logical id and returns None rather
+                # than raising when nothing matched, so an addressing mistake
+                # here would otherwise look like a clean run forever.
+                failures += 1
+                log.warning(
+                    "probe_replay_receipt_matched_no_row",
+                    group_id=group_id,
+                    entity_id=entity_id,
+                )
         except Exception as exc:
             failures += 1
             log.warning(
@@ -234,7 +252,13 @@ async def _passages_by_parent(
     if not parents:
         return {}
     try:
-        rows = normalize(await client.query(_PASSAGE_QUERY, {"parents": parents}))
+        rows = normalize(
+            await client.execute_query(
+                _PASSAGE_QUERY,
+                parents=parents,
+                _query_label="probes.replay.passages",
+            )
+        )
     except Exception as exc:
         # A probe can still match the parent, so a missing passage map costs
         # recall on the receipt rather than the whole replay.
@@ -243,7 +267,7 @@ async def _passages_by_parent(
     grouped: dict[str, list[str]] = {}
     for row in rows:
         parent = _optional_str(row.get("parent_entity_id"))
-        passage_id = _optional_str(row.get("id"))
+        passage_id = _optional_str(row.get("uuid"))
         if parent and passage_id:
             grouped.setdefault(parent, []).append(passage_id)
     return {parent: tuple(ids) for parent, ids in grouped.items()}

--- a/apps/api/src/sibyl/jobs/probes.py
+++ b/apps/api/src/sibyl/jobs/probes.py
@@ -1,0 +1,261 @@
+"""Re-ask probe-carrying memories whether they can still be found.
+
+A write-time rehearsal answers for the graph as it stood at that moment. The
+graph keeps moving: new memories crowd the ranking, consolidation merges rows,
+decay archives them, and an embedding backfill can change what a query matches.
+A memory that was retrievable on Tuesday can be unreachable by Friday without
+anything having been written to it.
+
+So the probes run again on a schedule and the verdict lands on the row as
+``probe_last_replay``. The summary log is metric-shaped on purpose: probes_total
+and probes_retrievable per org make "percent of probe-carrying memories that can
+still find themselves" a query over logs rather than a study.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+
+from sibyl_core.memory_pipeline.rehearsal import rehearse_memory_probes
+from sibyl_core.memory_pipeline.structure import (
+    PROBE_LAST_REPLAY_METADATA_KEY,
+    probes_from_metadata,
+)
+
+log = structlog.get_logger()
+
+# One replay is a search per probe, so the window and the cap are what bound the
+# job. A week covers every memory written since the last several runs, which
+# means a row missed to an outage is picked up rather than skipped forever.
+DEFAULT_REPLAY_WINDOW_HOURS = 168
+DEFAULT_MAX_MEMORIES_PER_RUN = 200
+
+_CANDIDATE_QUERY = """
+SELECT id, metadata, created_at FROM entity
+WHERE metadata.memory_probes != NONE
+  AND created_at > $since
+ORDER BY created_at DESC
+LIMIT $limit;
+"""
+
+# One query for the whole batch rather than one per parent: a passage counts as
+# finding its memory, so the targets have to be known before any probe runs.
+_PASSAGE_QUERY = """
+SELECT id, metadata.parent_entity_id AS parent_entity_id FROM entity
+WHERE metadata.parent_entity_id IN $parents;
+"""
+
+
+async def _get_graph_runtime(group_id: str) -> Any:
+    from sibyl_core.services.graph import get_surreal_graph_runtime
+
+    return await get_surreal_graph_runtime(group_id)
+
+
+async def _list_organization_ids() -> list[str]:
+    from sibyl.persistence.organization_runtime import list_org_ids
+
+    return await list_org_ids()
+
+
+async def replay_memory_probes(
+    ctx: dict[str, Any],  # noqa: ARG001
+    group_id: str,
+    window_hours: int = DEFAULT_REPLAY_WINDOW_HOURS,
+    max_memories: int = DEFAULT_MAX_MEMORIES_PER_RUN,
+) -> dict[str, Any]:
+    """Re-run every probe on recently written memories in one org.
+
+    Args:
+        ctx: arq context
+        group_id: Organization ID whose memories are replayed
+        window_hours: How far back to look for probe-carrying memories
+        max_memories: Safety cap on memories replayed per execution
+
+    Returns:
+        Counters for the run, including how many probes still find their memory.
+    """
+    from sibyl_core.services.graph import normalize_records
+
+    started_at = time.perf_counter()
+    log.info("probe_replay_started", group_id=group_id, window_hours=window_hours)
+
+    runtime = await _get_graph_runtime(group_id)
+    client = runtime.client
+    entity_manager = runtime.entity_manager
+
+    since = datetime.now(UTC) - timedelta(hours=max(int(window_hours), 1))
+    rows = normalize_records(
+        await client.query(
+            _CANDIDATE_QUERY,
+            {"since": since, "limit": max(int(max_memories), 1)},
+        )
+    )
+    candidates = [
+        (entity_id, metadata, probes)
+        for row in rows
+        if (entity_id := str(row.get("id") or ""))
+        and isinstance(metadata := row.get("metadata"), dict)
+        and (probes := probes_from_metadata(metadata))
+    ]
+    if not candidates:
+        log.info(
+            "probe_replay_completed",
+            group_id=group_id,
+            memories=0,
+            probes_total=0,
+            probes_retrievable=0,
+            duration_ms=round((time.perf_counter() - started_at) * 1000, 2),
+        )
+        return {
+            "group_id": group_id,
+            "memories": 0,
+            "probes_total": 0,
+            "probes_retrievable": 0,
+            "failures": 0,
+        }
+
+    passages = await _passages_by_parent(
+        client,
+        normalize_records,
+        [entity_id for entity_id, _metadata, _probes in candidates],
+    )
+
+    memories = 0
+    probes_total = 0
+    probes_retrievable = 0
+    failures = 0
+    for entity_id, metadata, probes in candidates:
+        scope_key = _optional_str(metadata.get("scope_key"))
+        try:
+            receipt = await rehearse_memory_probes(
+                probes=probes,
+                organization_id=group_id,
+                entity_id=entity_id,
+                passage_ids=passages.get(entity_id, ()),
+                principal_id=_optional_str(metadata.get("principal_id")),
+                memory_scope=str(metadata.get("memory_scope") or "private"),
+                scope_key=scope_key,
+                project=_optional_str(metadata.get("project_id")),
+                accessible_projects={scope_key} if scope_key else None,
+                surface="replay",
+            )
+        except Exception as exc:
+            failures += 1
+            log.warning(
+                "probe_replay_memory_failed",
+                group_id=group_id,
+                entity_id=entity_id,
+                error_type=type(exc).__name__,
+            )
+            continue
+
+        memories += 1
+        probes_total += int(receipt.get("total") or 0)
+        probes_retrievable += int(receipt.get("retrievable") or 0)
+        try:
+            await entity_manager.update(
+                entity_id,
+                {"metadata": {**metadata, PROBE_LAST_REPLAY_METADATA_KEY: receipt}},
+            )
+        except Exception as exc:
+            failures += 1
+            log.warning(
+                "probe_replay_receipt_not_stored",
+                group_id=group_id,
+                entity_id=entity_id,
+                error_type=type(exc).__name__,
+            )
+
+    summary = {
+        "group_id": group_id,
+        "memories": memories,
+        "probes_total": probes_total,
+        "probes_retrievable": probes_retrievable,
+        "failures": failures,
+    }
+    log.info(
+        "probe_replay_completed",
+        duration_ms=round((time.perf_counter() - started_at) * 1000, 2),
+        **summary,
+    )
+    return summary
+
+
+async def replay_memory_probes_all_orgs(ctx: dict[str, Any]) -> dict[str, Any]:
+    """Replay probes across every organization.
+
+    One org's retrieval being down says nothing about the next one's, so a
+    failure is counted and the walk continues.
+    """
+    log.info("probe_replay_all_orgs_started")
+
+    org_ids = await _list_organization_ids()
+    orgs_succeeded = 0
+    orgs_failed = 0
+    probes_total = 0
+    probes_retrievable = 0
+    for org_id in org_ids:
+        try:
+            result = await replay_memory_probes(ctx, group_id=org_id)
+        except Exception as exc:
+            orgs_failed += 1
+            log.warning("probe_replay_org_failed", org_id=org_id, error_type=type(exc).__name__)
+            continue
+        orgs_succeeded += 1
+        probes_total += int(result.get("probes_total") or 0)
+        probes_retrievable += int(result.get("probes_retrievable") or 0)
+
+    summary = {
+        "orgs_processed": len(org_ids),
+        "orgs_succeeded": orgs_succeeded,
+        "orgs_failed": orgs_failed,
+        "probes_total": probes_total,
+        "probes_retrievable": probes_retrievable,
+        # Emitted rather than derived downstream so a single log line answers
+        # "are our memories still findable" without a join.
+        "self_retrievable_pct": (
+            round(100.0 * probes_retrievable / probes_total, 2) if probes_total else None
+        ),
+    }
+    log.info("probe_replay_all_orgs_completed", **summary)
+    return summary
+
+
+async def _passages_by_parent(
+    client: Any,
+    normalize: Any,
+    parents: list[str],
+) -> dict[str, tuple[str, ...]]:
+    if not parents:
+        return {}
+    try:
+        rows = normalize(await client.query(_PASSAGE_QUERY, {"parents": parents}))
+    except Exception as exc:
+        # A probe can still match the parent, so a missing passage map costs
+        # recall on the receipt rather than the whole replay.
+        log.warning("probe_replay_passage_lookup_failed", error_type=type(exc).__name__)
+        return {}
+    grouped: dict[str, list[str]] = {}
+    for row in rows:
+        parent = _optional_str(row.get("parent_entity_id"))
+        passage_id = _optional_str(row.get("id"))
+        if parent and passage_id:
+            grouped.setdefault(parent, []).append(passage_id)
+    return {parent: tuple(ids) for parent, ids in grouped.items()}
+
+
+def _optional_str(value: object) -> str | None:
+    return str(value) if value else None
+
+
+__all__ = [
+    "DEFAULT_MAX_MEMORIES_PER_RUN",
+    "DEFAULT_REPLAY_WINDOW_HOURS",
+    "replay_memory_probes",
+    "replay_memory_probes_all_orgs",
+]

--- a/apps/api/src/sibyl/jobs/queue.py
+++ b/apps/api/src/sibyl/jobs/queue.py
@@ -36,6 +36,7 @@ __all__ = [
     "enqueue_memory_projection",
     "enqueue_operational_note_distillation",
     "enqueue_priority_decay",
+    "enqueue_probe_replay",
     "enqueue_raw_capture_changefeed_poll",
     "enqueue_raw_promotion",
     "enqueue_reflection_dream_cycle",
@@ -358,6 +359,20 @@ async def enqueue_priority_decay(
         group_id,
         min_age_days=min_age_days,
         max_archives_per_run=max_archives_per_run,
+    )
+
+
+async def enqueue_probe_replay(
+    group_id: str,
+    *,
+    window_hours: int = 168,
+    max_memories: int = 200,
+) -> str:
+    """Enqueue an org-scoped replay of probe-carrying memories."""
+    return await get_queue().enqueue_probe_replay(
+        group_id,
+        window_hours=window_hours,
+        max_memories=max_memories,
     )
 
 

--- a/apps/api/src/sibyl/jobs/worker.py
+++ b/apps/api/src/sibyl/jobs/worker.py
@@ -40,6 +40,7 @@ from sibyl.jobs.entities import (
 from sibyl.jobs.memory_extraction import extract_memory_entities
 from sibyl.jobs.operational_distillation import distill_operational_experience_notes
 from sibyl.jobs.privacy import purge_due_deleted_personal_memories
+from sibyl.jobs.probes import replay_memory_probes, replay_memory_probes_all_orgs
 from sibyl.jobs.raw_changefeed import (
     poll_all_raw_capture_changefeeds,
     poll_raw_capture_changefeed,
@@ -246,6 +247,15 @@ def get_schedule_specs() -> list[ScheduleSpec]:
     )
     schedule_specs.append(
         ScheduleSpec(
+            name="replay_memory_probes_all_orgs",
+            function=replay_memory_probes_all_orgs,
+            schedule_label="0 5 * * *",
+            hour=5,
+            minute=0,
+        )
+    )
+    schedule_specs.append(
+        ScheduleSpec(
             name="purge_due_deleted_personal_memories",
             function=purge_due_deleted_personal_memories,
             schedule_label="0 4 * * *",
@@ -309,6 +319,9 @@ class WorkerSettings:
         purge_due_deleted_personal_memories,
         run_reflection_dream_cycle,
         run_reflection_dream_cycle_all_orgs,
+        # Probe replay
+        replay_memory_probes,
+        replay_memory_probes_all_orgs,
     ]
 
     # Cron jobs for scheduled tasks

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -577,7 +577,11 @@ async def _remember_mcp_memory(
     active_task: bool = True,
     metadata: dict[str, Any] | None = None,
     idempotency_key: str | None = None,
+    spans: list[dict[str, Any]] | None = None,
+    atomic: bool = False,
+    probes: list[str] | None = None,
 ) -> dict[str, Any]:
+    from sibyl_core.memory_pipeline.structure import build_memory_structure
     from sibyl_core.services.surreal_content import remember_raw_memory
     from sibyl_core.tools.core import add
 
@@ -594,6 +598,10 @@ async def _remember_mcp_memory(
         if not idempotency_key or len(idempotency_key) > 255:
             raise ValueError("idempotency_key must be a non-empty string up to 255 characters")
 
+    # Ahead of the idempotency claim: a refused plan must not consume the key,
+    # or the caller's corrected retry would replay the rejection.
+    build_memory_structure(content.strip(), spans=spans, atomic=atomic, probes=probes)
+
     idempotency_payload = {
         "title": title,
         "content": content,
@@ -605,6 +613,9 @@ async def _remember_mcp_memory(
         "task_ids": task_ids,
         "active_task": active_task,
         "metadata": metadata,
+        "spans": spans,
+        "atomic": atomic,
+        "probes": probes,
     }
     idempotency_path = "mcp/remember"
     idempotency_claim: ApiIdempotencyRecord | None = None
@@ -673,6 +684,9 @@ async def _remember_mcp_memory(
         scope_key=project,
         principal_id=ctx.user_id,
         capture_surface="mcp",
+        spans=spans,
+        atomic=atomic,
+        probes=probes,
     )
     raw_revision = 1
 
@@ -712,6 +726,9 @@ async def _remember_mcp_memory(
             memory_scope=request.memory_scope,
             scope_key=request.scope_key,
             principal_id=request.principal_id,
+            spans=list(request.spans) if request.spans is not None else None,
+            atomic=request.atomic,
+            probes=list(request.probes) if request.probes is not None else None,
         )
         return _to_dict(result)
 
@@ -2358,6 +2375,9 @@ def _register_tools(mcp: FastMCP) -> None:
         active_task: bool = True,
         metadata: dict[str, Any] | None = None,
         idempotency_key: str | None = None,
+        spans: list[dict[str, Any]] | None = None,
+        atomic: bool = False,
+        probes: list[str] | None = None,
     ) -> dict[str, Any]:
         """Remember durable context from planning, ideation, building, or any domain.
 
@@ -2367,6 +2387,32 @@ def _register_tools(mcp: FastMCP) -> None:
         matters, remember stores what future agents should not have to relearn.
         Provide task_ids for exact task context. With a project, active_task
         links the memory to the single active doing task when one exists.
+
+        You can describe the shape of what you are storing, and you know it
+        better than any cutter reading it afterwards.
+
+        spans: where this memory's sections begin and end, as
+            [{"start": 0, "end": 812, "label": "Root cause"}, ...]. Offsets are
+            character positions into content after stripping leading and
+            trailing whitespace, half-open so one span's end is the next one's
+            start. They must cover the whole body with no gap and no overlap,
+            first starting at 0 and last ending at the final character. Each
+            span becomes an independently retrievable passage holding exactly
+            that text; labels are indexed with it, so name the section the way
+            someone would ask for it. Without spans, long memories are cut by a
+            mechanical prose cutter that guesses at the seams. An invalid plan is
+            rejected with the offset that broke it, never silently ignored.
+        atomic: true when the body is one thing that must not be cut, such as a
+            single fact, a short rule, or a snippet that only reads whole. Not
+            combinable with spans.
+        probes: up to 5 questions this memory has to answer later, for example
+            ["why did the JWT refresh fail silently"]. Each is run through the
+            live search path the moment the write lands, and the response reports
+            the rank it came back at or that it did not come back at all. Use
+            them when it matters that a memory is findable and not merely stored:
+            an absent probe is telling you to rewrite the memory now, while you
+            still have the context, rather than discovering months later that
+            nothing could reach it.
         """
 
         return await _remember_mcp_memory(
@@ -2381,6 +2427,9 @@ def _register_tools(mcp: FastMCP) -> None:
             active_task=active_task,
             metadata=metadata,
             idempotency_key=idempotency_key,
+            spans=spans,
+            atomic=atomic,
+            probes=probes,
         )
 
     # =========================================================================

--- a/apps/api/tests/test_jobs_probes.py
+++ b/apps/api/tests/test_jobs_probes.py
@@ -1,0 +1,240 @@
+"""The probe replay job, against rows shaped the way the graph actually returns them.
+
+Every assertion here exists because a hand-shaped double let the job look
+correct while addressing columns that do not exist. The rows below carry the
+real column names: the model's metadata is the `attributes` column, the logical
+id is `uuid`, and `normalize_records` moves the Surreal record id out of `id`
+into `record_id`, so a job reading `id` gets nothing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sibyl.jobs.probes import replay_memory_probes, replay_memory_probes_all_orgs
+from sibyl_core.projection.passages import passage_entity_id
+
+_GROUP = "org-probe-replay"
+_PARENT = "episode_probe_parent"
+
+
+def _candidate_row(*, probes: list[str], uuid: str = _PARENT) -> dict[str, Any]:
+    return {
+        "record_id": f"entity:{uuid}",
+        "uuid": uuid,
+        "created_at": datetime.now(UTC),
+        "attributes": {
+            "memory_probes": probes,
+            "memory_scope": "private",
+            "principal_id": "user-1",
+        },
+    }
+
+
+def _passage_row(*, index: int, parent: str = _PARENT) -> dict[str, Any]:
+    return {
+        "record_id": f"entity:passage-{index}",
+        "uuid": passage_entity_id(parent, index),
+        "parent_entity_id": parent,
+    }
+
+
+class _RecordingClient:
+    def __init__(self, candidates: list[dict[str, Any]], passages: list[dict[str, Any]]) -> None:
+        self._candidates = candidates
+        self._passages = passages
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_query(self, query: str, **params: Any) -> Any:
+        # Named for the method the graph runtime's client actually exposes. The
+        # low-level protocol also has `query`, and a double offering that name
+        # would let a job calling it pass here and fail live.
+        self.queries.append((query, dict(params)))
+        return self._passages if "parent_entity_id IN" in query else self._candidates
+
+
+class _RecordingEntityManager:
+    def __init__(self, *, matches: bool = True) -> None:
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+        self._matches = matches
+
+    async def update(self, entity_id: str, updates: dict[str, Any]) -> object | None:
+        self.updates.append((entity_id, updates))
+        return object() if self._matches else None
+
+
+def _runtime(client: Any, entity_manager: Any) -> Any:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(client=client, entity_manager=entity_manager)
+
+
+def _rehearsal(*, retrievable: int, total: int) -> dict[str, Any]:
+    return {"total": total, "retrievable": retrievable, "probes": [], "truncated": False}
+
+
+@pytest.mark.asyncio
+async def test_replay_reads_the_columns_the_graph_actually_has() -> None:
+    client = _RecordingClient([_candidate_row(probes=["why"])], [_passage_row(index=0)])
+    entity_manager = _RecordingEntityManager()
+    rehearse = AsyncMock(return_value=_rehearsal(retrievable=1, total=1))
+
+    with (
+        patch(
+            "sibyl.jobs.probes._get_graph_runtime",
+            AsyncMock(return_value=_runtime(client, entity_manager)),
+        ),
+        patch("sibyl.jobs.probes.rehearse_memory_probes", rehearse),
+    ):
+        summary = await replay_memory_probes({}, group_id=_GROUP)
+
+    assert summary["memories"] == 1
+    assert summary["probes_total"] == 1
+    assert summary["probes_retrievable"] == 1
+    assert summary["failures"] == 0
+
+    candidate_query = client.queries[0][0]
+    assert "attributes.memory_probes" in candidate_query
+    assert "metadata.memory_probes" not in candidate_query
+    # 3.x rejects ORDER BY on a field absent from a non-star projection.
+    assert "created_at" in candidate_query.split("FROM")[0]
+    # updated_at is stored as text rather than a datetime, so the window cannot use it.
+    assert "updated_at" not in candidate_query
+
+
+@pytest.mark.asyncio
+async def test_replay_addresses_the_memory_by_its_logical_id() -> None:
+    """The record id is not what the receipt write or a search result speaks."""
+    client = _RecordingClient([_candidate_row(probes=["why"])], [_passage_row(index=0)])
+    entity_manager = _RecordingEntityManager()
+    rehearse = AsyncMock(return_value=_rehearsal(retrievable=1, total=1))
+
+    with (
+        patch(
+            "sibyl.jobs.probes._get_graph_runtime",
+            AsyncMock(return_value=_runtime(client, entity_manager)),
+        ),
+        patch("sibyl.jobs.probes.rehearse_memory_probes", rehearse),
+    ):
+        await replay_memory_probes({}, group_id=_GROUP)
+
+    assert rehearse.await_args.kwargs["entity_id"] == _PARENT
+    assert rehearse.await_args.kwargs["passage_ids"] == (passage_entity_id(_PARENT, 0),)
+    assert rehearse.await_args.kwargs["surface"] == "replay"
+    written_id, updates = entity_manager.updates[0]
+    assert written_id == _PARENT
+    assert updates["metadata"]["probe_last_replay"]["retrievable"] == 1
+    # The probes themselves survive the write that records their verdict.
+    assert updates["metadata"]["memory_probes"] == ["why"]
+
+
+@pytest.mark.asyncio
+async def test_a_receipt_that_matched_no_row_is_counted_as_a_failure() -> None:
+    """update() returns None rather than raising, so silence has to be caught."""
+    client = _RecordingClient([_candidate_row(probes=["why"])], [])
+    entity_manager = _RecordingEntityManager(matches=False)
+
+    with (
+        patch(
+            "sibyl.jobs.probes._get_graph_runtime",
+            AsyncMock(return_value=_runtime(client, entity_manager)),
+        ),
+        patch(
+            "sibyl.jobs.probes.rehearse_memory_probes",
+            AsyncMock(return_value=_rehearsal(retrievable=0, total=1)),
+        ),
+    ):
+        summary = await replay_memory_probes({}, group_id=_GROUP)
+
+    assert summary["failures"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_memory_without_probes_is_not_replayed() -> None:
+    client = _RecordingClient([_candidate_row(probes=[])], [])
+    entity_manager = _RecordingEntityManager()
+
+    with (
+        patch(
+            "sibyl.jobs.probes._get_graph_runtime",
+            AsyncMock(return_value=_runtime(client, entity_manager)),
+        ),
+        patch("sibyl.jobs.probes.rehearse_memory_probes", AsyncMock()) as rehearse,
+    ):
+        summary = await replay_memory_probes({}, group_id=_GROUP)
+
+    assert summary["memories"] == 0
+    rehearse.assert_not_awaited()
+    assert entity_manager.updates == []
+
+
+@pytest.mark.asyncio
+async def test_a_failing_passage_lookup_still_replays_against_the_parent() -> None:
+    class _HalfBrokenClient(_RecordingClient):
+        async def execute_query(self, query: str, **params: Any) -> Any:
+            if "parent_entity_id IN" in query:
+                msg = "index unavailable"
+                raise RuntimeError(msg)
+            return await super().execute_query(query, **params)
+
+    client = _HalfBrokenClient([_candidate_row(probes=["why"])], [])
+    entity_manager = _RecordingEntityManager()
+    rehearse = AsyncMock(return_value=_rehearsal(retrievable=1, total=1))
+
+    with (
+        patch(
+            "sibyl.jobs.probes._get_graph_runtime",
+            AsyncMock(return_value=_runtime(client, entity_manager)),
+        ),
+        patch("sibyl.jobs.probes.rehearse_memory_probes", rehearse),
+    ):
+        summary = await replay_memory_probes({}, group_id=_GROUP)
+
+    assert summary["memories"] == 1
+    assert rehearse.await_args.kwargs["passage_ids"] == ()
+
+
+@pytest.mark.asyncio
+async def test_all_orgs_reports_a_self_retrievable_percentage() -> None:
+    with (
+        patch("sibyl.jobs.probes._list_organization_ids", AsyncMock(return_value=["a", "b"])),
+        patch(
+            "sibyl.jobs.probes.replay_memory_probes",
+            AsyncMock(
+                side_effect=[
+                    {"probes_total": 4, "probes_retrievable": 3},
+                    {"probes_total": 4, "probes_retrievable": 1},
+                ]
+            ),
+        ),
+    ):
+        summary = await replay_memory_probes_all_orgs({})
+
+    assert summary["orgs_succeeded"] == 2
+    assert summary["probes_total"] == 8
+    assert summary["self_retrievable_pct"] == 50.0
+
+
+@pytest.mark.asyncio
+async def test_one_orgs_failure_does_not_stop_the_walk() -> None:
+    with (
+        patch("sibyl.jobs.probes._list_organization_ids", AsyncMock(return_value=["a", "b"])),
+        patch(
+            "sibyl.jobs.probes.replay_memory_probes",
+            AsyncMock(
+                side_effect=[
+                    RuntimeError("graph down"),
+                    {"probes_total": 1, "probes_retrievable": 1},
+                ]
+            ),
+        ),
+    ):
+        summary = await replay_memory_probes_all_orgs({})
+
+    assert summary["orgs_failed"] == 1
+    assert summary["orgs_succeeded"] == 1
+    assert summary["self_retrievable_pct"] == 100.0

--- a/apps/api/tests/test_routes_entities_write.py
+++ b/apps/api/tests/test_routes_entities_write.py
@@ -2102,3 +2102,67 @@ async def test_update_entity_cannot_have_a_plan_planted_through_metadata() -> No
     written = runtime.entity_manager.update.await_args.args[1]["metadata"]
     assert written["note"] == "kept"
     assert "probe_rehearsal" not in written
+
+
+def test_bulk_create_validates_a_declared_plan_against_its_own_entry() -> None:
+    """The batch path writes rows directly, bypassing the graph writer's gate."""
+    now = datetime.now(UTC)
+
+    built = _entity_from_bulk_create(
+        EntityCreate(
+            name="Batch memory",
+            content=_SPANNED_BODY,
+            entity_type=EntityType.EPISODE,
+            skip_conflicts=True,
+            spans=[{"start": 0, "end": 20}, {"start": 20, "end": len(_SPANNED_BODY)}],
+        ),
+        group_id="org-1",
+        now=now,
+    )
+
+    assert built.metadata["agent_spans"] == [
+        {"start": 0, "end": 20},
+        {"start": 20, "end": len(_SPANNED_BODY)},
+    ]
+
+    with pytest.raises(HTTPException) as excinfo:
+        _entity_from_bulk_create(
+            EntityCreate(
+                name="Batch memory",
+                content=_SPANNED_BODY,
+                entity_type=EntityType.EPISODE,
+                skip_conflicts=True,
+                spans=[{"start": 0, "end": 10}, {"start": 12, "end": len(_SPANNED_BODY)}],
+            ),
+            group_id="org-1",
+            now=now,
+        )
+
+    assert excinfo.value.status_code == 422
+    assert "must leave no gap" in excinfo.value.detail["message"]
+
+
+def test_bulk_create_cannot_have_structure_planted_through_metadata() -> None:
+    built = _entity_from_bulk_create(
+        EntityCreate(
+            name="Batch memory",
+            content=_SPANNED_BODY,
+            entity_type=EntityType.EPISODE,
+            skip_conflicts=True,
+            metadata={
+                "agent_spans": [{"start": 0, "end": 1}],
+                "agent_atomic": True,
+                "memory_probes": ["forged"],
+                "probe_rehearsal": {"retrievable": 99},
+                "note": "kept",
+            },
+        ),
+        group_id="org-1",
+        now=datetime.now(UTC),
+    )
+
+    assert built.metadata["note"] == "kept"
+    assert "agent_spans" not in built.metadata
+    assert "agent_atomic" not in built.metadata
+    assert "memory_probes" not in built.metadata
+    assert "probe_rehearsal" not in built.metadata

--- a/apps/api/tests/test_routes_entities_write.py
+++ b/apps/api/tests/test_routes_entities_write.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import ExitStack, asynccontextmanager, contextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -12,6 +13,7 @@ from pydantic import ValidationError
 
 from sibyl.api.routes.entities import (
     _entity_from_bulk_create,
+    _reject_unsupported_bulk_entry,
     create_entities_bulk,
     create_entity,
     delete_entity,
@@ -1969,6 +1971,84 @@ async def test_update_entity_nulls_a_withdrawn_plan_because_merge_cannot_delete(
 
 
 @pytest.mark.asyncio
+async def test_update_entity_withdraws_a_receipt_about_a_body_that_is_gone() -> None:
+    """A pass recorded against the old text would read as a pass against the new."""
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _spanned_memory_entity(owner=owner)
+    existing.metadata = {
+        "memory_scope": "private",
+        "principal_id": owner,
+        "memory_probes": ["why did it break"],
+        "probe_rehearsal": {"retrievable": 1, "total": 1},
+        "probe_last_replay": {"retrievable": 1, "total": 1},
+    }
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=existing),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime):
+        await update_entity(
+            entity_id="decision_spanned",
+            update=EntityUpdate(content="a rewritten body with different words"),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    written = runtime.entity_manager.update.await_args.args[1]["metadata"]
+    # Explicit nulls rather than omissions: the update MERGEs, so a key left out
+    # of the patch keeps the verdict it had about a body that no longer exists.
+    assert written["probe_rehearsal"] is None
+    assert written["probe_last_replay"] is None
+    # The questions still stand; only the verdict about the old body is dropped.
+    assert written["memory_probes"] == ["why did it break"]
+
+
+@pytest.mark.asyncio
+async def test_update_entity_stores_content_stripped_like_the_writer_does() -> None:
+    """Validation strips, so storing the padded body would abandon the plan."""
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _spanned_memory_entity(owner=owner)
+    body = "one two three four five six seven"
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=_spanned_memory_entity(owner=owner, content=body)),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime, passages=2):
+        await update_entity(
+            entity_id="decision_spanned",
+            update=EntityUpdate(
+                content=f"\n\n  {body}   \n",
+                spans=[{"start": 0, "end": 13}, {"start": 13, "end": len(body)}],
+            ),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    updates = runtime.entity_manager.update.await_args.args[1]
+    assert updates["content"] == body
+    assert updates["metadata"]["agent_spans"] == [
+        {"start": 0, "end": 13},
+        {"start": 13, "end": len(body)},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_update_entity_revalidates_fresh_spans_against_the_new_body() -> None:
     org = _org()
     ctx = _ctx()
@@ -2104,42 +2184,32 @@ async def test_update_entity_cannot_have_a_plan_planted_through_metadata() -> No
     assert "probe_rehearsal" not in written
 
 
-def test_bulk_create_validates_a_declared_plan_against_its_own_entry() -> None:
-    """The batch path writes rows directly, bypassing the graph writer's gate."""
-    now = datetime.now(UTC)
-
-    built = _entity_from_bulk_create(
-        EntityCreate(
-            name="Batch memory",
-            content=_SPANNED_BODY,
-            entity_type=EntityType.EPISODE,
-            skip_conflicts=True,
-            spans=[{"start": 0, "end": 20}, {"start": 20, "end": len(_SPANNED_BODY)}],
-        ),
-        group_id="org-1",
-        now=now,
-    )
-
-    assert built.metadata["agent_spans"] == [
-        {"start": 0, "end": 20},
-        {"start": 20, "end": len(_SPANNED_BODY)},
-    ]
-
+@pytest.mark.parametrize(
+    ("field", "extra"),
+    [
+        ("spans", {"spans": [{"start": 0, "end": 20}, {"start": 20, "end": len(_SPANNED_BODY)}]}),
+        ("atomic", {"atomic": True}),
+        ("probes", {"probes": ["why"]}),
+    ],
+)
+def test_bulk_create_refuses_declared_structure_it_cannot_honor(
+    field: str, extra: dict[str, Any]
+) -> None:
+    """The batch path mints no passages, so accepting a plan would store a no-op."""
     with pytest.raises(HTTPException) as excinfo:
-        _entity_from_bulk_create(
+        _reject_unsupported_bulk_entry(
             EntityCreate(
                 name="Batch memory",
                 content=_SPANNED_BODY,
                 entity_type=EntityType.EPISODE,
                 skip_conflicts=True,
-                spans=[{"start": 0, "end": 10}, {"start": 12, "end": len(_SPANNED_BODY)}],
-            ),
-            group_id="org-1",
-            now=now,
+                **extra,
+            )
         )
 
     assert excinfo.value.status_code == 422
-    assert "must leave no gap" in excinfo.value.detail["message"]
+    assert field in excinfo.value.detail["message"]
+    assert excinfo.value.detail["details"]["field"] == field
 
 
 def test_bulk_create_cannot_have_structure_planted_through_metadata() -> None:

--- a/apps/api/tests/test_routes_entities_write.py
+++ b/apps/api/tests/test_routes_entities_write.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import asynccontextmanager
+from contextlib import ExitStack, asynccontextmanager, contextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1792,3 +1792,313 @@ def test_project_screen_gates_a_note_carrying_only_a_project() -> None:
 
     assert not _entity_visible_to_projects(note, set())
     assert _entity_visible_to_projects(note, {"proj-secret"})
+
+
+# =============================================================================
+# Agent-authored structure
+# =============================================================================
+
+
+_SPANNED_BODY = "alpha beta gamma delta epsilon zeta eta theta iota kappa"
+
+
+def _spanned_memory_entity(*, owner: str, content: str = _SPANNED_BODY) -> SimpleNamespace:
+    return SimpleNamespace(
+        id="decision_spanned",
+        entity_type=EntityType.DECISION,
+        name="Spanned decision",
+        description=content,
+        content=content,
+        category=None,
+        languages=[],
+        tags=[],
+        metadata={
+            "memory_scope": "private",
+            "principal_id": owner,
+            "agent_spans": [{"start": 0, "end": 20}, {"start": 20, "end": len(content)}],
+        },
+        source_file=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+
+@contextmanager
+def _update_patches(runtime: SimpleNamespace, *, passages: int = 0):
+    """Enter the auth and runtime patches an update route call needs.
+
+    Yields the reprojection mock, because the re-cut firing on the request path
+    is itself part of the contract under test.
+    """
+    reproject = AsyncMock(return_value=SimpleNamespace(errors=(), passages=passages))
+    with ExitStack() as stack:
+        for context in (
+            patch("sibyl.locks.entity_lock", _locked_entity),
+            patch(
+                "sibyl.api.routes.entities.get_entity_graph_runtime",
+                AsyncMock(return_value=runtime),
+            ),
+            patch("sibyl.api.routes.entities.verify_entity_project_access", AsyncMock()),
+            patch(
+                "sibyl.api.routes.entities.list_accessible_project_graph_ids",
+                AsyncMock(return_value=set()),
+            ),
+            patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),
+            patch("sibyl.api.routes.entities.reproject_entity_passages", reproject),
+        ):
+            stack.enter_context(context)
+        yield reproject
+
+
+@pytest.mark.asyncio
+async def test_create_entity_forwards_agent_structure_to_the_writer() -> None:
+    org = _org()
+    ctx = _ctx()
+    entity = EntityCreate(
+        name="Structured memory",
+        content=_SPANNED_BODY,
+        entity_type=EntityType.EPISODE,
+        spans=[{"start": 0, "end": 20}, {"start": 20, "end": len(_SPANNED_BODY)}],
+        probes=["what did we learn"],
+    )
+    add_result = SimpleNamespace(
+        success=True,
+        id="episode_new",
+        message="ok",
+        probe_rehearsal={"total": 1, "retrievable": 1, "probes": []},
+    )
+
+    with (
+        patch("sibyl_core.tools.core.add", AsyncMock(return_value=add_result)) as add_mock,
+        patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),
+        patch(
+            "sibyl.api.routes.entities.get_entity_graph_runtime",
+            AsyncMock(return_value=SimpleNamespace(entity_manager=SimpleNamespace())),
+        ),
+    ):
+        response = await create_entity(
+            request=_request(),
+            entity=entity,
+            org=org,
+            ctx=ctx,
+            content_session=None,
+            sync=False,
+        )
+
+    kwargs = add_mock.await_args.kwargs
+    assert kwargs["spans"] == [{"start": 0, "end": 20}, {"start": 20, "end": len(_SPANNED_BODY)}]
+    assert kwargs["probes"] == ["what did we learn"]
+    # Probes must force the synchronous shape, or the receipt they asked for is
+    # dropped in favour of a pending response.
+    assert kwargs["sync"] is True
+    assert response.probe_rehearsal == {"total": 1, "retrievable": 1, "probes": []}
+
+
+@pytest.mark.asyncio
+async def test_create_entity_refuses_a_plan_that_does_not_tile_the_body() -> None:
+    org = _org()
+    ctx = _ctx()
+    entity = EntityCreate(
+        name="Structured memory",
+        content=_SPANNED_BODY,
+        entity_type=EntityType.EPISODE,
+        spans=[{"start": 0, "end": 10}, {"start": 12, "end": len(_SPANNED_BODY)}],
+    )
+
+    with (
+        patch(
+            "sibyl.api.routes.entities.get_entity_graph_runtime",
+            AsyncMock(return_value=SimpleNamespace(entity_manager=SimpleNamespace())),
+        ),
+        pytest.raises(HTTPException) as excinfo,
+    ):
+        await create_entity(
+            request=_request(),
+            entity=entity,
+            org=org,
+            ctx=ctx,
+            content_session=None,
+            sync=True,
+        )
+
+    assert excinfo.value.status_code == 422
+    # The message reaches the caller intact: an agent correcting its own offsets
+    # cannot act on a generic rejection.
+    assert "must leave no gap" in excinfo.value.detail["message"]
+    assert excinfo.value.detail["details"]["field"] == "spans"
+
+
+@pytest.mark.asyncio
+async def test_update_entity_nulls_a_withdrawn_plan_because_merge_cannot_delete() -> None:
+    """Omitting the key would silently preserve the stale plan.
+
+    The entity update lands as `UPDATE entity MERGE $patch`, so a key left out of
+    the patch keeps whatever the row already held. A dict-backed fake would let an
+    omission look like a deletion, which is why this asserts the written value.
+    """
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _spanned_memory_entity(owner=owner)
+    updated = _spanned_memory_entity(owner=owner, content="a completely rewritten body")
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=updated),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime) as reproject:
+        await update_entity(
+            entity_id="decision_spanned",
+            update=EntityUpdate(content="a completely rewritten body"),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    written = runtime.entity_manager.update.await_args.args[1]["metadata"]
+    assert "agent_spans" in written
+    assert written["agent_spans"] is None
+    assert written["memory_scope"] == "private"
+    # The re-cut has to happen on the request path: the only other caller of the
+    # reprojection is an arq job nothing enqueues.
+    reproject.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_entity_revalidates_fresh_spans_against_the_new_body() -> None:
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _spanned_memory_entity(owner=owner)
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=existing),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime), pytest.raises(HTTPException) as excinfo:
+        await update_entity(
+            entity_id="decision_spanned",
+            update=EntityUpdate(
+                content="short body",
+                spans=[{"start": 0, "end": 20}, {"start": 20, "end": len(_SPANNED_BODY)}],
+            ),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    assert excinfo.value.status_code == 422
+    assert "out of bounds" in excinfo.value.detail["message"]
+    runtime.entity_manager.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_entity_stamps_a_fresh_plan_for_the_new_body() -> None:
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _spanned_memory_entity(owner=owner)
+    new_body = "one two three four five six seven"
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=_spanned_memory_entity(owner=owner, content=new_body)),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime, passages=2):
+        await update_entity(
+            entity_id="decision_spanned",
+            update=EntityUpdate(
+                content=new_body,
+                spans=[{"start": 0, "end": 13}, {"start": 13, "end": len(new_body)}],
+            ),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    written = runtime.entity_manager.update.await_args.args[1]["metadata"]
+    assert written["agent_spans"] == [
+        {"start": 0, "end": 13},
+        {"start": 13, "end": len(new_body)},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_entity_keeps_an_atomic_claim_across_a_content_edit() -> None:
+    """Offsets belong to a body; the claim that a body is one unit does not."""
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _spanned_memory_entity(owner=owner)
+    existing.metadata = {
+        "memory_scope": "private",
+        "principal_id": owner,
+        "agent_atomic": True,
+    }
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=existing),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime):
+        await update_entity(
+            entity_id="decision_spanned",
+            update=EntityUpdate(content="a rewritten but still atomic body"),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    written = runtime.entity_manager.update.await_args.args[1]["metadata"]
+    assert written["agent_atomic"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_entity_cannot_have_a_plan_planted_through_metadata() -> None:
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _private_memory_entity(owner=owner)
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=existing),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime):
+        await update_entity(
+            entity_id="decision_private",
+            update=EntityUpdate(
+                metadata={
+                    "agent_spans": [{"start": 0, "end": 1}],
+                    "probe_rehearsal": {"retrievable": 99},
+                    "note": "kept",
+                }
+            ),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    written = runtime.entity_manager.update.await_args.args[1]["metadata"]
+    assert written["note"] == "kept"
+    assert "probe_rehearsal" not in written

--- a/apps/api/tests/test_server_accessible_projects.py
+++ b/apps/api/tests/test_server_accessible_projects.py
@@ -483,6 +483,9 @@ async def test_remember_mcp_memory_scopes_project_metadata() -> None:
         memory_scope="project",
         scope_key="project-a",
         principal_id=ctx.user_id,
+        spans=None,
+        atomic=False,
+        probes=None,
     )
 
 

--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -984,18 +984,30 @@ class SibylClient:
         metadata: dict[str, Any] | None = None,
         sync: bool = False,
         skip_conflicts: bool = False,
+        spans: list[dict[str, Any]] | None = None,
+        atomic: bool = False,
+        probes: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create a new entity.
 
         Args:
             sync: If True, wait for entity creation to complete (slower but
                   entity is immediately available for operations like task start).
+            spans: Agent-authored cut plan tiling the stored content exactly.
+            atomic: Declare the body one retrievable unit that must not be cut.
+            probes: Questions the memory must answer, rehearsed at write time.
         """
         data: dict[str, Any] = {
             "name": name,
             "content": content,
             "entity_type": entity_type,
         }
+        if spans is not None:
+            data["spans"] = spans
+        if atomic:
+            data["atomic"] = True
+        if probes is not None:
+            data["probes"] = probes
         if description:
             data["description"] = description
         if category:

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -7,6 +7,7 @@ Server commands (serve, dev, db, generate, etc.) are in sibyl-server.
 """
 
 import asyncio
+import json
 import re
 import sys
 from collections.abc import Mapping
@@ -472,6 +473,9 @@ async def _write_memory_capture(
     skip_conflicts: bool = False,
     languages: list[str] | None = None,
     capture_metadata: Mapping[str, Any] | None = None,
+    spans: list[dict[str, Any]] | None = None,
+    atomic: bool = False,
+    probes: list[str] | None = None,
 ) -> dict[str, Any]:
     metadata: dict[str, Any] = {
         "capture_mode": capture_mode,
@@ -520,6 +524,9 @@ async def _write_memory_capture(
         capture_surface=surface,
         wait_searchable=wait_searchable,
         skip_conflicts=skip_conflicts,
+        spans=spans,
+        atomic=atomic,
+        probes=probes,
     )
 
     async def remember_raw_memory(capture: MemoryCaptureRequest) -> dict[str, Any]:
@@ -553,6 +560,9 @@ async def _write_memory_capture(
             metadata=dict(graph_metadata),
             sync=capture.wait_searchable,
             skip_conflicts=capture.skip_conflicts,
+            spans=[dict(span) for span in capture.spans] if capture.spans is not None else None,
+            atomic=capture.atomic,
+            probes=list(capture.probes) if capture.probes is not None else None,
         )
 
     service = MemoryCaptureService(
@@ -561,6 +571,66 @@ async def _write_memory_capture(
     )
     result = await service.capture(request)
     return result.to_payload()
+
+
+# Repeatable, so its annotation is a container and the option object has to live
+# at module scope for the default to be a name rather than a call.
+_PROBE_OPTION = typer.Option(
+    None,
+    "--probe",
+    help="Question this memory must answer; repeatable, rehearsed against live search",
+)
+
+
+def _parse_spans_json(raw: str | None) -> list[dict[str, Any]] | None:
+    """Decode a --spans-json payload, faulting on anything that is not a plan.
+
+    Only the JSON shape is checked here. The tiling rules belong to the server,
+    which is the only place that knows the exact body the offsets address.
+    """
+    if raw is None:
+        return None
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = f"--spans-json is not valid JSON: {exc.msg}"
+        raise ValueError(msg) from exc
+    if not isinstance(decoded, list) or not decoded:
+        msg = '--spans-json must be a non-empty JSON array of {"start":…,"end":…} objects'
+        raise ValueError(msg)
+    spans: list[dict[str, Any]] = []
+    for position, entry in enumerate(decoded):
+        if not isinstance(entry, dict) or "start" not in entry or "end" not in entry:
+            msg = f"--spans-json[{position}] must be an object with start and end"
+            raise ValueError(msg)
+        spans.append(cast("dict[str, Any]", entry))
+    return spans
+
+
+def _print_probe_rehearsal(data: Mapping[str, Any]) -> None:
+    """Show what each probe found, or that it found nothing."""
+    receipt = data.get("probe_rehearsal")
+    if not isinstance(receipt, Mapping):
+        return
+    entries = receipt.get("probes")
+    if not isinstance(entries, list) or not entries:
+        return
+    total = receipt.get("total", len(entries))
+    retrievable = receipt.get("retrievable", 0)
+    console.print(f"  [dim]Probes: {retrievable}/{total} retrievable[/dim]")
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        status = str(entry.get("status", "unknown"))
+        text = str(entry.get("probe", ""))
+        if status == "retrievable":
+            console.print(f"    [green]✓[/green] rank {entry.get('rank')} · {text}")
+        elif status == "absent":
+            console.print(f"    [yellow]✗ not retrievable[/yellow] · {text}")
+        else:
+            console.print(f"    [dim]{status}[/dim] · {text}")
+    if receipt.get("truncated"):
+        console.print("  [dim]Rehearsal stopped early on its time budget[/dim]")
 
 
 def _print_memory_capture_result(
@@ -581,6 +651,7 @@ def _print_memory_capture_result(
         console.print(f"  [dim]Raw: {raw_memory_id}[/dim]")
     if raw_policy_reason := data.get("raw_policy_reason"):
         console.print(f"  [dim]Policy: {raw_policy_reason}[/dim]")
+    _print_probe_rehearsal(data)
 
 
 def _print_reflection_persistence_summary(
@@ -3525,6 +3596,20 @@ def remember_memory(
         callback=_normalize_memory_proposal_scope,
         help="Nominate this memory for audited promotion to team scope",
     ),
+    spans_json: str | None = typer.Option(
+        None,
+        "--spans-json",
+        help=(
+            'Cut plan as JSON: \'[{"start":0,"end":812,"label":"Root cause"},...]\'. '
+            "Half-open character offsets into the stored body, tiling it exactly."
+        ),
+    ),
+    atomic: bool = typer.Option(
+        False,
+        "--atomic",
+        help="Declare this memory one retrievable unit that must not be cut into passages",
+    ),
+    probe: list[str] | None = _PROBE_OPTION,
 ) -> None:
     """Remember a decision, plan, idea, claim, artifact, session, or learning."""
 
@@ -3553,6 +3638,16 @@ def remember_memory(
     parsed_tags = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
     related_ids = _parse_csv_ids(related_to)
     task_ids = _parse_csv_ids(task)
+    probes = [entry.strip() for entry in (probe or []) if entry.strip()]
+    parsed_spans = _parse_spans_json(spans_json)
+    if parsed_spans is not None and atomic:
+        error("--atomic and --spans-json describe opposite things; pick one.")
+        raise typer.Exit(code=1)
+    if (raw or diary) and (parsed_spans is not None or atomic or probes):
+        # A raw-only write stores the verbatim record and no graph row, so there
+        # is nothing for spans to cut and nothing for a probe to retrieve.
+        error("--spans-json, --atomic, and --probe need a graph memory; drop --raw/--diary.")
+        raise typer.Exit(code=1)
     metadata = {
         "capture_mode": "remember",
         "capture_surface": surface,
@@ -3632,6 +3727,9 @@ def remember_memory(
                     scope_key=scope_key,
                     source_id=source_id,
                     capture_metadata=capture_metadata,
+                    spans=parsed_spans,
+                    atomic=atomic,
+                    probes=probes or None,
                 )
 
                 if json_output:

--- a/apps/cli/tests/test_main_capture.py
+++ b/apps/cli/tests/test_main_capture.py
@@ -841,6 +841,9 @@ def test_remember_command_records_domain_memory_with_links(
         },
         sync=False,
         skip_conflicts=False,
+        spans=None,
+        atomic=False,
+        probes=None,
     )
     mock_client.explore.assert_awaited_once_with(
         mode="list",
@@ -995,6 +998,9 @@ def test_remember_command_reads_body_from_stdin(
         },
         sync=False,
         skip_conflicts=False,
+        spans=None,
+        atomic=False,
+        probes=None,
     )
     mock_client.explore.assert_not_called()
     mock_resolve_project_from_cwd.assert_called_once_with()

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/__init__.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/__init__.py
@@ -20,10 +20,30 @@ from sibyl_core.memory_pipeline.quality import (
     normalize_memory_quality_metadata,
 )
 from sibyl_core.memory_pipeline.retrieval import CandidateSourceFailure, CandidateSourceResult
+from sibyl_core.memory_pipeline.structure import (
+    MAX_PROBE_CHARS,
+    MAX_PROBES_PER_MEMORY,
+    MEMORY_PROBES_METADATA_KEY,
+    PROBE_LAST_REPLAY_METADATA_KEY,
+    PROBE_REHEARSAL_METADATA_KEY,
+    STRUCTURE_METADATA_KEYS,
+    MemoryStructure,
+    MemoryStructureError,
+    build_memory_structure,
+    probes_from_metadata,
+    strip_structure_metadata,
+    structure_metadata,
+)
 
 __all__ = [
+    "MAX_PROBES_PER_MEMORY",
+    "MAX_PROBE_CHARS",
+    "MEMORY_PROBES_METADATA_KEY",
+    "PROBE_LAST_REPLAY_METADATA_KEY",
+    "PROBE_REHEARSAL_METADATA_KEY",
     "RECALL_EXCLUDED_LIFECYCLE_STATES",
     "RECALL_EXCLUDED_REVIEW_STATES",
+    "STRUCTURE_METADATA_KEYS",
     "CandidateSourceFailure",
     "CandidateSourceResult",
     "GraphMemoryCaptureWriter",
@@ -31,10 +51,16 @@ __all__ = [
     "MemoryCaptureResult",
     "MemoryCaptureService",
     "MemoryLifecycleView",
+    "MemoryStructure",
+    "MemoryStructureError",
     "RawMemoryCaptureWriter",
+    "build_memory_structure",
     "expand_memory_quality_storage_metadata",
     "memory_lifecycle_state",
     "memory_metadata_score",
     "normalize_memory_quality_metadata",
+    "probes_from_metadata",
     "raw_memory_lifecycle_recallable",
+    "strip_structure_metadata",
+    "structure_metadata",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sibyl_core.auth.memory_policy import stamp_memory_scope_metadata
 from sibyl_core.memory_pipeline.quality import normalize_memory_quality_metadata
+from sibyl_core.memory_pipeline.structure import MemoryStructure, build_memory_structure
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +32,33 @@ class MemoryCaptureRequest:
     diary: bool = False
     agent_id: str | None = None
     project_id: str | None = None
+    # Structure the writing agent supplies for its own memory. Spans are
+    # ``[start, end)`` offsets into ``stored_content`` and never replacement
+    # text; ``atomic`` refuses cutting outright; probes are the questions this
+    # memory has to answer, rehearsed against live retrieval at write time.
+    spans: Sequence[Mapping[str, Any]] | None = None
+    atomic: bool = False
+    probes: Sequence[str] | None = None
+
+    @property
+    def stored_content(self) -> str:
+        """The body the graph row will hold, and the string spans address.
+
+        The graph write strips the content, so offsets computed against an
+        unstripped string would land one place at validation and another at
+        projection. Validating against this property keeps both readings the
+        same one.
+        """
+        return self.content.strip()
+
+    def structure(self) -> MemoryStructure:
+        """Validate the declared structure against the body that will be stored."""
+        return build_memory_structure(
+            self.stored_content,
+            spans=self.spans,
+            atomic=self.atomic,
+            probes=self.probes,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,6 +97,11 @@ class MemoryCaptureService:
         self._create_graph_entity = create_graph_entity
 
     async def capture(self, request: MemoryCaptureRequest) -> MemoryCaptureResult:
+        # Before the raw write, not after. The raw capture lands first and the
+        # graph write validates the same plan again, so validating late would
+        # leave a verbatim record behind for a write that then fails, and the
+        # caller would retry into a duplicate.
+        request.structure()
         raw_memory = await self._remember_raw_memory(request)
         raw_memory_id = _optional_str(raw_memory.get("id"))
         raw_source_id = _optional_str(raw_memory.get("source_id"))

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/rehearsal.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/rehearsal.py
@@ -1,0 +1,196 @@
+"""Ask a memory, at the moment it is written, whether it can be found.
+
+A probe is the question the writing agent expects this memory to answer. Running
+it here turns retrievability from an assumption into a measurement: the probe
+goes through the same fused retrieval path a reader would use, and the receipt
+records the rank the memory came back at, or that it did not come back at all.
+
+Two exclusions make the measurement capable of failing, which is the only kind
+worth recording. Raw memory recall is off, because the verbatim capture of the
+text just written matches its own vocabulary by construction and would let every
+probe pass. Exposure recording is off, because a rehearsal is a synthetic query
+and counting it would inflate the usage signals that ranking and decay read.
+
+A rehearsal never fails a write. The memory is already durable when this runs;
+an unretrievable probe is a finding about retrieval, and a broken search is a
+finding about the search path. Both are recorded and neither is raised.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+log = structlog.get_logger()
+
+# One rehearsal reads the top of the ranking, not the tail. A memory that only
+# appears at rank 40 is not one a reader with a budget would ever see, so
+# counting it as retrievable would make the receipt flattering and useless.
+REHEARSAL_LIMIT = 10
+
+# Wall clock for the whole probe set. Past it the remaining probes are recorded
+# as skipped rather than silently dropped, so a truncated receipt is legible as
+# truncation instead of reading like an unretrievable memory.
+REHEARSAL_BUDGET_SECONDS = 6.0
+
+REHEARSAL_STATUS_RETRIEVABLE = "retrievable"
+REHEARSAL_STATUS_ABSENT = "absent"
+REHEARSAL_STATUS_SKIPPED = "skipped"
+REHEARSAL_STATUS_ERROR = "error"
+
+
+async def _default_search(**kwargs: Any) -> Any:
+    # Imported at call time: the search path imports the memory pipeline, so a
+    # module-level import here would close the loop.
+    from sibyl_core.tools.search import search
+
+    return await search(**kwargs)
+
+
+async def rehearse_memory_probes(
+    *,
+    probes: Sequence[str],
+    organization_id: str,
+    entity_id: str,
+    passage_ids: Iterable[str] = (),
+    principal_id: str | None = None,
+    memory_scope: str = "private",
+    scope_key: str | None = None,
+    project: str | None = None,
+    accessible_projects: set[str] | None = None,
+    limit: int = REHEARSAL_LIMIT,
+    budget_seconds: float = REHEARSAL_BUDGET_SECONDS,
+    search_fn: Callable[..., Any] | None = None,
+    surface: str = "write",
+) -> dict[str, Any]:
+    """Run every probe against live retrieval and return the receipt.
+
+    ``entity_id`` and ``passage_ids`` are the rows that count as a hit: a probe
+    that surfaces one of the memory's own spans found the memory, since the
+    reader can widen from a span to its parent in one lookup.
+    """
+    passage_targets = {str(passage_id) for passage_id in passage_ids if passage_id}
+    targets = {entity_id: "parent"} | dict.fromkeys(passage_targets, "passage")
+    run_search = search_fn or _default_search
+    started_at = time.perf_counter()
+    entries: list[dict[str, Any]] = []
+    truncated = False
+
+    for probe in probes:
+        if time.perf_counter() - started_at >= budget_seconds:
+            truncated = True
+            entries.append(
+                {
+                    "probe": probe,
+                    "status": REHEARSAL_STATUS_SKIPPED,
+                    "reason": "budget_exhausted",
+                    "rank": None,
+                }
+            )
+            continue
+        entries.append(
+            await _rehearse_one(
+                probe=probe,
+                targets=targets,
+                organization_id=organization_id,
+                principal_id=principal_id,
+                memory_scope=memory_scope,
+                scope_key=scope_key,
+                project=project,
+                accessible_projects=accessible_projects,
+                limit=limit,
+                run_search=run_search,
+            )
+        )
+
+    retrievable = sum(1 for entry in entries if entry["status"] == REHEARSAL_STATUS_RETRIEVABLE)
+    receipt = {
+        "checked_at": datetime.now(UTC).isoformat(),
+        "surface": surface,
+        "limit": limit,
+        "total": len(entries),
+        "retrievable": retrievable,
+        "truncated": truncated,
+        "probes": entries,
+    }
+    log.info(
+        "probe_rehearsal_complete",
+        entity_id=entity_id,
+        surface=surface,
+        probes_total=len(entries),
+        probes_retrievable=retrievable,
+        truncated=truncated,
+        duration_ms=round((time.perf_counter() - started_at) * 1000, 2),
+    )
+    return receipt
+
+
+async def _rehearse_one(
+    *,
+    probe: str,
+    targets: dict[str, str],
+    organization_id: str,
+    principal_id: str | None,
+    memory_scope: str,
+    scope_key: str | None,
+    project: str | None,
+    accessible_projects: set[str] | None,
+    limit: int,
+    run_search: Callable[..., Any],
+) -> dict[str, Any]:
+    try:
+        response = await run_search(
+            query=probe,
+            organization_id=organization_id,
+            principal_id=principal_id,
+            memory_scope=memory_scope,
+            scope_key=scope_key,
+            project=project,
+            accessible_projects=accessible_projects,
+            limit=limit,
+            include_content=False,
+            include_documents=False,
+            include_raw_memory=False,
+            record_exposure=False,
+        )
+    except Exception as exc:
+        log.warning(
+            "probe_rehearsal_search_failed",
+            error_type=type(exc).__name__,
+        )
+        return {
+            "probe": probe,
+            "status": REHEARSAL_STATUS_ERROR,
+            "error_type": type(exc).__name__,
+            "rank": None,
+        }
+
+    for rank, result in enumerate(getattr(response, "results", []) or [], start=1):
+        result_id = str(getattr(result, "id", "") or "")
+        matched_kind = targets.get(result_id)
+        if matched_kind is not None:
+            return {
+                "probe": probe,
+                "status": REHEARSAL_STATUS_RETRIEVABLE,
+                "rank": rank,
+                "matched_id": result_id,
+                "matched_kind": matched_kind,
+            }
+    return {"probe": probe, "status": REHEARSAL_STATUS_ABSENT, "rank": None}
+
+
+__all__ = [
+    "REHEARSAL_BUDGET_SECONDS",
+    "REHEARSAL_LIMIT",
+    "REHEARSAL_STATUS_ABSENT",
+    "REHEARSAL_STATUS_ERROR",
+    "REHEARSAL_STATUS_RETRIEVABLE",
+    "REHEARSAL_STATUS_SKIPPED",
+    "rehearse_memory_probes",
+]

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/spans.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/spans.py
@@ -1,0 +1,277 @@
+"""The cut plan an agent may supply for its own memory.
+
+The mechanical cutter in :mod:`sibyl_core.projection.slicing` reads a body it
+did not write and infers boundaries from Markdown structure. The agent that
+authored the memory already knows where the seams are, and knows when there are
+none. This module is the contract that lets it say so without the server ever
+inventing anything: the agent hands over offsets, the server validates them and
+either honors them exactly or refuses the write.
+
+Offsets address the stored body, which is ``content.strip()`` -- the same string
+the entity row holds and the same string the cutter would have sliced. A span is
+a half-open ``[start, end)`` range into it.
+
+Two properties are load-bearing and neither is negotiable.
+
+Verbatim: a passage's text is the parent's bytes from ``start`` to ``end``, never
+rewritten, reordered, or summarized. Structure is an index into the memory, not
+a replacement for it.
+
+Complete: the spans tile the whole body with no gap and no overlap. Retrieval
+lets spans stand in for their parent only when the pack holds indices exactly
+``range(total)`` (see ``_suppress_parents_of_passages``), so a plan that leaves
+text in neither a span nor a served parent makes that text unreachable. Half-open
+pairs can express a gap and an overlap, unlike a bare list of cut points, which
+is why the form carries its own validation burden here rather than pushing the
+error into retrieval.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+# A leaf module on purpose. The projection reads this contract and the capture
+# pipeline writes it, and both of those packages sit above heavyweight
+# ``__init__`` modules that reach into the graph runtime. Importing any of them
+# from here closes an import cycle, so the caps below restate their sources as
+# literals and ``test_memory_spans.py`` pins each one to the constant it mirrors.
+
+# The largest body one passage row may store, and the most rows one memory may
+# be cut into. Both are the substrate's shape rather than the cutter's, so they
+# live here where the agent contract and the mechanical cutter can share them.
+MAX_PASSAGE_CONTENT_CHARS = 18_000
+MAX_PASSAGES_PER_SOURCE = 64
+
+MAX_AGENT_SPANS = MAX_PASSAGES_PER_SOURCE
+
+# A label renders in the slot the mechanical cutter fills with a breadcrumb, so
+# it inherits that slot's ceiling: ``slicing.HEADER_MAX_CHARS``.
+MAX_SPAN_LABEL_CHARS = 120
+
+# ``tools.helpers.MAX_TITLE_LENGTH``, the cap on the name a passage header
+# restates.
+MAX_PASSAGE_TITLE_CHARS = 200
+
+# Every passage is rendered as header, then label, then span text. The header is
+# the parent's name plus a position counter, so the framing a valid span must
+# leave room for is bounded by the title cap plus the label cap plus the
+# counter and its newlines. Validating the span against the remaining budget is
+# what makes an accepted plan one the projection can store whole: a span that
+# only overflows once framed would be dropped at projection time, and a dropped
+# span is a silent hole in a tiling the agent was told was accepted.
+MAX_SPAN_FRAMING_CHARS = MAX_PASSAGE_TITLE_CHARS + MAX_SPAN_LABEL_CHARS + 32
+MAX_AGENT_SPAN_CHARS = MAX_PASSAGE_CONTENT_CHARS - MAX_SPAN_FRAMING_CHARS
+
+# An atomic memory is a claim that the body is one retrievable unit. Past the
+# ceiling one row can hold, no passage could carry it and the only copy is the
+# fat parent, which is the outcome the slice substrate exists to prevent. The
+# write is refused there rather than cut anyway, because cutting anyway would
+# override an explicit instruction silently.
+MAX_ATOMIC_CONTENT_CHARS = MAX_PASSAGE_CONTENT_CHARS
+
+AGENT_SPANS_METADATA_KEY = "agent_spans"
+AGENT_ATOMIC_METADATA_KEY = "agent_atomic"
+
+
+class MemoryStructureError(ValueError):
+    """An agent-supplied cut plan the server will not accept.
+
+    Carries the field it faults so a surface can render a 422 that names what to
+    fix, instead of a generic rejection the caller has to guess at.
+    """
+
+    def __init__(self, message: str, *, field: str = "spans") -> None:
+        super().__init__(message)
+        self.field = field
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSpan:
+    """One half-open ``[start, end)`` cut into a memory body."""
+
+    start: int
+    end: int
+    label: str | None = None
+
+    def slice_of(self, content: str) -> str:
+        return content[self.start : self.end]
+
+    def to_metadata(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"start": self.start, "end": self.end}
+        if self.label:
+            payload["label"] = self.label
+        return payload
+
+
+def coerce_agent_spans(value: object) -> tuple[AgentSpan, ...]:
+    """Read a wire payload into spans, faulting anything that is not one.
+
+    Surfaces hand over decoded JSON, so the shape is checked here rather than
+    assumed. A malformed entry is a rejection and never a silent skip: dropping
+    one span from a tiling turns a validated plan into a plan with a hole.
+    """
+    if value is None:
+        return ()
+    if isinstance(value, AgentSpan):
+        return (value,)
+    if isinstance(value, str) or not isinstance(value, list | tuple):
+        msg = "spans must be a list of {start, end, label?} objects"
+        raise MemoryStructureError(msg)
+    spans: list[AgentSpan] = []
+    for position, entry in enumerate(value):
+        if isinstance(entry, AgentSpan):
+            spans.append(entry)
+            continue
+        if not isinstance(entry, dict):
+            msg = f"spans[{position}] must be an object with start and end"
+            raise MemoryStructureError(msg)
+        try:
+            start = entry["start"]
+            end = entry["end"]
+        except KeyError as exc:
+            msg = f"spans[{position}] is missing {exc.args[0]!r}"
+            raise MemoryStructureError(msg) from exc
+        if isinstance(start, bool) or isinstance(end, bool):
+            msg = f"spans[{position}] start and end must be integers"
+            raise MemoryStructureError(msg)
+        if not isinstance(start, int) or not isinstance(end, int):
+            msg = f"spans[{position}] start and end must be integers"
+            raise MemoryStructureError(msg)
+        label = entry.get("label")
+        if label is not None and not isinstance(label, str):
+            msg = f"spans[{position}] label must be a string"
+            raise MemoryStructureError(msg)
+        normalized_label = " ".join(label.split()) if label else None
+        spans.append(AgentSpan(start=start, end=end, label=normalized_label or None))
+    return tuple(spans)
+
+
+def validate_agent_spans(content: str, spans: Sequence[AgentSpan]) -> tuple[AgentSpan, ...]:
+    """Accept a span plan only if it tiles ``content`` exactly.
+
+    Every rejection names the offending index and the numbers that made it
+    invalid. The plan is never repaired and never partially honored, because
+    both are ways of accepting a write while serving something the agent did
+    not author.
+    """
+    if not spans:
+        msg = "spans must contain at least one span"
+        raise MemoryStructureError(msg)
+    if len(spans) > MAX_AGENT_SPANS:
+        msg = f"spans must contain at most {MAX_AGENT_SPANS} spans, got {len(spans)}"
+        raise MemoryStructureError(msg)
+    if len(spans) < 2:
+        # One span is the parent again, so the projection would pay an embedding
+        # for a duplicate row and retrieval would gain nothing.
+        msg = "spans must contain at least 2 spans to be worth cutting"
+        raise MemoryStructureError(msg)
+
+    length = len(content)
+    cursor = 0
+    for index, span in enumerate(spans):
+        if span.start < 0 or span.end > length:
+            msg = (
+                f"spans[{index}] [{span.start}, {span.end}) is out of bounds for "
+                f"content of {length} characters"
+            )
+            raise MemoryStructureError(msg)
+        if span.end <= span.start:
+            msg = f"spans[{index}] must be non-empty, got [{span.start}, {span.end})"
+            raise MemoryStructureError(msg)
+        if span.start < cursor:
+            msg = (
+                f"spans[{index}] starts at {span.start} but the previous span ends "
+                f"at {cursor}: spans must not overlap"
+            )
+            raise MemoryStructureError(msg)
+        if span.start > cursor:
+            msg = (
+                f"spans[{index}] starts at {span.start} but the previous span ends "
+                f"at {cursor}: spans must leave no gap"
+            )
+            raise MemoryStructureError(msg)
+        span_chars = span.end - span.start
+        if span_chars > MAX_AGENT_SPAN_CHARS:
+            msg = (
+                f"spans[{index}] is {span_chars} characters, over the "
+                f"{MAX_AGENT_SPAN_CHARS} character limit for one passage"
+            )
+            raise MemoryStructureError(msg)
+        if span.label is not None and len(span.label) > MAX_SPAN_LABEL_CHARS:
+            msg = (
+                f"spans[{index}] label is {len(span.label)} characters, over the "
+                f"{MAX_SPAN_LABEL_CHARS} character limit"
+            )
+            raise MemoryStructureError(msg)
+        cursor = span.end
+
+    if cursor != length:
+        msg = (
+            f"spans must tile all {length} characters of the stored content, "
+            f"but the last span ends at {cursor}"
+        )
+        raise MemoryStructureError(msg)
+    return tuple(spans)
+
+
+def validate_atomic_content(content: str) -> None:
+    """Refuse an atomic claim the substrate could never serve as one unit."""
+    if len(content) > MAX_ATOMIC_CONTENT_CHARS:
+        msg = (
+            f"atomic memories must be at most {MAX_ATOMIC_CONTENT_CHARS} characters "
+            f"so one retrievable unit can hold the body, got {len(content)}; "
+            "supply spans instead"
+        )
+        raise MemoryStructureError(msg, field="atomic")
+
+
+def agent_spans_metadata(spans: Sequence[AgentSpan]) -> list[dict[str, Any]]:
+    return [span.to_metadata() for span in spans]
+
+
+def agent_spans_from_metadata(metadata: Mapping[str, Any] | None) -> tuple[AgentSpan, ...]:
+    """Read a stored plan back, treating anything malformed as absent.
+
+    The read side runs against rows written by older code and by the storage
+    round trip, so it degrades to the mechanical cutter rather than failing a
+    projection. Only the write path rejects; the write path is what guarantees
+    a stored plan is well formed in the first place.
+    """
+    if not metadata:
+        return ()
+    try:
+        return coerce_agent_spans(metadata.get(AGENT_SPANS_METADATA_KEY))
+    except MemoryStructureError:
+        return ()
+
+
+def agent_atomic_from_metadata(metadata: Mapping[str, Any] | None) -> bool:
+    if not metadata:
+        return False
+    return bool(metadata.get(AGENT_ATOMIC_METADATA_KEY))
+
+
+__all__ = [
+    "AGENT_ATOMIC_METADATA_KEY",
+    "AGENT_SPANS_METADATA_KEY",
+    "MAX_AGENT_SPANS",
+    "MAX_AGENT_SPAN_CHARS",
+    "MAX_ATOMIC_CONTENT_CHARS",
+    "MAX_PASSAGES_PER_SOURCE",
+    "MAX_PASSAGE_CONTENT_CHARS",
+    "MAX_PASSAGE_TITLE_CHARS",
+    "MAX_SPAN_FRAMING_CHARS",
+    "MAX_SPAN_LABEL_CHARS",
+    "AgentSpan",
+    "MemoryStructureError",
+    "agent_atomic_from_metadata",
+    "agent_spans_from_metadata",
+    "agent_spans_metadata",
+    "coerce_agent_spans",
+    "validate_agent_spans",
+    "validate_atomic_content",
+]

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/spans.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/spans.py
@@ -29,7 +29,7 @@ error into retrieval.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -129,19 +129,22 @@ def coerce_agent_spans(value: object) -> tuple[AgentSpan, ...]:
         if not isinstance(entry, dict):
             msg = f"spans[{position}] must be an object with start and end"
             raise MemoryStructureError(msg)
-        try:
-            start = entry["start"]
-            end = entry["end"]
-        except KeyError as exc:
-            msg = f"spans[{position}] is missing {exc.args[0]!r}"
-            raise MemoryStructureError(msg) from exc
+        mapping = cast("Mapping[str, Any]", entry)
+        for key in ("start", "end"):
+            if key not in mapping:
+                msg = f"spans[{position}] is missing {key!r}"
+                raise MemoryStructureError(msg)
+        start = mapping["start"]
+        end = mapping["end"]
+        # bool is an int subclass, and True as an offset is a payload bug rather
+        # than a position, so it is refused before the range checks run.
         if isinstance(start, bool) or isinstance(end, bool):
             msg = f"spans[{position}] start and end must be integers"
             raise MemoryStructureError(msg)
         if not isinstance(start, int) or not isinstance(end, int):
             msg = f"spans[{position}] start and end must be integers"
             raise MemoryStructureError(msg)
-        label = entry.get("label")
+        label = mapping.get("label")
         if label is not None and not isinstance(label, str):
             msg = f"spans[{position}] label must be a string"
             raise MemoryStructureError(msg)

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/structure.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/structure.py
@@ -133,7 +133,11 @@ def build_memory_structure(
         raise MemoryStructureError(msg, field="atomic")
     if atomic:
         validate_atomic_content(content)
-    validated_spans = validate_agent_spans(content, coerced_spans) if coerced_spans else ()
+    # Keyed on whether the field was sent, not on whether it holds anything. An
+    # empty list is a caller declaring a cut plan and handing over none of it,
+    # and treating that as absence would accept the write and quietly cut the
+    # body some other way.
+    validated_spans = validate_agent_spans(content, coerced_spans) if spans is not None else ()
     return MemoryStructure(spans=validated_spans, atomic=atomic, probes=coerced_probes)
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/structure.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/structure.py
@@ -1,0 +1,184 @@
+"""What a writing agent may declare about the memory it is storing.
+
+Three declarations, one contract. Spans say where the seams are, ``atomic`` says
+there are none, and probes say what the memory has to answer later. All three
+are validated and then stamped by the server; none of them can be forged through
+the metadata bag, because a plan the server did not validate is a plan whose
+tiling nothing has checked, and a rehearsal receipt the server did not run is a
+claim about retrievability with no measurement behind it.
+
+Probes exist because this campaign was twice burned by features that passed
+their unit tests and did nothing in production. A probe is the question the
+memory is being stored to answer, rehearsed against the real retrieval path at
+write time, so an inert memory is visible at the moment it is written rather
+than the first time somebody needed it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from sibyl_core.memory_pipeline.spans import (
+    AGENT_ATOMIC_METADATA_KEY,
+    AGENT_SPANS_METADATA_KEY,
+    AgentSpan,
+    MemoryStructureError,
+    agent_spans_metadata,
+    coerce_agent_spans,
+    validate_agent_spans,
+    validate_atomic_content,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+# One rehearsal is one search against the live retrieval path, so the count is
+# what bounds write latency. Five is the ceiling on questions worth pre-paying
+# for; past that the write is doing the reader's job.
+MAX_PROBES_PER_MEMORY = 5
+
+# A probe is a retrieval query, so it inherits the ceiling the refinement loop
+# already applies to the queries it synthesizes: this restates
+# ``retrieval.refinement.MAX_REFINEMENT_QUERY_CHARS``, which cannot be imported
+# here without closing an import cycle, and ``test_memory_spans.py`` pins the two
+# together.
+MAX_PROBE_CHARS = 500
+
+MEMORY_PROBES_METADATA_KEY = "memory_probes"
+PROBE_REHEARSAL_METADATA_KEY = "probe_rehearsal"
+PROBE_LAST_REPLAY_METADATA_KEY = "probe_last_replay"
+
+# Keys the server owns outright. A caller that forwards a request body cannot
+# name its own span plan or hand itself a passing rehearsal receipt, for the same
+# reason it cannot name the principal its row reads as.
+STRUCTURE_METADATA_KEYS = frozenset(
+    {
+        AGENT_ATOMIC_METADATA_KEY,
+        AGENT_SPANS_METADATA_KEY,
+        MEMORY_PROBES_METADATA_KEY,
+        PROBE_LAST_REPLAY_METADATA_KEY,
+        PROBE_REHEARSAL_METADATA_KEY,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryStructure:
+    """The validated structure one write declared."""
+
+    spans: tuple[AgentSpan, ...] = ()
+    atomic: bool = False
+    probes: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def declared(self) -> bool:
+        return bool(self.spans) or self.atomic or bool(self.probes)
+
+
+def coerce_probes(value: object) -> tuple[str, ...]:
+    """Read a wire payload into probes, faulting anything that is not one."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        msg = "probes must be a list of query strings"
+        raise MemoryStructureError(msg, field="probes")
+    if not isinstance(value, list | tuple):
+        msg = "probes must be a list of query strings"
+        raise MemoryStructureError(msg, field="probes")
+    probes: list[str] = []
+    for position, entry in enumerate(value):
+        if not isinstance(entry, str):
+            msg = f"probes[{position}] must be a string"
+            raise MemoryStructureError(msg, field="probes")
+        probes.append(entry.strip())
+    return tuple(probes)
+
+
+def validate_probes(probes: Sequence[str]) -> tuple[str, ...]:
+    """Accept probes only if each is a query the retrieval path can run."""
+    if len(probes) > MAX_PROBES_PER_MEMORY:
+        msg = f"probes must contain at most {MAX_PROBES_PER_MEMORY} probes, got {len(probes)}"
+        raise MemoryStructureError(msg, field="probes")
+    for index, probe in enumerate(probes):
+        if not probe:
+            msg = f"probes[{index}] must not be empty"
+            raise MemoryStructureError(msg, field="probes")
+        if len(probe) > MAX_PROBE_CHARS:
+            msg = (
+                f"probes[{index}] is {len(probe)} characters, over the "
+                f"{MAX_PROBE_CHARS} character limit"
+            )
+            raise MemoryStructureError(msg, field="probes")
+    return tuple(probes)
+
+
+def build_memory_structure(
+    content: str,
+    *,
+    spans: object = None,
+    atomic: bool = False,
+    probes: object = None,
+) -> MemoryStructure:
+    """Validate one write's declarations against the body it will store.
+
+    ``content`` must be the stored body, so callers strip before validating: the
+    offsets an agent computed against its own string are only meaningful against
+    the string the row ends up holding.
+    """
+    coerced_spans = coerce_agent_spans(spans)
+    coerced_probes = validate_probes(coerce_probes(probes))
+    if atomic and coerced_spans:
+        msg = "atomic memories cannot also declare spans: pick one"
+        raise MemoryStructureError(msg, field="atomic")
+    if atomic:
+        validate_atomic_content(content)
+    validated_spans = validate_agent_spans(content, coerced_spans) if coerced_spans else ()
+    return MemoryStructure(spans=validated_spans, atomic=atomic, probes=coerced_probes)
+
+
+def structure_metadata(structure: MemoryStructure) -> dict[str, Any]:
+    """Render the structure for storage on the parent row."""
+    metadata: dict[str, Any] = {}
+    if structure.spans:
+        metadata[AGENT_SPANS_METADATA_KEY] = agent_spans_metadata(structure.spans)
+    if structure.atomic:
+        metadata[AGENT_ATOMIC_METADATA_KEY] = True
+    if structure.probes:
+        metadata[MEMORY_PROBES_METADATA_KEY] = list(structure.probes)
+    return metadata
+
+
+def strip_structure_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Drop every server-owned structure key from an incoming metadata bag."""
+    if not metadata:
+        return {}
+    return {key: value for key, value in metadata.items() if key not in STRUCTURE_METADATA_KEYS}
+
+
+def probes_from_metadata(metadata: Mapping[str, Any] | None) -> tuple[str, ...]:
+    """Read stored probes back, treating anything malformed as absent."""
+    if not metadata:
+        return ()
+    try:
+        return coerce_probes(metadata.get(MEMORY_PROBES_METADATA_KEY))
+    except MemoryStructureError:
+        return ()
+
+
+__all__ = [
+    "MAX_PROBES_PER_MEMORY",
+    "MAX_PROBE_CHARS",
+    "MEMORY_PROBES_METADATA_KEY",
+    "PROBE_LAST_REPLAY_METADATA_KEY",
+    "PROBE_REHEARSAL_METADATA_KEY",
+    "STRUCTURE_METADATA_KEYS",
+    "MemoryStructure",
+    "MemoryStructureError",
+    "build_memory_structure",
+    "coerce_probes",
+    "probes_from_metadata",
+    "strip_structure_metadata",
+    "structure_metadata",
+    "validate_probes",
+]

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -368,10 +368,14 @@ async def reproject_entity_passages(
         created_source_id=source_id,
         generate_embeddings=generate_embeddings,
     )
-    retired = await _retire_passages_from(
+    retired = await _retire_passages_except(
         entity_manager,
         source_id=source_id,
-        first_stale_index=result.passages,
+        kept_indices=frozenset(
+            index
+            for passage in result.created_passages
+            if isinstance(index := passage.metadata.get("passage_index"), int)
+        ),
     )
     if retired:
         log.info(
@@ -394,36 +398,45 @@ async def retire_entity_passages(
     the text of something the caller deleted, which is the one outcome a delete
     must not produce.
     """
-    return await _retire_passages_from(
+    return await _retire_passages_except(
         entity_manager,
         source_id=source_id,
-        first_stale_index=0,
+        kept_indices=frozenset(),
     )
 
 
-async def _retire_passages_from(
+async def _retire_passages_except(
     entity_manager: Any,
     *,
     source_id: str,
-    first_stale_index: int,
+    kept_indices: frozenset[int],
 ) -> int:
-    """Delete passages at or past an index, stopping at the first absence.
+    """Delete every span of one memory that the current projection did not write.
 
-    The projection always writes a contiguous run from zero, so the first index
-    with no row marks the end of any previous run.
+    Keyed on the indices actually written rather than on how many were written.
+    The oversize-leaf branch can skip an index, so a projection that wrote
+    ``{0, 1, 3, 4}`` is not the same as one that wrote four contiguous spans, and
+    counting would delete index 4, the span that had just been minted.
+
+    The walk stops once it is past every kept index and has found an absence,
+    which is where any previous run must have ended.
     """
     delete = getattr(entity_manager, "delete", None)
     if not callable(delete):
         return 0
+    highest_kept = max(kept_indices, default=-1)
     retired = 0
-    for index in range(first_stale_index, MAX_PASSAGES_PER_SOURCE):
+    for index in range(MAX_PASSAGES_PER_SOURCE):
+        if index in kept_indices:
+            continue
         try:
             removed = await delete(passage_entity_id(source_id, index))
         except Exception:
             break
-        if not removed:
+        if removed:
+            retired += 1
+        elif index > highest_kept:
             break
-        retired += 1
     return retired
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -19,8 +19,17 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from sibyl_core.memory_pipeline.spans import (
+    MAX_PASSAGE_CONTENT_CHARS,
+    MAX_PASSAGES_PER_SOURCE,
+    AgentSpan,
+    MemoryStructureError,
+    agent_atomic_from_metadata,
+    agent_spans_from_metadata,
+    validate_agent_spans,
+)
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
-from sibyl_core.projection.slicing import HARD_MAX, render_slice, slice_prose
+from sibyl_core.projection.slicing import HARD_MAX, Slice, render_slice, slice_prose
 from sibyl_core.tools.helpers import _generate_id
 
 if TYPE_CHECKING:
@@ -28,9 +37,14 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger()
 
-MAX_PASSAGE_CONTENT_CHARS = 18_000
-MAX_PASSAGES_PER_SOURCE = 64
 PASSAGE_PROJECTION_KIND = "passage"
+
+# Which cutter produced a span, stamped on every passage. The replay job and any
+# audit of retrievability need to tell an agent's own seams apart from the ones
+# the prose cutter inferred, and a passage read alone carries no other clue.
+PASSAGE_PLAN_KEY = "passage_plan"
+PASSAGE_PLAN_AGENT = "agent"
+PASSAGE_PLAN_MECHANICAL = "mechanical"
 
 # Set only when the spans between them account for the whole parent body.
 # Retrieval reads it to decide whether the spans may stand in for the memory.
@@ -98,9 +112,22 @@ def passage_entity_id(source_id: str, passage_index: int) -> str:
 
 
 def should_project_passages(source: Entity) -> bool:
-    """Whether this memory is the kind, and the size, worth cutting."""
+    """Whether this memory is the kind, and the size, worth cutting.
+
+    An agent's own declarations outrank the size heuristic in both directions.
+    ``agent_atomic`` means the body is one retrievable unit and must not be cut
+    at any length. A supplied span plan means the writer named seams it wants
+    served, so the plan is honored even under the threshold the mechanical
+    cutter waits for: the heuristic exists because the cutter is guessing, and
+    here it is not.
+    """
     if source.entity_type not in PASSAGE_SOURCE_TYPES:
         return False
+    metadata = source.metadata or {}
+    if agent_atomic_from_metadata(metadata):
+        return False
+    if agent_spans_from_metadata(metadata):
+        return True
     return len(source.content or "") > PASSAGE_MIN_SOURCE_CHARS
 
 
@@ -129,7 +156,10 @@ def plan_entity_passages(
         )
         raise ValueError(msg)
 
-    slices, _ = slice_prose(source.content or "")
+    # Not named ``content``: the loop below rebinds that name to each rendered
+    # passage, and the parent body has to survive the whole walk.
+    body = source.content or ""
+    slices, plan_kind = _plan_slices(body, source)
     if len(slices) < 2:
         # One slice is the parent again. The projection has to earn its row.
         return [], []
@@ -187,6 +217,7 @@ def plan_entity_passages(
                     "passage_total": total,
                     "passage_breadcrumb": passage.breadcrumb,
                     "passage_cut_reason": passage.reason,
+                    PASSAGE_PLAN_KEY: plan_kind,
                     PASSAGE_COVERS_PARENT_KEY: True,
                 },
                 created_at=stamped,
@@ -449,6 +480,50 @@ async def _create_relationships(
     return tuple(relationships[:created])
 
 
+def _plan_slices(content: str, source: Entity) -> tuple[list[Slice], str]:
+    """Choose the cut plan for one body: the agent's if it has one, else the cutter's.
+
+    A stored plan is re-validated against the body it is about to cut. The write
+    path rejects a plan that does not tile its content, so disagreement here means
+    the body was rewritten by a path that did not refresh the plan. Refusing to
+    project would leave the memory fat with the previous revision's spans still
+    beside it, so the mechanical cutter takes over and says so.
+    """
+    spans = agent_spans_from_metadata(source.metadata)
+    if not spans:
+        mechanical, _ = slice_prose(content)
+        return mechanical, PASSAGE_PLAN_MECHANICAL
+    try:
+        validate_agent_spans(content, spans)
+    except MemoryStructureError as exc:
+        log.warning(
+            "passage_projection_agent_plan_stale",
+            source_id=source.id,
+            spans=len(spans),
+            content_chars=len(content),
+            reason=str(exc),
+        )
+        mechanical, _ = slice_prose(content)
+        return mechanical, PASSAGE_PLAN_MECHANICAL
+    return [_slice_from_span(content, span) for span in spans], PASSAGE_PLAN_AGENT
+
+
+def _slice_from_span(content: str, span: AgentSpan) -> Slice:
+    """Render one agent span in the shape the passage builder already consumes.
+
+    The label lands in the breadcrumb slot, which is where the mechanical cutter
+    puts the heading trail: it is part of the passage body, so it is indexed for
+    lexical search and read by the reader exactly like a slice header.
+    """
+    return Slice(
+        line_indices=[],
+        content=span.slice_of(content),
+        cut_depth=0,
+        breadcrumb=span.label or "",
+        reason="agent-span",
+    )
+
+
 def _passage_header(source: Entity, index: int, total: int) -> str:
     """Name the parent on every passage so a span read alone still locates itself."""
     return f"{source.name} · passage {index}/{total}"
@@ -480,6 +555,9 @@ __all__ = [
     "MAX_PASSAGE_CONTENT_CHARS",
     "PASSAGE_COVERS_PARENT_KEY",
     "PASSAGE_MIN_SOURCE_CHARS",
+    "PASSAGE_PLAN_AGENT",
+    "PASSAGE_PLAN_KEY",
+    "PASSAGE_PLAN_MECHANICAL",
     "PASSAGE_PROJECTION_KIND",
     "PASSAGE_SOURCE_TYPES",
     "PassageProjectionResult",

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -1919,7 +1919,7 @@ _SNAPSHOT_SHADOWED_METADATA_KEYS = frozenset(
 )
 
 
-def _snapshot_without_owned_keys(snapshot: Mapping[str, object]) -> dict[str, object]:
+def _snapshot_without_owned_keys(snapshot: Mapping[Any, Any]) -> dict[str, object]:
     return {
         str(key): value
         for key, value in snapshot.items()

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -1900,6 +1900,33 @@ async def get_surreal_graph_runtime(
     )
 
 
+# A row stores its metadata twice: flattened into ``attributes``, and again as a
+# JSON snapshot under ``attributes.metadata``. The flattened copy wins for any key
+# present in both, but an update writes only the flattened copy, so a key the
+# update deliberately removed comes back from the stale snapshot. For most keys
+# that is merely old data; for these the absence is the meaning. A withdrawn span
+# plan resurrected here would cut a rewritten body on seams the agent authored for
+# the previous revision, and a resurrected rehearsal receipt would report a verdict
+# about text that is gone. The flattened copy is the only place they are read from.
+_SNAPSHOT_SHADOWED_METADATA_KEYS = frozenset(
+    {
+        "agent_atomic",
+        "agent_spans",
+        "memory_probes",
+        "probe_last_replay",
+        "probe_rehearsal",
+    }
+)
+
+
+def _snapshot_without_owned_keys(snapshot: Mapping[str, object]) -> dict[str, object]:
+    return {
+        str(key): value
+        for key, value in snapshot.items()
+        if str(key) not in _SNAPSHOT_SHADOWED_METADATA_KEYS
+    }
+
+
 def entity_from_surreal_row(row: Mapping[str, object]) -> Entity:
     normalized_row = {str(key): value for key, value in row.items()}
     attributes = _row_attributes(normalized_row)
@@ -1912,10 +1939,10 @@ def entity_from_surreal_row(row: Mapping[str, object]) -> Entity:
             parsed = None
         if isinstance(parsed, dict):
             metadata.pop("metadata", None)
-            metadata = {str(key): value for key, value in parsed.items()} | metadata
+            metadata = _snapshot_without_owned_keys(parsed) | metadata
     elif isinstance(raw_metadata, dict):
         metadata.pop("metadata", None)
-        metadata = {str(key): value for key, value in raw_metadata.items()} | metadata
+        metadata = _snapshot_without_owned_keys(raw_metadata) | metadata
 
     if metadata.get("category") is None:
         metadata.pop("category", None)

--- a/packages/python/sibyl-core/src/sibyl_core/tools/add.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/add.py
@@ -10,6 +10,13 @@ from sibyl_core.auth.memory_policy import (
     stamp_memory_scope_metadata,
 )
 from sibyl_core.embeddings.providers import configured_embedding_provider
+from sibyl_core.memory_pipeline.structure import (
+    PROBE_REHEARSAL_METADATA_KEY,
+    MemoryStructure,
+    build_memory_structure,
+    strip_structure_metadata,
+    structure_metadata,
+)
 from sibyl_core.models.entities import (
     Entity,
     EntityType,
@@ -51,6 +58,64 @@ async def get_graph_runtime(group_id: str):
         group_id,
         embedding_provider=configured_embedding_provider(),
     )
+
+
+async def _rehearse_write(
+    *,
+    entity_manager: Any,
+    entity: Entity,
+    created_id: str,
+    org_id: str,
+    structure: MemoryStructure,
+    passage_ids: list[str],
+    principal_id: str | None,
+    memory_scope: str | None,
+    scope_key: str | None,
+    project: str | None,
+) -> dict[str, Any] | None:
+    """Run the write's probes and record the receipt on the row it describes.
+
+    Everything here is best effort. The memory is durable before this runs, so a
+    rehearsal that cannot complete costs the receipt and nothing else, and a
+    write that failed on a retrieval hiccup would be the worse outcome by far.
+    """
+    if not structure.probes:
+        return None
+
+    from sibyl_core.memory_pipeline.rehearsal import rehearse_memory_probes
+
+    try:
+        receipt = await rehearse_memory_probes(
+            probes=structure.probes,
+            organization_id=org_id,
+            entity_id=created_id,
+            passage_ids=passage_ids,
+            principal_id=principal_id,
+            memory_scope=memory_scope or "private",
+            scope_key=scope_key,
+            project=project,
+            accessible_projects={scope_key} if scope_key else None,
+        )
+    except Exception as exc:
+        log.warning(
+            "probe_rehearsal_failed",
+            entity_id=created_id,
+            error_type=type(exc).__name__,
+        )
+        return None
+
+    try:
+        await entity_manager.update(
+            created_id,
+            {"metadata": {**(entity.metadata or {}), PROBE_REHEARSAL_METADATA_KEY: receipt}},
+        )
+    except Exception as exc:
+        log.warning(
+            "probe_rehearsal_receipt_not_stored",
+            entity_id=created_id,
+            error_type=type(exc).__name__,
+        )
+    return receipt
 
 
 def _build_relationship(rel_data: dict[str, Any]) -> Relationship:
@@ -180,6 +245,10 @@ async def add(
     memory_scope: str | None = None,
     scope_key: str | None = None,
     principal_id: str | None = None,
+    # Structure the writing agent declares for its own memory
+    spans: list[dict[str, Any]] | None = None,
+    atomic: bool = False,
+    probes: list[str] | None = None,
 ) -> AddResponse:
     """Add new knowledge to the Sibyl knowledge graph.
 
@@ -233,6 +302,17 @@ async def add(
         memory_scope: Authorized audience for the row, resolved by the calling surface.
         scope_key: Authorized audience key (a verified project, never a payload value).
         principal_id: Authenticated author of the write.
+        spans: Agent-authored cut plan as [{"start": int, "end": int, "label": str?}].
+              Offsets are half-open into the stored (stripped) content and must tile
+              it exactly: no gap, no overlap, first starts at 0, last ends at the
+              final character. Honored verbatim in place of the mechanical prose
+              cutter; an invalid plan raises rather than falling back.
+        atomic: Declare the body one retrievable unit that must not be cut.
+              Mutually exclusive with spans.
+        probes: Questions this memory must answer later. Each is run through the
+              live search path once the write lands, and the ranks come back in
+              the response. Supplying probes forces a synchronous write, since a
+              rehearsal cannot observe a row that has not been written yet.
 
     Returns:
         AddResponse with created entity ID, auto-discovered links, conflicts, and timestamp.
@@ -279,6 +359,19 @@ async def add(
             message=f"Content exceeds {MAX_CONTENT_LENGTH} characters",
             timestamp=datetime.now(UTC),
         )
+
+    # The structure keys are server-owned. A surface that forwards a request body
+    # cannot plant a span plan nothing validated, nor hand itself a rehearsal
+    # receipt no search produced, for the same reason it cannot name the
+    # principal its row reads as.
+    if metadata:
+        metadata = strip_structure_metadata(metadata)
+    structure = build_memory_structure(content, spans=spans, atomic=atomic, probes=probes)
+    if structure.probes:
+        # A rehearsal has to observe the row it asks about, and the async path
+        # returns before the write lands. Probes are opt-in per write, so this
+        # buys the receipt only for callers that asked for one.
+        sync = True
 
     if (metadata or {}).get("memory_scope") is not None and memory_scope is None:
         # The stamp rebuilds the triple from the authorized values, so a scope
@@ -371,6 +464,7 @@ async def add(
                 scope_key=scope_key,
                 principal_id=principal_id,
             ),
+            **structure_metadata(structure),
         }
         if project:
             full_metadata["project_id"] = project
@@ -712,6 +806,20 @@ async def add(
                     relationships=passage_result.relationships,
                 )
 
+            # After the passages exist, so a probe that lands on a span counts.
+            rehearsal_receipt = await _rehearse_write(
+                entity_manager=entity_manager,
+                entity=entity,
+                created_id=created_id,
+                org_id=org_id,
+                structure=structure,
+                passage_ids=[passage.id for passage in passage_result.created_passages],
+                principal_id=principal_id,
+                memory_scope=memory_scope,
+                scope_key=scope_key,
+                project=project,
+            )
+
             message = f"Added: {title}"
             if relationships_to_create:
                 message += f" (linked: {len(relationships_to_create)})"
@@ -750,6 +858,7 @@ async def add(
                 timestamp=datetime.now(UTC),
                 conflicts=conflicts,
                 background_jobs=background_jobs,
+                probe_rehearsal=rehearsal_receipt,
             )
 
         # Async mode (default): queue arq job, return immediately

--- a/packages/python/sibyl-core/src/sibyl_core/tools/add.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/add.py
@@ -925,6 +925,26 @@ async def add(
                     errors=len(projection_result.errors),
                 )
 
+            # Same ordering as the sync branch: the parent exists, so the edges
+            # have something to point at. Without this the fallback stored a
+            # memory with no spans beside it, agent-planned or otherwise, and
+            # nothing later would notice.
+            fallback_passages = await project_entity_passages(
+                entity_manager=entity_manager,
+                relationship_manager=relationship_manager,
+                source=entity,
+                group_id=org_id,
+                created_source_id=created_id,
+                generate_embeddings=generate_embeddings,
+            )
+            if fallback_passages.errors:
+                log.warning(
+                    "add_fallback_passage_projection_failed",
+                    entity_id=created_id,
+                    passages=fallback_passages.passages,
+                    errors=fallback_passages.errors,
+                )
+
             fallback_message = f"Added (sync fallback): {title}"
             if conflicts:
                 fallback_message += f" (⚠️ {len(conflicts)} potential conflict(s) detected)"

--- a/packages/python/sibyl-core/src/sibyl_core/tools/responses.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/responses.py
@@ -101,6 +101,8 @@ class AddResponse:
     timestamp: datetime
     conflicts: list[ConflictWarning] = field(default_factory=list)
     background_jobs: dict[str, Any] = field(default_factory=dict)
+    # Per-probe rank-or-absent, present only when the write carried probes.
+    probe_rehearsal: dict[str, Any] | None = None
 
 
 @dataclass

--- a/packages/python/sibyl-core/tests/test_memory_rehearsal.py
+++ b/packages/python/sibyl-core/tests/test_memory_rehearsal.py
@@ -1,0 +1,189 @@
+"""Write-time probe rehearsal: what the receipt records, and what it cannot hide."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from sibyl_core.memory_pipeline.capture import MemoryCaptureRequest, MemoryCaptureService
+from sibyl_core.memory_pipeline.rehearsal import (
+    REHEARSAL_STATUS_ABSENT,
+    REHEARSAL_STATUS_ERROR,
+    REHEARSAL_STATUS_RETRIEVABLE,
+    REHEARSAL_STATUS_SKIPPED,
+    rehearse_memory_probes,
+)
+from sibyl_core.memory_pipeline.structure import MemoryStructureError
+
+_ENTITY = "episode_parent"
+_PASSAGE = "passage_child_0"
+
+
+@dataclass
+class _Result:
+    id: str
+
+
+@dataclass
+class _Response:
+    results: list[_Result]
+
+
+class _RecordingSearch:
+    def __init__(self, *responses: list[str]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> _Response:
+        self.calls.append(kwargs)
+        ids = self._responses.pop(0) if self._responses else []
+        return _Response(results=[_Result(id=value) for value in ids])
+
+
+async def _rehearse(probes: list[str], search: Any, **overrides: Any) -> dict[str, Any]:
+    return await rehearse_memory_probes(
+        probes=probes,
+        organization_id="org-1",
+        entity_id=_ENTITY,
+        passage_ids=[_PASSAGE],
+        principal_id="user-1",
+        search_fn=search,
+        **overrides,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_probe_that_finds_the_parent_records_its_rank() -> None:
+    search = _RecordingSearch(["other_1", _ENTITY])
+
+    receipt = await _rehearse(["why did it break"], search)
+
+    assert receipt["probes"][0]["status"] == REHEARSAL_STATUS_RETRIEVABLE
+    assert receipt["probes"][0]["rank"] == 2
+    assert receipt["probes"][0]["matched_kind"] == "parent"
+    assert receipt["retrievable"] == 1
+    assert receipt["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_probe_that_finds_one_of_the_memorys_spans_counts_as_found() -> None:
+    """A reader that lands on a span widens to its parent in one lookup."""
+    search = _RecordingSearch([_PASSAGE])
+
+    receipt = await _rehearse(["what fixed it"], search)
+
+    assert receipt["probes"][0]["status"] == REHEARSAL_STATUS_RETRIEVABLE
+    assert receipt["probes"][0]["matched_kind"] == "passage"
+    assert receipt["probes"][0]["matched_id"] == _PASSAGE
+
+
+@pytest.mark.asyncio
+async def test_a_probe_that_finds_nothing_is_recorded_as_absent() -> None:
+    """The honest failure. A rehearsal that cannot fail measures nothing."""
+    search = _RecordingSearch(["unrelated_1", "unrelated_2"])
+
+    receipt = await _rehearse(["totally unrelated vocabulary"], search)
+
+    assert receipt["probes"][0]["status"] == REHEARSAL_STATUS_ABSENT
+    assert receipt["probes"][0]["rank"] is None
+    assert receipt["retrievable"] == 0
+
+
+@pytest.mark.asyncio
+async def test_rehearsal_excludes_raw_recall_and_does_not_record_exposure() -> None:
+    """Raw recall would match the text just written and pass every probe."""
+    search = _RecordingSearch([_ENTITY])
+
+    await _rehearse(["why"], search)
+
+    call = search.calls[0]
+    assert call["include_raw_memory"] is False
+    assert call["include_documents"] is False
+    assert call["record_exposure"] is False
+    assert call["organization_id"] == "org-1"
+    assert call["principal_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_search_is_recorded_and_never_raised() -> None:
+    async def explode(**_kwargs: Any) -> None:
+        msg = "retrieval is down"
+        raise RuntimeError(msg)
+
+    receipt = await _rehearse(["why"], explode)
+
+    assert receipt["probes"][0]["status"] == REHEARSAL_STATUS_ERROR
+    assert receipt["probes"][0]["error_type"] == "RuntimeError"
+    assert receipt["retrievable"] == 0
+
+
+@pytest.mark.asyncio
+async def test_an_exhausted_budget_skips_the_rest_and_says_so() -> None:
+    search = _RecordingSearch([_ENTITY], [_ENTITY])
+
+    receipt = await _rehearse(["one", "two"], search, budget_seconds=0.0)
+
+    assert receipt["truncated"] is True
+    assert [entry["status"] for entry in receipt["probes"]] == [
+        REHEARSAL_STATUS_SKIPPED,
+        REHEARSAL_STATUS_SKIPPED,
+    ]
+    assert search.calls == []
+
+
+@pytest.mark.asyncio
+async def test_every_probe_gets_an_entry_in_order() -> None:
+    search = _RecordingSearch([_ENTITY], ["nope"], [_PASSAGE])
+
+    receipt = await _rehearse(["a", "b", "c"], search)
+
+    assert [entry["probe"] for entry in receipt["probes"]] == ["a", "b", "c"]
+    assert receipt["retrievable"] == 2
+    assert receipt["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
+# Capture spine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_plan_is_refused_before_the_verbatim_write() -> None:
+    """A raw capture left behind by a rejected write turns a retry into a duplicate."""
+    raw_writes: list[str] = []
+
+    async def remember_raw(request: MemoryCaptureRequest) -> dict[str, Any]:
+        raw_writes.append(request.content)
+        return {"id": "raw_1", "source_id": "src"}
+
+    async def create_graph_entity(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"id": "episode_1"}
+
+    service = MemoryCaptureService(
+        remember_raw_memory=remember_raw,
+        create_graph_entity=create_graph_entity,
+    )
+
+    with pytest.raises(MemoryStructureError):
+        await service.capture(
+            MemoryCaptureRequest(
+                title="t",
+                content="alpha beta gamma",
+                spans=[{"start": 0, "end": 4}, {"start": 9, "end": 16}],
+            )
+        )
+
+    assert raw_writes == []
+
+
+def test_spans_address_the_stored_body_not_the_untrimmed_one() -> None:
+    request = MemoryCaptureRequest(
+        title="t",
+        content="  alpha beta  ",
+        spans=[{"start": 0, "end": 5}, {"start": 5, "end": 10}],
+    )
+
+    assert request.stored_content == "alpha beta"
+    assert len(request.structure().spans) == 2

--- a/packages/python/sibyl-core/tests/test_memory_spans.py
+++ b/packages/python/sibyl-core/tests/test_memory_spans.py
@@ -39,7 +39,7 @@ def test_probe_cap_matches_the_refinement_query_cap() -> None:
 def test_span_cap_leaves_room_for_every_possible_framing() -> None:
     """An accepted span must render inside one passage row, framing included."""
     worst_case_header = MAX_PASSAGE_TITLE_CHARS + len(" · passage 64/64")
-    assert MAX_SPAN_FRAMING_CHARS >= worst_case_header + MAX_SPAN_LABEL_CHARS + 2
+    assert worst_case_header + MAX_SPAN_LABEL_CHARS + 2 <= MAX_SPAN_FRAMING_CHARS
     assert MAX_AGENT_SPAN_CHARS + MAX_SPAN_FRAMING_CHARS == MAX_PASSAGE_CONTENT_CHARS
 
 

--- a/packages/python/sibyl-core/tests/test_memory_spans.py
+++ b/packages/python/sibyl-core/tests/test_memory_spans.py
@@ -1,0 +1,58 @@
+"""Pin the span contract's restated caps to the constants they mirror.
+
+``memory_pipeline.spans`` is a leaf module: the projection reads it and the
+capture pipeline writes it, and importing either package from there closes a
+cycle through the graph runtime. So its caps restate their sources as literals,
+and these assertions are what keep the two copies from drifting apart.
+"""
+
+from __future__ import annotations
+
+from sibyl_core.memory_pipeline.spans import (
+    MAX_AGENT_SPAN_CHARS,
+    MAX_AGENT_SPANS,
+    MAX_ATOMIC_CONTENT_CHARS,
+    MAX_PASSAGE_CONTENT_CHARS,
+    MAX_PASSAGE_TITLE_CHARS,
+    MAX_PASSAGES_PER_SOURCE,
+    MAX_SPAN_FRAMING_CHARS,
+    MAX_SPAN_LABEL_CHARS,
+)
+from sibyl_core.memory_pipeline.structure import MAX_PROBE_CHARS
+from sibyl_core.projection.slicing import HEADER_MAX_CHARS
+from sibyl_core.retrieval.refinement import MAX_REFINEMENT_QUERY_CHARS
+from sibyl_core.tools.helpers import MAX_TITLE_LENGTH
+
+
+def test_label_cap_matches_the_slice_header_cap() -> None:
+    assert MAX_SPAN_LABEL_CHARS == HEADER_MAX_CHARS
+
+
+def test_title_cap_matches_the_add_title_cap() -> None:
+    assert MAX_PASSAGE_TITLE_CHARS == MAX_TITLE_LENGTH
+
+
+def test_probe_cap_matches_the_refinement_query_cap() -> None:
+    assert MAX_PROBE_CHARS == MAX_REFINEMENT_QUERY_CHARS
+
+
+def test_span_cap_leaves_room_for_every_possible_framing() -> None:
+    """An accepted span must render inside one passage row, framing included."""
+    worst_case_header = MAX_PASSAGE_TITLE_CHARS + len(" · passage 64/64")
+    assert MAX_SPAN_FRAMING_CHARS >= worst_case_header + MAX_SPAN_LABEL_CHARS + 2
+    assert MAX_AGENT_SPAN_CHARS + MAX_SPAN_FRAMING_CHARS == MAX_PASSAGE_CONTENT_CHARS
+
+
+def test_span_count_cap_is_the_passage_cap() -> None:
+    assert MAX_AGENT_SPANS == MAX_PASSAGES_PER_SOURCE
+
+
+def test_atomic_ceiling_is_one_passage_row() -> None:
+    assert MAX_ATOMIC_CONTENT_CHARS == MAX_PASSAGE_CONTENT_CHARS
+
+
+def test_the_projection_still_reads_its_caps_from_the_contract() -> None:
+    from sibyl_core.projection import passages
+
+    assert passages.MAX_PASSAGE_CONTENT_CHARS == MAX_PASSAGE_CONTENT_CHARS
+    assert passages.MAX_PASSAGES_PER_SOURCE == MAX_PASSAGES_PER_SOURCE

--- a/packages/python/sibyl-core/tests/test_memory_spans.py
+++ b/packages/python/sibyl-core/tests/test_memory_spans.py
@@ -56,3 +56,17 @@ def test_the_projection_still_reads_its_caps_from_the_contract() -> None:
 
     assert passages.MAX_PASSAGE_CONTENT_CHARS == MAX_PASSAGE_CONTENT_CHARS
     assert passages.MAX_PASSAGES_PER_SOURCE == MAX_PASSAGES_PER_SOURCE
+
+
+def test_snapshot_shadowed_keys_are_exactly_the_server_owned_ones() -> None:
+    """The storage layer restates the key set, so it has to stay in step.
+
+    A row keeps its metadata twice, and the graph reader refuses to read these
+    keys from the stale JSON snapshot because their absence is what carries the
+    meaning. A key added to the contract without being added there would come
+    back from the snapshot after being withdrawn.
+    """
+    from sibyl_core.memory_pipeline.structure import STRUCTURE_METADATA_KEYS
+    from sibyl_core.services.graph import _SNAPSHOT_SHADOWED_METADATA_KEYS
+
+    assert _SNAPSHOT_SHADOWED_METADATA_KEYS == STRUCTURE_METADATA_KEYS

--- a/packages/python/sibyl-core/tests/test_memory_structure.py
+++ b/packages/python/sibyl-core/tests/test_memory_structure.py
@@ -1,0 +1,263 @@
+"""The agent-supplied structure contract: what the server accepts and refuses."""
+
+from __future__ import annotations
+
+import pytest
+
+from sibyl_core.memory_pipeline.spans import (
+    MAX_AGENT_SPAN_CHARS,
+    MAX_AGENT_SPANS,
+    MAX_ATOMIC_CONTENT_CHARS,
+    MAX_SPAN_LABEL_CHARS,
+    AgentSpan,
+    agent_spans_from_metadata,
+    coerce_agent_spans,
+    validate_agent_spans,
+)
+from sibyl_core.memory_pipeline.structure import (
+    AGENT_ATOMIC_METADATA_KEY,
+    AGENT_SPANS_METADATA_KEY,
+    MAX_PROBE_CHARS,
+    MAX_PROBES_PER_MEMORY,
+    MEMORY_PROBES_METADATA_KEY,
+    PROBE_REHEARSAL_METADATA_KEY,
+    MemoryStructureError,
+    build_memory_structure,
+    probes_from_metadata,
+    strip_structure_metadata,
+    structure_metadata,
+)
+
+_BODY = "alpha beta gamma delta epsilon zeta eta theta"
+
+
+def _spans(*pairs: tuple[int, int]) -> list[dict[str, int]]:
+    return [{"start": start, "end": end} for start, end in pairs]
+
+
+# ---------------------------------------------------------------------------
+# Span validation matrix
+# ---------------------------------------------------------------------------
+
+
+def test_valid_tiling_is_accepted_and_slices_verbatim() -> None:
+    structure = build_memory_structure(_BODY, spans=_spans((0, 10), (10, len(_BODY))))
+
+    assert [(span.start, span.end) for span in structure.spans] == [(0, 10), (10, len(_BODY))]
+    assert "".join(span.slice_of(_BODY) for span in structure.spans) == _BODY
+
+
+def test_labels_are_kept_and_whitespace_collapsed() -> None:
+    structure = build_memory_structure(
+        _BODY,
+        spans=[
+            {"start": 0, "end": 10, "label": "  Cause \n of   it "},
+            {"start": 10, "end": len(_BODY), "label": "Fix"},
+        ],
+    )
+
+    assert [span.label for span in structure.spans] == ["Cause of it", "Fix"]
+
+
+def test_overlapping_spans_are_refused_by_name() -> None:
+    with pytest.raises(MemoryStructureError, match="must not overlap"):
+        build_memory_structure(_BODY, spans=_spans((0, 20), (10, len(_BODY))))
+
+
+def test_gapped_spans_are_refused_by_name() -> None:
+    with pytest.raises(MemoryStructureError, match="must leave no gap"):
+        build_memory_structure(_BODY, spans=_spans((0, 10), (12, len(_BODY))))
+
+
+def test_span_past_the_end_is_refused_as_out_of_bounds() -> None:
+    with pytest.raises(MemoryStructureError, match="out of bounds"):
+        build_memory_structure(_BODY, spans=_spans((0, 10), (10, len(_BODY) + 5)))
+
+
+def test_negative_start_is_refused_as_out_of_bounds() -> None:
+    with pytest.raises(MemoryStructureError, match="out of bounds"):
+        build_memory_structure(_BODY, spans=_spans((-1, 10), (10, len(_BODY))))
+
+
+def test_partial_coverage_is_refused_because_suppression_needs_the_whole_body() -> None:
+    with pytest.raises(MemoryStructureError, match="must tile all"):
+        build_memory_structure(_BODY, spans=_spans((0, 10), (10, len(_BODY) - 4)))
+
+
+def test_plan_that_does_not_start_at_zero_is_refused() -> None:
+    with pytest.raises(MemoryStructureError, match="must leave no gap"):
+        build_memory_structure(_BODY, spans=_spans((4, 10), (10, len(_BODY))))
+
+
+def test_empty_span_is_refused() -> None:
+    with pytest.raises(MemoryStructureError, match="must be non-empty"):
+        build_memory_structure(_BODY, spans=_spans((0, 0), (0, len(_BODY))))
+
+
+def test_single_span_is_refused_because_it_duplicates_the_parent() -> None:
+    with pytest.raises(MemoryStructureError, match="at least 2 spans"):
+        build_memory_structure(_BODY, spans=_spans((0, len(_BODY))))
+
+
+def test_too_many_spans_is_refused_at_the_passage_cap() -> None:
+    body = "x" * (MAX_AGENT_SPANS + 1)
+    pairs = [(index, index + 1) for index in range(MAX_AGENT_SPANS + 1)]
+
+    with pytest.raises(MemoryStructureError, match=f"at most {MAX_AGENT_SPANS} spans"):
+        build_memory_structure(body, spans=_spans(*pairs))
+
+
+def test_span_count_exactly_at_the_cap_is_accepted() -> None:
+    body = "x" * MAX_AGENT_SPANS
+    pairs = [(index, index + 1) for index in range(MAX_AGENT_SPANS)]
+
+    structure = build_memory_structure(body, spans=_spans(*pairs))
+
+    assert len(structure.spans) == MAX_AGENT_SPANS
+
+
+def test_oversize_span_is_refused_with_framing_room_left_over() -> None:
+    body = "y" * (MAX_AGENT_SPAN_CHARS + 100)
+
+    with pytest.raises(MemoryStructureError, match="over the"):
+        build_memory_structure(
+            body, spans=_spans((0, MAX_AGENT_SPAN_CHARS + 1), (MAX_AGENT_SPAN_CHARS + 1, len(body)))
+        )
+
+
+def test_oversize_label_is_refused() -> None:
+    with pytest.raises(MemoryStructureError, match="label is"):
+        build_memory_structure(
+            _BODY,
+            spans=[
+                {"start": 0, "end": 10, "label": "L" * (MAX_SPAN_LABEL_CHARS + 1)},
+                {"start": 10, "end": len(_BODY)},
+            ],
+        )
+
+
+def test_malformed_span_payloads_are_refused_rather_than_skipped() -> None:
+    with pytest.raises(MemoryStructureError, match="must be an object"):
+        coerce_agent_spans([{"start": 0, "end": 4}, "nope"])
+    with pytest.raises(MemoryStructureError, match="missing 'end'"):
+        coerce_agent_spans([{"start": 0}])
+    with pytest.raises(MemoryStructureError, match="must be integers"):
+        coerce_agent_spans([{"start": 0, "end": 4.5}])
+    with pytest.raises(MemoryStructureError, match="must be integers"):
+        coerce_agent_spans([{"start": True, "end": 4}])
+    with pytest.raises(MemoryStructureError, match="list of"):
+        coerce_agent_spans("0,4")
+
+
+def test_validate_agent_spans_accepts_span_objects_directly() -> None:
+    spans = validate_agent_spans(_BODY, [AgentSpan(0, 10), AgentSpan(10, len(_BODY))])
+
+    assert len(spans) == 2
+
+
+# ---------------------------------------------------------------------------
+# Atomic
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_is_accepted_under_the_single_unit_ceiling() -> None:
+    structure = build_memory_structure("z" * MAX_ATOMIC_CONTENT_CHARS, atomic=True)
+
+    assert structure.atomic is True
+    assert structure.spans == ()
+
+
+def test_atomic_over_the_ceiling_is_refused_with_a_remedy() -> None:
+    with pytest.raises(MemoryStructureError, match="supply spans instead") as excinfo:
+        build_memory_structure("z" * (MAX_ATOMIC_CONTENT_CHARS + 1), atomic=True)
+
+    assert excinfo.value.field == "atomic"
+
+
+def test_atomic_and_spans_together_are_refused() -> None:
+    with pytest.raises(MemoryStructureError, match="pick one"):
+        build_memory_structure(_BODY, atomic=True, spans=_spans((0, 10), (10, len(_BODY))))
+
+
+# ---------------------------------------------------------------------------
+# Probes
+# ---------------------------------------------------------------------------
+
+
+def test_probes_are_kept_in_order() -> None:
+    structure = build_memory_structure(_BODY, probes=["why did it break", "what fixed it"])
+
+    assert structure.probes == ("why did it break", "what fixed it")
+
+
+def test_too_many_probes_is_refused() -> None:
+    with pytest.raises(MemoryStructureError, match=f"at most {MAX_PROBES_PER_MEMORY}"):
+        build_memory_structure(
+            _BODY, probes=[f"probe {index}" for index in range(MAX_PROBES_PER_MEMORY + 1)]
+        )
+
+
+def test_oversize_probe_is_refused() -> None:
+    with pytest.raises(MemoryStructureError, match="over the") as excinfo:
+        build_memory_structure(_BODY, probes=["q" * (MAX_PROBE_CHARS + 1)])
+
+    assert excinfo.value.field == "probes"
+
+
+def test_blank_probe_is_refused() -> None:
+    with pytest.raises(MemoryStructureError, match="must not be empty"):
+        build_memory_structure(_BODY, probes=["   "])
+
+
+def test_probe_payload_must_be_a_list_of_strings() -> None:
+    with pytest.raises(MemoryStructureError, match="list of query strings"):
+        build_memory_structure(_BODY, probes="one probe")
+    with pytest.raises(MemoryStructureError, match="must be a string"):
+        build_memory_structure(_BODY, probes=[{"q": "x"}])
+
+
+# ---------------------------------------------------------------------------
+# Metadata contract
+# ---------------------------------------------------------------------------
+
+
+def test_structure_metadata_round_trips_through_storage() -> None:
+    structure = build_memory_structure(
+        _BODY,
+        spans=[{"start": 0, "end": 10, "label": "Cause"}, {"start": 10, "end": len(_BODY)}],
+        probes=["why did it break"],
+    )
+    stored = structure_metadata(structure)
+
+    assert stored[AGENT_SPANS_METADATA_KEY] == [
+        {"start": 0, "end": 10, "label": "Cause"},
+        {"start": 10, "end": len(_BODY)},
+    ]
+    assert stored[MEMORY_PROBES_METADATA_KEY] == ["why did it break"]
+    assert AGENT_ATOMIC_METADATA_KEY not in stored
+    assert agent_spans_from_metadata(stored) == structure.spans
+    assert probes_from_metadata(stored) == structure.probes
+
+
+def test_atomic_metadata_is_stamped_only_when_declared() -> None:
+    assert structure_metadata(build_memory_structure(_BODY, atomic=True)) == {
+        AGENT_ATOMIC_METADATA_KEY: True
+    }
+    assert structure_metadata(build_memory_structure(_BODY)) == {}
+
+
+def test_incoming_metadata_cannot_forge_structure_or_a_receipt() -> None:
+    forged = {
+        "domain": "keep me",
+        AGENT_SPANS_METADATA_KEY: [{"start": 0, "end": 1}],
+        AGENT_ATOMIC_METADATA_KEY: True,
+        MEMORY_PROBES_METADATA_KEY: ["forged"],
+        PROBE_REHEARSAL_METADATA_KEY: {"retrievable": 99},
+    }
+
+    assert strip_structure_metadata(forged) == {"domain": "keep me"}
+
+
+def test_malformed_stored_spans_read_as_absent_rather_than_raising() -> None:
+    assert agent_spans_from_metadata({AGENT_SPANS_METADATA_KEY: "garbage"}) == ()
+    assert probes_from_metadata({MEMORY_PROBES_METADATA_KEY: 7}) == ()

--- a/packages/python/sibyl-core/tests/test_memory_structure.py
+++ b/packages/python/sibyl-core/tests/test_memory_structure.py
@@ -99,6 +99,14 @@ def test_single_span_is_refused_because_it_duplicates_the_parent() -> None:
         build_memory_structure(_BODY, spans=_spans((0, len(_BODY))))
 
 
+def test_an_explicitly_empty_plan_is_refused_rather_than_read_as_absent() -> None:
+    """Sending the field and handing over nothing is a claim, not an omission."""
+    with pytest.raises(MemoryStructureError, match="at least one span"):
+        build_memory_structure(_BODY, spans=[])
+
+    assert build_memory_structure(_BODY, spans=None).spans == ()
+
+
 def test_too_many_spans_is_refused_at_the_passage_cap() -> None:
     body = "x" * (MAX_AGENT_SPANS + 1)
     pairs = [(index, index + 1) for index in range(MAX_AGENT_SPANS + 1)]

--- a/packages/python/sibyl-core/tests/test_projection_passages.py
+++ b/packages/python/sibyl-core/tests/test_projection_passages.py
@@ -651,3 +651,44 @@ async def test_reprojection_keeps_a_span_written_past_a_skipped_index() -> None:
         not in entity_manager.deleted
     }
     assert survivors == set(written)
+
+
+def test_a_withdrawn_plan_in_a_stale_snapshot_is_not_read_back() -> None:
+    """A row keeps its metadata twice; only the flattened copy may speak here."""
+    import json
+
+    from sibyl_core.services.graph import entity_from_surreal_row
+
+    body = _prose()
+    stale_plan = [{"start": 0, "end": 40, "label": "Old"}, {"start": 40, "end": len(body)}]
+    row = {
+        "uuid": _SOURCE_ID,
+        "name": "A long decision",
+        "entity_type": "decision",
+        "description": "short blurb",
+        "content": body,
+        "group_id": _GROUP,
+        "attributes": {
+            # The flattened copy no longer carries the plan; the snapshot still does.
+            "memory_scope": "private",
+            "metadata": json.dumps(
+                {
+                    "memory_scope": "private",
+                    "agent_spans": stale_plan,
+                    "probe_rehearsal": {"retrievable": 1},
+                    "keep_me": "kept",
+                }
+            ),
+        },
+    }
+
+    entity = entity_from_surreal_row(row)
+
+    assert entity.metadata["keep_me"] == "kept"
+    assert "agent_spans" not in entity.metadata
+    assert "probe_rehearsal" not in entity.metadata
+    entities, _ = plan_entity_passages(entity, source_id=_SOURCE_ID, group_id=_GROUP)
+    assert entities
+    assert all(
+        passage.metadata[PASSAGE_PLAN_KEY] == PASSAGE_PLAN_MECHANICAL for passage in entities
+    )

--- a/packages/python/sibyl-core/tests/test_projection_passages.py
+++ b/packages/python/sibyl-core/tests/test_projection_passages.py
@@ -4,12 +4,19 @@ from typing import Any
 
 import pytest
 
+from sibyl_core.memory_pipeline.spans import (
+    AGENT_ATOMIC_METADATA_KEY,
+    AGENT_SPANS_METADATA_KEY,
+)
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.projection.passages import (
     MAX_PASSAGE_CONTENT_CHARS,
     MAX_PASSAGES_PER_SOURCE,
     PASSAGE_COVERS_PARENT_KEY,
     PASSAGE_MIN_SOURCE_CHARS,
+    PASSAGE_PLAN_AGENT,
+    PASSAGE_PLAN_KEY,
+    PASSAGE_PLAN_MECHANICAL,
     passage_entity_id,
     plan_entity_passages,
     project_entity_passages,
@@ -461,3 +468,134 @@ async def test_retiring_a_memory_that_never_had_spans_is_a_no_op() -> None:
 
     assert retired == 0
     assert entity_manager.deleted == []
+
+
+# ---------------------------------------------------------------------------
+# Agent-authored cut plans
+# ---------------------------------------------------------------------------
+
+
+def _agent_metadata(*pairs: tuple[int, int, str | None]) -> dict[str, Any]:
+    return {
+        AGENT_SPANS_METADATA_KEY: [
+            {"start": start, "end": end, **({"label": label} if label else {})}
+            for start, end, label in pairs
+        ]
+    }
+
+
+def test_agent_spans_are_honored_verbatim_and_differ_from_the_cutter() -> None:
+    """The writer's seams win, and the passage text is the parent's own bytes."""
+    body = _prose()
+    third = len(body) // 3
+    source = _source(
+        content=body,
+        metadata=_agent_metadata(
+            (0, third, "Opening"),
+            (third, third * 2, "Middle"),
+            (third * 2, len(body), "Close"),
+        ),
+    )
+
+    entities, relationships = plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP)
+
+    assert len(entities) == 3
+    assert len(relationships) == 3
+    expected = [body[0:third], body[third : third * 2], body[third * 2 :]]
+    for entity, span_text in zip(entities, expected, strict=True):
+        assert entity.content.endswith(span_text)
+        assert span_text in entity.content
+    assert "".join(expected) == body
+
+    mechanical, _ = plan_entity_passages(
+        _source(content=body), source_id=_SOURCE_ID, group_id=_GROUP
+    )
+    assert [entity.content for entity in entities] != [entity.content for entity in mechanical]
+
+
+def test_agent_passages_stamp_the_same_contract_as_mechanical_ones() -> None:
+    body = _prose()
+    half = len(body) // 2
+    source = _source(
+        content=body, metadata=_agent_metadata((0, half, None), (half, len(body), None))
+    )
+
+    entities, _ = plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP)
+
+    assert [entity.metadata["passage_index"] for entity in entities] == [0, 1]
+    assert {entity.metadata["passage_total"] for entity in entities} == {2}
+    assert all(entity.metadata[PASSAGE_COVERS_PARENT_KEY] is True for entity in entities)
+    assert all(entity.metadata[PASSAGE_PLAN_KEY] == PASSAGE_PLAN_AGENT for entity in entities)
+    assert all(entity.metadata["passage_cut_reason"] == "agent-span" for entity in entities)
+
+
+def test_mechanical_passages_say_so_in_their_plan_stamp() -> None:
+    entities, _ = plan_entity_passages(_source(), source_id=_SOURCE_ID, group_id=_GROUP)
+
+    assert all(entity.metadata[PASSAGE_PLAN_KEY] == PASSAGE_PLAN_MECHANICAL for entity in entities)
+
+
+def test_a_span_label_is_carried_in_the_passage_body() -> None:
+    """Labels are indexed text, so they have to reach the stored content."""
+    body = _prose()
+    half = len(body) // 2
+    source = _source(
+        content=body,
+        metadata=_agent_metadata((0, half, "Root cause"), (half, len(body), "Remediation")),
+    )
+
+    entities, _ = plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP)
+
+    assert "Root cause" in entities[0].content
+    assert "Remediation" in entities[1].content
+    assert entities[0].metadata["passage_breadcrumb"] == "Root cause"
+
+
+def test_an_atomic_memory_is_never_cut_however_long_it_is() -> None:
+    source = _source(content=_prose(sections=12), metadata={AGENT_ATOMIC_METADATA_KEY: True})
+
+    assert should_project_passages(source) is False
+    assert plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP) == ([], [])
+
+
+def test_agent_spans_outrank_the_size_threshold() -> None:
+    """The threshold exists because the cutter guesses; here it does not."""
+    body = "one two three four five six seven eight"
+    assert len(body) < PASSAGE_MIN_SOURCE_CHARS
+    source = _source(content=body, metadata=_agent_metadata((0, 15, None), (15, len(body), None)))
+
+    assert should_project_passages(source) is True
+    entities, _ = plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP)
+    assert len(entities) == 2
+
+
+def test_a_stored_plan_that_no_longer_tiles_the_body_falls_back_to_the_cutter() -> None:
+    """A body rewritten behind the plan must not be cut on stale offsets."""
+    body = _prose()
+    source = _source(content=body, metadata=_agent_metadata((0, 40, None), (40, 90, None)))
+
+    entities, _ = plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP)
+
+    assert entities
+    assert all(entity.metadata[PASSAGE_PLAN_KEY] == PASSAGE_PLAN_MECHANICAL for entity in entities)
+
+
+def test_passages_do_not_inherit_their_parents_plan_or_probes() -> None:
+    body = _prose()
+    half = len(body) // 2
+    source = _source(
+        content=body,
+        metadata={
+            **_agent_metadata((0, half, None), (half, len(body), None)),
+            AGENT_ATOMIC_METADATA_KEY: False,
+            "memory_probes": ["why"],
+            "memory_scope": "private",
+        },
+    )
+
+    entities, _ = plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP)
+
+    for entity in entities:
+        assert AGENT_SPANS_METADATA_KEY not in entity.metadata
+        assert "memory_probes" not in entity.metadata
+        assert entity.metadata["memory_scope"] == "private"

--- a/packages/python/sibyl-core/tests/test_projection_passages.py
+++ b/packages/python/sibyl-core/tests/test_projection_passages.py
@@ -599,3 +599,55 @@ def test_passages_do_not_inherit_their_parents_plan_or_probes() -> None:
         assert AGENT_SPANS_METADATA_KEY not in entity.metadata
         assert "memory_probes" not in entity.metadata
         assert entity.metadata["memory_scope"] == "private"
+
+
+@pytest.mark.asyncio
+async def test_reprojection_keeps_a_span_written_past_a_skipped_index() -> None:
+    """A hole in the index run must not make the retire sweep eat a live span.
+
+    An unbroken line past the row ceiling is emitted as its own slice and then
+    skipped, so the written indices are not contiguous. Retiring by count would
+    treat the highest written index as stale and delete the span that had just
+    been minted, leaving that text reachable only through the parent.
+    """
+    giant_line = "x" * (MAX_PASSAGE_CONTENT_CHARS + 500)
+    body = "\n".join(
+        [
+            "# Root",
+            "",
+            "## First",
+            "",
+            " ".join(["alpha"] * 200),
+            "",
+            "## Huge",
+            "",
+            giant_line,
+            "",
+            "## Last",
+            "",
+            " ".join(["omega"] * 200),
+            "",
+        ]
+    )
+    source = _source(content=body)
+    entities, _ = plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP)
+    written = [entity.metadata["passage_index"] for entity in entities]
+    assert written != list(range(len(written))), "probe needs a skipped index to be meaningful"
+
+    entity_manager = _ReprojectEntityManager(existing_indices=set(written))
+    result = await reproject_entity_passages(
+        entity_manager=entity_manager,
+        relationship_manager=_RecordingRelationshipManager(),
+        source=source,
+        group_id=_GROUP,
+        created_source_id=_SOURCE_ID,
+    )
+
+    assert result.passages == len(written)
+    survivors = {
+        entity.metadata["passage_index"]
+        for entity in entity_manager.created
+        if passage_entity_id(_SOURCE_ID, entity.metadata["passage_index"])
+        not in entity_manager.deleted
+    }
+    assert survivors == set(written)


### PR DESCRIPTION
# 🔮 Agent-authored memory structure: spans, atoms, and probes that prove themselves

> Sits on the passage projection that already cuts long memories into retrievable spans. That cutter reads prose it did not write; this PR lets the agent that wrote the memory describe its shape instead, and lets a write assert that it can be found again.

## 💡 What this is

Two capabilities on the write path, sharing one contract. A writing agent can hand over `spans`, the character offsets where its memory's sections actually begin and end, and the server cuts passages on exactly those seams instead of guessing. It can hand over `atomic: true` to say the body is one thing that must not be cut at all. And it can hand over `probes`, the questions the memory exists to answer, which are run through the live search path the moment the write lands so the response says whether the memory can find itself.

The tempting version of this is a server that reads the memory and infers structure with a model. That is the version Sibyl will not build. The write path is deterministic, with no server-side LLM, and that is the one architectural property no competitor has. So the agent supplies the structure, the server validates it and either honors it exactly or refuses the write, and nothing anywhere invents a cut point.

Probes exist because this campaign has twice shipped features that passed their unit tests and did nothing in production, caught only by a discriminating live probe afterwards. A probe turns that lesson into machinery: retrievability becomes a measurement taken at write time rather than an assumption discovered months later.

## 🤔 Why we need it, and what it replaces

Long memories are already cut into `PASSAGE` entities so a reader gets the relevant span instead of a fat blob. Today the boundaries come from `slice_prose`, a mechanical cutter that nests Markdown by heading level and packs subtrees into a 600 to 1200 character band. It works, and it is guessing. The agent writing an incident note knows that the symptom, the root cause, and the remediation are three retrievable units, knows a four-line rule is one unit that reads wrong in halves, and knows which question the note is being stored to answer. None of that reached the server before this change.

What is deliberately not built: any inference. There is no heuristic that upgrades a partial plan into a complete one, no repair of an out-of-bounds offset, no quiet fallback to the mechanical cutter when a plan is rejected. A silent fallback would accept the write and then serve boundaries the agent never chose, which is precisely the inert-feature shape this PR is trying to kill. Invalid structure is a 422 with the offset that broke it.

Blast radius is opt-in per write. A write with no `spans`, no `atomic`, and no `probes` behaves exactly as it does on `main`: same mechanical cutter, same size threshold, same async write, no rehearsal, no extra queries. Every new field defaults to absent.

## 🎯 The invariant

Anchor the review on one property: **agent-supplied structure never changes the stored bytes.** A span is an index into the memory, not a replacement for it. `AgentSpan.slice_of(content)` returns `content[start:end]`, that exact text becomes the passage body under the same header and label framing a mechanical slice gets, and the parent keeps its whole body regardless.

The second property that guards the first is completeness. Spans must tile the entire body with no gap and no overlap, because retrieval only lets spans stand in for their parent when a pack holds indices exactly `range(total)` (`_suppress_parents_of_passages` in `tools/context.py`, untouched by this PR). A plan that left text in neither a span nor a served parent would make that text unreachable, so the validator rejects it.

## 🛠️ How it works

### 1. The contract lives in a leaf module

`packages/python/sibyl-core/src/sibyl_core/memory_pipeline/spans.py` holds `AgentSpan`, the caps, and `validate_agent_spans`. It imports nothing from `sibyl_core`, deliberately: the projection reads this contract and the capture pipeline writes it, and both sit above package `__init__` modules that reach the graph runtime, so importing either closes a cycle through `services.graph`. The three caps it restates as literals (label cap, title cap, probe cap) are pinned to their real sources by `packages/python/sibyl-core/tests/test_memory_spans.py`, which imports both copies and asserts they match.

`memory_pipeline/structure.py` composes spans, `atomic`, and `probes` into one validated `MemoryStructure`, and owns the metadata contract.

### 2. Validation is strict, and its messages are for a machine

`validate_agent_spans` faults on: fewer than two spans (one span is the parent again, with an embedding to pay for), more than `MAX_PASSAGES_PER_SOURCE`, out of bounds, empty, overlapping, gapped, oversize, oversize label, and any plan that does not tile the whole body. Each rejection names the index and the numbers that made it invalid:

```
spans[1] starts at 12 but the previous span ends at 10: spans must leave no gap
spans[1] starts at 10 but the previous span ends at 20: spans must not overlap
spans must tile all 2740 characters of the stored content, but the last span ends at 40
spans[1] [10, 999999) is out of bounds for content of 2740 characters
```

Those messages reach the client verbatim at 422, which is a deliberate exception to the house rule that error text stays generic. `unprocessable_entity()` in `api/errors.py` carries the message through sanitization; the messages stay under 200 characters and name no paths so they survive it. An agent correcting its own offsets has to know which span was wrong, and a sanitized "invalid request" would leave it re-guessing the whole plan.

Offsets address `content.strip()`, the exact string the row stores and the string the cutter would have sliced, since the graph write strips before storing. `MemoryCaptureRequest.stored_content` makes that one reading rather than two.

### 3. The span cap leaves room for framing

A passage renders as header, then label, then span text. A span validated only against `MAX_PASSAGE_CONTENT_CHARS` could pass validation and then overflow once framed, and the projection drops an overflowing passage, which would put a hole in a tiling the caller was told was accepted. So `MAX_AGENT_SPAN_CHARS` is the row ceiling minus a framing budget bounded by the title cap plus the label cap plus the counter, and `test_span_cap_leaves_room_for_every_possible_framing` pins the arithmetic.

### 4. The projection picks a plan, then behaves identically

`_plan_slices` in `projection/passages.py` reads the stored plan and re-validates it against the body it is about to cut. On a valid plan each span becomes a `Slice` whose breadcrumb slot holds the label, which is where the mechanical cutter puts its heading trail, so labels land in the stored passage body and are indexed with it. Everything downstream is shared: `passage_index`, `passage_total`, `passage_covers_parent`, the deterministic ids, the PART_OF edges, and the scope inheritance are stamped the same way for both plans. A new `passage_plan` field records which cutter produced the span, since a passage read alone carries no other clue.

`should_project_passages` now honors the agent in both directions. `agent_atomic` refuses cutting at any length. A supplied plan is honored even below the 2000 character threshold the mechanical cutter waits for, because that threshold exists to stop the cutter guessing on short bodies and here it is not guessing.

If a stored plan no longer tiles its body, the projection logs `passage_projection_agent_plan_stale` and falls back to the mechanical cutter. That is not the write-path fallback this PR forbids: it is a safety net for a row whose content was rewritten by a path that did not refresh the plan, where refusing to project would leave the memory fat with the previous revision's spans beside it.

### 5. The update rules, and the MERGE that could not delete

A content update without fresh spans drops the stored plan and hands the body back to the mechanical cutter, because offsets belong to the text they were computed over. Refusing the update instead would make a plain content edit impossible for any memory that was ever spanned. A content update with fresh spans re-validates them against the new content. The atomic claim is about the memory rather than about offsets, so it survives a content edit untouched unless restated, and it is re-validated against whatever body ends up stored since a rewrite can push a previously atomic memory past the ceiling one row can hold.

Two things had to be fixed for that rule to be real rather than written.

The reprojection was unreachable. `PATCH /entities` updates inline, and the only caller of `reproject_entity_passages` was the arq `update_entity` job, which nothing enqueues: `enqueue_update_entity` has no call sites outside its own export list. So a content update through the API left every passage cut from the old body in place, still serving the previous revision under its deterministic id. The re-cut now happens on the request path.

The drop could not be expressed, in two layers. The entity update lands as `UPDATE entity MERGE $patch`, and a MERGE cannot remove a key: one omitted from the patch keeps whatever the row already held, so building the new structure by spreading a partial dict over the stored metadata preserved the plan it was trying to drop. A withdrawn declaration is now written as an explicit null.

Underneath that, a row stores its metadata twice: flattened into the `attributes` column, and again as a JSON snapshot under `attributes.metadata`. The flattened copy wins for any key present in both, and an update writes only the flattened copy, so clearing `agent_spans` there handed the question to a snapshot still holding the previous revision's plan. For most keys a stale snapshot is old data the flattened copy overrides; for the five server-owned structure keys the absence is the meaning, so `entity_from_surreal_row` no longer reads them from the snapshot at all. A resurrected plan cuts a rewritten body on dead seams, and a resurrected receipt reports retrievability for text that is gone.

Both defects hide behind a length-changing edit, where the stale plan fails to tile the new body and the safety net mechanically re-cuts for the wrong reason. The unit test and probe (e) both use a length-preserving edit so the drop itself is what gets proven.

### 6. Probes run against the real search path

`memory_pipeline/rehearsal.py` runs each probe through `sibyl_core.tools.search.search`, the same function `POST /search` and the MCP `recall` tool call, scoped to the writer's own org, principal, and memory scope. It records the 1-based rank the memory came back at, or that it did not come back. A probe that surfaces one of the memory's own passages counts as a hit, since a reader can widen from a span to its parent in one lookup.

Two exclusions are what make the measurement capable of failing:

- **Raw memory recall is off.** The verbatim capture of the text just written matches its own vocabulary by construction, so including it would let every probe pass and the receipt would measure nothing.
- **Exposure recording is off.** A rehearsal is a synthetic query, and counting it would inflate the usage signals that ranking and decay read.

The receipt returns in the response and persists into the entity's metadata. Rehearsal never fails a write: the memory is already durable when it runs, so a search error is recorded as `status: "error"` and an exhausted time budget marks remaining probes `skipped` with `truncated: true`, rather than either being silently dropped.

Supplying probes forces the write synchronous, in the writer and in the route. A rehearsal cannot observe a row that has not been written yet, and a pending response shape would drop the receipt the caller asked for.

### 7. The replay job

A write-time rehearsal answers for the graph as it stood at that moment, and the graph keeps moving: new memories crowd the ranking, consolidation merges rows, decay archives them, an embedding backfill changes what a query matches. `jobs/probes.py` re-runs the probes at 05:00 daily and writes `probe_last_replay` to the row. Two queries bound the work per org, one for probe-carrying memories inside the window and one batched lookup for their passages. The window is a week rather than a day so a row missed to an outage is picked up next run instead of skipped forever. The summary log emits `probes_total`, `probes_retrievable`, and `self_retrievable_pct`, so "are our memories still findable" is one log line.

Three names in that job are easy to get wrong and silent when wrong. The model's metadata is the `attributes` column, not `metadata`. The logical id is `uuid`; the `id` column holds a Surreal record id that neither `EntityManager.update` (which matches `WHERE uuid = $uuid`) nor a search result speaks, and `normalize_records` moves it to `record_id` anyway. And the runtime client's method is `execute_query` with keyword params, not `query`. A receipt write that matches no row is counted as a failure, since `update` returns `None` rather than raising and an addressing mistake would otherwise report clean runs forever.

### 8. Where the fields are exposed

The MCP `remember` tool signature is its schema, so the docstring explains what offsets address and why an absent probe is worth acting on immediately, rather than listing parameter types. `EntityCreate` gains `spans` (a typed `MemorySpan` list), `atomic`, and `probes`; `EntityUpdate` gains `spans` and a tri-state `atomic`. The CLI gains `--spans-json`, `--atomic`, and a repeatable `--probe`, and prints the per-probe verdict. `--spans-json` with `--atomic` is refused, as is either with `--raw` or `--diary`, since a raw-only write stores no graph row for spans to cut and nothing for a probe to retrieve.

### 9. Nothing can forge a plan

The five structure keys (`agent_spans`, `agent_atomic`, `memory_probes`, `probe_rehearsal`, `probe_last_replay`) are server-owned and stripped from every incoming metadata bag: in `add()` on create, in the route on update, and in `_bulk_create_metadata` on the batch path. A surface that forwards a request body cannot plant a plan nothing validated, and cannot hand itself a passing rehearsal receipt no search produced.

### 10. Bulk create refuses all three fields

`POST /entities/bulk` reuses `EntityCreate`, so it inherited the new fields the moment they existed and would have accepted them while honoring none. That path writes rows itself and enqueues `project_memory_batch`, which extracts memory entities and never mints passages, so a stored plan would have no cutter to read it and a probe would have nothing searchable to rehearse against.

All three are refused with a 422 naming the field and pointing at `POST /entities`, rather than validated and stored as a no-op. The metadata strip still applies there, since a forged plan is a different concern from a declared one.

## 🗄️ Schema

No migration. Graph schema version stays at 17. Every new field lives in the entity's `metadata`, which is the `attributes` column and already `FLEXIBLE`, confirmed by reading the stored rows back off a live SurrealDB 3.2.3 during validation.

## 🧪 Validation

Automated gates at `e1e8e2ea`:

- Root `moon run :check` → 55 tasks completed, no failures.
- `core:test` → 2171 passed, 14 skipped. `api:test` → 2056 passed, 5 skipped. `api:extended-test` → green. The full `apps/api` suite outside the gate's ignore list → 2206 passed, 5 skipped. `apps/cli` → 455 passed.
- `core:typecheck`, `api:typecheck`, `cli:typecheck` → all checks passed.

New unit coverage: the span validation matrix (valid tiling, overlap, gap, out of bounds, empty, single span, explicitly empty list, count at and over the cap, oversize span, oversize label, malformed payloads), atomic at and over the ceiling, probe caps and shapes, the metadata round trip and the forge guard, agent-planned projection (verbatim slices, identical stamping, labels reaching the body, threshold override, stale-plan fallback, no inheritance onto passages), a withdrawn plan not returning from the stale snapshot, a re-cut keeping a span written past a skipped index, the rehearsal receipt in all four statuses, validation firing before the verbatim write, the update truth table at the route, bulk refusal per field, and the replay job against rows carrying the real column and method names.

**Discriminating live probes.** Unit tests over a hand-shaped double are what hid the last two inert features in this campaign, and they hid three more here: the replay job's column names, its id column, and its client method were all wrong in ways only a live run surfaced. So both halves were exercised against an isolated stack, SurrealDB 3.2.3 in a container on port 8200 with a scratch data dir and the API on port 3500, separate from any shared dev store.

Write path:

| Probe | Result |
| --- | --- |
| (a) 2740-char memory with 4 agent spans and labels | 4 passages, every span byte-exact, `plan=agent`, `index=0..3/4`, `covers=True`, labels present in the stored bodies |
| (a) same body through the mechanical cutter | cuts at `[0, 714, 1420, 2117]` versus the agent's `[0, 722, 1317, 2066]`; every boundary differs, and the agent's second passage opens mid-word on `"cause\n\nThe token service..."` where the cutter opens on `"## Root cause"` |
| (b) `atomic: true` on the same 2740-char body | 0 passages, `agent_atomic: True` stored on the row |
| (c) probe sharing the memory's vocabulary | `retrievable`, rank 1, `matched_kind: parent`, receipt persisted to the row |
| (d) probe sharing no vocabulary with the memory | `absent`, rank `null`, so the rehearsal can fail and does |
| (e) length-preserving content update without spans | `agent_spans` gone from the row, 4 passages re-cut with `plan=mechanical` matching the cutter's own slices for the new body |
| (f) gap, overlap, partial, out-of-bounds plans and an 18,500-char atomic memory | 422 on all five, each with the precise message quoted above |

Replay job, run as a function against that populated store:

```
probe_last_replay before: None
job summary: {'memories': 2, 'probes_total': 4, 'probes_retrievable': 2, 'failures': 0}
probe_last_replay after:  {"surface": "replay", "total": 2, "retrievable": 1, "truncated": false,
                           "checked_at": "2026-08-03T20:20:42.984947+00:00", "probes": [
                             {"probe": "why did pgbouncer pool exhaustion time out checkout",
                              "status": "retrievable", "rank": 1, "matched_kind": "parent"},
                             {"probe": "alpaca wool fiber micron grading", "status": "absent"}]}
```

⚠️ Not covered: the CLI's `--spans-json`, `--atomic`, and `--probe` flags are proven by unit tests over the client call and by the REST layer they write through, not by a live CLI invocation. The bulk refusal is asserted at the guard rather than over HTTP.

## 🔍 What reviewers should focus on

- **`_resolved_update_structure` in `api/routes/entities.py`.** Walk the truth table: spans given, atomic given true, atomic given false, neither, each against content changed and unchanged. It has to write an explicit null for anything withdrawn, because MERGE preserves omissions.
- **The `MAX_PASSAGE_CONTENT_CHARS` trimming branch in `plan_entity_passages`.** It trims the breadcrumb, never the span text, and a validated span can no longer reach it. Worth confirming the second `continue` (which sets `covers_parent = False`) is genuinely unreachable for an agent plan.
- **Whether any write surface can land structure onto a row without validation.** Two funnels own the keys: `add()` for creates and `_resolved_update_structure` for updates. Bulk create refuses them and strips the bag. A third path that writes entity metadata without passing one of those would be the real defect here.
- **The retire sweep in `reproject_entity_passages`.** It now keys on the indices actually written, because the oversize-leaf branch can skip one and a count-based sweep deleted the span it had just minted.
- **The stale-plan fallback in `_plan_slices`.** It is the one place a plan is not honored, and the argument for it being a safety net rather than the forbidden silent fallback is the thing to disagree with if you are going to.
- **The atomic ceiling decision.** Above `MAX_PASSAGE_CONTENT_CHARS` an atomic memory is refused with a remedy rather than cut anyway, on the grounds that cutting anyway overrides an explicit instruction quietly. A concrete case where refusing is worse than ignoring would change that call.

Out of scope: retrieval-side ranking of agent-planned versus mechanical passages, `POST /memory/raw` (a raw-only write mints no graph row), and any reader change at all.

## 📌 Follow-ups

- A test for the replay job's queries against a populated store, alongside the first real per-org `self_retrievable_pct` reading.
- `enqueue_update_entity` and the arq `update_entity` job are now dead in a second way: the reprojection they uniquely carried has moved to the request path. Removing them is a separate cleanup, since other fields of that job may still be wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
