### PR TITLE
feat(bench): fix what the stitch reaches and what it costs

### DIFF
--- a/benchmarks/longmemeval_v2_composition_replay.py
+++ b/benchmarks/longmemeval_v2_composition_replay.py
@@ -52,6 +52,7 @@ def main(argv: list[str] | None = None) -> int:
         neighbor_support_exempt=args.neighbor_support_exempt,
         neighbor_trajectory_preserving=args.neighbor_trajectory_preserving,
         neighbor_support_overflow_items=args.neighbor_support_overflow_items,
+        neighbor_stitch_spread=args.neighbor_stitch_spread,
     )
     output = Path(args.output).expanduser().resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -99,6 +100,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--neighbor-support-exempt", action="store_true")
     parser.add_argument("--neighbor-trajectory-preserving", action="store_true")
     parser.add_argument("--neighbor-support-overflow-items", type=int, default=0)
+    parser.add_argument("--neighbor-stitch-spread", action="store_true")
     args = parser.parse_args(argv)
     for name in (
         "max_items",
@@ -141,6 +143,7 @@ def replay_composition(
     neighbor_support_exempt: bool = False,
     neighbor_trajectory_preserving: bool = False,
     neighbor_support_overflow_items: int = 0,
+    neighbor_stitch_spread: bool = False,
 ) -> dict[str, Any]:
     rows: list[dict[str, Any]] = []
     sources: dict[str, dict[str, Any]] = {}
@@ -177,6 +180,7 @@ def replay_composition(
                     neighbor_support_exempt=neighbor_support_exempt,
                     neighbor_trajectory_preserving=neighbor_trajectory_preserving,
                     neighbor_support_overflow_items=neighbor_support_overflow_items,
+                    neighbor_stitch_spread=neighbor_stitch_spread,
                 )
             )
 
@@ -210,6 +214,7 @@ def replay_composition(
             "neighbor_support_exempt": neighbor_support_exempt,
             "neighbor_trajectory_preserving": neighbor_trajectory_preserving,
             "neighbor_support_overflow_items": neighbor_support_overflow_items,
+            "neighbor_stitch_spread": neighbor_stitch_spread,
         },
         "metrics": {
             "question_count": len(rows),
@@ -281,6 +286,7 @@ def replay_question(
     neighbor_support_exempt: bool = False,
     neighbor_trajectory_preserving: bool = False,
     neighbor_support_overflow_items: int = 0,
+    neighbor_stitch_spread: bool = False,
 ) -> dict[str, Any]:
     query = str(row.get("question_text") or "")
     baseline = result_candidates(row)
@@ -312,6 +318,7 @@ def replay_question(
         max_chunks_per_trajectory=max_chunks_per_trajectory,
         neighbor_stitch_items=neighbor_stitch_items,
         neighbor_stitch_span=neighbor_stitch_span,
+        neighbor_stitch_spread=neighbor_stitch_spread,
         query=query,
         state_part_completion_items=state_part_completion_items,
         state_part_refinement=state_part_refinement,

--- a/benchmarks/longmemeval_v2_composition_replay.py
+++ b/benchmarks/longmemeval_v2_composition_replay.py
@@ -51,6 +51,7 @@ def main(argv: list[str] | None = None) -> int:
         state_part_refinement=args.state_part_refinement,
         neighbor_support_exempt=args.neighbor_support_exempt,
         neighbor_trajectory_preserving=args.neighbor_trajectory_preserving,
+        neighbor_support_overflow_items=args.neighbor_support_overflow_items,
     )
     output = Path(args.output).expanduser().resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -97,6 +98,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--state-part-refinement", action="store_true")
     parser.add_argument("--neighbor-support-exempt", action="store_true")
     parser.add_argument("--neighbor-trajectory-preserving", action="store_true")
+    parser.add_argument("--neighbor-support-overflow-items", type=int, default=0)
     args = parser.parse_args(argv)
     for name in (
         "max_items",
@@ -138,6 +140,7 @@ def replay_composition(
     state_part_refinement: bool = False,
     neighbor_support_exempt: bool = False,
     neighbor_trajectory_preserving: bool = False,
+    neighbor_support_overflow_items: int = 0,
 ) -> dict[str, Any]:
     rows: list[dict[str, Any]] = []
     sources: dict[str, dict[str, Any]] = {}
@@ -173,6 +176,7 @@ def replay_composition(
                     state_part_refinement=state_part_refinement,
                     neighbor_support_exempt=neighbor_support_exempt,
                     neighbor_trajectory_preserving=neighbor_trajectory_preserving,
+                    neighbor_support_overflow_items=neighbor_support_overflow_items,
                 )
             )
 
@@ -205,6 +209,7 @@ def replay_composition(
             "state_part_refinement": state_part_refinement,
             "neighbor_support_exempt": neighbor_support_exempt,
             "neighbor_trajectory_preserving": neighbor_trajectory_preserving,
+            "neighbor_support_overflow_items": neighbor_support_overflow_items,
         },
         "metrics": {
             "question_count": len(rows),
@@ -275,6 +280,7 @@ def replay_question(
     state_part_refinement: bool,
     neighbor_support_exempt: bool = False,
     neighbor_trajectory_preserving: bool = False,
+    neighbor_support_overflow_items: int = 0,
 ) -> dict[str, Any]:
     query = str(row.get("question_text") or "")
     baseline = result_candidates(row)
@@ -318,6 +324,7 @@ def replay_question(
         mode="shared_relevance",
         neighbor_support_exempt=neighbor_support_exempt,
         neighbor_trajectory_preserving=neighbor_trajectory_preserving,
+        neighbor_support_overflow_items=neighbor_support_overflow_items,
     )
     phrases = answer_phrases(row)
     baseline_exposed = full_phrase_exposure(phrases, baseline)

--- a/benchmarks/longmemeval_v2_composition_replay.py
+++ b/benchmarks/longmemeval_v2_composition_replay.py
@@ -50,6 +50,7 @@ def main(argv: list[str] | None = None) -> int:
         state_part_completion_items=args.state_part_completion_items,
         state_part_refinement=args.state_part_refinement,
         neighbor_support_exempt=args.neighbor_support_exempt,
+        neighbor_trajectory_preserving=args.neighbor_trajectory_preserving,
     )
     output = Path(args.output).expanduser().resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -95,6 +96,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--state-part-completion-items", type=int, default=0)
     parser.add_argument("--state-part-refinement", action="store_true")
     parser.add_argument("--neighbor-support-exempt", action="store_true")
+    parser.add_argument("--neighbor-trajectory-preserving", action="store_true")
     args = parser.parse_args(argv)
     for name in (
         "max_items",
@@ -135,6 +137,7 @@ def replay_composition(
     state_part_completion_items: int = 0,
     state_part_refinement: bool = False,
     neighbor_support_exempt: bool = False,
+    neighbor_trajectory_preserving: bool = False,
 ) -> dict[str, Any]:
     rows: list[dict[str, Any]] = []
     sources: dict[str, dict[str, Any]] = {}
@@ -169,6 +172,7 @@ def replay_composition(
                     state_part_completion_items=state_part_completion_items,
                     state_part_refinement=state_part_refinement,
                     neighbor_support_exempt=neighbor_support_exempt,
+                    neighbor_trajectory_preserving=neighbor_trajectory_preserving,
                 )
             )
 
@@ -200,6 +204,7 @@ def replay_composition(
             "state_part_completion_items": state_part_completion_items,
             "state_part_refinement": state_part_refinement,
             "neighbor_support_exempt": neighbor_support_exempt,
+            "neighbor_trajectory_preserving": neighbor_trajectory_preserving,
         },
         "metrics": {
             "question_count": len(rows),
@@ -269,6 +274,7 @@ def replay_question(
     state_part_completion_items: int,
     state_part_refinement: bool,
     neighbor_support_exempt: bool = False,
+    neighbor_trajectory_preserving: bool = False,
 ) -> dict[str, Any]:
     query = str(row.get("question_text") or "")
     baseline = result_candidates(row)
@@ -311,6 +317,7 @@ def replay_question(
         max_items=max_items,
         mode="shared_relevance",
         neighbor_support_exempt=neighbor_support_exempt,
+        neighbor_trajectory_preserving=neighbor_trajectory_preserving,
     )
     phrases = answer_phrases(row)
     baseline_exposed = full_phrase_exposure(phrases, baseline)

--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -68,6 +68,7 @@ def main(argv: list[str] | None = None) -> int:
             "neighbor_support_exempt": args.neighbor_support_exempt,
             "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
             "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
+            "neighbor_stitch_spread": args.neighbor_stitch_spread,
             "typed_stream_retrieval": args.typed_stream_retrieval,
             "typed_stream_limit": args.typed_stream_limit,
         },
@@ -147,6 +148,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
     )
     parser.add_argument("--neighbor-support-overflow-items", type=int, default=0)
+    parser.add_argument(
+        "--neighbor-stitch-spread",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
     parser.add_argument("--typed-stream-retrieval", action="store_true")
     parser.add_argument("--typed-stream-limit", type=int, default=8)
     args = parser.parse_args(argv)
@@ -268,6 +274,7 @@ def build_run_config(
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
         "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
+        "neighbor_stitch_spread": args.neighbor_stitch_spread,
         "typed_stream_retrieval": args.typed_stream_retrieval,
         "typed_stream_limit": args.typed_stream_limit,
     }

--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -66,6 +66,7 @@ def main(argv: list[str] | None = None) -> int:
             "evidence_composition_mode": args.evidence_composition_mode,
             "source_evidence_bundling": args.source_evidence_bundling,
             "neighbor_support_exempt": args.neighbor_support_exempt,
+            "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
             "typed_stream_retrieval": args.typed_stream_retrieval,
             "typed_stream_limit": args.typed_stream_limit,
         },
@@ -136,6 +137,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--neighbor-support-exempt",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--neighbor-trajectory-preserving",
         action=argparse.BooleanOptionalAction,
         default=False,
     )
@@ -258,6 +264,7 @@ def build_run_config(
         "evidence_composition_mode": args.evidence_composition_mode,
         "source_evidence_bundling": args.source_evidence_bundling,
         "neighbor_support_exempt": args.neighbor_support_exempt,
+        "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
         "typed_stream_retrieval": args.typed_stream_retrieval,
         "typed_stream_limit": args.typed_stream_limit,
     }

--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -67,6 +67,7 @@ def main(argv: list[str] | None = None) -> int:
             "source_evidence_bundling": args.source_evidence_bundling,
             "neighbor_support_exempt": args.neighbor_support_exempt,
             "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
+            "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
             "typed_stream_retrieval": args.typed_stream_retrieval,
             "typed_stream_limit": args.typed_stream_limit,
         },
@@ -145,6 +146,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action=argparse.BooleanOptionalAction,
         default=False,
     )
+    parser.add_argument("--neighbor-support-overflow-items", type=int, default=0)
     parser.add_argument("--typed-stream-retrieval", action="store_true")
     parser.add_argument("--typed-stream-limit", type=int, default=8)
     args = parser.parse_args(argv)
@@ -265,6 +267,7 @@ def build_run_config(
         "source_evidence_bundling": args.source_evidence_bundling,
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
+        "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
         "typed_stream_retrieval": args.typed_stream_retrieval,
         "typed_stream_limit": args.typed_stream_limit,
     }

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -14,7 +14,7 @@ import sys
 import threading
 import time
 from collections import Counter
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import TypeVar
@@ -149,6 +149,7 @@ DEFAULT_STATE_PART_REFINEMENT = False
 DEFAULT_NEIGHBOR_SUPPORT_EXEMPT = False
 DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING = False
 DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS = 0
+DEFAULT_NEIGHBOR_STITCH_SPREAD = False
 DEFAULT_CONTEXT_EXPANSION_MAX_RATIO = 0.0
 CONTEXT_TOKENIZER_MODEL = "Qwen/Qwen3.5-9B"
 STATE_PART_REFINEMENT_MIN_SCORE_GAIN = 0.05
@@ -187,6 +188,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "neighbor_support_exempt",
         "neighbor_trajectory_preserving",
         "neighbor_support_overflow_items",
+        "neighbor_stitch_spread",
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
@@ -2375,6 +2377,7 @@ def assemble_context_results(
     max_chunks_per_trajectory: int,
     neighbor_stitch_items: int,
     neighbor_stitch_span: int,
+    neighbor_stitch_spread: bool = DEFAULT_NEIGHBOR_STITCH_SPREAD,
     query: str = "",
     state_part_completion_items: int = 0,
     state_part_refinement: bool = False,
@@ -2449,6 +2452,7 @@ def assemble_context_results(
         selected_keys=selected_keys,
         limit=neighbor_budget,
         span=neighbor_stitch_span,
+        spread=neighbor_stitch_spread,
     )
     selected.extend(neighbors)
     if len(selected) < max_items:
@@ -2853,29 +2857,57 @@ def _neighbor_results(
     selected_keys: set[tuple[str, int | str]],
     limit: int,
     span: int,
+    spread: bool = DEFAULT_NEIGHBOR_STITCH_SPREAD,
 ) -> list[dict[str, object]]:
     neighbors: list[dict[str, object]] = []
+    for seed, trajectory_id, neighbor_index, distance in _neighbor_stitch_plan(
+        seeds, span=span, spread=spread
+    ):
+        key = (trajectory_id, neighbor_index)
+        catalog_result = chunk_catalog.get(trajectory_id, {}).get(neighbor_index)
+        if catalog_result is None or key in selected_keys:
+            continue
+        neighbor = dict(catalog_result)
+        neighbor["score"] = seed.get("score")
+        neighbor["_selection_origin"] = "neighbor"
+        neighbor["_neighbor_of_search_rank"] = seed.get("_search_rank")
+        neighbor["_neighbor_distance"] = distance
+        neighbors.append(neighbor)
+        selected_keys.add(key)
+        if len(neighbors) >= limit:
+            return neighbors
+    return neighbors
+
+
+def _neighbor_stitch_plan(
+    seeds: list[dict[str, object]],
+    *,
+    span: int,
+    spread: bool,
+) -> Iterator[tuple[dict[str, object], str, int, int]]:
+    """Order the chunks the stitch may claim, as (seed, trajectory, index, distance).
+
+    Seed-major order drains the whole budget on the highest-ranked seed before
+    reaching the second, so at the shipped budget of two the stitch only ever
+    covers one seed's immediate chunks. Ring-major order walks every seed at
+    distance one before any seed at distance two, which spends the same budget
+    across the seed set and keeps the nearest chunks ahead of the farther ones.
+    """
+    anchors: list[tuple[dict[str, object], str, int]] = []
     for seed in seeds:
         trajectory_id, chunk_index = _result_chunk_key(seed)
-        if not isinstance(chunk_index, int):
-            continue
-        trajectory_catalog = chunk_catalog.get(trajectory_id, {})
-        for distance in range(1, span + 1):
-            for neighbor_index in (chunk_index - distance, chunk_index + distance):
-                key = (trajectory_id, neighbor_index)
-                catalog_result = trajectory_catalog.get(neighbor_index)
-                if catalog_result is None or key in selected_keys:
-                    continue
-                neighbor = dict(catalog_result)
-                neighbor["score"] = seed.get("score")
-                neighbor["_selection_origin"] = "neighbor"
-                neighbor["_neighbor_of_search_rank"] = seed.get("_search_rank")
-                neighbor["_neighbor_distance"] = distance
-                neighbors.append(neighbor)
-                selected_keys.add(key)
-                if len(neighbors) >= limit:
-                    return neighbors
-    return neighbors
+        if isinstance(chunk_index, int):
+            anchors.append((seed, trajectory_id, chunk_index))
+    if not spread:
+        for seed, trajectory_id, chunk_index in anchors:
+            for distance in range(1, span + 1):
+                for neighbor_index in (chunk_index - distance, chunk_index + distance):
+                    yield seed, trajectory_id, neighbor_index, distance
+        return
+    for distance in range(1, span + 1):
+        for direction in (-1, 1):
+            for seed, trajectory_id, chunk_index in anchors:
+                yield seed, trajectory_id, chunk_index + direction * distance, distance
 
 
 def _result_diversity_key(result: dict[str, object]) -> tuple[str, int | str]:
@@ -3206,6 +3238,11 @@ class SibylLiveApiMemory(Memory):
             "neighbor_support_overflow_items",
             DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS,
             minimum=0,
+        )
+        self.neighbor_stitch_spread = _param_bool(
+            memory_params,
+            "neighbor_stitch_spread",
+            DEFAULT_NEIGHBOR_STITCH_SPREAD,
         )
         self.evidence_types = _param_evidence_types(
             memory_params,
@@ -4271,6 +4308,11 @@ class SibylLiveApiMemory(Memory):
                 self,
                 "neighbor_stitch_span",
                 DEFAULT_NEIGHBOR_STITCH_SPAN,
+            ),
+            neighbor_stitch_spread=getattr(
+                self,
+                "neighbor_stitch_spread",
+                DEFAULT_NEIGHBOR_STITCH_SPREAD,
             ),
             query=query,
             state_part_completion_items=state_part_completion_items,

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -148,6 +148,7 @@ DEFAULT_STATE_PART_COMPLETION_ITEMS = 0
 DEFAULT_STATE_PART_REFINEMENT = False
 DEFAULT_NEIGHBOR_SUPPORT_EXEMPT = False
 DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING = False
+DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS = 0
 DEFAULT_CONTEXT_EXPANSION_MAX_RATIO = 0.0
 CONTEXT_TOKENIZER_MODEL = "Qwen/Qwen3.5-9B"
 STATE_PART_REFINEMENT_MIN_SCORE_GAIN = 0.05
@@ -185,6 +186,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "state_part_refinement",
         "neighbor_support_exempt",
         "neighbor_trajectory_preserving",
+        "neighbor_support_overflow_items",
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
@@ -690,6 +692,7 @@ def compile_operational_evidence_set(
     char_budget: int | None = None,
     neighbor_support_exempt: bool = DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
     neighbor_trajectory_preserving: bool = DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
+    neighbor_support_overflow_items: int = DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS,
 ) -> tuple[list[dict[str, object]], dict[str, object]]:
     """Compose the reader's pack from the typed and raw evidence pools.
 
@@ -797,6 +800,7 @@ def compile_operational_evidence_set(
             budget=raw_budget,
             neighbor_support_exempt=neighbor_support_exempt,
             neighbor_trajectory_preserving=neighbor_trajectory_preserving,
+            neighbor_support_overflow_items=neighbor_support_overflow_items,
         )
         selected = [*ranked_typed[:typed_reservation], *selected_raw]
         if len(selected) < max_items:
@@ -804,6 +808,10 @@ def compile_operational_evidence_set(
                 ranked_typed[typed_reservation : typed_reservation + max_items - len(selected)]
             )
         selected_chars = sum(len(_stripped_str(item.get("content"))) for item in selected)
+        support_overflow_items = min(
+            max(0, neighbor_support_overflow_items),
+            sum(_is_support_candidate(item) for item in selected_raw),
+        )
     else:
         # The note lane keeps its absolute count inside the budget, but the
         # budget outranks the pin when it cannot hold that many: a lane allowed
@@ -832,6 +840,8 @@ def compile_operational_evidence_set(
         typed_reservation = len(reserved)
         selected = [*reserved, *selected_raw, *overflow]
         selected_chars = spent
+        # A budgeted pack has no item bound for a support to overflow past.
+        support_overflow_items = 0
     for selection_rank, candidate in enumerate(selected, start=1):
         candidate["_evidence_selection_rank"] = selection_rank
 
@@ -857,6 +867,8 @@ def compile_operational_evidence_set(
         "selected_raw_count": len(selected) - selected_typed,
         "neighbor_support_exempt": neighbor_support_exempt,
         "neighbor_trajectory_preserving": neighbor_trajectory_preserving,
+        "neighbor_support_overflow_items": neighbor_support_overflow_items,
+        "support_overflow_items": support_overflow_items,
         "budget_mode": "items" if char_budget is None else "characters",
         "char_budget": char_budget,
         "selected_chars": selected_chars,
@@ -1019,6 +1031,7 @@ def _select_role_complete_raw_evidence(
     budget: int,
     neighbor_support_exempt: bool = DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
     neighbor_trajectory_preserving: bool = DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
+    neighbor_support_overflow_items: int = DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS,
 ) -> list[dict[str, object]]:
     if budget <= 0:
         return []
@@ -1044,6 +1057,12 @@ def _select_role_complete_raw_evidence(
         selected_links = _links_preserving_trajectory_coverage(
             primary, selected_links, budget=budget
         )
+    # Supports compete with seeds only because the pack is bounded by an item
+    # count, and the character budget that count stands in for runs about a
+    # third spent. Overflow slots hand a support its own room instead of a
+    # seed's, up to the granted count; supports past it displace as before.
+    granted_overflow = min(max(0, neighbor_support_overflow_items), len(selected_links))
+    budget += granted_overflow
     selected_support = [support for support, _parent in selected_links]
     selected_primary = _pack_primary_around_links(primary, selected_links, budget=budget)
     selected_primary_ids = {id(candidate) for candidate in selected_primary}
@@ -1189,6 +1208,12 @@ def _support_parent_search_rank(candidate: dict[str, object]) -> int | None:
 
 def _is_support_candidate(candidate: dict[str, object]) -> bool:
     return _stripped_str(candidate.get("_selection_origin")) in {"neighbor", "state_part"}
+
+
+def _nonnegative_int(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return max(0, value)
 
 
 def _optional_positive_int(value: object) -> int | None:
@@ -2311,6 +2336,7 @@ def context_pack_item_ceiling(
     max_items: int,
     char_budget: int | None,
     candidate_count: int,
+    overflow_items: int = 0,
 ) -> int:
     """Item ceiling for the pack stages that run after the API answers.
 
@@ -2322,7 +2348,7 @@ def context_pack_item_ceiling(
     never be measurable. The ceiling then rises to whatever the stage was handed
     so it cannot bind, and the composer stays the one place the pack is bounded.
     """
-    max_items = max(1, max_items)
+    max_items = max(1, max_items) + max(0, overflow_items)
     if char_budget is None:
         return max_items
     return max(max_items, candidate_count)
@@ -3174,6 +3200,12 @@ class SibylLiveApiMemory(Memory):
             memory_params,
             "neighbor_trajectory_preserving",
             DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
+        )
+        self.neighbor_support_overflow_items = _param_int(
+            memory_params,
+            "neighbor_support_overflow_items",
+            DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS,
+            minimum=0,
         )
         self.evidence_types = _param_evidence_types(
             memory_params,
@@ -4279,11 +4311,17 @@ class SibylLiveApiMemory(Memory):
                 "neighbor_trajectory_preserving",
                 DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
             ),
+            neighbor_support_overflow_items=getattr(
+                self,
+                "neighbor_support_overflow_items",
+                DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS,
+            ),
         )
         rendered_item_ceiling = context_pack_item_ceiling(
             max_items=self.max_context_items,
             char_budget=char_budget,
             candidate_count=len(evidence_set),
+            overflow_items=_nonnegative_int(evidence_composition.get("support_overflow_items")),
         )
         assembly_metadata["typed_context_candidate_count"] = len(typed_results)
         assembly_metadata["typed_context_selected_count"] = sum(

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -147,6 +147,7 @@ DEFAULT_NEIGHBOR_STITCH_SPAN = 1
 DEFAULT_STATE_PART_COMPLETION_ITEMS = 0
 DEFAULT_STATE_PART_REFINEMENT = False
 DEFAULT_NEIGHBOR_SUPPORT_EXEMPT = False
+DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING = False
 DEFAULT_CONTEXT_EXPANSION_MAX_RATIO = 0.0
 CONTEXT_TOKENIZER_MODEL = "Qwen/Qwen3.5-9B"
 STATE_PART_REFINEMENT_MIN_SCORE_GAIN = 0.05
@@ -183,6 +184,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "state_part_completion_items",
         "state_part_refinement",
         "neighbor_support_exempt",
+        "neighbor_trajectory_preserving",
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
@@ -687,6 +689,7 @@ def compile_operational_evidence_set(
     typed_reservation_items: int | None = None,
     char_budget: int | None = None,
     neighbor_support_exempt: bool = DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
+    neighbor_trajectory_preserving: bool = DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
 ) -> tuple[list[dict[str, object]], dict[str, object]]:
     """Compose the reader's pack from the typed and raw evidence pools.
 
@@ -793,6 +796,7 @@ def compile_operational_evidence_set(
             ranked_raw,
             budget=raw_budget,
             neighbor_support_exempt=neighbor_support_exempt,
+            neighbor_trajectory_preserving=neighbor_trajectory_preserving,
         )
         selected = [*ranked_typed[:typed_reservation], *selected_raw]
         if len(selected) < max_items:
@@ -813,6 +817,7 @@ def compile_operational_evidence_set(
             ranked_raw,
             budget=len(ranked_raw),
             neighbor_support_exempt=neighbor_support_exempt,
+            neighbor_trajectory_preserving=neighbor_trajectory_preserving,
         )
         selected_raw, spent = _admit_within_char_budget(
             ordered_raw,
@@ -851,6 +856,7 @@ def compile_operational_evidence_set(
         "selected_typed_count": selected_typed,
         "selected_raw_count": len(selected) - selected_typed,
         "neighbor_support_exempt": neighbor_support_exempt,
+        "neighbor_trajectory_preserving": neighbor_trajectory_preserving,
         "budget_mode": "items" if char_budget is None else "characters",
         "char_budget": char_budget,
         "selected_chars": selected_chars,
@@ -1012,6 +1018,7 @@ def _select_role_complete_raw_evidence(
     *,
     budget: int,
     neighbor_support_exempt: bool = DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
+    neighbor_trajectory_preserving: bool = DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
 ) -> list[dict[str, object]]:
     if budget <= 0:
         return []
@@ -1033,18 +1040,13 @@ def _select_role_complete_raw_evidence(
         )
     ]
     selected_links = _select_diverse_support_links(linked_support, limit=budget // 2)
+    if neighbor_trajectory_preserving:
+        selected_links = _links_preserving_trajectory_coverage(
+            primary, selected_links, budget=budget
+        )
     selected_support = [support for support, _parent in selected_links]
-    selected_primary: list[dict[str, object]] = []
-    selected_primary_ids: set[int] = set()
-    for _support, parent in selected_links:
-        if id(parent) not in selected_primary_ids:
-            selected_primary.append(parent)
-            selected_primary_ids.add(id(parent))
-    primary_budget = budget - len(selected_support)
-    for candidate in primary:
-        if id(candidate) not in selected_primary_ids and len(selected_primary) < primary_budget:
-            selected_primary.append(candidate)
-            selected_primary_ids.add(id(candidate))
+    selected_primary = _pack_primary_around_links(primary, selected_links, budget=budget)
+    selected_primary_ids = {id(candidate) for candidate in selected_primary}
     candidate_order = {id(candidate): index for index, candidate in enumerate(candidates)}
     selected_primary.sort(key=lambda candidate: candidate_order[id(candidate)])
     selected_support_ids = {id(candidate) for candidate in selected_support}
@@ -1065,6 +1067,64 @@ def _select_role_complete_raw_evidence(
         selected.append(candidate)
         selected.extend(support_by_parent_id.get(id(candidate), []))
     return selected
+
+
+def _pack_primary_around_links(
+    primary: list[dict[str, object]],
+    links: list[tuple[dict[str, object], dict[str, object]]],
+    *,
+    budget: int,
+) -> list[dict[str, object]]:
+    selected: list[dict[str, object]] = []
+    selected_ids: set[int] = set()
+    for _support, parent in links:
+        if id(parent) not in selected_ids:
+            selected.append(parent)
+            selected_ids.add(id(parent))
+    primary_budget = budget - len(links)
+    for candidate in primary:
+        if id(candidate) not in selected_ids and len(selected) < primary_budget:
+            selected.append(candidate)
+            selected_ids.add(id(candidate))
+    return selected
+
+
+def _links_preserving_trajectory_coverage(
+    primary: list[dict[str, object]],
+    links: list[tuple[dict[str, object], dict[str, object]]],
+    *,
+    budget: int,
+) -> list[tuple[dict[str, object], dict[str, object]]]:
+    # Every admitted support costs one tail seed, and a stitched neighbor
+    # almost always carries its parent's trajectory, so the trade can shrink
+    # the pack's trajectory coverage even while it improves state coverage.
+    # Admission is therefore checked one support at a time against the pack it
+    # would produce: a support that evicts the last remaining carrier of some
+    # trajectory is refused, and the seed keeps its slot.
+    admitted: list[tuple[dict[str, object], dict[str, object]]] = []
+    for link in links:
+        kept_before = _pack_primary_around_links(primary, admitted, budget=budget)
+        proposed = [*admitted, link]
+        kept_after = _pack_primary_around_links(primary, proposed, budget=budget)
+        kept_after_ids = {id(row) for row in kept_after}
+        evicted = [row for row in kept_before if id(row) not in kept_after_ids]
+        surviving = {
+            trajectory
+            for row in (*kept_after, *(support for support, _parent in proposed))
+            if (trajectory := _candidate_trajectory_id(row))
+        }
+        if all(
+            not (trajectory := _candidate_trajectory_id(row)) or trajectory in surviving
+            for row in evicted
+        ):
+            admitted = proposed
+    return admitted
+
+
+def _candidate_trajectory_id(candidate: dict[str, object]) -> str:
+    return _stripped_str(
+        _string_key_dict(candidate.get("metadata")).get("longmemeval_v2_trajectory_id")
+    )
 
 
 def _support_adds_query_coverage(
@@ -3110,6 +3170,11 @@ class SibylLiveApiMemory(Memory):
             "neighbor_support_exempt",
             DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
         )
+        self.neighbor_trajectory_preserving = _param_bool(
+            memory_params,
+            "neighbor_trajectory_preserving",
+            DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
+        )
         self.evidence_types = _param_evidence_types(
             memory_params,
             "evidence_types",
@@ -4208,6 +4273,11 @@ class SibylLiveApiMemory(Memory):
                 self,
                 "neighbor_support_exempt",
                 DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
+            ),
+            neighbor_trajectory_preserving=getattr(
+                self,
+                "neighbor_trajectory_preserving",
+                DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
             ),
         )
         rendered_item_ceiling = context_pack_item_ceiling(

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -73,6 +73,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "neighbor_support_exempt",
         "neighbor_trajectory_preserving",
         "neighbor_support_overflow_items",
+        "neighbor_stitch_spread",
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
@@ -456,6 +457,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
         default=False,
     )
     parser.add_argument("--neighbor-support-overflow-items", type=int, default=0)
+    parser.add_argument(
+        "--neighbor-stitch-spread",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
     parser.add_argument("--context-expansion-max-ratio", type=float, default=0.0)
     parser.add_argument(
         "--evidence-types",
@@ -690,6 +696,7 @@ def build_memory_config(args: argparse.Namespace) -> dict[str, object]:
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
         "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
+        "neighbor_stitch_spread": args.neighbor_stitch_spread,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "evidence_types": list(args.evidence_types),
         "evidence_char_budget": args.evidence_char_budget,
@@ -838,6 +845,7 @@ def build_run_plan(
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
         "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
+        "neighbor_stitch_spread": args.neighbor_stitch_spread,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "max_context_total_chars": args.max_context_total_chars,
         "evidence_types": list(args.evidence_types),

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -72,6 +72,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "state_part_refinement",
         "neighbor_support_exempt",
         "neighbor_trajectory_preserving",
+        "neighbor_support_overflow_items",
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
@@ -454,6 +455,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
         action=argparse.BooleanOptionalAction,
         default=False,
     )
+    parser.add_argument("--neighbor-support-overflow-items", type=int, default=0)
     parser.add_argument("--context-expansion-max-ratio", type=float, default=0.0)
     parser.add_argument(
         "--evidence-types",
@@ -687,6 +689,7 @@ def build_memory_config(args: argparse.Namespace) -> dict[str, object]:
         "state_part_refinement": args.state_part_refinement,
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
+        "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "evidence_types": list(args.evidence_types),
         "evidence_char_budget": args.evidence_char_budget,
@@ -834,6 +837,7 @@ def build_run_plan(
         "neighbor_stitch_span": args.neighbor_stitch_span,
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
+        "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "max_context_total_chars": args.max_context_total_chars,
         "evidence_types": list(args.evidence_types),

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -71,6 +71,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "state_part_completion_items",
         "state_part_refinement",
         "neighbor_support_exempt",
+        "neighbor_trajectory_preserving",
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
@@ -448,6 +449,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
         action=argparse.BooleanOptionalAction,
         default=False,
     )
+    parser.add_argument(
+        "--neighbor-trajectory-preserving",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
     parser.add_argument("--context-expansion-max-ratio", type=float, default=0.0)
     parser.add_argument(
         "--evidence-types",
@@ -680,6 +686,7 @@ def build_memory_config(args: argparse.Namespace) -> dict[str, object]:
         "state_part_completion_items": args.state_part_completion_items,
         "state_part_refinement": args.state_part_refinement,
         "neighbor_support_exempt": args.neighbor_support_exempt,
+        "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "evidence_types": list(args.evidence_types),
         "evidence_char_budget": args.evidence_char_budget,
@@ -826,6 +833,7 @@ def build_run_plan(
         "neighbor_stitch_items": args.neighbor_stitch_items,
         "neighbor_stitch_span": args.neighbor_stitch_span,
         "neighbor_support_exempt": args.neighbor_support_exempt,
+        "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "max_context_total_chars": args.max_context_total_chars,
         "evidence_types": list(args.evidence_types),

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -2506,6 +2506,126 @@ def test_sibyl_memory_exempt_neighbors_survive_composition_next_to_their_seed() 
     )
 
 
+def test_sibyl_memory_trajectory_preserving_refuses_a_sole_carrier_eviction() -> None:
+    """A neighbor is refused when the seed it displaces is its trajectory's last.
+
+    Exempting neighbors buys state coverage by spending tail seeds, and a
+    stitched neighbor carries its parent's trajectory, so the trade can cost
+    the pack a trajectory outright. Here every seed is the only carrier of its
+    own trajectory, so the preserving arm must refuse the neighbor and hand
+    back exactly the default pack.
+    """
+    module = _load_memory_module()
+    query = "inventory order dashboard prefix"
+    first = _search_result("t1", chunk_index=1, state_index=1, score=1.0)
+    neighbor = _search_result("t1", chunk_index=0, state_index=0, score=0.0)
+    neighbor["content"] = (
+        "Goal: inventory order dashboard prefix\n\n"
+        "State 0\nAccessibility tree:\nanswer-bearing neighboring state"
+    )
+    results = [
+        first,
+        _search_result("t2", chunk_index=0, state_index=0, score=0.9),
+        _search_result("t3", chunk_index=0, state_index=0, score=0.8),
+        _search_result("target", chunk_index=0, state_index=0, score=0.7),
+    ]
+    results[-1]["content"] = query
+    max_items = 4
+    assembled = _assemble_for_neighbor_arms(module, results, {"t1": {0: neighbor, 1: first}}, query)
+
+    selected, composition = module.compile_operational_evidence_set(
+        query=query,
+        typed_results=[],
+        raw_results=assembled,
+        max_items=max_items,
+        neighbor_support_exempt=True,
+        neighbor_trajectory_preserving=True,
+    )
+
+    assert composition["neighbor_trajectory_preserving"] is True
+    assert composition["selected_raw_support_count"] == 0
+    assert len(selected) == max_items
+    assert any(item["metadata"]["longmemeval_v2_trajectory_id"] == "target" for item in selected)
+    assert not any(
+        module._stripped_str(item.get("_selection_origin")) == "neighbor" for item in selected
+    )
+
+
+def test_sibyl_memory_trajectory_preserving_admits_a_replaceable_eviction() -> None:
+    """A neighbor still lands when its displaced seed's trajectory survives.
+
+    The refusal is scoped to trajectory coverage, not to displacement itself.
+    When the evicted tail seed shares its trajectory with a seed that stays in
+    the pack, nothing is lost by admitting the neighbor, so the preserving arm
+    composes the same pack as the plain exempt arm.
+    """
+    module = _load_memory_module()
+    query = "inventory order dashboard prefix"
+    first = _search_result("t1", chunk_index=1, state_index=1, score=1.0)
+    neighbor = _search_result("t1", chunk_index=0, state_index=0, score=0.0)
+    neighbor["content"] = (
+        "Goal: inventory order dashboard prefix\n\n"
+        "State 0\nAccessibility tree:\nanswer-bearing neighboring state"
+    )
+    results = [
+        first,
+        _search_result("t2", chunk_index=0, state_index=0, score=0.9),
+        _search_result("t3", chunk_index=0, state_index=0, score=0.8),
+        _search_result("t3", chunk_index=1, state_index=1, score=0.7),
+    ]
+    max_items = 4
+    assembled = _assemble_for_neighbor_arms(module, results, {"t1": {0: neighbor, 1: first}}, query)
+
+    selected, composition = module.compile_operational_evidence_set(
+        query=query,
+        typed_results=[],
+        raw_results=assembled,
+        max_items=max_items,
+        neighbor_support_exempt=True,
+        neighbor_trajectory_preserving=True,
+    )
+
+    assert composition["selected_raw_support_count"] == 1
+    assert len(selected) == max_items
+    origins_and_chunks = [
+        (
+            module._stripped_str(item.get("_selection_origin")),
+            item["metadata"]["longmemeval_v2_trajectory_id"],
+            item["metadata"]["longmemeval_v2_chunk_index"],
+        )
+        for item in selected
+    ]
+    seed_position = origins_and_chunks.index(("search", "t1", 1))
+    assert origins_and_chunks[seed_position + 1] == ("neighbor", "t1", 0)
+    assert ("search", "t3", 0) in origins_and_chunks
+    assert ("search", "t3", 1) not in origins_and_chunks
+
+
+def _assemble_for_neighbor_arms(
+    module: ModuleType,
+    results: list[dict[str, Any]],
+    chunk_catalog: dict[str, dict[int, dict[str, Any]]],
+    query: str,
+) -> list[dict[str, Any]]:
+    candidate_limit = module.context_assembly_candidate_limit(
+        max_items=4,
+        neighbor_stitch_items=1,
+        state_part_completion_items=0,
+        has_chunk_catalog=True,
+    )
+    assembled, metadata = module.assemble_context_results(
+        results,
+        chunk_catalog=chunk_catalog,
+        max_items=candidate_limit,
+        max_chunks_per_trajectory=2,
+        neighbor_stitch_items=1,
+        neighbor_stitch_span=1,
+        query=query,
+    )
+    assert metadata["stitched_neighbor_count"] == 1
+    return assembled
+
+
 def test_sibyl_memory_restores_transport_truncated_search_content() -> None:
     module = _load_memory_module()
     search_result = _search_result("t1", chunk_index=1, state_index=1, score=0.9)
@@ -4772,6 +4892,7 @@ def test_operational_evidence_set_calibrates_typed_and_raw_score_pools() -> None
         "selected_typed_count": 3,
         "selected_raw_count": 5,
         "neighbor_support_exempt": False,
+        "neighbor_trajectory_preserving": False,
         "budget_mode": "items",
         "char_budget": None,
         "selected_chars": sum(len(str(item["content"])) for item in selected),
@@ -5904,6 +6025,7 @@ def test_sibyl_memory_finalize_drains_jobs_before_search() -> None:
                 "selected_typed_count": 0,
                 "selected_raw_count": 0,
                 "neighbor_support_exempt": False,
+                "neighbor_trajectory_preserving": False,
                 "budget_mode": "items",
                 "char_budget": None,
                 "selected_chars": 0,

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -2601,6 +2601,88 @@ def test_sibyl_memory_trajectory_preserving_admits_a_replaceable_eviction() -> N
     assert ("search", "t3", 1) not in origins_and_chunks
 
 
+def test_sibyl_memory_additive_support_slots_spare_the_displaced_seed() -> None:
+    """Overflow slots let a support join the pack without evicting a seed.
+
+    Supports and seeds compete only because the pack is bounded by an item
+    count, and the character budget that count stands in for runs about a third
+    spent. With an overflow slot granted, the same fixture that forces a
+    sole-carrier eviction under the plain exempt arm keeps every baseline seed
+    and gains the neighbor, so the pack is the union of both arms.
+    """
+    module = _load_memory_module()
+    query = "inventory order dashboard prefix"
+    first = _search_result("t1", chunk_index=1, state_index=1, score=1.0)
+    neighbor = _search_result("t1", chunk_index=0, state_index=0, score=0.0)
+    neighbor["content"] = (
+        "Goal: inventory order dashboard prefix\n\n"
+        "State 0\nAccessibility tree:\nanswer-bearing neighboring state"
+    )
+    results = [
+        first,
+        _search_result("t2", chunk_index=0, state_index=0, score=0.9),
+        _search_result("t3", chunk_index=0, state_index=0, score=0.8),
+        _search_result("target", chunk_index=0, state_index=0, score=0.7),
+    ]
+    results[-1]["content"] = query
+    max_items = 4
+    assembled = _assemble_for_neighbor_arms(module, results, {"t1": {0: neighbor, 1: first}}, query)
+
+    selected, composition = module.compile_operational_evidence_set(
+        query=query,
+        typed_results=[],
+        raw_results=assembled,
+        max_items=max_items,
+        neighbor_support_exempt=True,
+        neighbor_support_overflow_items=2,
+    )
+
+    assert composition["support_overflow_items"] == 1
+    assert composition["selected_raw_support_count"] == 1
+    assert len(selected) == max_items + 1
+    origins_and_chunks = [
+        (
+            module._stripped_str(item.get("_selection_origin")),
+            item["metadata"]["longmemeval_v2_trajectory_id"],
+            item["metadata"]["longmemeval_v2_chunk_index"],
+        )
+        for item in selected
+    ]
+    seed_position = origins_and_chunks.index(("search", "t1", 1))
+    assert origins_and_chunks[seed_position + 1] == ("neighbor", "t1", 0)
+    assert ("search", "target", 0) in origins_and_chunks
+
+
+def test_sibyl_memory_render_ceiling_admits_the_granted_overflow() -> None:
+    """The item ceiling downstream of the composer has to follow it.
+
+    Without the overflow the render stage would clip an additive pack back to
+    the old geometry, so the extra items would never reach the reader and the
+    arm would be unmeasurable.
+    """
+    module = _load_memory_module()
+    max_items = 8
+    overflow_items = 2
+    candidate_count = 12
+    assert (
+        module.context_pack_item_ceiling(
+            max_items=max_items,
+            char_budget=None,
+            candidate_count=candidate_count,
+        )
+        == max_items
+    )
+    assert (
+        module.context_pack_item_ceiling(
+            max_items=max_items,
+            char_budget=None,
+            candidate_count=candidate_count,
+            overflow_items=overflow_items,
+        )
+        == max_items + overflow_items
+    )
+
+
 def _assemble_for_neighbor_arms(
     module: ModuleType,
     results: list[dict[str, Any]],
@@ -4893,6 +4975,8 @@ def test_operational_evidence_set_calibrates_typed_and_raw_score_pools() -> None
         "selected_raw_count": 5,
         "neighbor_support_exempt": False,
         "neighbor_trajectory_preserving": False,
+        "neighbor_support_overflow_items": 0,
+        "support_overflow_items": 0,
         "budget_mode": "items",
         "char_budget": None,
         "selected_chars": sum(len(str(item["content"])) for item in selected),
@@ -6026,6 +6110,8 @@ def test_sibyl_memory_finalize_drains_jobs_before_search() -> None:
                 "selected_raw_count": 0,
                 "neighbor_support_exempt": False,
                 "neighbor_trajectory_preserving": False,
+                "neighbor_support_overflow_items": 0,
+                "support_overflow_items": 0,
                 "budget_mode": "items",
                 "char_budget": None,
                 "selected_chars": 0,

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -2683,6 +2683,58 @@ def test_sibyl_memory_render_ceiling_admits_the_granted_overflow() -> None:
     )
 
 
+def test_sibyl_memory_stitch_spread_reaches_every_seed_before_the_second_ring() -> None:
+    """Ring-major stitch order spends the budget across seeds, not on the first.
+
+    Seed-major order gives the top seed both of its adjacent chunks and the
+    budget is gone, so a two-item stitch never reaches the second seed however
+    many seeds were retrieved. Ring-major order takes distance one from every
+    seed before distance two from any of them.
+    """
+    module = _load_memory_module()
+    query = "inventory order dashboard prefix"
+    seeds = [
+        _search_result("t1", chunk_index=2, state_index=2, score=1.0),
+        _search_result("t2", chunk_index=2, state_index=2, score=0.9),
+    ]
+    catalog = {
+        trajectory: {
+            index: _search_result(trajectory, chunk_index=index, state_index=index, score=0.0)
+            for index in (0, 1, 2, 3, 4)
+        }
+        for trajectory in ("t1", "t2")
+    }
+    stitch_items = 2
+
+    def stitched(*, spread: bool) -> list[tuple[str, int]]:
+        assembled, _metadata = module.assemble_context_results(
+            [dict(seed) for seed in seeds],
+            chunk_catalog=catalog,
+            max_items=module.context_assembly_candidate_limit(
+                max_items=8,
+                neighbor_stitch_items=stitch_items,
+                state_part_completion_items=0,
+                has_chunk_catalog=True,
+            ),
+            max_chunks_per_trajectory=8,
+            neighbor_stitch_items=stitch_items,
+            neighbor_stitch_span=2,
+            neighbor_stitch_spread=spread,
+            query=query,
+        )
+        return [
+            (
+                item["metadata"]["longmemeval_v2_trajectory_id"],
+                item["metadata"]["longmemeval_v2_chunk_index"],
+            )
+            for item in assembled
+            if module._stripped_str(item.get("_selection_origin")) == "neighbor"
+        ]
+
+    assert stitched(spread=False) == [("t1", 1), ("t1", 3)]
+    assert stitched(spread=True) == [("t1", 1), ("t2", 1)]
+
+
 def _assemble_for_neighbor_arms(
     module: ModuleType,
     results: list[dict[str, Any]],


### PR DESCRIPTION
# 🎯 What the stitch reaches, and what it costs

> Follows #344, which shipped the `neighbor_support_exempt` arm and its measured A/B. That arm proved stitched neighbors carry answers. This one fixes the price the pack pays for them and the reach the stitch never had. All three arms are off by default, so no banked number moves.

## 💡 What this is

The exempt arm bought web state recall by spending seeds, and the bill came due unevenly: web gained 8.3pp of state recall while enterprise lost 2.3pp, and trajectory recall fell about 2pp in both domains. This PR adds three arms, and reports what each one is worth.

The first arm, `neighbor_trajectory_preserving`, refuses the admissions that cost the pack a trajectory. It is a projected negative on web and a positive on enterprise, and it is included because the experiment is what exposed the real defect.

The second arm, `neighbor_support_overflow_items`, removes the price instead of rationing it. Supports and seeds compete for room only because the pack is bounded by an item count, and the character budget that item count stands in for is barely touched. Granting a support its own slot means nothing is displaced at all.

The third arm, `neighbor_stitch_spread`, fixes a separate cap one layer upstream. The stitch walks seeds in its outer loop, so the top-ranked seed claims both of its adjacent chunks and the budget is exhausted before the second seed is reached. Whatever the pack can hold, the stitch has only ever covered one seed.

## 🤔 Why the first arm is not the answer

A stitched neighbor carries its parent's trajectory, so admitting one adds no trajectory coverage while the tail seed it displaces is often the pack's only carrier of a different one. Refusing exactly those admissions should refund the trajectory tax, and it does. The problem is what else it refuses.

Projected against the banked stage-1 packs, on web every single state-recall win the exempt arm produced came from an admission this gate rejects, so web returns to its 47.9% baseline. On enterprise it inverts, because there the costly admissions only ever lost: refusing them recovers both losses and keeps the one win, reaching 79.5% against a 77.3% baseline.

An arm that helps one domain by giving up the other is a tuning knob, not a fix. What it did establish is where the real constraint lives.

## 🎯 The invariant to anchor on

The pack is bounded by two limits at once and only one of them binds. Across the banked stage-1 runs the median web pack spends 34,239 characters of its 60,000 budget, the median enterprise pack 42,412, and exactly 1 of 240 web packs and 10 of 211 enterprise packs come within 3,000 characters of the ceiling. Every displacement in this system is the composer rationing slots against a resource that is two thirds empty.

## 🛠️ How it works

**1. The overflow grant.** In `_select_role_complete_raw_evidence` (`benchmarks/longmemeval_v2_memory/sibyl_memory.py`), the primary lane has always received `budget` minus the admitted support count, which is what makes a support cost a seed. The arm grants up to `neighbor_support_overflow_items` supports their own slots by raising the effective budget by the number granted, so the primary lane keeps its full allocation. Supports beyond the granted count displace exactly as before, and a character-budgeted pack grants none because it has no item bound to overflow past.

**2. The trajectory gate.** `_links_preserving_trajectory_coverage` considers supports one at a time against the pack each would produce, using the same `_pack_primary_around_links` packing the composer uses, and drops any support whose admission would evict the last carrier of some trajectory. Displacement itself stays legal: when the evicted seed shares its trajectory with a seed that stays, the support lands.

**3. The render ceiling follows the composer.** `context_pack_item_ceiling` returns `max_items` whenever no character budget is in force, and both `render_memory_context` and `build_retrieval_trace` take that ceiling. Without teaching it about the grant, a wider pack is clipped back to the old geometry before the reader sees any of it and the arm measures as a no-op. The composer now reports `support_overflow_items` and the ceiling takes that number, keeping the composer the single place the pack is bounded.

**4. The stitch walk is ordered separately from admission.** `_neighbor_stitch_plan` yields the chunks the stitch may claim, seed-major as it always has or ring-major under the arm, and `_neighbor_results` does nothing but admit from that order. The default path's behavior is unchanged, and the two orders become directly comparable in one test. Nothing about the budget changes: `neighbor_stitch_items` and `neighbor_stitch_span` are already flags, and raising them costs no seeds upstream because `context_assembly_candidate_limit` grows the candidate pool by exactly the stitch budget, leaving `seed_limit` fixed.

**5. Every arm reaches every harness.** `longmemeval_v2_live_retrieval.py`, `longmemeval_v2_official.py` (including its runtime-key allowlist and run receipt), and `longmemeval_v2_composition_replay.py` all carry the flags, so any arm reproduces from a run config.

## 📊 What the numbers are, and how solid each one is

Every additive number below is measured, from a live run of both domains against the isolated stack. The exempt column is measured too, from the runs banked in #344. Only the preserving column is a projection, and it is the weakest of the three because it assumes a refused question reverts to its baseline outcome.

| metric | domain | baseline | exempt | preserving (projected) | additive | additive vs baseline |
| --- | --- | --- | --- | --- | --- | --- |
| state recall | web | 47.9% | 56.2% | 47.9% | 58.3% | +10.4pp |
| state recall | enterprise | 77.3% | 75.0% | 79.5% | 79.5% | +2.3pp |
| trajectory recall | web | 93.8% | 91.7% | 93.8% | 93.8% | +0.0pp |
| trajectory recall | enterprise | 95.5% | 93.2% | 95.5% | 95.5% | +0.0pp |
| exposure | web | 58.3% | 58.3% | n/a | 58.3% | +0.0pp |
| exposure | enterprise | 72.7% | 68.2% | n/a | 72.7% | +0.0pp |
| state phrase coverage | web | 52.4% | 60.4% | n/a | 61.8% | +9.4pp |
| state phrase coverage | enterprise | 79.9% | 78.8% | n/a | 82.2% | +2.3pp |
| source reachability | web | 64.6% | 68.8% | n/a | 68.8% | +4.2pp |
| source reachability | enterprise | 79.5% | 75.0% | n/a | 79.5% | +0.0pp |

Denominators are the state-scored cohorts, 48 web and 44 enterprise.

Both domains landed on the union bound exactly, at 58.3% and 79.5% state recall. Since the bound was computed before either run started, that agreement is the strongest evidence available that the mechanism is understood rather than merely observed.

The enterprise result is the one that settles the design question. Enterprise is where the exempt arm lost, and the additive arm turns every one of those losses around: state recall moves from a 2.3 point deficit to a 2.3 point gain, and trajectory recall, exposure, and source reachability all return to baseline from below it. The additive arm beats the exempt arm on all five metrics in both domains and beats baseline or ties it on all five, so there is no domain and no metric where removing the price costs something that rationing it did not.

Two failure classes deserve naming rather than burying. On web `state_selection_miss` falls from 22 questions to 17, which is the mechanism working. Against that, `evidence_exposure_miss` rises from 1 to 4 on web while the exposure metric itself holds flat at 58.3%, so a handful of questions shift into that class without the aggregate moving; enterprise shows no such drift, holding at 3. `reader_or_scoring_miss` drifts by one or two questions in both domains, which is inside the per-question retrieval nondeterminism this harness has (two runs at identical config disagree on roughly 5% of questions).

The bound covers state and trajectory recall specifically, and those two are the ones the character ceiling cannot reach. The diagnostics derive both from item metadata (`retrieved_state_pairs`), so a pack holding the gold state scores the hit whatever the renderer does to its text. Exposure is the metric that can move, because `exact_context_recall_at_k` reads the rendered content and `render_memory_context` responds to an over-budget pack by compacting every item rather than dropping any.

The first 53 web questions of the live run measure that trade rather than leaving it to projection. Packs widen from a mean of 7.55 items to 9.47. The rendered median rises from 31,122 characters to 36,444 against the 60,000 ceiling, so the total budget is not broadly binding, and while each item is compacted somewhat harder (59.6% of content withheld against the baseline's 52.5%) the packs put 16.5% more text in front of the reader in absolute terms.

Those same 53 questions also put a number on how approximate the bound is. The additive pack drops an item the baseline pack held on 4 of them, 7 items in total, against the exempt arm's 84 items across 44 of the same questions. Two of the seven are typed context-pack entries that the baseline backfilled into slack slots the supports now occupy.

Rank truncation turns out not to be a risk at all. A support past the granted count displaces rather than adds, so the pack cannot exceed `max_items` plus the grant however many supports qualify, and at a grant of two the ceiling is exactly the rank-10 window the diagnostics measure. Across the first 150 web questions the observed sizes are 10 items on 120 of them, 9 on 15, and 8 or fewer on the rest, with none above 10.

The stitch spread has no column here because it cannot be projected from banked artifacts at all. It changes which chunks become candidates, and the chunks it would add were never in any banked pack. The forensics on the web cohort put its counterfactual ceiling at roughly 83% state recall, computed against the full catalog rather than against a pack, and it wants its own run once the additive numbers land.

## 🧪 Validation

`uv run pytest tools/tests/test_longmemeval_v2_official.py -q` → **179 passed**, including five new tests:

- a sole-carrier fixture where the preserving gate refuses the neighbor and hands back exactly the default pack,
- a duplicated-trajectory fixture where it admits the neighbor beside its seed,
- the same sole-carrier fixture under the overflow grant, where the pack is the union of both arms (five items, target seed and neighbor both present),
- the render ceiling honoring the grant, since a clipped pack would make the arm unmeasurable,
- both stitch orders on one two-seed fixture, where seed-major yields `t1` chunks 1 and 3 and ring-major yields chunk 1 of each seed.

`uv run ruff check` over `benchmarks/` and the test file reports no new findings against `main`; the only deltas are two pre-existing `PLR0915` statement counts ticking up. `ruff format` clean.

Verified live at the first question of the running measurement: a 10-item pack with both overflow slots granted and reported, confirming the render ceiling follows the composer rather than clipping to 8.

## 🔍 What reviewers should focus on

- The effective-budget arithmetic in `_select_role_complete_raw_evidence`. `granted_overflow` is capped by the number of selected links, so it can never exceed the supports actually admitted, and the support cap itself stays tied to the base budget (`budget // 2`) so the pack cannot balloon.
- The ordering of the two arms. The preserving gate simulates against the un-inflated budget and the grant applies to whatever survives it, which keeps the two independent when both are on.
- `_pack_primary_around_links` is a straight extraction of the packing the composer already did. Worth confirming it reproduces the old membership exactly, since every projection in this PR rests on it.
- Whether granting two slots is the right bound. Every banked question admitted exactly two neighbors, and 8 plus 2 lands exactly on the diagnostics' rank-10 measuring window, which is why the running measurement uses 2.
- The ring-major walk in `_neighbor_stitch_plan`. It takes both directions at each distance before advancing, so a seed sitting at chunk 0 contributes only its forward neighbor and does not consume budget on a chunk that cannot exist.

Out of scope: turning any arm on by default. Each is a measurement decision and each wants its own numbers.


