### PR TITLE
fix(synthesis): never select synthesis or reflection output as a source

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py
@@ -117,6 +117,20 @@ CORRECTED_LIFECYCLE_STATES = {
     "contested",
     "superseded",
 }
+# Capture surfaces whose records are themselves synthesis or reflection
+# output. Search and neighborhood expansion must never select them: a
+# handbook citing a prior handbook compounds its own summarization loss on
+# every regeneration, which is the self-feeding loop the write-path integrity
+# gate exists to catch. Sources the caller names explicitly stay eligible,
+# because synthesizing FROM a chosen prior artifact is a deliberate request.
+SELF_FEEDING_CAPTURE_SURFACES = frozenset(
+    {
+        "reflection",
+        "reflection_candidate",
+        "reflection_source",
+        "synthesis_artifact",
+    }
+)
 MAX_EXPLICIT_NEIGHBORHOOD_IDS = 100
 
 
@@ -257,6 +271,20 @@ def _dedupe_sources(
         seen.add(source.id)
         deduped.append(source)
     return deduped
+
+
+def _is_self_feeding_source(source: SynthesisSourceReference) -> bool:
+    metadata = source.metadata or {}
+    capture_surface = str(metadata.get("capture_surface") or "").strip().lower()
+    if capture_surface in SELF_FEEDING_CAPTURE_SURFACES:
+        return True
+    return str(metadata.get("capture_mode") or "").strip().lower() == "synthesis"
+
+
+def _without_self_feeding_sources(
+    sources: Iterable[SynthesisSourceReference],
+) -> list[SynthesisSourceReference]:
+    return [source for source in sources if not _is_self_feeding_source(source)]
 
 
 async def _search_sources(
@@ -982,15 +1010,17 @@ async def plan_synthesis(
         ],
     ]
     explicit_sources = _dedupe_sources(explicit_sources)[:MAX_EXPLICIT_NEIGHBORHOOD_IDS]
-    searched_sources = await _search_sources(
-        query=base_query,
-        organization_id=organization_id,
-        project=request.project,
-        domain=request.domain,
-        accessible_projects=accessible_projects,
-        search_fn=search_fn,
+    searched_sources = _without_self_feeding_sources(
+        await _search_sources(
+            query=base_query,
+            organization_id=organization_id,
+            project=request.project,
+            domain=request.domain,
+            accessible_projects=accessible_projects,
+            search_fn=search_fn,
+        )
     )
-    neighborhood_sources = (
+    neighborhood_sources = _without_self_feeding_sources(
         await _neighborhood_sources(
             entity_ids=[source.id for source in explicit_sources],
             organization_id=organization_id,

--- a/packages/python/sibyl-core/tests/test_handbook.py
+++ b/packages/python/sibyl-core/tests/test_handbook.py
@@ -224,3 +224,115 @@ async def test_handbook_markdown_is_byte_stable_for_the_same_run() -> None:
     second = render_handbook_markdown(await _plan(search_fn))
 
     assert first == second
+
+
+# =============================================================================
+# handbook-integrity-gate (1.2 exit criterion)
+# =============================================================================
+class TestHandbookIntegrityGate:
+    """Zero hallucinated and zero self-referential writes from the distiller.
+
+    The pipeline is extractive by construction (no LLM pass anywhere in
+    plan/draft/verify), so integrity can only break two ways: a rendered line
+    that traces to no selected source, or the distiller selecting synthesis
+    and reflection output as its own input. Both are pinned here on a seeded
+    fixture.
+    """
+
+    @staticmethod
+    def _self_feeding_result(entity_id: str, capture_surface: str) -> SearchResult:
+        return SearchResult(
+            id=entity_id,
+            type="artifact",
+            name=f"Prior output {entity_id}",
+            content="A previously distilled handbook body",
+            score=0.99,
+            source=f"source:{entity_id}",
+            result_origin="graph",
+            metadata={"entity_type": "artifact", "capture_surface": capture_surface},
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "capture_surface",
+        ["synthesis_artifact", "reflection", "reflection_candidate", "reflection_source"],
+    )
+    async def test_self_feeding_surfaces_never_enter_the_plan(self, capture_surface: str) -> None:
+        poisoned = self._self_feeding_result("artifact-poison", capture_surface)
+        clean = _result("artifact-clean", "artifact", "Design doc", score=0.7)
+        run = await _plan(_populated_search([poisoned, clean]))
+
+        selected = {source.id for pack in run.source_packs for source in pack.sources}
+        assert "artifact-poison" not in selected
+        assert "artifact-clean" in selected
+        assert "artifact-poison" not in render_handbook_markdown(run)
+
+    @pytest.mark.asyncio
+    async def test_capture_mode_synthesis_is_excluded_without_a_surface(self) -> None:
+        poisoned = SearchResult(
+            id="artifact-mode",
+            type="artifact",
+            name="Remembered synthesis",
+            content="Synthesis-mode capture with no surface marker",
+            score=0.99,
+            source="source:artifact-mode",
+            result_origin="graph",
+            metadata={"entity_type": "artifact", "capture_mode": "synthesis"},
+        )
+        run = await _plan(_populated_search([poisoned]))
+
+        selected = {source.id for pack in run.source_packs for source in pack.sources}
+        assert "artifact-mode" not in selected
+
+    @pytest.mark.asyncio
+    async def test_every_rendered_line_is_scaffolding_or_traces_to_a_source(self) -> None:
+        fixtures = [
+            _result("decision-1", "decision", "Chose SurrealDB"),
+            _result("task-1", "task", "Ship the exporter"),
+            _result("artifact-1", "artifact", "Design doc"),
+            _result("claim-1", "claim", "Exports are deterministic"),
+        ]
+        run = await _plan(_populated_search(fixtures))
+        markdown = render_handbook_markdown(run)
+
+        fixture_ids = {result.id for result in fixtures}
+        fixture_names = {result.name for result in fixtures}
+        section_titles = {section.title for section in HANDBOOK_SECTIONS}
+        absence_scaffold = (
+            "No citable memory backs these sections yet. Absence here is a gap in "
+            "the graph, not a claim that nothing exists."
+        )
+
+        for line in markdown.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("## "):
+                assert stripped[3:] in ({"Not Covered"} | section_titles), (
+                    f"unexpected heading: {stripped}"
+                )
+                continue
+            if stripped.startswith("Sources: "):
+                cited = {token.strip("`,") for token in stripped.removeprefix("Sources: ").split()}
+                assert cited <= fixture_ids, f"hallucinated citation in: {stripped}"
+                continue
+            if stripped == "_No citable sources were available for this section._":
+                continue
+            if stripped == absence_scaffold:
+                continue
+            if stripped.startswith("- "):
+                traces = any(name in stripped for name in fixture_names) and any(
+                    f"[{source_id}]" in stripped for source_id in fixture_ids
+                )
+                uncovered_title = stripped.removeprefix("- ") in section_titles
+                assert traces or uncovered_title, f"unsourced content line: {stripped}"
+                continue
+            raise AssertionError(f"unrecognized handbook line shape: {stripped}")
+
+    @pytest.mark.asyncio
+    async def test_a_run_with_no_sources_renders_only_the_absence_statement(self) -> None:
+        run = await _plan(_empty_search)
+        markdown = render_handbook_markdown(run)
+
+        assert "## Not Covered" in markdown
+        assert "Sources:" not in markdown


### PR DESCRIPTION
# 🐍 The handbook stops eating its own tail

> Track B of 1.2, task `106e1856`. The exit criterion says both projection gates green; auditing them found B1's gate missing, and building the gate found a live defect, which is the order these things are supposed to happen in.

## 💡 What this is

Remembered synthesis artifacts are stored with `capture_surface: "synthesis_artifact"` and land in the graph, where the synthesis planner's artifact search bucket (types `artifact`/`document`/`source`/`config_file`) can return them. Nothing in `plan_synthesis` filtered on that marker, so a handbook regeneration could select the previous handbook as one of its own sources. Each cycle compounds summarization loss: the distillation of a distillation, drifting further from the underlying memories while looking increasingly authoritative.

The defect was proven live before the fix, not inferred: the new gate test seeds a `synthesis_artifact`-surfaced result with a winning score, and on the unfixed selection path it is selected into the plan and rendered (`1 failed`), then passes with the filter in place. That induced failure is the receipt that the gate bites.

## 🛠️ How it works

Searched and neighborhood sources pass through `_without_self_feeding_sources`, which drops anything whose `capture_surface` is in the reflection/synthesis set (the same four surfaces the v1.1 write-path integrity gate names: `reflection`, `reflection_candidate`, `reflection_source`, `synthesis_artifact`) or whose `capture_mode` is `synthesis`. Explicitly requested `artifact_ids` stay eligible: synthesizing from a named prior artifact is a deliberate request, and those references carry no metadata to filter on anyway.

## 🎯 The invariant to anchor on

The handbook pipeline is extractive by construction, so integrity can only break two ways: a rendered line that traces to no selected source, or the distiller selecting its own output as input. `TestHandbookIntegrityGate` pins both, which makes it the executable form of the 1.2 `handbook-integrity-gate` exit criterion.

## 🧪 Validation

- The four self-feeding surfaces are rejected one by one (parametrized), an unmarked artifact is caught by `capture_mode`, a clean artifact in the same plan survives, every rendered line must be scaffolding or trace to a fixture source and its citation, and a sourceless run renders only the absence statement. `test_handbook.py`: 16 passed (9 existing plus 7 new).
- Gate-bites receipt: with the filter stashed, `test_self_feeding_surfaces_never_enter_the_plan[synthesis_artifact]` fails; with it restored, all 16 pass.
- Full sibyl-core suite: 2467 passed, 14 skipped. Synthesis route tests: 8 passed. `ty check`, `ruff check`, `ruff format` clean.

## 🔍 What reviewers should focus on

- The exemption for explicit `artifact_ids`. The filter applies only to the searched and neighborhood streams, so a caller can still deliberately synthesize from a prior artifact. If you want recursion impossible even on request, the filter moves one call down and the exemption dies with it.
- Whether `capture_mode == "synthesis"` is too broad a second net. It currently catches artifacts remembered before any surface marker existed; nothing else writes that mode.

## 📌 Follow-ups (deliberate non-fixes)

The B2 files-projection gate needed no work: `test_memory_files.py` already pins byte-identical rebuilds, input-order invariance, on-disk re-materialization, clock isolation, and greppability (my audit initially missed them because the test names spell "byte identical" rather than "deterministic"). The one B2 property not unit-pinnable is citations being recorded when the server returns, which is live-integration scope. The B1 ship notes' "ranking still ungated" concern is about section-fit ranking quality, not integrity, and stays a separate item.