### PR TITLE
fix(retrieval): floor every HNSW search effort at the requested pool

### DIFF
--- a/apps/api/src/sibyl/persistence/surreal/content.py
+++ b/apps/api/src/sibyl/persistence/surreal/content.py
@@ -24,6 +24,7 @@ from sibyl.persistence.content_common import (
 )
 from sibyl_core.backends.surreal import SurrealContentClient
 from sibyl_core.backends.surreal.fulltext import build_fulltext_query
+from sibyl_core.backends.surreal.knn import knn_search_effort
 from sibyl_core.backends.surreal.records import (
     coerce_datetime as _coerce_datetime,
     coerce_uuid as _coerce_uuid,
@@ -669,6 +670,9 @@ def _combined_hybrid_score(vector_rank: int | None, lexical_rank: int | None) ->
     if lexical_rank is not None:
         score += _rrf_score(lexical_rank)
     return score
+
+
+_CONTENT_KNN_EF_FLOOR = 40
 
 
 def _search_candidate_limit(limit: int) -> int:
@@ -2311,6 +2315,7 @@ async def search_rag_chunks(
         return []
 
     candidate_limit = _search_candidate_limit(match_count)
+    knn_effort = knn_search_effort(candidate_limit, _CONTENT_KNN_EF_FLOOR)
     async with surreal_content_client() as client:
         sources = await _load_sources_for_search_scope(
             client,
@@ -2331,7 +2336,7 @@ async def search_rag_chunks(
             "(1 - vector::distance::knn()) AS score "
             "FROM document_chunks WHERE organization_id = $organization_id "
             "AND source_id INSIDE $source_ids "
-            f"AND embedding <|{candidate_limit}, 40|> $query_embedding"
+            f"AND embedding <|{candidate_limit}, {knn_effort}|> $query_embedding"
             ") WHERE score >= $similarity_threshold "
             "ORDER BY score DESC LIMIT $candidate_limit;",
             organization_id=str(organization_id),
@@ -2365,6 +2370,7 @@ async def search_code_example_chunks(
         return []
 
     candidate_limit = _search_candidate_limit(match_count)
+    knn_effort = knn_search_effort(candidate_limit, _CONTENT_KNN_EF_FLOOR)
     language_clause, language_params = _code_chunk_clause(language)
     async with surreal_content_client() as client:
         sources = await _load_sources_for_search_scope(
@@ -2387,7 +2393,7 @@ async def search_code_example_chunks(
             "FROM document_chunks WHERE organization_id = $organization_id "
             "AND source_id INSIDE $source_ids"
             f"{language_clause} "
-            f"AND embedding <|{candidate_limit}, 40|> $query_embedding "
+            f"AND embedding <|{candidate_limit}, {knn_effort}|> $query_embedding "
             ") "
             "ORDER BY score DESC LIMIT $candidate_limit;",
             organization_id=str(organization_id),
@@ -2426,6 +2432,7 @@ async def hybrid_search_chunks(
         return []
 
     candidate_limit = _search_candidate_limit(match_count)
+    knn_effort = knn_search_effort(candidate_limit, _CONTENT_KNN_EF_FLOOR)
     async with surreal_content_client() as client:
         sources = await _load_sources_for_search_scope(
             client,
@@ -2446,7 +2453,7 @@ async def hybrid_search_chunks(
             "(1 - vector::distance::knn()) AS score "
             "FROM document_chunks WHERE organization_id = $organization_id "
             "AND source_id INSIDE $source_ids "
-            f"AND embedding <|{candidate_limit}, 40|> $query_embedding"
+            f"AND embedding <|{candidate_limit}, {knn_effort}|> $query_embedding"
             ") WHERE score >= $similarity_threshold "
             "ORDER BY score DESC LIMIT $candidate_limit;",
             organization_id=str(organization_id),

--- a/apps/api/tests/test_content_runtime.py
+++ b/apps/api/tests/test_content_runtime.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import re
 from contextlib import asynccontextmanager
+from pathlib import Path
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
 
+import sibyl
 from sibyl.persistence import content_archive, content_common, content_runtime, settings_runtime
 from sibyl.persistence.surreal import content as surreal_content
 
@@ -686,3 +689,19 @@ async def test_surreal_chunk_searches_raise_knn_effort_to_the_candidate_pool(
     ]
     assert len(vector_queries) == 3
     assert all("embedding <|100, 100|> $query_embedding" in query for query in vector_queries)
+
+
+def test_every_api_knn_clause_takes_its_effort_from_the_helper() -> None:
+    # An HNSW read returns at most `ef` rows, so a literal effort in a
+    # `<|k, ef|>` clause silently truncates any pool deeper than the literal.
+    # Every clause in the app has to take its effort from knn_search_effort.
+    pattern = re.compile(r"<\|[^,|]+,\s*([^|]+)\|>")
+    offenders: list[tuple[str, str]] = []
+    for path in sorted(Path(sibyl.__file__).parent.rglob("*.py")):
+        # Whole-file scan rather than per-line: a clause wrapped across lines
+        # has to be caught too.
+        for match in pattern.finditer(path.read_text(encoding="utf-8")):
+            effort = " ".join(match.group(1).split())
+            if not effort.startswith("{") or not effort.rstrip("}").endswith("knn_effort"):
+                offenders.append((path.name, effort))
+    assert offenders == []

--- a/apps/api/tests/test_content_runtime.py
+++ b/apps/api/tests/test_content_runtime.py
@@ -616,3 +616,73 @@ async def test_surreal_hybrid_search_uses_direct_vector_and_fulltext_queries(
     assert "search::highlight('<mark>', '</mark>', 0) AS snippet" in lexical_query
     assert vector_params["source_ids"] == [str(source_id)]
     assert lexical_params["search_query"] == "auth"
+
+
+@pytest.mark.asyncio
+async def test_surreal_chunk_searches_raise_knn_effort_to_the_candidate_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A Surreal HNSW read returns at most `ef` rows, so the 100-candidate pool
+    # these lanes overfetch would silently come back at 40.
+    source_id = uuid4()
+    org_id = uuid4()
+
+    def fake_client_for_sources() -> FakeSurrealClient:
+        return FakeSurrealClient(
+            [
+                _query_result(
+                    [
+                        {
+                            "uuid": str(source_id),
+                            "organization_id": str(org_id),
+                            "name": "Docs",
+                            "url": "https://docs.example.com",
+                        }
+                    ]
+                ),
+                _raw_query_result([]),
+                _raw_query_result([]),
+                _query_result([]),
+            ]
+        )
+
+    clients: list[FakeSurrealClient] = []
+
+    @asynccontextmanager
+    async def fake_session():
+        client = fake_client_for_sources()
+        clients.append(client)
+        yield client
+
+    monkeypatch.setattr(surreal_content, "surreal_content_client", fake_session)
+
+    await surreal_content.search_rag_chunks(
+        None,
+        query_embedding=[0.1] * 1536,
+        organization_id=org_id,
+        similarity_threshold=0.5,
+        match_count=20,
+        source_name="Docs",
+    )
+    await surreal_content.search_code_example_chunks(
+        None,
+        query_embedding=[0.1] * 1536,
+        organization_id=org_id,
+        match_count=20,
+        source_id=source_id,
+    )
+    await surreal_content.hybrid_search_chunks(
+        None,
+        query_text="auth",
+        query_embedding=[0.1] * 1536,
+        organization_id=org_id,
+        similarity_threshold=0.5,
+        match_count=20,
+        source_name="Docs",
+    )
+
+    vector_queries = [
+        query for client in clients for query, _ in client.calls if "embedding <|" in query
+    ]
+    assert len(vector_queries) == 3
+    assert all("embedding <|100, 100|> $query_embedding" in query for query in vector_queries)

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -257,10 +257,15 @@ Vector index and reranking knobs. Changing HNSW parameters affects newly built i
 | ---------------------- | -------------------------------------- | ------------------------------------------------------- |
 | `SIBYL_GRAPH_HNSW_EFC` | `150`                                  | Surreal HNSW graph index EF-construction value          |
 | `SIBYL_GRAPH_HNSW_M`   | `12`                                   | Surreal HNSW index max connections per element          |
-| `SIBYL_GRAPH_KNN_EF`   | `40`                                   | Surreal KNN query effort for graph vector retrieval     |
+| `SIBYL_GRAPH_KNN_EF`   | `40`                                   | Floor on Surreal KNN query effort for graph vectors     |
 | `SIBYL_RERANK_ENABLED` | `false`                                | Cross-encoder reranking after RRF fusion                |
 | `SIBYL_RERANK_MODEL`   | `cross-encoder/ms-marco-MiniLM-L-6-v2` | Cross-encoder model for reranking                       |
 | `SIBYL_RERANK_TOP_K`   | `20`                                   | Top candidates to rerank; the rest pass through (1-100) |
+
+`SIBYL_GRAPH_KNN_EF` is a floor on search effort, not a ceiling. A Surreal HNSW read returns at most
+`ef` rows, so retrieval raises the effective effort to the candidate count a lane asked for whenever
+that pool runs deeper than the configured value. Lowering the setting therefore never truncates a
+result set; raising it only improves recall for shallow reads.
 
 Reranking requires the optional `reranking` extra (sentence-transformers). When the extra is not
 installed, the path degrades cleanly to the fused order instead of raising.

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/knn.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/knn.py
@@ -1,0 +1,15 @@
+"""SurrealDB KNN query helpers."""
+
+from __future__ import annotations
+
+
+def knn_search_effort(k: int, configured_ef: int) -> int:
+    """Return the search effort for a `<|k, ef|>` HNSW read.
+
+    An HNSW search keeps at most `ef` nodes in flight, so an effort below the
+    requested `k` truncates the read to `ef` rows and Surreal raises nothing.
+    The configured effort is a floor on search quality, never a ceiling on the
+    rows a caller asked for, so `k` raises it whenever the requested pool runs
+    deeper than the configuration.
+    """
+    return max(1, int(configured_ef), int(k))

--- a/packages/python/sibyl-core/src/sibyl_core/config.py
+++ b/packages/python/sibyl-core/src/sibyl_core/config.py
@@ -290,7 +290,11 @@ class CoreConfig(BaseSettings):
         default=40,
         ge=1,
         le=10_000,
-        description="Surreal KNN query effort for graph vector retrieval.",
+        description=(
+            "Floor on the Surreal KNN query effort for graph vector retrieval. An HNSW "
+            "read returns at most `ef` rows, so the effective effort is the larger of "
+            "this value and the candidate count the lane requested."
+        ),
     )
 
     # Retrieval: cross-encoder reranking (optional).

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/dedup.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/dedup.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 import numpy as np
 import structlog
 
+from sibyl_core.backends.surreal.knn import knn_search_effort
 from sibyl_core.config import settings
 from sibyl_core.models.entities import Entity
 from sibyl_core.services.graph import normalize_records
@@ -425,7 +426,7 @@ class EntityDeduplicator:
                 )
             return pairs
 
-        knn_effort = max(1, int(settings.graph_knn_ef))
+        knn_effort = knn_search_effort(candidate_limit, settings.graph_knn_ef)
         statements: list[str] = []
         params: dict[str, Any] = {
             "group_id": group_id,
@@ -550,7 +551,7 @@ class EntityDeduplicator:
             param_prefix="scope",
         )
 
-        knn_effort = max(1, int(settings.graph_knn_ef))
+        knn_effort = knn_search_effort(candidate_limit, settings.graph_knn_ef)
         rows = normalize_records(
             await execute_query(
                 """

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -24,6 +24,7 @@ from sibyl_core.backends.surreal.fulltext import (
     build_fulltext_terms,
     build_match_disjunction,
 )
+from sibyl_core.backends.surreal.knn import knn_search_effort
 from sibyl_core.backends.surreal.records import SurrealQueryError, query_error
 from sibyl_core.config import core_config
 from sibyl_core.embeddings.providers import EmbeddingMetadata, EmbeddingProvider
@@ -854,15 +855,6 @@ def _project_filter_selectivity(
     return 1.0 / len(accessible_projects)
 
 
-def _graph_knn_effort(candidate_limit: int) -> int:
-    # An HNSW search keeps at most `ef` nodes in flight, so an effort below the
-    # requested `k` truncates the read to `ef` rows and no error is raised. The
-    # configured effort is a floor on search quality, never a ceiling on the
-    # candidates a lane was budgeted, so `k` raises it when the seed budget runs
-    # deeper than the configuration.
-    return max(1, int(core_config.graph_knn_ef), int(candidate_limit))
-
-
 def _explicit_project_denied(plan: RetrievalPlan) -> bool:
     return bool(plan.project and not _authorized_project_ids(plan))
 
@@ -1227,7 +1219,7 @@ async def _node_vector_candidates(
         return []
     filter_clauses, filter_params = _node_filter_clause(search_filter)
     candidate_limit = max(int(limit), 1)
-    knn_effort = _graph_knn_effort(candidate_limit)
+    knn_effort = knn_search_effort(candidate_limit, core_config.graph_knn_ef)
     rows = await _execute_query_records(
         client,
         """
@@ -1275,7 +1267,7 @@ async def _edge_vector_candidates(
         return []
     filter_clauses, filter_params = _edge_filter_clause(search_filter)
     candidate_limit = max(int(limit), 1)
-    knn_effort = _graph_knn_effort(candidate_limit)
+    knn_effort = knn_search_effort(candidate_limit, core_config.graph_knn_ef)
     rows = await _execute_query_records(
         client,
         "SELECT * FROM ("

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -20,6 +20,7 @@ from sibyl_core.backends.surreal.fulltext import (
     build_fulltext_terms,
     build_match_disjunction,
 )
+from sibyl_core.backends.surreal.knn import knn_search_effort
 from sibyl_core.backends.surreal.records import raise_on_error
 from sibyl_core.backends.surreal.schema import bootstrap_schema
 from sibyl_core.config import settings
@@ -729,7 +730,7 @@ class EntityManager:
         type_values = [entity_type.value for entity_type in entity_types or ()]
         type_clause = "AND entity_type IN $entity_types" if type_values else ""
         candidate_limit = min(max(int(limit) * 4, 32), 200)
-        knn_effort = max(1, int(settings.graph_knn_ef))
+        knn_effort = knn_search_effort(candidate_limit, settings.graph_knn_ef)
         try:
             embeddings = await _embed_texts_with_timeout(
                 self._embedding_provider,

--- a/packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/surreal_content.py
@@ -21,6 +21,7 @@ from sibyl_core.backends.surreal.fulltext import (
     build_fulltext_terms,
     build_match_disjunction,
 )
+from sibyl_core.backends.surreal.knn import knn_search_effort
 from sibyl_core.config import settings
 from sibyl_core.embeddings.providers import (
     DeterministicEmbeddingProvider,
@@ -45,6 +46,7 @@ from sibyl_core.models.reflection import (
 )
 from sibyl_core.utils.resilience import with_timeout
 
+_CONTENT_KNN_EF_FLOOR = 40
 _DEFAULT_BATCH_SIZE = 128
 _DIRECT_SEARCH_QUERY_TIMEOUT_SECONDS = 3.0
 _LIFECYCLE_FILTER_OVERFETCH_FACTOR = 4
@@ -2226,6 +2228,7 @@ async def _recall_raw_memory_vector(
     limit: int,
 ) -> list[RawMemory]:
     candidate_limit = max(limit * _LIFECYCLE_FILTER_OVERFETCH_FACTOR, limit)
+    knn_effort = knn_search_effort(candidate_limit, _CONTENT_KNN_EF_FLOOR)
     rows = await with_timeout(
         _select_many_raw(
             client,
@@ -2233,7 +2236,7 @@ async def _recall_raw_memory_vector(
             f"SELECT {_RAW_MEMORY_RECALL_FIELDS}, "
             "(1 - vector::distance::knn()) AS score "
             f"FROM raw_captures WHERE {where_clause} "
-            f"AND embedding <|{candidate_limit}, 40|> $query_embedding"
+            f"AND embedding <|{candidate_limit}, {knn_effort}|> $query_embedding"
             ") ORDER BY score DESC, captured_at DESC LIMIT $candidate_limit;",
             **params,
             query_embedding=query_embedding,
@@ -3442,6 +3445,7 @@ async def search_document_chunks(
         return [], []
 
     candidate_limit = _document_search_candidate_limit(limit)
+    knn_effort = knn_search_effort(candidate_limit, _CONTENT_KNN_EF_FLOOR)
     language_clause, language_params = _document_language_clause(language)
     lexical_query_text = build_fulltext_query(query_text)
     errors: list[str] = []
@@ -3482,7 +3486,7 @@ async def search_document_chunks(
                         "FROM document_chunks WHERE organization_id = $organization_id "
                         "AND source_id INSIDE $source_ids"
                         f"{language_clause} "
-                        f"AND embedding <|{candidate_limit}, 40|> $query_embedding"
+                        f"AND embedding <|{candidate_limit}, {knn_effort}|> $query_embedding"
                         ") WHERE score >= $similarity_threshold "
                         "ORDER BY score DESC LIMIT $candidate_limit;",
                         **vector_params,

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -1140,6 +1140,34 @@ async def test_native_entity_manager_search_uses_configured_knn_effort(
 
 
 @pytest.mark.asyncio
+async def test_native_entity_manager_search_raises_knn_effort_to_the_candidate_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The vector lane overfetches 4x the request, so limit 50 asks for a 200-row
+    # pool; an HNSW read returns at most `ef` rows, so the effort has to follow.
+    client = _EmbeddingWriteClient()
+    provider = DeterministicEmbeddingProvider(
+        EmbeddingMetadata(
+            provider="deterministic",
+            model="unit-test",
+            dimensions=4,
+            cache_namespace="native-graph-test",
+            tokenizer_estimate_method="unit-test",
+        )
+    )
+    manager = EntityManager(
+        cast(SurrealGraphClient, client),
+        group_id=client.group_id,
+        embedding_provider=provider,
+    )
+    monkeypatch.setattr(graph_module.settings, "graph_knn_ef", 40)
+
+    await manager.search(query="deep vector pool", limit=50)
+
+    assert any("name_embedding <|200, 200|> $query_embedding" in query for query, _ in client.calls)
+
+
+@pytest.mark.asyncio
 async def test_native_entity_manager_search_projections_omit_embeddings() -> None:
     client = _EmbeddingWriteClient()
     manager = EntityManager(cast(SurrealGraphClient, client), group_id=client.group_id)

--- a/packages/python/sibyl-core/tests/test_retrieval_advanced.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_advanced.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import numpy as np
 import pytest
 
+import sibyl_core.retrieval.dedup as dedup_module
 import sibyl_core.retrieval.hybrid as hybrid_module
 import sibyl_core.retrieval.query_ranking as query_ranking_module
 import sibyl_core.retrieval.search as search_module
@@ -2074,6 +2075,80 @@ class TestEntityDeduplicatorFindDuplicates:
         assert matches["incoming_beta"].entity2_id == "existing_beta"
         assert len(client.calls) == 2
         assert all(query.count("name_embedding <|") == 1 for query, _ in client.calls)
+
+    @pytest.mark.asyncio
+    async def test_dedup_lanes_raise_knn_effort_to_the_candidate_pool(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # An HNSW read returns at most `ef` rows, so the 100-candidate pool the
+        # shipped batch size asks for would silently come back at 40.
+        monkeypatch.setattr(dedup_module.settings, "graph_knn_ef", 40)
+        incoming = [
+            Entity(
+                id="incoming_alpha",
+                name="Alpha",
+                entity_type=EntityType.TOPIC,
+                embedding=[1.0, 0.0],
+            ),
+            Entity(
+                id="incoming_beta",
+                name="Beta",
+                entity_type=EntityType.TOPIC,
+                embedding=[0.0, 1.0],
+            ),
+        ]
+        batch_client = HnswDedupClient()
+        batch_dedup = EntityDeduplicator(
+            client=batch_client,  # type: ignore[arg-type]
+            entity_manager=MockEntityManagerForDedup(),
+        )
+        fallback_client = HnswFallbackDedupClient()
+        fallback_dedup = EntityDeduplicator(
+            client=fallback_client,  # type: ignore[arg-type]
+            entity_manager=MockEntityManagerForDedup(),
+        )
+
+        await batch_dedup.resolve_existing_entities(incoming)
+        await fallback_dedup.resolve_existing_entities(incoming)
+
+        batch_query = batch_client.raw_calls[0][0]
+        assert batch_query.count("name_embedding <|100, 100|>") == 2
+        assert all("name_embedding <|100, 100|>" in query for query, _ in fallback_client.calls)
+
+    @pytest.mark.asyncio
+    async def test_dedup_lanes_keep_configured_knn_effort_for_shallow_pools(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A pool shallower than the configured effort must not lower it.
+        monkeypatch.setattr(dedup_module.settings, "graph_knn_ef", 40)
+        shallow_config = DedupConfig(batch_size=8, same_type_only=True, min_name_overlap=0.0)
+        client = HnswFallbackDedupClient()
+        dedup = EntityDeduplicator(
+            client=client,  # type: ignore[arg-type]
+            entity_manager=MockEntityManagerForDedup(),
+            config=shallow_config,
+        )
+
+        await dedup.resolve_existing_entities(
+            [
+                Entity(
+                    id="incoming_alpha",
+                    name="Alpha",
+                    entity_type=EntityType.TOPIC,
+                    embedding=[1.0, 0.0],
+                ),
+                Entity(
+                    id="incoming_beta",
+                    name="Beta",
+                    entity_type=EntityType.TOPIC,
+                    embedding=[0.0, 1.0],
+                ),
+            ]
+        )
+
+        assert all("name_embedding <|8, 40|>" in query for query, _ in client.calls)
 
     @pytest.mark.asyncio
     async def test_resolve_existing_entities_executes_surreal_hnsw_batch_query(

--- a/packages/python/sibyl-core/tests/test_search.py
+++ b/packages/python/sibyl-core/tests/test_search.py
@@ -2595,7 +2595,7 @@ async def test_vector_lanes_raise_knn_effort_to_the_seed_budget(
     assert plan.candidate_limits.node_vector == MAX_RETRIEVAL_LIMIT
     assert f"name_embedding <|{MAX_RETRIEVAL_LIMIT}, {MAX_RETRIEVAL_LIMIT}|>" in node_query
     assert f"fact_embedding <|{MAX_RETRIEVAL_LIMIT}, {MAX_RETRIEVAL_LIMIT}|>" in edge_query
-    assert search_module._graph_knn_effort(8) == 40
+    assert search_module.knn_search_effort(8, 40) == 40
 
 
 def test_node_record_candidates_keep_top_level_provenance_metadata() -> None:

--- a/packages/python/sibyl-core/tests/test_services_surreal_content.py
+++ b/packages/python/sibyl-core/tests/test_services_surreal_content.py
@@ -1001,6 +1001,38 @@ class TestSurrealContentHelpers:
         assert document_params["document_ids"] == ["doc-1"]
 
     @pytest.mark.asyncio
+    async def test_search_document_chunks_raises_knn_effort_to_the_candidate_pool(self) -> None:
+        # Document search overfetches 5x the request up to 100 candidates, and
+        # an HNSW read returns at most `ef` rows, so the effort has to follow.
+        fake_client = FakeClient(
+            [
+                _query_result([{"uuid": "src-1", "organization_id": "org-1", "name": "Docs"}]),
+                _raw_query_result([]),
+                _query_result([]),
+                _query_result([]),
+            ]
+        )
+
+        @asynccontextmanager
+        async def fake_session():
+            yield fake_client
+
+        from sibyl_core.services import surreal_content as content_service
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(content_service, "surreal_content_client", fake_session)
+            await search_document_chunks(
+                organization_id="org-1",
+                query_text="alpha",
+                query_embedding=[1.0, 0.0],
+                source_id="src-1",
+                limit=20,
+            )
+
+        vector_query = next(query for query, _ in fake_client.calls if "embedding <|" in query)
+        assert "embedding <|100, 100|> $query_embedding" in vector_query
+
+    @pytest.mark.asyncio
     async def test_search_document_chunks_filters_source_name_in_surreal(self) -> None:
         fake_client = FakeClient(
             [
@@ -2571,6 +2603,35 @@ class TestSurrealContentHelpers:
         assert "embedding <|8, 40|> $query_embedding" in vector_query
         assert vector_params["query_embedding"] == [1.0, 0.0]
         assert all(memory.score > 0 for memory in memories)
+
+    @pytest.mark.asyncio
+    async def test_recall_raw_memory_raises_knn_effort_to_the_candidate_pool(self) -> None:
+        # Raw memory recall overfetches 4x the request, so limit 50 asks for a
+        # 200-row pool; an HNSW read returns at most `ef` rows, so the effort
+        # has to follow the pool or the lane silently reads 40.
+        fake_client = FakeClient([_query_result([]), _raw_query_result([]), _query_result([])])
+
+        @asynccontextmanager
+        async def fake_session():
+            yield fake_client
+
+        async def query_embedding(_query: str):
+            return [1.0, 0.0]
+
+        from sibyl_core.services import surreal_content as content_service
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(content_service, "surreal_content_client", fake_session)
+            monkeypatch.setattr(content_service, "_raw_memory_query_embedding", query_embedding)
+            await recall_raw_memory(
+                organization_id="org-1",
+                principal_id="user-a",
+                query="surrealdb graph",
+                limit=50,
+            )
+
+        vector_query = next(query for query, _ in fake_client.calls if "embedding <|" in query)
+        assert "embedding <|200, 200|> $query_embedding" in vector_query
 
     @pytest.mark.asyncio
     async def test_recall_raw_memory_falls_back_when_vector_recall_fails(self) -> None:

--- a/packages/python/sibyl-core/tests/test_surreal_knn.py
+++ b/packages/python/sibyl-core/tests/test_surreal_knn.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import random
+import re
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+import sibyl_core
 from sibyl_core.backends.surreal.knn import knn_search_effort
 from sibyl_core.backends.surreal.schema import EMBEDDING_DIM
 from sibyl_core.config import settings
@@ -46,6 +49,32 @@ def test_default_configuration_leaves_deep_pools_short_without_the_floor() -> No
     assert settings.graph_knn_ef == 40
     assert knn_search_effort(100, settings.graph_knn_ef) == 100
     assert knn_search_effort(8, settings.graph_knn_ef) == 40
+
+
+KNN_CLAUSE_PATTERN = re.compile(r"<\|[^,|]+,\s*([^|]+)\|>")
+
+
+def knn_clause_offenders(root: Path, allowed_files: set[str]) -> list[tuple[str, str]]:
+    """Return (file, effort) for `<|k, ef|>` clauses whose effort skips the helper."""
+    offenders: list[tuple[str, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        if path.name in allowed_files:
+            continue
+        # Whole-file scan rather than per-line: a clause wrapped across lines
+        # has to be caught too.
+        for match in KNN_CLAUSE_PATTERN.finditer(path.read_text(encoding="utf-8")):
+            effort = " ".join(match.group(1).split())
+            if not effort.startswith("{") or not effort.rstrip("}").endswith("knn_effort"):
+                offenders.append((path.name, effort))
+    return offenders
+
+
+def test_every_core_knn_clause_takes_its_effort_from_the_helper() -> None:
+    # The defect this module guards is a literal or unfloored effort reaching a
+    # `<|k, ef|>` clause. knn.py documents the shape and query_plan_probes.py
+    # measures explicit efforts on purpose, so both are exempt.
+    root = Path(sibyl_core.__file__).parent
+    assert knn_clause_offenders(root, {"knn.py", "query_plan_probes.py"}) == []
 
 
 async def _seed_entities(client: SurrealGraphClient, count: int) -> None:

--- a/packages/python/sibyl-core/tests/test_surreal_knn.py
+++ b/packages/python/sibyl-core/tests/test_surreal_knn.py
@@ -1,0 +1,159 @@
+"""Effective KNN search effort for Surreal HNSW reads."""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from sibyl_core.backends.surreal.knn import knn_search_effort
+from sibyl_core.backends.surreal.schema import EMBEDDING_DIM
+from sibyl_core.config import settings
+from sibyl_core.embeddings.providers import DeterministicEmbeddingProvider, EmbeddingMetadata
+from sibyl_core.retrieval.dedup import DedupConfig, EntityDeduplicator
+from sibyl_core.services.graph import (
+    EntityManager,
+    SurrealGraphClient,
+    normalize_records,
+    prepare_graph_schema,
+)
+
+
+def test_effort_rises_to_the_requested_pool_depth() -> None:
+    # An HNSW read returns at most `ef` rows, so a pool deeper than the
+    # configured effort has to raise it or the read comes back short.
+    assert knn_search_effort(100, 40) == 100
+    assert knn_search_effort(200, 40) == 200
+
+
+def test_effort_keeps_the_configured_floor_for_shallow_pools() -> None:
+    # The configured effort is a quality floor, so a shallow pool must not
+    # lower it.
+    assert knn_search_effort(8, 40) == 40
+    assert knn_search_effort(32, 88) == 88
+
+
+def test_effort_stays_positive_for_degenerate_pools() -> None:
+    assert knn_search_effort(0, 1) == 1
+    assert knn_search_effort(-5, 1) == 1
+
+
+def test_default_configuration_leaves_deep_pools_short_without_the_floor() -> None:
+    # Pins the shipped default the fix has to survive: at ef 40 a 100-row pool
+    # is only fully served because `k` raises the effort.
+    assert settings.graph_knn_ef == 40
+    assert knn_search_effort(100, settings.graph_knn_ef) == 100
+    assert knn_search_effort(8, settings.graph_knn_ef) == 40
+
+
+async def _seed_entities(client: SurrealGraphClient, count: int) -> None:
+    """Insert `count` HNSW-indexed entity rows with distinct embeddings."""
+    rng = random.Random(count)
+    rows = [
+        {
+            "uuid": f"knn_pool_{index:04d}",
+            "group_id": client.group_id,
+            "name": f"Pool member {index}",
+            "entity_type": "topic",
+            "name_embedding": [rng.random() for _ in range(EMBEDDING_DIM)],
+            "created_at": datetime.now(UTC),
+        }
+        for index in range(count)
+    ]
+    await client.execute_query("INSERT INTO entity $rows;", rows=rows)
+
+
+def _knn_shape(query: str) -> str:
+    return "<|" + query.split("name_embedding <|")[1].split("|>")[0] + "|>"
+
+
+@pytest.mark.asyncio
+async def test_dedup_lanes_read_the_whole_candidate_pool_on_the_embedded_engine() -> None:
+    # The dedup pool is 100 candidates at the shipped batch size, well past the
+    # configured effort of 40, so an unfloored effort silently returns 40 rows.
+    client = SurrealGraphClient(group_id="org-knn-dedup-pool", url="memory://")
+    seen: list[tuple[str, int]] = []
+    try:
+        await prepare_graph_schema(client)
+        await _seed_entities(client, 150)
+        manager = EntityManager(client, group_id=client.group_id)
+        dedup = EntityDeduplicator(
+            client=client,
+            entity_manager=manager,
+            config=DedupConfig(batch_size=100, same_type_only=True, min_name_overlap=0.0),
+        )
+
+        async def counting_query(query: str, **params: object) -> Any:
+            rows = await client.execute_query(query, **params)
+            seen.append((_knn_shape(query), len(normalize_records(rows))))
+            return rows
+
+        rng = random.Random(5)
+        seeds = [
+            (
+                f"knn_seed_{index}",
+                f"Seed {index}",
+                "topic",
+                [rng.random() for _ in range(EMBEDDING_DIM)],
+            )
+            for index in range(2)
+        ]
+
+        await dedup._find_hnsw_candidates_for_seeds(
+            seeds[:1],
+            group_id=client.group_id,
+            entity_types=["topic"],
+            threshold=-1.0,
+            seen_pairs=set(),
+            execute_query=counting_query,
+            execute_query_raw=counting_query,
+        )
+        batch_lane = seen[-1]
+
+        await dedup._find_hnsw_candidates_for_seeds(
+            seeds,
+            group_id=client.group_id,
+            entity_types=["topic"],
+            threshold=-1.0,
+            seen_pairs=set(),
+            execute_query=counting_query,
+            execute_query_raw=None,
+        )
+        per_seed_lanes = seen[-2:]
+    finally:
+        await client.close()
+
+    assert batch_lane == ("<|100, 100|>", 100)
+    assert per_seed_lanes == [("<|100, 100|>", 100), ("<|100, 100|>", 100)]
+
+
+@pytest.mark.asyncio
+async def test_entity_search_vector_lane_reads_the_whole_pool_on_the_embedded_engine() -> None:
+    # EntityManager.search overfetches 4x the request, so limit 50 asks for a
+    # 200-row pool against a configured effort of 40.
+    client = SurrealGraphClient(group_id="org-knn-entity-pool", url="memory://")
+    provider = DeterministicEmbeddingProvider(
+        EmbeddingMetadata(
+            provider="deterministic",
+            model="unit-test",
+            dimensions=EMBEDDING_DIM,
+            cache_namespace="knn-pool-test",
+            tokenizer_estimate_method="utf8-byte-length",
+        )
+    )
+    try:
+        await prepare_graph_schema(client)
+        await _seed_entities(client, 250)
+        manager = EntityManager(
+            client,
+            group_id=client.group_id,
+            embedding_provider=provider,
+        )
+
+        results = await manager._vector_search(query="pool depth", entity_types=None, limit=50)
+    finally:
+        await client.close()
+
+    assert len(results) == 200


### PR DESCRIPTION
# 🎯 Finish the KNN effort class-kill: every HNSW read now gets the pool it asked for

> Follows #328, which floored the effort for the two context vector lanes. An adversarial
> verification pass on that PR found the same defect still armed at three more sites, and a sweep
> for this PR found five more. All eight are fixed here, behind one shared helper.

## 💡 What this is

A Surreal HNSW search keeps at most `ef` candidates in flight, so `<|k, ef|>` with `ef < k` returns
`ef` rows and raises nothing at all. The naive reading of the setting is what makes this bite:
`SIBYL_GRAPH_KNN_EF` looks like a quality dial you can tune down for latency, when it is really a
hard cap on how many rows any read can return. Every lane in Sibyl that overfetches a candidate pool
and then filters it was silently getting 40 rows.

This PR makes the effort follow the pool at every KNN read in the codebase. The configured value
becomes a floor on search quality, never a ceiling on rows, so `graph_knn_ef` can still be raised to
buy recall on shallow reads and can no longer truncate a deep one.

## 🤔 Why we need it and what it replaces

PR #328 fixed `_node_vector_candidates` and `_edge_vector_candidates` in
`packages/python/sibyl-core/src/sibyl_core/retrieval/search.py` with a local `_graph_knn_effort`
helper. The pattern it replaced, `max(1, int(settings.graph_knn_ef))`, was still live at three more
sites, all reachable at the shipped defaults:

| Site                                                | Pool depth (`k`)                    | Rows returned at ef 40 |
| --------------------------------------------------- | ----------------------------------- | ---------------------- |
| `retrieval/dedup.py` batch candidate lane           | 100 at the default `batch_size`     | 40                     |
| `retrieval/dedup.py` per-seed candidate lane        | 100 at the default `batch_size`     | 40                     |
| `services/graph.py` `_vector_search`                | `min(max(limit * 4, 32), 200)`      | 40 above limit 10      |

A grep for the config name is what made #328 look complete, and it is also what hid the rest of the
class. Five content reads never read the setting at all: they hardcoded `40` as a literal, so the
name never appeared near them.

| Site                                                        | Pool depth (`k`)                | Rows returned at ef 40 |
| ----------------------------------------------------------- | ------------------------------- | ---------------------- |
| `services/surreal_content.py` `_recall_raw_memory_vector`   | `limit * 4`, up to 200          | 40                     |
| `services/surreal_content.py` document chunk search         | `min(max(limit * 5, 1), 100)`   | 40 above limit 8       |
| `persistence/surreal/content.py` `search_rag_chunks`        | `min(max(limit * 5, 1), 100)`   | 40 above limit 8       |
| `persistence/surreal/content.py` `search_code_example_chunks` | `min(max(limit * 5, 1), 100)` | 40 above limit 8       |
| `persistence/surreal/content.py` `hybrid_search_chunks`     | `min(max(limit * 5, 1), 100)`   | 40 above limit 8       |

Raw memory recall is the one that stings: it sits in the default memory loop, and at the retrieval
ceiling of 50 it asked Surreal for 200 candidates and scored 40 of them.

Two sites are deliberately left alone because they are already correct.
`services/graph.py` `_fallback_text_search` uses a plain `LIMIT` with no KNN clause, and
`backends/surreal/query_plan_probes.py` takes its effort as an explicit parameter so a probe can
measure any effort it likes.

## 🎯 The invariant

Anchor the review on one property: for every `<|k, ef|>` in the codebase, `ef >= k`. There is now
exactly one expression that can produce an effort, and it cannot return a value below `k`.

## 🛠️ How it works

### 1. One helper, in the Surreal backend package

`packages/python/sibyl-core/src/sibyl_core/backends/surreal/knn.py` holds the whole rule:

```python
def knn_search_effort(k: int, configured_ef: int) -> int:
    return max(1, int(configured_ef), int(k))
```

It sits next to `fulltext.py` because both own a piece of Surreal query-shape semantics that callers
should not have to re-derive. It stays a pure function of both inputs rather than reading
`settings.graph_knn_ef` itself, which buys two things: each lane keeps its config read at the lane
(so `search.py` still reads `core_config`, `dedup.py` and `graph.py` still read `settings`, and the
existing monkeypatch-based tests keep reaching the value they always did), and the content lanes can
pass their own floor.

### 2. The graph lanes

Five call sites now route through it. Both vector lanes in `retrieval/search.py` pass
`core_config.graph_knn_ef` (the `_graph_knn_effort` wrapper #328 added is gone, its doc comment
moved onto the shared function), both dedup lanes in `retrieval/dedup.py` pass `settings`, and
`_vector_search` in `services/graph.py` does the same.

### 3. The content lanes

The five content reads keep their literal floor, now named `_CONTENT_KNN_EF_FLOOR = 40` in each
module, and pass it through the same helper. Shallow reads emit byte-identical SQL to before, so a
RAG search at `match_count=5` still ships `<|25, 40|>`; only reads whose pool outruns 40 change.

### 4. A guard against the ninth site

Two tests walk every module under `sibyl_core` and `sibyl`, find each `<|k, ef|>` clause, and require
its effort to be a `knn_effort` binding. A literal or any other expression fails the suite and names
the file and the effort it found. Both sweeps behind this branch missed sites for mechanical reasons
(the first searched for the config name and never saw the literals; the second only found them by
scanning the clause syntax), so the scan is what actually closes the class rather than the eight
individual fixes. `knn.py` is exempt because its docstring quotes the shape, and
`query_plan_probes.py` is exempt because measuring an explicit effort is its purpose.

### 5. The setting's documented meaning

`config.py` and `docs/deployment/environment.md` both described `graph_knn_ef` as "Surreal KNN query
effort for graph vector retrieval", which no longer says what it does. Both now state the floor
semantics, and the deployment doc spells out the consequence: lowering the value cannot truncate a
result set, and raising it only helps reads shallower than the value itself.

## 🧪 Validation

On `021d9d8b`: `moon run core:check api:check` green, with `core:test` 2142 passed / 14 skipped,
`api:test` 2038 passed / 5 skipped, and lint plus typecheck clean on both (`core:lint` 271 files
formatted, `api:lint` 384). An earlier full-tree run on this branch also had `cli:test` 455 passed and
the four root gate suites green (reflection quality 8, auth session 8, adapter ingest 9, enterprise
readiness).

**Embedded-engine row counts, real schema.** A 250-row HNSW table built through
`prepare_graph_schema` (dimension 1024, cosine, EFC 150, M 12), driven through the actual code paths
rather than hand-written SQL:

| Lane                                     | Shape before | Rows before | Shape after     | Rows after |
| ---------------------------------------- | ------------ | ----------- | --------------- | ---------- |
| `dedup.candidates` (per-seed)            | `<\|100, 40\|>` | 40       | `<\|100, 100\|>` | 100     |
| `dedup.candidates.batch`                 | `<\|100, 40\|>` | 40       | `<\|100, 100\|>` | 100     |
| `entity.search.vector` at limit 50       | `<\|200, 40\|>` | 40       | `<\|200, 200\|>` | 200     |

The content tables reproduce it on their own index parameters (dimension 1536, cosine, EFC 150,
M 12): `document_chunks` and `raw_captures` each returned 40 of 100 and 40 of 200 rows at the old
effort, and the full pool once the effort follows `k`.

**Live confirmation and the latency cost.** Against the dev graph (7223 embedded entities, read-only,
nine interleaved repetitions per arm), the shipped node-vector query shape at `k=50`:

| Effective ef | Rows | Median  | Range           |
| ------------ | ---- | ------- | --------------- |
| 40           | 40   | 24.5 ms | 21.2 to 30.1 ms |
| 50           | 50   | 30.9 ms | 27.7 to 33.9 ms |

The delta is +6.3 ms median for ten more rows, and the ef 40 arm is the defect visible on live data:
a lane that asked for 50 candidates got 40. The absolute numbers ran on a heavily loaded machine, so
treat the delta as the signal rather than the raw milliseconds.

**Mutation resistance.** Both plausible regressions fail loudly. Reverting the helper to
`max(1, ef)` fails 4 tests in `test_surreal_knn.py` plus both dedup lane tests, the graph lane test,
the search lane test from #328, and all three content lane tests. Reducing it to `max(1, k)` fails
the shallow-pool assertions, including the pre-existing
`test_native_entity_manager_search_uses_configured_knn_effort`, which pins `<|32, 88|>`.

**The guard, proven by planting a violation.** A literal effort written back into
`services/graph.py` fails the scan with `assert [('graph.py', '40')] == []`, and the same literal
wrapped across two lines fails identically.

**CI.** Every required check is green on this head: Build, E2E, Package Tests, Static Checks,
Dependency Audit, Live SurrealDB 3.x Ingestion, and the LongMemEval local embedding smoke. The five
skipped jobs are the dispatch-only eval and Storybook runs.

**Web.** `moon run web:check` is green as well: `web:test` 40 of 40 files and 161 of 161 tests,
`web:lint` clean across 275 files, `web:typecheck` clean. No file under `apps/web` is touched here.

⚠️ `test_default_memory_loop.py` timed out twice during this work on a 60-second subprocess boot
budget while the machine sat at load average 73, which reads as a failure and is not one: both of its
tests pass in the runs above, and they fail the same way with this branch's changes stashed.

## 🔍 What reviewers should focus on

- The latency trade at the deep end. A dedup pass now runs HNSW at ef 100 instead of ef 40, and a
  document search at limit 20 does the same. The +6.3 ms measured at ef 50 is the only live number
  in hand, and the wider gaps (ef 200 versus 40) are unmeasured on production-sized data.
- Whether the content lanes should keep a per-module literal floor. `_CONTENT_KNN_EF_FLOOR = 40`
  preserves today's behavior exactly, but a `content_knn_ef` setting would give operators the same
  dial the graph lanes have. That is a config-surface decision, so this PR does not make it.
- Whether a source-scanning guard earns its keep. The scan reads whole files rather than lines, so it
  catches a wrapped clause, and it names the file and effort it rejected. A reviewer who dislikes
  this style of test should say so now rather than after the next sweep.
- The eval workflow records `graph_knn_ef` as run metadata (`.github/workflows/eval.yml` lines 457,
  657, and 955) while pinning `SIBYL_GRAPH_KNN_EF=40`. That metadata now describes a floor rather
  than the effort a run actually used, since the effective effort rises with pool depth. Benchmark
  receipts from before and after this change are comparable in configuration but not in retrieval
  depth. The workflow is untouched here on purpose.
- The one behavior change that is not a row count: `search.py` no longer has a `_graph_knn_effort`
  function, so anything reaching for it by name outside the package would break. Nothing in the
  repo does.

## 📌 Follow-ups (deliberate non-fixes)

- The eval metadata caveat above wants either a recorded effective effort per query or a note in the
  benchmark receipts, in whichever lane owns eval provenance. It is not fixed here because the eval
  workflow belongs to another lane.
- The content lanes could take a configurable floor instead of `_CONTENT_KNN_EF_FLOOR`. Today's
  literal preserves current behavior exactly, which is the right default for a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

