### PR TITLE
fix(api): stop scrubbing record identifiers out of error messages

### DIFF
--- a/apps/api/src/sibyl/api/errors.py
+++ b/apps/api/src/sibyl/api/errors.py
@@ -47,11 +47,13 @@ SAFE_DETAIL_FIELDS = frozenset(
         "request_id",
     }
 )
+# Bare UUIDs are deliberately NOT in this set. Record identifiers are the
+# system's public vocabulary: clients send them, mutation receipts return
+# them, and tasks mint them as bare uuid4. Scrubbing them replaced every
+# "Task not found: <id>" with a field-less "Invalid request data.", which made
+# 400/404s undiagnosable while protecting nothing the caller did not already
+# hold.
 _SENSITIVE_DETAIL_PATTERNS = (
-    re.compile(
-        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
-        re.IGNORECASE,
-    ),
     re.compile(r"\b(?:SELECT|INSERT|UPDATE|DELETE|MATCH|RELATE)\b", re.IGNORECASE),
     re.compile(r"(?:/[\w.-]+){2,}"),
     re.compile(r"[A-Za-z]:\\"),

--- a/apps/api/tests/test_error_factories.py
+++ b/apps/api/tests/test_error_factories.py
@@ -113,7 +113,7 @@ class TestForbidden:
         """Sensitive permission details should not look like validation failures."""
         exc = HTTPException(
             status_code=403,
-            detail="Project 00000000-0000-0000-0000-000000000000 is forbidden",
+            detail="Project credential missing for /var/lib/sibyl/keys",
         )
 
         assert http_exception_payload(exc, "req_forbidden") == {
@@ -129,7 +129,7 @@ class TestForbidden:
             status_code=403,
             detail={
                 "error": "project_access_denied",
-                "message": "No access to project 00000000-0000-0000-0000-000000000000",
+                "message": "No access; key stored at /var/lib/sibyl/keys/project.pem",
             },
         )
 
@@ -332,3 +332,46 @@ class TestUsagePatterns:
 
         assert exc_info.value.status_code == 403
         assert "admin or owner" in exc_info.value.detail
+
+
+# =============================================================================
+# Record identifiers survive sanitization
+# =============================================================================
+class TestRecordIdsSurviveSanitization:
+    """Sibyl mints record IDs as bare uuid4; errors must be able to name them.
+
+    The sanitizer used to treat any UUID as sensitive and replaced the whole
+    message with a field-less "Invalid request data.", which burned request
+    after request on guessing which argument was wrong.
+    """
+
+    def test_not_found_payload_names_the_missing_id(self) -> None:
+        exc = not_found("Task", "0f9b2f66-4a4d-49c1-a8ff-3f5c9b2d7e11")
+        payload = http_exception_payload(exc, "req_nf")
+
+        assert payload["message"] == ("Task not found: 0f9b2f66-4a4d-49c1-a8ff-3f5c9b2d7e11")
+
+    def test_bad_request_payload_names_the_offending_id(self) -> None:
+        exc = bad_request("Entity 0f9b2f66-4a4d-49c1-a8ff-3f5c9b2d7e11 is not an epic")
+        payload = http_exception_payload(exc, "req_epic")
+
+        assert payload["message"] == ("Entity 0f9b2f66-4a4d-49c1-a8ff-3f5c9b2d7e11 is not an epic")
+
+    def test_sql_fragments_still_sanitize(self) -> None:
+        exc = bad_request("SELECT * FROM entity failed")
+        payload = http_exception_payload(exc, "req_sql")
+
+        assert "SELECT" not in str(payload["message"])
+
+    def test_secret_words_still_sanitize(self) -> None:
+        exc = bad_request("invalid api_key for 0f9b2f66-4a4d-49c1-a8ff-3f5c9b2d7e11")
+        payload = http_exception_payload(exc, "req_key")
+
+        assert "api_key" not in str(payload["message"])
+        assert "0f9b2f66" not in str(payload["message"])
+
+    def test_filesystem_paths_still_sanitize(self) -> None:
+        exc = bad_request("could not read /etc/sibyl/config.toml")
+        payload = http_exception_payload(exc, "req_path")
+
+        assert "/etc" not in str(payload["message"])


### PR DESCRIPTION
# 🏷️ Errors get to name the ID they rejected

> Track C of 1.2 (dogfood trust-debt), task `25e24fd2`. Mined from a transcript that burned eight request IDs guessing an epic-ID shape because every error came back as "Invalid request data."

## 💡 What this is

`sanitize_error_text` replaces the entire message with `"Invalid request data."` when any sensitive pattern matches, and the pattern set included a bare-UUID regex. Sibyl mints task and entity IDs as bare uuid4, so the system treated its own identifiers as secrets: `Task not found: <id>` and `Entity <id> is not an epic` both reached callers field-less, across the roughly 44 sites that interpolate an ID into error detail. The defect dates to 2026-05-15 (`946bf319`), pre-1.0, and was already noted as a wart in the shipped skill pack.

Record identifiers are the system's public vocabulary. Clients send them in requests, mutation receipts return them, and `sibyl task list` prints them. A caller who receives their own ID back in an error learns nothing they did not already hold, and an error that cannot name the argument it rejected is undiagnosable by construction.

## 🛠️ How it works

The UUID regex comes out of `_SENSITIVE_DETAIL_PATTERNS` (`apps/api/src/sibyl/api/errors.py`), with a comment stating why identifiers are exempt. Everything else scrubs exactly as before: SQL keywords, multi-segment filesystem paths, Windows drive paths, and secret words (`token`, `secret`, `password`, `credential`, `api_key`). The 200-character cap and the 5xx generic-message replacement in `_safe_message_for_status` are untouched, and a message containing both a UUID and a secret word still sanitizes, which is test-pinned.

The two 403 redaction tests used a UUID as their sanitization trigger, so they now trigger on genuinely sensitive content (a filesystem path, the word `credential`). Their real pin is preserved: a redacted 403 reads as forbidden, never as a validation failure.

## 🧪 Validation

- New test class `TestRecordIdsSurviveSanitization`: the 404 and 400 shapes from the incident pass through verbatim, and SQL, secret-word, and path messages still redact (a UUID does not launder a message that also contains `api_key`). `test_error_factories.py`: 43 passed.
- Full API suite in the worktree venv: 2239 passed, 5 skipped. `ty check`, `ruff check`, `ruff format` clean.

## 🔍 What reviewers should focus on

- Whether any error path interpolates a UUID the caller did not supply. The audit trail here is the factory functions (`not_found`, `bad_request`), which are caller-echo by construction; a hand-built message naming another tenant's record would now pass through, though knowing a bare UUID exists confirms nothing about which org owns it and the namespace-per-org isolation means it cannot be dereferenced across a boundary.
- The 403 test retargeting, which is a test-semantics change rather than a behavior change.

## 📌 Follow-ups (deliberate non-fixes)

Two secondary defects found while the original report was being corrected stay open on the task: the `epic_id` versus `parent_task_id` hierarchy drift needs a design call on which field is canonical (re-parenting currently leaves progress counted under the old epic), and `task update -e` does not resolve ID prefixes even though the positional task argument does. The first is design work, the second is a small CLI fix that belongs with it.
