### PR TITLE
docs: document the fresh-store schema path and sibyld db init

### DIFF
--- a/docs/admin/installing.md
+++ b/docs/admin/installing.md
@@ -195,6 +195,22 @@ Without one of these configured, Sibyl logs those emails to its JSONL outbox and
 delivery, so invited users and password-reset requests never receive a link. When setting SMTP
 passwords in a Compose `.env` file, escape literal `$` characters as `$$`.
 
+## Database Schema
+
+The backend applies the auth and content schemas to SurrealDB automatically at startup, records
+applied migrations in `schema_version`, and refuses to start if bootstrap fails outside development
+mode, so a fresh store needs no manual step. To apply or repair the schemas by hand (an empty store,
+a restore, a bootstrap failure named in the logs), run:
+
+```bash
+sibyld db init
+```
+
+The command is non-destructive and safe to run repeatedly: it never drops tables, skips migrations
+already recorded, and verifies schema invariants after applying. If requests fail with
+`table ... does not exist`, see
+[the troubleshooting entry](../deployment/troubleshooting.md#schema-issues).
+
 ## First Owner
 
 The default Sibyl install is local-first. The first setup signup creates the owner/admin user. After

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -171,6 +171,49 @@ default install, OIDC is off and local auth is expected.
    echo $SIBYL_PUBLIC_URL
    ```
 
+## Schema Issues
+
+### "table ... does not exist" on a Fresh Store
+
+**Symptoms:**
+
+- API requests return HTTP 500 `internal_error` with a generic message.
+- Server logs show `NotFoundError: table projects does not exist` (or `team_projects`,
+  `raw_captures`, another core table) against a newly provisioned SurrealDB.
+- The instance was just installed, restored onto an empty database, or pointed at a new
+  `SIBYL_SURREAL_URL`.
+
+**What it usually means:**
+
+The auth and content schemas were never applied to this store. The server applies both automatically
+at startup and refuses to start on failure outside development, so hitting this at request time
+means the server started in `development` mode against an empty store, or startup bootstrap failed
+and the log line was missed.
+
+**Solutions:**
+
+1. **Apply the schemas directly (safe to run repeatedly):**
+
+   ```bash
+   sibyld db init
+   ```
+
+   The command applies pending auth and content migrations, verifies schema invariants, never drops
+   tables, and skips migrations already recorded in `schema_version`.
+
+2. **Check the startup bootstrap log** for the failure that stopped the automatic path:
+
+   ```bash
+   sibyl logs tail -l error -s api
+   ```
+
+   Look for `Surreal auth schema bootstrap failed` or `Surreal content schema bootstrap failed`;
+   each names the plane, target version, and error.
+
+3. **Verify readiness before sending traffic.** The readiness endpoint reports schema bootstrap
+   state, and compose/Kubernetes health checks gate on it, so an unhealthy backend that keeps
+   restarting is usually this failure loudly refusing to serve.
+
 ## Performance Issues
 
 ### Slow Queries


### PR DESCRIPTION
# 📖 The fresh-store path gets written down

> Track C of 1.2 (dogfood trust-debt), task `4fd323a5`. Mined from the 7/21 incident: eight minutes of whack-a-mole against `table projects does not exist` because no doc named the init step.

## 💡 What this is

The incident had three asks and two of them were already fixed on 7/24, three days after it happened: `sibyld db init` exists as the non-destructive schema-repair verb (`ef6ee3bd`), and startup bootstrap logs failures loudly, names `db init` as remediation, fails closed outside development, and gates compose/Kubernetes health on readiness (`6078bd8f`). What never landed was the documentation, so the verb remained undiscoverable to exactly the operator who needs it, which was the original complaint.

This PR is that missing third: a **Schema Issues** section in the troubleshooting guide keyed to the literal symptom (HTTP 500 `internal_error` with `NotFoundError: table ... does not exist` in the logs), and a **Database Schema** section in the install guide stating that a fresh store needs no manual step and naming `sibyld db init` for the repair cases.

## 🧪 Validation

Prettier clean on both files (the docs lint gate). Content claims verified against the code: the startup bootstrap behavior and remediation string are quoted from `surreal_runtime_startup.py`, and the `db init` semantics (idempotent, never drops, skips recorded migrations, verifies invariants) from its docstring and implementation in `cli/db.py`.

## 🔍 What reviewers should focus on

Whether the "fails closed outside development" phrasing matches your operational intent for dev mode, where a bootstrap failure is currently swallowed at startup and surfaces via readiness instead. The docs describe that behavior as-is rather than proposing to change it.

With this merged, all three asks on task `4fd323a5` are closed.