### PR TITLE
fix: embedding backfill false-negatives on entities that exist

### DIFF
--- a/apps/api/src/sibyl/jobs/entities.py
+++ b/apps/api/src/sibyl/jobs/entities.py
@@ -877,6 +877,7 @@ async def backfill_entity_embeddings(
             lambda: runtime.entity_manager.backfill_embeddings_if_current(entities),
         )
         expected_entity_ids = {entity.id for entity in entities}
+        stale_entity_ids: list[str] = []
         if set(created_ids) != expected_entity_ids:
             if expected_manifest is not None:
                 manifest_state = await _load_operational_manifest_state(
@@ -893,9 +894,24 @@ async def backfill_entity_embeddings(
                         "manifest_state": manifest_state,
                     }
             missing_ids = sorted(expected_entity_ids - set(created_ids))
-            raise RuntimeError(
-                "partial entity embedding backfill; "
-                f"missing current entities: {', '.join(missing_ids)}"
+            # A refused write is not a missing row: operational ids are
+            # stable, so a re-capture between enqueue and drain updates the
+            # row and the currency fence rightly refuses the stale payload
+            # while the newer capture's own backfill owns the current text.
+            # Only rows that are actually gone fail the job.
+            present = await runtime.entity_manager.get_many(missing_ids)
+            present_ids = {entity.id for entity in present}
+            stale_entity_ids = [entity_id for entity_id in missing_ids if entity_id in present_ids]
+            absent_ids = [entity_id for entity_id in missing_ids if entity_id not in present_ids]
+            if absent_ids:
+                raise RuntimeError(
+                    "partial entity embedding backfill; "
+                    f"missing current entities: {', '.join(absent_ids)}"
+                )
+            log.warning(
+                "entity_embedding_backfill_stale_expectations",
+                entity_ids=stale_entity_ids,
+                group_id=group_id,
             )
 
         relationship_ids: list[str] = []
@@ -945,6 +961,8 @@ async def backfill_entity_embeddings(
         "relationship_ids": relationship_ids,
         "embedding_usage": embedding_usage,
     }
+    if stale_entity_ids:
+        result["stale_entity_ids"] = stale_entity_ids
     if manifest_state is not None:
         result["manifest_state"] = manifest_state
     log.info("entity_embedding_backfill_complete", **result)

--- a/apps/api/tests/test_jobs_entities.py
+++ b/apps/api/tests/test_jobs_entities.py
@@ -350,6 +350,54 @@ class TestBackfillEntityEmbeddingsJob:
         entity_manager.backfill_embeddings_if_current.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_stale_but_present_entities_still_complete_a_pending_manifest(self) -> None:
+        entity = Entity(
+            id="session-123",
+            entity_type=EntityType.SESSION,
+            name="Operational session",
+            content="Persisted before embeddings were available.",
+        )
+        current_row = entity.model_copy(update={"content": "Rewritten by a later capture."})
+        pending_manifest = _embedding_manifest(state="embedding_pending")
+        complete_manifest = _embedding_manifest(state="complete")
+        entity_manager = MagicMock()
+        entity_manager.get = AsyncMock(
+            side_effect=[pending_manifest, pending_manifest, pending_manifest]
+        )
+        entity_manager.backfill_embeddings_if_current = AsyncMock(return_value=[])
+        entity_manager.get_many = AsyncMock(return_value=[current_row])
+        entity_manager.create_direct_bulk = AsyncMock(return_value=[complete_manifest.id])
+        runtime = SimpleNamespace(
+            entity_manager=entity_manager,
+            relationship_manager=MagicMock(),
+        )
+
+        with (
+            patch(
+                "sibyl.jobs.entities.get_surreal_graph_runtime",
+                AsyncMock(return_value=runtime),
+            ),
+            patch("sibyl.locks.entity_lock", _acquired_lock),
+            patch("sibyl.jobs.entities.log") as log_mock,
+        ):
+            result = await backfill_entity_embeddings(
+                {},
+                [entity.model_dump(mode="json")],
+                "org-1",
+                completion_manifest=complete_manifest.model_dump(mode="json"),
+            )
+
+        assert result["manifest_state"] == "completed"
+        assert result["entities"] == 0
+        assert result["stale_entity_ids"] == [entity.id]
+        entity_manager.get_many.assert_awaited_once_with([entity.id])
+        entity_manager.create_direct_bulk.assert_awaited_once()
+        written = entity_manager.create_direct_bulk.await_args.args[0]
+        assert written[0].metadata["operational_projection_state"] == "complete"
+        warning_events = [call.args[0] for call in log_mock.warning.call_args_list]
+        assert "entity_embedding_backfill_stale_expectations" in warning_events
+
+    @pytest.mark.asyncio
     async def test_completes_manifest_only_after_every_entity_is_ready(self) -> None:
         entity = Entity(
             id="session-123",

--- a/apps/api/tests/test_jobs_entities.py
+++ b/apps/api/tests/test_jobs_entities.py
@@ -280,7 +280,7 @@ class TestBackfillEntityEmbeddingsJob:
         assert sleep_calls == [0.25]
 
     @pytest.mark.asyncio
-    async def test_stale_entity_payload_cannot_recreate_or_overwrite_rows(self) -> None:
+    async def test_absent_entity_fails_the_backfill(self) -> None:
         entity = Entity(
             id="session-123",
             entity_type="session",
@@ -289,6 +289,7 @@ class TestBackfillEntityEmbeddingsJob:
         )
         entity_manager = MagicMock()
         entity_manager.backfill_embeddings_if_current = AsyncMock(return_value=[])
+        entity_manager.get_many = AsyncMock(return_value=[])
         runtime = SimpleNamespace(
             entity_manager=entity_manager,
             relationship_manager=MagicMock(),
@@ -299,13 +300,52 @@ class TestBackfillEntityEmbeddingsJob:
                 "sibyl.jobs.entities.get_surreal_graph_runtime",
                 AsyncMock(return_value=runtime),
             ),
-            pytest.raises(RuntimeError, match="partial entity embedding backfill"),
+            pytest.raises(RuntimeError, match="missing current entities: session-123"),
         ):
             await backfill_entity_embeddings(
                 {},
                 [entity.model_dump(mode="json")],
                 "org-1",
             )
+        entity_manager.get_many.assert_awaited_once_with(["session-123"])
+
+    @pytest.mark.asyncio
+    async def test_stale_but_present_entity_is_skipped_not_fatal(self) -> None:
+        stale = Entity(
+            id="event-42",
+            entity_type="event",
+            name="Action at observation 42",
+            content="Goal: g\nAction: click",
+        )
+        current_row = stale.model_copy(update={"content": "Goal: g\nAction: click\nAfter: /x"})
+        embedded = Entity(
+            id="session-123",
+            entity_type="session",
+            name="Lexical session",
+            content="Persisted before embeddings were available.",
+        )
+        entity_manager = MagicMock()
+        entity_manager.backfill_embeddings_if_current = AsyncMock(return_value=[embedded.id])
+        entity_manager.get_many = AsyncMock(return_value=[current_row])
+        runtime = SimpleNamespace(
+            entity_manager=entity_manager,
+            relationship_manager=MagicMock(),
+        )
+
+        with patch(
+            "sibyl.jobs.entities.get_surreal_graph_runtime",
+            AsyncMock(return_value=runtime),
+        ):
+            result = await backfill_entity_embeddings(
+                {},
+                [embedded.model_dump(mode="json"), stale.model_dump(mode="json")],
+                "org-1",
+            )
+
+        assert result["entities"] == 1
+        assert result["entity_ids"] == [embedded.id]
+        assert result["stale_entity_ids"] == [stale.id]
+        entity_manager.get_many.assert_awaited_once_with([stale.id])
 
         entity_manager.backfill_embeddings_if_current.assert_awaited_once()
 
@@ -360,6 +400,7 @@ class TestBackfillEntityEmbeddingsJob:
         entity_manager = MagicMock()
         entity_manager.get = AsyncMock(side_effect=[pending_manifest, pending_manifest])
         entity_manager.backfill_embeddings_if_current = AsyncMock(return_value=[])
+        entity_manager.get_many = AsyncMock(return_value=[])
         entity_manager.create_direct_bulk = AsyncMock()
         runtime = SimpleNamespace(
             entity_manager=entity_manager,

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -2851,12 +2851,14 @@ async def _update_entity_embedding_if_current(
 
 
 def _persisted_entity_embedding_text(entity: Entity) -> str:
+    # Mirrors entity_from_surreal_row's read-side fallbacks; any divergence
+    # makes the currency fence refuse rows that are byte-identical on disk.
     summary = entity.description[:500] if entity.description else entity.name
     persisted = entity.model_copy(
         update={
             "name": entity.name.strip(),
             "description": (entity.description or summary).strip(),
-            "content": entity.content or summary,
+            "content": _first_content(entity.content, entity.metadata.get("content"), summary),
         }
     )
     return entity_embedding_text(persisted)

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -1445,6 +1445,51 @@ async def test_native_embedding_backfill_accepts_hydrated_storage_defaults() -> 
 
 
 @pytest.mark.asyncio
+async def test_native_embedding_backfill_accepts_metadata_content_fallback() -> None:
+    client = SurrealGraphClient(group_id="org-native-meta-content", url="memory://")
+    provider = DeterministicEmbeddingProvider(
+        EmbeddingMetadata(
+            provider="deterministic",
+            model="unit-test",
+            dimensions=1024,
+            cache_namespace="native-meta-content-test",
+            tokenizer_estimate_method="utf8-byte-length",
+        )
+    )
+    try:
+        await prepare_graph_schema(client)
+        manager = EntityManager(
+            client,
+            group_id=client.group_id,
+            embedding_provider=provider,
+        )
+        # Hydration reads content through metadata when the column is empty
+        # (_first_content), so the original payload must still count as
+        # current: refusing it strands the row unembedded forever, because
+        # no later job carries a matching payload.
+        raw = Entity(
+            id="session_meta_content",
+            entity_type=EntityType.SESSION,
+            name="Session capture",
+            content="",
+            organization_id=client.group_id,
+            metadata={"projection_kind": "session", "content": "stashed body in metadata"},
+        )
+        await manager.create_direct_bulk((raw,), generate_embeddings=False)
+
+        original_ids = await manager.backfill_embeddings_if_current((raw,))
+        hydrated = await manager.get(raw.id)
+        hydrated_ids = await manager.backfill_embeddings_if_current((hydrated,))
+        stored = await manager.get(raw.id)
+    finally:
+        await client.close()
+
+    assert original_ids == [raw.id]
+    assert hydrated_ids == [raw.id]
+    assert stored.embedding
+
+
+@pytest.mark.asyncio
 async def test_native_relationship_bulk_persists_edges_readable_after_write() -> None:
     # Regression guard for the bulk relates_to upsert path: it must execute and
     # persist edges that are then readable (the prior unit test used a fake client


### PR DESCRIPTION
## Why

Task `85c4dc53`: requeued `embed_entities` jobs failed with `partial entity embedding backfill; missing current entities: <ids>` while the entities API returned 200 for those exact ids (2026-07-21 benchmark corpus build, insert ~42/100 during inline drain). The failure cost corpus rebuilds and forced the inline-embeddings workaround (`defer_embeddings=false`) for benchmark corpora.

An empirical repro matrix against an embedded store isolated two independent mechanisms, both producing the exact field signature:

1. **Emulation gap 🧪** An entity persisted with an empty `content` column and a `metadata["content"]` body false-negatives on every drain of its original payload. Hydration reads content through `_first_content(row.content, metadata.content, row.summary)`; the fence's storage-normalization emulation (`_persisted_entity_embedding_text`) skipped the metadata fallback and jumped to summary. Such rows can never match, so their embeddings never land: no later job carries a matching payload.
2. **Refusal conflated with absence ⚡** Operational projection ids are stable, so overlapping captures update rows between a job's enqueue and its drain. The currency fence rightly refuses the stale payload (the newer capture's own backfill owns the current text), but the job converted every refusal into a batch-fatal "missing current entities" error, killing the whole batch including rows that embedded fine.

## What

- `sibyl_core/services/graph.py`: `_persisted_entity_embedding_text` now mirrors hydration's `_first_content` chain exactly (content → `metadata["content"]` → summary), which also covers whitespace-only content columns.
- `sibyl/jobs/entities.py`: after a partial backfill, the job splits the refused set with an indexed presence check (`get_many`, which already avoids the `uuid IN $list` planner trap). Present rows are reported as `stale_entity_ids` in the job result with a warning log; only genuinely absent rows raise. Manifest completion proceeds when nothing is absent, because a stale-present row's current text is tracked by the capture that rewrote it.

## Operational notes

- The `entity_embedding_backfill_stale_expectations` warning is the only surface where a future fence-vs-hydration divergence shows up: the raise this PR removes is how the emulation gap was originally noticed. The warning carries the refused entity ids and the group id, and it deserves alert-level attention in log monitoring, not debug-noise treatment. A divergence regression looks like this warning firing steadily for payload shapes that were never rewritten.
- A row PATCHed during a drain can now reach a COMPLETE manifest unembedded: the fence refuses the in-flight payload, the manifest completes, and the update path does not own re-embedding. The generic `entity_ids` arm of `/entities/bulk/requeue-background-jobs` repairs any such row on demand. The update-path embedding-ownership gap pre-exists on main and is tracked as task `6ec73846`.

## Invariants preserved

- The currency fence itself is untouched: stale payloads still never overwrite or resurrect rows (round-3 through round-6 review contract). The atomic `_update_entity_embedding_if_current` write guard is unchanged.
- Absent rows still fail loudly, and a pending manifest stays pending on failure so the requeue path can recover (`test_partial_backfill_leaves_current_manifest_pending`, updated for the presence check).
- Exact-inventory requeue semantics (round-5/6) are untouched; this changes only how the job classifies a refused write.

## Receipts

- `moon run core:check` green (core:test 55s, 4 tasks completed).
- `moon run api:lint api:typecheck api:test` green (18 job-entity tests pass, 1917-suite unaffected).
- Regression tests, three new plus one repurposed:
  - `test_native_embedding_backfill_accepts_metadata_content_fallback` (new; mechanism 1, fails on main)
  - `test_stale_but_present_entity_is_skipped_not_fatal` and `test_stale_but_present_entities_still_complete_a_pending_manifest` (new; mechanism 2 split and its composition with a pending manifest: completion proceeds, warning fires, `stale_entity_ids` populated)
  - `test_absent_entity_fails_the_backfill` (repurposed from `test_stale_entity_payload_cannot_recreate_or_overwrite_rows`; the no-overwrite/no-resurrect invariant it guarded lives on in core's `test_graph.py` fence tests)

## Not done here

- The stale `/tmp/sibyld-3434-nova.log` evidence from the original incident is gone (tmp purge), so the 2026-07-21 event is attributed by mechanism reproduction, not by log replay.
- Six client-side pending writes referencing task ids that no longer exist (same-prefix-different-tail UUIDs) surfaced during verification; that is a separate queue-hygiene defect, reported to the orchestrator rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
