### PR TITLE
docs(plan): record the A3 screen verdict; traversal closes for 1.2

### DIFF
--- a/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_2_IMPLEMENTATION_PLAN.md
@@ -482,6 +482,19 @@ wins factoid lookups — route, don't force.
   ceiling: the 27s knee); GO = ≥ +3pp mean paired over the then-best config, numbers pre-registered
   before the first paid run.
 
+**Status (2026-08-13, decision `8b69af3de865` pre-registration): CLOSED for v1.2 by screen FAIL; no
+paid run made.** The unpaid screen ran the merged arm at its shipped defaults over the full 211
+enterprise questions with activity receipts in every row (traversal armed 211/211, widening round
+used in 209). Paired against the same-commit baseline: pack coverage −4 questions (gate: ≥ +6,
+regression floor −2 breached; 2 rescued, 6 lost) and paired latency +28.4s median (screen line: ≤
++4s; the 15s scored ceiling is unreachable by an order of magnitude). Mechanism: gathered candidates
+grow the pack (median 11 items vs 7) but displace winning evidence more often than they rescue
+misses, and the sufficiency stop never fired (0 early stops in 211), so the loop gathers
+indiscriminately. Traversal moves to v1.3 needing a discriminating sufficiency stop,
+displacement-safe admission, and the latency budget work (§7). Route receipt: the first screen
+attempt ran silently arm-off and was caught by row-level receipt checks — the loaded-memory merge
+was dropping arm flags entirely (fixed as the class in PR #373).
+
 ### A4. Full-451 + leaderboard submission — MOVED TO v1.3 (2026-08-12)
 
 - Gate `baseline-beat-gate`: combined full-451 ≥ 42.8% at ≤ 10s avg with committed receipts.
@@ -691,7 +704,8 @@ Re-scoped 2026-08-12 (decision `e180be76037b`): the benchmark-beat criteria move
   `95677ae0b87b`) and every 2026-08 lever class adjudicated in the §2.4 ledger with receipts
   (**done**: decisions `715454c60c9b`, `14686f9a4056`, `e180be76037b`).
 - A3 traversal arm merged with its scored gate documented and pre-registered numbers recorded, run
-  or explicitly deferred to v1.3 by Bliss's call.
+  or explicitly deferred to v1.3 by Bliss's call (**done**: screen FAILED its pre-registered gate
+  2026-08-13, decision `8b69af3de865`; closed for v1.2 with no paid run, traversal to v1.3).
 - Overfetch fast path (PR #371) adjudicated by the metric-level re-screen: merged on a clean paired
   read or closed with the verdict in the PR body.
 - Accurate-mode fate executed; `query_planning.py` audit closed (**done**: #355 deprecation notice,


### PR DESCRIPTION
## Why

The re-scoped exit criteria (PR #372) left one open Track A item: the A3 agentic-traversal gate, to be run or explicitly closed. It ran on 2026-08-13 and failed its pre-registered screen, so the plan doc needs to carry the verdict and the close-out.

## What

The §A3 gate bullet gains its status: closed for v1.2 by screen FAIL, no paid run made. The screen ran the merged arm at shipped defaults over all 211 enterprise questions with activity receipts in every row (armed 211/211, widening round used in 209), paired against the same-commit baseline. Coverage regressed 4 questions against a +6 gate (2 rescued, 6 lost), and paired latency grew +28.4s median against a +4s line, putting the scored gate's 15s ceiling out of reach by an order of magnitude. The mechanism section records why: gathered candidates displace winning evidence more often than they rescue misses, and the sufficiency stop never fired. The §10 exit-criteria line flips to done.

## Receipts

Pre-registration `decision 8b69af3de865` (banked before any result existed). Screen artifacts `a1-stage2-ent-screen-a3trav-chunked` paired against `a1-stage2-ent-screen-mainbase-chunked`, both at anchor serving commit `05ad48d8`. The first screen attempt ran silently arm-off and was caught by row-level receipt checks; the class fix is merged as PR #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v1.2 implementation plan to record the unsuccessful A3 retrieval evaluation.
  * Documented reduced coverage, regression-floor issues, increased latency, and the lack of early stopping.
  * Deferred A3 retrieval improvements to v1.3, pending further performance and stopping-condition work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->