### PR TITLE
ci(release): release notes on Opus 5; action-setup 6.0.10

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: 24
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v6.0.10
 
       - name: Install dependencies
         working-directory: docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
           to: HEAD
           version-name: ${{ steps.version.outputs.version }}
           provider: anthropic
-          model: claude-opus-4-8
+          model: claude-opus-5
           api-key: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: "◇ Prepare release notes"

--- a/tools/tests/test_release_workflow.py
+++ b/tools/tests/test_release_workflow.py
@@ -53,7 +53,7 @@ RELEASE_WORKFLOW_REQUIRED_FRAGMENTS = (
     "Generate AI release notes",
     "provider: anthropic",
     "version: v2.1.0",
-    "model: claude-opus-4-8",
+    "model: claude-opus-5",
     "secrets.ANTHROPIC_API_KEY",
     "Prepare release notes",
     "steps.ai_release_notes.outputs.content",


### PR DESCRIPTION
## Why

The release-notes generator (the git-iris GitHub Action step in `release.yml`) still pins Opus 4.8, and the docs workflow carries the last open dependabot actions bump.

## What

- `model: claude-opus-5` on the git-iris release-notes step, with the workflow-contract test updated to pin the new string (the test is what makes the pin deliberate).
- `pnpm/action-setup` to 6.0.10 in `docs.yml`, absorbing dependabot #370.

## Receipts

`uv run pytest tools/tests/test_release_workflow.py -q` → `21 passed`. The release workflow itself only runs on dispatch, so the contract test is the meaningful gate for this diff; the PR CI exercises none of the changed lines beyond static checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)