### PR TITLE
fix(graph): retire IN-list uuid tablescans and the bare-array labels index

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -109,7 +109,7 @@ DEFINE FIELD IF NOT EXISTS name_embedding ON entity TYPE option<array<float, {EM
 
 DEFINE INDEX IF NOT EXISTS idx_entity_uuid ON entity FIELDS uuid UNIQUE;
 DEFINE INDEX IF NOT EXISTS idx_entity_type ON entity FIELDS entity_type;
-DEFINE INDEX IF NOT EXISTS idx_entity_labels ON entity FIELDS labels;
+DEFINE INDEX IF NOT EXISTS idx_entity_labels ON entity FIELDS labels.*;
 DEFINE INDEX IF NOT EXISTS idx_entity_project ON entity FIELDS project_id;
 DEFINE INDEX IF NOT EXISTS idx_entity_parent_task ON entity FIELDS parent_task_id;
 DEFINE INDEX IF NOT EXISTS idx_entity_task ON entity FIELDS task_id;
@@ -528,6 +528,15 @@ DEFINE FIELD OVERWRITE retrieval_keys_normalized ON entity TYPE option<array<str
 DEFINE INDEX OVERWRITE idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized.*;
 """
 
+# Same element-vs-array distinction as idx_entity_retrieval_keys above: the
+# bare-array shape answers CONTAINS with a table scan and bare equality with
+# zero rows on SurrealDB 3.2.3. OVERWRITE converts the index every existing
+# namespace already has; CONCURRENTLY because every row carries labels, and a
+# single-transaction rebuild fails on RocksDB once the table is large.
+ENTITY_LABELS_ELEMENT_INDEX_DEFINITIONS = """
+DEFINE INDEX OVERWRITE idx_entity_labels ON entity FIELDS labels.* CONCURRENTLY;
+"""
+
 ENTITY_REQUIRED_FIELD_REPAIR_DEFINITIONS = f"""
 {ENTITY_REQUIRED_FIELD_OPTIONAL_DEFINITIONS}
 UPDATE entity SET revision = 1 WHERE revision = NONE OR revision < 1;
@@ -690,6 +699,13 @@ GRAPH_SCHEMA_MIGRATIONS = (
         version=18,
         name="entity_retrieval_keys_column",
         statements=tuple(split_statements(ENTITY_RETRIEVAL_KEYS_COLUMN_DEFINITIONS)),
+    ),
+    # Converts the label index to element form on namespaces that bootstrapped
+    # before the FIELDS labels.* fix; label-filtered search reads this index.
+    SchemaMigration(
+        version=19,
+        name="entity_labels_element_index",
+        statements=tuple(split_statements(ENTITY_LABELS_ELEMENT_INDEX_DEFINITIONS)),
     ),
 )
 
@@ -1075,6 +1091,7 @@ __all__ = [
     "EMBEDDING_DIM",
     "EMBEDDING_VECTOR_FIELDS",
     "ENTITY_ACTOR_ATTRIBUTION_DEFINITIONS",
+    "ENTITY_LABELS_ELEMENT_INDEX_DEFINITIONS",
     "ENTITY_MEMORY_SCOPE_COLUMN_DEFINITIONS",
     "ENTITY_MISLED_USAGE_SIGNAL_DEFINITIONS",
     "ENTITY_REQUIRED_FIELD_OPTIONAL_DEFINITIONS",

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
@@ -11,7 +11,7 @@ from typing import Protocol, cast
 
 from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement, split_statements
 
-GRAPH_SCHEMA_CURRENT_VERSION = 18
+GRAPH_SCHEMA_CURRENT_VERSION = 19
 GRAPH_SCHEMA_NAME = "graph"
 SCHEMA_VERSION_TABLE = "schema_version"
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -279,9 +279,15 @@ INSERT INTO entity $rows ON DUPLICATE KEY UPDATE
 """
 _RELATIONSHIP_BULK_UPSERT_QUERY = """
 BEGIN TRANSACTION;
-DELETE FROM relates_to
-WHERE uuid IN $uuids
-  AND (in != $sources[uuid] OR out != $targets[uuid]);
+-- The planner never serves `uuid IN $list` from idx_relates_uuid (TableScan
+-- for every statement type, seconds per capture batch once the table is
+-- large), so the endpoint-move cleanup iterates the batch and addresses each
+-- row through the unique index instead. The endpoint guard stays on the
+-- DELETE itself so it evaluates atomically on the addressed record.
+FOR $edge IN $edges {
+    DELETE (SELECT VALUE id FROM relates_to WHERE uuid = $edge.uuid LIMIT 1)
+    WHERE in != $edge.src OR out != $edge.tgt;
+};
 INSERT RELATION INTO relates_to $rows ON DUPLICATE KEY UPDATE
     name = $input.name,
     fact = $input.fact,
@@ -489,16 +495,28 @@ class EntityManager:
             return []
         rows = normalize_records(
             await self._client.execute_query(
+                # `uuid IN $list` is never index-served, and here the scan
+                # decodes every full row (contents plus embeddings), so each
+                # uuid gets its own indexed lookup. The closure body may
+                # reference nothing but its own argument: any other binding
+                # silently evaluates to nothing on at least one engine, so the
+                # group guard is applied to the returned rows instead (uuid is
+                # unique table-wide). A missing uuid yields a NONE entry,
+                # which normalize_records drops.
                 """
-                SELECT *
-                FROM entity
-                WHERE group_id = $group_id AND uuid IN $uuids;
+                RETURN $uuids.map(|$u|
+                    (SELECT * FROM entity WHERE uuid = $u LIMIT 1)[0]
+                );
                 """,
-                group_id=self._group_id,
                 uuids=ordered_ids,
             )
         )
-        entities_by_id = {entity.id: entity for entity in (_entity_from_row(row) for row in rows)}
+        entities_by_id = {
+            entity.id: entity
+            for entity in (
+                _entity_from_row(row) for row in rows if row.get("group_id") == self._group_id
+            )
+        }
         return [
             entities_by_id[entity_id] for entity_id in ordered_ids if entity_id in entities_by_id
         ]
@@ -1474,14 +1492,23 @@ class RelationshipManager:
             return 0
         rows = await _execute_graph_transaction(
             self._client,
+            # `uuid IN $list` is never index-served, so the targets resolve
+            # through per-uuid indexed lookups first and the DELETE addresses
+            # records directly; RETURN BEFORE still yields the deleted rows.
+            # The closures reference nothing but their own argument (any other
+            # binding silently evaluates to nothing on at least one engine),
+            # so the group guard lives on the DELETE, where it still evaluates
+            # per addressed record.
             """
             BEGIN TRANSACTION;
-            DELETE FROM relates_to
-            WHERE group_id = $group_id AND uuid IN $uuids
-            RETURN BEFORE;
-            DELETE FROM mentions
-            WHERE group_id = $group_id AND uuid IN $uuids
-            RETURN BEFORE;
+            LET $edge_targets = $uuids.map(|$u|
+                (SELECT VALUE id FROM relates_to WHERE uuid = $u LIMIT 1)[0]);
+            DELETE array::filter($edge_targets, |$t| $t != NONE)
+                WHERE group_id = $group_id RETURN BEFORE;
+            LET $mention_targets = $uuids.map(|$u|
+                (SELECT VALUE id FROM mentions WHERE uuid = $u LIMIT 1)[0]);
+            DELETE array::filter($mention_targets, |$t| $t != NONE)
+                WHERE group_id = $group_id RETURN BEFORE;
             COMMIT TRANSACTION;
             """,
             group_id=self._group_id,
@@ -3169,12 +3196,19 @@ async def _record_ids(
         return {}
     rows = normalize_records(
         await client.execute_query(
+            # `uuid IN $list` is never index-served (a whole-table scan per
+            # capture batch), so each uuid gets its own indexed lookup. The
+            # closure body may reference nothing but its own argument: any
+            # other binding silently evaluates to nothing on at least one
+            # engine, so the group guard is applied to the returned rows
+            # instead (uuid is unique table-wide). A missing uuid yields a
+            # NONE entry, which normalize_records drops.
             """
-            SELECT uuid, id AS record_id
-            FROM entity
-            WHERE group_id = $group_id AND uuid IN $uuids;
+            RETURN $uuids.map(|$u|
+                (SELECT uuid, group_id, id AS record_id FROM entity
+                 WHERE uuid = $u LIMIT 1)[0]
+            );
             """,
-            group_id=group_id,
             uuids=unique,
         )
     )
@@ -3182,7 +3216,7 @@ async def _record_ids(
     for row in rows:
         uuid = row.get("uuid")
         record_id = row.get("record_id")
-        if isinstance(uuid, str) and record_id is not None:
+        if isinstance(uuid, str) and record_id is not None and row.get("group_id") == group_id:
             resolved[uuid] = record_id
     return resolved
 
@@ -3218,16 +3252,12 @@ async def _replace_relationships_bulk(
     if not rows:
         return []
 
-    uuids = [str(row["uuid"]) for row in rows]
-    sources = {str(row["uuid"]): row["in"] for row in rows}
-    targets = {str(row["uuid"]): row["out"] for row in rows}
+    edges = [{"uuid": str(row["uuid"]), "src": row["in"], "tgt": row["out"]} for row in rows]
     try:
         await client.execute_query(
             _RELATIONSHIP_BULK_UPSERT_QUERY,
             rows=rows,
-            uuids=uuids,
-            sources=sources,
-            targets=targets,
+            edges=edges,
         )
     except Exception as exc:
         if not _is_transient_connection_error(exc):
@@ -3237,9 +3267,7 @@ async def _replace_relationships_bulk(
         await client.execute_query(
             _RELATIONSHIP_BULK_UPSERT_QUERY,
             rows=rows,
-            uuids=uuids,
-            sources=sources,
-            targets=targets,
+            edges=edges,
         )
     return written_ids
 

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -74,7 +74,7 @@ class _BatchEntityReadClient:
 
     async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
         self.calls.append((query, params))
-        return [
+        rows: list[dict[str, object]] = [
             {
                 "uuid": entity_id,
                 "name": entity_id,
@@ -86,6 +86,20 @@ class _BatchEntityReadClient:
             }
             for entity_id in ("first", "second")
         ]
+        # The per-uuid lookup is unscoped (uuid is unique table-wide), so the
+        # manager must drop a row whose group does not match its own.
+        rows.append(
+            {
+                "uuid": "foreign",
+                "name": "foreign",
+                "entity_type": "session",
+                "description": "Row from another org",
+                "content": "Row from another org",
+                "group_id": "other-org",
+                "attributes": {},
+            }
+        )
+        return rows
 
 
 class _EntityUpdatePatchClient:
@@ -790,9 +804,13 @@ async def test_native_entity_manager_get_many_preserves_requested_order_and_scop
 
     assert [entity.id for entity in entities] == ["second", "first"]
     query, params = client.calls[0]
-    assert "uuid IN $uuids" in query
+    # Per-uuid indexed lookups: `uuid IN $list` is never index-served, so the
+    # bulk read maps over the ids instead of scanning the table. The closure
+    # sees only its own argument, so scope enforcement happens app-side.
+    assert "uuid IN" not in query
+    assert "$uuids.map" in query
+    assert "uuid = $u" in query
     assert params == {
-        "group_id": "org-native",
         "uuids": ["second", "first", "missing"],
     }
 
@@ -2536,7 +2554,10 @@ class _RelationshipBulkWriteClient:
         self.calls.append((query, params))
         if "AS record_id" in query and "FROM entity" in query:
             uuids = cast("list[str]", params["uuids"])
-            return [{"uuid": uuid, "record_id": f"entity:{uuid}"} for uuid in uuids]
+            return [
+                {"uuid": uuid, "group_id": self.group_id, "record_id": f"entity:{uuid}"}
+                for uuid in uuids
+            ]
         return []
 
 
@@ -2573,12 +2594,21 @@ async def test_native_relationship_bulk_writes_in_one_surreal_query() -> None:
     assert len(write_calls) == 1
     assert len(endpoint_lookups) == 1
 
-    _, write_params = write_calls[0]
+    lookup_query, _ = endpoint_lookups[0]
+    # `uuid IN $list` is never index-served; the lookup must map per-uuid.
+    assert "uuid IN" not in lookup_query
+    assert "$uuids.map" in lookup_query
+
+    write_query, write_params = write_calls[0]
+    # The endpoint-move cleanup iterates the batch through the unique index
+    # instead of scanning the table with an IN-list DELETE.
+    assert "FOR $edge IN $edges" in write_query
+    assert "DELETE FROM relates_to" not in write_query
     rows = cast("list[dict[str, object]]", write_params["rows"])
     assert len(rows) == len(relationships)
-    assert write_params["uuids"] == [relationship.id for relationship in relationships]
-    assert set(cast("dict[str, object]", write_params["sources"])) == set(write_params["uuids"])
-    assert set(cast("dict[str, object]", write_params["targets"])) == set(write_params["uuids"])
+    edges = cast("list[dict[str, object]]", write_params["edges"])
+    assert [edge["uuid"] for edge in edges] == [relationship.id for relationship in relationships]
+    assert all(edge["src"] is not None and edge["tgt"] is not None for edge in edges)
     assert all(row["group_id"] == client.group_id for row in rows)
     assert all("in" in row and "out" in row for row in rows)
     assert {str(row["uuid"]) for row in rows} == {relationship.id for relationship in relationships}

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -1087,6 +1087,32 @@ def test_graph_retrieval_key_columns_are_versioned_and_indexed() -> None:
     )
 
 
+def test_graph_label_index_is_element_indexed_and_versioned() -> None:
+    """Label-filtered search reads idx_entity_labels, so its shape is the contract.
+
+    On SurrealDB 3.2.3 an index on the bare array field answers CONTAINS with a
+    full table scan and answers a bare equality with zero rows unless the WHERE
+    clause happens to carry a second predicate. Only the element form
+    (FIELDS labels.*) makes the filter index-served and correct on its own, and
+    the migration must OVERWRITE because every pre-v19 namespace already holds
+    the bare-array index under the same name.
+    """
+    migration = next(
+        item for item in GRAPH_SCHEMA_MIGRATIONS if item.name == "entity_labels_element_index"
+    )
+    migration_sql = "\n".join(migration.statements)
+
+    assert GRAPH_SCHEMA_CURRENT_VERSION >= 19
+    assert migration.version == 19
+    assert (
+        "DEFINE INDEX OVERWRITE idx_entity_labels ON entity FIELDS labels.* CONCURRENTLY"
+        in migration_sql
+    )
+    assert "DEFINE INDEX IF NOT EXISTS idx_entity_labels ON entity FIELDS labels.*" in (
+        NODE_DEFINITIONS
+    )
+
+
 def test_graph_schema_current_version_matches_latest_migration() -> None:
     latest_migration_version = max(migration.version for migration in GRAPH_SCHEMA_MIGRATIONS)
 


### PR DESCRIPTION
# 🐌 Graph IN-list class kill: every uuid-list statement now rides the unique index

> Sibling of #341, found on the same LongMemEval-V2 gate corpus. That PR fixed one tablescanning UPDATE; this one retires the remaining class: four graph statements whose `uuid IN $list` predicate the planner refuses to index, two of them on the capture hot path. Also converts `idx_entity_labels` to an element index so label-filtered search stops scanning (or silently returning nothing).

## 💡 What this is

SurrealDB's planner never serves a parameterized `uuid IN $list` from a unique index. EXPLAIN shows `TableScan` for every statement type, SELECT included, at every table size, and the `WITH INDEX` hint is ignored for IN predicates. Four statements in `packages/python/sibyl-core/src/sibyl_core/services/graph.py` carried that shape: the relationship bulk-upsert's endpoint-cleanup DELETE, the `_record_ids` endpoint resolver, `EntityManager.get_many`, and `RelationshipManager.delete_bulk`. The two on the capture path compound into the write collapse measured on the gate corpus: at 350K edges the DELETE cost 9.4 seconds per capture batch and `_record_ids` cost 3.3 seconds per batch, both linear in table size, both holding org-pool sockets while they scan.

Each site now addresses rows through the unique index one uuid at a time: a `FOR` loop for the transactional DELETE, closure maps (`$uuids.map(|$u| ...)`) for the bulk reads. Same batch sizes, same tables: the DELETE drops to 16ms and the 1,400-uuid endpoint resolve drops to 128ms.

The second commit gives `idx_entity_labels` the same element-index repair `retrieval_keys` got in schema v18. A bare-array index on 3.2.x answers `CONTAINS` with a table scan and answers bare equality with zero rows unless a second predicate happens to be present, which leaves every label-filtered search read (`labels CONTAINS $node_label`, both node and edge filter paths) either scanning or silently empty.

## 🎯 The anchor

One property carries the review: **a SurrealQL closure body may reference nothing but its own argument.** Any other binding silently evaluates to nothing in at least one supported engine. An RPC param (`$group_id`) inside a closure returns zero rows on the SDK-embedded 2.0 engine that the unit suites run on, and even a `LET`-rebound copy returns zero rows on the live 3.2.0 server. No error is raised either way; the guarded lookup just misses everything.

The rewritten closures therefore look up by uuid alone, which is sound because `uuid` carries a UNIQUE index on every graph table, and enforce group scope where bindings resolve normally: app-side on the returned rows (`get_many`, `_record_ids`) or in the enclosing DELETE's own WHERE (`delete_bulk`, the bulk-upsert endpoint guard). Each org also lives in its own Surreal namespace, so the group filter is defense in depth rather than the primary isolation boundary. The `get_many` unit test now feeds a foreign-group row through its fake client to pin the app-side filter.

## 🛠️ How it works

1. **Bulk-upsert DELETE** (`_RELATIONSHIP_BULK_UPSERT_QUERY`): `FOR $edge IN $edges` addresses each row via `DELETE (SELECT VALUE id FROM relates_to WHERE uuid = $edge.uuid LIMIT 1) WHERE in != $edge.src OR out != $edge.tgt`. The subquery is pure indexed addressing; the endpoint-move guard evaluates atomically on the DELETE. The caller passes one `edges` list instead of the old `uuids`/`sources`/`targets` triple.
2. **`_record_ids`**: closure map projecting `uuid, group_id, id AS record_id`; rows whose `group_id` mismatches are dropped in the existing result loop. Missing uuids yield NONE entries that `normalize_records` already discards.
3. **`get_many`**: same closure map with `SELECT *`; the group check moved into the row comprehension. Requested-order preservation is unchanged (the caller reorders by its input list).
4. **`delete_bulk`**: `LET` resolves targets per uuid, `DELETE array::filter($targets, |$t| $t != NONE) WHERE group_id = $group_id RETURN BEFORE` deletes only in-scope rows and still returns the deleted rows the caller counts.
5. **Labels index**: bootstrap DDL becomes `FIELDS labels.*`, and migration v19 replays `DEFINE INDEX OVERWRITE idx_entity_labels ON entity FIELDS labels.* CONCURRENTLY` for existing namespaces. CONCURRENTLY because, unlike the empty-by-construction v18 retrieval_keys index, labels are populated on every row, and a single-transaction rebuild fails on RocksDB once the table is large.

Rejected shape, for the record: porting #341's subquery addressing to IN-lists (`DELETE (SELECT ... WHERE uuid IN $uuids ...)`) is catastrophically worse than the shape it would replace. It ran past ten minutes at 350K rows before being killed, against 9.4s for the plain IN DELETE.

## 🧪 Validation

- Targeted suites at HEAD: `uv run --directory packages/python/sibyl-core pytest tests/test_graph.py tests/test_surreal_schema_syntax.py -q` → 152 passed, including the new v19 migration pin and the foreign-group exclusion test.
- Full packages: core suite → 2457 passed, 14 skipped; apps/api suite → 2233 passed, 5 skipped. `ruff check` and `ruff format --check` clean on all five touched files.
- Live semantics on SurrealDB 3.2.0 (throwaway namespace, cleaned up): fresh insert, same-endpoint re-upsert (fact updated in place), endpoint move (old edge deleted, re-inserted with new endpoints), record_ids hit/miss/group shapes, delete_bulk scope guard (in-scope row deleted, foreign-group row survives, ghost uuid no-op), and RETURN BEFORE rows arriving in per-statement results.
- Timing on the gate corpus (350,677 relates_to / 167,296 entity rows, non-destructive probes): DELETE shape 9,401ms → 15.9ms per 700-uuid batch; record_ids shape 3,254ms → 127.8ms per 1,400 real uuids. EXPLAIN receipts: `uuid IN $list` plans TableScan, `uuid = $u` plans IndexScan on the unique index.
- Embedded-engine parity: the full bulk-upsert statement and both closure shapes verified by hand on `memory://` (SDK 2.0 engine) in addition to the suites, since 2.x/3.x divergence is exactly where this class of bug hides.
- ⚠️ No test pins the query-plan property itself (the old and new statements are semantically equivalent; only the plan differs). The timing receipts above and the anti-IN assertions in the updated unit tests are the guard. Same residual as #341.

## 🔍 What reviewers should focus on

- The scope-enforcement move in `get_many`/`_record_ids`: uuid-only lookup plus app-side group filter must be equivalent to the old server-side `group_id AND uuid IN` for every caller. Namespace-per-org isolation means a cross-org uuid cannot appear in the namespace at all; the filter covers the same-namespace defense-in-depth case.
- `delete_bulk`'s count semantics: the caller intersects RETURN BEFORE uuids with its request list; the LET statements return nothing and normalize away.
- The FOR-loop DELETE's guard placement: `WHERE in != $edge.src OR out != $edge.tgt` on the DELETE, not the subquery, so the compare-and-delete stays atomic per record.
- Migration v19 on a populated namespace: OVERWRITE + CONCURRENTLY converts the live bare-array index in place.
- Out of scope, tracked: the shared-namespace IN-list sites in apps/api (users, project_members, crawled_documents; small tables, no collapse risk today) are Sibyl task `f0d7c1ae`; the `UPDATE entity MERGE` OR-guard sibling from #341's list is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved graph lookups and relationship operations for faster indexed retrieval, especially with multiple entities and endpoints.

* **Bug Fixes**
  * Improved filtering to prevent results from unrelated groups from being returned.
  * Enhanced relationship cleanup and bulk updates for more reliable graph data handling.

* **Maintenance**
  * Updated the graph schema to support indexed label elements and migrated existing namespaces automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->