### PR TITLE
docs(api): budget row reflects the sized-by-budget render

### DIFF
--- a/docs/api/mcp-context.md
+++ b/docs/api/mcp-context.md
@@ -34,7 +34,7 @@ interface ContextInput {
 
   // Output Shaping
   audit?: boolean; // Include full retrieval metadata per item (default false)
-  markdown_token_budget?: number; // Cap rendered markdown at ~this many tokens
+  markdown_token_budget?: number; // Size rendered markdown to ~this many tokens (default 4000, max 32000; null renders count-bounded)
 }
 ```
 

--- a/docs/api/rest-memory.md
+++ b/docs/api/rest-memory.md
@@ -195,7 +195,7 @@ Compiles a structured context pack for an agent goal. This is the REST equivalen
 | `related_limit`         | integer | No       | 3        | Related items per context item (0-5)        |
 | `audit`                 | boolean | No       | false    | Include full retrieval metadata per item    |
 | `record_exposure`       | boolean | No       | true     | Record returned items as exposure signals   |
-| `markdown_token_budget` | integer | No       | -        | Cap rendered markdown (~100-8000 tokens)    |
+| `markdown_token_budget` | integer | No       | 4000     | Size rendered markdown (100-32,000 tokens)  |
 | `evidence`              | object  | No       | -        | Enhanced source-evidence retrieval controls |
 
 #### Evidence Controls


### PR DESCRIPTION
# 📏 Two doc lines catch up with #347

> Follow-up flagged in #355's body. #347 changed `markdown_token_budget` from a trim-only cap (max 8000, no default) to the value that sizes the pack (default 4000 on the API surface, max 32,000, explicit `null` for a count-bounded render). The REST table row and the MCP signature comment still described the old contract.

Both lines now state the shipped behavior, verified against the schema (`markdown_token_budget: int | None = DEFAULT_MARKDOWN_TOKEN_BUDGET`, `le=32_000`) rather than from memory. Prettier clean.