### PR TITLE
fix(search): degrade document search to scan when the embedder is down

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/document_search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/document_search.py
@@ -508,6 +508,24 @@ async def search_documents(
             query_embedding=query_embedding,
         )
 
+    if query_embedding is None and not vector_rows_raw and not lexical_rows_raw:
+        # A soft embedding failure leaves only the lexical lane, and a
+        # sentence-shaped query can strike out there entirely. Empty results
+        # here mean the embedder was down, not that nothing matches, so take
+        # the same scan path a hard search failure gets.
+        log.warning("document_search_degraded_to_scan")
+        return await _search_documents_surreal_scan(
+            query=query,
+            organization_id=organization_id,
+            source_id=source_id,
+            source_name=source_name,
+            language=language,
+            limit=limit,
+            include_content=include_content,
+            content_max_chars=content_max_chars,
+            query_embedding=None,
+        )
+
     vector_results = _build_document_results_from_rows(
         vector_rows_raw,
         limit=limit,

--- a/packages/python/sibyl-core/tests/test_services_document_search.py
+++ b/packages/python/sibyl-core/tests/test_services_document_search.py
@@ -327,6 +327,107 @@ class TestDocumentSearch:
         assert direct_search.await_args.kwargs["query_embedding"] is None
 
     @pytest.mark.asyncio
+    async def test_search_documents_degrades_to_scan_when_embedding_and_lexical_both_miss(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dead embedder plus a lexical strikeout must degrade, not go empty.
+
+        Sentence-shaped queries routinely return zero lexical rows, so with the
+        embedder down the direct lanes produce nothing without raising. That is
+        the embedder being down, not a true no-match, and it takes the same
+        scope-scan path a hard search failure gets.
+        """
+        monkeypatch.setattr(document_search_service.settings, "store", "surreal")
+        monkeypatch.setattr(
+            document_search_service,
+            "DOCUMENT_EMBEDDING_TIMEOUT_SECONDS",
+            0.01,
+        )
+
+        source = ContentSource(
+            id="src-1",
+            organization_id="org-1",
+            name="Docs",
+            url="https://docs.example.com",
+        )
+        document = ContentDocument(
+            id="doc-1",
+            source_id="src-1",
+            url="https://docs.example.com/guide",
+            title="Guide",
+            content="alpha beta guide",
+            has_code=False,
+        )
+        chunks = [
+            ContentChunk(
+                id="chunk-1",
+                document_id="doc-1",
+                content="alpha beta",
+                context="intro",
+                heading_path=["Intro"],
+            ),
+        ]
+
+        async def slow_embed_text(query: str) -> list[float]:
+            await asyncio.sleep(1)
+            return [1.0, 0.0]
+
+        direct_search = AsyncMock(return_value=([], []))
+        scope_loader = AsyncMock(
+            return_value=(
+                [source],
+                {source.id: source},
+                {document.id: document},
+                chunks,
+            )
+        )
+        with (
+            patch(
+                "sibyl_core.services.document_search.search_document_chunks",
+                direct_search,
+            ),
+            patch(
+                "sibyl_core.services.document_search.load_search_scope",
+                scope_loader,
+            ),
+            patch("sibyl_core.services.document_search._embed_text", slow_embed_text),
+        ):
+            results = await search_documents("alpha", organization_id="org-1", limit=5)
+
+        assert results, "degraded search must surface lexical scan results, not empty"
+        assert results[0].metadata["document_id"] == "doc-1"
+        direct_search.assert_awaited_once()
+        scope_loader.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_search_documents_healthy_empty_result_does_not_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With a healthy embedder, a true no-match stays a fast empty result."""
+        monkeypatch.setattr(document_search_service.settings, "store", "surreal")
+
+        direct_search = AsyncMock(return_value=([], []))
+        scope_loader = AsyncMock()
+        with (
+            patch(
+                "sibyl_core.services.document_search.search_document_chunks",
+                direct_search,
+            ),
+            patch(
+                "sibyl_core.services.document_search.load_search_scope",
+                scope_loader,
+            ),
+            patch(
+                "sibyl_core.services.document_search._embed_text",
+                AsyncMock(return_value=[1.0, 0.0]),
+            ),
+        ):
+            results = await search_documents("alpha", organization_id="org-1", limit=5)
+
+        assert results == []
+        scope_loader.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_search_documents_tokenizes_document_content_once(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
# 🔦 Document search degrades instead of going dark

> Track C of 1.2 (dogfood trust-debt), task `411a5611`. Found during the 2026-07-24 fulltext-lane severity investigation, independent of the fulltext work itself.

## 💡 What this is

Document search has a two-lane primary path (vector plus lexical) and a scope-scan fallback. The fallback only fires on a `RuntimeError` from the search itself. An embedding failure is deliberately soft: it logs a warning and continues with `query_embedding=None`, which silently reduces the primary path to the lexical lane alone. The doc-chunk lexical lane returns zero rows for sentence-shaped queries, so a slow or down embedding provider produces empty vector results and empty lexical results with nothing raised, and document search returns nothing at all.

That empty answer is a lie: it reads as "no documents match" when the truth is "the embedder was down". It is user-visible on every surface that includes the document arm, which is `sibyl search` (document arm on by default), REST `/api/search`, and the MCP search tool (`include_documents` defaults true).

## 🎯 The invariant to anchor on

Empty-with-a-dead-embedder now takes the same scan path a hard failure takes, and empty-with-a-healthy-embedder still returns empty without scanning. Both directions are test-pinned, so the degradation cannot silently become a scan-on-every-miss regression.

## 🛠️ How it works

One guard in `search_documents` (`packages/python/sibyl-core/src/sibyl_core/services/document_search.py`): when `query_embedding is None` and both row sets came back empty, log `document_search_degraded_to_scan` and return `_search_documents_surreal_scan(...)`, the same fallback the `RuntimeError` branch already uses. The scan runs lexical matching over the loaded scope, so it returns real results with the embedder down and its results carry the same shape as the primary lanes.

The log line is the operational tell: a spike of `document_search_degraded_to_scan` means the embedding provider is unhealthy, not that users suddenly started searching for things that do not exist.

## 🧪 Validation

- New regression: dead embedder (timeout) plus zero lexical rows yields non-empty scan results, with the scope loader awaited exactly once.
- New guard test: healthy embedder with a true no-match returns empty and never touches the scope loader, so the fast path is unchanged.
- Full sibyl-core suite in the worktree venv: 2462 passed, 14 skipped. `ty check` clean, `ruff check` and `ruff format --check` clean on both changed files.
- ⚠️ Not exercised live: a real provider outage end to end. The unit pins simulate the timeout at the `_embed_text` seam; killing the embedding provider against a live stack and running `sibyl search` is the natural post-merge probe.

## 🔍 What reviewers should focus on

- Whether scan-on-degraded is acceptable latency-wise. The scan loads the search scope for the org, which is the same cost the existing hard-failure fallback already accepts; this change adds no new cost class, it extends an existing one to a case that previously returned nothing.
- The guard's placement after the direct search rather than at embedding failure, which keeps the lexical lane's chance to answer cheaply before any scan happens.

Out of scope: the doc-chunk lexical lane returning zero for sentence queries (the per-term disjunction conversion), which is why the strikeout is common enough to matter. This fix makes the outage visible-but-degraded rather than invisible; that one makes the lexical lane better at sentences.
