### PR TITLE
ci: fail dataset fetches at the download instead of at the checksum

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -393,7 +393,8 @@ jobs:
           mkdir -p .moon/cache/benchmarks
           dataset=.moon/cache/benchmarks/longmemeval_s_cleaned.json
           if [[ ! -f "$dataset" ]]; then
-            curl -L --retry 3 --retry-delay 5 "$LONGMEMEVAL_URL" -o "$dataset"
+            curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+              "$LONGMEMEVAL_URL" -o "$dataset"
           fi
           echo "$LONGMEMEVAL_SHA256  $dataset" | sha256sum -c -
 
@@ -589,7 +590,8 @@ jobs:
           mkdir -p .moon/cache/benchmarks
           dataset=.moon/cache/benchmarks/longmemeval_s_cleaned.json
           if [[ ! -f "$dataset" ]]; then
-            curl -L --retry 3 --retry-delay 5 "$LONGMEMEVAL_URL" -o "$dataset"
+            curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+              "$LONGMEMEVAL_URL" -o "$dataset"
           fi
           echo "$LONGMEMEVAL_SHA256  $dataset" | sha256sum -c -
 
@@ -874,7 +876,8 @@ jobs:
           mkdir -p .moon/cache/benchmarks
           dataset=.moon/cache/benchmarks/longmemeval_s_cleaned.json
           if [[ ! -f "$dataset" ]]; then
-            curl -L --retry 3 --retry-delay 5 "$LONGMEMEVAL_URL" -o "$dataset"
+            curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+              "$LONGMEMEVAL_URL" -o "$dataset"
           fi
           echo "$LONGMEMEVAL_SHA256  $dataset" | sha256sum -c -
 

--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -257,22 +257,31 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$DATA_ROOT/haystacks" ".moon/cache/evals"
-          curl -L --retry 3 --retry-delay 5 \
-            "$HF_BASE/checksums.sha256?download=true" \
-            -o "$DATA_ROOT/checksums.sha256"
-          curl -L --retry 3 --retry-delay 5 \
-            "$HF_BASE/questions.jsonl?download=true" \
-            -o "$DATA_ROOT/questions.jsonl"
-          curl -L --retry 3 --retry-delay 5 \
-            "$HF_BASE/SCHEMA.md?download=true" \
-            -o "$DATA_ROOT/SCHEMA.md"
-          curl -L --retry 3 --retry-delay 5 \
-            "$HF_BASE/haystacks/lme_v2_${{ matrix.tier }}.json?download=true" \
-            -o "$DATA_ROOT/haystacks/lme_v2_${{ matrix.tier }}.json"
+          # -f keeps an HTTP error page from being written over the target.
+          # Without it curl saves the error body and still exits 0, so an
+          # upstream hiccup on checksums.sha256 destroys the verifier for every
+          # other file and only surfaces as an unreadable checksum list below.
+          fetch() {
+            curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "$1" -o "$2"
+          }
+          fetch "$HF_BASE/checksums.sha256?download=true" \
+            "$DATA_ROOT/checksums.sha256"
+          fetch "$HF_BASE/questions.jsonl?download=true" \
+            "$DATA_ROOT/questions.jsonl"
+          fetch "$HF_BASE/SCHEMA.md?download=true" \
+            "$DATA_ROOT/SCHEMA.md"
+          fetch "$HF_BASE/haystacks/lme_v2_${{ matrix.tier }}.json?download=true" \
+            "$DATA_ROOT/haystacks/lme_v2_${{ matrix.tier }}.json"
           (
             cd "$DATA_ROOT"
-            grep -E '  (questions.jsonl|SCHEMA.md|haystacks/lme_v2_${{ matrix.tier }}\.json)$' \
-              checksums.sha256 | sha256sum -c -
+            pattern='  (questions.jsonl|SCHEMA.md|haystacks/lme_v2_${{ matrix.tier }}\.json)$'
+            listed=$(grep -Ec "$pattern" checksums.sha256 || true)
+            if [ "$listed" -ne 3 ]; then
+              echo "checksums.sha256 lists $listed of the 3 expected entries" >&2
+              head -c 400 checksums.sha256 >&2
+              exit 1
+            fi
+            grep -E "$pattern" checksums.sha256 | sha256sum -c -
           )
 
       - name: Run LongMemEval-V2 probe


### PR DESCRIPTION
# 🛡️ Dataset fetches that fail at the download, not three steps later

> Fixes the `Probe medium` failure on `main` at `64b86736`, which is the same failure that took the job down at `fd38059f` three days earlier.

## 💡 What this is

`curl` was invoked with `--retry` but without `-f`, and without `-f` an HTTP error is not an error. curl writes the response body over the destination file and exits 0. Because the exit code is 0, `set -euo pipefail` has nothing to catch, so a transient upstream hiccup does not stop the step that caused it. It produces a data file full of someone's error page and fails later, somewhere else, with a message that points at the wrong thing.

## 🤔 Why it bit this particular job

The LongMemEval-V2 probe fetches four files and its first one is `checksums.sha256`, the file every other download is verified against. An error page landing there does not just corrupt one input, it removes verification from all of them, and the only symptom is this:

```
sha256sum: 'standard input': no properly formatted checksum lines found
```

That message is about an empty grep, three lines below the download that actually broke, and it reads like a checksum mismatch or an upstream schema change. It is neither. The upstream files were intact both times the job failed: `checksums.sha256` currently returns 200 and lists all three expected entries, and `haystacks/lme_v2_medium.json` returns 200.

## 🛠️ How it works

**1. Every fetch fails at the fetch.** All seven sites across `longmemeval-v2.yml` and `eval.yml` now pass `-fsSL`. With `-f`, an HTTP error leaves no file behind and returns non-zero, so the step stops where the problem is. `--retry-all-errors` keeps the retry behavior covering the transient cases that `-f` now surfaces, so a single blip still recovers rather than failing the run.

**2. The four probe fetches share one helper.** `longmemeval-v2.yml` had the same flags copy-pasted four times, which is how three of them would have kept the old shape after a partial fix. They now call a local `fetch` function.

**3. The verifier is checked before it is trusted.** The probe asserts that `checksums.sha256` lists all three entries it is about to verify, and prints the head of the file if it does not. An upstream layout change would otherwise empty the grep and produce exactly the same misleading message as a corrupt download.

The `eval.yml` sites verify against a pinned `$LONGMEMEVAL_SHA256` rather than a fetched list, so their failure mode was a confusing checksum mismatch instead of a broken verifier. Same defect, milder symptom, same one-flag fix.

## 🧪 Validation

Both shapes run against a missing HuggingFace path, which is the failure the runners hit:

```
OLD: curl -L --retry 1               → exit=0  size=15  "Entry not found"  (written to the target)
NEW: curl -fsSL --retry 1 --retry-all-errors → exit=56  no file  "curl: (56) The requested URL returned error: 404"
```

The new guard, against a poisoned checksum file and against the real upstream one:

```
poisoned (body "Entry not found") → GUARD TRIPPED: lists 0 of the 3 expected entries
real upstream checksums.sha256    → lists 3 of 3 expected entries
```

Both workflow files parse (`yaml.safe_load`, 3 and 5 jobs respectively). The behavior change is confined to error paths: on a healthy fetch, `-f` and `--retry-all-errors` change nothing about what is downloaded.

## 🔍 What reviewers should focus on

- Whether `--retry-all-errors` is too aggressive anywhere here. It makes curl retry on errors it previously treated as final, which is what we want for a flaky CDN, and the retry count stays at 3 with a 5 second delay.
- The expected-entry count of 3 in the probe guard is tied to the three files it verifies (`questions.jsonl`, `SCHEMA.md`, and the tier haystack). Adding a fourth verified file means updating that number, and the guard will say so loudly if anyone forgets.
- `-s` is paired with `-S` throughout, so progress meters go away but error messages do not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when downloading evaluation datasets by adding automatic retries and clearer failure handling.
  * Strengthened checksum validation to detect incomplete or truncated metadata before processing files.
  * Enhanced error reporting when dataset downloads or integrity checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->