### PR TITLE
feat(retrieval): writer-declared retrieval keys and the exact-match arm

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -69,6 +69,7 @@ from sibyl_core.auth.memory_policy import (
     private_scope_granted_for,
     stamp_memory_scope_metadata,
 )
+from sibyl_core.memory_pipeline.retrieval_keys import normalize_retrieval_keys
 from sibyl_core.memory_pipeline.structure import strip_structure_metadata
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.projection import (
@@ -381,7 +382,7 @@ def _bulk_create_metadata(
 ) -> dict[str, Any]:
     request_metadata = strip_structure_metadata(entity.metadata)
     project_id = str(request_metadata.get("project_id") or "").strip()
-    return {
+    metadata: dict[str, Any] = {
         "category": entity.category,
         "languages": entity.languages or [],
         "tags": entity.tags or [],
@@ -393,6 +394,15 @@ def _bulk_create_metadata(
             verified_project_id=project_id or None,
         ),
     }
+    # The bulk path builds its Entity rows directly rather than through add(),
+    # so it has to normalize the declaration itself or the field would be
+    # accepted on the wire and silently dropped before the row is written.
+    declared_keys, _match_forms = normalize_retrieval_keys(entity.retrieval_keys)
+    if declared_keys:
+        metadata["retrieval_keys"] = declared_keys
+    else:
+        metadata.pop("retrieval_keys", None)
+    return metadata
 
 
 def _reject_unsupported_bulk_entry(entity: EntityCreate) -> None:
@@ -2167,6 +2177,7 @@ async def create_entity(
         memory_scope=str(declared_memory_scope) if declared_memory_scope is not None else None,
         scope_key=authorized_scope_key,
         principal_id=authorized_principal_id,
+        retrieval_keys=entity.retrieval_keys,
         spans=[span.model_dump(exclude_none=True) for span in entity.spans]
         if entity.spans is not None
         else None,

--- a/apps/api/src/sibyl/api/schemas/entities.py
+++ b/apps/api/src/sibyl/api/schemas/entities.py
@@ -5,6 +5,10 @@ from typing import Annotated, Any, Literal, Self
 
 from pydantic import BaseModel, Field, StringConstraints, model_validator
 
+from sibyl_core.memory_pipeline.retrieval_keys import (
+    MAX_RETRIEVAL_KEY_LENGTH,
+    MAX_RETRIEVAL_KEYS,
+)
 from sibyl_core.memory_pipeline.spans import MAX_AGENT_SPANS, MAX_SPAN_LABEL_CHARS
 from sibyl_core.memory_pipeline.structure import MAX_PROBE_CHARS, MAX_PROBES_PER_MEMORY
 from sibyl_core.models.entities import EntityType
@@ -81,6 +85,16 @@ class EntityCreate(EntityBase, MemoryStructureFields):
     defer_embeddings: bool = Field(
         default=False,
         description="Persist lexical graph records first and queue embedding backfill",
+    )
+    retrieval_keys: list[Annotated[str, Field(max_length=MAX_RETRIEVAL_KEY_LENGTH)]] | None = Field(
+        default=None,
+        max_length=MAX_RETRIEVAL_KEYS,
+        description=(
+            "Exact-match identifiers this entity answers to (error strings, symbols, "
+            "config flags, aliases). Matched case-insensitively against "
+            "identifier-shaped queries, so a key may name something the content "
+            "never spells out."
+        ),
     )
 
 

--- a/apps/api/src/sibyl/api/schemas/entities.py
+++ b/apps/api/src/sibyl/api/schemas/entities.py
@@ -1,9 +1,10 @@
 """Entity and raw-capture request/response models."""
 
+import unicodedata
 from datetime import datetime
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import BaseModel, Field, StringConstraints, model_validator
+from pydantic import BaseModel, Field, StringConstraints, field_validator, model_validator
 
 from sibyl_core.memory_pipeline.retrieval_keys import (
     MAX_RETRIEVAL_KEY_LENGTH,
@@ -96,6 +97,22 @@ class EntityCreate(EntityBase, MemoryStructureFields):
             "never spells out."
         ),
     )
+
+    @field_validator("retrieval_keys")
+    @classmethod
+    def _reject_unprintable_retrieval_keys(cls, value: list[str] | None) -> list[str] | None:
+        """Refuse a control character here so the caller gets a 422, not a 500.
+
+        The key contract raises on control characters at the write boundary, and
+        that exception has no handler on this route, so the one input class the
+        length and count bounds do not cover would surface as a server error.
+        """
+        if value is None:
+            return None
+        for key in value:
+            if any(unicodedata.category(char) == "Cc" for char in key):
+                raise ValueError("retrieval keys must not contain control characters")
+        return value
 
 
 class EntityBulkCreateRequest(BaseModel):

--- a/apps/api/src/sibyl/api/schemas/entities.py
+++ b/apps/api/src/sibyl/api/schemas/entities.py
@@ -106,11 +106,17 @@ class EntityCreate(EntityBase, MemoryStructureFields):
         The key contract raises on control characters at the write boundary, and
         that exception has no handler on this route, so the one input class the
         length and count bounds do not cover would surface as a server error.
+
+        Whitespace is exempt, and the exemption matters: the key contract
+        collapses internal whitespace runs by design, so a newline or a tab in a
+        key is a documented, accepted input. Rejecting those here would make the
+        wire stricter than the contract on exactly the case the contract
+        advertises, refusing a key pasted out of wrapped text.
         """
         if value is None:
             return None
         for key in value:
-            if any(unicodedata.category(char) == "Cc" for char in key):
+            if any(unicodedata.category(char) == "Cc" and not char.isspace() for char in key):
                 raise ValueError("retrieval keys must not contain control characters")
         return value
 

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -583,6 +583,7 @@ async def _remember_mcp_memory(
     task_ids: list[str] | None = None,
     active_task: bool = True,
     metadata: dict[str, Any] | None = None,
+    retrieval_keys: list[str] | None = None,
     idempotency_key: str | None = None,
     spans: list[dict[str, Any]] | None = None,
     atomic: bool = False,
@@ -620,6 +621,7 @@ async def _remember_mcp_memory(
         "task_ids": task_ids,
         "active_task": active_task,
         "metadata": metadata,
+        "retrieval_keys": retrieval_keys,
         "spans": spans,
         "atomic": atomic,
         "probes": probes,
@@ -685,6 +687,7 @@ async def _remember_mcp_memory(
         tags=tags,
         related_to=resolved_links,
         metadata=full_metadata,
+        retrieval_keys=retrieval_keys,
         provenance={"remember_kind": kind, "related_to": resolved_links or []},
         source_id=f"mcp:remember:{kind}",
         memory_scope=memory_scope,
@@ -733,6 +736,9 @@ async def _remember_mcp_memory(
             memory_scope=request.memory_scope,
             scope_key=request.scope_key,
             principal_id=request.principal_id,
+            retrieval_keys=list(request.retrieval_keys)
+            if request.retrieval_keys is not None
+            else None,
             spans=list(request.spans) if request.spans is not None else None,
             atomic=request.atomic,
             probes=list(request.probes) if request.probes is not None else None,
@@ -2535,6 +2541,7 @@ def _register_tools(mcp: FastMCP) -> None:
         task_ids: list[str] | None = None,
         active_task: bool = True,
         metadata: dict[str, Any] | None = None,
+        retrieval_keys: list[str] | None = None,
         idempotency_key: str | None = None,
         spans: list[dict[str, Any]] | None = None,
         atomic: bool = False,
@@ -2548,6 +2555,14 @@ def _register_tools(mcp: FastMCP) -> None:
         matters, remember stores what future agents should not have to relearn.
         Provide task_ids for exact task context. With a project, active_task
         links the memory to the single active doing task when one exists.
+
+        Use retrieval_keys for the exact strings a future agent will search by
+        and that similarity cannot reach: an error code, an env var, a symbol,
+        a commit SHA, a config flag, an alias. You know them now and the reader
+        will not, so declare them even when the body already mentions them, and
+        especially when it does not. A query containing one of these strings
+        matches this memory exactly, case-insensitively. Up to 16 keys, 200
+        characters each. Skip keys for a memory nobody would look up by name.
 
         You can describe the shape of what you are storing, and you know it
         better than any cutter reading it afterwards.
@@ -2587,6 +2602,7 @@ def _register_tools(mcp: FastMCP) -> None:
             task_ids=task_ids,
             active_task=active_task,
             metadata=metadata,
+            retrieval_keys=retrieval_keys,
             idempotency_key=idempotency_key,
             spans=spans,
             atomic=atomic,

--- a/apps/api/tests/test_routes_entities_write.py
+++ b/apps/api/tests/test_routes_entities_write.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from sibyl.api.routes.entities import (
+    _bulk_create_metadata,
     _entity_from_bulk_create,
     _reject_unsupported_bulk_entry,
     create_entities_bulk,
@@ -29,6 +30,10 @@ from sibyl.api.schemas import (
 from sibyl.auth.context import AuthContext
 from sibyl.auth.errors import ProjectAccessDeniedError
 from sibyl_core.auth import ProjectRole
+from sibyl_core.memory_pipeline.retrieval_keys import (
+    MAX_RETRIEVAL_KEY_LENGTH,
+    MAX_RETRIEVAL_KEYS,
+)
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from tests.harness.auth import stub_auth_context
 
@@ -187,6 +192,101 @@ async def test_create_entity_can_defer_embeddings_to_background_backfill() -> No
     assert response.background_jobs["embedding_backfill"]["status"] == "deferred"
     add.assert_awaited_once()
     assert add.await_args.kwargs["generate_embeddings"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_entity_forwards_declared_retrieval_keys() -> None:
+    org = _org()
+    ctx = _ctx()
+    entity = EntityCreate(
+        name="Connection resets on startup",
+        content="The socket drops mid-handshake and the retry loop gives up.",
+        entity_type=EntityType.NOTE,
+        retrieval_keys=["ERR_CONN_RESET_0x7f31", "connection reset by peer"],
+    )
+    add_result = SimpleNamespace(success=True, id="note_new", message="ok")
+    runtime = SimpleNamespace(entity_manager=SimpleNamespace(get=AsyncMock()))
+
+    with (
+        patch("sibyl_core.tools.core.add", AsyncMock(return_value=add_result)) as add,
+        patch(
+            "sibyl.api.routes.entities.get_entity_graph_runtime",
+            AsyncMock(return_value=runtime),
+        ),
+        patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),
+    ):
+        response = await create_entity(
+            request=_request(),
+            entity=entity,
+            org=org,
+            ctx=ctx,
+            content_session=None,
+            sync=False,
+        )
+
+    assert response.id == "note_new"
+    assert add.await_args is not None
+    assert add.await_args.kwargs["retrieval_keys"] == [
+        "ERR_CONN_RESET_0x7f31",
+        "connection reset by peer",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_entity_rejects_an_over_long_retrieval_key() -> None:
+    """Bounds live in the schema, so an over-long key never reaches the write."""
+
+    with pytest.raises(ValidationError):
+        EntityCreate(
+            name="Over-long key",
+            content="Body",
+            entity_type=EntityType.NOTE,
+            retrieval_keys=["k" * (MAX_RETRIEVAL_KEY_LENGTH + 1)],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_entity_rejects_too_many_retrieval_keys() -> None:
+    with pytest.raises(ValidationError):
+        EntityCreate(
+            name="Too many keys",
+            content="Body",
+            entity_type=EntityType.NOTE,
+            retrieval_keys=[f"key_{index}" for index in range(MAX_RETRIEVAL_KEYS + 1)],
+        )
+
+
+def test_bulk_create_metadata_normalizes_declared_retrieval_keys() -> None:
+    """The bulk path builds rows itself, so it must normalize on its own."""
+
+    entity = EntityCreate(
+        name="Bulk keyed note",
+        content="Body",
+        entity_type=EntityType.NOTE,
+        retrieval_keys=["  ERR_X  ", "err_x", ""],
+    )
+
+    metadata = _bulk_create_metadata(
+        entity,
+        group_id="org-123",
+        now=datetime(2026, 8, 3, tzinfo=UTC),
+        principal_id="user-alice",
+    )
+
+    assert metadata["retrieval_keys"] == ["ERR_X"]
+
+
+def test_bulk_create_metadata_omits_the_field_without_a_declaration() -> None:
+    entity = EntityCreate(name="Plain note", content="Body", entity_type=EntityType.NOTE)
+
+    metadata = _bulk_create_metadata(
+        entity,
+        group_id="org-123",
+        now=datetime(2026, 8, 3, tzinfo=UTC),
+        principal_id="user-alice",
+    )
+
+    assert "retrieval_keys" not in metadata
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_server_accessible_projects.py
+++ b/apps/api/tests/test_server_accessible_projects.py
@@ -483,6 +483,9 @@ async def test_remember_mcp_memory_scopes_project_metadata() -> None:
         memory_scope="project",
         scope_key="project-a",
         principal_id=ctx.user_id,
+        # This capture declares no exact-match keys, and None says exactly that,
+        # so the write preserves whatever keys the row already carries.
+        retrieval_keys=None,
         spans=None,
         atomic=False,
         probes=None,

--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -984,6 +984,7 @@ class SibylClient:
         metadata: dict[str, Any] | None = None,
         sync: bool = False,
         skip_conflicts: bool = False,
+        retrieval_keys: list[str] | None = None,
         spans: list[dict[str, Any]] | None = None,
         atomic: bool = False,
         probes: list[str] | None = None,
@@ -993,6 +994,7 @@ class SibylClient:
         Args:
             sync: If True, wait for entity creation to complete (slower but
                   entity is immediately available for operations like task start).
+            retrieval_keys: Exact-match identifiers this entity answers to.
             spans: Agent-authored cut plan tiling the stored content exactly.
             atomic: Declare the body one retrievable unit that must not be cut.
             probes: Questions the memory must answer, rehearsed at write time.
@@ -1022,6 +1024,8 @@ class SibylClient:
             data["metadata"] = metadata
         if skip_conflicts:
             data["skip_conflicts"] = True
+        if retrieval_keys:
+            data["retrieval_keys"] = retrieval_keys
 
         params = {"sync": "true"} if sync else None
         return await self._request("POST", "/entities", json=data, params=params)

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -472,6 +472,7 @@ async def _write_memory_capture(
     source_id: str | None = None,
     skip_conflicts: bool = False,
     languages: list[str] | None = None,
+    retrieval_keys: list[str] | None = None,
     capture_metadata: Mapping[str, Any] | None = None,
     spans: list[dict[str, Any]] | None = None,
     atomic: bool = False,
@@ -514,6 +515,7 @@ async def _write_memory_capture(
         related_to=resolved_links,
         languages=languages,
         metadata=metadata,
+        retrieval_keys=retrieval_keys,
         provenance={
             "remember_kind": kind,
             "related_to": resolved_links or [],
@@ -560,6 +562,9 @@ async def _write_memory_capture(
             metadata=dict(graph_metadata),
             sync=capture.wait_searchable,
             skip_conflicts=capture.skip_conflicts,
+            retrieval_keys=list(capture.retrieval_keys)
+            if capture.retrieval_keys is not None
+            else None,
             spans=[dict(span) for span in capture.spans] if capture.spans is not None else None,
             atomic=capture.atomic,
             probes=list(capture.probes) if capture.probes is not None else None,
@@ -3550,6 +3555,16 @@ def remember_memory(
         help="Do not auto-scope to the linked project",
     ),
     tags: str | None = typer.Option(None, "--tags", help="Comma-separated tags"),
+    keys: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--key",
+            help=(
+                "Exact-match retrieval key this memory answers to (error string, symbol, "
+                "config flag, alias). Repeatable, up to 16."
+            ),
+        ),
+    ] = None,
     related_to: str | None = typer.Option(
         None,
         "--related-to",
@@ -3636,6 +3651,10 @@ def remember_memory(
         raise typer.Exit(code=1)
 
     parsed_tags = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+    # Not comma-split: a retrieval key can legitimately contain a comma (an error
+    # string, a formatted tuple), so repeating --key is the only unambiguous way
+    # to declare one.
+    parsed_keys = [key.strip() for key in keys or () if key.strip()] or None
     related_ids = _parse_csv_ids(related_to)
     task_ids = _parse_csv_ids(task)
     probes = [entry.strip() for entry in (probe or []) if entry.strip()]
@@ -3726,6 +3745,7 @@ def remember_memory(
                     memory_scope=memory_scope,
                     scope_key=scope_key,
                     source_id=source_id,
+                    retrieval_keys=parsed_keys,
                     capture_metadata=capture_metadata,
                     spans=parsed_spans,
                     atomic=atomic,

--- a/apps/cli/tests/test_main_capture.py
+++ b/apps/cli/tests/test_main_capture.py
@@ -841,6 +841,7 @@ def test_remember_command_records_domain_memory_with_links(
         },
         sync=False,
         skip_conflicts=False,
+        retrieval_keys=None,
         spans=None,
         atomic=False,
         probes=None,
@@ -998,12 +999,53 @@ def test_remember_command_reads_body_from_stdin(
         },
         sync=False,
         skip_conflicts=False,
+        retrieval_keys=None,
         spans=None,
         atomic=False,
         probes=None,
     )
     mock_client.explore.assert_not_called()
     mock_resolve_project_from_cwd.assert_called_once_with()
+
+
+@patch("sibyl_cli.main.resolve_project_from_cwd", return_value=None)
+@patch("sibyl_cli.main.get_client")
+def test_remember_command_forwards_repeated_retrieval_keys(
+    mock_get_client: MagicMock,
+    mock_resolve_project_from_cwd: MagicMock,
+) -> None:
+    """--key is repeatable because a key can legitimately contain a comma."""
+
+    mock_client = MagicMock()
+    mock_client.remember_raw_memory = AsyncMock(
+        return_value={"id": "raw_123", "source_id": "cli:manual"}
+    )
+    mock_client.create_entity = AsyncMock(return_value={"id": "note_123"})
+    mock_client.explore = AsyncMock()
+    mock_get_client.return_value = _FakeClientContext(mock_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "remember",
+            "Connection resets on startup",
+            "--key",
+            "ERR_CONN_RESET_0x7f31",
+            "--key",
+            "connection reset, by peer",
+        ],
+        input="The socket dropped mid-handshake.",
+    )
+
+    assert result.exit_code == 0
+    awaited = mock_client.create_entity.await_args
+    assert awaited is not None
+    assert awaited.kwargs["retrieval_keys"] == [
+        "ERR_CONN_RESET_0x7f31",
+        "connection reset, by peer",
+    ]
+    assert mock_resolve_project_from_cwd.called
 
 
 @patch("sibyl_cli.main.resolve_project_from_cwd", return_value=None)

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -103,6 +103,8 @@ DEFINE FIELD IF NOT EXISTS complexity ON entity TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS feature ON entity TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS tags ON entity TYPE option<array<string>>;
 DEFINE FIELD IF NOT EXISTS memory_scope ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS retrieval_keys ON entity TYPE option<array<string>>;
+DEFINE FIELD IF NOT EXISTS retrieval_keys_normalized ON entity TYPE option<array<string>>;
 DEFINE FIELD IF NOT EXISTS name_embedding ON entity TYPE option<array<float, {EMBEDDING_DIM}>>;
 
 DEFINE INDEX IF NOT EXISTS idx_entity_uuid ON entity FIELDS uuid UNIQUE;
@@ -113,6 +115,7 @@ DEFINE INDEX IF NOT EXISTS idx_entity_parent_task ON entity FIELDS parent_task_i
 DEFINE INDEX IF NOT EXISTS idx_entity_task ON entity FIELDS task_id;
 DEFINE INDEX IF NOT EXISTS idx_entity_status ON entity FIELDS status;
 DEFINE INDEX IF NOT EXISTS idx_entity_memory_scope ON entity FIELDS memory_scope;
+DEFINE INDEX IF NOT EXISTS idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized;
 DEFINE INDEX IF NOT EXISTS idx_entity_priority ON entity FIELDS priority;
 DEFINE INDEX IF NOT EXISTS idx_entity_updated ON entity FIELDS updated_at, created_at, uuid;
 DEFINE INDEX IF NOT EXISTS idx_entity_last_recalled ON entity FIELDS last_recalled_at, created_at, uuid;
@@ -511,6 +514,12 @@ WHERE memory_scope = NONE
     AND attributes.memory_scope != NONE;
 """
 
+ENTITY_RETRIEVAL_KEYS_COLUMN_DEFINITIONS = """
+DEFINE FIELD OVERWRITE retrieval_keys ON entity TYPE option<array<string>>;
+DEFINE FIELD OVERWRITE retrieval_keys_normalized ON entity TYPE option<array<string>>;
+DEFINE INDEX IF NOT EXISTS idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized;
+"""
+
 ENTITY_REQUIRED_FIELD_REPAIR_DEFINITIONS = f"""
 {ENTITY_REQUIRED_FIELD_OPTIONAL_DEFINITIONS}
 UPDATE entity SET revision = 1 WHERE revision = NONE OR revision < 1;
@@ -663,6 +672,16 @@ GRAPH_SCHEMA_MIGRATIONS = (
         version=17,
         name="entity_memory_scope_column",
         statements=tuple(split_statements(ENTITY_MEMORY_SCOPE_COLUMN_DEFINITIONS)),
+    ),
+    # Writer-declared exact-match keys. The column carries the writer's casing
+    # for display and its normalized twin carries the indexed match form; the
+    # exact-match retrieval arm reads the index, which a metadata bag could
+    # never offer. No backfill: no row predates the field, because the write
+    # path that can declare a key ships with this version.
+    SchemaMigration(
+        version=18,
+        name="entity_retrieval_keys_column",
+        statements=tuple(split_statements(ENTITY_RETRIEVAL_KEYS_COLUMN_DEFINITIONS)),
     ),
 )
 
@@ -1052,6 +1071,7 @@ __all__ = [
     "ENTITY_MISLED_USAGE_SIGNAL_DEFINITIONS",
     "ENTITY_REQUIRED_FIELD_OPTIONAL_DEFINITIONS",
     "ENTITY_REQUIRED_FIELD_REPAIR_DEFINITIONS",
+    "ENTITY_RETRIEVAL_KEYS_COLUMN_DEFINITIONS",
     "ENTITY_REVISION_MIGRATION_DEFINITIONS",
     "ENTITY_SCHEMA_DRIFT_REPAIR_DEFINITIONS",
     "ENTITY_UPDATED_AT_DATETIME_FIELD_REPAIR_DEFINITIONS",

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -115,7 +115,7 @@ DEFINE INDEX IF NOT EXISTS idx_entity_parent_task ON entity FIELDS parent_task_i
 DEFINE INDEX IF NOT EXISTS idx_entity_task ON entity FIELDS task_id;
 DEFINE INDEX IF NOT EXISTS idx_entity_status ON entity FIELDS status;
 DEFINE INDEX IF NOT EXISTS idx_entity_memory_scope ON entity FIELDS memory_scope;
-DEFINE INDEX IF NOT EXISTS idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized;
+DEFINE INDEX IF NOT EXISTS idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized.*;
 DEFINE INDEX IF NOT EXISTS idx_entity_priority ON entity FIELDS priority;
 DEFINE INDEX IF NOT EXISTS idx_entity_updated ON entity FIELDS updated_at, created_at, uuid;
 DEFINE INDEX IF NOT EXISTS idx_entity_last_recalled ON entity FIELDS last_recalled_at, created_at, uuid;
@@ -514,10 +514,18 @@ WHERE memory_scope = NONE
     AND attributes.memory_scope != NONE;
 """
 
+# The index is on `.*`, the array's elements, rather than on the array itself.
+# The distinction is not cosmetic on SurrealDB 3.2.3: an index on the bare array
+# field answers a set-membership read with a full table scan, and answers a bare
+# equality with zero rows unless the WHERE clause happens to carry another
+# predicate. Indexing the elements makes CONTAINS and CONTAINSANY index-served
+# and correct on their own. OVERWRITE rather than IF NOT EXISTS so a namespace
+# that already ran an earlier build of this migration gets the element index
+# instead of silently keeping the one that scans.
 ENTITY_RETRIEVAL_KEYS_COLUMN_DEFINITIONS = """
 DEFINE FIELD OVERWRITE retrieval_keys ON entity TYPE option<array<string>>;
 DEFINE FIELD OVERWRITE retrieval_keys_normalized ON entity TYPE option<array<string>>;
-DEFINE INDEX IF NOT EXISTS idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized;
+DEFINE INDEX OVERWRITE idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized.*;
 """
 
 ENTITY_REQUIRED_FIELD_REPAIR_DEFINITIONS = f"""

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
@@ -11,7 +11,7 @@ from typing import Protocol, cast
 
 from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement, split_statements
 
-GRAPH_SCHEMA_CURRENT_VERSION = 17
+GRAPH_SCHEMA_CURRENT_VERSION = 18
 GRAPH_SCHEMA_NAME = "graph"
 SCHEMA_VERSION_TABLE = "schema_version"
 

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sibyl_core.auth.memory_policy import stamp_memory_scope_metadata
 from sibyl_core.memory_pipeline.quality import normalize_memory_quality_metadata
+from sibyl_core.memory_pipeline.retrieval_keys import normalize_retrieval_keys
 from sibyl_core.memory_pipeline.structure import MemoryStructure, build_memory_structure
 
 
@@ -20,6 +21,10 @@ class MemoryCaptureRequest:
     tags: Sequence[str] | None = None
     related_to: Sequence[str] | None = None
     languages: Sequence[str] | None = None
+    # Exact-match keys the writing agent declares for this memory: an error
+    # string, a symbol, an alias. Not derived from the content, so a key may
+    # name something the body never spells out.
+    retrieval_keys: Sequence[str] | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
     provenance: Mapping[str, Any] = field(default_factory=dict)
     source_id: str | None = None
@@ -97,11 +102,16 @@ class MemoryCaptureService:
         self._create_graph_entity = create_graph_entity
 
     async def capture(self, request: MemoryCaptureRequest) -> MemoryCaptureResult:
-        # Before the raw write, not after. The raw capture lands first and the
-        # graph write validates the same plan again, so validating late would
-        # leave a verbatim record behind for a write that then fails, and the
-        # caller would retry into a duplicate.
+        # Everything the writer declared is validated before the raw write, not
+        # after. The raw capture lands first and the graph write validates the
+        # same declarations again, so validating late would leave a verbatim
+        # record behind for a write that then fails, and the caller would retry
+        # into a duplicate. Validating here rather than at the storage edge is
+        # also what lets the caller be told its declaration was refused, instead
+        # of finding out by never retrieving the memory again.
         request.structure()
+        declared_keys, _match_forms = normalize_retrieval_keys(request.retrieval_keys)
+
         raw_memory = await self._remember_raw_memory(request)
         raw_memory_id = _optional_str(raw_memory.get("id"))
         raw_source_id = _optional_str(raw_memory.get("source_id"))
@@ -122,6 +132,8 @@ class MemoryCaptureService:
                 principal_id=request.principal_id,
             )
         )
+        if declared_keys:
+            graph_metadata["retrieval_keys"] = declared_keys
         if raw_memory_id:
             graph_metadata["raw_memory_id"] = raw_memory_id
         if raw_source_id:

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/retrieval_keys.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/retrieval_keys.py
@@ -1,0 +1,148 @@
+"""Writer-declared retrieval keys: the exact-match contract for a memory.
+
+A retrieval key is an identifier the writing agent asserts this memory answers
+to: an error string, a symbol name, a config flag, an alias. It is not derived
+from the content, so a key may name something the body never spells out, and
+that is the whole point -- dense similarity and full-text both need the token to
+appear somewhere in the text before they can find it.
+
+Matching semantics, which every surface has to agree on:
+
+* A key is compared by Unicode casefold, so ``ERR_CONN_RESET`` and
+  ``err_conn_reset`` are the same key. The verbatim form is kept for display.
+* Internal whitespace runs collapse to one space, so a key copied out of
+  wrapped text still matches one typed on a single line.
+* Nothing else is transformed. No stemming, no punctuation stripping, no
+  tokenization: an exact key is exact, which is what buys the precision.
+
+Two entry points, deliberately asymmetric. ``normalize_retrieval_keys`` refuses
+a violation, because a write boundary is where a caller can still be told its
+key list is too long. ``coerce_retrieval_keys`` drops what it cannot use,
+because the storage edge reads rows written by older code and must not fail a
+whole projection over one bad key.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Iterable, Sequence
+
+# A key names a memory rather than describing it, so it is bounded by the same
+# length as a title (sibyl_core.tools.helpers.MAX_TITLE_LENGTH, pinned equal by
+# test_retrieval_keys.py). Anything longer is prose and belongs in the content.
+MAX_RETRIEVAL_KEY_LENGTH = 200
+# A writer declaring more than this many exact keys is describing a document
+# rather than naming it, and the cap also bounds the indexed payload a single
+# row can add (16 * 200 chars).
+MAX_RETRIEVAL_KEYS = 16
+
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+__all__ = [
+    "MAX_RETRIEVAL_KEYS",
+    "MAX_RETRIEVAL_KEY_LENGTH",
+    "coerce_retrieval_keys",
+    "normalize_retrieval_keys",
+    "retrieval_key_match_form",
+]
+
+
+def retrieval_key_match_form(value: str) -> str:
+    """The form two keys are compared in: casefolded, whitespace-collapsed."""
+
+    return _WHITESPACE_RUN.sub(" ", value).strip().casefold()
+
+
+def _display_form(value: str) -> str:
+    return _WHITESPACE_RUN.sub(" ", value).strip()
+
+
+def _printable(value: str) -> bool:
+    # A control character in a key cannot have been typed on purpose and would
+    # not survive a round trip through a query string.
+    return all(unicodedata.category(char) != "Cc" for char in value)
+
+
+def normalize_retrieval_keys(values: Iterable[str] | None) -> tuple[list[str], list[str]]:
+    """Validate a writer's declared keys into (display forms, match forms).
+
+    Both lists are the same length and in the same order: index ``i`` of the
+    match list is the comparable form of index ``i`` of the display list. The
+    display list keeps the writer's casing, deduplicated by match form so
+    ``ERR_X`` and ``err_x`` collapse to whichever was declared first.
+
+    Raises ``ValueError`` when a key is longer than
+    ``MAX_RETRIEVAL_KEY_LENGTH`` or when more than ``MAX_RETRIEVAL_KEYS``
+    distinct keys are declared. Truncating instead would silently ship a key
+    the writer did not declare, which fails at retrieval time with no receipt.
+    """
+
+    if values is None:
+        return [], []
+
+    display: list[str] = []
+    match: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        if not isinstance(raw, str):
+            raise ValueError(f"retrieval key must be a string, got {type(raw).__name__}")
+        shown = _display_form(raw)
+        if not shown:
+            continue
+        if len(shown) > MAX_RETRIEVAL_KEY_LENGTH:
+            raise ValueError(
+                f"retrieval key exceeds {MAX_RETRIEVAL_KEY_LENGTH} characters: {shown[:60]!r}..."
+            )
+        if not _printable(shown):
+            raise ValueError(f"retrieval key contains control characters: {shown[:60]!r}")
+        comparable = retrieval_key_match_form(shown)
+        if comparable in seen:
+            continue
+        seen.add(comparable)
+        display.append(shown)
+        match.append(comparable)
+
+    if len(display) > MAX_RETRIEVAL_KEYS:
+        raise ValueError(
+            f"at most {MAX_RETRIEVAL_KEYS} retrieval keys may be declared, got {len(display)}"
+        )
+    return display, match
+
+
+def coerce_retrieval_keys(value: object) -> tuple[list[str], list[str]] | None:
+    """Best-effort read of keys off a metadata bag or a stored row.
+
+    Returns ``None`` when the value says nothing about keys, which the write
+    path treats as "this write does not speak to retrieval keys" and therefore
+    preserves whatever the row already carries. An empty list is a statement
+    (no keys) and comes back as empty lists.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        candidates: Sequence[object] = [value]
+    elif isinstance(value, Sequence):
+        candidates = value
+    else:
+        return None
+
+    display: list[str] = []
+    match: list[str] = []
+    seen: set[str] = set()
+    for raw in candidates:
+        if not isinstance(raw, str):
+            continue
+        shown = _display_form(raw)[:MAX_RETRIEVAL_KEY_LENGTH]
+        if not shown or not _printable(shown):
+            continue
+        comparable = retrieval_key_match_form(shown)
+        if comparable in seen:
+            continue
+        seen.add(comparable)
+        display.append(shown)
+        match.append(comparable)
+        if len(display) == MAX_RETRIEVAL_KEYS:
+            break
+    return display, match

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py
@@ -1,0 +1,164 @@
+"""Deciding when a query is asking for an identifier rather than a topic.
+
+The exact-match arm is only worth a read when the query actually carries
+something that could be an exact key. "how do we handle authentication" has no
+such token and must leave the arm inert; "why does ERR_CONN_RESET_0x7f31 fire"
+has exactly one and should probe it.
+
+The test is mechanical and per-token: no scoring, no thresholds, no model. A
+token is identifier-shaped when its own characters say so, because identifier
+syntax is visibly different from English orthography. The rules, each a named
+predicate below so the matrix test can target it:
+
+* a quoted span, which is the caller explicitly asking for an exact string
+  (double quotes or backticks only; a bare apostrophe is English possessive
+  far more often than it is a quote)
+* letters and digits mixed in one token (``0x7f31``, ``sha256``, ``v2beta``)
+* an underscore (``ERR_CONN_RESET``, ``snake_case``)
+* a ``::`` path separator (``std::vector``)
+* dotted segments of two or more characters each (``search.py``,
+  ``sibyl_core.retrieval``), which admits file names and module paths while
+  rejecting ``e.g``, ``i.e`` and a sentence's trailing period
+* a hexadecimal run of eight or more characters containing at least one digit
+  (a commit SHA, a pointer), the digit being what separates a SHA from an
+  English word that happens to spell in ``a-f``
+* a lower-to-upper transition inside one alphanumeric token (``EntityManager``,
+  ``getUserById``), which a capitalized sentence opener does not have
+
+False positives are cheap and false negatives are not. A token that looks like
+an identifier but matches no declared key costs one indexed read and returns
+nothing, while a missed identifier costs the hit the whole arm exists to find.
+"""
+
+from __future__ import annotations
+
+import re
+from itertools import pairwise
+
+from sibyl_core.memory_pipeline.retrieval_keys import (
+    MAX_RETRIEVAL_KEYS,
+    retrieval_key_match_form,
+)
+
+# A probe cannot usefully carry more distinct keys than one memory is allowed to
+# declare, so the writer's cap bounds the reader's too.
+MAX_IDENTIFIER_PROBE_TOKENS = MAX_RETRIEVAL_KEYS
+# Below three characters there is no room for a shape: every rule needs at least
+# a separator or a case transition plus something on both sides of it.
+MIN_IDENTIFIER_TOKEN_LENGTH = 3
+
+_QUOTED_SPAN = re.compile(r"\"([^\"]+)\"|`([^`]+)`")
+# Angle brackets stay: they are generic-type syntax far more often than prose
+# punctuation, and stripping them would cut `std::vector<int>` down to a key
+# nobody declared.
+_LEADING_PUNCTUATION = "([{\"'"
+_TRAILING_PUNCTUATION = ")]},;:!?.\"'"
+_HEX_RUN = re.compile(r"[0-9a-fA-F]{8,}")
+_WORD_CHARACTER = re.compile(r"[^\W_]", re.UNICODE)
+
+__all__ = [
+    "MAX_IDENTIFIER_PROBE_TOKENS",
+    "MIN_IDENTIFIER_TOKEN_LENGTH",
+    "identifier_probe_tokens",
+    "is_identifier_shaped_query",
+    "is_identifier_shaped_token",
+]
+
+
+def _has_letter_and_digit(token: str) -> bool:
+    return any(char.isalpha() for char in token) and any(char.isdigit() for char in token)
+
+
+def _has_underscore(token: str) -> bool:
+    # Leading and trailing underscores are decoration; the rule is about an
+    # underscore joining two parts of a name.
+    stripped = token.strip("_")
+    return "_" in stripped and bool(_WORD_CHARACTER.search(stripped))
+
+
+def _has_scope_separator(token: str) -> bool:
+    return "::" in token
+
+
+def _has_dotted_segments(token: str) -> bool:
+    if "." not in token:
+        return False
+    segments = token.split(".")
+    if len(segments) < 2:
+        return False
+    return all(len(segment) >= 2 and _WORD_CHARACTER.search(segment) for segment in segments)
+
+
+def _has_hex_run(token: str) -> bool:
+    return any(any(char.isdigit() for char in run.group()) for run in _HEX_RUN.finditer(token))
+
+
+def _has_case_transition(token: str) -> bool:
+    return any(previous.islower() and current.isupper() for previous, current in pairwise(token))
+
+
+_TOKEN_SHAPE_RULES = (
+    _has_letter_and_digit,
+    _has_underscore,
+    _has_scope_separator,
+    _has_dotted_segments,
+    _has_hex_run,
+    _has_case_transition,
+)
+
+
+def is_identifier_shaped_token(token: str) -> bool:
+    """Whether one bare token (already unquoted, already trimmed) is a probe."""
+
+    if len(token) < MIN_IDENTIFIER_TOKEN_LENGTH:
+        return False
+    if not _WORD_CHARACTER.search(token):
+        return False
+    return any(rule(token) for rule in _TOKEN_SHAPE_RULES)
+
+
+def _trim_token(token: str) -> str:
+    return token.lstrip(_LEADING_PUNCTUATION).rstrip(_TRAILING_PUNCTUATION)
+
+
+def identifier_probe_tokens(query: str) -> tuple[str, ...]:
+    """The exact-key probes a query carries, in match form, order preserved.
+
+    An empty result means the exact-match arm does not fire at all: no read is
+    issued and the fused pool is byte-identical to what the query would have
+    produced before keys existed.
+    """
+
+    if not query or not query.strip():
+        return ()
+
+    probes: list[str] = []
+    seen: set[str] = set()
+
+    def offer(value: str) -> None:
+        comparable = retrieval_key_match_form(value)
+        if not comparable or comparable in seen:
+            return
+        seen.add(comparable)
+        probes.append(comparable)
+
+    residual = query
+    for span in _QUOTED_SPAN.finditer(query):
+        quoted = span.group(1) or span.group(2) or ""
+        # A quoted span is taken whole, spaces and all: an error string is the
+        # canonical multi-word exact key, and the quotes are the caller saying
+        # so. Only the length floor applies.
+        if len(quoted.strip()) >= MIN_IDENTIFIER_TOKEN_LENGTH:
+            offer(quoted)
+        residual = residual.replace(span.group(0), " ", 1)
+
+    for raw in residual.split():
+        token = _trim_token(raw)
+        if is_identifier_shaped_token(token):
+            offer(token)
+
+    return tuple(probes[:MAX_IDENTIFIER_PROBE_TOKENS])
+
+
+def is_identifier_shaped_query(query: str) -> bool:
+    return bool(identifier_probe_tokens(query))

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py
@@ -13,7 +13,9 @@ predicate below so the matrix test can target it:
 * a quoted span, which is the caller explicitly asking for an exact string
   (double quotes or backticks only; a bare apostrophe is English possessive
   far more often than it is a quote)
-* letters and digits mixed in one token (``0x7f31``, ``sha256``, ``v2beta``)
+* letters and digits mixed in one token (``0x7f31``, ``sha256``, ``v2beta``),
+  excluding digits with an English suffix (``3rd``, ``10am``, ``1990s``), which
+  mix the two characters classes while being plainly prose
 * an underscore (``ERR_CONN_RESET``, ``snake_case``)
 * a ``::`` path separator (``std::vector``)
 * dotted segments of two or more characters each (``search.py``,
@@ -61,6 +63,7 @@ _QUOTED_SPAN = re.compile(r"\"([^\"]+)\"|`([^`]+)`")
 _LEADING_PUNCTUATION = "([{\"'"
 _TRAILING_PUNCTUATION = ")]},;:!?.\"'"
 _HEX_RUN = re.compile(r"[0-9a-fA-F]{8,}")
+_ENGLISH_NUMBER_WORD = re.compile(r"\d+(?:st|nd|rd|th|s|am|pm)", re.IGNORECASE)
 _WORD_CHARACTER = re.compile(r"[^\W_]", re.UNICODE)
 
 __all__ = [
@@ -72,7 +75,20 @@ __all__ = [
 ]
 
 
+def _is_english_number_word(token: str) -> bool:
+    """Digits carrying an English suffix: an ordinal, a clock time, a decade.
+
+    These mix letters and digits, so the shape rule admits them, and they are
+    plainly prose rather than identifiers. The suffix list is closed and short
+    on purpose: `2fa` and `v2beta` are identifiers and stay admitted.
+    """
+
+    return bool(_ENGLISH_NUMBER_WORD.fullmatch(token))
+
+
 def _has_letter_and_digit(token: str) -> bool:
+    if _is_english_number_word(token):
+        return False
     return any(char.isalpha() for char in token) and any(char.isdigit() for char in token)
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py
@@ -14,8 +14,8 @@ predicate below so the matrix test can target it:
   (double quotes or backticks only; a bare apostrophe is English possessive
   far more often than it is a quote)
 * letters and digits mixed in one token (``0x7f31``, ``sha256``, ``v2beta``),
-  excluding digits with an English suffix (``3rd``, ``10am``, ``1990s``), which
-  mix the two characters classes while being plainly prose
+  excluding ordinals and clock times (``3rd``, ``21st``, ``10am``,
+  ``10am-11am``), which mix the two character classes while being plainly prose
 * an underscore (``ERR_CONN_RESET``, ``snake_case``)
 * a ``::`` path separator (``std::vector``)
 * dotted segments of two or more characters each (``search.py``,
@@ -63,7 +63,7 @@ _QUOTED_SPAN = re.compile(r"\"([^\"]+)\"|`([^`]+)`")
 _LEADING_PUNCTUATION = "([{\"'"
 _TRAILING_PUNCTUATION = ")]},;:!?.\"'"
 _HEX_RUN = re.compile(r"[0-9a-fA-F]{8,}")
-_ENGLISH_NUMBER_WORD = re.compile(r"\d+(?:st|nd|rd|th|s|am|pm)", re.IGNORECASE)
+_ENGLISH_NUMBER_WORD = re.compile(r"\d+(?:(?:st|nd|rd|th)s?|am|pm)", re.IGNORECASE)
 _WORD_CHARACTER = re.compile(r"[^\W_]", re.UNICODE)
 
 __all__ = [
@@ -76,14 +76,28 @@ __all__ = [
 
 
 def _is_english_number_word(token: str) -> bool:
-    """Digits carrying an English suffix: an ordinal, a clock time, a decade.
+    """Digits carrying an English suffix: an ordinal or a clock time.
 
-    These mix letters and digits, so the shape rule admits them, and they are
-    plainly prose rather than identifiers. The suffix list is closed and short
-    on purpose: `2fa` and `v2beta` are identifiers and stay admitted.
+    These mix letters and digits, so the shape rule would admit them, and they
+    are plainly prose. Tested per hyphen-separated segment, because a token is
+    still prose when the number word is only part of it (`10am-11am`), and a
+    trailing plural is allowed so `3rds` reads the same as `3rd`.
+
+    A bare `<digits>s` is deliberately NOT here. A decade (`1990s`) and a
+    duration (`30s`, `300s`, `443s`) are indistinguishable by their characters,
+    durations appear verbatim in the error strings this arm exists to match, and
+    the costs are asymmetric: a false positive is one indexed read returning
+    nothing, a false negative loses the hit. So the duration wins and the decade
+    fires.
     """
 
-    return bool(_ENGLISH_NUMBER_WORD.fullmatch(token))
+    segments = [segment for segment in token.split("-") if segment]
+    if not segments:
+        return False
+    digit_segments = [segment for segment in segments if any(c.isdigit() for c in segment)]
+    if not digit_segments:
+        return False
+    return all(_ENGLISH_NUMBER_WORD.fullmatch(segment) for segment in digit_segments)
 
 
 def _has_letter_and_digit(token: str) -> bool:

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py
@@ -24,6 +24,13 @@ predicate below so the matrix test can target it:
   English word that happens to spell in ``a-f``
 * a lower-to-upper transition inside one alphanumeric token (``EntityManager``,
   ``getUserById``), which a capitalized sentence opener does not have
+* a long command-line option (``--wait-searchable``), which carries none of the
+  other shapes and which English never produces
+
+One shape is deliberately absent: a bare all-caps acronym such as ``TTL`` or
+``EFC``. English writes acronyms exactly the same way, so admitting them would
+fire the arm on ordinary emphasis. A writer who needs one found declares it as
+a key and a caller quotes it.
 
 False positives are cheap and false negatives are not. A token that looks like
 an identifier but matches no declared key costs one indexed read and returns
@@ -97,6 +104,13 @@ def _has_case_transition(token: str) -> bool:
     return any(previous.islower() and current.isupper() for previous, current in pairwise(token))
 
 
+def _is_command_flag(token: str) -> bool:
+    # A long option is an identifier that carries none of the other shapes:
+    # --wait-searchable has no digit, underscore, dot or case transition. English
+    # never opens a word with a double hyphen, so the prefix is unambiguous.
+    return token.startswith("--") and bool(_WORD_CHARACTER.search(token[2:3]))
+
+
 _TOKEN_SHAPE_RULES = (
     _has_letter_and_digit,
     _has_underscore,
@@ -104,6 +118,7 @@ _TOKEN_SHAPE_RULES = (
     _has_dotted_segments,
     _has_hex_run,
     _has_case_transition,
+    _is_command_flag,
 )
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -523,6 +523,19 @@ async def context_search(
         )
         for signal, candidates in source_lists
     ]
+    # Counted after the scope filter, never before. A pre-filter count answers
+    # "does any memory in this organization declare the string I just sent",
+    # which is a question an unauthorized caller must not be able to ask: the
+    # rows are withheld but their existence would leak, one guessed key at a
+    # time.
+    authorized_exact_key_candidates = next(
+        (
+            candidates
+            for signal, candidates in filtered_lists
+            if signal is RetrievalSignal.EXACT_KEY
+        ),
+        [],
+    )
     temporal_target = resolve_temporal_reference(search_plan.query, datetime.now(UTC))
     fusion_backend = fusion_backend_from_env()
     fusion_failures: list[CandidateSourceFailure] = []
@@ -581,7 +594,7 @@ async def context_search(
             **vector_fetch.as_metadata(),
             **_exact_key_receipt_metadata(
                 probe_tokens=probe_tokens,
-                candidates=graph_candidate_lists[3],
+                candidates=authorized_exact_key_candidates,
             ),
             "stage_timings_ms": stage_timings_ms,
         },
@@ -1044,66 +1057,62 @@ async def _exact_key_candidates(
     if not probe_tokens:
         return []
     filter_clauses, filter_params = _node_filter_clause(search_filter)
-    # One indexed equality per probe rather than a single set-membership read.
-    # On SurrealDB 3.2.3 an array-element index answers `field = $value` with an
-    # IndexScan, while `CONTAINSANY` falls back to a full TableScan; a
-    # multi-value `IN` and an OR of equalities each return no rows at all
-    # despite matching data, verified live against 3.2.3 before this shape was
-    # chosen. Probe tokens are capped, so this is a bounded fan-out of point
-    # lookups rather than a scan that grows with the corpus.
-    row_query = (
+    # CONTAINSANY against the index defined on `retrieval_keys_normalized.*`.
+    # The element index is what makes this both correct and index-served: on
+    # SurrealDB 3.2.3 an index on the bare array field turns this same read into
+    # a full table scan, and turns a bare equality into zero rows unless the
+    # WHERE clause happens to carry a second predicate. Verified live on 3.2.3
+    # (UnionIndexScan across one branch per probe), so the `.*` in the index
+    # definition is load-bearing rather than stylistic.
+    rows = await _execute_query_records(
+        client,
         """
         SELECT *
         FROM entity
         WHERE """
         + _where_clause(["group_id = $group_id", *filter_clauses])
         + """
-          AND retrieval_keys_normalized = $probe_key
+          AND retrieval_keys_normalized CONTAINSANY $probe_keys
         ORDER BY created_at DESC, uuid DESC
         LIMIT $limit;
-        """
-    )
-    row_limit = max(int(limit), 1)
-    reads = await asyncio.gather(
-        *(
-            _execute_query_records(
-                client,
-                row_query,
-                group_id=plan.organization_id,
-                probe_key=probe_key,
-                limit=row_limit,
-                **filter_params,
-            )
-            for probe_key in probe_tokens
-        )
+        """,
+        group_id=plan.organization_id,
+        probe_keys=list(probe_tokens),
+        limit=max(int(limit), 1),
+        **filter_params,
     )
 
-    matched_by_uuid: dict[str, list[str]] = defaultdict(list)
-    row_by_uuid: dict[str, Mapping[str, object]] = {}
-    for probe_key, rows in zip(probe_tokens, reads, strict=True):
-        for row in rows:
-            uuid = str(row.get("uuid") or "")
-            if not uuid:
-                continue
-            row_by_uuid.setdefault(uuid, row)
-            matched_by_uuid[uuid].append(probe_key)
-
-    # A row that answers more of the query's identifiers is the better answer, so
-    # overlap orders the lane. Counted here because the reads are per probe.
-    ordered = sorted(
-        matched_by_uuid.items(),
-        key=lambda item: (-len(item[1]), item[0]),
-    )
+    probes = set(probe_tokens)
+    scored: list[tuple[int, str, list[str], Mapping[str, object]]] = []
+    for row in rows:
+        matched = _matched_retrieval_keys(row, probes)
+        if not matched:
+            continue
+        scored.append((len(matched), str(row.get("uuid") or ""), matched, row))
+    # A row answering more of the query's identifiers is the better answer, so
+    # overlap orders the lane. Counted here rather than in SurrealQL to keep the
+    # read to one index lookup and no array functions.
+    scored.sort(key=lambda item: (-item[0], item[1]))
     candidates: list[RetrievalCandidate] = []
-    for uuid, matched in ordered[:row_limit]:
+    for _count, _uuid, matched, row in scored:
         candidate = _candidate_from_node_record(
-            row_by_uuid[uuid],
+            row,
             signal=RetrievalSignal.EXACT_KEY,
-            score=len(matched) / len(probe_tokens),
+            score=len(matched) / len(probes),
         )
-        candidate.metadata["matched_retrieval_keys"] = list(matched)
+        candidate.metadata["matched_retrieval_keys"] = matched
         candidates.append(candidate)
     return candidates
+
+
+def _matched_retrieval_keys(
+    row: Mapping[str, object],
+    probes: set[str],
+) -> list[str]:
+    stored = row.get("retrieval_keys_normalized")
+    if not isinstance(stored, list | tuple):
+        return []
+    return [str(key) for key in stored if str(key) in probes]
 
 
 async def _episode_fulltext_candidates(
@@ -2861,13 +2870,18 @@ def _merge_exact_key_metadata(
         fusion_metadata["matched_retrieval_keys"] = [str(key) for key in matched]
 
 
-def _candidate_query_text(candidate: RetrievalCandidate) -> str:
-    # Declared keys count as the candidate's own text. Without them the coverage
-    # re-rank sees an exact-key hit whose body never spells the token out as a
-    # zero-coverage row and pushes it back down, undoing the arm.
-    keys = candidate.metadata.get("retrieval_keys")
-    key_parts = [str(key) for key in keys] if isinstance(keys, list | tuple) else []
-    parts = [part for part in (candidate.name, candidate.content, *key_parts) if part]
+def _candidate_query_text(
+    candidate: RetrievalCandidate,
+    *,
+    matched_keys: Sequence[str] = (),
+) -> str:
+    # Only the keys this query actually matched, never the row's whole declared
+    # list. The keys are here so the coverage re-rank cannot bury an exact-key
+    # hit whose body never spells the token out, which needs the matched key and
+    # nothing more. Folding in every declared key would move scores on queries
+    # the arm never fired for, and would hand a writer an ungated ranking lever:
+    # sixteen keys of prose keywords buying a permanent coverage lift.
+    parts = [part for part in (candidate.name, candidate.content, *matched_keys) if part]
     return " ".join(parts).lower()
 
 
@@ -2887,10 +2901,22 @@ def _apply_query_coverage_to_fused(
     metadata_by_id = {
         id(candidate): fusion_metadata for candidate, _score, fusion_metadata in fused
     }
+    # Fusion holds the matched keys, not the candidate, because a row reached by
+    # two lanes keeps whichever instance arrived first. The coverage text is
+    # therefore resolved through the fused metadata rather than off the row.
+    matched_keys_by_id = {
+        id(candidate): tuple(
+            str(key) for key in (fusion_metadata.get("matched_retrieval_keys") or ())
+        )
+        for candidate, _score, fusion_metadata in fused
+    }
     reranked, _applied, _refined = rank_items_by_query_coverage(
         query,
         [(candidate, score) for candidate, score, _fusion_metadata in fused],
-        text_fn=_candidate_query_text,
+        text_fn=lambda candidate: _candidate_query_text(
+            candidate,
+            matched_keys=matched_keys_by_id.get(id(candidate), ()),
+        ),
         id_fn=lambda candidate: candidate.id,
         timestamp_fn=lambda candidate: get_entity_timestamp(candidate) or candidate.created_at,
         temporal_target=temporal_target,

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -474,16 +474,33 @@ async def context_search(
     vector_candidate_lists = [vector_fetch.node_candidates, vector_fetch.edge_candidates]
     stage_timings_ms["vector_candidates"] = _elapsed_ms(stage_started_at)
 
+    def candidate_authorized(candidate: RetrievalCandidate) -> bool:
+        return _candidate_allowed(
+            candidate,
+            plan=search_plan,
+            requested_types=requested_types,
+            facet=facet,
+        )
+
     stage_started_at = time.perf_counter()
     graph_expansion_source = await _gather_graph_expansion_source(
         _graph_expansion_candidates(
             client=client,
             plan=search_plan,
             search_filter=search_filter,
+            # Seeds are authorized before they are walked, not only after. A
+            # denied row's own content never reached the caller, but seeding the
+            # walk from it exported its edges: the neighbour passes its own check
+            # and comes back, so the seed's existence became observable through
+            # somebody else's row. That is an oracle whenever the caller chooses
+            # the seed, which an exact-key probe does by construction, and the
+            # walk should not start from a row this reader cannot see regardless
+            # of which lane proposed it.
             seed_candidates=[
                 candidate
                 for source in [*graph_candidate_lists, *vector_candidate_lists]
                 for candidate in source
+                if candidate_authorized(candidate)
             ],
             limit=search_plan.candidate_limits.graph_expansion,
         )
@@ -508,19 +525,7 @@ async def context_search(
         (RetrievalSignal.GRAPH_EXPANSION, graph_expansion_candidates),
     ]
     filtered_lists = [
-        (
-            signal,
-            [
-                candidate
-                for candidate in candidates
-                if _candidate_allowed(
-                    candidate,
-                    plan=search_plan,
-                    requested_types=requested_types,
-                    facet=facet,
-                )
-            ],
-        )
+        (signal, [candidate for candidate in candidates if candidate_authorized(candidate)])
         for signal, candidates in source_lists
     ]
     # Counted after the scope filter, never before. A pre-filter count answers
@@ -1056,6 +1061,7 @@ async def _exact_key_candidates(
 
     if not probe_tokens:
         return []
+    row_limit = max(int(limit), 1)
     filter_clauses, filter_params = _node_filter_clause(search_filter)
     # CONTAINSANY against the index defined on `retrieval_keys_normalized.*`.
     # The element index is what makes this both correct and index-served: on
@@ -1078,7 +1084,12 @@ async def _exact_key_candidates(
         """,
         group_id=plan.organization_id,
         probe_keys=list(probe_tokens),
-        limit=max(int(limit), 1),
+        # Read one lane's worth of rows per probe, not one in total. The database
+        # truncates by recency, and overlap is only computed here, so a single
+        # lane-sized read lets newer single-match rows crowd out the older row
+        # that answers every identifier in the query. Probes are capped, so this
+        # is the same bounded breadth a read per probe would have had.
+        limit=row_limit * len(probe_tokens),
         **filter_params,
     )
 
@@ -1094,7 +1105,9 @@ async def _exact_key_candidates(
     # read to one index lookup and no array functions.
     scored.sort(key=lambda item: (-item[0], item[1]))
     candidates: list[RetrievalCandidate] = []
-    for _count, _uuid, matched, row in scored:
+    # Truncated after the overlap sort, so the lane hands fusion its best rows
+    # rather than its newest ones.
+    for _count, _uuid, matched, row in scored[:row_limit]:
         candidate = _candidate_from_node_record(
             row,
             signal=RetrievalSignal.EXACT_KEY,

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -37,6 +37,7 @@ from sibyl_core.retrieval.candidates import (
     VectorCandidateFetch,
 )
 from sibyl_core.retrieval.fusion import rrf_merge
+from sibyl_core.retrieval.identifier_query import identifier_probe_tokens
 from sibyl_core.retrieval.query_ranking import rank_items_by_query_coverage
 from sibyl_core.retrieval.temporal import (
     get_entity_timestamp,
@@ -156,6 +157,7 @@ class RetrievalSignal(StrEnum):
     NODE_VECTOR = "node_vector"
     EDGE_VECTOR = "edge_vector"
     GRAPH_EXPANSION = "graph_expansion"
+    EXACT_KEY = "exact_key"
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,6 +166,11 @@ class RetrievalWeights:
     active_task_state_boost: float = 1.3
     project_match_boost: float = 1.2
     direct_raw_source_boost: float = 1.4
+    # Deliberately equal to direct_raw_source_boost: both express the same thing,
+    # a candidate reached through a channel somebody declared outright rather
+    # than one inferred by similarity. A writer stamping an exact key is the
+    # write-side twin of a caller naming a raw source, so the magnitudes match.
+    exact_key_boost: float = 1.4
     graph_expansion_only_boost: float = 0.45
     graph_native_signal_boost_cap: float = 1.2
     freshness_boost_cap: float = 1.5
@@ -178,6 +185,7 @@ class CandidateLimits:
     node_vector: int = DEFAULT_CANDIDATES_PER_SIGNAL
     edge_vector: int = DEFAULT_CANDIDATES_PER_SIGNAL
     graph_expansion: int = DEFAULT_CANDIDATES_PER_SIGNAL
+    exact_key: int = DEFAULT_CANDIDATES_PER_SIGNAL
 
 
 @dataclass(frozen=True, slots=True)
@@ -208,6 +216,7 @@ class RetrievalPlan:
         RetrievalSignal.NODE_VECTOR,
         RetrievalSignal.EDGE_VECTOR,
         RetrievalSignal.GRAPH_EXPANSION,
+        RetrievalSignal.EXACT_KEY,
     )
     project: str | None = None
     accessible_projects: frozenset[str] | None = None
@@ -343,6 +352,7 @@ def build_context_retrieval_plan(
             node_vector=per_signal_limit,
             edge_vector=per_signal_limit,
             graph_expansion=per_signal_limit,
+            exact_key=per_signal_limit,
         ),
         project=project,
         accessible_projects=scoped_accessible_projects,
@@ -389,6 +399,11 @@ async def context_search(
     node_sources_allowed = _node_sources_allowed(requested_types)
     episode_sources_allowed = _episode_sources_allowed(requested_types)
     edge_sources_allowed = _edge_sources_allowed(requested_types)
+    probe_tokens = (
+        identifier_probe_tokens(search_plan.query)
+        if RetrievalSignal.EXACT_KEY in search_plan.signals
+        else ()
+    )
     graph_tasks = [
         (
             RetrievalSignal.NODE_FULLTEXT,
@@ -421,6 +436,18 @@ async def context_search(
                 limit=search_plan.candidate_limits.edge_fulltext,
             )
             if edge_sources_allowed
+            else _empty_candidate_source(),
+        ),
+        (
+            RetrievalSignal.EXACT_KEY,
+            _exact_key_candidates(
+                client=client,
+                plan=search_plan,
+                search_filter=search_filter,
+                limit=search_plan.candidate_limits.exact_key,
+                probe_tokens=probe_tokens,
+            )
+            if node_sources_allowed and probe_tokens
             else _empty_candidate_source(),
         ),
     ]
@@ -475,6 +502,7 @@ async def context_search(
         (RetrievalSignal.NODE_FULLTEXT, graph_candidate_lists[0]),
         (RetrievalSignal.EPISODE_FULLTEXT, graph_candidate_lists[1]),
         (RetrievalSignal.EDGE_FULLTEXT, graph_candidate_lists[2]),
+        (RetrievalSignal.EXACT_KEY, graph_candidate_lists[3]),
         (RetrievalSignal.NODE_VECTOR, vector_candidate_lists[0]),
         (RetrievalSignal.EDGE_VECTOR, vector_candidate_lists[1]),
         (RetrievalSignal.GRAPH_EXPANSION, graph_expansion_candidates),
@@ -551,6 +579,10 @@ async def context_search(
             **candidate_source_metadata,
             **raw_recall_metadata,
             **vector_fetch.as_metadata(),
+            **_exact_key_receipt_metadata(
+                probe_tokens=probe_tokens,
+                candidates=graph_candidate_lists[3],
+            ),
             "stage_timings_ms": stage_timings_ms,
         },
         graph_count=len([result for result in results if result.result_origin == "graph"]),
@@ -747,6 +779,21 @@ def _fusion_receipt_metadata(
     return metadata
 
 
+def _exact_key_receipt_metadata(
+    *,
+    probe_tokens: Sequence[str],
+    candidates: Sequence[RetrievalCandidate],
+) -> dict[str, object]:
+    """Say whether the exact-match arm fired, so "inert" is a checkable claim."""
+
+    metadata: dict[str, object] = {"exact_key_probe_fired": bool(probe_tokens)}
+    if not probe_tokens:
+        return metadata
+    metadata["exact_key_probe_tokens"] = list(probe_tokens)
+    metadata["exact_key_hit_count"] = len(candidates)
+    return metadata
+
+
 def _candidate_list_or_empty(result: object) -> list[RetrievalCandidate]:
     if isinstance(result, BaseException) or not isinstance(result, list):
         return []
@@ -785,6 +832,7 @@ def _candidate_limits_for_limit(
         node_vector=max(1, min(candidate_limits.node_vector, source_limit)),
         edge_vector=max(1, min(candidate_limits.edge_vector, source_limit)),
         graph_expansion=max(1, min(candidate_limits.graph_expansion, source_limit)),
+        exact_key=max(1, min(candidate_limits.exact_key, source_limit)),
     )
 
 
@@ -972,6 +1020,78 @@ async def _node_fulltext_candidates(
         )
         for row in rows
     ]
+
+
+async def _exact_key_candidates(
+    *,
+    client: Any,
+    plan: RetrievalPlan,
+    search_filter: SearchFilter,
+    limit: int,
+    probe_tokens: Sequence[str],
+) -> list[RetrievalCandidate]:
+    """Rows whose writer declared one of the query's identifier-shaped tokens.
+
+    This is the one lane that can find a memory whose text never contains the
+    query: the key is an assertion layered onto the content, not extracted from
+    it. Everything is exact, so the lane cannot return a weakly relevant row and
+    the precision problem that keeps BM25 out of fusion does not arise here.
+
+    Inert by construction when the query carries no identifier: no probe tokens
+    means no read at all, and the fused pool is exactly what it was before.
+    """
+
+    if not probe_tokens:
+        return []
+    filter_clauses, filter_params = _node_filter_clause(search_filter)
+    rows = await _execute_query_records(
+        client,
+        """
+        SELECT *
+        FROM entity
+        WHERE """
+        + _where_clause(["group_id = $group_id", *filter_clauses])
+        + """
+          AND retrieval_keys_normalized CONTAINSANY $probe_keys
+        ORDER BY created_at DESC, uuid DESC
+        LIMIT $limit;
+        """,
+        group_id=plan.organization_id,
+        probe_keys=list(probe_tokens),
+        limit=max(int(limit), 1),
+        **filter_params,
+    )
+    probes = set(probe_tokens)
+    scored: list[tuple[float, list[str], Mapping[str, object]]] = []
+    for row in rows:
+        matched = _matched_retrieval_keys(row, probes)
+        if not matched:
+            continue
+        scored.append((len(matched) / len(probes), matched, row))
+    # Overlap is counted here rather than in SurrealQL so the lane depends on one
+    # index lookup and no array functions, which keeps it identical across the
+    # embedded test engine and the deployed server.
+    scored.sort(key=lambda item: item[0], reverse=True)
+    candidates: list[RetrievalCandidate] = []
+    for score, matched, row in scored:
+        candidate = _candidate_from_node_record(
+            row,
+            signal=RetrievalSignal.EXACT_KEY,
+            score=score,
+        )
+        candidate.metadata["matched_retrieval_keys"] = matched
+        candidates.append(candidate)
+    return candidates
+
+
+def _matched_retrieval_keys(
+    row: Mapping[str, object],
+    probes: set[str],
+) -> list[str]:
+    stored = row.get("retrieval_keys_normalized")
+    if not isinstance(stored, list | tuple):
+        return []
+    return [str(key) for key in stored if str(key) in probes]
 
 
 async def _episode_fulltext_candidates(
@@ -2142,6 +2262,7 @@ def _selected_record_metadata(row: Mapping[str, object]) -> dict[str, object]:
         "complexity",
         "feature",
         "tags",
+        "retrieval_keys",
         "project_id",
         "epic_id",
         "task_id",
@@ -2684,6 +2805,13 @@ def _rank_fused_candidates(
         if graph_signal_multiplier > 1.0:
             score *= graph_signal_multiplier
             fusion_metadata["graph_native_signal_boost"] = graph_signal_multiplier
+        exact_key_multiplier = _exact_key_multiplier(plan, signals=fusion_metadata["sources"])
+        if exact_key_multiplier > 1.0:
+            score *= exact_key_multiplier
+            fusion_metadata["exact_key_boost"] = exact_key_multiplier
+            fusion_metadata["matched_retrieval_keys"] = list(
+                candidate.metadata.get("matched_retrieval_keys") or ()
+            )
         boosted, temporal_multiplier = _boost_score(
             candidate,
             score,
@@ -2709,7 +2837,12 @@ def _merge_graph_expansion_metadata(
 
 
 def _candidate_query_text(candidate: RetrievalCandidate) -> str:
-    parts = [part for part in (candidate.name, candidate.content) if part]
+    # Declared keys count as the candidate's own text. Without them the coverage
+    # re-rank sees an exact-key hit whose body never spells the token out as a
+    # zero-coverage row and pushes it back down, undoing the arm.
+    keys = candidate.metadata.get("retrieval_keys")
+    key_parts = [str(key) for key in keys] if isinstance(keys, list | tuple) else []
+    parts = [part for part in (candidate.name, candidate.content, *key_parts) if part]
     return " ".join(parts).lower()
 
 
@@ -2771,6 +2904,25 @@ def _graph_expansion_only_multiplier(
     if set(signals) != {RetrievalSignal.GRAPH_EXPANSION.value}:
         return 1.0
     return max(min(plan.weights.graph_expansion_only_boost, 1.0), 0.0)
+
+
+def _exact_key_multiplier(
+    plan: RetrievalPlan,
+    *,
+    signals: Sequence[str],
+) -> float:
+    """Lift a candidate whose writer declared one of the query's exact keys.
+
+    Rank-only RRF would score this candidate like the top of any other lane,
+    which is the failure that keeps a weak lexical arm out of fusion: an equal
+    vote for an unequal signal. The boost is what makes the arm high-precision
+    rather than merely present, and it applies to the candidate, not the lane,
+    so a row found by both the key and the vector index is lifted once.
+    """
+
+    if RetrievalSignal.EXACT_KEY.value not in signals:
+        return 1.0
+    return max(plan.weights.exact_key_boost, 1.0)
 
 
 def _graph_native_signal_multiplier(
@@ -2868,6 +3020,11 @@ def _search_result_from_candidate(
         )
     if fusion_metadata.get("graph_native_signal_boost"):
         metadata["graph_native_signal_boost"] = fusion_metadata.get("graph_native_signal_boost")
+    if fusion_metadata.get("exact_key_boost"):
+        metadata["exact_key_boost"] = fusion_metadata.get("exact_key_boost")
+        metadata["matched_retrieval_keys"] = list(
+            fusion_metadata.get("matched_retrieval_keys") or ()
+        )
     if fusion_metadata.get("temporal_decay_multiplier") is not None:
         metadata["temporal_decay_multiplier"] = round(
             float(fusion_metadata["temporal_decay_multiplier"]),

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -1063,7 +1063,7 @@ async def _exact_key_candidates(
     # a full table scan, and turns a bare equality into zero rows unless the
     # WHERE clause happens to carry a second predicate. Verified live on 3.2.3
     # (UnionIndexScan across one branch per probe), so the `.*` in the index
-    # definition is load-bearing rather than stylistic.
+    # definition is what this read depends on, not a stylistic choice.
     rows = await _execute_query_records(
         client,
         """

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -1044,54 +1044,66 @@ async def _exact_key_candidates(
     if not probe_tokens:
         return []
     filter_clauses, filter_params = _node_filter_clause(search_filter)
-    rows = await _execute_query_records(
-        client,
+    # One indexed equality per probe rather than a single set-membership read.
+    # On SurrealDB 3.2.3 an array-element index answers `field = $value` with an
+    # IndexScan, while `CONTAINSANY` falls back to a full TableScan; a
+    # multi-value `IN` and an OR of equalities each return no rows at all
+    # despite matching data, verified live against 3.2.3 before this shape was
+    # chosen. Probe tokens are capped, so this is a bounded fan-out of point
+    # lookups rather than a scan that grows with the corpus.
+    row_query = (
         """
         SELECT *
         FROM entity
         WHERE """
         + _where_clause(["group_id = $group_id", *filter_clauses])
         + """
-          AND retrieval_keys_normalized CONTAINSANY $probe_keys
+          AND retrieval_keys_normalized = $probe_key
         ORDER BY created_at DESC, uuid DESC
         LIMIT $limit;
-        """,
-        group_id=plan.organization_id,
-        probe_keys=list(probe_tokens),
-        limit=max(int(limit), 1),
-        **filter_params,
+        """
     )
-    probes = set(probe_tokens)
-    scored: list[tuple[float, list[str], Mapping[str, object]]] = []
-    for row in rows:
-        matched = _matched_retrieval_keys(row, probes)
-        if not matched:
-            continue
-        scored.append((len(matched) / len(probes), matched, row))
-    # Overlap is counted here rather than in SurrealQL so the lane depends on one
-    # index lookup and no array functions, which keeps it identical across the
-    # embedded test engine and the deployed server.
-    scored.sort(key=lambda item: item[0], reverse=True)
-    candidates: list[RetrievalCandidate] = []
-    for score, matched, row in scored:
-        candidate = _candidate_from_node_record(
-            row,
-            signal=RetrievalSignal.EXACT_KEY,
-            score=score,
+    row_limit = max(int(limit), 1)
+    reads = await asyncio.gather(
+        *(
+            _execute_query_records(
+                client,
+                row_query,
+                group_id=plan.organization_id,
+                probe_key=probe_key,
+                limit=row_limit,
+                **filter_params,
+            )
+            for probe_key in probe_tokens
         )
-        candidate.metadata["matched_retrieval_keys"] = matched
+    )
+
+    matched_by_uuid: dict[str, list[str]] = defaultdict(list)
+    row_by_uuid: dict[str, Mapping[str, object]] = {}
+    for probe_key, rows in zip(probe_tokens, reads, strict=True):
+        for row in rows:
+            uuid = str(row.get("uuid") or "")
+            if not uuid:
+                continue
+            row_by_uuid.setdefault(uuid, row)
+            matched_by_uuid[uuid].append(probe_key)
+
+    # A row that answers more of the query's identifiers is the better answer, so
+    # overlap orders the lane. Counted here because the reads are per probe.
+    ordered = sorted(
+        matched_by_uuid.items(),
+        key=lambda item: (-len(item[1]), item[0]),
+    )
+    candidates: list[RetrievalCandidate] = []
+    for uuid, matched in ordered[:row_limit]:
+        candidate = _candidate_from_node_record(
+            row_by_uuid[uuid],
+            signal=RetrievalSignal.EXACT_KEY,
+            score=len(matched) / len(probe_tokens),
+        )
+        candidate.metadata["matched_retrieval_keys"] = list(matched)
         candidates.append(candidate)
     return candidates
-
-
-def _matched_retrieval_keys(
-    row: Mapping[str, object],
-    probes: set[str],
-) -> list[str]:
-    stored = row.get("retrieval_keys_normalized")
-    if not isinstance(stored, list | tuple):
-        return []
-    return [str(key) for key in stored if str(key) in probes]
 
 
 async def _episode_fulltext_candidates(
@@ -2775,6 +2787,12 @@ def _rank_fused_candidates(
             fusion_metadata["original_scores"][signal.value] = candidate.score
             if signal is RetrievalSignal.GRAPH_EXPANSION:
                 _merge_graph_expansion_metadata(fusion_metadata, candidate)
+            if signal is RetrievalSignal.EXACT_KEY:
+                # Merged here, from the lane's own candidate instance, because
+                # candidates_by_id keeps whichever lane saw the row first: a row
+                # found by both full-text and the key would otherwise report an
+                # empty match list off the full-text instance.
+                _merge_exact_key_metadata(fusion_metadata, candidate)
 
     ranked: list[tuple[RetrievalCandidate, float, dict[str, Any]]] = []
     for candidate_id, score in score_by_id.items():
@@ -2809,9 +2827,6 @@ def _rank_fused_candidates(
         if exact_key_multiplier > 1.0:
             score *= exact_key_multiplier
             fusion_metadata["exact_key_boost"] = exact_key_multiplier
-            fusion_metadata["matched_retrieval_keys"] = list(
-                candidate.metadata.get("matched_retrieval_keys") or ()
-            )
         boosted, temporal_multiplier = _boost_score(
             candidate,
             score,
@@ -2834,6 +2849,16 @@ def _merge_graph_expansion_metadata(
         value = metadata.get(key)
         if value is not None:
             fusion_metadata[key] = value
+
+
+def _merge_exact_key_metadata(
+    fusion_metadata: dict[str, Any],
+    candidate: RetrievalCandidate,
+) -> None:
+    metadata = candidate.metadata if isinstance(candidate.metadata, Mapping) else {}
+    matched = metadata.get("matched_retrieval_keys")
+    if isinstance(matched, list | tuple):
+        fusion_metadata["matched_retrieval_keys"] = [str(key) for key in matched]
 
 
 def _candidate_query_text(candidate: RetrievalCandidate) -> str:

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -35,6 +35,7 @@ from sibyl_core.memory_pipeline.quality import (
     expand_memory_quality_storage_metadata,
     normalize_memory_quality_metadata,
 )
+from sibyl_core.memory_pipeline.retrieval_keys import coerce_retrieval_keys
 from sibyl_core.models.entities import (
     Entity,
     EntityType,
@@ -261,6 +262,11 @@ INSERT INTO entity $rows ON DUPLICATE KEY UPDATE
     -- fail-open. A caller that means "no scope" sends CLEAR_MEMORY_SCOPE.
     memory_scope = IF $input.memory_scope = '{CLEAR_MEMORY_SCOPE}' {{ NONE }}
         ELSE {{ $input.memory_scope ?? memory_scope }},
+    -- Same absence rule as memory_scope, for the same reason: a write is a full
+    -- replace, and a reprojection or restore that rebuilds an Entity without
+    -- the keys must not strip the writer's exact-match declaration off the row.
+    retrieval_keys = $input.retrieval_keys ?? retrieval_keys,
+    retrieval_keys_normalized = $input.retrieval_keys_normalized ?? retrieval_keys_normalized,
     epic_id = $input.epic_id,
     parent_task_id = $input.parent_task_id,
     task_id = $input.task_id,
@@ -1978,6 +1984,9 @@ def entity_from_surreal_row(row: Mapping[str, object]) -> Entity:
     row_tags = normalized_row.get("tags")
     if row_tags is not None and metadata.get("tags") is None:
         metadata["tags"] = row_tags
+    row_retrieval_keys = normalized_row.get("retrieval_keys")
+    if row_retrieval_keys is not None and metadata.get("retrieval_keys") is None:
+        metadata["retrieval_keys"] = row_retrieval_keys
 
     entity_id = _entity_id_from_row(normalized_row)
     record_id = _row_record_id(normalized_row)
@@ -2900,6 +2909,12 @@ def _entity_record(
     # genuinely means "no scope" says so with CLEAR_MEMORY_SCOPE, which reaches
     # the query as a value and overwrites rather than being skipped.
     memory_scope = _metadata_str(metadata, "memory_scope")
+    # The writer's exact-match declaration, promoted for the same reason the
+    # scope is: only a column can carry the index the exact-match arm reads.
+    # Coerced rather than validated here because this is the storage edge and a
+    # single malformed key must not fail an otherwise valid write; the surfaces
+    # that accept keys from a caller validate strictly instead.
+    retrieval_keys = coerce_retrieval_keys(metadata.get("retrieval_keys"))
     epic_id = _metadata_str(metadata, "epic_id")
     parent_task_id = _metadata_str(metadata, "parent_task_id")
     if canonicalize_parent_task_id and not parent_task_id and entity.entity_type == EntityType.TASK:
@@ -2951,6 +2966,11 @@ def _entity_record(
         "tags": tags,
         "name_embedding": entity.embedding,
     }
+    # Absent rather than NONE when the entity declares no keys, so a namespace
+    # that has not reached graph schema v18 still accepts an ordinary write.
+    if retrieval_keys is not None:
+        record["retrieval_keys"] = retrieval_keys[0]
+        record["retrieval_keys_normalized"] = retrieval_keys[1]
     if last_recalled_at is not None:
         record["last_recalled_at"] = last_recalled_at
     if last_used_at is not None:
@@ -3034,6 +3054,13 @@ def _entity_update_patch(updates: Mapping[str, Any], *, updated_at: datetime) ->
         tags = _metadata_str_list(metadata_patch.get("tags")) or []
         patch["tags"] = tags
         attributes_patch["tags"] = tags
+    if "retrieval_keys" in metadata_patch:
+        # Naming the field in an update IS the explicit statement the bulk
+        # upsert's absence rule refuses to infer, so an empty list clears.
+        display, match = coerce_retrieval_keys(metadata_patch.get("retrieval_keys")) or ([], [])
+        patch["retrieval_keys"] = display
+        patch["retrieval_keys_normalized"] = match
+        attributes_patch["retrieval_keys"] = display
     return patch
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/tools/add.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/add.py
@@ -10,6 +10,10 @@ from sibyl_core.auth.memory_policy import (
     stamp_memory_scope_metadata,
 )
 from sibyl_core.embeddings.providers import configured_embedding_provider
+from sibyl_core.memory_pipeline.retrieval_keys import (
+    coerce_retrieval_keys,
+    normalize_retrieval_keys,
+)
 from sibyl_core.memory_pipeline.structure import (
     PROBE_REHEARSAL_METADATA_KEY,
     MemoryStructure,
@@ -245,6 +249,7 @@ async def add(
     memory_scope: str | None = None,
     scope_key: str | None = None,
     principal_id: str | None = None,
+    retrieval_keys: list[str] | None = None,
     # Structure the writing agent declares for its own memory
     spans: list[dict[str, Any]] | None = None,
     atomic: bool = False,
@@ -302,6 +307,10 @@ async def add(
         memory_scope: Authorized audience for the row, resolved by the calling surface.
         scope_key: Authorized audience key (a verified project, never a payload value).
         principal_id: Authenticated author of the write.
+        retrieval_keys: Exact-match identifiers this entity answers to (error strings,
+              symbols, config flags, aliases). Matched case-insensitively against
+              identifier-shaped queries, so a key may name something the content
+              never spells out. Max 16 keys, 200 characters each.
         spans: Agent-authored cut plan as [{"start": int, "end": int, "label": str?}].
               Offsets are half-open into the stored (stripped) content and must tile
               it exactly: no gap, no overlap, first starts at 0, last ends at the
@@ -313,6 +322,7 @@ async def add(
               live search path once the write lands, and the ranks come back in
               the response. Supplying probes forces a synchronous write, since a
               rehearsal cannot observe a row that has not been written yet.
+
 
     Returns:
         AddResponse with created entity ID, auto-discovered links, conflicts, and timestamp.
@@ -468,6 +478,21 @@ async def add(
         }
         if project:
             full_metadata["project_id"] = project
+        # Every graph write funnels through here, so this is where a declaration
+        # arriving as an explicit argument and one arriving inside a forwarded
+        # metadata bag become the same normalized list. The explicit argument is
+        # validated strictly because a surface resolved it and can be told it was
+        # refused; the bag is coerced, because it also carries arbitrary caller
+        # junk that must not fail an otherwise valid write.
+        if retrieval_keys is not None:
+            declared_retrieval_keys, _match_forms = normalize_retrieval_keys(retrieval_keys)
+        else:
+            coerced_keys = coerce_retrieval_keys(full_metadata.get("retrieval_keys"))
+            declared_retrieval_keys = coerced_keys[0] if coerced_keys else []
+        if declared_retrieval_keys:
+            full_metadata["retrieval_keys"] = declared_retrieval_keys
+        else:
+            full_metadata.pop("retrieval_keys", None)
 
         # Create appropriate entity type
         entity: Entity | Episode | Pattern | Procedure | Task | Project

--- a/packages/python/sibyl-core/tests/fixtures/identifier_flank/a2_probe_set.json
+++ b/packages/python/sibyl-core/tests/fixtures/identifier_flank/a2_probe_set.json
@@ -1,0 +1,165 @@
+{
+  "fixture_id": "sibyl-a2-identifier-flank-probe-set",
+  "version": "2026-08-03.1",
+  "purpose": "Standing regression probe for the A2 identifier flank: writer-declared retrieval keys plus the exact-match retrieval arm. Each firing case names a memory whose body does NOT contain the queried token, so a pass cannot be explained by full-text or dense similarity. Each inert case is prose that must leave the arm unfired, which is what keeps the arm from becoming a general lexical lane.",
+  "cases": [
+    {
+      "id": "error-code-hex",
+      "query": "why does ERR_CONN_RESET_0x7f31 keep firing on startup",
+      "expect_fire": true,
+      "expected_probe_tokens": ["err_conn_reset_0x7f31"],
+      "memory": {
+        "title": "Connection resets during handshake",
+        "body": "The socket drops mid-handshake and the retry loop gives up after three attempts.",
+        "retrieval_keys": ["ERR_CONN_RESET_0x7f31"]
+      }
+    },
+    {
+      "id": "env-var",
+      "query": "what does SIBYL_FUSION_BACKEND change",
+      "expect_fire": true,
+      "expected_probe_tokens": ["sibyl_fusion_backend"],
+      "memory": {
+        "title": "Choosing where fusion runs",
+        "body": "Fusion can execute in process or inside the database; the default is the in-process path.",
+        "retrieval_keys": ["SIBYL_FUSION_BACKEND"]
+      }
+    },
+    {
+      "id": "module-path",
+      "query": "who owns sibyl_core.retrieval.search",
+      "expect_fire": true,
+      "expected_probe_tokens": ["sibyl_core.retrieval.search"],
+      "memory": {
+        "title": "Retrieval planning lives in one module",
+        "body": "Plan construction, lane orchestration and fusion all sit together so a lane cannot be added without touching the plan.",
+        "retrieval_keys": ["sibyl_core.retrieval.search"]
+      }
+    },
+    {
+      "id": "file-name",
+      "query": "is proxy.ts the middleware file",
+      "expect_fire": true,
+      "expected_probe_tokens": ["proxy.ts"],
+      "memory": {
+        "title": "Next.js renamed the middleware entry point",
+        "body": "The framework now looks for the request interceptor under a different filename than it used to.",
+        "retrieval_keys": ["proxy.ts", "middleware.ts"]
+      }
+    },
+    {
+      "id": "commit-sha",
+      "query": "what landed in 89684d05a1b2c3d4",
+      "expect_fire": true,
+      "expected_probe_tokens": ["89684d05a1b2c3d4"],
+      "memory": {
+        "title": "Per-lane seed budget now scales with the request",
+        "body": "A lane may propose no more rows than the whole answer holds, so a wider ask pays for a wider read.",
+        "retrieval_keys": ["89684d05a1b2c3d4"]
+      }
+    },
+    {
+      "id": "scoped-symbol",
+      "query": "why did std::vector<int> blow up here",
+      "expect_fire": true,
+      "expected_probe_tokens": ["std::vector<int>"],
+      "memory": {
+        "title": "Reserve before pushing in the hot loop",
+        "body": "Repeated growth reallocates the buffer and invalidates every outstanding iterator.",
+        "retrieval_keys": ["std::vector<int>"]
+      }
+    },
+    {
+      "id": "camel-case-symbol",
+      "query": "when should I call getSurrealGraphClient",
+      "expect_fire": true,
+      "expected_probe_tokens": ["getsurrealgraphclient"],
+      "memory": {
+        "title": "One pooled client per organization namespace",
+        "body": "Each tenant gets a dedicated pooled handle; sharing one across tenants routes queries into the wrong namespace.",
+        "retrieval_keys": ["getSurrealGraphClient"]
+      }
+    },
+    {
+      "id": "quoted-error-string",
+      "query": "the log said \"connection reset by peer\" again",
+      "expect_fire": true,
+      "expected_probe_tokens": ["connection reset by peer"],
+      "memory": {
+        "title": "Upstream closes idle sockets at sixty seconds",
+        "body": "The load balancer drops an idle connection well before the client's own timeout fires.",
+        "retrieval_keys": ["connection reset by peer"]
+      }
+    },
+    {
+      "id": "command-flag",
+      "query": "does --wait-searchable slow the capture down",
+      "expect_fire": true,
+      "expected_probe_tokens": ["--wait-searchable"],
+      "memory": {
+        "title": "Capture can block until the row is retrievable",
+        "body": "By default a capture returns as soon as the verbatim record is durable and finishes projecting in the background.",
+        "retrieval_keys": ["--wait-searchable"]
+      }
+    },
+    {
+      "id": "two-identifiers-one-query",
+      "query": "does search.py still gate on SIBYL_FUSION_BACKEND",
+      "expect_fire": true,
+      "expected_probe_tokens": ["search.py", "sibyl_fusion_backend"],
+      "memory": {
+        "title": "The backend choice is read from the environment per query",
+        "body": "Nothing caches the selection, so flipping it takes effect on the next request without a restart.",
+        "retrieval_keys": ["search.py", "SIBYL_FUSION_BACKEND"]
+      }
+    },
+    {
+      "id": "case-insensitive-declaration",
+      "query": "anything on err_conn_reset_0x7f31",
+      "expect_fire": true,
+      "expected_probe_tokens": ["err_conn_reset_0x7f31"],
+      "memory": {
+        "title": "Retry budget exhausted on the second hop",
+        "body": "The inner call gives up first, so the outer error is a symptom rather than the cause.",
+        "retrieval_keys": ["ERR_CONN_RESET_0X7F31"]
+      }
+    },
+    {
+      "id": "prose-topic-question",
+      "query": "how do we handle authentication",
+      "expect_fire": false,
+      "expected_probe_tokens": []
+    },
+    {
+      "id": "prose-decision-question",
+      "query": "what did we decide about connection pooling",
+      "expect_fire": false,
+      "expected_probe_tokens": []
+    },
+    {
+      "id": "prose-dotted-abbreviation",
+      "query": "e.g. the retrieval plan we shipped",
+      "expect_fire": false,
+      "expected_probe_tokens": []
+    },
+    {
+      "id": "prose-bare-year",
+      "query": "what changed in 2026",
+      "expect_fire": false,
+      "expected_probe_tokens": []
+    },
+    {
+      "id": "prose-hex-spelling-word",
+      "query": "the facade pattern we accede to",
+      "expect_fire": false,
+      "expected_probe_tokens": []
+    },
+    {
+      "id": "prose-bare-acronym",
+      "query": "why does Redis expire the TTL early",
+      "expect_fire": false,
+      "expected_probe_tokens": [],
+      "note": "A bare all-caps acronym deliberately does not fire: English writes acronyms identically, so admitting them would fire the arm on ordinary emphasis. A caller who needs one matched quotes it."
+    }
+  ]
+}

--- a/packages/python/sibyl-core/tests/test_identifier_flank_probe_set.py
+++ b/packages/python/sibyl-core/tests/test_identifier_flank_probe_set.py
@@ -27,9 +27,7 @@ from sibyl_core.retrieval import search as search_module
 from sibyl_core.retrieval.identifier_query import identifier_probe_tokens
 from sibyl_core.retrieval.search import RetrievalSignal, build_context_retrieval_plan
 
-FIXTURE_PATH = (
-    Path(__file__).parent / "fixtures" / "identifier_flank" / "a2_probe_set.json"
-)
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "identifier_flank" / "a2_probe_set.json"
 
 
 def load_probe_set() -> dict[str, Any]:

--- a/packages/python/sibyl-core/tests/test_identifier_flank_probe_set.py
+++ b/packages/python/sibyl-core/tests/test_identifier_flank_probe_set.py
@@ -1,0 +1,234 @@
+"""The A2 identifier-flank probe set, run against the detector and the arm.
+
+The fixture is the standing regression probe the 1.2 ranking gate references, so
+it is checked here rather than only read by an offline harness: a change to the
+detector or the arm that breaks the flank fails in CI instead of in a leaderboard
+run weeks later.
+
+Each firing case asserts the discriminating property in both directions. The
+memory's body must not contain the queried token, so a hit cannot be explained
+by full-text or dense similarity, and the arm must nonetheless return it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sibyl_core.memory_pipeline.retrieval_keys import (
+    normalize_retrieval_keys,
+    retrieval_key_match_form,
+)
+from sibyl_core.models.context import ContextFacet
+from sibyl_core.retrieval import search as search_module
+from sibyl_core.retrieval.identifier_query import identifier_probe_tokens
+from sibyl_core.retrieval.search import RetrievalSignal, build_context_retrieval_plan
+
+FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "identifier_flank" / "a2_probe_set.json"
+)
+
+
+def load_probe_set() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+PROBE_SET = load_probe_set()
+CASES: list[dict[str, Any]] = PROBE_SET["cases"]
+FIRING_CASES = [case for case in CASES if case["expect_fire"]]
+INERT_CASES = [case for case in CASES if not case["expect_fire"]]
+
+
+def _case_ids(cases: list[dict[str, Any]]) -> list[str]:
+    return [str(case["id"]) for case in cases]
+
+
+class _KeyIndexClient:
+    """A Surreal stand-in for one indexed equality read against a seeded row.
+
+    Mirrors the array-element index: the row comes back when any element of its
+    stored key list equals the bound probe.
+    """
+
+    def __init__(self, row: dict[str, object]) -> None:
+        self.row = row
+        self.reads = 0
+
+    async def execute_query(self, _query: str, **params: object) -> list[dict[str, object]]:
+        self.reads += 1
+        probe = params.get("probe_key")
+        stored = {str(key) for key in self.row.get("retrieval_keys_normalized") or ()}
+        return [dict(self.row)] if probe is not None and str(probe) in stored else []
+
+
+def _plan(query: str) -> search_module.RetrievalPlan:
+    return build_context_retrieval_plan(
+        query=query,
+        organization_id="org-a2",
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["episode", "note"]},
+        principal_id="user-a2",
+        project=None,
+        accessible_projects=None,
+    )
+
+
+def _row_for(case: dict[str, Any]) -> dict[str, object]:
+    memory = case["memory"]
+    display, match = normalize_retrieval_keys(memory["retrieval_keys"])
+    return {
+        "uuid": f"note_{case['id']}",
+        "name": memory["title"],
+        "content": memory["body"],
+        "entity_type": "note",
+        "group_id": "org-a2",
+        "retrieval_keys": display,
+        "retrieval_keys_normalized": match,
+        "attributes": {
+            "memory_scope": "private",
+            "principal_id": "user-a2",
+            "retrieval_keys": display,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# The fixture's own claims
+# ---------------------------------------------------------------------------
+
+
+def test_probe_set_is_sized_for_a_standing_gate() -> None:
+    assert 10 <= len(CASES) <= 20
+    assert len(FIRING_CASES) >= 8
+    assert len(INERT_CASES) >= 5
+    assert len(_case_ids(CASES)) == len(set(_case_ids(CASES)))
+
+
+@pytest.mark.parametrize("case", CASES, ids=_case_ids(CASES))
+def test_detector_agrees_with_the_declared_expectation(case: dict[str, Any]) -> None:
+    probes = identifier_probe_tokens(case["query"])
+
+    assert list(probes) == list(case["expected_probe_tokens"])
+    assert bool(probes) is case["expect_fire"]
+
+
+@pytest.mark.parametrize("case", FIRING_CASES, ids=_case_ids(FIRING_CASES))
+def test_firing_case_is_discriminating(case: dict[str, Any]) -> None:
+    """The body must not contain the token, or the case proves nothing."""
+
+    body = case["memory"]["body"].casefold()
+    title = case["memory"]["title"].casefold()
+    for token in case["expected_probe_tokens"]:
+        assert token not in body
+        assert token not in title
+
+
+@pytest.mark.parametrize("case", FIRING_CASES, ids=_case_ids(FIRING_CASES))
+def test_firing_case_declares_a_key_that_matches_its_probe(case: dict[str, Any]) -> None:
+    _display, match = normalize_retrieval_keys(case["memory"]["retrieval_keys"])
+
+    assert set(case["expected_probe_tokens"]) & set(match)
+
+
+# ---------------------------------------------------------------------------
+# The arm, end to end over the fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", FIRING_CASES, ids=_case_ids(FIRING_CASES))
+async def test_arm_returns_the_expected_memory(case: dict[str, Any]) -> None:
+    plan = _plan(case["query"])
+    client = _KeyIndexClient(_row_for(case))
+
+    candidates = await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=plan.candidate_limits.exact_key,
+        probe_tokens=identifier_probe_tokens(case["query"]),
+    )
+
+    assert [candidate.id for candidate in candidates] == [f"note_{case['id']}"]
+    assert candidates[0].retrieval_signals == (RetrievalSignal.EXACT_KEY.value,)
+    assert search_module._candidate_allowed(
+        candidates[0],
+        plan=plan,
+        requested_types=set(),
+        facet=None,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", FIRING_CASES, ids=_case_ids(FIRING_CASES))
+async def test_expected_memory_survives_fusion_against_a_lexical_rival(
+    case: dict[str, Any],
+) -> None:
+    """A hit that ranks below prose noise is a hit nobody reads."""
+
+    plan = _plan(case["query"])
+    client = _KeyIndexClient(_row_for(case))
+    exact = await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=plan.candidate_limits.exact_key,
+        probe_tokens=identifier_probe_tokens(case["query"]),
+    )
+    rival = search_module._candidate_from_node_record(
+        {
+            "uuid": "lexical_rival",
+            "name": "Something the query words happen to touch",
+            "content": case["query"],
+            "entity_type": "note",
+            "group_id": "org-a2",
+            "attributes": {"memory_scope": "private", "principal_id": "user-a2"},
+        },
+        signal=RetrievalSignal.NODE_FULLTEXT,
+        score=1.0,
+    )
+
+    ranked = search_module._fuse_candidates(
+        [
+            (RetrievalSignal.NODE_FULLTEXT, [rival]),
+            (RetrievalSignal.EXACT_KEY, exact),
+        ],
+        plan=plan,
+        limit=2,
+    )
+
+    assert ranked[0][0].id == f"note_{case['id']}"
+    assert ranked[0][2]["exact_key_boost"] == plan.weights.exact_key_boost
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", INERT_CASES, ids=_case_ids(INERT_CASES))
+async def test_inert_case_issues_no_read(case: dict[str, Any]) -> None:
+    plan = _plan(case["query"])
+    client = _KeyIndexClient({"uuid": "must-not-be-read"})
+
+    candidates = await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=plan.candidate_limits.exact_key,
+        probe_tokens=identifier_probe_tokens(case["query"]),
+    )
+
+    assert candidates == []
+    assert client.reads == 0
+    assert search_module._exact_key_receipt_metadata(
+        probe_tokens=identifier_probe_tokens(case["query"]),
+        candidates=[],
+    ) == {"exact_key_probe_fired": False}
+
+
+def test_declared_keys_match_case_insensitively() -> None:
+    case = next(item for item in FIRING_CASES if item["id"] == "case-insensitive-declaration")
+    _display, match = normalize_retrieval_keys(case["memory"]["retrieval_keys"])
+
+    assert match == [retrieval_key_match_form(case["memory"]["retrieval_keys"][0])]
+    assert match == list(case["expected_probe_tokens"])

--- a/packages/python/sibyl-core/tests/test_identifier_flank_probe_set.py
+++ b/packages/python/sibyl-core/tests/test_identifier_flank_probe_set.py
@@ -45,10 +45,10 @@ def _case_ids(cases: list[dict[str, Any]]) -> list[str]:
 
 
 class _KeyIndexClient:
-    """A Surreal stand-in for one indexed equality read against a seeded row.
+    """A Surreal stand-in for the exact-key read against one seeded row.
 
-    Mirrors the array-element index: the row comes back when any element of its
-    stored key list equals the bound probe.
+    Mirrors CONTAINSANY over an index on the array's elements: the row comes
+    back when any element of its stored key list is among the bound probes.
     """
 
     def __init__(self, row: dict[str, object]) -> None:
@@ -57,9 +57,12 @@ class _KeyIndexClient:
 
     async def execute_query(self, _query: str, **params: object) -> list[dict[str, object]]:
         self.reads += 1
-        probe = params.get("probe_key")
+        raw_probes = params.get("probe_keys")
+        if not isinstance(raw_probes, list | tuple):
+            return []
+        probes = {str(probe) for probe in raw_probes}
         stored = {str(key) for key in self.row.get("retrieval_keys_normalized") or ()}
-        return [dict(self.row)] if probe is not None and str(probe) in stored else []
+        return [dict(self.row)] if probes & stored else []
 
 
 def _plan(query: str) -> search_module.RetrievalPlan:

--- a/packages/python/sibyl-core/tests/test_retrieval_exact_key_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_exact_key_arm.py
@@ -250,6 +250,38 @@ async def test_arm_issues_no_read_without_a_probe() -> None:
 
 
 @pytest.mark.asyncio
+async def test_best_overlap_row_survives_a_lane_limit_smaller_than_the_match_count() -> None:
+    """The database truncates by recency, and overlap is only known here.
+
+    Regression: reading one lane's worth of rows in total let newer single-match
+    rows crowd out the older row that answers every identifier in the query, so
+    the lane advertised an overlap ranking it could not deliver. The read is now
+    sized per probe and the truncation happens after the sort.
+    """
+
+    metadata = await _captured_metadata()
+    both = _row(metadata, normalized_keys=["key_a", "key_b"]) | {"uuid": "both"}
+    newer_one = _row(metadata, normalized_keys=["key_a"]) | {"uuid": "newer_a"}
+    newer_two = _row(metadata, normalized_keys=["key_b"]) | {"uuid": "newer_b"}
+    # Ordered the way the database would hand them back: newest first, so the
+    # best-overlap row arrives last.
+    client = _RecordingClient([newer_one, newer_two, both])
+    plan = _plan()
+
+    candidates = await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=2,
+        probe_tokens=("key_a", "key_b"),
+    )
+
+    assert [candidate.id for candidate in candidates] == ["both", "newer_a"]
+    _query, params = client.queries[0]
+    assert params["limit"] == 4
+
+
+@pytest.mark.asyncio
 async def test_arm_drops_a_row_whose_stored_keys_do_not_actually_match() -> None:
     """The index is a filter, not the decision: overlap is confirmed in Python."""
 
@@ -370,6 +402,106 @@ async def test_project_scoped_exact_key_hit_is_denied_outside_the_project() -> N
         requested_types=set(),
         facet=None,
     )
+
+
+# ---------------------------------------------------------------------------
+# Graph expansion must not walk from a row the reader cannot see
+# ---------------------------------------------------------------------------
+
+
+class _EmptyClient:
+    async def execute_query(self, _query: str, **_params: object) -> list[dict[str, object]]:
+        return []
+
+
+async def _seeds_for(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    reader: str,
+    probe_key: str,
+) -> list[str]:
+    """Run a real context_search and report which uuids seeded graph expansion."""
+
+    metadata = await _captured_metadata(principal_id="user-alice")
+    victim = _row(metadata, normalized_keys=[PROBE_KEY.casefold()])
+    seeds: list[str] = []
+
+    async def fake_exact_key_candidates(**kwargs: Any) -> list[RetrievalCandidate]:
+        probes = set(kwargs["probe_tokens"])
+        if PROBE_KEY.casefold() not in probes:
+            return []
+        return [
+            search_module._candidate_from_node_record(
+                victim,
+                signal=RetrievalSignal.EXACT_KEY,
+                score=1.0,
+            )
+        ]
+
+    async def fake_graph_expansion(**kwargs: Any) -> list[RetrievalCandidate]:
+        seeds.extend(candidate.id for candidate in kwargs["seed_candidates"])
+        return []
+
+    class Runtime:
+        client = _EmptyClient()
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> Runtime:
+        return Runtime()
+
+    async def no_raw_recall(**_kwargs: object) -> list[Any]:
+        return []
+
+    monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+    monkeypatch.setattr(search_module, "_exact_key_candidates", fake_exact_key_candidates)
+    monkeypatch.setattr(search_module, "_graph_expansion_candidates", fake_graph_expansion)
+
+    await search_module.context_search(
+        plan=_plan(principal_id=reader, query=f"why does {probe_key} fire"),
+        limit=10,
+        raw_memory_recall_fn=no_raw_recall,
+    )
+    return seeds
+
+
+@pytest.mark.asyncio
+async def test_expansion_seeds_from_a_denied_exact_key_hit_are_withheld(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A denied row must not seed the walk, or its edges export its existence.
+
+    The row's own content was already withheld, but seeding graph expansion from
+    it returns a neighbour the reader IS allowed to see, so a caller who guesses
+    another principal's declared key gets a different result set than one who
+    guesses wrong. That is an oracle over somebody else's keys, and auto-linking
+    supplies the neighbour.
+    """
+
+    seeds = await _seeds_for(monkeypatch, reader="user-bob", probe_key=PROBE_KEY)
+
+    assert seeds == []
+
+
+@pytest.mark.asyncio
+async def test_expansion_still_seeds_from_an_authorized_exact_key_hit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fix withholds denied seeds without disarming expansion for the owner."""
+
+    seeds = await _seeds_for(monkeypatch, reader="user-alice", probe_key=PROBE_KEY)
+
+    assert seeds == ["note_1"]
+
+
+@pytest.mark.asyncio
+async def test_a_wrong_key_and_a_right_key_look_identical_to_a_denied_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The property the oracle violated, stated directly."""
+
+    correct = await _seeds_for(monkeypatch, reader="user-bob", probe_key=PROBE_KEY)
+    wrong = await _seeds_for(monkeypatch, reader="user-bob", probe_key="ERR_NOT_A_REAL_KEY_0x00")
+
+    assert correct == wrong == []
 
 
 # ---------------------------------------------------------------------------

--- a/packages/python/sibyl-core/tests/test_retrieval_exact_key_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_exact_key_arm.py
@@ -500,6 +500,45 @@ def test_a_candidate_found_only_by_the_key_is_not_demoted_as_vector_only() -> No
     assert "graph_expansion_only_demoted" not in ranked[0][2]
 
 
+def test_an_inert_lane_changes_no_score_and_no_metadata() -> None:
+    """Inertness is a structural claim, not an observation about one query.
+
+    rrf_merge drops empty lists before it assigns weights, so an unfired
+    exact-key lane cannot shift another candidate's fused score. Pinned here
+    because the alternative failure is silent: a query with no identifier would
+    rank differently than it did before keys existed.
+    """
+
+    plan = _plan()
+    lexical = _candidate("lexical")
+    vector = _candidate("vector")
+
+    without_lane = search_module._fuse_candidates(
+        [
+            (RetrievalSignal.NODE_FULLTEXT, [lexical]),
+            (RetrievalSignal.NODE_VECTOR, [vector]),
+        ],
+        plan=plan,
+        limit=10,
+    )
+    with_inert_lane = search_module._fuse_candidates(
+        [
+            (RetrievalSignal.NODE_FULLTEXT, [lexical]),
+            (RetrievalSignal.EXACT_KEY, []),
+            (RetrievalSignal.NODE_VECTOR, [vector]),
+        ],
+        plan=plan,
+        limit=10,
+    )
+
+    assert [(candidate.id, score) for candidate, score, _meta in without_lane] == [
+        (candidate.id, score) for candidate, score, _meta in with_inert_lane
+    ]
+    assert [meta for _candidate, _score, meta in without_lane] == [
+        meta for _candidate, _score, meta in with_inert_lane
+    ]
+
+
 def test_declared_keys_join_the_coverage_text() -> None:
     """Without this the coverage re-rank buries a hit whose body lacks the token."""
 

--- a/packages/python/sibyl-core/tests/test_retrieval_exact_key_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_exact_key_arm.py
@@ -1,0 +1,562 @@
+"""The exact-match arm: firing, inertness, scope authorization, fusion behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from sibyl_core.memory_pipeline.capture import MemoryCaptureRequest, MemoryCaptureService
+from sibyl_core.models.context import ContextFacet
+from sibyl_core.retrieval import search as search_module
+from sibyl_core.retrieval.candidates import RetrievalCandidate
+from sibyl_core.retrieval.search import (
+    RetrievalSignal,
+    build_context_retrieval_plan,
+)
+
+PROBE_KEY = "ERR_CONN_RESET_0x7f31"
+PROBE_QUERY = f"why does {PROBE_KEY} keep firing"
+# The discriminating property: the body never contains the key, so no lexical or
+# dense lane can reach this row. Only the writer's declaration can.
+BODY_WITHOUT_THE_KEY = "The socket dropped mid-handshake and the retry loop gave up."
+
+
+class _RecordingClient:
+    """A Surreal stand-in that answers one indexed equality read per probe key.
+
+    Matching mirrors what SurrealDB does for an array-element index: the row
+    comes back when any element of its stored key list equals the bound probe.
+    """
+
+    def __init__(self, rows: list[dict[str, object]] | None = None) -> None:
+        self.rows = rows or []
+        self.queries: list[tuple[str, dict[str, object]]] = []
+
+    async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+        self.queries.append((query, dict(params)))
+        probe = params.get("probe_key")
+        if probe is None:
+            return list(self.rows)
+        return [
+            dict(row)
+            for row in self.rows
+            if str(probe) in {str(key) for key in row.get("retrieval_keys_normalized") or ()}
+        ]
+
+
+def _plan(
+    *,
+    principal_id: str = "user-alice",
+    query: str = PROBE_QUERY,
+    project: str | None = "project_123",
+) -> search_module.RetrievalPlan:
+    return build_context_retrieval_plan(
+        query=query,
+        organization_id="org-123",
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["episode", "note"]},
+        principal_id=principal_id,
+        project=project,
+        accessible_projects={project} if project else None,
+    )
+
+
+async def _captured_metadata(
+    *,
+    principal_id: str = "user-alice",
+    retrieval_keys: list[str] | None = None,
+    memory_scope: str = "private",
+    scope_key: str | None = None,
+) -> dict[str, object]:
+    """Run a real capture and hand back the metadata the graph row would carry."""
+
+    captured: dict[str, object] = {}
+
+    async def remember_raw_memory(_request: MemoryCaptureRequest) -> Mapping[str, object]:
+        return {"id": "raw_1"}
+
+    async def create_graph_entity(
+        _request: MemoryCaptureRequest,
+        metadata: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        captured.update(metadata)
+        return {"id": "note_1"}
+
+    await MemoryCaptureService(
+        remember_raw_memory=remember_raw_memory,
+        create_graph_entity=create_graph_entity,
+    ).capture(
+        MemoryCaptureRequest(
+            title="Connection resets on startup",
+            content=BODY_WITHOUT_THE_KEY,
+            entity_type="note",
+            metadata={"project_id": "project_123"},
+            retrieval_keys=[PROBE_KEY] if retrieval_keys is None else retrieval_keys,
+            memory_scope=memory_scope,
+            scope_key=scope_key,
+            principal_id=principal_id,
+        )
+    )
+    return captured
+
+
+def _row(
+    metadata: Mapping[str, object],
+    *,
+    normalized_keys: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "uuid": "note_1",
+        "name": "Connection resets on startup",
+        "content": BODY_WITHOUT_THE_KEY,
+        "group_id": "org-123",
+        "project_id": "project_123",
+        "entity_type": "note",
+        "retrieval_keys": list(metadata.get("retrieval_keys") or ()),
+        "retrieval_keys_normalized": normalized_keys or [PROBE_KEY.casefold()],
+        "attributes": dict(metadata),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Capture stamps the declaration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capture_stamps_declared_keys_onto_the_graph_metadata() -> None:
+    metadata = await _captured_metadata()
+
+    assert metadata["retrieval_keys"] == [PROBE_KEY]
+
+
+@pytest.mark.asyncio
+async def test_capture_omits_the_field_when_no_key_is_declared() -> None:
+    metadata = await _captured_metadata(retrieval_keys=[])
+
+    assert "retrieval_keys" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_capture_refuses_an_invalid_declaration_before_the_raw_write() -> None:
+    """An invalid key list must not strand a verbatim record with no projection."""
+
+    raw_writes: list[str] = []
+
+    async def remember_raw_memory(_request: MemoryCaptureRequest) -> Mapping[str, object]:
+        raw_writes.append("written")
+        return {"id": "raw_1"}
+
+    async def create_graph_entity(
+        _request: MemoryCaptureRequest,
+        _metadata: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        return {"id": "note_1"}
+
+    service = MemoryCaptureService(
+        remember_raw_memory=remember_raw_memory,
+        create_graph_entity=create_graph_entity,
+    )
+    with pytest.raises(ValueError, match="at most 16 retrieval keys"):
+        await service.capture(
+            MemoryCaptureRequest(
+                title="Too many keys",
+                content="Body",
+                retrieval_keys=[f"key_{index}" for index in range(17)],
+                principal_id="user-alice",
+            )
+        )
+
+    assert raw_writes == []
+
+
+# ---------------------------------------------------------------------------
+# The lane
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arm_finds_a_row_whose_body_never_contains_the_query() -> None:
+    metadata = await _captured_metadata()
+    client = _RecordingClient([_row(metadata)])
+    plan = _plan()
+
+    candidates = await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=8,
+        probe_tokens=(PROBE_KEY.casefold(),),
+    )
+
+    assert [candidate.id for candidate in candidates] == ["note_1"]
+    assert PROBE_KEY.casefold() not in candidates[0].content.casefold()
+    assert candidates[0].metadata["matched_retrieval_keys"] == [PROBE_KEY.casefold()]
+    assert candidates[0].retrieval_signals == (RetrievalSignal.EXACT_KEY.value,)
+
+
+@pytest.mark.asyncio
+async def test_arm_reads_the_indexed_column_with_one_equality_per_probe() -> None:
+    """The access path is load-bearing, not stylistic.
+
+    On SurrealDB 3.2.3 an array-element index serves `field = $value` with an
+    IndexScan; CONTAINSANY degrades to a full table scan, and both a multi-value
+    IN and an OR of equalities return nothing at all despite matching data. A
+    refactor back to any of those shapes is a silent correctness or scale
+    regression, so the shape is pinned here.
+    """
+
+    client = _RecordingClient()
+    plan = _plan()
+
+    await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=8,
+        probe_tokens=("err_conn_reset_0x7f31", "search.py"),
+    )
+
+    assert len(client.queries) == 2
+    for query, params in client.queries:
+        assert "retrieval_keys_normalized = $probe_key" in query
+        assert "CONTAINSANY" not in query
+        assert "retrieval_keys_normalized IN" not in query
+        assert params["group_id"] == "org-123"
+    assert [params["probe_key"] for _query, params in client.queries] == [
+        "err_conn_reset_0x7f31",
+        "search.py",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_arm_issues_no_read_without_a_probe() -> None:
+    client = _RecordingClient([{"uuid": "should-not-be-read"}])
+    plan = _plan(query="how do we handle authentication")
+
+    candidates = await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=8,
+        probe_tokens=(),
+    )
+
+    assert candidates == []
+    assert client.queries == []
+
+
+@pytest.mark.asyncio
+async def test_arm_drops_a_row_whose_stored_keys_do_not_actually_match() -> None:
+    """The index is a filter, not the decision: overlap is confirmed in Python."""
+
+    metadata = await _captured_metadata()
+    client = _RecordingClient([_row(metadata, normalized_keys=["some_other_key"])])
+    plan = _plan()
+
+    candidates = await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=8,
+        probe_tokens=(PROBE_KEY.casefold(),),
+    )
+
+    assert candidates == []
+
+
+@pytest.mark.asyncio
+async def test_arm_ranks_more_matched_keys_above_fewer() -> None:
+    metadata = await _captured_metadata()
+    two_of_two = _row(metadata, normalized_keys=["key_a", "key_b"]) | {"uuid": "both"}
+    one_of_two = _row(metadata, normalized_keys=["key_a"]) | {"uuid": "one"}
+    client = _RecordingClient([one_of_two, two_of_two])
+    plan = _plan()
+
+    candidates = await search_module._exact_key_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module._search_filter_for_plan(plan),
+        limit=8,
+        probe_tokens=("key_a", "key_b"),
+    )
+
+    assert [candidate.id for candidate in candidates] == ["both", "one"]
+    assert candidates[0].score == 1.0
+    assert candidates[1].score == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Scope authorization, both directions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exact_key_hit_reaches_its_owner() -> None:
+    metadata = await _captured_metadata(principal_id="user-alice")
+    candidate = search_module._candidate_from_node_record(
+        _row(metadata),
+        signal=RetrievalSignal.EXACT_KEY,
+        score=1.0,
+    )
+
+    assert search_module._candidate_allowed(
+        candidate,
+        plan=_plan(principal_id="user-alice"),
+        requested_types=set(),
+        facet=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_exact_key_hit_is_denied_to_a_project_co_member() -> None:
+    """A declared key is not a scope override: the private row stays private."""
+
+    metadata = await _captured_metadata(principal_id="user-alice")
+    candidate = search_module._candidate_from_node_record(
+        _row(metadata),
+        signal=RetrievalSignal.EXACT_KEY,
+        score=1.0,
+    )
+
+    assert not search_module._candidate_allowed(
+        candidate,
+        plan=_plan(principal_id="user-bob"),
+        requested_types=set(),
+        facet=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_project_scoped_exact_key_hit_reaches_a_co_member() -> None:
+    metadata = await _captured_metadata(
+        principal_id="user-alice",
+        memory_scope="project",
+        scope_key="project_123",
+    )
+    candidate = search_module._candidate_from_node_record(
+        _row(metadata),
+        signal=RetrievalSignal.EXACT_KEY,
+        score=1.0,
+    )
+
+    assert search_module._candidate_allowed(
+        candidate,
+        plan=_plan(principal_id="user-bob"),
+        requested_types=set(),
+        facet=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_project_scoped_exact_key_hit_is_denied_outside_the_project() -> None:
+    metadata = await _captured_metadata(
+        principal_id="user-alice",
+        memory_scope="project",
+        scope_key="project_123",
+    )
+    candidate = search_module._candidate_from_node_record(
+        _row(metadata),
+        signal=RetrievalSignal.EXACT_KEY,
+        score=1.0,
+    )
+
+    assert not search_module._candidate_allowed(
+        candidate,
+        plan=_plan(principal_id="user-bob", project="project_other"),
+        requested_types=set(),
+        facet=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fusion behavior
+# ---------------------------------------------------------------------------
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    retrieval_keys: list[str] | None = None,
+    matched: list[str] | None = None,
+    project_id: str = "project_123",
+) -> RetrievalCandidate:
+    metadata: dict[str, Any] = {}
+    if retrieval_keys is not None:
+        metadata["retrieval_keys"] = retrieval_keys
+    if matched is not None:
+        metadata["matched_retrieval_keys"] = matched
+    return RetrievalCandidate(
+        id=candidate_id,
+        type="note",
+        name=candidate_id,
+        content=BODY_WITHOUT_THE_KEY,
+        score=1.0,
+        source=None,
+        metadata=metadata,
+        project_id=project_id,
+    )
+
+
+def test_exact_key_hit_outranks_an_equally_ranked_lexical_hit() -> None:
+    plan = _plan()
+    exact = _candidate("exact", retrieval_keys=[PROBE_KEY], matched=[PROBE_KEY.casefold()])
+    lexical = _candidate("lexical")
+
+    ranked = search_module._fuse_candidates(
+        [
+            (RetrievalSignal.NODE_FULLTEXT, [lexical]),
+            (RetrievalSignal.EXACT_KEY, [exact]),
+        ],
+        plan=plan,
+        limit=2,
+    )
+
+    assert [candidate.id for candidate, _score, _meta in ranked] == ["exact", "lexical"]
+    exact_metadata = ranked[0][2]
+    assert exact_metadata["exact_key_boost"] == plan.weights.exact_key_boost
+    assert exact_metadata["matched_retrieval_keys"] == [PROBE_KEY.casefold()]
+    assert "exact_key_boost" not in ranked[1][2]
+
+
+def test_exact_key_boost_matches_the_direct_raw_source_boost() -> None:
+    """The stated derivation, pinned: a declared channel, not an inferred one."""
+
+    plan = _plan()
+
+    assert plan.weights.exact_key_boost == plan.weights.direct_raw_source_boost
+
+
+def test_exact_key_boost_applies_once_to_a_candidate_found_by_two_lanes() -> None:
+    plan = _plan()
+    both = _candidate("both", retrieval_keys=[PROBE_KEY], matched=[PROBE_KEY.casefold()])
+
+    ranked = search_module._fuse_candidates(
+        [
+            (RetrievalSignal.NODE_FULLTEXT, [both]),
+            (RetrievalSignal.EXACT_KEY, [both]),
+        ],
+        plan=plan,
+        limit=2,
+    )
+
+    assert len(ranked) == 1
+    assert ranked[0][2]["exact_key_boost"] == plan.weights.exact_key_boost
+
+
+def test_matched_keys_survive_a_row_that_another_lane_found_first() -> None:
+    """Regression: candidates_by_id keeps whichever lane saw the row first.
+
+    A live probe caught this. Full-text can reach a row through a sub-token of
+    the identifier, so the same uuid arrives from two lanes with two candidate
+    instances, and only the exact-key instance carries the match list. Reading
+    the match list off the surviving instance reported an empty one.
+    """
+
+    plan = _plan()
+    from_fulltext = _candidate("shared")
+    from_key = _candidate("shared", retrieval_keys=[PROBE_KEY], matched=[PROBE_KEY.casefold()])
+
+    ranked = search_module._fuse_candidates(
+        [
+            (RetrievalSignal.NODE_FULLTEXT, [from_fulltext]),
+            (RetrievalSignal.EXACT_KEY, [from_key]),
+        ],
+        plan=plan,
+        limit=2,
+    )
+
+    assert len(ranked) == 1
+    assert ranked[0][2]["matched_retrieval_keys"] == [PROBE_KEY.casefold()]
+
+
+def test_a_candidate_found_only_by_the_key_is_not_demoted_as_vector_only() -> None:
+    accessible_projects = {f"project_{index}" for index in range(20)}
+    plan = build_context_retrieval_plan(
+        query=PROBE_QUERY,
+        organization_id="org-123",
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["note"]},
+        principal_id="user-alice",
+        project="project_0",
+        accessible_projects=accessible_projects,
+    )
+    exact = _candidate(
+        "exact",
+        retrieval_keys=[PROBE_KEY],
+        matched=[PROBE_KEY.casefold()],
+        project_id="project_0",
+    )
+
+    ranked = search_module._fuse_candidates(
+        [(RetrievalSignal.EXACT_KEY, [exact])],
+        plan=plan,
+        limit=1,
+    )
+
+    assert "vector_only_demoted" not in ranked[0][2]
+    assert "graph_expansion_only_demoted" not in ranked[0][2]
+
+
+def test_declared_keys_join_the_coverage_text() -> None:
+    """Without this the coverage re-rank buries a hit whose body lacks the token."""
+
+    exact = _candidate("exact", retrieval_keys=[PROBE_KEY])
+
+    text = search_module._candidate_query_text(exact)
+
+    assert PROBE_KEY.casefold() in text
+
+
+def test_a_candidate_without_keys_has_unchanged_coverage_text() -> None:
+    plain = _candidate("plain")
+
+    assert search_module._candidate_query_text(plain) == f"plain {BODY_WITHOUT_THE_KEY}".lower()
+
+
+# ---------------------------------------------------------------------------
+# Receipts
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_reports_the_arm_inert_without_a_probe() -> None:
+    metadata = search_module._exact_key_receipt_metadata(probe_tokens=(), candidates=[])
+
+    assert metadata == {"exact_key_probe_fired": False}
+
+
+def test_receipt_reports_probe_tokens_and_hit_count() -> None:
+    metadata = search_module._exact_key_receipt_metadata(
+        probe_tokens=("err_conn_reset_0x7f31",),
+        candidates=[_candidate("exact")],
+    )
+
+    assert metadata == {
+        "exact_key_probe_fired": True,
+        "exact_key_probe_tokens": ["err_conn_reset_0x7f31"],
+        "exact_key_hit_count": 1,
+    }
+
+
+def test_search_result_surfaces_the_boost_and_the_matched_keys() -> None:
+    plan = _plan()
+    exact = _candidate("exact", retrieval_keys=[PROBE_KEY], matched=[PROBE_KEY.casefold()])
+    ranked = search_module._fuse_candidates(
+        [(RetrievalSignal.EXACT_KEY, [exact])],
+        plan=plan,
+        limit=1,
+    )
+    candidate, score, fusion_metadata = ranked[0]
+
+    result = search_module._search_result_from_candidate(
+        candidate,
+        score=score,
+        fusion_metadata=fusion_metadata,
+        include_content=True,
+    )
+
+    assert result.metadata["exact_key_boost"] == plan.weights.exact_key_boost
+    assert result.metadata["matched_retrieval_keys"] == [PROBE_KEY.casefold()]
+    assert result.metadata["retrieval_signals"] == [RetrievalSignal.EXACT_KEY.value]

--- a/packages/python/sibyl-core/tests/test_retrieval_exact_key_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_exact_key_arm.py
@@ -24,10 +24,12 @@ BODY_WITHOUT_THE_KEY = "The socket dropped mid-handshake and the retry loop gave
 
 
 class _RecordingClient:
-    """A Surreal stand-in that answers one indexed equality read per probe key.
+    """A Surreal stand-in for the exact-key read, recording the query it got.
 
-    Matching mirrors what SurrealDB does for an array-element index: the row
-    comes back when any element of its stored key list equals the bound probe.
+    Matching mirrors CONTAINSANY against an index on the array's elements: the
+    row comes back when any element of its stored key list is among the bound
+    probes. Verified against a live 3.2.3 server, which is the only reason this
+    stand-in can be trusted to mean the same thing the server does.
     """
 
     def __init__(self, rows: list[dict[str, object]] | None = None) -> None:
@@ -36,13 +38,14 @@ class _RecordingClient:
 
     async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
         self.queries.append((query, dict(params)))
-        probe = params.get("probe_key")
-        if probe is None:
+        raw_probes = params.get("probe_keys")
+        if not isinstance(raw_probes, list | tuple):
             return list(self.rows)
+        probes = {str(probe) for probe in raw_probes}
         return [
             dict(row)
             for row in self.rows
-            if str(probe) in {str(key) for key in row.get("retrieval_keys_normalized") or ()}
+            if probes & {str(key) for key in row.get("retrieval_keys_normalized") or ()}
         ]
 
 
@@ -198,14 +201,15 @@ async def test_arm_finds_a_row_whose_body_never_contains_the_query() -> None:
 
 
 @pytest.mark.asyncio
-async def test_arm_reads_the_indexed_column_with_one_equality_per_probe() -> None:
-    """The access path is load-bearing, not stylistic.
+async def test_arm_reads_the_indexed_column_with_one_set_membership_query() -> None:
+    """The read shape and the index definition are one contract, verified live.
 
-    On SurrealDB 3.2.3 an array-element index serves `field = $value` with an
-    IndexScan; CONTAINSANY degrades to a full table scan, and both a multi-value
-    IN and an OR of equalities return nothing at all despite matching data. A
-    refactor back to any of those shapes is a silent correctness or scale
-    regression, so the shape is pinned here.
+    On SurrealDB 3.2.3 this same CONTAINSANY is index-served only because the
+    index is defined on the array's elements (`retrieval_keys_normalized.*`). An
+    index on the bare array field turns it into a full table scan, and turns a
+    bare equality into zero rows unless the WHERE clause happens to carry a
+    second predicate. Both halves are pinned: the query here, the index
+    definition in test_surreal_schema_syntax.py.
     """
 
     client = _RecordingClient()
@@ -219,16 +223,13 @@ async def test_arm_reads_the_indexed_column_with_one_equality_per_probe() -> Non
         probe_tokens=("err_conn_reset_0x7f31", "search.py"),
     )
 
-    assert len(client.queries) == 2
-    for query, params in client.queries:
-        assert "retrieval_keys_normalized = $probe_key" in query
-        assert "CONTAINSANY" not in query
-        assert "retrieval_keys_normalized IN" not in query
-        assert params["group_id"] == "org-123"
-    assert [params["probe_key"] for _query, params in client.queries] == [
-        "err_conn_reset_0x7f31",
-        "search.py",
-    ]
+    assert len(client.queries) == 1
+    query, params = client.queries[0]
+    assert "retrieval_keys_normalized CONTAINSANY $probe_keys" in query
+    assert "retrieval_keys_normalized =" not in query
+    assert "retrieval_keys_normalized IN" not in query
+    assert params["probe_keys"] == ["err_conn_reset_0x7f31", "search.py"]
+    assert params["group_id"] == "org-123"
 
 
 @pytest.mark.asyncio
@@ -539,20 +540,64 @@ def test_an_inert_lane_changes_no_score_and_no_metadata() -> None:
     ]
 
 
-def test_declared_keys_join_the_coverage_text() -> None:
+def test_matched_keys_join_the_coverage_text() -> None:
     """Without this the coverage re-rank buries a hit whose body lacks the token."""
 
     exact = _candidate("exact", retrieval_keys=[PROBE_KEY])
 
-    text = search_module._candidate_query_text(exact)
+    text = search_module._candidate_query_text(exact, matched_keys=(PROBE_KEY.casefold(),))
 
     assert PROBE_KEY.casefold() in text
+
+
+def test_declared_but_unmatched_keys_stay_out_of_the_coverage_text() -> None:
+    """A declared key is not a ranking lever on queries it never matched.
+
+    Folding a row's whole declared list into its coverage text moved scores on
+    prose queries the arm never fired for, which would let a writer buy a
+    permanent coverage lift with sixteen keys of prose keywords.
+    """
+
+    keyed = _candidate("keyed", retrieval_keys=["connection pooling handbook"])
+
+    assert search_module._candidate_query_text(keyed) == f"keyed {BODY_WITHOUT_THE_KEY}".lower()
+    assert "handbook" not in search_module._candidate_query_text(keyed)
 
 
 def test_a_candidate_without_keys_has_unchanged_coverage_text() -> None:
     plain = _candidate("plain")
 
     assert search_module._candidate_query_text(plain) == f"plain {BODY_WITHOUT_THE_KEY}".lower()
+
+
+def test_coverage_rerank_ignores_keys_the_query_did_not_match() -> None:
+    """The end-to-end version of the same property, through the real re-ranker."""
+
+    keyed = _candidate("keyed", retrieval_keys=["connection pooling handbook"])
+    rival = _candidate("rival")
+    fused: list[tuple[RetrievalCandidate, float, dict[str, Any]]] = [
+        (keyed, 1.0, {"sources": [RetrievalSignal.NODE_FULLTEXT.value]}),
+        (rival, 0.9, {"sources": [RetrievalSignal.NODE_FULLTEXT.value]}),
+    ]
+
+    reranked = search_module._apply_query_coverage_to_fused(
+        "how do we handle connection pooling",
+        fused,
+        temporal_target=None,
+    )
+    scores = {candidate.id: score for candidate, score, _meta in reranked}
+
+    stripped: list[tuple[RetrievalCandidate, float, dict[str, Any]]] = [
+        (_candidate("keyed"), 1.0, {"sources": [RetrievalSignal.NODE_FULLTEXT.value]}),
+        (_candidate("rival"), 0.9, {"sources": [RetrievalSignal.NODE_FULLTEXT.value]}),
+    ]
+    baseline = search_module._apply_query_coverage_to_fused(
+        "how do we handle connection pooling",
+        stripped,
+        temporal_target=None,
+    )
+
+    assert scores == {candidate.id: score for candidate, score, _meta in baseline}
 
 
 # ---------------------------------------------------------------------------
@@ -576,6 +621,25 @@ def test_receipt_reports_probe_tokens_and_hit_count() -> None:
         "exact_key_probe_fired": True,
         "exact_key_probe_tokens": ["err_conn_reset_0x7f31"],
         "exact_key_hit_count": 1,
+    }
+
+
+def test_receipt_counts_authorized_hits_only() -> None:
+    """A pre-filter count is an existence oracle for a caller-supplied string.
+
+    An unauthorized caller gets no rows, so the count must not tell them that
+    exactly one memory in the organization declares the key they guessed.
+    """
+
+    denied = search_module._exact_key_receipt_metadata(
+        probe_tokens=("err_conn_reset_0x7f31",),
+        candidates=[],
+    )
+
+    assert denied == {
+        "exact_key_probe_fired": True,
+        "exact_key_probe_tokens": ["err_conn_reset_0x7f31"],
+        "exact_key_hit_count": 0,
     }
 
 

--- a/packages/python/sibyl-core/tests/test_retrieval_keys.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_keys.py
@@ -1,0 +1,279 @@
+"""Writer-declared retrieval keys: normalization, and the query detector matrix."""
+
+from __future__ import annotations
+
+import pytest
+
+from sibyl_core.memory_pipeline.retrieval_keys import (
+    MAX_RETRIEVAL_KEYS,
+    MAX_RETRIEVAL_KEY_LENGTH,
+    coerce_retrieval_keys,
+    normalize_retrieval_keys,
+    retrieval_key_match_form,
+)
+from sibyl_core.retrieval.identifier_query import (
+    MAX_IDENTIFIER_PROBE_TOKENS,
+    identifier_probe_tokens,
+    is_identifier_shaped_query,
+    is_identifier_shaped_token,
+)
+from sibyl_core.tools.helpers import MAX_TITLE_LENGTH
+
+# ---------------------------------------------------------------------------
+# Key normalization
+# ---------------------------------------------------------------------------
+
+
+def test_key_length_bound_is_the_title_bound() -> None:
+    """The cited derivation, enforced: a key names a memory, so it is title-sized."""
+
+    assert MAX_RETRIEVAL_KEY_LENGTH == MAX_TITLE_LENGTH
+
+
+def test_none_declares_nothing() -> None:
+    assert normalize_retrieval_keys(None) == ([], [])
+    assert coerce_retrieval_keys(None) is None
+
+
+def test_empty_list_is_a_statement_not_a_silence() -> None:
+    assert coerce_retrieval_keys([]) == ([], [])
+
+
+def test_display_form_keeps_casing_and_match_form_casefolds() -> None:
+    display, match = normalize_retrieval_keys(["ERR_CONN_RESET_0x7F31"])
+
+    assert display == ["ERR_CONN_RESET_0x7F31"]
+    assert match == ["err_conn_reset_0x7f31"]
+
+
+def test_keys_are_stripped_and_internal_whitespace_collapses() -> None:
+    display, match = normalize_retrieval_keys(["  connection   reset\nby peer  "])
+
+    assert display == ["connection reset by peer"]
+    assert match == ["connection reset by peer"]
+
+
+def test_dedupe_is_case_insensitive_and_keeps_the_first_declaration() -> None:
+    display, match = normalize_retrieval_keys(["ERR_X", "err_x", "Err_X"])
+
+    assert display == ["ERR_X"]
+    assert match == ["err_x"]
+
+
+def test_blank_keys_are_dropped_rather_than_stored() -> None:
+    display, match = normalize_retrieval_keys(["", "   ", "\t\n", "real_key"])
+
+    assert display == ["real_key"]
+    assert match == ["real_key"]
+
+
+def test_match_form_is_unicode_casefold_not_ascii_lower() -> None:
+    assert retrieval_key_match_form("STRASSE") == retrieval_key_match_form("straße")
+
+
+def test_over_long_key_is_refused_at_the_write_boundary() -> None:
+    with pytest.raises(ValueError, match="exceeds 200 characters"):
+        normalize_retrieval_keys(["k" * (MAX_RETRIEVAL_KEY_LENGTH + 1)])
+
+
+def test_key_at_exactly_the_bound_is_accepted() -> None:
+    display, _match = normalize_retrieval_keys(["k" * MAX_RETRIEVAL_KEY_LENGTH])
+
+    assert display == ["k" * MAX_RETRIEVAL_KEY_LENGTH]
+
+
+def test_too_many_keys_are_refused_rather_than_truncated() -> None:
+    with pytest.raises(ValueError, match="at most 16 retrieval keys"):
+        normalize_retrieval_keys([f"key_{index}" for index in range(MAX_RETRIEVAL_KEYS + 1)])
+
+
+def test_control_characters_are_refused() -> None:
+    with pytest.raises(ValueError, match="control characters"):
+        normalize_retrieval_keys(["err\x00null"])
+
+
+def test_non_string_key_is_refused() -> None:
+    with pytest.raises(ValueError, match="must be a string"):
+        normalize_retrieval_keys([42])  # type: ignore[list-item]
+
+
+def test_storage_edge_coerces_where_the_boundary_refuses() -> None:
+    """The asymmetry: one bad entry must not fail a whole projection."""
+
+    coerced = coerce_retrieval_keys(["good_key", 42, None, "k" * 400, ""])
+
+    assert coerced is not None
+    display, match = coerced
+    assert display[0] == "good_key"
+    assert len(display[1]) == MAX_RETRIEVAL_KEY_LENGTH
+    assert len(display) == len(match) == 2
+
+
+def test_storage_edge_caps_instead_of_raising() -> None:
+    coerced = coerce_retrieval_keys([f"key_{index}" for index in range(40)])
+
+    assert coerced is not None
+    assert len(coerced[0]) == MAX_RETRIEVAL_KEYS
+
+
+def test_storage_edge_accepts_a_bare_string() -> None:
+    assert coerce_retrieval_keys("ERR_X") == (["ERR_X"], ["err_x"])
+
+
+def test_storage_edge_ignores_a_shape_it_cannot_read() -> None:
+    assert coerce_retrieval_keys({"not": "a list"}) is None
+
+
+# ---------------------------------------------------------------------------
+# The identifier-shaped query detector: positives
+# ---------------------------------------------------------------------------
+
+IDENTIFIER_POSITIVES = [
+    # letters and digits in one token
+    "ERR_CONN_RESET_0x7f31",
+    "0x7f31",
+    "sha256",
+    "v2beta",
+    "utf8mb4",
+    # underscores
+    "SIBYL_FUSION_BACKEND",
+    "snake_case_name",
+    "retrieval_keys",
+    # scope separator
+    "std::vector",
+    "sibyl::core::Entity",
+    # dotted segments
+    "search.py",
+    "sibyl_core.retrieval.search",
+    "package.json",
+    # hex run with a digit
+    "89684d05a1b2c3d4",
+    "deadbeef01",
+    # internal case transition
+    "EntityManager",
+    "getUserById",
+    "MemoryCaptureRequest",
+]
+
+
+@pytest.mark.parametrize("token", IDENTIFIER_POSITIVES)
+def test_identifier_shaped_tokens_fire(token: str) -> None:
+    assert is_identifier_shaped_token(token)
+    assert identifier_probe_tokens(token) == (retrieval_key_match_form(token),)
+
+
+# ---------------------------------------------------------------------------
+# The identifier-shaped query detector: negatives
+# ---------------------------------------------------------------------------
+
+IDENTIFIER_NEGATIVES = [
+    # ordinary English words, including ones that spell in hex
+    "authentication",
+    "database",
+    "pooling",
+    "connection",
+    "deadbeefcafe",
+    "accede",
+    # capitalized proper nouns without an internal transition
+    "Redis",
+    "Sibyl",
+    "Postgres",
+    # acronyms without an underscore
+    "TTL",
+    "HTTP",
+    "JWT",
+    # bare numbers and years
+    "2026",
+    "42",
+    # dotted abbreviations, which is why segments must be two characters
+    "e.g",
+    "i.e",
+    "a.m",
+    "U.S",
+    # hyphenated English
+    "state-of-the-art",
+    "well-known",
+    # too short to carry a shape
+    "a_",
+    "x1",
+    "ok",
+    # punctuation alone
+    "...",
+    "---",
+]
+
+
+@pytest.mark.parametrize("token", IDENTIFIER_NEGATIVES)
+def test_plain_language_tokens_do_not_fire(token: str) -> None:
+    assert not is_identifier_shaped_token(token)
+
+
+PROSE_QUERIES = [
+    "how do we handle authentication",
+    "database connection pooling",
+    "what is the plan for 2026",
+    "e.g. the first one we tried",
+    "i.e. this approach",
+    "state-of-the-art retrieval",
+    "why does Redis expire the TTL",
+    "the error was a reset",
+    "who decided this and when",
+    "",
+    "   ",
+]
+
+
+@pytest.mark.parametrize("query", PROSE_QUERIES)
+def test_prose_queries_leave_the_arm_inert(query: str) -> None:
+    assert identifier_probe_tokens(query) == ()
+    assert not is_identifier_shaped_query(query)
+
+
+# ---------------------------------------------------------------------------
+# The detector in whole queries
+# ---------------------------------------------------------------------------
+
+
+def test_one_identifier_inside_prose_fires_on_that_token_only() -> None:
+    assert identifier_probe_tokens("why does ERR_CONN_RESET_0x7f31 keep firing on startup") == (
+        "err_conn_reset_0x7f31",
+    )
+
+
+def test_trailing_sentence_punctuation_is_not_part_of_the_probe() -> None:
+    assert identifier_probe_tokens("what about search.py?") == ("search.py",)
+    assert identifier_probe_tokens("(see EntityManager),") == ("entitymanager",)
+
+
+def test_generic_type_syntax_survives_trimming() -> None:
+    assert identifier_probe_tokens("std::vector<int> blows up") == ("std::vector<int>",)
+
+
+def test_a_quoted_span_is_taken_whole_including_spaces() -> None:
+    assert identifier_probe_tokens('the log said "connection reset by peer" again') == (
+        "connection reset by peer",
+    )
+
+
+def test_a_backtick_span_is_a_quoted_span() -> None:
+    assert identifier_probe_tokens("the flag is `defer embeddings`") == ("defer embeddings",)
+
+
+def test_an_apostrophe_is_not_a_quote() -> None:
+    assert identifier_probe_tokens("what didn't work in the plan") == ()
+
+
+def test_probes_dedupe_case_insensitively_and_preserve_order() -> None:
+    assert identifier_probe_tokens("ERR_X then err_x then OTHER_KEY") == ("err_x", "other_key")
+
+
+def test_probe_count_is_bounded_by_the_writer_cap() -> None:
+    query = " ".join(f"key_{index}" for index in range(MAX_IDENTIFIER_PROBE_TOKENS * 3))
+
+    assert len(identifier_probe_tokens(query)) == MAX_IDENTIFIER_PROBE_TOKENS
+
+
+def test_a_quoted_span_and_a_bare_identifier_both_probe() -> None:
+    probes = identifier_probe_tokens('"connection reset by peer" from ERR_CONN_RESET_0x7f31')
+
+    assert probes == ("connection reset by peer", "err_conn_reset_0x7f31")

--- a/packages/python/sibyl-core/tests/test_retrieval_keys.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_keys.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import pytest
 
 from sibyl_core.memory_pipeline.retrieval_keys import (
-    MAX_RETRIEVAL_KEYS,
     MAX_RETRIEVAL_KEY_LENGTH,
+    MAX_RETRIEVAL_KEYS,
     coerce_retrieval_keys,
     normalize_retrieval_keys,
     retrieval_key_match_form,

--- a/packages/python/sibyl-core/tests/test_retrieval_keys.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_keys.py
@@ -156,6 +156,16 @@ IDENTIFIER_POSITIVES = [
 ]
 
 
+KEPT_POSITIVES_NEAR_THE_NUMBER_EXCLUSION = ["2fa", "v2beta", "sha256", "utf8mb4", "0x7f31"]
+
+
+@pytest.mark.parametrize("token", KEPT_POSITIVES_NEAR_THE_NUMBER_EXCLUSION)
+def test_number_suffix_exclusion_keeps_real_identifiers(token: str) -> None:
+    """The suffix list is closed, so digit-bearing identifiers still fire."""
+
+    assert is_identifier_shaped_token(token)
+
+
 @pytest.mark.parametrize("token", IDENTIFIER_POSITIVES)
 def test_identifier_shaped_tokens_fire(token: str) -> None:
     assert is_identifier_shaped_token(token)
@@ -185,6 +195,13 @@ IDENTIFIER_NEGATIVES = [
     # bare numbers and years
     "2026",
     "42",
+    # digits carrying an English suffix: ordinals, clock times, decades
+    "3rd",
+    "21st",
+    "10am",
+    "7pm",
+    "1990s",
+    "80s",
     # dotted abbreviations, which is why segments must be two characters
     "e.g",
     "i.e",
@@ -210,6 +227,9 @@ def test_plain_language_tokens_do_not_fire(token: str) -> None:
 
 PROSE_QUERIES = [
     "how do we handle authentication",
+    "what happened on the 3rd attempt",
+    "the meeting is at 10am tomorrow",
+    "back in the 1990s nobody cared",
     "database connection pooling",
     "what is the plan for 2026",
     "e.g. the first one we tried",

--- a/packages/python/sibyl-core/tests/test_retrieval_keys.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_keys.py
@@ -156,7 +156,22 @@ IDENTIFIER_POSITIVES = [
 ]
 
 
-KEPT_POSITIVES_NEAR_THE_NUMBER_EXCLUSION = ["2fa", "v2beta", "sha256", "utf8mb4", "0x7f31"]
+# A decade and a duration cannot be told apart by their characters, and a
+# duration appears verbatim in the error strings this arm exists to match, so the
+# exclusion stops at ordinals and clock times and these all still fire.
+KEPT_POSITIVES_NEAR_THE_NUMBER_EXCLUSION = [
+    "2fa",
+    "v2beta",
+    "sha256",
+    "utf8mb4",
+    "0x7f31",
+    "utf-8",
+    "30s",
+    "60s",
+    "300s",
+    "443s",
+    "1990s",
+]
 
 
 @pytest.mark.parametrize("token", KEPT_POSITIVES_NEAR_THE_NUMBER_EXCLUSION)
@@ -195,13 +210,13 @@ IDENTIFIER_NEGATIVES = [
     # bare numbers and years
     "2026",
     "42",
-    # digits carrying an English suffix: ordinals, clock times, decades
+    # ordinals and clock times, including hyphen-joined and pluralized forms
     "3rd",
     "21st",
+    "3rds",
     "10am",
     "7pm",
-    "1990s",
-    "80s",
+    "10am-11am",
     # dotted abbreviations, which is why segments must be two characters
     "e.g",
     "i.e",
@@ -229,7 +244,8 @@ PROSE_QUERIES = [
     "how do we handle authentication",
     "what happened on the 3rd attempt",
     "the meeting is at 10am tomorrow",
-    "back in the 1990s nobody cared",
+    "the window is 10am-11am on the 2nd",
+    "we tried it three 3rds of the way in",
     "database connection pooling",
     "what is the plan for 2026",
     "e.g. the first one we tried",

--- a/packages/python/sibyl-core/tests/test_search.py
+++ b/packages/python/sibyl-core/tests/test_search.py
@@ -312,6 +312,7 @@ def _flat_cap_lane_limits(limit: int) -> dict[str, int]:
         "node_vector": per_signal,
         "edge_vector": per_signal,
         "graph_expansion": per_signal,
+        "exact_key": per_signal,
     }
 
 
@@ -336,6 +337,7 @@ def test_seed_budget_widens_lanes_at_slice_scale_limits(
         "node_vector": per_signal,
         "edge_vector": per_signal,
         "graph_expansion": per_signal,
+        "exact_key": per_signal,
     }
     assert lane_limits["node_fulltext"] > _flat_cap_lane_limits(limit)["node_fulltext"]
 

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -1072,12 +1072,19 @@ def test_graph_retrieval_key_columns_are_versioned_and_indexed() -> None:
         assert f"DEFINE FIELD IF NOT EXISTS {field} ON entity TYPE option<array<string>>" in (
             NODE_DEFINITIONS
         )
-    index_definition = (
-        "DEFINE INDEX IF NOT EXISTS idx_entity_retrieval_keys "
-        "ON entity FIELDS retrieval_keys_normalized"
+    # The `.*` is the contract, not a detail. On SurrealDB 3.2.3 an index on the
+    # bare array field turns the arm's CONTAINSANY into a full table scan, and
+    # turns a bare equality into zero rows unless the WHERE clause happens to
+    # carry a second predicate. Dropping the suffix would leave every test green
+    # while the lane scanned the table.
+    assert (
+        "DEFINE INDEX OVERWRITE idx_entity_retrieval_keys "
+        "ON entity FIELDS retrieval_keys_normalized.*" in migration_sql
     )
-    assert index_definition in migration_sql
-    assert index_definition in NODE_DEFINITIONS
+    assert (
+        "DEFINE INDEX IF NOT EXISTS idx_entity_retrieval_keys "
+        "ON entity FIELDS retrieval_keys_normalized.*" in NODE_DEFINITIONS
+    )
 
 
 def test_graph_schema_current_version_matches_latest_migration() -> None:

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -1051,6 +1051,35 @@ def test_graph_enum_assertion_replay_admits_passage_entity_type() -> None:
         assert f"'{entity_type.value}'" in migration_sql
 
 
+def test_graph_retrieval_key_columns_are_versioned_and_indexed() -> None:
+    """The exact-match arm reads an index, so the migration must define one.
+
+    Bootstrap DDL and the migration have to agree, because a fresh namespace
+    takes the first path and an existing one takes the second; a field defined
+    in only one of them is a column that exists on some tenants and not others.
+    """
+    migration = next(
+        item for item in GRAPH_SCHEMA_MIGRATIONS if item.name == "entity_retrieval_keys_column"
+    )
+    migration_sql = "\n".join(migration.statements)
+
+    assert GRAPH_SCHEMA_CURRENT_VERSION >= 18
+    assert migration.version == 18
+    for field in ("retrieval_keys", "retrieval_keys_normalized"):
+        assert f"DEFINE FIELD OVERWRITE {field} ON entity TYPE option<array<string>>" in (
+            migration_sql
+        )
+        assert f"DEFINE FIELD IF NOT EXISTS {field} ON entity TYPE option<array<string>>" in (
+            NODE_DEFINITIONS
+        )
+    index_definition = (
+        "DEFINE INDEX IF NOT EXISTS idx_entity_retrieval_keys "
+        "ON entity FIELDS retrieval_keys_normalized"
+    )
+    assert index_definition in migration_sql
+    assert index_definition in NODE_DEFINITIONS
+
+
 def test_graph_schema_current_version_matches_latest_migration() -> None:
     latest_migration_version = max(migration.version for migration in GRAPH_SCHEMA_MIGRATIONS)
 


### PR DESCRIPTION
# 🔮 Writer-declared retrieval keys, and the exact-match arm that reads them

> Closes the A2 identifier flank from the 1.2 plan (`docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md` §4 A2). Graph schema moves to v18. Sibyl task `cf87b32b`.

## 💡 What this is

A memory's identifiers are known at write time and unrecoverable at read time. An error code, an env var, a symbol, a commit SHA: the agent writing the memory knows the exact strings a future agent will search by, and the future agent knows nothing else. So the writer declares them, and retrieval gains a high-precision arm that fires only when a query actually carries an identifier.

The naive fix is to put BM25 back into fusion, and it is wrong here for a measured reason: on a sliced substrate, unmodified BM25 poisons the pool (RRF 0.523 against dense-alone 0.659). The 2026 fix of record is retrieve-wide plus a cross-encoder rerank, which buys precision at 50 to 200 milliseconds on every query, including the overwhelming majority that carry no identifier at all. Declaring the keys at write time moves the intelligence to the moment it already exists, and the read side stays deterministic: a query with no identifier issues no extra read and returns a byte-identical result set.

The keys are structure layered onto verbatim capture, never a mutation of it. A key may name something the memory's body never spells out, and that case is the whole point, because it is exactly the case neither full-text nor dense similarity can satisfy.

## 🤔 Why we need it and what it replaces

Today a query for `ERR_CONN_RESET_0x7f31` reaches a memory only if the token appears in that memory's own text. Full-text needs the term present; the vector index needs the embedding to be close, and an opaque identifier embeds nowhere near the prose that explains it. The result is that the single most searchable thing about an incident memory is the one thing retrieval cannot use.

What is deliberately not built:

- **BM25 is still out of fusion.** Nothing here relaxes that. The exact-match arm is not a lexical lane: it cannot return a weakly relevant row, because every row it returns was declared by its writer to answer that exact string.
- **No cross-encoder, no rerank stage, no LLM on the write path.** The write path stays deterministic; the calling agent supplies the judgement.
- **No server-side key extraction.** Deriving keys from content would reintroduce the failure the feature exists to fix, since a derived key can only name what the text already says.

Blast radius: a query carrying no identifier-shaped token is unchanged, and the receipt proves it (`exact_key_probe_fired: false`, no read issued). A memory with no declared keys is unchanged. The `retrieval_keys` field is optional on every surface, so an existing caller sends nothing and gets exactly what it got before.

## 🎯 The invariant

Anchor the review on one property: **a declared key is a reachability hint, never an authorization override.** Every candidate the arm produces flows through the same `_candidate_allowed` filter as every other lane, so it still has to pass `memory_metadata_read_allowed` before it can be returned. Tests pin both directions, and the live probe confirms that a principal without scope access sees nothing while the arm still fires for them.

## 🛠️ How it works

### 1. The key contract

`packages/python/sibyl-core/src/sibyl_core/memory_pipeline/retrieval_keys.py` is the single definition of what a key is and how two keys are compared. Matching is Unicode casefold, internal whitespace runs collapse to one space, and nothing else is transformed: no stemming, no punctuation stripping. An exact key is exact, which is what buys the precision.

Normalization is deliberately asymmetric, and the asymmetry is the design:

- `normalize_retrieval_keys` refuses a violation. A write boundary is where a caller can still be told its key list was too long or its key was over-length. Truncating instead would ship a key the writer never declared, which fails at retrieval time with no receipt.
- `coerce_retrieval_keys` drops what it cannot use. The storage edge reads rows written by older code, and one malformed key must not fail a whole projection.

Bounds are 16 keys of at most 200 characters. The length bound equals `MAX_TITLE_LENGTH` from `sibyl_core.tools.helpers`, since a key names a memory rather than describing it, and `test_key_length_bound_is_the_title_bound` pins the two together so the derivation cannot drift.

### 2. Two columns, one index

Graph schema v18 (`ENTITY_RETRIEVAL_KEYS_COLUMN_DEFINITIONS` in `backends/surreal/schema.py`) adds `retrieval_keys`, holding the writer's own casing for display, and `retrieval_keys_normalized`, holding the casefolded match form. The index is `idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized.*`, on the array's **elements**, and the suffix is the whole contract (see section 4). Two columns rather than one, because the arm needs a case-insensitive index while a reader needs the key as it was declared, and deriving the normalized form inside SurrealQL would need array closures that diverge between the embedded test engine and the deployed 3.2.x server.

The migration defines the fields and the index with no data movement, because no row predates them: the write path that can declare a key ships in this same version. Bootstrap DDL and the migration are pinned against each other by `test_graph_retrieval_key_columns_are_versioned_and_indexed`, since a fresh namespace takes the first path and an existing namespace takes the second, and a field defined in only one of them is a column that exists on some tenants and not others.

`_entity_record` in `services/graph.py` promotes the keys from metadata into the columns, exactly as it already does for `memory_scope`. The bulk upsert preserves stored keys when a write says nothing about them, for the same reason the scope column does: a write is a full replace, and a reprojection that rebuilds an `Entity` without the keys must not strip the writer's declaration off the row.

### 3. The detector

`packages/python/sibyl-core/src/sibyl_core/retrieval/identifier_query.py` decides whether a query carries anything that could be an exact key. The test is mechanical and per-token, with no scoring and no thresholds, because identifier syntax is visibly unlike English orthography. Each rule is a named predicate so the matrix test can target it.

| Rule | Fires on | Does not fire on |
| --- | --- | --- |
| letters and digits mixed | `0x7f31`, `sha256`, `v2beta`, `2fa`, `30s`, `1990s` | `2026`, `42`, `3rd`, `3rds`, `10am`, `10am-11am` |
| underscore | `ERR_CONN_RESET`, `snake_case` | `state-of-the-art` |
| scope separator | `std::vector<int>` | |
| dotted segments, each 2+ chars | `search.py`, `sibyl_core.retrieval` | `e.g`, `i.e`, `a.m`, `U.S` |
| hex run of 8+ with a digit | `89684d05a1b2c3d4` | `deadbeefcafe`, `accede` |
| internal lower-to-upper shift | `EntityManager`, `getUserById` | `Redis`, `Postgres`, `TTL` |
| long command-line option | `--wait-searchable` | |
| quoted span | `"connection reset by peer"` | `didn't` |

Three rules earn their edge cases. Dotted segments must each be at least two characters, which admits file names and module paths while rejecting the dotted abbreviations English actually writes. A hex run must contain a digit, which separates a commit SHA from a word that happens to spell in `a-f`. Ordinals and clock times are excluded (`st`, `nd`, `rd`, `th`, optionally pluralized, plus `am` and `pm`), tested per hyphen-separated segment so `10am-11am` is prose too. A bare digits-plus-s is deliberately **not** excluded: a decade and a duration cannot be told apart by their characters, `30s` and `443s` appear verbatim in the error strings this arm exists to match, and the costs are asymmetric, so the duration wins and `1990s` fires.

The case-transition rule does fire on technology names written with an internal capital: `PostgreSQL`, `JavaScript`, `TypeScript`, `GitHub`, `MacBook`. Those are plausible keys, so they are left admitted rather than special-cased, and the cost of a miss is one indexed read (about 2.5 ms live) that returns nothing.

One shape is deliberately absent: a bare all-caps acronym such as `TTL` or `EFC`. English writes acronyms identically, so admitting them would fire the arm on ordinary emphasis. A caller who needs one matched quotes it.

False positives cost one indexed read that returns nothing. False negatives cost the hit the arm exists to find, so the rules lean permissive.

### 4. The arm, and the access path the index actually serves

`_exact_key_candidates` in `retrieval/search.py` issues one bound set-membership read, `retrieval_keys_normalized CONTAINSANY $probe_keys`, and computes per-row overlap in Python. That works only because the index is defined on the array's elements. On a live SurrealDB 3.2.3 server the difference between the two index shapes is not a matter of speed, it is a matter of whether the query works at all.

| Index shape | Predicate | Plan | Correct |
| --- | --- | --- | --- |
| `FIELDS field` (bare array) | `field CONTAINSANY [$a,$b]` | **TableScan** | yes |
| `FIELDS field` (bare array) | `field = $v`, with another predicate present | IndexScan | yes |
| `FIELDS field` (bare array) | `field = $v`, as the only predicate | IndexScan | **zero rows, despite matching data** |
| `FIELDS field` (bare array) | `field IN [$a,$b]` | UnionIndexScan | **zero rows, despite matching data** |
| `FIELDS field.*` (elements) | `field CONTAINS $v` | IndexScan | yes, standalone |
| `FIELDS field.*` (elements) | `field CONTAINSANY [$a,$b]` | UnionIndexScan, one branch per probe | yes, standalone |

The bare-array row that matters most is the third one: an equality against a bare-array index is correct only while some other predicate shares the WHERE clause. A lane relying on that is one refactor away from going dark with every test green, since `group_id` is redundant inside a per-org namespace and is exactly the kind of clause somebody removes. Indexing the elements removes the dependency, so both halves are pinned by tests: the `.*` in `test_graph_retrieval_key_columns_are_versioned_and_indexed`, the read shape in `test_arm_reads_the_indexed_column_with_one_set_membership_query`.

The migration uses `DEFINE INDEX OVERWRITE`, because a namespace that already ran an earlier build of this branch holds the bare index and `IF NOT EXISTS` would leave it there. Converting a bare index in place and reading correctly through the result is verified live.

A row answering more of the query's identifiers scores higher (`matched / total probes`), so overlap orders the lane.

### 5. Fusion, without an eighth equal vote

Hits join the fused pool as ordinary members and are then lifted by `_exact_key_multiplier`. Rank-only RRF would score an exact key like the top of any other lane, an equal vote for an unequal signal, and that is precisely the failure that keeps a weak lexical arm out of fusion. The boost is set equal to `direct_raw_source_boost` (1.4), and the equality is the argument: both express a candidate reached through a channel somebody declared outright rather than one inferred by similarity. It applies per candidate rather than per lane, so a row found by both the key and the vector index is lifted once.

The keys a query **matched** also join that candidate's coverage text in `_candidate_query_text`. Without them, the post-fusion coverage re-rank reads an exact hit whose body never spells the token out as a zero-coverage row and pushes it back down, undoing the arm one stage after it worked. Only the matched keys, never the row's whole declared list: folding in every key would move scores on queries the arm never fired for, and would let a writer buy a permanent coverage lift with sixteen keys of prose keywords. The matched keys are resolved through the fused metadata rather than off the candidate, because a row reached by two lanes keeps whichever instance arrived first.

Exact hits also join the seed set for graph expansion, alongside the full-text and vector lanes, because an exact key is the strongest anchor a query can have. Seeds are authorized **before** the walk, for every lane: a row this reader cannot see does not seed expansion, so its edges cannot export its existence through a neighbour the reader can see. On a query with no identifier the seed set is unchanged, because the lane contributed nothing to it.

The response carries a receipt so inertness is checkable rather than asserted: `exact_key_probe_fired`, plus `exact_key_probe_tokens` and `exact_key_hit_count` when it fired. The hit count is taken **after** the scope filter. A pre-filter count answers "does any memory in this organization declare the string I just sent" for a caller authorized to read none of them, which withholds the rows while leaking their existence one guessed key at a time. A hit carries `exact_key_boost` and `matched_retrieval_keys`.

### 6. Surfaces

The MCP `remember` docstring matters most here, because it is the only instruction the writing model ever reads. It names what a key is for rather than what the parameter accepts, and it says to declare the strings a future agent will search by even when the body already mentions them, and especially when it does not.

`POST /entities` takes `retrieval_keys` as a first-class field with per-key and per-list bounds in the schema, so an over-long key is a 422 rather than a write that half-succeeds. The bulk route normalizes inside `_bulk_create_metadata`, because it constructs `Entity` rows directly instead of going through `add()` and would otherwise accept the field on the wire and drop it before the row was written. The CLI takes `--key` repeatably rather than comma-separated, because a retrieval key can legitimately contain a comma.

### 7. The A2 probe set

`packages/python/sibyl-core/tests/fixtures/identifier_flank/a2_probe_set.json` holds 17 cases, 11 firing and 6 inert, as a fixture rather than a test body so the 1.2 ranking gate can consume the same cases the suite does. Every firing case asserts its own discriminating property first: the memory's title and body must not contain the queried token, or a pass proves nothing about the arm. The fixture's own claims are checked too, so a case that stops discriminating fails loudly instead of quietly passing for the wrong reason.

## 🔁 What changed since the first review round

An independent adversarial pass returned PASS with three should-fix findings. All three are fixed here, and each one is now pinned by a test that fails if it regresses.

- 🛡️ **The hit count was a cross-scope existence oracle.** `exact_key_hit_count` was taken before the scope filter, so an unauthorized caller got no rows and a reliable yes/no answer about whether any memory in the organization declares a string they chose. Counted after the filter now; the live probe asserts a stranger sees `exact_key_hit_count: 0` while the arm still fires.
- 🚨 **The arm's read silently depended on an unrelated clause.** Against an index on the bare array field, an equality returns zero rows unless the WHERE clause happens to carry a second predicate, so the lane worked only because `group_id` is always present, and removing that clause would have taken it dark with every test green. The index is now on the array's elements, which also restores the single-query CONTAINSANY read.
- **Declared keys moved scores on queries the arm never fired for.** The coverage text folded in a row's whole key list rather than the keys the query matched, which contradicted the inertness claim and handed writers an ungated ranking lever. Matched keys only now, resolved through the fused metadata.

A second adversarial pass over those fixes returned PASS and found two more, both fixed here with live repros.

- 🛡️ **The existence oracle moved rather than closed.** Withholding the rows was not enough while graph expansion still seeded from the unfiltered lane lists: a scope-denied hit exported its edges, and the neighbour the reader IS allowed to see came back, so a correct-key guess looked different from a wrong one. Live, before the fix: the attacker's correct key returned `['note_attacker']`, a wrong key returned `[]`. Both return `[]` now. Seeds are filtered for **every** lane, so the class is closed rather than the instance; the same setup showed full-text leaking a neighbour too, which means unfiltered seeding predated this feature and what the exact-key lane changed is that the caller now supplies the seed verbatim.
- **The lane was truncated by recency before overlap was known.** Collapsing to a single read dropped the slice that followed the overlap sort, so `ORDER BY created_at` plus `LIMIT` kept the newest matches rather than the best ones, and a row answering every identifier lost to newer rows answering one. Live: at lane limit 2 the best-overlap row was absent, at limit 3 it appeared first. The read is now sized per probe and truncation happens after the sort.

Three narrower gaps from that pass: the ordinal and clock-time exclusion is tested per hyphen-separated segment (so `10am-11am` and `3rds` stop firing), duration literals like `30s` and `443s` are deliberately admitted (a decade and a duration are indistinguishable by their characters, durations appear in the error strings this arm matches, and a false positive costs one read while a false negative loses the hit), and the wire contract stops being stricter than the key contract about whitespace, which the contract collapses by design.

Both new regression tests were verified discriminating by reverting each fix, where they fail.

Two smaller gaps from the first pass, also closed: the detector no longer fires on ordinals, clock times and decades (`3rd`, `10am`, `1990s`), and a control character in a key is a 422 instead of a 500, which was the one malformed-key class the schema bounds did not cover.

The review also found that `idx_entity_labels` has the same bare-array shape and has had it since long before this PR, so label-filtered reads scan. Out of scope here and filed separately.

## 🧪 Validation

Suites, run per package at `b7b7d4f7`, rebased onto current main:

- `moon run core:check` → **2455 passed, 14 skipped** (44s), lint and typecheck clean
- `moon run api:check` → **2083 passed, 5 skipped** (32s), lint and typecheck clean
- `moon run cli:check` → **456 passed**, lint and typecheck clean
- `moon run web:check` → 161 passed across 40 files, untouched by this PR
- `moon run :check` → **56 tasks completed**, root gate green
- New coverage: 101 tests in `test_retrieval_keys.py` (normalization plus the detector matrix, positives and negatives), 30 in `test_retrieval_exact_key_arm.py` (lane, scope both directions, fusion, receipts, structural inertness, the coverage-text leak, seed authorization, overlap ranking), 69 in `test_identifier_flank_probe_set.py` (the fixture driven end to end)

The MCP tool schema is generated from the signature, so it was checked against a constructed server rather than assumed: `remember` advertises `retrieval_keys` as `{"anyOf": [{"items": {"type": "string"}, "type": "array"}, {"type": "null"}], "default": null}`, and the tool description carries the guidance line a writing model reads.

**Live discriminating probe** against a real SurrealDB 3.2.3 server on an isolated stack (port 8400, its own RocksDB data directory, never the shared dev stack), 22 of 22 checks pass:

- Access path: `EXPLAIN` reports a `UnionIndexScan` over `idx_entity_retrieval_keys` with `access: = 'err_conn_reset_0x7f31'`, and no `TableScan`. `INFO FOR TABLE entity` confirms the shipped definition is `FIELDS retrieval_keys_normalized.*`
- **(a)** A memory titled "Upstream drops idle handles early", whose body shares no analyzer sub-token with `ERR_CONN_RESET_0x7f31`, is written with that key declared. The arm-less baseline misses it (`['note_decoy_probe']`), the armed run returns it first (`['note_keyed_probe', 'note_decoy_probe']`), attributed to `["exact_key"]` with `matched_retrieval_keys: ["err_conn_reset_0x7f31"]` and a receipt of `exact_key_hit_count: 1`
- **(b)** The same query from a principal without scope access returns `[]` with `exact_key_hit_count: 0`, while `exact_key_probe_fired` stays true, so the denial is the scope filter doing its job rather than the arm failing to run, and the count discloses nothing
- **(c)** The prose query "how do we handle connection pooling" leaves the detector unfired, and the armed and arm-less result sets are identical down to the score: `[('note_decoy_probe', 1.501682729), ('note_keyed_probe', 0.283297435)]`

- **(d)** The oracle repro: a victim row private to its owner declaring `SECRET_KEY_0x99`, with the attacker's own row as its graph neighbour and no query term appearing in the victim's text. The attacker's correct-key and wrong-key probes both return `[]`, the victim row is never returned, and the owner still reaches it. Reverting the seed filter makes this fail, which is what makes it a receipt rather than an assertion.

One finding from that probe is worth stating on its own, because it bounds where the arm helps. The `class` tokenizer splits `ERR_CONN_RESET_0x7f31` into `err` / `conn` / `reset` / digit runs, and full-text ORs its terms, so a memory whose title contains "resets" is already reachable through the identifier's own fragments. The arm's marginal value is largest exactly where the identifier shares no fragment with the prose, and the probe now enforces that condition on itself before it claims anything.

⚠️ Not covered: the arm is verified against a real 3.2.3 server through the core retrieval path rather than through a booted HTTP API, so the REST and MCP surfaces are covered by unit tests asserting the forwarded arguments rather than by an end-to-end HTTP round trip. `tests/test_default_memory_loop.py::test_default_entrypoints_import_and_wire_routes` failed once mid-work on its 60-second subprocess timeout; the same import takes 76.5s on unmodified `main` in this environment against 30.6s on this branch, and the test passes under `moon run core:test`. No retrieval-quality number is claimed here: this PR ships the flank and its standing probe, and the ranking gate that scores it is separate work.

## 🔍 What reviewers should focus on

- **The boost magnitude.** `exact_key_boost = 1.4` mirrors `direct_raw_source_boost` on the argument that both are declared rather than inferred channels. If that reading is wrong, the number is the thing to argue about.
- **Pool membership versus reservation.** Exact hits are guaranteed members of the fused pool and earn their final position through the boost. There is no hard reservation, so a low-overlap hit can in principle fall outside `limit` on a crowded query. The alternative was the reservation machinery, which this PR deliberately leaves alone.
- **The detector's permissiveness.** Every rule is a judgement about orthography, and the negatives in the matrix are the ones that matter, since a false positive there turns a precision arm into a lexical lane.
- **Absence rules on the upsert.** `retrieval_keys = $input.retrieval_keys ?? retrieval_keys` follows the `memory_scope` precedent, so a write that says nothing preserves stored keys and only an explicit update path clears them.
- **Expansion seeding.** Exact hits seed graph expansion, so an identifier query can surface a neighbour it would not have reached before. Seeds are now scope-filtered for every lane, which is a behaviour change beyond this feature: unfiltered seeding predated the exact-key lane and the same live setup showed full-text leaking a neighbour the same way. Worth a look if any caller depended on expansion reaching past a denied row.
- **Whether keys should propagate to passages.** A passage projected from a keyed memory currently inherits no keys. Propagating them would widen reach and could dilute precision across every span of one memory, so the call is deferred rather than guessed.

Out of scope: BM25's exclusion from fusion, `TYPED_NOTE_RESERVATION_ITEMS`, the evidence composer, and any ranking measurement.

## 📌 Follow-ups

- **Passage inheritance of parent keys**, once a measurement exists that can tell reach from dilution.
- **A key surface for raw-only captures.** `POST /memory/raw` writes the verbatim record and no graph row, so it has no exact-match lane to serve and the field would be unconsumed there today.
- **Ranking-gate consumption of the fixture.** The probe set is committed and green in CI; wiring it into the 1.2 ranking gate belongs to that lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

