### PR TITLE
fix(bench): stop the loaded-memory merge from silently dropping arm flags

### DIFF
--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -233,6 +233,11 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "traversal_search_limit",
         "semantic_prior_rescue_weight",
         "typed_pool",
+        "typed_stream_retrieval",
+        "typed_stream_limit",
+        "note_distillation",
+        "note_distillation_model",
+        "typed_reservation_items",
     }
 )
 SAVED_MEMORY_IDENTITY_KEYS = frozenset(

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -89,6 +89,16 @@ LOADED_MEMORY_RUNTIME_KEYS = frozenset(
         "retrieval_max_planned_queries",
         "knn_type_overfetch",
         "checkpoint_dir",
+        "semantic_prior_rescue_weight",
+        "typed_pool",
+        "agentic_traversal",
+        "traversal_widening_rounds",
+        "traversal_model",
+        "traversal_max_actions",
+        "traversal_followup_searches",
+        "traversal_deadline_seconds",
+        "traversal_overflow_items",
+        "traversal_search_limit",
     }
 )
 QWEN_READER_MODEL_FRAGMENT = "qwen3.5-9b"
@@ -793,6 +803,30 @@ def install_memory_credentials(args: argparse.Namespace) -> None:
             os.environ[environment_key] = value
 
 
+# Requested keys deliberately NOT merged into a loaded memory config: ingest
+# identity is pinned by the saved corpus, and transport/provenance describe
+# this run, not retrieval behavior. Every other requested key MUST be in
+# LOADED_MEMORY_RUNTIME_KEYS or the merge below would silently drop it (the
+# arm-off-under-the-arm's-name failure mode).
+LOADED_MEMORY_NON_MERGED_KEYS = frozenset(
+    {
+        "api_url",
+        "project_id",
+        "run_id",
+        "reuse_existing_project",
+        "content_max_chars",
+        "chunking_mode",
+        "include_screenshot_refs",
+        "defer_embeddings",
+        "bulk_max_entities",
+        "bulk_max_content_chars",
+        "embedding_backfill_max_pending_jobs",
+        "embedding_job_wait_timeout_seconds",
+        "runner_provenance",
+    }
+)
+
+
 def build_loaded_memory_config(
     memory_dir: Path,
     *,
@@ -807,6 +841,14 @@ def build_loaded_memory_config(
     requested_params = requested_config.get("memory_params")
     if not isinstance(saved_params, dict) or not isinstance(requested_params, dict):
         msg = f"Saved or requested memory config is missing memory_params: {saved_path}"
+        raise RuntimeError(msg)
+    dropped = set(requested_params) - LOADED_MEMORY_RUNTIME_KEYS - LOADED_MEMORY_NON_MERGED_KEYS
+    if dropped:
+        msg = (
+            "loaded-memory merge would silently drop requested keys "
+            f"{sorted(dropped)}; classify them in LOADED_MEMORY_RUNTIME_KEYS "
+            "or LOADED_MEMORY_NON_MERGED_KEYS"
+        )
         raise RuntimeError(msg)
     effective_params = dict(saved_params)
     effective_params.update(

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -7155,3 +7155,86 @@ def test_raw_reserve_none_is_byte_identical_to_the_shipped_budget_path() -> None
     base_meta.pop("char_budget_raw_reserve")
     none_meta.pop("char_budget_raw_reserve")
     assert base_meta == none_meta
+
+
+def _load_adapter_module_for_keys() -> ModuleType:
+    return _load_module(
+        Path(__file__).parents[2] / "benchmarks" / "longmemeval_v2_memory" / "sibyl_memory.py",
+        "sibyl_memory_for_runtime_keys",
+    )
+
+
+def test_loaded_runtime_keys_stay_in_parity_with_the_adapter() -> None:
+    """The runner and the adapter each merge saved configs against their own
+    copy of LOADED_MEMORY_RUNTIME_KEYS. A key present in one copy and absent
+    from the other is silently dropped by that side's merge, which turns an
+    armed run into a baseline replica under the arm's name (the A3 traversal
+    screen failed exactly this way). The only tolerated divergence is the
+    adapter-side secret aliases the runner never produces."""
+    runner = _load_runner_module()
+    adapter = _load_adapter_module_for_keys()
+    runner_keys = set(runner.LOADED_MEMORY_RUNTIME_KEYS)
+    adapter_keys = set(adapter.LOADED_MEMORY_RUNTIME_KEYS)
+    assert runner_keys <= adapter_keys
+    assert adapter_keys - runner_keys == {"api_credentials_path", "refresh_token"}
+
+
+def test_loaded_memory_merge_threads_every_behavioral_request_key(tmp_path: Path) -> None:
+    module = _load_runner_module()
+    memory_dir = tmp_path / "memory_state"
+    memory_dir.mkdir()
+    max_actions = 3
+    rescue_weight = 0.5
+    (memory_dir / "memory_config.json").write_text(
+        json.dumps(
+            {
+                "memory_type": "sibyl_live_api",
+                "memory_params": {
+                    "api_url": "http://127.0.0.1:3434/api",
+                    "project_id": "project_saved",
+                    "run_id": "run-saved",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = module.parse_args(
+        [
+            "--data-root",
+            str(tmp_path / "data"),
+            "--domain",
+            "enterprise",
+            "--output-dir",
+            str(tmp_path / "output"),
+            "--api-url",
+            "http://127.0.0.1:3434/api",
+            "--load-memory-dir",
+            str(memory_dir),
+            "--agentic-traversal",
+            "--traversal-max-actions",
+            str(max_actions),
+            "--semantic-prior-rescue-weight",
+            str(rescue_weight),
+        ]
+    )
+    params = module.build_memory_config(args)["memory_params"]
+    assert params["agentic_traversal"] is True
+    assert params["traversal_max_actions"] == max_actions
+    assert params["traversal_model"] == args.traversal_model
+    assert params["semantic_prior_rescue_weight"] == pytest.approx(rescue_weight)
+
+
+def test_loaded_memory_merge_rejects_unclassified_request_keys(tmp_path: Path) -> None:
+    module = _load_runner_module()
+    memory_dir = tmp_path / "memory_state"
+    memory_dir.mkdir()
+    (memory_dir / "memory_config.json").write_text(
+        json.dumps({"memory_type": "sibyl_live_api", "memory_params": {"run_id": "run-saved"}}),
+        encoding="utf-8",
+    )
+    requested = {
+        "memory_type": "sibyl_live_api",
+        "memory_params": {"run_id": "run-new", "future_arm_flag": True},
+    }
+    with pytest.raises(RuntimeError, match="future_arm_flag"):
+        module.build_loaded_memory_config(memory_dir, requested_config=requested)


### PR DESCRIPTION
## Why

The A3 traversal screen launched tonight banked `agentic_traversal: true` in its plan and then ran all 25 questions of its first chunk as a plain baseline: no traversal trace in any row, no nano calls made, latency identical to the arm-off geometry. The flag never reached the adapter. `--load-memory-dir` runs merge the saved corpus config against `LOADED_MEMORY_RUNTIME_KEYS`, and the runner and the adapter each keep their own copy of that set. The copies had drifted in both directions: the runner's copy lacked every traversal key and both ranking-lever keys (`semantic_prior_rescue_weight`, `typed_pool`), and the adapter's copy lacked the note-distillation, typed-stream, and reservation keys. A key missing from the merging side's copy is dropped without a trace, and the adapter's t=0 missing-credentials guard cannot fire because the adapter legitimately believes the arm is off.

This is the same failure class as the #371 verification FAIL (an armed run silently measuring the baseline), one layer earlier in the pipeline. Each prior lane (#361, #371) had patched its own keys into both copies by hand; nothing killed the class.

## What

- Both copies of `LOADED_MEMORY_RUNTIME_KEYS` now carry the full union (runner gains the traversal + ranking keys, adapter gains the note/typed-stream/reservation keys).
- `build_loaded_memory_config` now raises at t=0 if the requested config contains any key the merge would silently drop, with `LOADED_MEMORY_NON_MERGED_KEYS` naming the identity/transport keys that are deliberately not merged. A future arm flag added to `build_memory_config` but not classified dies loudly on every load run instead of producing a baseline replica.
- A parity test pins the two copies together (tolerating only the adapter-side secret aliases the runner never produces), a threading test proves `--agentic-traversal` and `--semantic-prior-rescue-weight` survive the load merge, and a rejection test locks the guard.

## Receipts

- `uv run pytest tools/tests/test_longmemeval_v2_official.py tools/tests/test_longmemeval_v2_live_retrieval.py tools/tests/test_longmemeval_agentic_traversal.py -q` → `220 passed in 3.03s`
- ruff format and check clean on the three touched files (finding parity with main).
- No shipped verdict is invalidated: the ranking screens receipted arm activity through a different harness path, the overfetch screens banked their key through both copies, and the inert A3 chunk was wiped before any adjudication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of saved memory configurations, including typed retrieval, note distillation, semantic rescue, and agentic traversal settings.
  * Preserved traversal and semantic-prior request parameters when loading saved memory.
  * Added validation to prevent unsupported or unclassified configuration options from being applied.

* **Tests**
  * Expanded coverage to verify consistent configuration handling across memory evaluation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->