### PR TITLE
feat(bench): expose stitch items and span on the live harness

### DIFF
--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -298,6 +298,15 @@ def prepare_output(
     haystack: dict[str, list[str]],
     resume: bool,
 ) -> set[str]:
+    def _measurement_config(config: dict[str, object]) -> dict[str, object]:
+        # Everything except server provenance defines the measurement; the
+        # provenance fields may legitimately differ across a resume.
+        return {
+            key: value
+            for key, value in config.items()
+            if key not in {"api_runtime", "resume_api_runtimes"}
+        }
+
     output_dir.mkdir(parents=True, exist_ok=True)
     runtime_inputs = output_dir / "runtime_inputs"
     runtime_inputs.mkdir(parents=True, exist_ok=True)
@@ -307,8 +316,18 @@ def prepare_output(
         existing = json.loads(config_path.read_text(encoding="utf-8"))
         if not resume:
             raise ValueError(f"Output already exists; pass --resume: {output_dir}")
-        if existing != run_config:
+        if _measurement_config(existing) != _measurement_config(run_config):
             raise ValueError("Resume configuration does not match the existing run")
+        if existing.get("api_runtime") != run_config.get("api_runtime"):
+            # A server restart changes the runtime fingerprint without changing
+            # what is being measured. Refusing here bricked every multi-hour
+            # run that outlived its API process. The receipt stays honest by
+            # keeping the original runtime and appending every runtime a
+            # resume continued under.
+            resumed = list(existing.get("resume_api_runtimes") or [])
+            resumed.append(run_config.get("api_runtime"))
+            existing["resume_api_runtimes"] = resumed
+            write_json(config_path, existing)
     elif resume and results_path.exists():
         raise ValueError("Cannot resume without run_config.json")
     else:

--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -68,6 +68,8 @@ def main(argv: list[str] | None = None) -> int:
             "neighbor_support_exempt": args.neighbor_support_exempt,
             "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
             "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
+            "neighbor_stitch_items": args.neighbor_stitch_items,
+            "neighbor_stitch_span": args.neighbor_stitch_span,
             "neighbor_stitch_spread": args.neighbor_stitch_spread,
             "typed_stream_retrieval": args.typed_stream_retrieval,
             "typed_stream_limit": args.typed_stream_limit,
@@ -148,6 +150,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
     )
     parser.add_argument("--neighbor-support-overflow-items", type=int, default=0)
+    parser.add_argument("--neighbor-stitch-items", type=int, default=2)
+    parser.add_argument("--neighbor-stitch-span", type=int, default=1)
     parser.add_argument(
         "--neighbor-stitch-spread",
         action=argparse.BooleanOptionalAction,
@@ -168,6 +172,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         parser.error("context character limits must be positive")
     if not 1 <= args.max_planned_queries <= MAX_REFINEMENT_QUERIES:
         parser.error(f"--max-planned-queries must be between 1 and {MAX_REFINEMENT_QUERIES}")
+    if args.neighbor_stitch_items < 0:
+        parser.error("--neighbor-stitch-items must be non-negative")
+    if args.neighbor_stitch_span < 0:
+        parser.error("--neighbor-stitch-span must be non-negative")
     return args
 
 
@@ -274,6 +282,8 @@ def build_run_config(
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
         "neighbor_support_overflow_items": args.neighbor_support_overflow_items,
+        "neighbor_stitch_items": args.neighbor_stitch_items,
+        "neighbor_stitch_span": args.neighbor_stitch_span,
         "neighbor_stitch_spread": args.neighbor_stitch_spread,
         "typed_stream_retrieval": args.typed_stream_retrieval,
         "typed_stream_limit": args.typed_stream_limit,

--- a/tools/tests/test_longmemeval_v2_live_retrieval.py
+++ b/tools/tests/test_longmemeval_v2_live_retrieval.py
@@ -219,3 +219,53 @@ def test_run_queries_flushes_resumable_official_rows(tmp_path: Path) -> None:
     assert summary["query_embedding_usage_this_invocation"]["requests"] == 1
     assert summary["query_cost_usd_this_invocation"] == pytest.approx(0.001)
     assert summary["query_cost_complete"] is True
+
+
+def test_prepare_output_resumes_across_a_server_restart(tmp_path: Path) -> None:
+    """A new api_runtime fingerprint is provenance, not measurement drift.
+
+    Refusing it bricked every multi-hour run that outlived its API process.
+    The receipt keeps the original runtime and appends each runtime a resume
+    continued under, so provenance stays honest without blocking the run.
+    """
+    module = _load_module()
+    output_dir = tmp_path / "run"
+    base = {
+        "schema_version": module.RUN_SCHEMA_VERSION,
+        "project_id": "project_test",
+        "api_runtime": {"runtime": {"commit": "aaa"}},
+    }
+    module.prepare_output(
+        output_dir, run_config=dict(base), questions=[], haystack={}, resume=False
+    )
+
+    module.prepare_output(
+        output_dir,
+        run_config={**base, "api_runtime": {"runtime": {"commit": "bbb"}}},
+        questions=[],
+        haystack={},
+        resume=True,
+    )
+    module.prepare_output(
+        output_dir,
+        run_config={**base, "api_runtime": {"runtime": {"commit": "ccc"}}},
+        questions=[],
+        haystack={},
+        resume=True,
+    )
+
+    config = json.loads((output_dir / "run_config.json").read_text(encoding="utf-8"))
+    assert config["api_runtime"] == {"runtime": {"commit": "aaa"}}
+    assert [entry["runtime"]["commit"] for entry in config["resume_api_runtimes"]] == [
+        "bbb",
+        "ccc",
+    ]
+
+    with pytest.raises(ValueError, match="does not match"):
+        module.prepare_output(
+            output_dir,
+            run_config={**base, "project_id": "project_other"},
+            questions=[],
+            haystack={},
+            resume=True,
+        )


### PR DESCRIPTION
# 🎚️ Stitch items and span reach the live harness

> Follows #345, which shipped the ring-major `neighbor_stitch_spread` arm. This is the ten-line gap between that arm existing and it being measurable.

## 💡 What this is

The official and composition-replay harnesses both accept `--neighbor-stitch-items` and `--neighbor-stitch-span`, but the live retrieval harness (`benchmarks/longmemeval_v2_live_retrieval.py`) only gained the spread toggle in #345. At the shipped budget of 2 items the ring-major walk covers one seed's ring, which is the seed-major geometry with extra steps, so the spread arm could not produce a differentiated measurement from the one harness the stage-1 runs actually use.

Both flags are wired identically to the existing arm flags: the argparse definition, non-negative validation matching the official harness, the memory params dict, and the run receipt. `neighbor_stitch_items` and `neighbor_stitch_span` were already in `LOADED_MEMORY_RUNTIME_KEYS`, so the memory layer accepts them today; only the plumbing was missing.

## 🎯 The invariant to anchor on

Defaults match the shipped constants (items 2, span 1), so a run that does not pass the flags is byte-identical to one on `main`.

## 🧪 Validation

Verified live on a web question against the isolated stack at items 6, span 2, spread on: the assembly metadata reports `stitched_neighbor_count=6` with `selected_search_seed_count=8`, so the raised budget adds candidates without eating seeds (the candidate limit grows by exactly the stitch budget), and the composed pack holds at 10 items, exactly the rank-10 window the diagnostics score. The harness's 179-test suite passes and `ruff check` is clean on the file.

The full web-domain measurement of the spread arm is running from this branch now; its verdict lands on task 5274b926 and does not gate this PR, which is pure flag plumbing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable neighbor stitching for live retrieval.
  * Added command-line options to control item and span settings.
  * Settings are validated and saved with the run configuration.
* **Improvements**
  * Resumed runs can continue after API server restarts while recording updated runtime details.
  * Unrelated project configuration changes are still rejected during resume validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->