### PR TITLE
feat(retrieval): typed-overfetch KNN arm with exactness fallback

### DIFF
--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -124,6 +124,7 @@ def _context_evidence_request(
         boost_recent=False,
         include_retrieval_diagnostics=request.evidence.include_retrieval_diagnostics,
         record_exposure=(request.record_exposure and not request.evidence.reserve_distilled_notes),
+        knn_type_overfetch=request.evidence.knn_type_overfetch,
     )
 
 
@@ -148,6 +149,7 @@ def _distilled_context_evidence_request(
         boost_recent=False,
         include_retrieval_diagnostics=request.evidence.include_retrieval_diagnostics,
         record_exposure=False,
+        knn_type_overfetch=request.evidence.knn_type_overfetch,
     )
 
 
@@ -830,6 +832,7 @@ async def context_pack(
                 related_limit=request.related_limit,
                 audit=request.audit,
                 record_exposure=request.record_exposure,
+                knn_type_overfetch=request.knn_type_overfetch,
                 allowed_memory_scope_keys=set(ctx.api_key_memory_scope_keys)
                 if ctx.api_key_memory_scope_keys is not None
                 else None,

--- a/apps/api/src/sibyl/api/routes/search.py
+++ b/apps/api/src/sibyl/api/routes/search.py
@@ -171,6 +171,7 @@ async def execute_search_request(
             limit=request.limit,
             offset=request.offset,
             include_content=request.include_content,
+            knn_type_overfetch=request.knn_type_overfetch,
             content_max_chars=request.content_max_chars,
             include_documents=request.include_documents,
             include_graph=request.include_graph,

--- a/apps/api/src/sibyl/api/schemas/context.py
+++ b/apps/api/src/sibyl/api/schemas/context.py
@@ -64,6 +64,19 @@ class ContextEvidenceRequest(BaseModel):
         default=True,
         description="Reserve a typed lane for distilled operational notes",
     )
+    knn_type_overfetch: int = Field(
+        default=0,
+        ge=0,
+        le=32,
+        description=(
+            "When >0 and a type filter is set, typed vector reads walk an "
+            "untyped KNN pool this many times the candidate budget and filter "
+            "types outside the HNSW bracket (a selective predicate beside the "
+            "bracket forces a 10-15x deeper walk); a full head is exactly the "
+            "typed KNN head, a shortfall falls back to the classic form. "
+            "0 keeps the classic typed query."
+        ),
+    )
 
 
 class ContextPackRequest(BaseModel):
@@ -98,6 +111,19 @@ class ContextPackRequest(BaseModel):
     evidence: ContextEvidenceRequest | None = Field(
         default=None,
         description="Run enhanced source-evidence retrieval alongside context compilation",
+    )
+    knn_type_overfetch: int = Field(
+        default=0,
+        ge=0,
+        le=32,
+        description=(
+            "When >0 and a type filter is set, typed vector reads walk an "
+            "untyped KNN pool this many times the candidate budget and filter "
+            "types outside the HNSW bracket (a selective predicate beside the "
+            "bracket forces a 10-15x deeper walk); a full head is exactly the "
+            "typed KNN head, a shortfall falls back to the classic form. "
+            "0 keeps the classic typed query."
+        ),
     )
 
 

--- a/apps/api/src/sibyl/api/schemas/search.py
+++ b/apps/api/src/sibyl/api/schemas/search.py
@@ -14,6 +14,19 @@ class SearchRequest(BaseModel):
     """
 
     query: str = Field(..., min_length=1, description="Natural language search query")
+    knn_type_overfetch: int = Field(
+        default=0,
+        ge=0,
+        le=32,
+        description=(
+            "When >0 and a type filter is set, typed vector reads walk an "
+            "untyped KNN pool this many times the candidate budget and filter "
+            "types outside the HNSW bracket (a selective predicate beside the "
+            "bracket forces a 10-15x deeper walk); a full head is exactly the "
+            "typed KNN head, a shortfall falls back to the classic form. "
+            "0 keeps the classic typed query."
+        ),
+    )
     types: list[str] | None = Field(
         default=None,
         description="Filter by entity types. Options: pattern, rule, template, topic, "

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -4417,6 +4417,14 @@ class SibylLiveApiMemory(Memory):
             "filters": filters,
         }
 
+    def _knn_overfetch_extras(self, evidence_request: dict[str, object]) -> dict[str, object]:
+        knn_type_overfetch = getattr(self, "knn_type_overfetch", DEFAULT_KNN_TYPE_OVERFETCH)
+        if knn_type_overfetch <= 0:
+            # Same omit-when-unset rule as char_budget.
+            return {}
+        evidence_request["knn_type_overfetch"] = knn_type_overfetch
+        return {"knn_type_overfetch": knn_type_overfetch}
+
     def query(self, query: str, query_image: str | None = None) -> list[MemoryContextItem]:
         pending_jobs = len(self._pending_embedding_job_ids) + len(self._pending_projection_job_ids)
         if pending_jobs or not self._ingest_finalized:
@@ -4454,12 +4462,7 @@ class SibylLiveApiMemory(Memory):
             # Omitted rather than sent as null when unset, so a run reproducing
             # the old geometry puts a byte-identical request on the wire.
             evidence_request["char_budget"] = char_budget
-        knn_type_overfetch = getattr(self, "knn_type_overfetch", DEFAULT_KNN_TYPE_OVERFETCH)
-        pack_request_extras: dict[str, object] = {}
-        if knn_type_overfetch > 0:
-            # Same omit-when-unset rule as char_budget.
-            evidence_request["knn_type_overfetch"] = knn_type_overfetch
-            pack_request_extras["knn_type_overfetch"] = knn_type_overfetch
+        pack_request_extras = self._knn_overfetch_extras(evidence_request)
         context_response = self._request_json(
             "POST",
             "/context/pack",

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -142,6 +142,7 @@ TYPED_STREAM_TYPES = ("note", "event", "procedure", "error_pattern")
 # would have ranked.
 DEFAULT_EVIDENCE_TYPES = ("session",)
 SUPPORTED_EVIDENCE_TYPES = frozenset({"passage", "session"})
+DEFAULT_KNN_TYPE_OVERFETCH = 0
 DEFAULT_RETRIEVAL_MAX_PLANNED_QUERIES = 3
 DEFAULT_API_TIMEOUT_SECONDS = 600.0
 DEFAULT_API_RETRY_ATTEMPTS = 3
@@ -215,6 +216,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "source_evidence_bundling",
         "retrieval_mode",
         "retrieval_max_planned_queries",
+        "knn_type_overfetch",
         "checkpoint_dir",
         "agentic_traversal",
         "traversal_widening_rounds",
@@ -3342,6 +3344,12 @@ class SibylLiveApiMemory(Memory):
             DEFAULT_RETRIEVAL_MAX_PLANNED_QUERIES,
             minimum=1,
         )
+        self.knn_type_overfetch = _param_int(
+            memory_params,
+            "knn_type_overfetch",
+            DEFAULT_KNN_TYPE_OVERFETCH,
+            minimum=0,
+        )
         if self.retrieval_max_planned_queries > MAX_REFINEMENT_QUERIES:
             raise ValueError(
                 f"retrieval_max_planned_queries must be at most {MAX_REFINEMENT_QUERIES}"
@@ -4283,6 +4291,20 @@ class SibylLiveApiMemory(Memory):
         self,
         query: str,
     ) -> tuple[list[dict[str, object]], dict[str, object]]:
+        stream_evidence: dict[str, object] = {
+            "types": list(TYPED_STREAM_TYPES),
+            "limit": self.typed_stream_limit,
+            "content_max_chars": self.max_context_chars_per_item,
+            "include_retrieval_diagnostics": False,
+            "retrieval_mode": "fast",
+            "max_planned_queries": 1,
+        }
+        stream_extras: dict[str, object] = {}
+        stream_overfetch = getattr(self, "knn_type_overfetch", DEFAULT_KNN_TYPE_OVERFETCH)
+        if stream_overfetch > 0:
+            # Same omit-when-unset rule as the main evidence request.
+            stream_evidence["knn_type_overfetch"] = stream_overfetch
+            stream_extras["knn_type_overfetch"] = stream_overfetch
         response = self._request_json(
             "POST",
             "/context/pack",
@@ -4296,14 +4318,8 @@ class SibylLiveApiMemory(Memory):
                 "related_limit": 3,
                 "audit": True,
                 "record_exposure": False,
-                "evidence": {
-                    "types": list(TYPED_STREAM_TYPES),
-                    "limit": self.typed_stream_limit,
-                    "content_max_chars": self.max_context_chars_per_item,
-                    "include_retrieval_diagnostics": False,
-                    "retrieval_mode": "fast",
-                    "max_planned_queries": 1,
-                },
+                "evidence": stream_evidence,
+                **stream_extras,
             },
         )
         results, filters = _required_context_evidence(response)
@@ -4358,6 +4374,12 @@ class SibylLiveApiMemory(Memory):
             # Omitted rather than sent as null when unset, so a run reproducing
             # the old geometry puts a byte-identical request on the wire.
             evidence_request["char_budget"] = char_budget
+        knn_type_overfetch = getattr(self, "knn_type_overfetch", DEFAULT_KNN_TYPE_OVERFETCH)
+        pack_request_extras: dict[str, object] = {}
+        if knn_type_overfetch > 0:
+            # Same omit-when-unset rule as char_budget.
+            evidence_request["knn_type_overfetch"] = knn_type_overfetch
+            pack_request_extras["knn_type_overfetch"] = knn_type_overfetch
         context_response = self._request_json(
             "POST",
             "/context/pack",
@@ -4372,6 +4394,7 @@ class SibylLiveApiMemory(Memory):
                 "audit": True,
                 "record_exposure": False,
                 "evidence": evidence_request,
+                **pack_request_extras,
             },
         )
         typed_results = context_pack_to_search_results(

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -86,6 +86,7 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "typed_reservation_items",
         "retrieval_mode",
         "retrieval_max_planned_queries",
+        "knn_type_overfetch",
         "checkpoint_dir",
     }
 )
@@ -496,6 +497,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
     parser.add_argument("--note-distillation", action="store_true")
     parser.add_argument("--note-distillation-model", default="gpt-5.4-nano")
     parser.add_argument("--typed-reservation-items", type=int, default=None)
+    parser.add_argument("--knn-type-overfetch", type=int, default=0)
     parser.add_argument(
         "--retrieval-mode",
         choices=["fast", "accurate"],
@@ -726,6 +728,7 @@ def build_memory_config(args: argparse.Namespace) -> dict[str, object]:
         "note_distillation_model": args.note_distillation_model,
         "typed_reservation_items": args.typed_reservation_items,
         "retrieval_mode": args.retrieval_mode,
+        "knn_type_overfetch": args.knn_type_overfetch,
         "retrieval_max_planned_queries": args.retrieval_max_planned_queries,
         "agentic_traversal": args.agentic_traversal,
         "traversal_widening_rounds": args.traversal_widening_rounds,
@@ -884,6 +887,7 @@ def build_run_plan(
         "note_distillation_model": args.note_distillation_model,
         "typed_reservation_items": args.typed_reservation_items,
         "retrieval_mode": args.retrieval_mode,
+        "knn_type_overfetch": args.knn_type_overfetch,
         "retrieval_max_planned_queries": args.retrieval_max_planned_queries,
         "agentic_traversal": args.agentic_traversal,
         "traversal_widening_rounds": args.traversal_widening_rounds,

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/knn.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/knn.py
@@ -2,6 +2,26 @@
 
 from __future__ import annotations
 
+KNN_TYPE_OVERFETCH_CAP = 4_000
+"""Ceiling on the untyped pool a typed overfetch read walks.
+
+Probed warm at 0.82s on a 95K-row namespace; past this depth the walk cost
+approaches the table-scan it exists to avoid.
+"""
+
+
+def knn_overfetch_pool(candidate_limit: int, overfetch: int) -> int:
+    """Depth of the untyped KNN pool for a typed overfetch read.
+
+    A selective predicate beside the HNSW bracket forces the walk 10-15x
+    deeper regardless of syntax, so typed vector reads walk an untyped pool
+    `overfetch` times the candidate budget and filter types on the
+    materialized rows instead. When the filtered head fills the budget it is
+    exactly the typed KNN head: every typed row nearer than the pool's k-th
+    member is inside the pool by definition.
+    """
+    return min(max(int(candidate_limit), 1) * max(int(overfetch), 1), KNN_TYPE_OVERFETCH_CAP)
+
 
 def knn_search_effort(k: int, configured_ef: int) -> int:
     """Return the search effort for a `<|k, ef|>` HNSW read.

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py
@@ -249,12 +249,14 @@ async def _vector_search_attempt(
     entity_types: list[Any] | None = None,
     limit: int = 20,
     result_filter: Callable[[Any], bool] | None = None,
+    knn_type_overfetch: int = 0,
 ) -> _VectorSearchAttempt:
     try:
         results = await entity_manager.search(
             query=query,
             entity_types=entity_types,
             limit=limit,
+            knn_type_overfetch=knn_type_overfetch,
         )
         results = _filter_entity_results(results, result_filter)
         log.debug("vector_search_complete", **query_log_fields(query), results=len(results))
@@ -585,6 +587,7 @@ async def hybrid_search(
     include_metadata: bool = False,
     group_id: str | None = None,
     result_filter: Callable[[Any], bool] | None = None,
+    knn_type_overfetch: int = 0,
 ) -> HybridResult:
     """Perform hybrid search combining multiple retrieval strategies.
 
@@ -635,6 +638,7 @@ async def hybrid_search(
         entity_types,
         limit=limit * 2,
         result_filter=result_filter,
+        knn_type_overfetch=knn_type_overfetch,
     )
     vector_results = vector_attempt.results
     stage_timings_ms["seed_search"] = _elapsed_ms(stage_started_at)

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py
@@ -252,11 +252,15 @@ async def _vector_search_attempt(
     knn_type_overfetch: int = 0,
 ) -> _VectorSearchAttempt:
     try:
+        # Omit the kwarg entirely when unset: entity_manager is duck-typed and
+        # pre-arm implementers do not accept it; the off-arm call shape must
+        # stay byte-identical to main.
+        arm_kwargs = {"knn_type_overfetch": knn_type_overfetch} if knn_type_overfetch > 0 else {}
         results = await entity_manager.search(
             query=query,
             entity_types=entity_types,
             limit=limit,
-            knn_type_overfetch=knn_type_overfetch,
+            **arm_kwargs,
         )
         results = _filter_entity_results(results, result_filter)
         log.debug("vector_search_complete", **query_log_fields(query), results=len(results))

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -24,7 +24,7 @@ from sibyl_core.backends.surreal.fulltext import (
     build_fulltext_terms,
     build_match_disjunction,
 )
-from sibyl_core.backends.surreal.knn import knn_search_effort
+from sibyl_core.backends.surreal.knn import knn_overfetch_pool, knn_search_effort
 from sibyl_core.backends.surreal.records import SurrealQueryError, query_error
 from sibyl_core.config import core_config
 from sibyl_core.embeddings.providers import EmbeddingMetadata, EmbeddingProvider
@@ -208,6 +208,7 @@ class RetrievalPlan:
     denied_scopes: tuple[MemoryPolicyDecision, ...]
     candidate_limits: CandidateLimits = field(default_factory=CandidateLimits)
     weights: RetrievalWeights = field(default_factory=RetrievalWeights)
+    knn_type_overfetch: int = 0
     signals: tuple[RetrievalSignal, ...] = (
         RetrievalSignal.RAW_LEXICAL,
         RetrievalSignal.NODE_FULLTEXT,
@@ -233,6 +234,7 @@ class SearchFilter:
     project_ids: tuple[str, ...] = ()
     edge_uuids: tuple[str, ...] = ()
     edge_types: tuple[str, ...] = ()
+    knn_type_overfetch: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -283,6 +285,7 @@ def build_context_retrieval_plan(
     agent_id: str | None = None,
     limit: int = 24,
     allowed_memory_scope_keys: Iterable[str] | None = None,
+    knn_type_overfetch: int = 0,
 ) -> RetrievalPlan:
     scopes: list[ScopeSpec] = []
     denied_scopes: list[MemoryPolicyDecision] = []
@@ -344,6 +347,7 @@ def build_context_retrieval_plan(
         facet_types=facet_types_by_facet,
         scopes=tuple(scopes),
         denied_scopes=tuple(denied_scopes),
+        knn_type_overfetch=max(0, int(knn_type_overfetch)),
         candidate_limits=CandidateLimits(
             raw_lexical=max(1, min(per_signal_limit, limit // RAW_LEXICAL_LIMIT_DIVISOR or 1)),
             node_fulltext=per_signal_limit,
@@ -894,6 +898,7 @@ def _search_filter_for_plan(
     requested_types = requested_types or set()
     return SearchFilter(
         node_types=_node_types_for_requested_types(requested_types),
+        knn_type_overfetch=plan.knn_type_overfetch,
         project_ids=_authorized_project_ids(plan),
     )
 
@@ -1375,6 +1380,50 @@ async def _node_vector_candidates(
     filter_clauses, filter_params = _node_filter_clause(search_filter)
     candidate_limit = max(int(limit), 1)
     knn_effort = knn_search_effort(candidate_limit, core_config.graph_knn_ef)
+    overfetch = search_filter.knn_type_overfetch
+    if search_filter.node_types and overfetch > 0:
+        # A selective predicate beside the HNSW bracket forces the walk 10-15x
+        # deeper regardless of syntax, so the arm walks an untyped pool and
+        # filters types outside the bracket. A full head is exactly the typed
+        # KNN head; a shortfall falls back to the classic form below.
+        pool = knn_overfetch_pool(candidate_limit, overfetch)
+        pool_knn_effort = knn_search_effort(pool, core_config.graph_knn_ef)
+        overfetch_clauses = [
+            clause for clause in filter_clauses if clause != "entity_type IN $node_types"
+        ]
+        rows = await _execute_query_records(
+            client,
+            """
+            SELECT *
+            FROM (
+                SELECT *,
+                       (1 - vector::distance::knn()) AS score
+                FROM entity
+                WHERE """
+            + _where_clause(["group_id = $group_id", *overfetch_clauses])
+            + f"""
+                  AND name_embedding <|{pool}, {pool_knn_effort}|> $query_embedding
+            )
+            WHERE score >= $min_score AND entity_type IN $node_types
+            ORDER BY score DESC, created_at DESC, uuid DESC
+            LIMIT $limit;
+            """,
+            group_id=plan.organization_id,
+            query_embedding=list(query_embedding),
+            min_score=plan.vector_min_score,
+            limit=candidate_limit,
+            **filter_params,
+        )
+        if len(rows) >= candidate_limit:
+            return [
+                _candidate_from_node_record(
+                    row,
+                    signal=RetrievalSignal.NODE_VECTOR,
+                    score=_record_score(row),
+                    embedding_metadata=embedding_metadata,
+                )
+                for row in rows
+            ]
     rows = await _execute_query_records(
         client,
         """
@@ -1423,6 +1472,44 @@ async def _edge_vector_candidates(
     filter_clauses, filter_params = _edge_filter_clause(search_filter)
     candidate_limit = max(int(limit), 1)
     knn_effort = knn_search_effort(candidate_limit, core_config.graph_knn_ef)
+    overfetch = search_filter.knn_type_overfetch
+    if search_filter.edge_types and overfetch > 0:
+        # Same HNSW planner trap as the node lane; the edge-type filter moves
+        # outside the bracket and a shortfall falls back to the classic form.
+        pool = knn_overfetch_pool(candidate_limit, overfetch)
+        pool_knn_effort = knn_search_effort(pool, core_config.graph_knn_ef)
+        overfetch_clauses = [
+            clause for clause in filter_clauses if clause != "name IN $edge_types"
+        ]
+        rows = await _execute_query_records(
+            client,
+            "SELECT * FROM ("
+            + _edge_select(extra="(1 - vector::distance::knn()) AS score")
+            + " WHERE "
+            + _where_clause(["group_id = $group_id", *overfetch_clauses])
+            + f"""
+              AND fact_embedding <|{pool}, {pool_knn_effort}|> $query_embedding
+            )
+            WHERE score >= $min_score AND name IN $edge_types
+            ORDER BY score DESC, created_at DESC, uuid DESC
+            LIMIT $limit;
+            """,
+            group_id=plan.organization_id,
+            query_embedding=list(query_embedding),
+            min_score=plan.vector_min_score,
+            limit=candidate_limit,
+            **filter_params,
+        )
+        if len(rows) >= candidate_limit:
+            return [
+                _candidate_from_edge_record(
+                    row,
+                    signal=RetrievalSignal.EDGE_VECTOR,
+                    score=_record_score(row),
+                    embedding_metadata=embedding_metadata,
+                )
+                for row in rows
+            ]
     rows = await _execute_query_records(
         client,
         "SELECT * FROM ("

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -1478,9 +1478,7 @@ async def _edge_vector_candidates(
         # outside the bracket and a shortfall falls back to the classic form.
         pool = knn_overfetch_pool(candidate_limit, overfetch)
         pool_knn_effort = knn_search_effort(pool, core_config.graph_knn_ef)
-        overfetch_clauses = [
-            clause for clause in filter_clauses if clause != "name IN $edge_types"
-        ]
+        overfetch_clauses = [clause for clause in filter_clauses if clause != "name IN $edge_types"]
         rows = await _execute_query_records(
             client,
             "SELECT * FROM ("

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -20,7 +20,7 @@ from sibyl_core.backends.surreal.fulltext import (
     build_fulltext_terms,
     build_match_disjunction,
 )
-from sibyl_core.backends.surreal.knn import knn_search_effort
+from sibyl_core.backends.surreal.knn import knn_overfetch_pool, knn_search_effort
 from sibyl_core.backends.surreal.records import raise_on_error
 from sibyl_core.backends.surreal.schema import bootstrap_schema
 from sibyl_core.config import settings
@@ -608,6 +608,7 @@ class EntityManager:
         query: str,
         entity_types: Sequence[EntityType] | None = None,
         limit: int = 10,
+        knn_type_overfetch: int = 0,
     ) -> list[tuple[Entity, float]]:
         search_query = build_fulltext_query(query)
         if not search_query:
@@ -626,6 +627,7 @@ class EntityManager:
                 query=query,
                 entity_types=entity_types,
                 limit=result_limit,
+                knn_type_overfetch=knn_type_overfetch,
             ),
         ]
         if anchor_search_query and anchor_search_query != search_query:
@@ -742,12 +744,31 @@ class EntityManager:
             for entity in (_entity_from_row(row) for row in rows)
         ]
 
+    @staticmethod
+    def _typed_overfetch_vector_query(*, candidate_limit: int, overfetch: int) -> str:
+        # The inner query walks the HNSW index with only the group predicate;
+        # the type filter applies to the materialized pool outside the bracket.
+        pool = knn_overfetch_pool(candidate_limit, overfetch)
+        overfetch_knn_effort = knn_search_effort(pool, settings.graph_knn_ef)
+        return (
+            "SELECT * FROM ("
+            "SELECT "
+            + _ENTITY_SEARCH_FIELDS
+            + ", (1 - vector::distance::knn()) AS score"
+            " FROM entity WHERE group_id = $group_id"
+            f" AND name_embedding <|{pool}, {overfetch_knn_effort}|> $query_embedding"
+            ") WHERE entity_type IN $entity_types"
+            " ORDER BY score DESC, created_at DESC, uuid DESC"
+            " LIMIT $limit;"
+        )
+
     async def _vector_search(
         self,
         *,
         query: str,
         entity_types: Sequence[EntityType] | None,
         limit: int,
+        knn_type_overfetch: int = 0,
     ) -> list[tuple[Entity, float]]:
         if self._embedding_provider is None:
             return []
@@ -767,6 +788,32 @@ class EntityManager:
                 embeddings,
                 self._embedding_provider.metadata.dimensions,
             )
+            rows: list[dict[str, Any]] = []
+            if type_values and knn_type_overfetch > 0:
+                rows = normalize_records(
+                    await self._client.execute_query(
+                        self._typed_overfetch_vector_query(
+                            candidate_limit=candidate_limit,
+                            overfetch=knn_type_overfetch,
+                        ),
+                        group_id=self._group_id,
+                        query_embedding=query_embedding,
+                        entity_types=type_values,
+                        limit=candidate_limit,
+                        _query_label="entity.search.vector.overfetch",
+                    )
+                )
+                if len(rows) >= candidate_limit:
+                    return [(_entity_from_row(row), _row_score(row)) for row in rows]
+                # Yield shortfall: the query embedding sits in a cluster the
+                # requested types do not reach at this depth, so the exactness
+                # argument no longer covers the tail. Fall through to the
+                # classic typed form, which digs as deep as it needs to.
+                log.info(
+                    "entity_vector_search_overfetch_fallback",
+                    typed_yield=len(rows),
+                    candidate_limit=candidate_limit,
+                )
             rows = normalize_records(
                 await self._client.execute_query(
                     "SELECT *"

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -752,9 +752,7 @@ class EntityManager:
         overfetch_knn_effort = knn_search_effort(pool, settings.graph_knn_ef)
         return (
             "SELECT * FROM ("
-            "SELECT "
-            + _ENTITY_SEARCH_FIELDS
-            + ", (1 - vector::distance::knn()) AS score"
+            "SELECT " + _ENTITY_SEARCH_FIELDS + ", (1 - vector::distance::knn()) AS score"
             " FROM entity WHERE group_id = $group_id"
             f" AND name_embedding <|{pool}, {overfetch_knn_effort}|> $query_embedding"
             ") WHERE entity_type IN $entity_types"

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -1520,6 +1520,7 @@ async def compile_context(
     active_work_fn: ActiveWorkFn | None = None,
     allowed_memory_scope_keys: set[str] | None = None,
     record_exposure: bool = True,
+    knn_type_overfetch: int = 0,
 ) -> ContextPack:
     """Build a small, structured context pack for an agent goal."""
 
@@ -1548,6 +1549,7 @@ async def compile_context(
         agent_id=agent_id,
         limit=limit,
         allowed_memory_scope_keys=allowed_memory_scope_keys,
+        knn_type_overfetch=knn_type_overfetch,
     )
 
     sections: list[ContextSection] = []

--- a/packages/python/sibyl-core/src/sibyl_core/tools/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/search.py
@@ -724,6 +724,7 @@ async def search(
     allowed_memory_scope_keys: set[str] | None = None,
     record_exposure: bool = True,
     include_retrieval_diagnostics: bool = False,
+    knn_type_overfetch: int = 0,
 ) -> SearchResponse:
     """Unified semantic search across knowledge graph AND documentation.
 
@@ -1077,6 +1078,7 @@ async def search(
                             entity_types=entity_types,
                             limit=limit * 3,
                             config=hybrid_config,
+                            knn_type_overfetch=knn_type_overfetch,
                             include_metadata=include_retrieval_diagnostics,
                             group_id=organization_id,
                             result_filter=graph_result_allowed,
@@ -1111,6 +1113,7 @@ async def search(
                             query=query,
                             entity_types=entity_types,
                             limit=limit * 3,
+                            knn_type_overfetch=knn_type_overfetch,
                         ),
                         timeout_seconds=TIMEOUTS["search"],
                         operation_name="search",

--- a/packages/python/sibyl-core/src/sibyl_core/tools/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/search.py
@@ -1078,7 +1078,11 @@ async def search(
                             entity_types=entity_types,
                             limit=limit * 3,
                             config=hybrid_config,
-                            knn_type_overfetch=knn_type_overfetch,
+                            **(
+                                {"knn_type_overfetch": knn_type_overfetch}
+                                if knn_type_overfetch > 0
+                                else {}
+                            ),
                             include_metadata=include_retrieval_diagnostics,
                             group_id=organization_id,
                             result_filter=graph_result_allowed,
@@ -1113,7 +1117,11 @@ async def search(
                             query=query,
                             entity_types=entity_types,
                             limit=limit * 3,
-                            knn_type_overfetch=knn_type_overfetch,
+                            **(
+                                {"knn_type_overfetch": knn_type_overfetch}
+                                if knn_type_overfetch > 0
+                                else {}
+                            ),
                         ),
                         timeout_seconds=TIMEOUTS["search"],
                         operation_name="search",

--- a/packages/python/sibyl-core/tests/test_surreal_knn.py
+++ b/packages/python/sibyl-core/tests/test_surreal_knn.py
@@ -268,9 +268,7 @@ async def test_entity_vector_search_off_arm_is_the_classic_typed_query() -> None
         entity_types=[EntityType.TOPIC],
         limit=10,
     )
-    vector_calls = [
-        (q, p) for q, p in client.calls if "name_embedding <|" in q
-    ]
+    vector_calls = [(q, p) for q, p in client.calls if "name_embedding <|" in q]
     assert len(vector_calls) == 1
     query, params = vector_calls[0]
     assert params.get("_query_label") == "entity.search.vector"
@@ -283,9 +281,7 @@ async def test_entity_vector_search_overfetch_walks_untyped_pool_and_filters_out
     # Full yield: the overfetch head fills the candidate budget, so no
     # fallback query runs.
     full_head = [_entity_row(f"hit_{i:03d}") for i in range(40)]
-    client = _ScriptedClient(
-        "org-overfetch", {"entity.search.vector.overfetch": full_head}
-    )
+    client = _ScriptedClient("org-overfetch", {"entity.search.vector.overfetch": full_head})
     manager = EntityManager(
         client,
         group_id=client.group_id,
@@ -298,9 +294,7 @@ async def test_entity_vector_search_overfetch_walks_untyped_pool_and_filters_out
         knn_type_overfetch=10,
     )
     vector_calls = [(q, p) for q, p in client.calls if "name_embedding <|" in q]
-    assert [p.get("_query_label") for _, p in vector_calls] == [
-        "entity.search.vector.overfetch"
-    ]
+    assert [p.get("_query_label") for _, p in vector_calls] == ["entity.search.vector.overfetch"]
     query, _params = vector_calls[0]
     # Inner bracket walks the untyped pool (40 * 10); the type filter sits
     # outside the bracket, i.e. after it in the composed text.
@@ -333,9 +327,7 @@ async def test_entity_vector_search_overfetch_shortfall_falls_back_to_classic() 
         knn_type_overfetch=10,
     )
     labels = [
-        params.get("_query_label")
-        for query, params in client.calls
-        if "name_embedding <|" in query
+        params.get("_query_label") for query, params in client.calls if "name_embedding <|" in query
     ]
     assert labels == ["entity.search.vector.overfetch", "entity.search.vector"]
     assert len(results) == 12

--- a/packages/python/sibyl-core/tests/test_surreal_knn.py
+++ b/packages/python/sibyl-core/tests/test_surreal_knn.py
@@ -186,3 +186,257 @@ async def test_entity_search_vector_lane_reads_the_whole_pool_on_the_embedded_en
         await client.close()
 
     assert len(results) == 200
+
+
+# --- typed-overfetch arm (knn_type_overfetch) --------------------------------
+#
+# A selective predicate beside the HNSW bracket forces the walk 10-15x deeper
+# regardless of syntax (probed live: group-only 0.48s vs any typed predicate
+# 3.2-5.6s at 95K rows), so the arm walks an untyped pool `overfetch` times
+# the candidate budget and filters types outside the bracket. A full head is
+# exactly the typed KNN head; a shortfall falls back to the classic form.
+
+from sibyl_core.backends.surreal.knn import (  # noqa: E402
+    KNN_TYPE_OVERFETCH_CAP,
+    knn_overfetch_pool,
+)
+from sibyl_core.models.entities import EntityType  # noqa: E402
+from sibyl_core.retrieval.search import (  # noqa: E402
+    RetrievalPlan,
+    SearchFilter,
+    _node_vector_candidates,
+)
+
+
+def test_overfetch_pool_scales_and_caps() -> None:
+    assert knn_overfetch_pool(48, 10) == 480
+    assert knn_overfetch_pool(200, 32) == KNN_TYPE_OVERFETCH_CAP
+    assert knn_overfetch_pool(48, 1) == 48
+
+
+class _ScriptedClient:
+    """Captures composed queries; serves scripted rows per query label."""
+
+    def __init__(self, group_id: str, rows_by_label: dict[str, list[dict[str, object]]]) -> None:
+        self.group_id = group_id
+        self.rows_by_label = rows_by_label
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+        self.calls.append((query, params))
+        label = str(params.get("_query_label") or "")
+        return list(self.rows_by_label.get(label, []))
+
+
+def _entity_row(uuid: str, entity_type: str = "topic", score: float = 0.9) -> dict[str, object]:
+    return {
+        "record_id": f"entity:{uuid}",
+        "uuid": uuid,
+        "name": uuid,
+        "entity_type": entity_type,
+        "summary": uuid,
+        "group_id": "org-overfetch",
+        "attributes": {},
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+        "score": score,
+    }
+
+
+def _overfetch_provider(namespace: str) -> DeterministicEmbeddingProvider:
+    return DeterministicEmbeddingProvider(
+        EmbeddingMetadata(
+            provider="deterministic",
+            model="unit-test",
+            dimensions=EMBEDDING_DIM,
+            cache_namespace=namespace,
+            tokenizer_estimate_method="utf8-byte-length",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_entity_vector_search_off_arm_is_the_classic_typed_query() -> None:
+    client = _ScriptedClient("org-overfetch", {})
+    manager = EntityManager(
+        client,
+        group_id=client.group_id,
+        embedding_provider=_overfetch_provider("overfetch-off"),
+    )
+    await manager._vector_search(
+        query="off arm",
+        entity_types=[EntityType.TOPIC],
+        limit=10,
+    )
+    vector_calls = [
+        (q, p) for q, p in client.calls if "name_embedding <|" in q
+    ]
+    assert len(vector_calls) == 1
+    query, params = vector_calls[0]
+    assert params.get("_query_label") == "entity.search.vector"
+    assert "entity_type IN $entity_types" in query
+    assert "<|40, 40|>" in query
+
+
+@pytest.mark.asyncio
+async def test_entity_vector_search_overfetch_walks_untyped_pool_and_filters_outside() -> None:
+    # Full yield: the overfetch head fills the candidate budget, so no
+    # fallback query runs.
+    full_head = [_entity_row(f"hit_{i:03d}") for i in range(40)]
+    client = _ScriptedClient(
+        "org-overfetch", {"entity.search.vector.overfetch": full_head}
+    )
+    manager = EntityManager(
+        client,
+        group_id=client.group_id,
+        embedding_provider=_overfetch_provider("overfetch-on"),
+    )
+    results = await manager._vector_search(
+        query="on arm",
+        entity_types=[EntityType.TOPIC],
+        limit=10,
+        knn_type_overfetch=10,
+    )
+    vector_calls = [(q, p) for q, p in client.calls if "name_embedding <|" in q]
+    assert [p.get("_query_label") for _, p in vector_calls] == [
+        "entity.search.vector.overfetch"
+    ]
+    query, _params = vector_calls[0]
+    # Inner bracket walks the untyped pool (40 * 10); the type filter sits
+    # outside the bracket, i.e. after it in the composed text.
+    assert "<|400, 400|>" in query
+    assert "entity_type IN $entity_types" in query
+    assert query.index("entity_type IN $entity_types") > query.index("name_embedding <|")
+    assert len(results) == 40
+
+
+@pytest.mark.asyncio
+async def test_entity_vector_search_overfetch_shortfall_falls_back_to_classic() -> None:
+    short_head = [_entity_row(f"few_{i}") for i in range(3)]
+    classic_head = [_entity_row(f"classic_{i}") for i in range(12)]
+    client = _ScriptedClient(
+        "org-overfetch",
+        {
+            "entity.search.vector.overfetch": short_head,
+            "entity.search.vector": classic_head,
+        },
+    )
+    manager = EntityManager(
+        client,
+        group_id=client.group_id,
+        embedding_provider=_overfetch_provider("overfetch-fallback"),
+    )
+    results = await manager._vector_search(
+        query="fallback",
+        entity_types=[EntityType.TOPIC],
+        limit=10,
+        knn_type_overfetch=10,
+    )
+    labels = [
+        params.get("_query_label")
+        for query, params in client.calls
+        if "name_embedding <|" in query
+    ]
+    assert labels == ["entity.search.vector.overfetch", "entity.search.vector"]
+    assert len(results) == 12
+    assert all(entity.id.startswith("classic_") for entity, _ in results)
+
+
+@pytest.mark.asyncio
+async def test_node_vector_lane_overfetch_and_fallback_shapes() -> None:
+    plan = RetrievalPlan(
+        query="lane",
+        organization_id="org-overfetch",
+        facets=(),
+        facet_types={},
+        scopes=(),
+        denied_scopes=(),
+    )
+
+    class _LaneClient:
+        def __init__(self, first_rows: int) -> None:
+            self.first_rows = first_rows
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+            self.calls.append((query, params))
+            count = self.first_rows if len(self.calls) == 1 else 8
+            return [_entity_row(f"lane_{len(self.calls)}_{i}") for i in range(count)]
+
+    meta = EmbeddingMetadata(
+        provider="deterministic",
+        model="unit-test",
+        dimensions=EMBEDDING_DIM,
+        cache_namespace="lane-overfetch",
+        tokenizer_estimate_method="utf8-byte-length",
+    )
+    # Full yield: one query, type filter outside the bracket.
+    client = _LaneClient(first_rows=8)
+    await _node_vector_candidates(
+        client=client,
+        plan=plan,
+        search_filter=SearchFilter(node_types=("topic",), knn_type_overfetch=10),
+        query_embedding=[0.0] * EMBEDDING_DIM,
+        embedding_metadata=meta,
+        limit=8,
+    )
+    assert len(client.calls) == 1
+    query, _ = client.calls[0]
+    assert "<|80, 80|>" in query
+    assert query.index("entity_type IN $node_types") > query.index("name_embedding <|")
+    # Shortfall: fallback second query in the classic shape.
+    client = _LaneClient(first_rows=2)
+    await _node_vector_candidates(
+        client=client,
+        plan=plan,
+        search_filter=SearchFilter(node_types=("topic",), knn_type_overfetch=10),
+        query_embedding=[0.0] * EMBEDDING_DIM,
+        embedding_metadata=meta,
+        limit=8,
+    )
+    assert len(client.calls) == 2
+    fallback_query, _ = client.calls[1]
+    assert fallback_query.index("entity_type IN $node_types") < fallback_query.index(
+        "name_embedding <|"
+    )
+    assert "<|8, 40|>" in fallback_query
+
+
+@pytest.mark.asyncio
+async def test_overfetch_head_matches_classic_head_on_the_embedded_engine() -> None:
+    client = SurrealGraphClient(group_id="org-overfetch-sem", url="memory://")
+    provider = _overfetch_provider("overfetch-sem")
+    try:
+        await prepare_graph_schema(client)
+        rng = random.Random(11)
+        rows = [
+            {
+                "uuid": f"of_{index:03d}",
+                "group_id": client.group_id,
+                "name": f"Overfetch member {index}",
+                "entity_type": ("topic", "task")[index % 2],
+                "name_embedding": [rng.random() for _ in range(EMBEDDING_DIM)],
+                "created_at": datetime.now(UTC),
+            }
+            for index in range(120)
+        ]
+        await client.execute_query("INSERT INTO entity $rows;", rows=rows)
+        manager = EntityManager(
+            client,
+            group_id=client.group_id,
+            embedding_provider=provider,
+        )
+        classic = await manager._vector_search(
+            query="overfetch parity",
+            entity_types=[EntityType.TOPIC],
+            limit=10,
+        )
+        armed = await manager._vector_search(
+            query="overfetch parity",
+            entity_types=[EntityType.TOPIC],
+            limit=10,
+            knn_type_overfetch=10,
+        )
+    finally:
+        await client.close()
+    assert sorted(e.id for e, _ in classic) == sorted(e.id for e, _ in armed)


### PR DESCRIPTION
## Why

A selective predicate beside the HNSW bracket forces the walk 10-15x deeper regardless of syntax. Live probes on the 95K-row stage-2 enterprise namespace (warm, production query shape): group-only predicate 0.48s, `entity_type = 'session'` 3.53s, `entity_type = 'note'` 5.57s, `entity_type IN [3 types]` 3.22s. The planner post-filters along the walk, so selectivity is the cost driver; the #342 IN-list class kill does not transfer to HNSW reads. With re-ranking refuted by the ranking gate (the miss set is pool-boundary limited), wider candidate pools are a primary recall lever, and this arm is what makes wide typed pools affordable.

## What

`knn_type_overfetch` (off by default, byte-identical off, on the wire and in duck-typed call shapes alike): when set and a type filter is present, typed vector reads walk an untyped KNN pool `overfetch` times the candidate budget (capped 4000) and filter types outside the bracket; on yield shortfall the read falls back to the classic typed form. Covers all three vector lanes (`EntityManager._vector_search`, `_node_vector_candidates`, `_edge_vector_candidates`), plumbed end to end (`SearchRequest` / `ContextEvidenceRequest` / `ContextPackRequest` → tools/search → hybrid seed → compile_context → retrieval plan → lanes, plus the LME adapter runtime key and `--knn-type-overfetch` flag). The kwarg is omitted from duck-typed calls entirely when unset, so pre-arm search implementers keep their exact call contract.

## Evidence

**Exactness, unit level (deterministic):** embedded-engine head-parity tests pin that the armed head equals the classic typed head when yield fills the budget, plus composed-shape tests (classic when off, bracket-outside filter when on, fallback ordering on shortfall) and pool-cap arithmetic. When the filtered head fills, every returned typed row is provably within the walked pool; at approximate-HNSW boundaries different (k,ef) walks can tie-break differently, which is why fallback exists and why run-level pack identity is not the claim.

**Re-screen (2026-08-12, same-base pairing, adjudicated GO):** the promised same-commit re-screen ran and closed the attribution gap. Both runs used the identical chunked fresh-stack protocol over the same 211 enterprise questions: the arm at this branch tip (main `05ad48d8` + the arm commits, `knn_type_overfetch: 10` receipted in the banked runtime config) against a fresh baseline served from clean main at `05ad48d8`. Metric level, paired over all 211: all-phrase pack coverage arm 102 vs baseline 101 (one question flipped up, none down); items/pack median 8 vs 7. Pack identity: 171/211 identical, 40 divergent (19%), inside the independently measured ~30% same-commit jitter band. Latency, both sides chunk-fresh: graph-search p95 3.75s vs 7.91s, total memory latency median 31.2s vs 35.6s and p95 37.0s vs 70.5s. The type-filtered KNN tail is the thing this arm exists to kill, and it is gone at pack parity. Adjudication banked as sibyl `decision_106f71e196e8`.

**Fallback economics (arm-internal, stands):** ~89% of sparse-type graph-lane attempts fall back (typed streams at ~4% row density rarely fill from the untyped pool); broad-type pack lanes carry the win. Density-conditional arming is the natural follow-up.

Gates: full core suite 2480 passed / 14 skipped, `moon run core:check` exit 0, api and bench-gate suites green.

## Blast radius

Off by default on every surface; requests without the knob compose byte-identical queries, payloads, and call shapes. Scope predicates and app-side gates are untouched (identical post-filters on both paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional KNN overfetch configuration to search and context-pack requests.
  * Improved filtered vector search by retrieving additional candidates before applying type filters.
  * Added configurable overfetch support to benchmark and retrieval workflows, with values from 0–32.
* **Bug Fixes**
  * Added fallback behavior when overfetching does not produce enough matching results.
  * Preserved existing search behavior when overfetch is disabled.
* **Tests**
  * Added coverage for scaling, limits, filtering, fallback behavior, and result consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->