### PR TITLE
fix(api): recover interrupted idempotency receipts on retry

### DIFF
--- a/apps/api/src/sibyl/api/idempotency.py
+++ b/apps/api/src/sibyl/api/idempotency.py
@@ -329,13 +329,21 @@ async def replay_idempotent_response[ResponseModelT: BaseModel](
             detail="Idempotency-Key was already used for a different request",
         )
     if idempotency_record_pending(record):
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                "Idempotent operation is still in progress or was interrupted before "
-                "its receipt completed"
-            ),
+        # Every caller executes under serialize_idempotent_request's lock, so a
+        # live executor cannot hold this key: it would still own the lock this
+        # request just acquired. A pending reservation observed here was
+        # interrupted before its receipt completed. Adopt the claim and let the
+        # handler re-execute; completion overwrites the same record id. A truly
+        # in-flight duplicate never reaches this branch, because it blocks at
+        # lock acquisition and surfaces as 409 lock contention instead.
+        log.warning(
+            "api_idempotency_interrupted_takeover",
+            method=method,
+            path=path,
+            organization_id=str(organization_id),
         )
+        _store_request_claim(request, record)
+        return None
     response = response_model.model_validate(record.response_body)
     receipt = getattr(response, "mutation_receipt", None)
     if isinstance(receipt, MutationReceipt):

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -643,16 +643,24 @@ async def _remember_mcp_memory(
             if record.request_hash != idempotency_request_hash(idempotency_payload):
                 raise ValueError("idempotency_key was already used for a different request")
             if idempotency_record_pending(record):
-                raise ValueError(
-                    "idempotent operation is still in progress or was interrupted before "
-                    "its receipt completed"
+                # This branch runs under _serialize_mcp_idempotency's lock, so
+                # no executor is live on this key: the reservation was
+                # interrupted before its receipt completed. Adopt it and
+                # re-execute; completion overwrites the same record id.
+                log.warning(
+                    "mcp_idempotency_interrupted_takeover",
+                    path=idempotency_path,
+                    organization_id=ctx.org_id,
                 )
-            replayed = cast("dict[str, Any]", deepcopy(record.response_body))
-            receipt = replayed.get("mutation_receipt")
-            if isinstance(receipt, dict):
-                replayed["mutation_receipt"] = {**receipt, "replayed": True}
-            return replayed
-        idempotency_claim = record
+                idempotency_claim = record
+            else:
+                replayed = cast("dict[str, Any]", deepcopy(record.response_body))
+                receipt = replayed.get("mutation_receipt")
+                if isinstance(receipt, dict):
+                    replayed["mutation_receipt"] = {**receipt, "replayed": True}
+                return replayed
+        else:
+            idempotency_claim = record
 
     memory_scope = "project" if project else "private"
     write_decision = _authorize_mcp_memory_write(
@@ -1697,25 +1705,27 @@ async def _manage_mcp_action(
                     "data": {},
                 }
             if idempotency_record_pending(record):
-                return {
-                    "success": False,
-                    "action": normalized_action,
-                    "entity_id": entity_id,
-                    "message": (
-                        "idempotent operation is still in progress or was interrupted before "
-                        "its receipt completed"
-                    ),
-                    "data": {},
-                }
-            replayed = cast("dict[str, Any]", deepcopy(record.response_body))
-            raw_response_data = replayed.get("data")
-            if isinstance(raw_response_data, dict):
-                response_data = cast("dict[str, Any]", raw_response_data)
-                receipt = response_data.get("mutation_receipt")
-                if isinstance(receipt, dict):
-                    response_data["mutation_receipt"] = {**receipt, "replayed": True}
-            return replayed
-        idempotency_claim = record
+                # This branch runs under _serialize_mcp_idempotency's lock, so
+                # no executor is live on this key: the reservation was
+                # interrupted before its receipt completed. Adopt it and
+                # re-execute; completion overwrites the same record id.
+                log.warning(
+                    "mcp_idempotency_interrupted_takeover",
+                    path=idempotency_path,
+                    organization_id=ctx.org_id,
+                )
+                idempotency_claim = record
+            else:
+                replayed = cast("dict[str, Any]", deepcopy(record.response_body))
+                raw_response_data = replayed.get("data")
+                if isinstance(raw_response_data, dict):
+                    response_data = cast("dict[str, Any]", raw_response_data)
+                    receipt = response_data.get("mutation_receipt")
+                    if isinstance(receipt, dict):
+                        response_data["mutation_receipt"] = {**receipt, "replayed": True}
+                return replayed
+        else:
+            idempotency_claim = record
 
     full_data = request_data
     full_data["organization_id"] = ctx.org_id

--- a/apps/api/tests/test_api_idempotency.py
+++ b/apps/api/tests/test_api_idempotency.py
@@ -61,23 +61,43 @@ async def test_concurrent_idempotent_requests_execute_mutation_once() -> None:
 
 
 @pytest.mark.asyncio
-async def test_pending_reservation_fences_retry_after_completion_failure() -> None:
+async def test_interrupted_reservation_is_taken_over_and_completed_on_retry() -> None:
+    """A reservation orphaned at 102 recovers on retry instead of bricking the key.
+
+    Every caller of replay_idempotent_response executes under the serialize
+    lock, so a pending record observed there proves the original executor is
+    gone. The retry adopts the claim, re-executes, and completes the same
+    record id; a later duplicate then replays the stored response.
+    """
     organization_id = uuid4()
     stored_record: object | None = None
+    fail_next_save = False
 
     async def get_record(*_args: object, **_kwargs: object) -> object:
         return stored_record
 
     async def save_record(*_args: object, **kwargs: object) -> object:
-        nonlocal stored_record
-        record = kwargs["record"]
-        if stored_record is not None:
+        nonlocal stored_record, fail_next_save
+        if fail_next_save:
+            fail_next_save = False
             raise RuntimeError("receipt store unavailable")
-        stored_record = record
-        return record
+        stored_record = kwargs["record"]
+        return stored_record
+
+    payload = {"body": {"title": "Durable reservation"}}
+
+    def replay_kwargs() -> dict[str, object]:
+        return {
+            "organization_id": organization_id,
+            "principal_id": "user-1",
+            "method": "POST",
+            "path": "/memory/raw",
+            "payload": payload,
+            "response_model": _MutationResponse,
+            "content_session": None,
+        }
 
     request = SimpleNamespace(headers={"Idempotency-Key": "remember-1"})
-    payload = {"body": {"title": "Durable reservation"}}
     with (
         patch(
             "sibyl.api.idempotency.content_runtime.get_api_idempotency_record",
@@ -88,18 +108,10 @@ async def test_pending_reservation_fences_retry_after_completion_failure() -> No
             side_effect=save_record,
         ),
     ):
-        replayed = await replay_idempotent_response(
-            request,
-            organization_id=organization_id,
-            principal_id="user-1",
-            method="POST",
-            path="/memory/raw",
-            payload=payload,
-            response_model=_MutationResponse,
-            content_session=None,
-        )
+        replayed = await replay_idempotent_response(request, **replay_kwargs())
         assert replayed is None
 
+        fail_next_save = True
         with pytest.raises(HTTPException) as completion_error:
             await save_idempotent_response(
                 request,
@@ -114,17 +126,81 @@ async def test_pending_reservation_fences_retry_after_completion_failure() -> No
             )
         assert completion_error.value.status_code == 503
 
-        with pytest.raises(HTTPException) as retry_error:
+        retry_request = SimpleNamespace(headers={"Idempotency-Key": "remember-1"})
+        retried = await replay_idempotent_response(retry_request, **replay_kwargs())
+        assert retried is None, "retry must take the orphaned reservation over"
+
+        pending_id = getattr(stored_record, "id", None)
+        await save_idempotent_response(
+            retry_request,
+            organization_id=organization_id,
+            principal_id="user-1",
+            method="POST",
+            path="/memory/raw",
+            payload=payload,
+            response=_MutationResponse(value="applied"),
+            status_code=200,
+            content_session=None,
+        )
+        assert getattr(stored_record, "id", None) == pending_id
+        assert getattr(stored_record, "response_status_code", None) == 200
+
+        final = await replay_idempotent_response(
+            SimpleNamespace(headers={"Idempotency-Key": "remember-1"}),
+            **replay_kwargs(),
+        )
+
+    assert isinstance(final, _MutationResponse)
+    assert final.value == "applied"
+
+
+@pytest.mark.asyncio
+async def test_pending_takeover_rejects_a_different_payload() -> None:
+    """Takeover is scoped to the identical request: a new payload still 409s."""
+    organization_id = uuid4()
+    stored_record: object | None = None
+
+    async def get_record(*_args: object, **_kwargs: object) -> object:
+        return stored_record
+
+    async def save_record(*_args: object, **kwargs: object) -> object:
+        nonlocal stored_record
+        stored_record = kwargs["record"]
+        return stored_record
+
+    with (
+        patch(
+            "sibyl.api.idempotency.content_runtime.get_api_idempotency_record",
+            side_effect=get_record,
+        ),
+        patch(
+            "sibyl.api.idempotency.content_runtime.save_api_idempotency_record",
+            side_effect=save_record,
+        ),
+    ):
+        reserved = await replay_idempotent_response(
+            SimpleNamespace(headers={"Idempotency-Key": "remember-1"}),
+            organization_id=organization_id,
+            principal_id="user-1",
+            method="POST",
+            path="/memory/raw",
+            payload={"body": {"title": "original"}},
+            response_model=_MutationResponse,
+            content_session=None,
+        )
+        assert reserved is None
+
+        with pytest.raises(HTTPException) as mismatch:
             await replay_idempotent_response(
                 SimpleNamespace(headers={"Idempotency-Key": "remember-1"}),
                 organization_id=organization_id,
                 principal_id="user-1",
                 method="POST",
                 path="/memory/raw",
-                payload=payload,
+                payload={"body": {"title": "tampered"}},
                 response_model=_MutationResponse,
                 content_session=None,
             )
 
-    assert retry_error.value.status_code == 409
-    assert "interrupted" in str(retry_error.value.detail)
+    assert mismatch.value.status_code == 409
+    assert "different request" in str(mismatch.value.detail)

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -173,6 +173,8 @@ def flush_writes(
     @run_async
     async def run_flush() -> None:
         failures = 0
+        replayed = 0
+        contended = 0
         async with AsyncExitStack() as stack:
             clients: dict[tuple[str, str | None], SibylClient] = {}
             for item in replayable:
@@ -198,14 +200,26 @@ def flush_writes(
                         _idempotency_key=str(current["idempotency_key"]),
                     )
                     record_pending_metric("replayed")
+                    replayed += 1
                     success(f"Flushed {write_id[:12]}")
                 except SibylClientError as exc:
                     failures += 1
                     error(f"Failed {write_id[:12]}: {exc.detail or exc}")
+                    if exc.status_code == 409:
+                        contended += 1
                     if _should_abort_flush(exc):
                         error("Stopping flush; remaining writes are still buffered.")
                         break
         if failures:
+            warn(
+                f"{replayed} replayed, {failures} failed; failed writes stay "
+                "buffered and are safe to flush again."
+            )
+            if contended:
+                warn(
+                    f"{contended} hit an identical request still executing on the "
+                    "server; those clear on their own, flush again shortly."
+                )
             raise typer.Exit(code=1)
 
     run_flush()

--- a/apps/cli/tests/test_pending_cli.py
+++ b/apps/cli/tests/test_pending_cli.py
@@ -217,3 +217,45 @@ def test_pending_writes_flush_stops_after_auth_refresh_failure(
     assert calls[0] in {"/memory/raw", "/tasks"}
     assert len(pending_writes.list_pending_writes()) == 2
     assert "Stopping flush" in result.stdout
+
+
+def test_pending_writes_flush_failure_summary_names_both_classes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    _create_pending("/memory/raw")
+    _create_pending("/tasks")
+
+    class FakeClient:
+        def __init__(self, *, base_url: str, context_name: str | None = None) -> None:
+            self.base_url = base_url
+            self.context_name = context_name
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+            if path == "/tasks":
+                raise SibylClientError(
+                    "conflict",
+                    status_code=409,
+                    detail="An identical idempotent request is still in progress.",
+                )
+            pending_writes.delete_pending_write(str(kwargs["_pending_write_id"]))
+            return {"ok": True}
+
+    monkeypatch.setattr(pending, "SibylClient", FakeClient)
+
+    result = CliRunner().invoke(pending.app, ["flush"])
+
+    assert result.exit_code == 1
+    remaining = pending_writes.list_pending_writes()
+    assert len(remaining) == 1
+    assert remaining[0]["path"] == "/tasks"
+    assert "1 replayed, 1 failed" in result.stdout
+    assert "safe to flush again" in result.stdout
+    assert "flush again shortly" in result.stdout


### PR DESCRIPTION
# 🔁 Interrupted idempotency receipts recover on retry

> Track C of 1.2 (dogfood trust-debt), task `df317be0`. Mined from the 7/17 bare-metal outage: two remembers were permanently stuck with "Idempotent operation is still in progress or was interrupted before its receipt completed", and the only way out was re-entering them by hand and discarding the queue.

## 💡 What this is

A reservation row is written at status 102 before an idempotent handler runs. When the server dies between the mutation and its receipt, that row stays pending forever, and every retry with the same key hits the pending branch and gets a 409. The client keeps the write buffered, correctly, since a 409 does not prove the write never applied. The result is a write that can never leave the queue and no recovery verb anywhere.

The naive fix is a TTL on pending reservations, and it is the wrong primitive: any timeout either expires a slow-but-live operation or leaves the dead window long. The system already has the exact discriminator: the serialize lock. A live executor holds and renews it, and a retry only reaches the pending check after acquiring it. Holding the lock while observing a pending record proves the original executor is gone.

## 🎯 The invariant to anchor on

Every caller of `replay_idempotent_response` and both MCP reserve sites execute under the serialize lock. That claim was audited, not assumed: seven HTTP replay sites (all under `@serialize_idempotent_request`, including the five task transitions that route through `_task_transition_response`) and two MCP sites (both under `@_serialize_mcp_idempotency`). Takeover is safe exactly because the branch is unreachable while an executor lives, since a live duplicate blocks at lock acquisition and surfaces as lock contention instead.

## 🛠️ How it works

**1. Takeover in `replay_idempotent_response`** (`apps/api/src/sibyl/api/idempotency.py`). A pending record with a matching request hash is adopted as the request's claim and the handler re-executes; `complete_idempotency_record` overwrites the same record id, so later duplicates replay the stored response as if nothing had ever gone wrong.

**2. The same takeover at both MCP sites** (`apps/api/src/sibyl/server.py`, `mcp/remember` and `mcp/manage/<action>`), which previously raised the interrupted error as a `ValueError`.

**3. Flush summary says what to do per class** (`apps/cli/src/sibyl_cli/pending.py`). A failing flush now ends with how many replayed, how many failed and stay buffered (safe to flush again), and how many hit an identical request still executing server-side (clears on its own). With the server fix, `sibyl pending-writes flush` is the recovery verb for every buffered class; no new verb needed.

**Deliberately unchanged:** hash-mismatch on a reused key still 409s (takeover is scoped to the byte-identical request), read-like POSTs still never enter the queue, and the client still refuses to drop a write on 409, because ambiguity about application is the reason it stays buffered.

## 🤔 The one real trade

Re-execution after a receipt-write failure can re-apply a mutation that landed just before its receipt was lost. That ambiguity is inherent to the interrupted state; the old code resolved it toward a permanent brick, this resolves it toward at-most-once-visible retry. Dedup-on-write absorbs the duplicate for capture-shaped writes, and task transitions converge on the same target state.

## 🧪 Validation

- `test_api_idempotency.py`: the old test pinned the brick (retry after completion failure must 409) and was rewritten to pin the recovery: reserve, completion fails with 503, retry takes over and returns None, completion succeeds against the same record id, and a later duplicate replays the stored response. A new test pins that a different payload on the same key still 409s. 3 passed.
- Full API suite in the worktree venv: 2235 passed, 5 skipped. CLI suite: 457 passed (8 pending-specific, including a new test pinning the two-class failure summary).
- `ty check` clean on `apps/api` and `apps/cli`; `ruff check` and `ruff format --check` clean on every changed file.
- ⚠️ Not exercised live: a real mid-mutation server kill. The unit pin simulates the receipt-store failure path that produced the incident; the nine writes currently stranded in a live queue are the natural post-merge probe, and flushing them against a patched server is the follow-up receipt.

## 🔍 What reviewers should focus on

- The audit claim in the anchor section. If a future route calls `replay_idempotent_response` without `@serialize_idempotent_request`, takeover there would race a live executor. Worth a comment-level convention or a lint later; the docstring on the takeover branch states the requirement.
- The MCP `manage` branch restructure (`if pending: adopt / else: replay-and-return`), since the original fell through to a shared replay block.
- Whether the re-execution trade reads as acceptable for non-capture writes. The alternative that preserves the brick for unknown shapes is a per-route opt-in, which quietly reintroduces the stuck class for exactly the routes nobody audits.
