### PR TITLE
feat(bench): expose evidence types and char budget on the live harness

### DIFF
--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -66,6 +66,7 @@ def main(argv: list[str] | None = None) -> int:
             "evidence_composition_mode": args.evidence_composition_mode,
             "evidence_types": list(args.evidence_types),
             "evidence_char_budget": args.evidence_char_budget,
+            "evidence_char_budget_raw_reserve": args.evidence_char_budget_raw_reserve,
             "source_evidence_bundling": args.source_evidence_bundling,
             "neighbor_support_exempt": args.neighbor_support_exempt,
             "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
@@ -149,6 +150,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Bound the composed pack by characters instead of item count, mirroring "
             "the official harness flag. Leave unset for the shipped item-bounded "
             "geometry."
+        ),
+    )
+    parser.add_argument(
+        "--evidence-char-budget-raw-reserve",
+        type=int,
+        default=None,
+        help=(
+            "Reserve this many characters of the budget for the raw evidence lane, "
+            "mirroring the official harness flag. Requires --evidence-char-budget."
         ),
     )
     parser.add_argument(
@@ -302,6 +312,7 @@ def build_run_config(
         "evidence_composition_mode": args.evidence_composition_mode,
         "evidence_types": sorted(args.evidence_types),
         "evidence_char_budget": args.evidence_char_budget,
+        "evidence_char_budget_raw_reserve": args.evidence_char_budget_raw_reserve,
         "source_evidence_bundling": args.source_evidence_bundling,
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,

--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -64,6 +64,8 @@ def main(argv: list[str] | None = None) -> int:
             "retrieval_mode": args.retrieval_mode,
             "retrieval_max_planned_queries": args.max_planned_queries,
             "evidence_composition_mode": args.evidence_composition_mode,
+            "evidence_types": list(args.evidence_types),
+            "evidence_char_budget": args.evidence_char_budget,
             "source_evidence_bundling": args.source_evidence_bundling,
             "neighbor_support_exempt": args.neighbor_support_exempt,
             "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,
@@ -129,6 +131,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--max-context-total-chars", type=int, default=60_000)
     parser.add_argument("--retrieval-mode", choices=("fast", "accurate"), default="accurate")
     parser.add_argument("--max-planned-queries", type=int, default=3)
+    parser.add_argument(
+        "--evidence-types",
+        nargs="+",
+        choices=["passage", "session"],
+        default=["session"],
+        help=(
+            "Entity types the raw evidence lane may retrieve, mirroring the official "
+            "harness flag. Defaults to the shipped whole-state substrate."
+        ),
+    )
+    parser.add_argument(
+        "--evidence-char-budget",
+        type=int,
+        default=None,
+        help=(
+            "Bound the composed pack by characters instead of item count, mirroring "
+            "the official harness flag. Leave unset for the shipped item-bounded "
+            "geometry."
+        ),
+    )
     parser.add_argument(
         "--evidence-composition-mode",
         choices=sorted(EVIDENCE_COMPOSITION_MODES),
@@ -278,6 +300,8 @@ def build_run_config(
         "max_context_chars_per_item": args.max_context_chars_per_item,
         "max_context_total_chars": args.max_context_total_chars,
         "evidence_composition_mode": args.evidence_composition_mode,
+        "evidence_types": sorted(args.evidence_types),
+        "evidence_char_budget": args.evidence_char_budget,
         "source_evidence_bundling": args.source_evidence_bundling,
         "neighbor_support_exempt": args.neighbor_support_exempt,
         "neighbor_trajectory_preserving": args.neighbor_trajectory_preserving,

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -3515,10 +3515,7 @@ class SibylLiveApiMemory(Memory):
             if raw_reserve is not None
             else None
         )
-        if (
-            self.evidence_char_budget_raw_reserve is not None
-            and self.evidence_char_budget is None
-        ):
+        if self.evidence_char_budget_raw_reserve is not None and self.evidence_char_budget is None:
             raise ValueError("evidence_char_budget_raw_reserve requires evidence_char_budget")
         self.context_expansion_max_ratio = _param_context_expansion_ratio(
             memory_params,

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -211,6 +211,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
+        "evidence_char_budget_raw_reserve",
         "evidence_composition_mode",
         "source_evidence_bundling",
         "retrieval_mode",
@@ -719,6 +720,7 @@ def compile_operational_evidence_set(
     mode: str = DEFAULT_EVIDENCE_COMPOSITION_MODE,
     typed_reservation_items: int | None = None,
     char_budget: int | None = None,
+    char_budget_raw_reserve: int | None = None,
     neighbor_support_exempt: bool = DEFAULT_NEIGHBOR_SUPPORT_EXEMPT,
     neighbor_trajectory_preserving: bool = DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING,
     neighbor_support_overflow_items: int = DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS,
@@ -748,6 +750,16 @@ def compile_operational_evidence_set(
             raise ValueError("char_budget must be positive")
         if mode != "shared_relevance":
             msg = f"char_budget is only defined for shared_relevance composition, not {mode!r}"
+            raise ValueError(msg)
+    if char_budget_raw_reserve is not None:
+        if char_budget is None:
+            raise ValueError("char_budget_raw_reserve requires char_budget")
+        if not 0 < char_budget_raw_reserve < char_budget:
+            msg = (
+                f"char_budget_raw_reserve ({char_budget_raw_reserve}) must be positive "
+                f"and below char_budget ({char_budget}); reserving the whole budget "
+                "leaves the reserved note lane no room and stops measuring a partition"
+            )
             raise ValueError(msg)
     max_items = max(1, max_items)
     typed_candidates: list[dict[str, object]] = []
@@ -847,27 +859,57 @@ def compile_operational_evidence_set(
         # The note lane keeps its absolute count inside the budget, but the
         # budget outranks the pin when it cannot hold that many: a lane allowed
         # to overrun the budget is not a budget.
-        reserved, spent = _admit_within_char_budget(
-            ranked_typed[: max(1, requested_reservation)],
-            budget=char_budget,
-            spent=0,
-        )
         ordered_raw = _select_role_complete_raw_evidence(
             ranked_raw,
             budget=len(ranked_raw),
             neighbor_support_exempt=neighbor_support_exempt,
             neighbor_trajectory_preserving=neighbor_trajectory_preserving,
         )
-        selected_raw, spent = _admit_within_char_budget(
-            ordered_raw,
-            budget=char_budget,
-            spent=spent,
-        )
-        overflow, spent = _admit_within_char_budget(
-            ranked_typed[len(reserved) :],
-            budget=char_budget,
-            spent=spent,
-        )
+        if char_budget_raw_reserve is None:
+            reserved, spent = _admit_within_char_budget(
+                ranked_typed[: max(1, requested_reservation)],
+                budget=char_budget,
+                spent=0,
+            )
+            selected_raw, spent = _admit_within_char_budget(
+                ordered_raw,
+                budget=char_budget,
+                spent=spent,
+            )
+            overflow, spent = _admit_within_char_budget(
+                ranked_typed[len(reserved) :],
+                budget=char_budget,
+                spent=spent,
+            )
+        else:
+            # Partitioned admission: the raw lane spends into its own reserve
+            # FIRST, so typed items can never consume the evidence lane's
+            # budget, and prefix-stop on a fat raw candidate costs at most the
+            # reserve rather than the whole pack. Unspent reserve returns to
+            # the shared pool, and each lane's admission stays a contiguous
+            # prefix of its ranking (a continuation with a larger budget
+            # extends the same prefix).
+            selected_raw, raw_spent = _admit_within_char_budget(
+                ordered_raw,
+                budget=char_budget_raw_reserve,
+                spent=0,
+            )
+            reserved, spent = _admit_within_char_budget(
+                ranked_typed[: max(1, requested_reservation)],
+                budget=char_budget,
+                spent=raw_spent,
+            )
+            raw_continuation, spent = _admit_within_char_budget(
+                ordered_raw[len(selected_raw) :],
+                budget=char_budget,
+                spent=spent,
+            )
+            selected_raw = [*selected_raw, *raw_continuation]
+            overflow, spent = _admit_within_char_budget(
+                ranked_typed[len(reserved) :],
+                budget=char_budget,
+                spent=spent,
+            )
         typed_reservation = len(reserved)
         selected = [*reserved, *selected_raw, *overflow]
         selected_chars = spent
@@ -933,6 +975,7 @@ def compile_operational_evidence_set(
         "traversal_admitted_items": len(traversal_admitted),
         "budget_mode": "items" if char_budget is None else "characters",
         "char_budget": char_budget,
+        "char_budget_raw_reserve": char_budget_raw_reserve,
         "selected_chars": selected_chars,
     }
 
@@ -3466,6 +3509,17 @@ class SibylLiveApiMemory(Memory):
             max_context_chars_per_item=self.max_context_chars_per_item,
             max_context_total_chars=self.max_context_total_chars,
         )
+        raw_reserve = memory_params.get("evidence_char_budget_raw_reserve")
+        self.evidence_char_budget_raw_reserve = (
+            _param_int(memory_params, "evidence_char_budget_raw_reserve", 0, minimum=1)
+            if raw_reserve is not None
+            else None
+        )
+        if (
+            self.evidence_char_budget_raw_reserve is not None
+            and self.evidence_char_budget is None
+        ):
+            raise ValueError("evidence_char_budget_raw_reserve requires evidence_char_budget")
         self.context_expansion_max_ratio = _param_context_expansion_ratio(
             memory_params,
             "context_expansion_max_ratio",
@@ -4478,6 +4532,7 @@ class SibylLiveApiMemory(Memory):
             ),
             typed_reservation_items=getattr(self, "typed_reservation_items", None),
             char_budget=char_budget,
+            char_budget_raw_reserve=getattr(self, "evidence_char_budget_raw_reserve", None),
             neighbor_support_exempt=getattr(
                 self,
                 "neighbor_support_exempt",

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -77,6 +77,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "context_expansion_max_ratio",
         "evidence_types",
         "evidence_char_budget",
+        "evidence_char_budget_raw_reserve",
         "evidence_composition_mode",
         "source_evidence_bundling",
         "typed_stream_retrieval",
@@ -475,6 +476,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
         ),
     )
     parser.add_argument(
+        "--evidence-char-budget-raw-reserve",
+        type=int,
+        default=None,
+        help=(
+            "Reserve this many characters of --evidence-char-budget for the raw "
+            "evidence lane, admitted before typed items spend anything. Requires "
+            "--evidence-char-budget; unset reproduces the shared-budget admission."
+        ),
+    )
+    parser.add_argument(
         "--evidence-char-budget",
         type=int,
         default=None,
@@ -718,6 +729,7 @@ def build_memory_config(args: argparse.Namespace) -> dict[str, object]:
         "context_expansion_max_ratio": args.context_expansion_max_ratio,
         "evidence_types": list(args.evidence_types),
         "evidence_char_budget": args.evidence_char_budget,
+        "evidence_char_budget_raw_reserve": args.evidence_char_budget_raw_reserve,
         "evidence_composition_mode": args.evidence_composition_mode,
         "source_evidence_bundling": args.source_evidence_bundling,
         "typed_stream_retrieval": args.typed_stream_retrieval,
@@ -876,6 +888,7 @@ def build_run_plan(
         "max_context_total_chars": args.max_context_total_chars,
         "evidence_types": list(args.evidence_types),
         "evidence_char_budget": args.evidence_char_budget,
+        "evidence_char_budget_raw_reserve": args.evidence_char_budget_raw_reserve,
         "evidence_composition_mode": args.evidence_composition_mode,
         "source_evidence_bundling": args.source_evidence_bundling,
         "typed_stream_retrieval": args.typed_stream_retrieval,

--- a/tools/tests/test_longmemeval_v2_live_retrieval.py
+++ b/tools/tests/test_longmemeval_v2_live_retrieval.py
@@ -269,3 +269,51 @@ def test_prepare_output_resumes_across_a_server_restart(tmp_path: Path) -> None:
             haystack={},
             resume=True,
         )
+
+
+def test_evidence_geometry_flags_thread_into_the_run_config(tmp_path: Path) -> None:
+    from benchmarks.longmemeval_v2_live_retrieval import build_run_config, parse_args
+
+    questions = tmp_path / "questions.json"
+    haystack = tmp_path / "haystack.json"
+    ids = tmp_path / "ids.json"
+    for f in (questions, haystack, ids):
+        f.write_text("[]", encoding="utf-8")
+    trajectories = tmp_path / "trajectories.jsonl"
+    trajectories.write_text("", encoding="utf-8")
+
+    base = [
+        "--api-token-file", str(tmp_path / "tok"),
+        "--project-id", "project_x",
+        "--run-id", "run_x",
+        "--questions", str(questions),
+        "--haystack", str(haystack),
+        "--trajectories", str(trajectories),
+        "--question-ids-file", str(ids),
+        "--output-dir", str(tmp_path / "out"),
+    ]
+
+    defaults = parse_args(base)
+    default_config = build_run_config(
+        defaults,
+        question_ids=[],
+        questions_path=questions,
+        haystack_path=haystack,
+        api_runtime={},
+    )
+    # The shipped geometry is the default: whole-state substrate, item-bounded.
+    assert default_config["evidence_types"] == ["session"]
+    assert default_config["evidence_char_budget"] is None
+
+    armed = parse_args(
+        [*base, "--evidence-types", "passage", "session", "--evidence-char-budget", "16000"]
+    )
+    armed_config = build_run_config(
+        armed,
+        question_ids=[],
+        questions_path=questions,
+        haystack_path=haystack,
+        api_runtime={},
+    )
+    assert armed_config["evidence_types"] == ["passage", "session"]
+    assert armed_config["evidence_char_budget"] == 16000

--- a/tools/tests/test_longmemeval_v2_live_retrieval.py
+++ b/tools/tests/test_longmemeval_v2_live_retrieval.py
@@ -272,7 +272,8 @@ def test_prepare_output_resumes_across_a_server_restart(tmp_path: Path) -> None:
 
 
 def test_evidence_geometry_flags_thread_into_the_run_config(tmp_path: Path) -> None:
-    from benchmarks.longmemeval_v2_live_retrieval import build_run_config, parse_args
+    module = _load_module()
+    armed_char_budget = 16000
 
     questions = tmp_path / "questions.json"
     haystack = tmp_path / "haystack.json"
@@ -283,18 +284,26 @@ def test_evidence_geometry_flags_thread_into_the_run_config(tmp_path: Path) -> N
     trajectories.write_text("", encoding="utf-8")
 
     base = [
-        "--api-token-file", str(tmp_path / "tok"),
-        "--project-id", "project_x",
-        "--run-id", "run_x",
-        "--questions", str(questions),
-        "--haystack", str(haystack),
-        "--trajectories", str(trajectories),
-        "--question-ids-file", str(ids),
-        "--output-dir", str(tmp_path / "out"),
+        "--api-token-file",
+        str(tmp_path / "tok"),
+        "--project-id",
+        "project_x",
+        "--run-id",
+        "run_x",
+        "--questions",
+        str(questions),
+        "--haystack",
+        str(haystack),
+        "--trajectories",
+        str(trajectories),
+        "--question-ids-file",
+        str(ids),
+        "--output-dir",
+        str(tmp_path / "out"),
     ]
 
-    defaults = parse_args(base)
-    default_config = build_run_config(
+    defaults = module.parse_args(base)
+    default_config = module.build_run_config(
         defaults,
         question_ids=[],
         questions_path=questions,
@@ -305,10 +314,17 @@ def test_evidence_geometry_flags_thread_into_the_run_config(tmp_path: Path) -> N
     assert default_config["evidence_types"] == ["session"]
     assert default_config["evidence_char_budget"] is None
 
-    armed = parse_args(
-        [*base, "--evidence-types", "passage", "session", "--evidence-char-budget", "16000"]
+    armed = module.parse_args(
+        [
+            *base,
+            "--evidence-types",
+            "passage",
+            "session",
+            "--evidence-char-budget",
+            str(armed_char_budget),
+        ]
     )
-    armed_config = build_run_config(
+    armed_config = module.build_run_config(
         armed,
         question_ids=[],
         questions_path=questions,
@@ -316,4 +332,4 @@ def test_evidence_geometry_flags_thread_into_the_run_config(tmp_path: Path) -> N
         api_runtime={},
     )
     assert armed_config["evidence_types"] == ["passage", "session"]
-    assert armed_config["evidence_char_budget"] == 16000
+    assert armed_config["evidence_char_budget"] == armed_char_budget

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -5034,6 +5034,7 @@ def test_operational_evidence_set_calibrates_typed_and_raw_score_pools() -> None
         "traversal_admitted_items": 0,
         "budget_mode": "items",
         "char_budget": None,
+        "char_budget_raw_reserve": None,
         "selected_chars": sum(len(str(item["content"])) for item in selected),
     }
 
@@ -6172,6 +6173,7 @@ def test_sibyl_memory_finalize_drains_jobs_before_search() -> None:
                 "traversal_admitted_items": 0,
                 "budget_mode": "items",
                 "char_budget": None,
+        "char_budget_raw_reserve": None,
                 "selected_chars": 0,
             },
             "context_budget": {
@@ -7003,3 +7005,144 @@ def _passage_result(
             "passage_index": passage_index,
         },
     }
+
+
+def test_raw_reserve_cures_fat_head_starvation() -> None:
+    """A fat top-ranked raw candidate must not zero out the evidence lane.
+
+    Without a reserve, prefix-stop admission lets the reserved notes spend
+    first and the fat head then exceeds the remainder, so the raw lane admits
+    nothing (the observed stage-2 slice-screen geometry). With the reserve,
+    the raw lane spends first and the same pool keeps its evidence.
+    """
+    module = _load_memory_module()
+    typed = [
+        {
+            "id": f"note_{index}",
+            "type": "note",
+            "content": "distilled note ".ljust(200, "n"),
+            "metadata": {"longmemeval_v2_trajectory_id": f"nt{index}"},
+        }
+        for index in range(3)
+    ]
+    raw = [
+        {
+            "id": "session_fat",
+            "type": "session",
+            "content": "fat state ".ljust(5_000, "f"),
+            "metadata": {"longmemeval_v2_trajectory_id": "tf"},
+        },
+        {
+            "id": "passage_small",
+            "type": "passage",
+            "content": "small slice ".ljust(400, "p"),
+            "metadata": {"longmemeval_v2_trajectory_id": "tp"},
+        },
+    ]
+
+    starved, starved_meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=8,
+        mode="shared_relevance",
+        char_budget=5_500,
+    )
+    starved_ids = {item["id"] for item in starved}
+    assert "session_fat" not in starved_ids
+    assert "passage_small" not in starved_ids
+
+    cured, cured_meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=8,
+        mode="shared_relevance",
+        char_budget=5_500,
+        char_budget_raw_reserve=5_200,
+    )
+    assert cured_meta["char_budget_raw_reserve"] == 5_200
+    assert cured_meta["selected_chars"] <= 5_500
+    assert any(item["id"] == "session_fat" for item in cured)
+
+
+def test_raw_reserve_returns_unspent_budget_to_the_shared_pool() -> None:
+    module = _load_memory_module()
+    typed = [
+        {
+            "id": f"note_{index}",
+            "type": "note",
+            "content": "typed item ".ljust(300, "t"),
+            "metadata": {"longmemeval_v2_trajectory_id": f"nt{index}"},
+        }
+        for index in range(12)
+    ]
+    raw = [
+        {
+            "id": "passage_only",
+            "type": "passage",
+            "content": "tiny slice ".ljust(500, "p"),
+            "metadata": {"longmemeval_v2_trajectory_id": "tp"},
+        }
+    ]
+
+    selected, meta = module.compile_operational_evidence_set(
+        query="find the field",
+        typed_results=typed,
+        raw_results=raw,
+        max_items=8,
+        mode="shared_relevance",
+        char_budget=6_000,
+        char_budget_raw_reserve=3_000,
+    )
+    assert any(item["id"] == "passage_only" for item in selected)
+    # The raw lane spent 500 of its 3000 reserve; typed overflow must reach
+    # past 3600 (reserve + notes) or the unspent reserve was burned.
+    assert meta["selected_chars"] > 3_600
+    assert meta["selected_chars"] <= 6_000
+    assert meta["selected_chars"] == sum(len(str(item["content"])) for item in selected)
+
+
+def test_raw_reserve_validation() -> None:
+    module = _load_memory_module()
+    typed, raw = _budget_pools(note_chars=200, raw_chars=1_000)
+    with pytest.raises(ValueError, match="requires char_budget"):
+        module.compile_operational_evidence_set(
+            query="q",
+            typed_results=typed,
+            raw_results=raw,
+            max_items=8,
+            mode="shared_relevance",
+            char_budget_raw_reserve=1_000,
+        )
+    with pytest.raises(ValueError, match="below char_budget"):
+        module.compile_operational_evidence_set(
+            query="q",
+            typed_results=typed,
+            raw_results=raw,
+            max_items=8,
+            mode="shared_relevance",
+            char_budget=5_000,
+            char_budget_raw_reserve=5_000,
+        )
+
+
+def test_raw_reserve_none_is_byte_identical_to_the_shipped_budget_path() -> None:
+    module = _load_memory_module()
+    typed, raw = _budget_pools(note_chars=200, raw_chars=1_000)
+    kwargs = {
+        "query": "find the field",
+        "typed_results": typed,
+        "raw_results": raw,
+        "max_items": 8,
+        "mode": "shared_relevance",
+        "char_budget": 3 * 200 + 10 * 1_000,
+    }
+    base_selected, base_meta = module.compile_operational_evidence_set(**kwargs)
+    none_selected, none_meta = module.compile_operational_evidence_set(
+        **kwargs, char_budget_raw_reserve=None
+    )
+    assert [item["id"] for item in base_selected] == [item["id"] for item in none_selected]
+    base_meta.pop("char_budget_raw_reserve")
+    none_meta.pop("char_budget_raw_reserve")
+    assert base_meta == none_meta

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -6173,7 +6173,7 @@ def test_sibyl_memory_finalize_drains_jobs_before_search() -> None:
                 "traversal_admitted_items": 0,
                 "budget_mode": "items",
                 "char_budget": None,
-        "char_budget_raw_reserve": None,
+                "char_budget_raw_reserve": None,
                 "selected_chars": 0,
             },
             "context_budget": {
@@ -7040,13 +7040,15 @@ def test_raw_reserve_cures_fat_head_starvation() -> None:
         },
     ]
 
-    starved, starved_meta = module.compile_operational_evidence_set(
+    char_budget = 5_500
+    raw_reserve = 5_200
+    starved, _starved_meta = module.compile_operational_evidence_set(
         query="find the field",
         typed_results=typed,
         raw_results=raw,
         max_items=8,
         mode="shared_relevance",
-        char_budget=5_500,
+        char_budget=char_budget,
     )
     starved_ids = {item["id"] for item in starved}
     assert "session_fat" not in starved_ids
@@ -7058,11 +7060,11 @@ def test_raw_reserve_cures_fat_head_starvation() -> None:
         raw_results=raw,
         max_items=8,
         mode="shared_relevance",
-        char_budget=5_500,
-        char_budget_raw_reserve=5_200,
+        char_budget=char_budget,
+        char_budget_raw_reserve=raw_reserve,
     )
-    assert cured_meta["char_budget_raw_reserve"] == 5_200
-    assert cured_meta["selected_chars"] <= 5_500
+    assert cured_meta["char_budget_raw_reserve"] == raw_reserve
+    assert cured_meta["selected_chars"] <= char_budget
     assert any(item["id"] == "session_fat" for item in cured)
 
 
@@ -7086,20 +7088,23 @@ def test_raw_reserve_returns_unspent_budget_to_the_shared_pool() -> None:
         }
     ]
 
+    char_budget = 6_000
+    raw_reserve = 3_000
+    note_chars = 600
     selected, meta = module.compile_operational_evidence_set(
         query="find the field",
         typed_results=typed,
         raw_results=raw,
         max_items=8,
         mode="shared_relevance",
-        char_budget=6_000,
-        char_budget_raw_reserve=3_000,
+        char_budget=char_budget,
+        char_budget_raw_reserve=raw_reserve,
     )
     assert any(item["id"] == "passage_only" for item in selected)
     # The raw lane spent 500 of its 3000 reserve; typed overflow must reach
-    # past 3600 (reserve + notes) or the unspent reserve was burned.
-    assert meta["selected_chars"] > 3_600
-    assert meta["selected_chars"] <= 6_000
+    # past reserve + notes or the unspent reserve was burned.
+    assert meta["selected_chars"] > raw_reserve + note_chars
+    assert meta["selected_chars"] <= char_budget
     assert meta["selected_chars"] == sum(len(str(item["content"])) for item in selected)
 
 


### PR DESCRIPTION
## Why

The A2 slice-serving arm needs an unpaid replay screen before any scored run (protocol law: replay before paid). The official harness already accepts `--evidence-types` and `--evidence-char-budget`, and both sit in the loaded-memory runtime key set, but the live retrieval harness — the only unpaid measurement path — could not select them. A slice-geometry screen therefore could not run without paying for a reader. Same gap shape #348 closed for the stitch flags.

## What

Mirrors both flags onto `benchmarks/longmemeval_v2_live_retrieval.py` with the official harness's exact semantics (`--evidence-types` as a hard node-type filter defaulting to the shipped whole-state substrate; `--evidence-char-budget` bounding the composed pack in characters, unset by default), threading them into the adapter's memory params and the run's measurement config.

## Invariants

- Defaults reproduce the shipped geometry exactly; pinned by `test_evidence_geometry_flags_thread_into_the_run_config`.
- The new keys join the measurement config, so the strict-equality resume gate correctly rejects resuming a run banked before this change. No in-flight runs exist, so nothing is bricked; a fresh run under the old geometry produces the same measurements as before.

## Screen verdicts

Both geometry arms ran the full 211-question unpaid screen on the stage-2 enterprise corpus (serving commit `05ad48d8`, identical to the regenerated baseline; chunked with stack bounces) and both are dead as screened. Paired over the same 16 labeled slice questions: state recall@10 baseline 25.0% vs partition 6.3% vs budget28k 0.0%; state answer-phrase coverage 35.4% vs 9.4% vs 5.2%. Pack geometry receipts over all 211: items/pack median 8 (baseline) vs 3 (partition) vs 4 (budget28k); chars/pack median 45.7K vs 13.1K vs 23.9K.

The mechanism is spec-level, not a bug in these flags: evidence slices materialize at ~6K chars each, so any char budget under the baseline's ~46K packs fewer retrieval units, and the partition's raw reserve leaves the slice lane ~4K. The flags did exactly what they say; the geometry they enable cannot win at this slice granularity. Full adjudication: sibyl `decision_14686f9a4056` (partition mechanism) and `decision_e180be76037b` (gate closure + 1.2 re-scope).

These flags merge as bench instrumentation: they are inert unless passed, they are the only way to reproduce the screen receipts above, and the v1.3 corpus-rebuild round (sub-1K slices) will need exactly this harness surface to re-screen geometry without rebuilding tooling.

## Receipts

- `uv run pytest tools/tests/test_longmemeval_v2_live_retrieval.py -q` → `10 passed in 5.41s`
- `moon run bench-gate-test` → green (28s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to select evidence types and limit composed evidence by character count.
  * Added an optional raw-evidence character reserve to prioritize raw evidence within the shared budget.
  * Unused reserved capacity can be returned to other evidence, with settings preserved across runs and resumes.
  * Added validation for reserve values while preserving existing behavior when unset.

* **Tests**
  * Added coverage for evidence settings, budget allocation, validation, and run configuration propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
