### PR TITLE
fix(api): scope-carrying promotion + passage scope restamp

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -2445,11 +2445,16 @@ async def update_entity(
                 # The body did not change, so the cut is still valid, but the
                 # audience did: spans inherit their reader checks from these
                 # stamps, and a stale copy keeps serving a tightened memory's
-                # text through search until it is refreshed.
+                # text through search until it is refreshed. The managers
+                # enable the failed-write recovery path: this trigger diffs
+                # pre/post stamps, so once the parent carries the new stamps a
+                # partial restamp would never re-fire.
                 await restamp_entity_passages(
                     entity_manager=runtime.entity_manager,
                     source=updated,
                     created_source_id=entity_id,
+                    relationship_manager=runtime.relationship_manager,
+                    group_id=group_id,
                 )
 
             response = EntityResponse(

--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -74,8 +74,10 @@ from sibyl_core.memory_pipeline.structure import strip_structure_metadata
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.projection import (
     MANIFEST_STATE_COMPLETE,
+    entity_scope_stamps,
     extract_projected_memory_entities,
     reproject_entity_passages,
+    restamp_entity_passages,
     retire_entity_passages,
 )
 from sibyl_core.services import KnowledgeReadService
@@ -2439,6 +2441,16 @@ async def update_entity(
                         entity_id=entity_id,
                         errors=passage_result.errors,
                     )
+            elif entity_scope_stamps(existing) != entity_scope_stamps(updated):
+                # The body did not change, so the cut is still valid, but the
+                # audience did: spans inherit their reader checks from these
+                # stamps, and a stale copy keeps serving a tightened memory's
+                # text through search until it is refreshed.
+                await restamp_entity_passages(
+                    entity_manager=runtime.entity_manager,
+                    source=updated,
+                    created_source_id=entity_id,
+                )
 
             response = EntityResponse(
                 id=updated.id,

--- a/apps/api/src/sibyl/jobs/entities.py
+++ b/apps/api/src/sibyl/jobs/entities.py
@@ -23,6 +23,8 @@ from sibyl_core.projection import (
     project_memory_entities,
     project_memory_entity,
     reproject_entity_passages,
+    restamp_entity_passages,
+    scope_bearing_entity_update,
 )
 from sibyl_core.services.graph import get_surreal_graph_runtime
 from sibyl_core.services.surreal_content import MemoryScope
@@ -1398,6 +1400,15 @@ async def update_entity(
                     entity_id=entity_id,
                     errors=passage_result.errors,
                 )
+        elif result is not None and scope_bearing_entity_update(updates):
+            # A scope-only edit leaves the cut valid but changes who may read
+            # the spans; their inherited stamps have to follow the parent or a
+            # tightened memory keeps serving its text through search.
+            await restamp_entity_passages(
+                entity_manager=entity_manager,
+                source=result,
+                created_source_id=entity_id,
+            )
 
         if result:
             # Broadcast update event

--- a/apps/api/src/sibyl/jobs/entities.py
+++ b/apps/api/src/sibyl/jobs/entities.py
@@ -1403,11 +1403,15 @@ async def update_entity(
         elif result is not None and scope_bearing_entity_update(updates):
             # A scope-only edit leaves the cut valid but changes who may read
             # the spans; their inherited stamps have to follow the parent or a
-            # tightened memory keeps serving its text through search.
+            # tightened memory keeps serving its text through search. The
+            # managers enable the failed-write recovery path: a later retrigger
+            # never comes because the parent already carries the new stamps.
             await restamp_entity_passages(
                 entity_manager=entity_manager,
                 source=result,
                 created_source_id=entity_id,
+                relationship_manager=runtime.relationship_manager,
+                group_id=group_id,
             )
 
         if result:

--- a/apps/api/src/sibyl/jobs/raw_promotion.py
+++ b/apps/api/src/sibyl/jobs/raw_promotion.py
@@ -28,6 +28,7 @@ from sibyl.persistence.content_runtime import (
     save_document_chunks,
 )
 from sibyl.persistence.graph_runtime import get_entity_graph_runtime
+from sibyl_core.auth.memory_policy import MEMORY_OWNER_METADATA_KEYS
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.models.sources import SourceImportManifest
 from sibyl_core.observability import elapsed_ms
@@ -76,7 +77,6 @@ async def promote_raw_captures(
         "skipped_superseded_count": 0,
         "skipped_existing_count": 0,
         "skipped_review_count": 0,
-        "skipped_scope_count": 0,
         "failed_count": 0,
         "chunk_count": 0,
         "raw_memory_ids": [],
@@ -109,15 +109,14 @@ async def promote_raw_captures(
             result["promoted_count"] += 1
             result["chunk_count"] += outcome["chunk_count"]
             result["raw_memory_ids"].append(memory.id)
-            result["document_ids"].append(outcome["document_id"])
+            if outcome["document_id"] is not None:
+                result["document_ids"].append(outcome["document_id"])
         elif outcome["status"] == "skipped_deleted":
             result["skipped_deleted_count"] += 1
         elif outcome["status"] == "skipped_superseded":
             result["skipped_superseded_count"] += 1
         elif outcome["status"] == "skipped_existing":
             result["skipped_existing_count"] += 1
-        elif outcome["status"] == "skipped_scope":
-            result["skipped_scope_count"] += 1
         else:
             result["skipped_review_count"] += 1
 
@@ -162,60 +161,75 @@ async def _promote_one(
         return {"status": skip_status, "chunk_count": 0}
 
     document = _document_from_raw_memory(memory)
-    chunks = chunker.chunk_document(document, strategy=_chunk_strategy(memory))
-    if not chunks:
-        raise ValueError("raw capture produced no chunks")
+    scope_restricted = _memory_scope_restricted(memory)
 
-    embeddings = await embedder.embed_chunks(chunks)
-    if len(embeddings) != len(chunks):
-        msg = f"embedding count mismatch: {len(embeddings)} for {len(chunks)} chunks"
-        raise ValueError(msg)
+    if scope_restricted:
+        # The document/chunk store is searched org-wide with no per-row scope
+        # filter, so writing a scoped capture's text there re-opens the leak
+        # this promotion path closes. The capture promotes to the graph only:
+        # its anchor entity and extraction both carry the scope stamps, and
+        # the raw layer already serves the text to its authorized audience.
+        stored_document = document
+        saved_chunk_count = 0
+    else:
+        chunks = chunker.chunk_document(document, strategy=_chunk_strategy(memory))
+        if not chunks:
+            raise ValueError("raw capture produced no chunks")
 
-    db_chunks = [
-        DocumentChunkRecord(
-            id=uuid5(NAMESPACE_URL, f"sibyl.raw_promotion:{memory.id}:{chunk.chunk_index}"),
-            document_id=document.id,
-            organization_id=document.organization_id,
-            source_id=memory.source_id,
-            chunk_index=chunk.chunk_index,
-            chunk_type=chunk.chunk_type,
-            content=chunk.content,
-            context=chunk.context,
-            token_count=chunk.token_count,
-            start_char=chunk.start_char,
-            end_char=chunk.end_char,
-            heading_path=chunk.heading_path,
-            language=chunk.language,
-            embedding=embeddings[index],
-            is_complete=True,
-            has_entities=False,
-            entity_ids=[],
-        )
-        for index, chunk in enumerate(chunks)
-    ]
+        embeddings = await embedder.embed_chunks(chunks)
+        if len(embeddings) != len(chunks):
+            msg = f"embedding count mismatch: {len(embeddings)} for {len(chunks)} chunks"
+            raise ValueError(msg)
 
-    async with get_content_read_session() as session:
-        stored_document = await save_crawled_document_record(session, document=document)
-        await delete_document_chunks_for_document(
-            session,
-            document_id=stored_document.id,
-            organization_id=stored_document.organization_id,
-        )
-        saved_chunks = await save_document_chunks(session, chunks=db_chunks)
+        db_chunks = [
+            DocumentChunkRecord(
+                id=uuid5(NAMESPACE_URL, f"sibyl.raw_promotion:{memory.id}:{chunk.chunk_index}"),
+                document_id=document.id,
+                organization_id=document.organization_id,
+                source_id=memory.source_id,
+                chunk_index=chunk.chunk_index,
+                chunk_type=chunk.chunk_type,
+                content=chunk.content,
+                context=chunk.context,
+                token_count=chunk.token_count,
+                start_char=chunk.start_char,
+                end_char=chunk.end_char,
+                heading_path=chunk.heading_path,
+                language=chunk.language,
+                embedding=embeddings[index],
+                is_complete=True,
+                has_entities=False,
+                entity_ids=[],
+            )
+            for index, chunk in enumerate(chunks)
+        ]
+
+        async with get_content_read_session() as session:
+            stored_document = await save_crawled_document_record(session, document=document)
+            await delete_document_chunks_for_document(
+                session,
+                document_id=stored_document.id,
+                organization_id=stored_document.organization_id,
+            )
+            saved_chunks = await save_document_chunks(session, chunks=db_chunks)
+        saved_chunk_count = len(saved_chunks)
 
     entity_id = await _upsert_document_entity(
-        memory, stored_document, chunk_count=len(saved_chunks)
+        memory, stored_document, chunk_count=saved_chunk_count
     )
     promoted_at = datetime.now(UTC).isoformat()
     metadata = dict(memory.metadata)
     metadata.update(
         {
             "raw_promotion_state": "promoted",
-            "raw_promotion_document_id": str(stored_document.id),
-            "raw_promotion_chunk_count": len(saved_chunks),
+            "raw_promotion_chunk_count": saved_chunk_count,
             "raw_promotion_promoted_at": promoted_at,
         }
     )
+    if scope_restricted:
+        metadata["raw_promotion_content_store"] = "skipped_scoped"
+    else:
+        metadata["raw_promotion_document_id"] = str(stored_document.id)
     metadata.update(
         await _source_extraction_metadata(
             memory,
@@ -229,8 +243,8 @@ async def _promote_one(
     await save_raw_memory(memory)
     return {
         "status": "promoted",
-        "document_id": str(stored_document.id),
-        "chunk_count": len(saved_chunks),
+        "document_id": None if scope_restricted else str(stored_document.id),
+        "chunk_count": saved_chunk_count,
         "entity_id": entity_id,
     }
 
@@ -299,7 +313,43 @@ def _chunk_strategy(memory: RawMemory) -> ChunkStrategy:
     return ChunkStrategy.SEMANTIC
 
 
-_PROMOTABLE_MEMORY_SCOPES = frozenset({MemoryScope.ORGANIZATION, MemoryScope.PUBLIC})
+# Org-wide audiences read through the absent-scope contract: the graph read
+# path admits private/project/team/delegated stamps and denies everything
+# else, so an organization or public row is readable BECAUSE it is unstamped.
+# Stamping one would revoke every reader it has.
+_ORG_WIDE_MEMORY_SCOPES = frozenset({MemoryScope.ORGANIZATION, MemoryScope.PUBLIC})
+
+
+def _memory_scope_restricted(memory: RawMemory) -> bool:
+    return memory.memory_scope not in _ORG_WIDE_MEMORY_SCOPES
+
+
+def _promotion_scope_metadata(memory: RawMemory) -> dict[str, object]:
+    """The scope stamps a promoted row inherits from its capture.
+
+    Values come from the capture's own authorized columns, never a payload, so
+    this is the trusted-job counterpart of stamp_memory_scope_metadata: the
+    capture already proved it may live at this scope, and promotion's whole
+    contract is to preserve that audience rather than re-derive it.
+
+    Org-wide captures return no stamps on purpose (see the frozenset above).
+    """
+    if not _memory_scope_restricted(memory):
+        return {}
+    stamps: dict[str, object] = {"memory_scope": memory.memory_scope.value}
+    if memory.principal_id:
+        stamps["principal_id"] = memory.principal_id
+    if memory.memory_scope is not MemoryScope.PRIVATE and memory.scope_key:
+        stamps["scope_key"] = memory.scope_key
+    if memory.memory_scope is MemoryScope.PROJECT and memory.scope_key:
+        # The read path treats project_id as the audience channel; mirroring
+        # the key is what the extraction projection does for project scope.
+        stamps["project_id"] = memory.scope_key
+    elif memory.project_id:
+        stamps["project_id"] = memory.project_id
+    if memory.agent_id:
+        stamps["agent_id"] = memory.agent_id
+    return stamps
 
 
 def _promotion_skip_status(memory: RawMemory, *, force: bool) -> str | None:
@@ -307,8 +357,6 @@ def _promotion_skip_status(memory: RawMemory, *, force: bool) -> str | None:
         return "skipped_deleted"
     if _raw_memory_superseded(memory):
         return "skipped_superseded"
-    if memory.memory_scope not in _PROMOTABLE_MEMORY_SCOPES:
-        return "skipped_scope"
     if not force and memory.metadata.get("raw_promotion_state") == "promoted" and memory.entity_id:
         return "skipped_existing"
     if not raw_memory_currently_recallable(memory):
@@ -349,6 +397,7 @@ async def _upsert_document_entity(
                 "source_id": memory.source_id,
                 "document_id": str(document.id),
                 "chunk_count": chunk_count,
+                **_promotion_scope_metadata(memory),
             },
         ),
         generate_embedding=False,
@@ -648,15 +697,23 @@ def _memory_extraction_source_payload(
     *,
     entity_id: str,
 ) -> dict[str, object]:
+    base_metadata = {
+        key: value
+        for key, value in dict(memory.metadata).items()
+        if key not in MEMORY_OWNER_METADATA_KEYS
+    }
     metadata = {
-        **dict(memory.metadata),
+        **base_metadata,
         "raw_memory_id": memory.id,
         "source_id": memory.source_id,
         "document_id": str(document.id),
-        "memory_scope": memory.memory_scope.value,
-        "scope_key": memory.scope_key,
-        "principal_id": memory.principal_id,
         "capture_surface": memory.capture_surface,
+        # The extraction projection inherits these onto every entity it mints,
+        # so the stamps here decide who may read the extracted knowledge. An
+        # org-wide capture stays unstamped: an inherited "organization" stamp
+        # would be denied by the read path, which admits only
+        # private/project/team/delegated and reads org-wide as absence.
+        **_promotion_scope_metadata(memory),
     }
     return {
         "id": entity_id,

--- a/apps/api/tests/test_jobs_raw_promotion.py
+++ b/apps/api/tests/test_jobs_raw_promotion.py
@@ -200,13 +200,34 @@ async def test_promote_raw_captures_writes_chunks_and_graph_entity(
 
 
 @pytest.mark.asyncio
-async def test_promote_raw_captures_skips_private_memories_without_materializing(
+async def test_promote_raw_captures_promotes_a_private_memory_graph_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    memory = _raw_memory(memory_scope=MemoryScope.PRIVATE)
+    """A private capture reaches the graph carrying its scope, never the doc store.
 
-    async def fail_save_memory(_memory: RawMemory) -> RawMemory:
-        raise AssertionError("private raw memories should not be marked or materialized")
+    The document/chunk store is searched org-wide with no per-row scope filter,
+    so a scoped capture's text must not land there; refusing to promote at all
+    was the old behavior and it silently stranded every scoped capture.
+    """
+    memory = _raw_memory(memory_scope=MemoryScope.PRIVATE)
+    saved_memories: list[RawMemory] = []
+    created_entities = []
+
+    async def fail_content_store(*_args: object, **_kwargs: object):
+        raise AssertionError("a scoped capture must not touch the shared document store")
+
+    async def fake_save_memory(updated: RawMemory) -> RawMemory:
+        saved_memories.append(updated)
+        return updated
+
+    class FakeEntityManager:
+        async def create_direct(self, entity, *, generate_embedding: bool = False):
+            created_entities.append(entity)
+            return entity.id
+
+    async def fake_graph_runtime(group_id: str):
+        assert group_id == memory.organization_id
+        return SimpleNamespace(entity_manager=FakeEntityManager())
 
     monkeypatch.setattr(
         raw_promotion,
@@ -214,14 +235,51 @@ async def test_promote_raw_captures_skips_private_memories_without_materializing
         _list_memories([memory]),
     )
     monkeypatch.setattr(raw_promotion, "EmbeddingService", _fake_embedder)
-    monkeypatch.setattr(raw_promotion, "save_raw_memory", fail_save_memory)
+    monkeypatch.setattr(raw_promotion, "save_crawled_document_record", fail_content_store)
+    monkeypatch.setattr(raw_promotion, "delete_document_chunks_for_document", fail_content_store)
+    monkeypatch.setattr(raw_promotion, "save_document_chunks", fail_content_store)
+    monkeypatch.setattr(raw_promotion, "get_entity_graph_runtime", fake_graph_runtime)
+    monkeypatch.setattr(raw_promotion, "save_raw_memory", fake_save_memory)
+    monkeypatch.setattr(raw_promotion.settings, "auto_extract_entities", False)
 
     result = await raw_promotion.promote_raw_captures({}, memory.organization_id)
 
-    assert result["promoted_count"] == 0
-    assert result["skipped_scope_count"] == 1
+    assert result["promoted_count"] == 1
     assert result["failed_count"] == 0
     assert result["document_ids"] == []
+    entity = created_entities[0]
+    assert entity.metadata["memory_scope"] == "private"
+    assert entity.metadata["principal_id"] == "user-1"
+    assert "scope_key" not in entity.metadata
+    marked = saved_memories[-1]
+    assert marked.entity_id == memory.id
+    assert marked.metadata["raw_promotion_state"] == "promoted"
+    assert marked.metadata["raw_promotion_content_store"] == "skipped_scoped"
+    assert marked.metadata["raw_promotion_chunk_count"] == 0
+    assert "raw_promotion_document_id" not in marked.metadata
+
+
+def test_promotion_scope_stamps_by_scope() -> None:
+    org_wide = _raw_memory(memory_scope=MemoryScope.ORGANIZATION)
+    assert raw_promotion._promotion_scope_metadata(org_wide) == {}
+
+    public = _raw_memory(memory_scope=MemoryScope.PUBLIC)
+    assert raw_promotion._promotion_scope_metadata(public) == {}
+
+    project = _raw_memory(memory_scope=MemoryScope.PROJECT)
+    project.scope_key = "project_x"
+    stamps = raw_promotion._promotion_scope_metadata(project)
+    assert stamps["memory_scope"] == "project"
+    assert stamps["scope_key"] == "project_x"
+    # The read path treats project_id as the audience channel.
+    assert stamps["project_id"] == "project_x"
+    assert stamps["principal_id"] == "user-1"
+
+    team = _raw_memory(memory_scope=MemoryScope.TEAM)
+    team.scope_key = "team_y"
+    team_stamps = raw_promotion._promotion_scope_metadata(team)
+    assert team_stamps["memory_scope"] == "team"
+    assert team_stamps["scope_key"] == "team_y"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_routes_entities_write.py
+++ b/apps/api/tests/test_routes_entities_write.py
@@ -1929,10 +1929,11 @@ def _spanned_memory_entity(*, owner: str, content: str = _SPANNED_BODY) -> Simpl
 def _update_patches(runtime: SimpleNamespace, *, passages: int = 0):
     """Enter the auth and runtime patches an update route call needs.
 
-    Yields the reprojection mock, because the re-cut firing on the request path
-    is itself part of the contract under test.
+    Yields the reprojection and restamp mocks, because which of the two fires
+    on the request path is itself part of the contract under test.
     """
     reproject = AsyncMock(return_value=SimpleNamespace(errors=(), passages=passages))
+    restamp = AsyncMock(return_value=0)
     with ExitStack() as stack:
         for context in (
             patch("sibyl.locks.entity_lock", _locked_entity),
@@ -1947,9 +1948,10 @@ def _update_patches(runtime: SimpleNamespace, *, passages: int = 0):
             ),
             patch("sibyl.api.routes.entities.broadcast_event", AsyncMock()),
             patch("sibyl.api.routes.entities.reproject_entity_passages", reproject),
+            patch("sibyl.api.routes.entities.restamp_entity_passages", restamp),
         ):
             stack.enter_context(context)
-        yield reproject
+        yield reproject, restamp
 
 
 @pytest.mark.asyncio
@@ -2051,7 +2053,7 @@ async def test_update_entity_nulls_a_withdrawn_plan_because_merge_cannot_delete(
         relationship_manager=SimpleNamespace(),
     )
 
-    with _update_patches(runtime) as reproject:
+    with _update_patches(runtime) as (reproject, _restamp):
         await update_entity(
             entity_id="decision_spanned",
             update=EntityUpdate(content="a completely rewritten body"),
@@ -2282,6 +2284,70 @@ async def test_update_entity_cannot_have_a_plan_planted_through_metadata() -> No
     written = runtime.entity_manager.update.await_args.args[1]["metadata"]
     assert written["note"] == "kept"
     assert "probe_rehearsal" not in written
+
+
+@pytest.mark.asyncio
+async def test_update_entity_restamps_spans_when_only_the_scope_changed() -> None:
+    """A scope-only edit must refresh span stamps without re-cutting the body."""
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _spanned_memory_entity(owner=owner)
+    updated = _spanned_memory_entity(owner=owner)
+    updated.metadata = {
+        **updated.metadata,
+        "memory_scope": "project",
+        "scope_key": "project_x",
+    }
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=updated),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime) as (reproject, restamp):
+        await update_entity(
+            entity_id="decision_spanned",
+            update=EntityUpdate(metadata={"note": "cosmetic"}),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    reproject.assert_not_awaited()
+    restamp.assert_awaited_once()
+    assert restamp.await_args.kwargs["source"] is updated
+
+
+@pytest.mark.asyncio
+async def test_update_entity_leaves_spans_alone_when_stamps_are_unchanged() -> None:
+    org = _org()
+    ctx = _ctx()
+    owner = str(ctx.user.id)
+    existing = _spanned_memory_entity(owner=owner)
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=existing),
+            update=AsyncMock(return_value=existing),
+        ),
+        relationship_manager=SimpleNamespace(),
+    )
+
+    with _update_patches(runtime) as (reproject, restamp):
+        await update_entity(
+            entity_id="decision_spanned",
+            update=EntityUpdate(metadata={"note": "cosmetic"}),
+            request=_request(),
+            org=org,
+            ctx=ctx,
+            content_session=None,
+        )
+
+    reproject.assert_not_awaited()
+    restamp.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/packages/python/sibyl-core/src/sibyl_core/projection/__init__.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/__init__.py
@@ -25,11 +25,14 @@ from sibyl_core.projection.passages import (
     PASSAGE_MIN_SOURCE_CHARS,
     PASSAGE_SOURCE_TYPES,
     PassageProjectionResult,
+    entity_scope_stamps,
     passage_entity_id,
     plan_entity_passages,
     project_entity_passages,
     reproject_entity_passages,
+    restamp_entity_passages,
     retire_entity_passages,
+    scope_bearing_entity_update,
     should_project_passages,
 )
 
@@ -45,6 +48,7 @@ __all__ = [
     "ProjectedEntitySourceLink",
     "ProjectedMemoryEntity",
     "ProjectedMemoryFact",
+    "entity_scope_stamps",
     "extract_projected_memory_entities",
     "extract_projected_memory_facts",
     "operational_experience_manifest_id",
@@ -58,6 +62,8 @@ __all__ = [
     "project_memory_entity",
     "project_operational_experience",
     "reproject_entity_passages",
+    "restamp_entity_passages",
     "retire_entity_passages",
+    "scope_bearing_entity_update",
     "should_project_passages",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -13,6 +13,7 @@ reader that finds a passage can always widen to the memory it came from.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -90,6 +91,11 @@ _SCOPE_METADATA_KEYS = (
     "source_id",
     "raw_source_id",
 )
+
+# The subset of an entity update that changes who may read its spans. A caller
+# that sees any of these in an update must refresh the spans' inherited stamps
+# even though the body, and therefore the cut, is unchanged.
+SCOPE_BEARING_UPDATE_KEYS = frozenset(_SCOPE_METADATA_KEYS)
 
 
 @dataclass(frozen=True, slots=True)
@@ -418,6 +424,103 @@ async def reproject_entity_passages(
     return result
 
 
+def scope_bearing_entity_update(updates: Mapping[str, Any]) -> bool:
+    """Whether this update names any field the spans' scope stamps inherit.
+
+    Presence-based rather than change-based because most callers hold only the
+    post-update row. Firing on presence is safe: the restamp itself compares
+    stamps before writing, so a no-op trigger costs reads, never writes.
+    """
+    if any(key in updates for key in SCOPE_BEARING_UPDATE_KEYS):
+        return True
+    metadata = updates.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return False
+    return any(key in metadata for key in SCOPE_BEARING_UPDATE_KEYS)
+
+
+def entity_scope_stamps(entity: Entity) -> dict[str, object | None]:
+    """The scope-stamp projection of one entity, absent keys as None.
+
+    None is deliberate: a stamp the parent no longer carries has to be removed
+    from its spans, and update MERGE semantics express removal as an explicit
+    None, so this shape feeds both the comparison and the write.
+    """
+    metadata = entity.metadata or {}
+    return {key: metadata.get(key) for key in _SCOPE_METADATA_KEYS}
+
+
+async def restamp_entity_passages(
+    *,
+    entity_manager: Any,
+    source: Entity,
+    created_source_id: str | None = None,
+) -> int:
+    """Refresh the inherited scope stamps on existing spans after a scope edit.
+
+    A scope-only edit leaves the body, and therefore the cut, valid: the spans'
+    text is current and their embeddings still describe it, so re-projecting
+    would pay a full re-cut and re-embed to fix a few metadata fields. This
+    walks the deterministic span ids instead and rewrites only the stamps, and
+    only on spans whose stamps actually differ.
+
+    The walk covers every possible index rather than stopping at the first
+    absence, because the oversize-leaf branch of the cutter can skip an index
+    and a stale-scope span past the gap is exactly the row this exists to fix.
+
+    Removal has one known soft spot: the row's ``attributes.metadata`` snapshot
+    is not rewritten by an update, so a key this pass removes can resurface in
+    reads merged from the snapshot. That cannot widen access: a private row's
+    reader check keys on ``principal_id`` before any resurrected ``scope_key``,
+    and a resurrected ``memory_scope`` fails closed, never open.
+    """
+    get = getattr(entity_manager, "get", None)
+    update = getattr(entity_manager, "update", None)
+    if not callable(get) or not callable(update):
+        return 0
+
+    source_id = created_source_id or source.id
+    wanted = entity_scope_stamps(source)
+    restamped = 0
+    for index in range(MAX_PASSAGES_PER_SOURCE):
+        passage_id = passage_entity_id(source_id, index)
+        try:
+            passage = await get(passage_id)
+        except KeyError:
+            continue
+        except Exception as exc:
+            log.warning(
+                "passage_scope_restamp_read_failed",
+                source_id=source_id,
+                passage_id=passage_id,
+                error_type=type(exc).__name__,
+            )
+            continue
+        if passage is None:
+            continue
+        current = {key: (passage.metadata or {}).get(key) for key in _SCOPE_METADATA_KEYS}
+        if current == wanted:
+            continue
+        try:
+            await update(passage_id, {"metadata": dict(wanted)})
+        except Exception as exc:
+            log.warning(
+                "passage_scope_restamp_write_failed",
+                source_id=source_id,
+                passage_id=passage_id,
+                error_type=type(exc).__name__,
+            )
+            continue
+        restamped += 1
+    if restamped:
+        log.info(
+            "passage_scope_restamped",
+            source_id=source_id,
+            restamped=restamped,
+        )
+    return restamped
+
+
 async def retire_entity_passages(
     *,
     entity_manager: Any,
@@ -604,12 +707,16 @@ __all__ = [
     "PASSAGE_PLAN_MECHANICAL",
     "PASSAGE_PROJECTION_KIND",
     "PASSAGE_SOURCE_TYPES",
+    "SCOPE_BEARING_UPDATE_KEYS",
     "PassageProjectionResult",
+    "entity_scope_stamps",
     "passage_entity_id",
     "plan_entity_passages",
     "project_entity_passages",
     "reproject_entity_passages",
+    "restamp_entity_passages",
     "retire_entity_passages",
+    "scope_bearing_entity_update",
     "should_project_passages",
     "spans_cover_parent",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -455,6 +455,8 @@ async def restamp_entity_passages(
     entity_manager: Any,
     source: Entity,
     created_source_id: str | None = None,
+    relationship_manager: Any | None = None,
+    group_id: str | None = None,
 ) -> int:
     """Refresh the inherited scope stamps on existing spans after a scope edit.
 
@@ -468,6 +470,14 @@ async def restamp_entity_passages(
     absence, because the oversize-leaf branch of the cutter can skip an index
     and a stale-scope span past the gap is exactly the row this exists to fix.
 
+    A failed span write cannot be left to a retry that will never come: once
+    the parent carries the new stamps, the trigger's pre/post diff is empty on
+    every later edit, so a partially-restamped set would persist indefinitely.
+    When any write fails and the caller supplied ``relationship_manager`` and
+    ``group_id``, the walk stops and full reprojection runs as the recovery
+    path: it rebuilds every span from the parent with correct stamps and
+    retires whatever the failed writes left behind.
+
     Removal has one known soft spot: the row's ``attributes.metadata`` snapshot
     is not rewritten by an update, so a key this pass removes can resurface in
     reads merged from the snapshot. That cannot widen access: a private row's
@@ -479,9 +489,11 @@ async def restamp_entity_passages(
     if not callable(get) or not callable(update):
         return 0
 
+    recovery_available = relationship_manager is not None and group_id is not None
     source_id = created_source_id or source.id
     wanted = entity_scope_stamps(source)
     restamped = 0
+    write_failed = False
     for index in range(MAX_PASSAGES_PER_SOURCE):
         passage_id = passage_entity_id(source_id, index)
         try:
@@ -510,8 +522,30 @@ async def restamp_entity_passages(
                 passage_id=passage_id,
                 error_type=type(exc).__name__,
             )
+            write_failed = True
+            if recovery_available:
+                break
             continue
         restamped += 1
+    if write_failed and recovery_available:
+        log.warning(
+            "passage_scope_restamp_recovering_via_reprojection",
+            source_id=source_id,
+        )
+        result = await reproject_entity_passages(
+            entity_manager=entity_manager,
+            relationship_manager=relationship_manager,
+            source=source,
+            group_id=str(group_id),
+            created_source_id=source_id,
+        )
+        if result.errors:
+            log.warning(
+                "passage_scope_restamp_recovery_failed",
+                source_id=source_id,
+                errors=result.errors,
+            )
+        return result.passages
     if restamped:
         log.info(
             "passage_scope_restamped",

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -1983,6 +1983,10 @@ def entity_from_surreal_row(row: Mapping[str, object]) -> Entity:
 
     for key in (
         "project_id",
+        # The scope column is authoritative when attributes lost the stamp: a
+        # row whose scope lives only in the column would otherwise parse as
+        # unscoped and hand the read path its fail-open.
+        "memory_scope",
         "epic_id",
         "parent_task_id",
         "task_id",

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -743,6 +743,43 @@ def test_entity_from_surreal_row_preserves_native_policy_metadata() -> None:
     assert "category" not in entity.metadata
 
 
+def test_entity_from_surreal_row_reads_a_column_only_scope() -> None:
+    """A row whose scope lives only in the column must not parse as unscoped.
+
+    The read path checks metadata, so dropping the column here handed a
+    column-only private row to the fail-open and served it org-wide.
+    """
+    entity = entity_from_surreal_row(
+        {
+            "id": "entity:decision_column_scope",
+            "uuid": "decision_column_scope",
+            "name": "Column-scoped decision",
+            "entity_type": "decision",
+            "group_id": "org-native",
+            "memory_scope": "private",
+            "attributes": {},
+        }
+    )
+
+    assert entity.metadata["memory_scope"] == "private"
+
+
+def test_entity_from_surreal_row_keeps_the_attribute_scope_over_the_column() -> None:
+    entity = entity_from_surreal_row(
+        {
+            "id": "entity:decision_both_scopes",
+            "uuid": "decision_both_scopes",
+            "name": "Doubly scoped decision",
+            "entity_type": "decision",
+            "group_id": "org-native",
+            "memory_scope": "project",
+            "attributes": {"memory_scope": "private"},
+        }
+    )
+
+    assert entity.metadata["memory_scope"] == "private"
+
+
 def test_entity_from_surreal_row_preserves_content_whitespace() -> None:
     entity = entity_from_surreal_row(
         {

--- a/packages/python/sibyl-core/tests/test_projection_passages.py
+++ b/packages/python/sibyl-core/tests/test_projection_passages.py
@@ -17,6 +17,7 @@ from sibyl_core.projection.passages import (
     PASSAGE_PLAN_AGENT,
     PASSAGE_PLAN_KEY,
     PASSAGE_PLAN_MECHANICAL,
+    PassageProjectionResult,
     passage_entity_id,
     plan_entity_passages,
     project_entity_passages,
@@ -827,3 +828,81 @@ async def test_restamp_reaches_spans_past_an_index_gap() -> None:
     )
 
     assert restamped == survivors
+
+
+@pytest.mark.asyncio
+async def test_a_failed_restamp_write_recovers_through_reprojection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A partial restamp can never re-fire, so recovery must happen now.
+
+    The route trigger diffs pre/post stamp projections; once the parent
+    carries the new stamps that diff is empty on every later edit, and a span
+    the failed write left behind would serve the old audience indefinitely.
+    """
+    from sibyl_core.projection import passages as passages_module
+
+    manager = await _spans_in_store(_project_scoped_source())
+
+    first_span_id = sorted(manager.entities)[0]
+    original_update = manager.update
+
+    async def failing_update(entity_id: str, updates: dict[str, Any]) -> Entity:
+        if entity_id == first_span_id:
+            raise RuntimeError("surreal write refused")
+        return await original_update(entity_id, updates)
+
+    manager.update = failing_update  # type: ignore[method-assign]
+
+    reproject_calls: list[dict[str, Any]] = []
+
+    async def fake_reproject(**kwargs: Any) -> PassageProjectionResult:
+        reproject_calls.append(kwargs)
+        return PassageProjectionResult(source_id=kwargs["created_source_id"], passages=4)
+
+    monkeypatch.setattr(passages_module, "reproject_entity_passages", fake_reproject)
+
+    tightened = _source(metadata={"memory_scope": "private", "principal_id": "user-1"})
+    relationship_manager = _RecordingRelationshipManager()
+
+    restamped = await restamp_entity_passages(
+        entity_manager=manager,
+        source=tightened,
+        created_source_id=_SOURCE_ID,
+        relationship_manager=relationship_manager,
+        group_id=_GROUP,
+    )
+
+    assert len(reproject_calls) == 1
+    recovery = reproject_calls[0]
+    assert recovery["source"] is tightened
+    assert recovery["group_id"] == _GROUP
+    assert recovery["created_source_id"] == _SOURCE_ID
+    assert recovery["relationship_manager"] is relationship_manager
+    assert restamped == 4
+
+
+@pytest.mark.asyncio
+async def test_a_failed_restamp_without_recovery_managers_keeps_walking() -> None:
+    """Callers that cannot reproject still get every span the walk can fix."""
+    manager = await _spans_in_store(_project_scoped_source())
+
+    first_span_id = sorted(manager.entities)[0]
+    original_update = manager.update
+
+    async def failing_update(entity_id: str, updates: dict[str, Any]) -> Entity:
+        if entity_id == first_span_id:
+            raise RuntimeError("surreal write refused")
+        return await original_update(entity_id, updates)
+
+    manager.update = failing_update  # type: ignore[method-assign]
+
+    tightened = _source(metadata={"memory_scope": "private", "principal_id": "user-1"})
+
+    restamped = await restamp_entity_passages(
+        entity_manager=manager,
+        source=tightened,
+        created_source_id=_SOURCE_ID,
+    )
+
+    assert restamped == len(manager.entities) - 1

--- a/packages/python/sibyl-core/tests/test_projection_passages.py
+++ b/packages/python/sibyl-core/tests/test_projection_passages.py
@@ -21,7 +21,9 @@ from sibyl_core.projection.passages import (
     plan_entity_passages,
     project_entity_passages,
     reproject_entity_passages,
+    restamp_entity_passages,
     retire_entity_passages,
+    scope_bearing_entity_update,
     should_project_passages,
 )
 
@@ -692,3 +694,136 @@ def test_a_withdrawn_plan_in_a_stale_snapshot_is_not_read_back() -> None:
     assert all(
         passage.metadata[PASSAGE_PLAN_KEY] == PASSAGE_PLAN_MECHANICAL for passage in entities
     )
+
+
+class _ScopedStoreEntityManager:
+    """Get/update over a dict of entities, mirroring update MERGE semantics."""
+
+    def __init__(self, entities: dict[str, Entity]) -> None:
+        self.entities = dict(entities)
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+
+    async def get(self, entity_id: str) -> Entity:
+        try:
+            return self.entities[entity_id]
+        except KeyError:
+            raise KeyError(entity_id) from None
+
+    async def update(self, entity_id: str, updates: dict[str, Any]) -> Entity:
+        self.updates.append((entity_id, updates))
+        entity = self.entities[entity_id]
+        metadata = dict(entity.metadata or {})
+        for key, value in (updates.get("metadata") or {}).items():
+            if value is None:
+                metadata.pop(key, None)
+            else:
+                metadata[key] = value
+        updated = entity.model_copy(update={"metadata": metadata})
+        self.entities[entity_id] = updated
+        return updated
+
+
+def _project_scoped_source() -> Entity:
+    return _source(
+        metadata={
+            "memory_scope": "project",
+            "scope_key": "project_x",
+            "project_id": "project_x",
+            "principal_id": "user-1",
+        }
+    )
+
+
+async def _spans_in_store(source: Entity) -> _ScopedStoreEntityManager:
+    entities, _ = plan_entity_passages(source, source_id=_SOURCE_ID, group_id=_GROUP)
+    assert entities
+    return _ScopedStoreEntityManager({entity.id: entity for entity in entities})
+
+
+def test_scope_bearing_update_detection() -> None:
+    assert scope_bearing_entity_update({"memory_scope": "private"}) is True
+    assert scope_bearing_entity_update({"metadata": {"scope_key": "p"}}) is True
+    assert scope_bearing_entity_update({"metadata": {"project_id": None}}) is True
+    assert scope_bearing_entity_update({"name": "renamed"}) is False
+    assert scope_bearing_entity_update({"metadata": {"category": "note"}}) is False
+    assert scope_bearing_entity_update({"content": "new body"}) is False
+
+
+@pytest.mark.asyncio
+async def test_a_tightened_parent_restamps_its_spans_private() -> None:
+    """Tighten parent to private: a stranger's search gate must refuse its spans."""
+    from sibyl_core.auth.memory_policy import memory_metadata_read_allowed
+
+    manager = await _spans_in_store(_project_scoped_source())
+    tightened = _source(
+        metadata={
+            "memory_scope": "private",
+            "principal_id": "user-1",
+        }
+    )
+
+    restamped = await restamp_entity_passages(
+        entity_manager=manager,
+        source=tightened,
+        created_source_id=_SOURCE_ID,
+    )
+
+    assert restamped == len(manager.entities)
+    for span in manager.entities.values():
+        assert span.metadata["memory_scope"] == "private"
+        assert span.metadata["principal_id"] == "user-1"
+        # The project audience the parent left behind must leave the spans too.
+        assert "scope_key" not in span.metadata
+        assert "project_id" not in span.metadata
+        # The gate search and traversal share: owner reads, a stranger does not.
+        assert (
+            memory_metadata_read_allowed(
+                span.metadata,
+                principal_id="user-1",
+                private_scope_granted=True,
+                accessible_projects={"project_x"},
+            )
+            is True
+        )
+        assert (
+            memory_metadata_read_allowed(
+                span.metadata,
+                principal_id="user-2",
+                private_scope_granted=True,
+                accessible_projects={"project_x"},
+            )
+            is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_matching_stamps_are_left_unwritten() -> None:
+    source = _project_scoped_source()
+    manager = await _spans_in_store(source)
+
+    restamped = await restamp_entity_passages(
+        entity_manager=manager,
+        source=source,
+        created_source_id=_SOURCE_ID,
+    )
+
+    assert restamped == 0
+    assert manager.updates == []
+
+
+@pytest.mark.asyncio
+async def test_restamp_reaches_spans_past_an_index_gap() -> None:
+    """The oversize-leaf branch can skip an index; stale rows past it still count."""
+    manager = await _spans_in_store(_project_scoped_source())
+    dropped = passage_entity_id(_SOURCE_ID, 0)
+    del manager.entities[dropped]
+    survivors = len(manager.entities)
+    tightened = _source(metadata={"memory_scope": "private", "principal_id": "user-1"})
+
+    restamped = await restamp_entity_passages(
+        entity_manager=manager,
+        source=tightened,
+        created_source_id=_SOURCE_ID,
+    )
+
+    assert restamped == survivors

--- a/packages/python/sibyl-core/tests/test_search.py
+++ b/packages/python/sibyl-core/tests/test_search.py
@@ -3493,3 +3493,101 @@ def test_node_content_resolution_skips_empty_carriers() -> None:
     attributes: dict[str, object] = {"content": "", "description": ""}
 
     assert search_module._content_for_node(node, attributes) == "node summary"
+
+
+@pytest.mark.asyncio
+async def test_restamped_span_stops_surfacing_through_search() -> None:
+    """Tighten a parent to private: the search lane must drop its spans.
+
+    This runs the real projection cut, the real restamp, and the real retrieval
+    candidate gate end to end, because the unit-level stamp assertions cannot
+    catch a drift between what the restamp writes and what the search lane
+    reads.
+    """
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.projection.passages import plan_entity_passages, restamp_entity_passages
+
+    body_lines = ["# Root", ""]
+    for index in range(6):
+        body_lines.extend([f"## Section {index}", "", " ".join([f"word{index}"] * 60), ""])
+    parent = Entity(
+        id="decision_search_lane",
+        entity_type=EntityType.DECISION,
+        name="A long project decision",
+        description="short blurb",
+        content="\n".join(body_lines),
+        organization_id="org-123",
+        created_by="user-alice",
+        metadata={
+            "memory_scope": "project",
+            "scope_key": "project_123",
+            "project_id": "project_123",
+            "principal_id": "user-alice",
+        },
+    )
+    spans, _ = plan_entity_passages(parent, source_id=parent.id, group_id="org-123")
+    assert spans
+
+    class _StoreManager:
+        def __init__(self, entities: dict[str, Entity]) -> None:
+            self.entities = dict(entities)
+
+        async def get(self, entity_id: str) -> Entity:
+            try:
+                return self.entities[entity_id]
+            except KeyError:
+                raise KeyError(entity_id) from None
+
+        async def update(self, entity_id: str, updates: dict[str, object]) -> Entity:
+            entity = self.entities[entity_id]
+            metadata = dict(entity.metadata or {})
+            for key, value in (updates.get("metadata") or {}).items():  # type: ignore[union-attr]
+                if value is None:
+                    metadata.pop(key, None)
+                else:
+                    metadata[key] = value
+            updated = entity.model_copy(update={"metadata": metadata})
+            self.entities[entity_id] = updated
+            return updated
+
+    manager = _StoreManager({span.id: span for span in spans})
+    span_id = spans[0].id
+
+    def surfaces_for(principal_id: str) -> bool:
+        span = manager.entities[span_id]
+        candidate = search_module._candidate_from_node_record(
+            {
+                "uuid": span.id,
+                "name": span.name,
+                "content": span.content,
+                "group_id": "org-123",
+                "project_id": (span.metadata or {}).get("project_id"),
+                "attributes": dict(span.metadata or {}),
+            },
+            signal=RetrievalSignal.NODE_FULLTEXT,
+            score=1.0,
+        )
+        return search_module._candidate_allowed(
+            candidate,
+            plan=_plan_for(principal_id, "project_123"),
+            requested_types=set(),
+            facet=None,
+        )
+
+    # Before the tighten, a project co-member reads the span.
+    assert surfaces_for("user-bob") is True
+
+    tightened = parent.model_copy(
+        update={"metadata": {"memory_scope": "private", "principal_id": "user-alice"}}
+    )
+    restamped = await restamp_entity_passages(
+        entity_manager=manager,
+        source=tightened,
+        created_source_id=parent.id,
+    )
+    assert restamped == len(spans)
+
+    # After it, the same search-lane gate serves the owner and refuses the
+    # stranger, and the span text never reaches the candidate list for them.
+    assert surfaces_for("user-alice") is True
+    assert surfaces_for("user-bob") is False


### PR DESCRIPTION
## Why

Two holes in the memory-scope surface, both found during 1.2 Track C adjudication:

1. **Scoped captures never reach the graph.** Raw-memory promotion admits only ORGANIZATION/PUBLIC captures (`skipped_scope` for everything else). That interim gate closed the original cross-scope leak by stranding every PRIVATE/PROJECT/TEAM/SHARED/DELEGATED capture outside the graph, which is the functionality regression Bliss rejected in PR #133. This PR replaces refusal with preservation: every scope promotes, and the row carries its audience with it.

2. **Scope-only edits leave stale span stamps.** `reproject_entity_passages` fired only when `content` changed, so tightening a memory to private left its PASSAGE rows carrying the old inherited scope stamps. `fetch_slice` was already closed by parent authorization (#334), but the search path authorizes per-row stamps, so a stale span kept serving a now-private memory's text through search.

Independent security verification: PASS, no reachable cross-scope leak, all five claims confirmed.

## What

**Passage restamp on scope-only edits** (`b410d645` + `3acdec69`, task `037c034a`)

- 💎 `restamp_entity_passages` in `sibyl_core.projection.passages` walks the deterministic span ids and rewrites only the scope stamps, because the body (and therefore the cut and its embeddings) is still valid. Full reprojection would re-embed every span to fix a few metadata fields.
- Both update surfaces trigger it: the PATCH route diffs stamp projections of the pre- and post-update rows; the arq job fires on scope-bearing keys in the update dict (it holds no pre-state, and the restamp's own diff guard makes a false trigger cost reads, never writes).
- **Reachable triggers today:** through the API, the restamp fires on `project_id`/`agent_id`/`source_id` edits, because the PATCH route strips `memory_scope`/`scope_key`/`principal_id` from caller metadata and the arq update job currently has no producers. The full scope-key coverage is defensively placed for future internal writers (scope promotion pipeline, corrections).
- **Failure recovery:** a failed span write cannot wait for a retry that never comes, because once the parent carries the new stamps the route trigger's pre/post diff is empty on every later edit. When any write fails, the walk stops and full reprojection runs as the recovery path, rebuilding every span from the parent with correct stamps and retiring what the failed writes left behind. Callers that cannot reproject keep the walk-and-log behavior.
- Removal is written as explicit `None` because entity updates land as `UPDATE ... MERGE` and omitting a key preserves it. The `attributes.metadata` snapshot resurrection soft spot is analyzed in the helper docstring: it cannot widen access, private reads key on `principal_id` before any resurrected `scope_key`, and a resurrected `memory_scope` fails closed.

**Scope-carrying promotion** (`ef5d7cad`, tasks `4736bf2d` + `a97502ad` folded in)

- Promotion admits every scope. The anchor DOCUMENT entity and the extraction source payload both carry stamps from the capture's authorized columns, so extraction-projected knowledge inherits them and `memory_metadata_read_allowed` (the gate every graph read surface runs) enforces the audience.
- **Org-wide captures stay deliberately unstamped.** The read path admits only private/project/team/delegated stamps and treats absence as org-readable; an `organization` stamp would revoke every reader the row has. The payload builder previously stamped exactly that onto extraction sources, which would have made extracted knowledge from org captures unreadable. It now uses the same helper.
- **Scoped captures skip the shared document/chunk store.** Document search is org-scoped with no per-row scope filter, so writing a scoped capture's text there would re-open the leak through the RAG lane. The capture's text stays served by the raw layer, which already enforces scope. Recorded on the capture as `raw_promotion_content_store=skipped_scoped`.
- `entity_from_surreal_row` folds the `memory_scope` column into parsed metadata when attributes lost the stamp, closing the column-only fail-open (task `a97502ad`).

## Receipts

- `moon run core:check` → 2478 passed, 14 skipped
- `moon run api:test` → 2110 passed, 5 skipped
- `moon run api:lint api:typecheck` → all checks passed
- Regression coverage: tightened parent denies a stranger through the same gate search runs; restamp reaches spans past an index gap; **end-to-end search-lane test** (real cut → real restamp → real retrieval candidate gate: co-member reads before the tighten, is refused after, owner keeps reading); **failed-write recovery** (first span write raises → reprojection observed with the tightened parent); private capture promotes graph-only with stamps and never touches the doc store; org/public stamps stay empty; column-only scope parses closed.

## Blast radius and residuals

- Team/delegated stamps **fail closed** on graph reads: the read path forwards no team or delegation memberships (`memory_metadata_read_allowed` takes `accessible_projects` only). No leak, but team-scoped promoted rows are invisible until membership forwarding lands. This is the "shared auth helper" Track C residual.
- **SHARED-scope captures promote into rows nobody can read**: `authorize_memory_read` has no SHARED branch, so the stamp fails closed for every reader, including the author. This is part of the legacy-scope decision space (task `2f462492`) and is tracked separately; promotion preserving the stamp is what makes the gap observable rather than silently org-wide.
- The 2,845 legacy unscoped rows (task `2f462492`, decision reserved for Bliss) are untouched: they read org-wide today via the fail-open and still do after this PR. Nothing here changes their behavior in either direction.
- The scope backfill writes rows directly through the bulk upsert, bypassing `entity_manager.update`, so a backfill stamp does not trigger the runtime restamp; passages of backfilled parents are covered by the backfill's own pass 2 (project derivation) or remain for the `2f462492` decision.
- `skipped_scope_count` is gone from the promotion result payload; nothing in the repo read it.
- Scoped captures are absent from RAG document search by design (see above); their text remains reachable to its audience through raw-memory search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
