### PR TITLE
feat(bench): arm-selectable survival for stitched neighbors, with the measured A/B

### DIFF
--- a/benchmarks/longmemeval_v2_composition_replay.py
+++ b/benchmarks/longmemeval_v2_composition_replay.py
@@ -49,6 +49,7 @@ def main(argv: list[str] | None = None) -> int:
         neighbor_stitch_span=args.neighbor_stitch_span,
         state_part_completion_items=args.state_part_completion_items,
         state_part_refinement=args.state_part_refinement,
+        neighbor_support_exempt=args.neighbor_support_exempt,
     )
     output = Path(args.output).expanduser().resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -93,6 +94,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--neighbor-stitch-span", type=int, default=1)
     parser.add_argument("--state-part-completion-items", type=int, default=0)
     parser.add_argument("--state-part-refinement", action="store_true")
+    parser.add_argument("--neighbor-support-exempt", action="store_true")
     args = parser.parse_args(argv)
     for name in (
         "max_items",
@@ -132,6 +134,7 @@ def replay_composition(
     neighbor_stitch_span: int,
     state_part_completion_items: int = 0,
     state_part_refinement: bool = False,
+    neighbor_support_exempt: bool = False,
 ) -> dict[str, Any]:
     rows: list[dict[str, Any]] = []
     sources: dict[str, dict[str, Any]] = {}
@@ -165,6 +168,7 @@ def replay_composition(
                     neighbor_stitch_span=neighbor_stitch_span,
                     state_part_completion_items=state_part_completion_items,
                     state_part_refinement=state_part_refinement,
+                    neighbor_support_exempt=neighbor_support_exempt,
                 )
             )
 
@@ -195,6 +199,7 @@ def replay_composition(
             "neighbor_stitch_span": neighbor_stitch_span,
             "state_part_completion_items": state_part_completion_items,
             "state_part_refinement": state_part_refinement,
+            "neighbor_support_exempt": neighbor_support_exempt,
         },
         "metrics": {
             "question_count": len(rows),
@@ -263,6 +268,7 @@ def replay_question(
     neighbor_stitch_span: int,
     state_part_completion_items: int,
     state_part_refinement: bool,
+    neighbor_support_exempt: bool = False,
 ) -> dict[str, Any]:
     query = str(row.get("question_text") or "")
     baseline = result_candidates(row)
@@ -304,6 +310,7 @@ def replay_question(
         raw_results=candidate_assembled,
         max_items=max_items,
         mode="shared_relevance",
+        neighbor_support_exempt=neighbor_support_exempt,
     )
     phrases = answer_phrases(row)
     baseline_exposed = full_phrase_exposure(phrases, baseline)

--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -65,6 +65,7 @@ def main(argv: list[str] | None = None) -> int:
             "retrieval_max_planned_queries": args.max_planned_queries,
             "evidence_composition_mode": args.evidence_composition_mode,
             "source_evidence_bundling": args.source_evidence_bundling,
+            "neighbor_support_exempt": args.neighbor_support_exempt,
             "typed_stream_retrieval": args.typed_stream_retrieval,
             "typed_stream_limit": args.typed_stream_limit,
         },
@@ -132,6 +133,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--source-evidence-bundling",
         action=argparse.BooleanOptionalAction,
         default=True,
+    )
+    parser.add_argument(
+        "--neighbor-support-exempt",
+        action=argparse.BooleanOptionalAction,
+        default=False,
     )
     parser.add_argument("--typed-stream-retrieval", action="store_true")
     parser.add_argument("--typed-stream-limit", type=int, default=8)
@@ -251,6 +257,7 @@ def build_run_config(
         "max_context_total_chars": args.max_context_total_chars,
         "evidence_composition_mode": args.evidence_composition_mode,
         "source_evidence_bundling": args.source_evidence_bundling,
+        "neighbor_support_exempt": args.neighbor_support_exempt,
         "typed_stream_retrieval": args.typed_stream_retrieval,
         "typed_stream_limit": args.typed_stream_limit,
     }

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -146,6 +146,7 @@ DEFAULT_NEIGHBOR_STITCH_ITEMS = 2
 DEFAULT_NEIGHBOR_STITCH_SPAN = 1
 DEFAULT_STATE_PART_COMPLETION_ITEMS = 0
 DEFAULT_STATE_PART_REFINEMENT = False
+DEFAULT_NEIGHBOR_SUPPORT_EXEMPT = False
 DEFAULT_CONTEXT_EXPANSION_MAX_RATIO = 0.0
 CONTEXT_TOKENIZER_MODEL = "Qwen/Qwen3.5-9B"
 STATE_PART_REFINEMENT_MIN_SCORE_GAIN = 0.05
@@ -181,6 +182,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "neighbor_stitch_span",
         "state_part_completion_items",
         "state_part_refinement",
+        "neighbor_support_exempt",
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
@@ -684,6 +686,7 @@ def compile_operational_evidence_set(
     mode: str = DEFAULT_EVIDENCE_COMPOSITION_MODE,
     typed_reservation_items: int | None = None,
     char_budget: int | None = None,
+    neighbor_support_exempt: bool = DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
 ) -> tuple[list[dict[str, object]], dict[str, object]]:
     """Compose the reader's pack from the typed and raw evidence pools.
 
@@ -786,7 +789,11 @@ def compile_operational_evidence_set(
             max(1, min(requested_reservation, max_items - 1)),
         )
         raw_budget = min(len(ranked_raw), max_items - typed_reservation)
-        selected_raw = _select_role_complete_raw_evidence(ranked_raw, budget=raw_budget)
+        selected_raw = _select_role_complete_raw_evidence(
+            ranked_raw,
+            budget=raw_budget,
+            neighbor_support_exempt=neighbor_support_exempt,
+        )
         selected = [*ranked_typed[:typed_reservation], *selected_raw]
         if len(selected) < max_items:
             selected.extend(
@@ -802,7 +809,11 @@ def compile_operational_evidence_set(
             budget=char_budget,
             spent=0,
         )
-        ordered_raw = _select_role_complete_raw_evidence(ranked_raw, budget=len(ranked_raw))
+        ordered_raw = _select_role_complete_raw_evidence(
+            ranked_raw,
+            budget=len(ranked_raw),
+            neighbor_support_exempt=neighbor_support_exempt,
+        )
         selected_raw, spent = _admit_within_char_budget(
             ordered_raw,
             budget=char_budget,
@@ -839,6 +850,7 @@ def compile_operational_evidence_set(
         ),
         "selected_typed_count": selected_typed,
         "selected_raw_count": len(selected) - selected_typed,
+        "neighbor_support_exempt": neighbor_support_exempt,
         "budget_mode": "items" if char_budget is None else "characters",
         "char_budget": char_budget,
         "selected_chars": selected_chars,
@@ -999,6 +1011,7 @@ def _select_role_complete_raw_evidence(
     candidates: list[dict[str, object]],
     *,
     budget: int,
+    neighbor_support_exempt: bool = DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
 ) -> list[dict[str, object]]:
     if budget <= 0:
         return []
@@ -1013,7 +1026,11 @@ def _select_role_complete_raw_evidence(
         for candidate in candidates
         if _is_support_candidate(candidate)
         and (parent_rank := _support_parent_search_rank(candidate)) in primary_by_search_rank
-        and _support_adds_query_coverage(candidate, primary_by_search_rank[parent_rank])
+        and _support_adds_query_coverage(
+            candidate,
+            primary_by_search_rank[parent_rank],
+            neighbor_exempt=neighbor_support_exempt,
+        )
     ]
     selected_links = _select_diverse_support_links(linked_support, limit=budget // 2)
     selected_support = [support for support, _parent in selected_links]
@@ -1053,8 +1070,20 @@ def _select_role_complete_raw_evidence(
 def _support_adds_query_coverage(
     support: dict[str, object],
     parent: dict[str, object],
+    *,
+    neighbor_exempt: bool,
 ) -> bool:
     if _stripped_str(support.get("_selection_origin")) == "state_part":
+        return True
+    # The overlap comparison asks a stitched neighbor to beat its parent on
+    # QUERY-term coverage, but the neighbor role exists for ANSWER adjacency
+    # and the answer is rarely phrased in the query, so the strict gate
+    # rejects exactly the neighbors that carry the answer (20/21 dropped
+    # stitched chunks in the web stage-1 cohort held the gold state's
+    # trajectory; 8 held the gold state itself). Exemption is arm-selectable
+    # because surviving neighbors displace tail seeds, a trade that has to be
+    # measured, not assumed.
+    if neighbor_exempt:
         return True
     return _numeric_score(support.get("_evidence_selection_overlap")) > _numeric_score(
         parent.get("_evidence_selection_overlap")
@@ -3076,6 +3105,11 @@ class SibylLiveApiMemory(Memory):
             "state_part_refinement",
             DEFAULT_STATE_PART_REFINEMENT,
         )
+        self.neighbor_support_exempt = _param_bool(
+            memory_params,
+            "neighbor_support_exempt",
+            DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
+        )
         self.evidence_types = _param_evidence_types(
             memory_params,
             "evidence_types",
@@ -4170,6 +4204,11 @@ class SibylLiveApiMemory(Memory):
             ),
             typed_reservation_items=getattr(self, "typed_reservation_items", None),
             char_budget=char_budget,
+            neighbor_support_exempt=getattr(
+                self,
+                "neighbor_support_exempt",
+                DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
+            ),
         )
         rendered_item_ceiling = context_pack_item_ceiling(
             max_items=self.max_context_items,

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -70,6 +70,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "neighbor_stitch_span",
         "state_part_completion_items",
         "state_part_refinement",
+        "neighbor_support_exempt",
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
@@ -442,6 +443,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
         action=argparse.BooleanOptionalAction,
         default=False,
     )
+    parser.add_argument(
+        "--neighbor-support-exempt",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
     parser.add_argument("--context-expansion-max-ratio", type=float, default=0.0)
     parser.add_argument(
         "--evidence-types",
@@ -673,6 +679,7 @@ def build_memory_config(args: argparse.Namespace) -> dict[str, object]:
         "neighbor_stitch_span": args.neighbor_stitch_span,
         "state_part_completion_items": args.state_part_completion_items,
         "state_part_refinement": args.state_part_refinement,
+        "neighbor_support_exempt": args.neighbor_support_exempt,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "evidence_types": list(args.evidence_types),
         "evidence_char_budget": args.evidence_char_budget,
@@ -818,6 +825,7 @@ def build_run_plan(
         "max_chunks_per_trajectory": args.max_chunks_per_trajectory,
         "neighbor_stitch_items": args.neighbor_stitch_items,
         "neighbor_stitch_span": args.neighbor_stitch_span,
+        "neighbor_support_exempt": args.neighbor_support_exempt,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "max_context_total_chars": args.max_context_total_chars,
         "evidence_types": list(args.evidence_types),

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -2462,8 +2462,9 @@ def test_sibyl_memory_exempt_neighbors_survive_composition_next_to_their_seed() 
         _search_result("target", chunk_index=0, state_index=0, score=0.7),
     ]
     results[-1]["content"] = query
+    max_items = 4
     candidate_limit = module.context_assembly_candidate_limit(
-        max_items=4,
+        max_items=max_items,
         neighbor_stitch_items=1,
         state_part_completion_items=0,
         has_chunk_catalog=True,
@@ -2482,14 +2483,14 @@ def test_sibyl_memory_exempt_neighbors_survive_composition_next_to_their_seed() 
         query=query,
         typed_results=[],
         raw_results=assembled,
-        max_items=4,
+        max_items=max_items,
         neighbor_support_exempt=True,
     )
 
     assert metadata["stitched_neighbor_count"] == 1
     assert composition["neighbor_support_exempt"] is True
     assert composition["selected_raw_support_count"] == 1
-    assert len(selected) == 4
+    assert len(selected) == max_items
     origins_and_chunks = [
         (
             module._stripped_str(item.get("_selection_origin")),

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -2437,6 +2437,74 @@ def test_sibyl_memory_expansion_candidates_do_not_consume_seed_budget() -> None:
     assert composition["selected_raw_support_count"] == 0
 
 
+def test_sibyl_memory_exempt_neighbors_survive_composition_next_to_their_seed() -> None:
+    """The exempt arm admits stitched neighbors regardless of query coverage.
+
+    The default gate requires a neighbor to beat its parent on query-term
+    overlap, which structurally rejects answer-bearing neighbors (the answer
+    is rarely phrased in the query). With the exemption on, the same
+    no-coverage-gain neighbor must survive composition adjacent to its seed,
+    and the displacement cost is explicit: the support slot comes out of the
+    tail of the primary lane.
+    """
+    module = _load_memory_module()
+    query = "inventory order dashboard prefix"
+    first = _search_result("t1", chunk_index=1, state_index=1, score=1.0)
+    neighbor = _search_result("t1", chunk_index=0, state_index=0, score=0.0)
+    neighbor["content"] = (
+        "Goal: inventory order dashboard prefix\n\n"
+        "State 0\nAccessibility tree:\nanswer-bearing neighboring state"
+    )
+    results = [
+        first,
+        _search_result("t2", chunk_index=0, state_index=0, score=0.9),
+        _search_result("t3", chunk_index=0, state_index=0, score=0.8),
+        _search_result("target", chunk_index=0, state_index=0, score=0.7),
+    ]
+    results[-1]["content"] = query
+    candidate_limit = module.context_assembly_candidate_limit(
+        max_items=4,
+        neighbor_stitch_items=1,
+        state_part_completion_items=0,
+        has_chunk_catalog=True,
+    )
+
+    assembled, metadata = module.assemble_context_results(
+        results,
+        chunk_catalog={"t1": {0: neighbor, 1: first}},
+        max_items=candidate_limit,
+        max_chunks_per_trajectory=2,
+        neighbor_stitch_items=1,
+        neighbor_stitch_span=1,
+        query=query,
+    )
+    selected, composition = module.compile_operational_evidence_set(
+        query=query,
+        typed_results=[],
+        raw_results=assembled,
+        max_items=4,
+        neighbor_support_exempt=True,
+    )
+
+    assert metadata["stitched_neighbor_count"] == 1
+    assert composition["neighbor_support_exempt"] is True
+    assert composition["selected_raw_support_count"] == 1
+    assert len(selected) == 4
+    origins_and_chunks = [
+        (
+            module._stripped_str(item.get("_selection_origin")),
+            item["metadata"]["longmemeval_v2_trajectory_id"],
+            item["metadata"]["longmemeval_v2_chunk_index"],
+        )
+        for item in selected
+    ]
+    seed_position = origins_and_chunks.index(("search", "t1", 1))
+    assert origins_and_chunks[seed_position + 1] == ("neighbor", "t1", 0)
+    assert not any(
+        item["metadata"]["longmemeval_v2_trajectory_id"] == "target" for item in selected
+    )
+
+
 def test_sibyl_memory_restores_transport_truncated_search_content() -> None:
     module = _load_memory_module()
     search_result = _search_result("t1", chunk_index=1, state_index=1, score=0.9)
@@ -4702,6 +4770,7 @@ def test_operational_evidence_set_calibrates_typed_and_raw_score_pools() -> None
         "selected_raw_support_count": 0,
         "selected_typed_count": 3,
         "selected_raw_count": 5,
+        "neighbor_support_exempt": False,
         "budget_mode": "items",
         "char_budget": None,
         "selected_chars": sum(len(str(item["content"])) for item in selected),
@@ -5833,6 +5902,7 @@ def test_sibyl_memory_finalize_drains_jobs_before_search() -> None:
                 "selected_raw_support_count": 0,
                 "selected_typed_count": 0,
                 "selected_raw_count": 0,
+                "neighbor_support_exempt": False,
                 "budget_mode": "items",
                 "char_budget": None,
                 "selected_chars": 0,


### PR DESCRIPTION
# 🧪 Neighbor-support exemption: an arm-selectable fix for the stitch budget that composition structurally deleted

> Benchmark harness only, no server code. Adds one composition arm to the LongMemEval-V2 adapter, default off, and ships with a completed live A/B on the stage-1 gate corpus: web state recall +8.3pp, enterprise −2.3pp. The numbers are in this description because the arm exists to be judged by them.

## 💡 What this is

Stage-1 forensics traced the 30-point web-vs-enterprise state-recall gap to a single mechanism: in 20 of 21 web misses where the right trajectory was retrieved, the adapter's neighbor stitch had already fetched the adjacent chunk and evidence composition dropped it. In 8 of those the dropped chunk held the gold state itself.

The cause is not trim ordering. Composition already carries seed-anchored survival machinery for support chunks (`_select_role_complete_raw_evidence` links a neighbor to its parent seed and emits them adjacent). The kill happens at its gate: `_support_adds_query_coverage` admits a neighbor only when it beats its parent on QUERY-term overlap. The neighbor role exists for ANSWER adjacency, and answers are rarely phrased in queries, so the gate structurally rejects exactly the neighbors that carry the answer. The stitch budget has been dead weight since it shipped.

This PR makes the gate arm-selectable: `neighbor_support_exempt` (default false) admits linked neighbors unconditionally. It is a new arm rather than a default change because surviving neighbors displace tail seeds, an existing test pins that trade deliberately, and the net effect had to be measured.

## 🎯 The measured verdict

Live A/B on the stage-1 gate corpus (identical flags, hash-verified identical inputs, same isolated store; banked stage-1 runs as control; scored with the v3-strict diagnostics):

| state recall@10 | control | exempt arm | delta |
| --- | --- | --- | --- |
| web (n=48 eligible) | 47.9% | 56.2% | +8.3pp |
| enterprise (n=44 eligible) | 77.3% | 75.0% | −2.3pp |

Web answer-phrase state coverage rises 52.4% → 60.4%. Enterprise exposure falls 72.7% → 68.2%, and trajectory recall dips about 2pp in BOTH domains: an admitted neighbor's support slot comes out of the primary lane, and sometimes the displaced tail seed was the only representative of its trajectory. The effect is gold-state-density-dependent, which is why it splits by domain: web gold states are sparse (the neighbor IS the payload), enterprise gold states are dense (any state in the right trajectory hits, so neighbors are redundant and displaced seeds are pure cost).

The earlier counterfactual projected web at 64.6% because it assumed survival with zero displacement cost; the measured 56.2% is the honest number. Default stays off. The next experiment this enables is trajectory-preserving displacement (admit a neighbor only when the displaced seed is not the last representative of its trajectory), which targets keeping the web gain while cutting the trajectory-recall cost.

## 🛠️ How it works

1. `benchmarks/longmemeval_v2_memory/sibyl_memory.py`: `compile_operational_evidence_set` gains `neighbor_support_exempt` (default `DEFAULT_NEIGHBOR_SUPPORT_EXEMPT = False`), threads it to `_select_role_complete_raw_evidence`, and `_support_adds_query_coverage` returns true for neighbors under the exemption (state_parts were already exempt). The setting is recorded in composition metadata and accepted as a runtime memory param.
2. `benchmarks/longmemeval_v2_live_retrieval.py` and `benchmarks/longmemeval_v2_official.py`: `--neighbor-support-exempt` (BooleanOptionalAction, default false), passed into memory params and stamped into `run_config` / run receipts for provenance.
3. `benchmarks/longmemeval_v2_composition_replay.py`: same flag for offline replays. Note the replay's seal check rightly refuses slice-substrate runs (their stored seeds are server-side slice renders, not catalog chunks), which is why this arm was measured live rather than replayed.

## 🧪 Validation

- Adapter suite: `uv run pytest tools/tests/test_longmemeval_v2_official.py -q` → 174 passed, including a new test pinning the exempt arm (the no-coverage-gain neighbor survives adjacent to its seed, and the tail seed it displaces is asserted out, keeping the cost visible) and the pre-existing default-arm test untouched.
- Default-arm invariance: with the flag off, composition metadata is byte-identical except the new `neighbor_support_exempt: false` key; two exact-metadata tests were extended with that key and nothing else.
- The live A/B above is the functional validation: 451 questions re-retrieved on the isolated stack, run configs carrying the flag, diagnostics reports in `.moon/cache/evals/a1-stage1/diagnostics-{web,ent}-nse/`.
- `ruff check` and `ruff format --check` clean on all touched files (the two pre-existing findings in `composition_replay.py` and `official.py` reproduce on main unchanged).

## 🔍 What reviewers should focus on

- The gate change reads as three lines in `_support_adds_query_coverage`; the review question is whether any OTHER caller of `_select_role_complete_raw_evidence` should have been given the flag (both call sites in `compile_operational_evidence_set` thread it; there are no others).
- The default-off contract: every existing arm and receipt composes exactly as before.
- Whether the run-receipt stamping in `official.py` covers every place a stage-2 scored run would need to reproduce the arm.
- Out of scope: changing the default (needs the trajectory-preserving variant measured first), the span-2 stitch-budget spread (the larger counterfactual rung), and the enterprise regression under the exemption (inherent to the arm, documented above, and the reason it is opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to exempt neighbor support from query-coverage filtering during evidence composition.
  * Exposed the setting across replay, live retrieval, and official benchmark command-line workflows.
  * Preserved the setting in run configurations and reports for reproducibility.

* **Bug Fixes**
  * Ensured eligible neighbor support can remain alongside its seed and participate in support-slot selection when enabled.

* **Tests**
  * Added regression coverage for exempt neighbor support behavior and default metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->