### PR TITLE
fix(api): make sibyl debug query usable for aggregates and builtins

### DIFF
--- a/apps/api/src/sibyl/api/routes/admin.py
+++ b/apps/api/src/sibyl/api/routes/admin.py
@@ -942,7 +942,33 @@ def _query_has_additional_statement(query: str) -> bool:
     return False
 
 
-def _query_has_namespace_separator(query: str) -> bool:
+# Read-only SurrealQL function namespaces a debug SELECT may call. http:: is
+# absent because it performs network egress, and function:: because it runs
+# arbitrary embedded scripts; everything listed only computes over its inputs.
+_GRAPH_DEBUG_ALLOWED_FUNCTION_NAMESPACES = frozenset(
+    {
+        "array",
+        "bytes",
+        "crypto",
+        "duration",
+        "encoding",
+        "geo",
+        "math",
+        "meta",
+        "object",
+        "parse",
+        "rand",
+        "record",
+        "session",
+        "string",
+        "time",
+        "type",
+        "vector",
+    }
+)
+
+
+def _query_disallowed_namespace_call(query: str) -> bool:
     index = 0
     length = len(query)
     while index < length:
@@ -958,7 +984,24 @@ def _query_has_namespace_separator(query: str) -> bool:
             index = _skip_query_comment(query, index)
             continue
         if char == ":" and next_char == ":":
-            return True
+            # Walk back over the full chain (string::semver::compare walks a
+            # nested separator back to its root) and judge the root namespace.
+            end = index
+            start = end
+            while start > 0:
+                prev = query[start - 1]
+                if prev.isalnum() or prev == "_":
+                    start -= 1
+                elif start >= 2 and query[start - 2 : start] == "::":
+                    start -= 2
+                else:
+                    break
+            namespace = query[start:end].lower()
+            root = namespace.split("::", 1)[0] if namespace else ""
+            if root not in _GRAPH_DEBUG_ALLOWED_FUNCTION_NAMESPACES:
+                return True
+            index += 2
+            continue
         index += 1
     return False
 
@@ -969,7 +1012,7 @@ def _is_supported_debug_dialect(query: str) -> bool:
         bool(tokens)
         and tokens[0] == "SELECT"
         and not _query_has_additional_statement(query)
-        and not _query_has_namespace_separator(query)
+        and not _query_disallowed_namespace_call(query)
         and set(tokens).isdisjoint(_GRAPH_DEBUG_FORBIDDEN_TOKENS)
     )
 

--- a/apps/api/src/sibyl/persistence/surreal/content.py
+++ b/apps/api/src/sibyl/persistence/surreal/content.py
@@ -97,8 +97,11 @@ _CONTENT_DEBUG_SELECT_PATTERN = re.compile(
     rf"(?P<table>{_CONTENT_DEBUG_TABLE_PATTERN})\b(?P<tail>.*)\Z",
     re.IGNORECASE | re.DOTALL,
 )
+# GROUP is matched bare because SurrealQL spells aggregates GROUP ALL and
+# allows GROUP <field> without BY; matching only GROUP BY swallows those into
+# the preceding expression.
 _CONTENT_DEBUG_BOUNDARY_PATTERN = re.compile(
-    r"\b(?:GROUP\s+BY|ORDER\s+BY|LIMIT|START|FETCH|TIMEOUT|PARALLEL|EXPLAIN)\b",
+    r"\b(?:GROUP|ORDER\s+BY|LIMIT|START|FETCH|TIMEOUT|PARALLEL|EXPLAIN)\b",
     re.IGNORECASE,
 )
 _CONTENT_DEBUG_WHERE_PATTERN = re.compile(r"\bWHERE\b", re.IGNORECASE)
@@ -817,16 +820,23 @@ def _scope_content_debug_query(query: str) -> str:
         before_where = tail[: where_match.start()]
         after_condition = tail[condition_end:].lstrip()
         suffix = f" {after_condition}" if after_condition else ""
-        return (
-            f"{prefix}{before_where}WHERE ({condition}) "
-            "AND organization_id = $organization_id"
-            f"{suffix}"
-        )
+        head = _content_debug_scope_head(f"{prefix}{before_where}")
+        return f"{head}WHERE ({condition}) AND organization_id = $organization_id{suffix}"
 
     before_boundary = tail[:boundary_start]
     after_boundary = tail[boundary_start:].lstrip()
     suffix = f" {after_boundary}" if after_boundary else ""
-    return f"{prefix}{before_boundary}WHERE organization_id = $organization_id{suffix}"
+    head = _content_debug_scope_head(f"{prefix}{before_boundary}")
+    return f"{head}WHERE organization_id = $organization_id{suffix}"
+
+
+def _content_debug_scope_head(head: str) -> str:
+    # A bare `SELECT * FROM <table>` has an empty tail, so nothing supplies the
+    # separator before the injected WHERE and the query melts into
+    # `<table>WHERE ...`. Guarantee it here rather than at each call site.
+    if head and not head[-1].isspace():
+        return f"{head} "
+    return head
 
 
 async def execute_debug_query(

--- a/apps/api/tests/test_routes_admin.py
+++ b/apps/api/tests/test_routes_admin.py
@@ -813,3 +813,48 @@ def test_parse_surreal_metric_names_and_sample() -> None:
     assert sample["surrealdb_transaction_conflicts_total"] is True
     assert sample["surrealdb_http_request_duration_seconds"] is True
     assert sample["surrealdb_query_duration_seconds"] is False
+
+
+class TestDebugDialectBuiltins:
+    """The graph debug gate allowlists read-only builtins instead of banning ::."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT string::len(name) FROM entity LIMIT 5",
+            "SELECT math::mean(scores) FROM entity GROUP ALL",
+            "SELECT time::now() FROM entity LIMIT 1",
+            "SELECT type::thing('entity', id) FROM entity LIMIT 1",
+            "SELECT string::semver::compare(a, b) FROM entity LIMIT 1",
+        ],
+    )
+    def test_read_only_builtins_are_allowed(self, query: str) -> None:
+        from sibyl.api.routes import admin
+
+        assert admin._is_supported_debug_dialect(query)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT http::get('https://attacker.example') FROM entity",
+            "SELECT function::custom(name) FROM entity",
+            "SELECT ::orphan(name) FROM entity",
+        ],
+    )
+    def test_unlisted_namespaces_are_rejected(self, query: str) -> None:
+        from sibyl.api.routes import admin
+
+        assert not admin._is_supported_debug_dialect(query)
+
+    def test_separator_inside_string_literal_is_ignored(self) -> None:
+        from sibyl.api.routes import admin
+
+        assert admin._is_supported_debug_dialect(
+            "SELECT name FROM entity WHERE name = 'http::get' LIMIT 1"
+        )
+
+    def test_mutating_statements_stay_rejected(self) -> None:
+        from sibyl.api.routes import admin
+
+        assert not admin._is_supported_debug_dialect("DELETE entity")
+        assert not admin._is_supported_debug_dialect("SELECT * FROM entity; DELETE entity")

--- a/apps/api/tests/test_surreal_content_debug.py
+++ b/apps/api/tests/test_surreal_content_debug.py
@@ -68,3 +68,48 @@ def test_scope_content_debug_query_allows_comment_markers_inside_strings() -> No
         scoped == "SELECT * FROM raw_captures WHERE (text = '-- not a comment') "
         "AND organization_id = $organization_id LIMIT 5"
     )
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM raw_captures",
+        "SELECT * FROM raw_captures;",
+    ],
+)
+def test_scope_content_debug_query_bare_table_keeps_separator(query: str) -> None:
+    scoped = content_persistence._scope_content_debug_query(query)
+
+    assert scoped == "SELECT * FROM raw_captures WHERE organization_id = $organization_id"
+
+
+def test_scope_content_debug_query_treats_group_all_as_boundary() -> None:
+    query = "SELECT count() FROM raw_captures GROUP ALL"
+
+    scoped = content_persistence._scope_content_debug_query(query)
+
+    assert scoped == (
+        "SELECT count() FROM raw_captures WHERE organization_id = $organization_id GROUP ALL"
+    )
+
+
+def test_scope_content_debug_query_treats_bare_group_as_boundary() -> None:
+    query = "SELECT count() FROM document_chunks GROUP document_id"
+
+    scoped = content_persistence._scope_content_debug_query(query)
+
+    assert scoped == (
+        "SELECT count() FROM document_chunks "
+        "WHERE organization_id = $organization_id GROUP document_id"
+    )
+
+
+def test_scope_content_debug_query_wraps_where_before_group_all() -> None:
+    query = "SELECT count() FROM raw_captures WHERE memory_scope = 'private' GROUP ALL"
+
+    scoped = content_persistence._scope_content_debug_query(query)
+
+    assert scoped == (
+        "SELECT count() FROM raw_captures "
+        "WHERE (memory_scope = 'private') AND organization_id = $organization_id GROUP ALL"
+    )


### PR DESCRIPTION
# 🔎 debug query learns aggregates and builtins

> Track C of 1.2 (dogfood trust-debt), task `3f20f0e2`. All three defects were pinned live on 2026-08-03 by running the scoping functions directly; the verified input/output matrix from that session is now the regression suite.

## 💡 What this is

`sibyl debug query` is the owner-only introspection surface, and three separate defects made it useless for exactly the queries an operator reaches for during debugging, each failing with a generic 400 or broken SurrealQL that never named the real cause.

**Every builtin was banned.** The graph route's dialect gate rejected any query containing `::`, which is every SurrealQL function: `string::len`, `math::mean`, `time::now`, all of `type::`. The intent was to block dangerous namespaces; the implementation blocked the language.

**A bare table select produced melted SurrealQL.** The content route injects the org filter into the query text, and with an empty tail nothing supplied the separator, so `SELECT * FROM raw_captures` became `raw_capturesWHERE organization_id = ...`. Add any `LIMIT` or `WHERE` and it worked, which is why the breakage looked total in one report and unreproducible in another.

**Aggregates hit both defects at once.** The clause boundary pattern only knew `GROUP BY`, but SurrealQL spells aggregates `GROUP ALL` and accepts `GROUP <field>`, so `SELECT count() FROM raw_captures GROUP ALL` swallowed GROUP into the table expression and then also lost the space.

## 🛠️ How it works

**1. The separator ban becomes a read-only namespace allowlist** (`apps/api/src/sibyl/api/routes/admin.py`). `_query_disallowed_namespace_call` replaces `_query_has_namespace_separator`, reusing the same literal- and comment-skipping scan. At each `::` it walks the full chain back to its root (`string::semver::compare` judges `string`) and checks the root against the allowlist. `http::` is deliberately absent because it performs network egress from the server, and `function::` because it runs arbitrary embedded scripts. A leading `::` with no namespace is rejected.

**2. The injected head guarantees its own separator** (`apps/api/src/sibyl/persistence/surreal/content.py`). `_content_debug_scope_head` appends the space when the text before the injected `WHERE` does not end in whitespace, in both the wrap-existing-WHERE and no-WHERE branches, so the fix cannot regress to depending on what the tail happens to contain.

**3. GROUP is a bare boundary keyword.** The boundary pattern treats `GROUP` like `LIMIT` rather than requiring `BY`, covering `GROUP ALL`, `GROUP BY x`, and `GROUP x`.

## 🎯 The invariant to anchor on

The mutation gate did not move: statement chaining, DELETE/UPDATE/CREATE tokens, and comments are rejected exactly as before, and a `::` inside a string literal still does not count as a function call. The allowlist only widens what a single read-only SELECT may compute.

## 🧪 Validation

- Content scoping matrix, each row a test: bare select, bare select with trailing semicolon, `GROUP ALL`, bare `GROUP <field>`, and `WHERE` before `GROUP ALL`, plus the pre-existing LIMIT/WHERE rows that always worked. 14 passed.
- Dialect gate: allowed (`string::len`, `math::mean`, `time::now`, `type::thing`, nested `string::semver::compare`), rejected (`http::get`, `function::custom`, leading `::`), separator inside a string literal ignored, mutating and chained statements still rejected. 49 passed in `test_routes_admin.py`.
- Full API suite in the worktree venv: 2249 passed, 5 skipped. `ty check`, `ruff check`, and `ruff format` clean.
- ⚠️ Not exercised live: the fixed queries against a running server. The 2026-08-03 pinning ran the same functions this change edits, so the unit matrix mirrors live behavior; a `sibyl debug query "SELECT count() FROM raw_captures GROUP ALL"` against a patched server is the one-command post-merge probe.

## 🔍 What reviewers should focus on

- The allowlist contents. Every listed namespace computes over its inputs only; if any listed namespace can reach the network or filesystem in SurrealDB 3.x, it must come out.
- The walk-back in `_query_disallowed_namespace_call`, which is the one new piece of scanning logic. It intentionally judges only the root of a nested chain.
- Whether bare `GROUP` as a boundary can misfire on a field literally named `group` inside a WHERE condition. An unquoted `group` is already a SurrealQL keyword collision the query would have to backtick to parse, so the practical answer is no, but it is the one behavioral widening in the pattern.
