### PR TITLE
fix(projection): stop the operational manifest body from inlining its own inventory

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/projection/experience.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/experience.py
@@ -813,7 +813,7 @@ def project_operational_experience(
             id=manifest_id,
             entity_type=EntityType.ARTIFACT,
             name=f"Operational experience manifest {experience.source_id}",
-            content=json.dumps(manifest.model_dump(mode="json"), sort_keys=True),
+            content=_manifest_body(manifest),
             organization_id=organization_id,
             created_by=created_by,
             modified_by=created_by,
@@ -830,6 +830,33 @@ def project_operational_experience(
         entities=tuple(entities),
         relationships=tuple(relationships),
         manifest=manifest,
+    )
+
+
+def _manifest_body(manifest: OperationalExperienceManifest) -> str:
+    """Describe the manifest without inlining its id inventory.
+
+    The inventory grows with the projection, roughly 25 characters per id, so
+    dumping the whole model here put an unbounded body on a row that the
+    50,000-char entity content limit then refused: a 101-observation capture
+    projects past 7,000 ids. Shrinking the per-observation chunk size makes it
+    worse rather than better, because more chunks mean more ids, so no caller
+    setting can bound this.
+
+    ``expected_entity_ids`` and ``expected_relationship_ids`` in the row's
+    metadata remain the authoritative inventory, and every consumer already
+    reads them from there. The counts below are for humans reading a row.
+    """
+    return json.dumps(
+        {
+            "source_id": manifest.source_id,
+            "schema_version": manifest.schema_version,
+            "content_hash": manifest.content_hash,
+            "manifest_entity_id": manifest.manifest_entity_id,
+            "entity_count": len(manifest.entity_ids),
+            "relationship_count": len(manifest.relationship_ids),
+        },
+        sort_keys=True,
     )
 
 

--- a/packages/python/sibyl-core/tests/test_experience_projection.py
+++ b/packages/python/sibyl-core/tests/test_experience_projection.py
@@ -30,6 +30,10 @@ from sibyl_core.projection.experience import (
     MAX_TYPED_ENTITY_CONTENT_CHARS,
 )
 from sibyl_core.projection.slicing import slice_body
+from sibyl_core.services.graph import (
+    MAX_ENTITY_CONTENT_CHARS,
+    _enforce_entity_content_limit,
+)
 
 
 def _experience(*, outcome: str = "success") -> OperationalExperience:
@@ -374,8 +378,14 @@ def test_projection_is_deterministic_and_manifest_is_self_describing() -> None:
     )
     payload = json.loads(manifest_entity.content)
     assert payload["content_hash"] == first.manifest.content_hash
-    assert set(payload["entity_ids"]) == {entity.id for entity in first.entities}
-    assert set(payload["relationship_ids"]) == {
+    assert payload["entity_count"] == len(first.entities)
+    assert payload["relationship_count"] == len(first.relationships)
+    # The inventory itself lives in metadata, which is where every consumer
+    # reads it; the body carries counts so it cannot grow without bound.
+    assert set(manifest_entity.metadata["expected_entity_ids"]) == {
+        entity.id for entity in first.entities
+    }
+    assert set(manifest_entity.metadata["expected_relationship_ids"]) == {
         relationship.id for relationship in first.relationships
     }
 
@@ -443,6 +453,51 @@ def test_projection_rejects_typed_content_overflow() -> None:
                 }
             )
         )
+
+
+def test_large_capture_manifest_body_stays_inside_the_entity_content_cap() -> None:
+    """A big capture must not project a manifest the graph will refuse.
+
+    The manifest body used to inline the projection's whole id inventory, so a
+    capture large enough to project a few thousand records produced a row past
+    the 50,000-char entity content limit and 422'd on write. The inventory
+    scales with record count, and shrinking the per-observation chunk size only
+    adds records, so no caller setting could bound it.
+    """
+    observations = tuple(
+        OperationalObservation(
+            id=f"state-{index}",
+            ordinal=index,
+            uri=f"https://example.test/incidents/INC{index:04d}",
+            action=f"click('INC{index:04d}')",
+            reasoning="Open the incident.",
+            evidence=(
+                OperationalEvidencePart(
+                    id=f"tree-{index}",
+                    content="\n".join(
+                        f"Row: INC{index:04d} field {field} value {field * 3}"
+                        for field in range(40)
+                    ),
+                ),
+            ),
+        )
+        for index in range(360)
+    )
+    projection = project_operational_experience(
+        _experience().model_copy(update={"observations": observations})
+    )
+    manifest_entity = next(
+        entity
+        for entity in projection.entities
+        if entity.id == projection.manifest.manifest_entity_id
+    )
+
+    # Teeth: the retired shape would have been refused on this same capture.
+    retired_body = json.dumps(projection.manifest.model_dump(mode="json"), sort_keys=True)
+    assert len(retired_body) > MAX_ENTITY_CONTENT_CHARS
+
+    assert len(manifest_entity.content or "") <= MAX_ENTITY_CONTENT_CHARS
+    _enforce_entity_content_limit(projection.entities)
 
 
 def test_operational_experience_rejects_unbounded_metadata() -> None:

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -1506,6 +1506,53 @@ def test_sibyl_memory_oversized_state_parts_repeat_identity() -> None:
     }
 
 
+def test_sibyl_memory_bodies_respect_the_declared_content_max_chars() -> None:
+    """Every body the adapter authors stays inside the cap it declares.
+
+    The adapter threads one ``content_max_chars`` into three emission
+    surfaces, and each reaches the graph as an entity body: the session
+    payloads under both chunking modes, and the evidence parts of the
+    operational experience the server projects into sessions and passages.
+    A surface that skips the cap sends the server a body it will refuse,
+    and the refusal lands mid-ingest after earlier trajectories have
+    already spent embedding credits.
+    """
+    module = _load_memory_module()
+    trajectory = _trajectory("t1", tree="button " + ("Priority " * 400))
+    bodies: list[str] = []
+
+    for mode in ("state", "trajectory"):
+        payloads = module.build_entity_payloads_for_trajectory(
+            trajectory,
+            project_id="project_lme",
+            run_id="run_lme",
+            content_max_chars=TEST_CONTENT_MAX_CHARS,
+            chunking_mode=mode,
+            include_screenshot_refs=True,
+        )
+        assert len(payloads) > 1, mode
+        bodies.extend(str(payload["content"]) for payload in payloads)
+
+    experience = module.build_operational_experience_payload(
+        trajectory,
+        project_id="project_lme",
+        run_id="run_lme",
+        content_max_chars=TEST_CONTENT_MAX_CHARS,
+        include_screenshot_refs=True,
+    )["experience"]
+    evidence_bodies = [
+        str(part["content"])
+        for observation in experience["observations"]
+        for part in observation["evidence"]
+    ]
+    assert len(evidence_bodies) > len(experience["observations"])
+    bodies.extend(evidence_bodies)
+
+    oversized = [len(body) for body in bodies if len(body) > TEST_CONTENT_MAX_CHARS]
+    assert oversized == [], oversized
+    assert max(len(body) for body in bodies) > TEST_CONTENT_MAX_CHARS // 2
+
+
 def test_sibyl_memory_oversized_blocks_split_on_line_boundaries() -> None:
     module = _load_memory_module()
     header = "Trajectory: t1"


### PR DESCRIPTION
## Why

An operational experience capture whose projection exceeds roughly 1,800 records is refused on write. It surfaced as the LongMemEval-V2 corpus rebuild dying on trajectory 6 of 100, identically under both `--chunking-mode trajectory` and `--chunking-mode state`:

```
POST /memory/experience -> HTTP 422
entity content exceeds the 50,000 character limit:
artifact_4df01a669ceece6f (52,553 chars).
Split the body or store it as a document rather than a single entity.
```

This is a product bug, not a benchmark artifact. **51 of 100 enterprise trajectories cannot be ingested through `/memory/experience` at all**, and any caller with large operational experiences hits the same wall.

## 🔎 Root cause

`packages/python/sibyl-core/src/sibyl_core/projection/experience.py:816` serialized the entire `OperationalExperienceManifest` into the manifest row's body:

```python
content=json.dumps(manifest.model_dump(mode="json"), sort_keys=True),
```

`OperationalExperienceManifest` carries `entity_ids` and `relationship_ids`, so the body grew at roughly 25 characters per projected id, unbounded. `_validate_typed_entity_sizes` (`experience.py:557-573`) caps EVENT, PROCEDURE, ERROR_PATTERN, and PASSAGE; SESSION is bounded by its writer. ARTIFACT was bounded by nothing.

**The non-obvious part is that no configuration escapes it, because the coupling runs backwards.** A smaller per-observation chunk size produces more chunks, more projected records, and therefore a *larger* inventory. Measured across the enterprise tier:

| chunk size | worst manifest | over the 50,000 cap |
| --- | --- | --- |
| 4,000 | 506,593 | 62 / 100 |
| 18,000 (shipped) | 243,085 | 51 / 100 |
| 49,999 (largest the cap permits) | **224,752** | 50 / 100 |

Every figure is the maximum across all 100 enterprise trajectories; exact byte counts shift by a few characters with `run_id` length, since `source_id` appears in the body.

At the largest value the entity cap itself allows, the worst manifest is still 4.5x over, and 50 of 100 trajectories still fail. The knob makes things worse in the direction you would reach for first, which is why this is fixed where the body is built rather than configured around. The inventory is dominated by passage ids (2,254 of 2,489 entities on trajectory `02dad10c`), and passages are cut by `slice_body(evidence.content)` (`experience.py:441`) at a fixed span, so their count follows text volume.

Winding the knob the other way fails differently, which closes off the last escape. At 49,999 the projection puts **174 non-manifest entities** over the cap, the worst a 52,510-char session on trajectory `4919aae9`, because the adapter's chunk ceiling plus the identity header the projection prepends crosses 50,000 on its own. So the low end inflates the manifest and the high end overflows the session rows: there is no setting at which this projection writes cleanly.

The threshold row is trajectory `4b3a3363`: 16 states, 666 entities, 1,403 relationships, **52,535 chars**, the smallest over-cap manifest and therefore the first one any run hits. The refusal lands on the *pending* manifest, which `persist_operational_experience` writes first, so no partial trajectory is left behind.

## 🛠️ The fix

The body now carries identifying fields plus record counts:

```json
{"content_hash": "...", "entity_count": 1765, "manifest_entity_id": "artifact_c59732ea5e980057",
 "relationship_count": 3707, "schema_version": 6, "source_id": "longmemeval-v2:gate:72e456ca"}
```

The id inventory stays in metadata under `expected_entity_ids` / `expected_relationship_ids`, **byte-identical**, which is where every consumer already reads it.

**`d5c84874` is untouched: no raised cap, no bypass, no truncation.** Rejecting an oversized body rather than shortening it is right for rows carrying retrieved text, and at the shipped 18,000 setting every real retrieval unit already fits: across the enterprise tier zero non-manifest entities exceed the cap, the largest being a 21,066-char session. The manifest was collateral, a provenance row whose body no reader ever sees.

Verified across the enterprise tier: **51 over-cap manifests before, 0 after, worst body 251 characters.**

## 💎 Why this is provably safe, not merely tested

The manifest is load-bearing for capture-resume, holding the `entity_lock(manifest_id)` and the exact-inventory 409 reconciliation, so "no consumer reads the body" needs to be more than a passing test suite. It is:

**The body already contradicted its own metadata, and nothing noticed.** `operational_experience_manifest_with_state` rewrites metadata via `model_copy(update={"metadata": ...})` and passes the body straight through (`experience.py:875-899`). So in the `pending` and `embedding_pending` publications, the row on disk listed the *complete* inventory in its body while its metadata deliberately held `[]` (pending) or an old-union-new set (retained). Those two publications are exactly the states capture-resume and requeue read. **Any consumer reading the body instead of metadata would have been resuming against the wrong inventory for as long as the pending publication has existed.** Resume works, so nothing reads the body. That is a property of the running system, not an artifact of coverage.

Corroborating: `test_operational_source_retrieval.py:67-83` builds its manifest fixture with **no `content` field at all**, and `fetch_operational_source_inventory` still returns `complete`.

## 🚨 A latent hazard this closes

`PASSAGE_SOURCE_TYPES` includes `EntityType.ARTIFACT`, and `PASSAGE_MIN_SOURCE_CHARS` is `HARD_MAX` (`projection/passages.py:63`). An oversized manifest body reaching `project_entity_passages` would therefore have been **sliced into passage rows, which are real retrieval units** in `SUPPORTED_EVIDENCE_TYPES` — an id inventory entering the evidence lane as retrievable text.

It has not fired, because the operational write path calls `entity_manager.create_direct_bulk` directly and the three passage callers are the create-entity job (`jobs/entities.py:651`), the update-entity job (`:1388`), and `PATCH /entities/{id}` (`routes/entities.py:2429`). The hazard was one refactor away: any change routing operational writes through the ordinary entity-write path would have started publishing manifest fragments as evidence. A body bounded at ~250 characters sits permanently below `PASSAGE_MIN_SOURCE_CHARS`, so this fix removes the hazard rather than continuing to depend on the call graph avoiding it.

## 🎯 Consumer-contract audit

Every manifest consumer reads metadata, never the body. Audited independently as a stop condition:

- Reconciliation and stale-record pruning: `_manifest_inventory` (`experience.py:836-843`), `_manifest_matches_state` (`:857-865`), `persist_operational_experience` (`:968`).
- Capture-resume validation: `retrieval/operational_sources.py:98-135`, `:191-217`, `:244-247`.
- Exact-inventory 409 recovery: `routes/entities.py:1884`, `:1974`.
- Worker manifest state: `jobs/entities.py:37-63`.
- Distillation and coordination: `jobs/operational_distillation.py:141`, `coordination/broker.py:172`.

`OperationalExperienceManifest` is constructed only from a live projection (`experience.py:803`) and never rehydrated by parsing a stored body. No `json.loads` of an entity body exists in any projection or recovery path. `content` is not an idempotence or dedup key: `create_direct_bulk` REPLACEs on `group_id` + `uuid` (`services/graph.py:2759`), with no body-derived hash. A repo-wide grep for `expected_entity_ids|expected_relationship_ids|operational_projection_state|manifest_entity_id` outside `*.py` returns zero hits, so no TypeScript, SQL, or serializer depends on these fields either.

The row is also never embedded, in any path (`experience.py:986-992`, `:1025-1031`, `:978-980`, `routes/experience.py:118-123`), so it cannot enter vector search, and retrieval refinement already discards manifest text outright (`retrieval/refinement.py:439-440`).

One lexical consequence, which nothing relies on: a search for a single member id no longer matches the manifest row, because every inventory read goes through metadata.

## 🧪 Tests

**`test_large_capture_manifest_body_stays_inside_the_entity_content_cap`** is the one the production side owns. A 360-observation capture projects past the retired bound, and the test asserts that first (`len(retired_body) > MAX_ENTITY_CONTENT_CHARS`) so it has teeth, then asserts the real body fits and runs the actual `_enforce_entity_content_limit` over the whole projection.

**`test_sibyl_memory_bodies_respect_the_declared_content_max_chars`** locks the benchmark adapter's own cap across its three emission surfaces. Stated plainly: **this test would not have caught this bug.** The adapter never emitted an oversized body; measured across all 1,870 trajectories, worst session body 18,000, worst evidence body 17,999, zero violations. It guards a real invariant, just not this one.

`test_projection_is_deterministic_and_manifest_is_self_describing` now asserts the counts in the body and the inventory in metadata.

```
core projection/operational/graph suites   150 passed
api experience/jobs/entities/coordination  106 passed
benchmark adapter suite                    173 passed
```

## ⚠️ Comparability

A corpus rebuilt on this branch is **not** comparable to the frozen 31.26% baseline, and the manifest is not why. That receipt dates from 2026-07-22; operational passage projection landed 2026-07-25 in `a6e68020`, so the baseline corpus contains **zero passage rows** while a rebuild mints thousands per trajectory, and `passage` is a retrieval type. The substrate change is the point of the rebuild, so any gate run needs its own re-baseline.

The manifest's own contribution leaves the retrievable-unit set identical. One second-order effect is worth naming: `idx_entity_content_text_ft ON entity FIELDS content ... BM25` (`backends/surreal/schema.py:138`) indexes every row's content, so oversized manifests did sit in the BM25 corpus and skew average document length for the rows that *are* retrieved, which is exactly the mechanism `d5c84874` targets. Shrinking them shifts lexical ranking slightly, in the direction the cap intends. That shift is unmeasured and likely sub-noise, but a new corpus is not bit-identical to an old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
