### PR TITLE
feat(api): deprecate retrieval_mode=accurate with an in-band notice

### DIFF
--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -349,6 +349,9 @@ def _fuse_context_evidence(
         query=question,
         filters={
             "retrieval_mode": "accurate",
+            "retrieval_mode_deprecated": (
+                "accurate is deprecated and will be removed; use fast (the default)"
+            ),
             "planner_status": planner_status,
             "planner_strategy": "deterministic_refinement_v3",
             "planner_usage": planner_usage,
@@ -697,6 +700,14 @@ async def _compile_context_with_evidence(
     with capture_embedding_usage(embedding_provider) as embedding_usage:
         pack_task = asyncio.create_task(compile_pack())
         if request.evidence.retrieval_mode == "accurate":
+            # A5 deprecation (measured at full benchmark scale: lower accuracy
+            # AND 2.5x latency vs fast). Served for one release, warned, then
+            # removed together with the planner unless A3 adopts it.
+            log.warning(
+                "retrieval_mode_accurate_deprecated",
+                organization_id=str(org.id),
+                remediation="switch to retrieval_mode=fast (the default)",
+            )
             evidence_task = asyncio.create_task(
                 _execute_accurate_context_evidence_search(
                     request,

--- a/apps/api/src/sibyl/api/schemas/context.py
+++ b/apps/api/src/sibyl/api/schemas/context.py
@@ -47,7 +47,12 @@ class ContextEvidenceRequest(BaseModel):
     )
     retrieval_mode: Literal["fast", "accurate"] = Field(
         default="fast",
-        description="Use one search or deterministic multi-step evidence refinement",
+        description=(
+            "Use one search (fast) or deterministic multi-step evidence refinement "
+            "(accurate). DEPRECATED: accurate measured lower accuracy at 2.5x the "
+            "latency of fast at full benchmark scale and will be removed in a "
+            "future release; requests selecting it are served but warned."
+        ),
     )
     max_planned_queries: int = Field(
         default=3,

--- a/apps/api/tests/test_routes_context.py
+++ b/apps/api/tests/test_routes_context.py
@@ -2390,3 +2390,28 @@ def test_context_pack_request_defaults_to_a_markdown_budget() -> None:
 
     assert request.markdown_token_budget == DEFAULT_MARKDOWN_TOKEN_BUDGET
     assert ContextPackRequest(goal="x", markdown_token_budget=None).markdown_token_budget is None
+
+
+def test_accurate_evidence_response_carries_the_deprecation_marker() -> None:
+    """A5: accurate mode is served but announces its own removal in-band."""
+    response = _fuse_context_evidence(
+        question="ship faster",
+        query_specs=[{"name": "original", "query": "ship faster", "facet": "original"}],
+        planned_queries=[],
+        responses=[_search_response("ship faster", ("original", 0.9))],
+        limit=1,
+        candidate_limit=2,
+        failures=[],
+        planner_usage={},
+    )
+
+    marker = response.filters["retrieval_mode_deprecated"]
+    assert "deprecated" in marker
+    assert "fast" in marker
+
+
+def test_retrieval_mode_schema_documents_the_deprecation() -> None:
+    from sibyl.api.schemas.context import ContextEvidenceRequest
+
+    description = ContextEvidenceRequest.model_fields["retrieval_mode"].description
+    assert "DEPRECATED" in description

--- a/docs/api/rest-memory.md
+++ b/docs/api/rest-memory.md
@@ -210,9 +210,15 @@ compilation:
 | `max_results_per_source`        | integer  | -             | In accurate mode, prefer source-diverse evidence first (1-50)   |
 | `content_max_chars`             | integer  | 500           | Maximum content characters per evidence result (0-50000)        |
 | `include_retrieval_diagnostics` | boolean  | false         | Include authorized evidence ranking diagnostics                 |
-| `retrieval_mode`                | string   | `fast`        | `fast` (one search) or `accurate` (multi-step refinement)       |
+| `retrieval_mode`                | string   | `fast`        | `fast` (one search) or `accurate` (deprecated, see below)       |
 | `max_planned_queries`           | integer  | 3             | Maximum feedback searches across accurate-mode refinement (1-3) |
 | `reserve_distilled_notes`       | boolean  | true          | Reserve a typed lane for distilled operational notes            |
+
+::: warning `retrieval_mode=accurate` is deprecated Measured at full benchmark scale, accurate mode
+returned lower accuracy than `fast` at 2.5x the latency, so it is scheduled for removal. Requests
+selecting it are still served; the server logs a deprecation warning and the evidence response
+carries a `retrieval_mode_deprecated` filter naming the replacement. Use `fast`, the default, which
+also makes `max_results_per_source` and `max_planned_queries` irrelevant. :::
 
 The response is a context pack with `sections`, `total_items`, `usage_metadata`, `usage_hint`, and a
 rendered `markdown` field. When evidence retrieval was requested, the response also carries an


### PR DESCRIPTION
# 📉 Accurate mode announces its own retirement

> Track A of 1.2, task `75c19be8` (A5). The kill was decided by measurement (`decision_3da12cba3ccd`, confirming `decision_0d07482dd334`); this PR is the one-release deprecation notice that decision prescribed.

## 💡 What this is

At full 451-question benchmark scale, `retrieval_mode=accurate` returned lower accuracy than `fast` (4 points down on enterprise) at 2.5 times the latency. Its single remaining win, 1.7 points on the web split, would require forking the product per domain to keep, which the plan rejects as surface without a mechanism. The mode is deprecated for one release before removal, and this PR is the notice, not the removal.

## 🛠️ How it works

An accurate request is served exactly as before, and three things now tell the caller it is on borrowed time: the server logs `retrieval_mode_accurate_deprecated` with remediation, the evidence response carries a `retrieval_mode_deprecated` filter naming the replacement (in-band, so API consumers see it without reading server logs), and the OpenAPI schema description plus the REST docs carry the deprecation with the measured numbers.

## 🎯 The invariant to anchor on

Behavior is unchanged for every request. This diff adds a log line, a response filter, a schema description, and a docs block; the accurate execution path itself is untouched, so nothing needs re-measurement.

## 🧪 Validation

Two new pins: the accurate evidence response carries the deprecation marker, and the schema description says DEPRECATED (so removing either without removing the mode fails a test). `test_routes_context.py`: 46 passed. Full API suite: 2236 passed, 5 skipped. `ty check`, `ruff`, and Prettier (docs) clean.

## 📌 Follow-ups (deliberate non-fixes)

The planner (`retrieval/query_planning.py`) stays. Its deletion is sequenced behind A3, which may reuse the score-blind planner as a traversal seed; the mode removal and the planner decision land together after A3. Also spotted while editing the docs: the `markdown_token_budget` row still describes the pre-#347 ceiling (8000) and not the new default; that correction ships separately since it belongs to #347's change, not this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation**
  * Marked accurate retrieval mode as deprecated.
  * Accurate retrieval remains available but now produces warnings and a deprecation indicator in response metadata.
  * Callers are directed to use fast retrieval instead.

* **Documentation**
  * Updated API guidance with accurate mode’s latency and accuracy characteristics.
  * Clarified that fast retrieval is the default and documented its handling of result and query limits.

* **Tests**
  * Added coverage for deprecation warnings, response metadata, and updated schema documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->