### PR TITLE
fix(graph): stop the embedding backfill from tablescanning per write

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -2786,8 +2786,14 @@ async def _update_entity_embedding_if_current(
         return False
     rows = normalize_records(
         await client.execute_query(
+            # Addressed through a subquery because the UPDATE planner (unlike
+            # SELECT's) abandons idx_entity_uuid once the if-current guards are
+            # stacked on and iterates the whole table: 2.8s/statement at 43K
+            # rows vs 20ms addressed, and the backfill runs eight of these
+            # concurrently. The guards still evaluate atomically inside the
+            # UPDATE, so if-current semantics are unchanged.
             """
-            UPDATE entity SET
+            UPDATE (SELECT VALUE id FROM entity WHERE group_id = $group_id AND uuid = $uuid LIMIT 1) SET
                 name_embedding = $name_embedding,
                 attributes.embedding_metadata = $embedding_metadata,
                 attributes.updated_at = $updated_at,


### PR DESCRIPTION
# 🐌 Record-addressed embedding backfill: the if-current UPDATE no longer scans the table

> One statement in `sibyl-core`, found while building the LongMemEval-V2 gate corpus on an isolated stack. The same statement produces the 800-900ms `surreal_query_slow` warnings on live instances today.

## 💡 What this is

The embedding backfill's compare-and-set UPDATE (`_update_entity_embedding_if_current` in `packages/python/sibyl-core/src/sibyl_core/services/graph.py`) addressed the whole `entity` table and relied on the WHERE clause to find its one row. That looks index-friendly, and for SELECT it is: the SELECT planner serves `group_id AND uuid` from `idx_entity_uuid`. The UPDATE planner does not. Once the if-current guards (`name`, `description`, `content`, the summary check) stack onto the WHERE, SurrealDB 3.2.x plans the UPDATE as a full table iteration that deserializes every row, including 18K-char contents and 1024-float vectors, to update one record.

The fix targets the row through a subquery on the indexed lookup and keeps every guard in the UPDATE's own WHERE:

```surql
UPDATE (SELECT VALUE id FROM entity WHERE group_id = $group_id AND uuid = $uuid LIMIT 1) SET
    ...
WHERE group_id = $group_id AND uuid = $uuid AND entity_type = $entity_type
  AND name = $name AND description = $description AND content = $content
  AND (attributes.summary ?? '') = $summary
RETURN AFTER;
```

## 🤔 Why we need it

The cost is linear in table size and the backfill runs up to eight of these concurrently, so the defect compounds into a throughput collapse rather than a slow query. Measured on a 43K-entity store: the old shape takes 2.83s per statement from a fresh connection while the record-addressed equivalent takes under 10ms. Under sustained operational ingest the concurrent scans held the org pool's sockets, every other query queued behind them (backfill UPDATEs measured p50 36.8s and max 690s for a statement that runs in 3ms solo), SurrealDB pegged eight cores while the API sat idle, and capture latency degraded from 10s to 100-700s per experience by 30K entities. Three consecutive corpus ingests died this way before the statement was isolated as the cause. Live instances pay the same scan on every backfill write; at smaller table sizes it surfaces as the familiar 800-900ms slow-query warnings rather than a collapse, and it grows with the graph.

## 🎯 The anchor

One property carries the review: the if-current semantics are unchanged. The subquery only picks the row; every guard still evaluates inside the UPDATE itself, atomically, on the addressed record. All three outcomes behave exactly as before: guards match and the row updates and returns (caller sees `True`), guards mismatch and zero rows return (`False`), row absent and the subquery yields an empty set so the UPDATE is a no-op (`False`).

## 🧪 Validation

- Unit suites on the touched paths: `uv run --directory packages/python/sibyl-core pytest tests/test_graph.py -q -k embedding` → 9 passed; `uv run --directory apps/api pytest tests/test_jobs_entities.py -q` → 16 passed.
- Live semantics on SurrealDB 3.2.x at 43K rows: the new shape returns the row with `uuid` intact on guard match (caller's `any(...)` check verified) and returns `[]` on guard mismatch. Timing 20-130ms under concurrent ingest load versus 2.83s for the old shape on the same row.
- Production-shape proof: with this commit, three consecutive LongMemEval-V2 corpus ingests (100 trajectories, roughly 70K entities each) ran to completion at 6-20s per trajectory on stores up to 167K entities. On the parent commit the same workload crawled at 128-258s per trajectory and never finished.
- `ruff check` and `ruff format --check` clean on the file.
- ⚠️ No unit test distinguishes the old and new statement shapes because they are semantically equivalent; the difference is the query plan. The live timing and the ingest throughput above are the receipts for the performance claim.

## 🔍 What reviewers should focus on

- The guard equivalence in the three cases above, especially row-absent: the old query and the new one both return zero rows, just via different paths.
- The `RETURN AFTER` row shape flowing through `normalize_records` to the caller's `uuid` comparison, which is unchanged.
- Whether any other caller reaches this function with expectations about table-wide matching. There is exactly one call site (`graph.py:431`) and it passes a single entity.
- Out of scope, filed as Sibyl tasks: the sibling `UPDATE entity MERGE` at `graph.py:544` carries an OR-expression guard that may hit the same planner behavior (low volume, entity edit path), and the relationship bulk DELETE (`uuid IN $uuids`) tablescans for a different reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of conditional entity updates while preserving current-content checks and embedding metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->