### PR TITLE
docs(architecture): 1.3 rethink synthesis + seven-lane audit reports

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -17,6 +17,7 @@ export default defineConfig({
     // retrieval-system.md is the one lowercase architecture doc and ships.
     srcExclude: [
         'architecture/[A-Z]*.md',
+        'architecture/AUDIT_*/**',
         '_archive/**',
         'research/**',
         'testing/PERMISSION_TEST_STRATEGY.md',

--- a/docs/architecture/AUDIT_2026-08-13/debt-api.md
+++ b/docs/architecture/AUDIT_2026-08-13/debt-api.md
@@ -1,0 +1,989 @@
+# apps/api tech-debt audit (sibyld server daemon)
+
+Repo: `/Users/bliss/dev/sibyl` @ `5388d986` (main, clean). Lane: `apps/api` only.
+Everything below was read in the tree as it stands today. Line numbers are from the
+current working copy. Findings the 2026-05-28 audit already fixed are not re-listed.
+
+Scale of the surface: 390 Python files, ~151k lines including tests. 31 routers, 185
+REST routes, 204 route handlers and 332 module-private helpers inside
+`src/sibyl/api/routes/`.
+
+---
+
+## Severity index
+
+| # | Finding | Severity | Fix |
+|---|---|---|---|
+| 1 | Broker/scheduler/lock startup failures swallowed; readiness reports ready | blocker | M |
+| 2 | `GET /backups/jobs/{job_id}` is cross-org readable | major | S |
+| 3 | Idempotency lock scope defaults to the literal string `"unknown"` | major | S |
+| 4 | Rate limiting is inert outside 6 auth routes; tests assert the config dict | major | S |
+| 5 | `X-Request-ID` validation bypassed by middleware ordering | major | S |
+| 6 | Setup-mode auth bypass gates instance-wide settings on data presence | major | M |
+| 7 | No test asserts every mounted route carries an auth dependency | major | S |
+| 8 | API-key REST scope check depends on unpinned Starlette `Mount` behavior | major | S |
+| 9 | 6.5k lines of domain logic living in the route package | major | L |
+| 10 | Hand-rolled SurrealQL lexer as a security boundary in a route file | major | M |
+| 11 | Config lives in `os.environ`, mutated at startup and by route handlers | major | M |
+| 12 | The FastAPI app's `lifespan` never runs in the deployed process | major | S |
+| 13 | `get_current_organization` returns an org without checking membership | major | M |
+| 14 | Errors swallowed into 200 responses (5 sites) | minor | S |
+| 15 | Raw exception strings returned in 200 bodies, bypassing sanitization | minor | S |
+| 16 | Three auth-dependency families across two architectural layers | minor | M |
+| 17 | Two WebSocket endpoints, two hand-written auth paths, one via query param | minor | M |
+| 18 | WebSocket broadcast is serial; one slow client stalls the org | minor | S |
+| 19 | `is_setup_mode()` / readiness open an unpooled Surreal client per call | minor | S |
+| 20 | Duplicated config validators; dead `fully_surreal`; dead `auth/rls.py` | minor | S |
+| 21 | `enqueue_crawl`/`enqueue_sync` take an optional `organization_id` | minor | S |
+| 22 | 2.5k-line migration/cutover CLI ships in the daemon wheel | minor | M |
+| 23 | `disable_auth` is a half-implemented mode, resolved at import time | minor | S |
+| 24 | `SessionMiddleware` reuses the JWT signing secret | minor | S |
+| 25 | CORS allows `localhost:3337` in production | minor | S |
+| 26 | Six `BaseHTTPMiddleware` layers on every request | minor | M |
+| M1 | `api:read`/`api:write` never enforced on the MCP surface | blocker | M |
+| M2 | MCP accepts a client-supplied project as an authorization input | major | S |
+| M3 | MCP writes carry no org-role gate; VIEWER can write | major | M |
+| M4 | MCP re-implements REST handlers, with measured divergence | major | L |
+| M5 | Third verbatim copy of the REST scope check in the persistence layer | major | S |
+| M6 | mcp 2.0 migration surface (assessment) | n/a | M |
+| M7 | Conditional `user_id` overwrite; unpoliced `manage` actions | minor | S |
+| J1 | `coordination_backend="auto"` never selects Redis; default queue is in-memory | blocker | M |
+| J2 | Delivery semantics differ by backend; no `max_tries`, no local timeout | major | M |
+| J3 | A failed local job blocks its own retry for 24 hours | major | S |
+| J4 | `run_backup` reports failure as a successful job | major | S |
+| J5 | The local scheduler double-fires with more than one process | major | M |
+| J6 | Local backend breaks five coordination guarantees across processes | major | M |
+| J7 | Five jobs run without an org scope | major | S |
+| J8 | Shutdown drains the backlog, then kills running work | minor | S |
+| J9 | Failure-looks-like-success is systemic across job bodies | major | M |
+
+---
+
+## 1. Startup failures are swallowed and readiness cannot see them (blocker, M)
+
+`src/sibyl/runtime_services.py:52-114`. Each of `_startup_broker`, `_startup_scheduler`,
+`_startup_pubsub`, and `_startup_locks` wraps its work in `try/except Exception` and
+downgrades any failure to a `log.warning`, then continues. `startup()` returns normally.
+
+`src/sibyl/api/readiness.py:102-111` probes SurrealDB reachability and schema bootstrap,
+nothing else. `src/sibyl/api/app.py:339-354` `/health` returns `"healthy"`
+unconditionally.
+
+So a process that failed to connect its job broker, failed to start the scheduler, and
+failed to initialize distributed locks passes both probes and takes production traffic.
+Every enqueue against that process, every cron-scheduled backup, and every idempotency
+lock acquisition then fails or silently no-ops behind a warning line that nobody is
+paging on. This is the single highest-leverage finding in the lane: it converts a
+recoverable startup fault into silent data loss.
+
+Fix: track which subsystems are required, record their status on the `RuntimeServices`
+instance (the flags already exist: `_broker_initialized`, `_scheduler_initialized`,
+`_locks_initialized`), and surface them as `DependencyStatus` entries in
+`check_readiness()`. Either fail startup outright or report not-ready.
+
+Related: `src/sibyl/api/app.py:161-166` calls `runtime_services.startup()` outside the
+`try`, so a partial startup leaks whatever did initialize.
+
+## 2. `GET /backups/jobs/{job_id}` is cross-org readable (major, S)
+
+`src/sibyl/api/routes/backups.py:428-449`.
+
+```python
+@router.get("/jobs/{job_id}")
+async def get_backup_job_status(job_id: str) -> dict[str, Any]:
+    from sibyl.jobs.queue import get_job_status
+    info = await get_job_status(job_id)
+    return {..., "result": info.result, "error": info.error}
+```
+
+It is the only route in the file with no `org: AuthOrganization = Depends(get_current_organization)`
+(compare `:184, :194, :225, :283, :318, :345, :370, :407`). The router-level
+`Depends(require_org_admin())` at `:76` only proves the caller administers *some* org, and
+the codebase itself documents that this is no privilege at all: `persistence/surreal/setup.py:154-156`
+notes "every user owns a personal organization with the OWNER role, so an org-scoped check
+gates nothing for instance-wide settings."
+
+`info.result` for a backup job is the payload built at `src/sibyl/jobs/backup.py:455-462`,
+which carries `organization_id`, `backup_id`, and error text.
+
+The correct pattern already exists one file over: `src/sibyl/api/routes/jobs.py:42-80`
+`_job_visible_to_org`, applied at `jobs.py:349-350` and `:373-374`, which 404s on mismatch.
+Fix is to reuse it.
+
+## 3. Idempotency lock scope defaults to `"unknown"` (major, S)
+
+`src/sibyl/api/idempotency.py:268-275`:
+
+```python
+org = arguments.get("org")
+organization_id = str(getattr(org, "id", "unknown"))
+actor = arguments.get("auth") or arguments.get("ctx") or arguments.get("user")
+principal_id = str(getattr(actor, "user_id", None) or ... or getattr(actor, "id", "unknown"))
+```
+
+`serialize_idempotent_request` recovers the tenant by *introspecting the decorated
+handler's parameter names*. A handler that names its org parameter anything other than
+`org`, or its actor anything other than `auth`/`ctx`/`user`, silently falls back to the
+literal string `"unknown"` — and `idempotency_lock` then acquires the lock in a shared
+`"unknown"` scope (`idempotency.py:230`, `manager.acquire(organization_id, lock_id)`).
+
+Two consequences. Cross-tenant contention: two orgs replaying the same `Idempotency-Key`
+against the same path serialize against each other. And divergence: the lock is scoped to
+`"unknown"` while the idempotency *record* is written with the real `organization_id`
+passed separately by the route (`replay_idempotent_response(organization_id=...)`), so the
+mutual exclusion the record's replay logic assumes is not the exclusion actually held.
+
+This is the exact "group_id defaulted/confused" shape the multi-tenancy contract forbids.
+Fix: raise on a missing org/actor rather than defaulting, and make the resolution explicit
+rather than name-based.
+
+Second defect in the same module, `idempotency.py:234-243`: when the lock lease cannot be
+extended, `renew_lease` logs `idempotency_lock_lease_lost` and returns. The critical
+section keeps executing without a lock, and `:252` then releases with a token that is no
+longer valid. Lease loss should abort the operation, not narrate it.
+
+## 4. Rate limiting is inert on 179 of 185 routes (major, S)
+
+`src/sibyl/api/app.py:187-188` sets `app.state.limiter` and registers the 429 handler, but
+**`SlowAPIMiddleware` is never added**. In slowapi, `default_limits` are applied by that
+middleware; without it, only routes carrying an explicit `@limiter.limit(...)` decorator
+are limited. There are exactly six, all in `src/sibyl/api/routes/auth.py` (`:870, :961,
+:987, :1413, :1451, :1532`).
+
+So `settings.rate_limit_default` ("100/minute", `config.py:374-377`) is advertised in
+config, documented, and enforced nowhere. `RATE_LIMITS` and `get_rate_limit()`
+(`src/sibyl/api/rate_limit.py:36-54`) have no caller in `src/` at all.
+
+The test file makes this worse rather than catching it.
+`tests/test_rate_limiting.py:9-42` asserts that the `RATE_LIMITS` dict contains the
+expected string values and that `get_rate_limit("auth") == RATE_LIMITS["auth"]` — it
+tests a dictionary that nothing reads. No test issues N+1 requests and expects a 429.
+This is a green suite over an inert feature.
+
+Two smaller issues in the same file. `_get_key` (`rate_limit.py:17-22`) reads
+`request.state.jwt_claims`, which `AuthMiddleware` only populates for JWTs, never for
+`sk_` API keys — so all API-key traffic from one egress IP shares a single bucket. And
+`limiter` is constructed at import time from `settings`, so `reload_settings_from_env()`
+cannot affect it.
+
+## 5. `X-Request-ID` validation is bypassed by middleware ordering (major, S)
+
+`src/sibyl/api/errors.py:259-266` `get_request_id` validates a caller-supplied header
+against `_REQUEST_ID_RE = ^[A-Za-z0-9_.:-]{1,128}$` — but only *after* checking
+`request.state.request_id` first and returning it if already set.
+
+`src/sibyl/api/app.py:130-131` `RequestIdMiddleware` sets
+`request.state.request_id = request.headers.get(REQUEST_ID_HEADER) or generate_request_id()`
+with no validation at all.
+
+Middleware order (`app.py:267-289`; `add_middleware` prepends, so last-added is outermost)
+is VersionHeader → RequestId → AccessLog → Auth → Session → CORS. `RequestIdMiddleware`
+therefore always runs first and always wins, and the regex in `errors.py` is dead for
+every real request. An arbitrary-length, arbitrary-content client string flows into the
+structlog context (`app.py:133`), into every error payload
+(`errors.py:281`, `safe_error_payload`), and back out in the response header
+(`app.py:136`).
+
+Also note `AccessLogMiddleware` and `RequestIdMiddleware` both set `request.state.request_id`
+and both stamp the response header — duplicated responsibility across two layers with
+different rules. Collapse them into one.
+
+## 6. Setup mode is an unauthenticated bypass gated on data presence (major, M)
+
+`src/sibyl/persistence/surreal/setup.py:42-44`:
+
+```python
+async def is_setup_mode() -> bool:
+    return not (await get_setup_status()).setup_complete
+```
+
+and `setup_complete` is `_has_records(payload["initialized_memberships"])`
+(`setup.py:57-71`) — i.e. "does at least one org_members row exist with role owner or
+admin".
+
+Four dependencies return with **zero authentication** when that is true:
+`require_setup_mode_or_auth` (`:107-113`), `require_setup_mode_or_admin` (`:116-138`),
+`require_settings_admin` (`:141-148`), `require_settings_owner` (`:151-163`).
+
+What sits behind them:
+
+- `src/sibyl/api/routes/settings.py:174` `GET /settings`, `:205` `PATCH /settings` —
+  the PATCH writes provider API keys. Note both call `await require_settings_owner(request)`
+  *inside the handler body* (`:186`, `:217`) rather than as a `Depends`, so the gate is
+  invisible to the dependency graph and to the OpenAPI schema. `DELETE /settings/{key}`
+  (`:308`) is the only one that pre-blocks setup mode explicitly (`:319-320`).
+- `src/sibyl/ai/llm/routes.py:38` (`/settings/ai`, mounted at `app.py:303`) — all 8 routes
+  have no `Depends` whatsoever and call `require_settings_owner(request)` in the body
+  (`:116, 133, 158, 182, 191, 203, 230`).
+- `src/sibyl/api/routes/setup.py:291` `POST /setup/config` — writes API keys.
+
+The risk is that the gate is derived from data rather than from state: an instance that
+loses its `organization_members` rows (bad restore, mid-migration, wrong namespace
+selected, a query that returns empty for a transport reason) re-opens the entire settings
+surface to anonymous writes. There is no explicit "setup completed" marker, no one-way
+latch, and no network restriction on the bypass.
+
+Fix: persist an explicit `setup_completed_at` marker that only ever transitions forward,
+and move the in-body `require_*` calls into route `dependencies=[...]` so the gate is
+declarative and auditable.
+
+## 7. Nothing tests that routes have auth (major, S)
+
+Finding #2 exists because the test suite cannot see it. `tests/test_wire_scope.py:1-8`
+is the closest thing to an end-to-end auth test and its own docstring says it "substitut[es]
+only the auth dependencies" — it overrides `get_auth_context`, `get_current_organization`,
+`get_current_org_role`, which means a route that *forgot* those dependencies is
+indistinguishable from one that has them. `tests/test_route_access_seams.py` calls the
+`_verify_*_access` helpers directly with mocks.
+
+There is no test that walks `create_api_app().routes` and asserts each non-allowlisted
+route resolves an auth dependency. That test is maybe 30 lines, it would have caught #2,
+and it is the cheapest durable guard in this report.
+
+## 8. API-key REST scope enforcement rests on unpinned Starlette behavior (major, S)
+
+`src/sibyl/auth/dependencies.py:48-56`:
+
+```python
+def _is_rest_request(request: Request) -> bool:
+    return request.url.path.startswith("/api/")
+```
+
+This is the *only* thing that makes `api:read` / `api:write` scopes apply to REST
+(`dependencies.py:132-135`). The FastAPI app is mounted at `/api`
+(`src/sibyl/main.py:166`), so whether this predicate fires depends on whether
+`request.url.path` inside a mounted sub-app is the full path or the prefix-stripped one.
+
+I verified it against the installed Starlette 1.6.0: `Mount.matches` builds `child_scope`
+with `root_path = root_path + matched_path` and deliberately does **not** rewrite
+`scope["path"]`, while `URL.__init__` uses bare `scope["path"]`. So today the predicate is
+correct and scopes are enforced.
+
+The debt is that nothing pins it. `tests/test_auth_api_key_scopes_rest.py:15-19`
+hand-constructs a scope dict with `"path": "/api/me"` and never drives the real mounted
+app. Older Starlette versions *did* strip the mount prefix from `scope["path"]`. If a
+future upgrade reverts to that, every API key silently gains unscoped read and write on
+the whole REST surface and this test stays green. One `TestClient(create_combined_app())`
+test that sends a read-only key at a POST and expects 403 closes it permanently.
+
+## 9. Domain logic lives in the route package (major, L)
+
+Measured by AST over `src/sibyl/api/routes/`: 204 route handlers totalling 9,096 lines,
+plus **332 module-private helper functions totalling 6,559 lines**. The helpers are not
+serialization glue; they are the domain.
+
+Worst concentrations:
+
+- `src/sibyl/api/routes/memory.py` — 3,362 lines, of which the first ~1,690 are ~60
+  private helpers before a single route: authorization policy composition
+  (`_authorize_memory_policy:300`, `_authorize_project_scope_write:246`,
+  `_authorize_raw_promotion_api_key_scopes:1476`, `_authorize_share_api_key_scopes:1564`),
+  audit-event derivation (`_derived_records_from_audit:1169`, `_correction_history:1207`),
+  and promotion/share state machines (`_promotion_state:1237`, `_share_state:1253`).
+- `src/sibyl/api/routes/context.py:224-616` — retrieval fusion and refinement:
+  `_fuse_context_evidence` (139 lines, `:251`), `_execute_context_refinement_round` (`:393`),
+  `_execute_accurate_context_evidence_search` (164 lines, `:449`), `_refinement_frontier`
+  (`:238`). This is core retrieval algorithm sitting behind an HTTP decorator.
+- `src/sibyl/api/routes/entities.py:568-1190` — the whole entity visibility model
+  (`_entity_visible_to_reader`, `_raw_capture_visible_to_reader`,
+  `_resolve_entity_list_project_filter`, `_reader_memory_grants`).
+- `src/sibyl/api/routes/auth.py:1087-1387` — `_render_device_verify_page`, 300 lines of
+  inline HTML and CSS in a route module, in a repo that ships a Next.js frontend.
+
+Individual handlers are correspondingly large: `entities.py:2076 create_entity` 237 lines,
+`entities.py:1655 create_entities_bulk` 195, `tasks.py:791 update_task` 194,
+`entities.py:1451 get_entity` 190.
+
+Consequence beyond aesthetics: this logic is only reachable through HTTP, so the MCP
+surface either duplicates it or silently diverges from it, and the tests that cover it are
+route tests with mocked dependencies rather than unit tests over the rule.
+
+Six route modules also each define their own identical `get_entity_graph_runtime(group_id)`
+lazy-import wrapper: `entities.py:89`, `graph.py:39`, `rag.py:60`, `context.py:78`,
+`tasks.py:60`, plus `graph.py:45` for the query adapter. Same three lines, six copies.
+
+## 10. A hand-rolled SurrealQL lexer is the security boundary on `/admin/debug/query` (major, M)
+
+`src/sibyl/api/routes/admin.py:726-1018` is roughly 290 lines of character-by-character
+SurrealQL scanning — `_skip_query_literal`, `_skip_query_comment`, `_skip_query_separators`,
+`_has_identifier_boundary`, `_read_query_string_value`, `_query_has_dynamic_content_table`,
+`_query_has_additional_statement`, `_query_disallowed_namespace_call` — feeding
+`_is_supported_debug_dialect` (`:1009-1017`), which gates `debug_query` (`:1025`).
+
+The code is careful and clearly hard-won (the comment at `:987-988` about walking nested
+`::` chains shows real iteration). The debt is structural:
+
+- It is a **deny-list** (`_GRAPH_DEBUG_FORBIDDEN_TOKENS`, `:893-921`). Any SurrealQL
+  keyword added by a future server version defaults to permitted. `LET`, `RETURN`, `FOR`,
+  and `IF` are not in the list; today they are blocked only incidentally by the
+  "first token must be SELECT" rule.
+- It is a security boundary implemented as string parsing, in a route file, with no
+  fuzzing and no property tests.
+- It is the wrong layer. SurrealDB can express read-only access directly; a
+  scoped read-only session or a DEFINE-level permission would make the parser unnecessary.
+
+Blast radius is bounded — the endpoint is `_OWNER_ONLY` and executes against
+`str(org.id)`'s own namespace, with client-supplied `group_id`/`organization_id`/`org_id`
+params correctly rejected at `_debug_params_for_org` (`:881-890`). But a boundary this
+fragile should not live in a route module.
+
+Same endpoint, second issue: `admin.py:1057-1067` catches every exception and returns
+**HTTP 200** with `error=str(e)` in the body. That path never touches
+`http_exception_payload`, so `sanitize_error_text` (`errors.py:350-358`) never runs and
+raw SurrealDB exception text — which can echo query fragments and internal identifiers —
+goes straight to the client. `_validate_content_debug_query`'s `ValueError` (`:868-878`)
+lands here too, so a validation failure returns 200 instead of 400.
+
+## 11. Configuration is process environment, mutated at startup and by routes (major, M)
+
+Three separate mechanisms fight over the same state.
+
+`src/sibyl/config.py:805` instantiates a module-global `settings` at import. Modules
+capture values from it at import time (e.g. the security warning at
+`auth/dependencies.py:40`, the `limiter` at `rate_limit.py:26-31`, and the
+`require_org_role`/`require_org_admin` branch selection at `dependencies.py:206` and `:269`).
+`reload_settings_from_env()` (`config.py:808-812`) mutates `settings.__dict__` in place and
+none of those captured values move.
+
+`src/sibyl/services/settings.py:394-433` `load_runtime_settings_from_db` reads eleven
+settings out of SurrealDB at startup and writes them into `os.environ` via
+`os.environ.setdefault`. Provider keys, embedding models, and embedding dimensions are
+therefore transported through the process environment.
+
+`src/sibyl/api/routes/settings.py:170-171` does the same thing at request time:
+`os.environ[env_var] = str(value)` inside a route handler.
+
+Net effect: config is global mutable process state written from three places, one of which
+is an HTTP handler. `os.environ.setdefault` also makes it a one-way door — a value loaded
+at startup can never be cleared without a restart, which is why
+`DELETE /settings/{key}` has to hand-clear env vars (`settings.py:329-331`).
+
+Separately, `Settings` carries ~85 fields with three overlapping `model_validator(mode="after")`
+passes, two of which duplicate the same defaulting logic verbatim: `config.py:232-235` and
+`config.py:519-522` are identical four-line blocks setting `auth_store` and
+`local_auth_enabled`.
+
+## 12. The FastAPI app's `lifespan` never runs in the deployed process (major, S)
+
+`src/sibyl/api/app.py:158-166` defines a `lifespan` that constructs `RuntimeServices` and
+calls `startup()`/`shutdown()`, and passes it to `FastAPI(lifespan=lifespan)` at `:183`.
+
+In the deployed process the API app is a **mounted sub-app** (`src/sibyl/main.py:166`,
+`Mount("/api", app=api_app)`). Starlette delivers `lifespan` scope only to the top-level
+router; mounted ASGI apps never receive it. The outer Starlette lifespan
+(`main.py:106-159`) does the real startup.
+
+So `api/app.py`'s lifespan is dead in production and live only under
+`TestClient(create_api_app())`. Two failure modes follow: tests exercise a startup path
+production does not, and if the mounting ever changes to propagate lifespan,
+`RuntimeServices.startup()` runs twice with no guard against it. Delete the sub-app
+lifespan, or make `RuntimeServices` idempotent and say which one owns the lifecycle.
+
+Adjacent dead branch in the same file: `main.py:142-159`. `worker_task` is initialized to
+`None` and never assigned — with `coordination_backend == "local"` it logs "runs
+in-process", otherwise it logs "Embedded worker disabled in surreal mode". So
+`SIBYL_RUN_WORKER=true` (`main.py:249`) does nothing on the redis backend while logging as
+though the decision were deliberate, and the cancellation block at `:156-159` is
+unreachable.
+
+## 13. `get_current_organization` does not verify membership (major, M)
+
+`src/sibyl/persistence/surreal/auth.py:702-774` `SurrealAuthContextResolver.resolve` runs
+one query returning `user`, `organization`, and `membership` independently (`:725-741`).
+`AuthContext.organization` is populated from the org row **whenever the `org` claim names a
+real organization**, regardless of whether the membership row exists — only `org_role`
+goes `None` (`:764-769`).
+
+`src/sibyl/auth/dependencies.py:180-186` `get_current_organization` then checks only
+`ctx.organization is None`. So the dependency that every org-scoped route uses to obtain
+`group_id` — and that `get_entity_manager`/`get_graph_store`
+(`src/sibyl/api/dependencies.py:67-100`) use to open a client on that org's Surreal
+namespace — never asserts the caller is a member.
+
+The tenancy invariant holds today only because the *separate* `require_org_role`
+dependency is present on the routers that matter, and because token issuance does check
+membership: `persistence/surreal/organization_runtime.py:760-768` (`switch_org`) 404s when
+`membership is None`. I checked the refresh path too — `api/routes/auth.py:1571-1584` takes
+the org from the signed refresh token's own claims, not from client input.
+
+Two residual gaps. Membership is never re-verified on refresh
+(`persistence/surreal/auth_runtime/sessions.py:241-256` mints a new access token from the
+caller-supplied `organization_id` without re-reading the session's org or the membership
+row), so a user removed from an org keeps refreshing into it until the session is revoked;
+they are stopped by `org_role is None` at the role check, not by the org resolution. And
+the WebSocket path (`src/sibyl/api/websocket.py:398-399`) scopes broadcasts purely on the
+`org` claim with no membership check at all.
+
+Fix: make `resolve` refuse to populate `organization` without a membership row, so the
+invariant is enforced once at the chokepoint instead of 31 times at the routers.
+
+## 14. Errors swallowed into 200 responses (minor, S)
+
+- `src/sibyl/api/routes/crawler.py:291-350` `preview_url`: the handler raises
+  `HTTPException(400, "Invalid URL")` at `:299` **inside** a `try` whose `except Exception`
+  at `:347` catches it and returns HTTP 200 with `{"error": "Failed to preview URL"}`.
+  `HTTPException` is an `Exception`. So an invalid URL, an SSRF block, a timeout, and a
+  successful fetch are all 200s.
+- `src/sibyl/api/routes/jobs.py:191-193` `list_jobs`: queue unreachable returns
+  `{"jobs": [], "total": 0, "error": ...}` with status 200 — a caller cannot distinguish
+  "no jobs" from "the queue is down".
+- `src/sibyl/api/routes/jobs.py:146-152` `jobs_health`: returns `status: "unhealthy"` at 200.
+- `src/sibyl/api/routes/rag.py:756-763`: graph search failure returns an empty related-entity
+  list at 200.
+- `src/sibyl/api/routes/admin.py:277-286` `health`: returns `HealthResponse(status="unhealthy",
+  errors=[str(e)])` at 200.
+
+## 15. Raw exception text returned in 200 bodies (minor, S)
+
+`admin.py:1063-1066` (`error=str(e)`) and `admin.py:279-286` (`errors=[str(e)]`) return
+exception strings in successful responses, which bypasses the entire sanitization pipeline
+in `src/sibyl/api/errors.py`. That pipeline only runs for `HTTPException` and unhandled
+exceptions via the handlers at `app.py:209-258`.
+
+Worth noting the sanitizer is also aggressive in the other direction:
+`sanitize_error_text` (`errors.py:350-358`) replaces any message longer than 200 chars, or
+containing two or more path-like segments, or matching
+`token|secret|password|credential|api_key`, with the generic "Invalid request data." A
+legitimate message like "Password reset token has expired" is destroyed. And `_safe_details`
+(`errors.py:376-385`) drops every detail key outside a 7-item allowlist, so
+`ProjectAuthorizationError`'s `project_id` (`auth/authorization.py:113`) never reaches the
+client.
+
+## 16. Three auth-dependency families across two layers (minor, M)
+
+- `src/sibyl/auth/dependencies.py` — `require_org_role`, `require_org_admin`,
+  `get_current_org_role`.
+- `src/sibyl/auth/authorization.py` — `require_project_role/read/write/admin`,
+  `verify_entity_project_access`.
+- `src/sibyl/persistence/surreal/setup.py:107-171` — `require_global_admin`,
+  `require_settings_admin`, `require_settings_owner`, `require_setup_mode_or_admin`,
+  `require_setup_mode_or_auth`.
+
+The third family is FastAPI dependency code living inside the **persistence** package,
+imported directly by routes (`api/routes/logs.py:18`, `api/routes/setup.py:19-20`). It
+imports back up into `sibyl.auth.dependencies` (`setup.py:12`), so the layering is circular
+in intent if not in module graph. `auth/authorization.py:97-119` also still carries a class
+explicitly marked `DEPRECATED` in its own docstring.
+
+## 17. Two WebSocket endpoints, two hand-written auth paths (minor, M)
+
+`src/sibyl/api/websocket.py:371-399` `_extract_org_from_token` and
+`src/sibyl/api/routes/logs.py:71-99` `_validate_owner_token` independently reimplement
+token extraction, JWT verification, and session validation. Neither reuses
+`resolve_claims`. Neither supports `sk_` API keys.
+
+`logs.py:110-114` takes the token as a **query parameter** (`ws://host/api/logs/stream?token=<jwt>`),
+which puts a live access token into reverse-proxy access logs and browser history.
+
+Both validate once at connect and never again, so revoking a session does not close an open
+socket — a revoked admin keeps streaming server logs until they disconnect.
+
+## 18. WebSocket broadcast is serial (minor, S)
+
+`src/sibyl/api/websocket.py:122-130` awaits `conn.websocket.send_json(message)` in a loop
+over every connection in the org. One slow or backpressured client delays delivery for
+every other client in that organization and blocks the calling request handler that
+triggered the broadcast. `asyncio.gather` with per-connection exception capture is the
+straightforward fix.
+
+## 19. Unpooled Surreal clients on hot paths (minor, S)
+
+`src/sibyl/persistence/surreal/setup.py:47-74` `get_setup_status` calls
+`build_surreal_auth_client()` and `client.close()` on every invocation — and `is_setup_mode()`
+is called on **every request** to `/settings`, `/settings/ai`, and `/setup`. Same shape in
+`src/sibyl/api/readiness.py:63-78`, which connects and closes a fresh client per readiness
+probe (every few seconds under a k8s `readinessProbe`). Both bypass the pooling described
+in `CLAUDE.md`'s "Surreal Connection Pooling" section.
+
+## 20. Dead and duplicated code (minor, S)
+
+- `src/sibyl/config.py:793-796` `fully_surreal` is `return True` with **zero callers** in
+  the repo.
+- `src/sibyl/auth/rls.py` (71 lines) — the whole module is a retired shim.
+  `get_rls_session`/`require_rls_session` raise 501 and nothing in `src/` imports any of it.
+- `src/sibyl/config.py:232-235` and `:519-522` — the same four-line defaulting block
+  duplicated across two validators.
+- `src/sibyl/api/rate_limit.py:36-54` — `RATE_LIMITS` and `get_rate_limit`, referenced only
+  by the test that asserts their contents.
+- `src/sibyl/api/routes/logs.py`, `websocket.py`, `setup.py` all carry their own
+  `disable_auth` special case (`logs.py:74`, `websocket.py:379`, `websocket.py:420`).
+
+## 21. `enqueue_crawl` / `enqueue_sync` take an optional org (minor, S)
+
+`src/sibyl/jobs/queue.py:76-98` are the only two enqueue functions with
+`organization_id: str | None = None`; all fifteen others require it
+(`:105, 126, 134, 148, 170, 188, 204, 218, 233, 256, 274, 290, 317, 338, 352, 366, 380`).
+
+Every real caller passes it (`api/routes/crawler.py:546-553`,
+`core_runtime_ports.py:126-141` — the port even types it as required), so the optionality
+buys nothing and costs real complexity: `api/routes/jobs.py:59-79` has a whole fallback
+branch that re-derives the org for `crawl_source`/`sync_source` jobs by loading the source
+record, purely because those two jobs might not carry one. Tighten the signature and the
+fallback deletes itself.
+
+## 22. Migration/cutover tooling ships in the daemon (minor, M)
+
+`src/sibyl/cli/migrate.py` is 2,548 lines — the second-largest file in `apps/api` — with 13
+commands including `rehearse` (`:1907`), `cutover` (`:2090`), `auth-flow-compare` (`:1833`),
+and `consolidate` (`:1362`). It shells out to `ssh`/`subprocess` (`:189, :228`), runs moon
+tasks (`:530`), and drives a full pre-cutover acceptance suite (`:599`).
+
+This is one-time Neo4j-era migration rehearsal machinery. `settings.store` is now
+`Literal["surreal"]` (`config.py:169-172`) and `fully_surreal` is hardcoded `True`
+(`config.py:794-796`), so the alternative the cutover moves *from* no longer exists in the
+codebase. It ships in every `sibyld` wheel.
+
+## 23. `disable_auth` is a half mode, resolved at import (minor, S)
+
+`require_org_role` and `require_org_admin` (`auth/dependencies.py:198-208`, `:258-271`)
+choose between the real check and a `_noop` **when the decorator is constructed**, i.e. at
+router-module import. `reload_settings_from_env()` cannot change it afterwards.
+
+The mode is also incomplete: with `disable_auth=True` the role checks vanish, but
+`get_current_organization` still raises 401 because `resolve_claims` returns nothing, so
+most routes still fail. Production is protected (`config.py:237-241`), but as a dev mode it
+half-works, and each of `logs.py:74`, `websocket.py:379`, `websocket.py:420` handles it
+differently.
+
+## 24-26. Middleware and transport hygiene (minor)
+
+- `src/sibyl/api/app.py:274-279`: `SessionMiddleware(secret_key=settings.jwt_secret.get_secret_value())`
+  reuses the JWT signing key for itsdangerous cookie signing. Two cryptographic purposes,
+  one key; rotating either forces rotating both.
+- `src/sibyl/api/app.py:261-273`: `cors_origins` hardcodes `http://localhost:3337` and
+  `http://127.0.0.1:3337` alongside `public_url`, with `allow_credentials=True`, in every
+  environment including production.
+- Six middleware layers on every request, four of them `BaseHTTPMiddleware`
+  (`VersionHeader`, `RequestId`, `AccessLog`, `Auth`) plus `SessionMiddleware` and CORS.
+  `BaseHTTPMiddleware` wraps each request in an anyio task group and is the known-costly
+  option; `AuthMiddleware` (`auth/middleware.py:22-35`) exists only to pre-decode a JWT that
+  `resolve_claims` re-verifies anyway (`auth/dependencies.py:102-115`), and its output feeds
+  exactly one other consumer, the rate-limit key function that finding #4 shows is inert on
+  almost every route. Pure ASGI middleware, or folding these into one layer, is the fix.
+
+---
+
+# MCP surface
+
+`src/sibyl/server.py` (2,844 lines) registers 13 tools and 2 resources on
+`mcp.server.fastmcp.FastMCP`, mounted at `/` (`src/sibyl/main.py:167`) alongside REST at
+`/api`.
+
+## M1. `api:read` / `api:write` are not enforced on MCP at all (blocker, M)
+
+I grepped `server.py`, `auth/mcp_auth.py`, and `auth/mcp_oauth.py` for `api:read` and
+`api:write`. **Zero hits.** Those scopes exist only in the two REST copies
+(`auth/dependencies.py:35-36` and `persistence/surreal/auth_runtime/_common.py:79-80`).
+
+The REST gate fires only for paths under `/api/` (`auth/dependencies.py:48-49`, finding #8),
+and MCP is mounted at `/`, so MCP requests never reach it. The result:
+
+- The default scope set for a newly created API key is `["mcp"]`
+  (`src/sibyl/api/routes/auth.py:117`; the allowlist is
+  `{"api:read", "api:write", "mcp"}` at `auth.py:111`).
+- That default key is correctly **refused** every mutating REST call
+  (`dependencies.py:132-135` → 403 `insufficient_api_scope`).
+- The same key is **fully accepted** by MCP `add` (`server.py:2436`), `remember`
+  (`server.py:2544`), and `manage` (`server.py:2677`) — including
+  `manage("complete_task")`, `manage("correct_memory")`, and `manage("crawl")`.
+
+So `mcp` is a single all-or-nothing capability with no read/write distinction, and the
+least-privilege story the REST scopes tell is undone by the surface that most agents
+actually connect through. This is the most consequential finding in the MCP lane.
+
+Two scope fallbacks make it worse:
+
+- `auth/mcp_oauth.py:393`: `scopes = list(auth.scopes or []) or [OAUTH_SCOPE]` — an API key
+  with **zero** scopes is upgraded to `["mcp"]` and admitted.
+- `auth/mcp_oauth.py:98`: `_parse_scopes_from_claims` falls through to `return [OAUTH_SCOPE]`,
+  so a JWT carrying no `scope`/`scopes` claim is granted `mcp`.
+
+`auth/mcp_auth.py` gets this right — `SibylMcpTokenVerifier` hard-rejects a missing `mcp`
+scope on both branches (`:43-44`, `:70-71`) with no fallback. It is dead code:
+`server.py:1822` leaves `token_verifier = None` and passes it as `None` at `server.py:1851`.
+81 lines of correct, unreachable enforcement.
+
+## M2. MCP takes a client-supplied project as authorization input (major, S)
+
+`src/sibyl/server.py:319-323`:
+
+```python
+accessible_projects = await _get_accessible_projects(ctx)
+if accessible_projects is None:
+    if project:
+        return {project}
+    return None
+```
+
+`_get_accessible_projects` returns `None` when `ctx.user_id` is falsy and
+`api_key_project_ids is None` (`server.py:296-301`), and also whenever
+`resolve_accessible_project_graph_ids` returns `None`. On that branch the caller's raw
+`project` string becomes the authoritative scope set with **no membership check and no
+existence check**, and is then passed as `accessible_projects` into the memory policy
+(`server.py:1104, 1256, 1269`) and into `authorize_memory_write`. Client input becomes an
+authorization input.
+
+The REST twins never do this: `api/routes/context.py:632-639` and
+`api/routes/search.py:391-399` always route a named project through
+`verify_entity_project_access(..., require_existing_project=True)` first.
+
+## M3. MCP writes carry no org-role gate (major, M)
+
+REST write routes gate on `require_org_role(*_WRITE_ROLES)`
+(`api/routes/memory.py:1878`, `api/routes/entities.py:2072`) or an explicit role check
+(`api/routes/synthesis.py:121-122`). On MCP, `McpContext.org_role` defaults to `None`
+(`server.py:126`) and the API-key branch of `_get_mcp_context` (`server.py:184-201`) never
+populates it. It is forwarded into `MemoryPolicyContext.organization_role`
+(`server.py:143`) but no MCP tool ever compares it against a write-role set. The only role
+check on the entire MCP surface is `_require_owner_mcp_context` for the `logs` tool
+(`server.py:1796-1799`).
+
+Concretely: `_resolve_mcp_project_scope` does a plain set-membership test
+(`server.py:325-327`), so a project **VIEWER** can drive `remember` and `add` writes through
+MCP where REST demands CONTRIBUTOR.
+
+`_add_mcp_entity` (`server.py:1068-1158`) also skips `_validate_related_to_targets_for_write`
+(`api/routes/entities.py:808`, applied at `:2112`), so `related_to` targets go from tool
+argument (`server.py:2443`) into core `add` (`server.py:1126`) unvalidated.
+
+## M4. MCP re-implements REST handlers rather than sharing them (major, L)
+
+Not stylistic duplication — the copies have measurably diverged:
+
+- **API-key memory-scope gate.** `server.py:437` vs `api/routes/memory.py:274`:
+  `effective = ctx.user_id if memory_scope == MemoryScope.PRIVATE.value else scope_key`
+  versus `... if memory_scope == "private" and not scope_key else scope_key`. MCP discards
+  an explicitly supplied `scope_key` on a private write; REST honours it. Same intent, two
+  answers.
+- **Active-task link resolution.** `_resolve_mcp_capture_links` (`server.py:532-571`) vs
+  `_resolve_reflection_links` (`api/routes/context.py:644-683`) — same probe, but MCP passes
+  `allowed_memory_scope_keys=ctx.api_key_memory_scope_keys` (`server.py:557`) and REST omits
+  the argument entirely (`context.py:661-670`).
+- **Context pack.** `_compile_mcp_context_pack` (`server.py:333-411`) vs `context_pack`
+  (`context.py:796-879`) — REST normalizes the query via `normalize_retrieval_question`
+  (`context.py:816`) and MCP never calls it, so an identical goal retrieves differently on
+  the two surfaces. REST also supports `record_exposure` and `knn_type_overfetch`
+  (`context.py:834-835`); MCP has neither.
+- **Deny auditing.** REST writes `memory.policy_deny` audit rows on both denial paths
+  (`memory.py:347-358`, `:371-382`); MCP raises a bare `ValueError(decision.reason)`
+  (`server.py:510`, `:485`) and writes nothing. Policy denials on the MCP surface are
+  invisible to the audit log.
+- **Idempotency.** MCP hand-rolls reserve/replay/complete twice — `server.py:632-663` and
+  `server.py:1688-1728` — including a duplicated "interrupted takeover" comment block
+  (`server.py:646-655` ≡ `:1707-1717`). REST gets the same behavior from
+  `@serialize_idempotent_request` (`memory.py:1880`) and helpers.
+- **Byte-identical duplicate:** `_append_unique_ids` at `server.py:522-529` and
+  `context.py:616-623`.
+- Also `_log_mcp_policy_decision` (`server.py:414-430`) ≡ `_log_policy_decision`
+  (`memory.py:167-183`); `_deny_mcp_api_key_memory_scope` (`server.py:465-485`) ≡
+  `_api_key_memory_scope_denial` (`memory.py:279-297`); `_authorize_mcp_memory_write`
+  (`server.py:488-519`) ≡ `_authorize_memory_policy` (`memory.py:300-387`);
+  `_reflect_mcp_memory` (`server.py:784-889`) ≡ `reflect_context` (`context.py:925-1014`).
+
+`_manage_workflow_transition` (`server.py:1332-1491`) re-derives transition responses,
+message strings, revision validation, citation recording, and learning-job enqueue on top
+of the shared `transition_work_item` service. The comment at `server.py:1274-1277`
+acknowledges it was written to catch MCP up to REST — which is the diagnosis, not the fix.
+
+Root cause is finding #9: the shared rule lives in the route package, so the only way to
+reach it from MCP is to copy it.
+
+Separately, `logs` uses `has_owner_membership` on MCP (`server.py:1796-1799`) while REST
+`/logs` uses `require_global_admin` (`api/routes/logs.py:31, 58`) — two different admin
+notions guarding the same data.
+
+## M5. A third copy of the REST scope check lives in the persistence layer (major, S)
+
+`persistence/surreal/auth_runtime/_common.py:78-100` contains verbatim copies of
+`_SAFE_HTTP_METHODS`, `_REST_READ_SCOPES`, `_REST_WRITE_SCOPE`, `_is_rest_request`,
+`_api_key_allows_rest`, and `_insufficient_api_scope` from `auth/dependencies.py:34-73`.
+Both are live: the `_common` copy runs inside `resolve_request_claims`
+(`persistence/surreal/auth_runtime/sessions.py:200-207`), reached from `logout`
+(`api/routes/auth.py:1613`) and `resolve_request_user`.
+
+A security check duplicated across the auth layer and the persistence layer will drift, and
+when it does one request path will enforce and the other will not.
+
+## M6. mcp 2.0 migration surface (assessment, not a defect)
+
+Every `mcp.` import in `src`:
+
+| file:line | symbols |
+|---|---|
+| `server.py:17` | `mcp.server.auth.middleware.auth_context.get_access_token` |
+| `server.py:18` | `mcp.server.fastmcp.FastMCP` |
+| `server.py:1824` | `mcp.server.auth.settings.AuthSettings`, `ClientRegistrationOptions` |
+| `auth/mcp_auth.py:16` | `mcp.server.auth.provider.AccessToken` |
+| `auth/mcp_oauth.py:29-36` | `AccessToken`, `AuthorizationCode`, `AuthorizationParams`, `OAuthAuthorizationServerProvider`, `RefreshToken`, `TokenError` |
+| `auth/mcp_oauth.py:37` | `mcp.shared.auth.OAuthClientInformationFull`, `OAuthToken` |
+
+Plus tests (`test_mcp_oauth_multi_org_selection.py:10-11`,
+`test_mcp_oauth_session_refresh.py:9-10`, `test_server_accessible_projects.py:1799`) and
+client-side `mcp.ClientSession` in `tools/baselines/replay.py:10-11`.
+
+FastMCP surface actually used: constructor kwargs `host`/`port`/`stateless_http`/`auth`/
+`auth_server_provider`/`token_verifier` (`server.py:1844-1852`); `@mcp.tool()` ×13;
+`@mcp.resource(uri)` ×2; `@mcp.custom_route(...)` ×4 (`server.py:1856, 1860, 1864, 1868`);
+`streamable_http_app()` (`main.py:104`); `session_manager.run()` (`main.py:152`);
+`run(transport="stdio")` (`main.py:212`). `sse_app` is unused.
+
+**The good news: the 13 tool bodies are decoupled.** No tool takes a `Context` parameter and
+no tool imports from `mcp`; signatures are plain Python types and returns are
+`dict[str, Any]` via `_to_dict` (`server.py:1877`). A 2.0 bump would not touch them.
+
+What it does touch, in cost order:
+
+1. **`SibylMcpOAuthProvider`** (`auth/mcp_oauth.py:166-425`) — subclasses
+   `OAuthAuthorizationServerProvider[...]` and implements 9 abstract methods (`get_client:177`,
+   `register_client:193`, `authorize:203`, `load_authorization_code:215`,
+   `exchange_authorization_code:225`, `load_refresh_token:276`, `exchange_refresh_token:322`,
+   `load_access_token:388`, `revoke_token:423`) plus an `AuthorizationCode` subclass
+   (`:132-134`). A full protocol implementation pinned to the 1.x provider ABC. This is the
+   dominant cost.
+2. **`get_access_token()` ambient lookup** (`server.py:168`) — the entire MCP auth model
+   hangs off this contextvar. `_get_mcp_context` is the single identity source for every
+   tool via `_require_mcp_context` (`server.py:240-252`). If 2.0 changes ambient-token
+   retrieval, all 13 tools lose their identity source simultaneously.
+3. **`create_mcp_server`** (`server.py:1802-1874`) — constructor kwargs, the
+   `AuthSettings`/`ClientRegistrationOptions` shape (`:1827-1836`), and the
+   `auth_server_provider` vs `token_verifier` mutual exclusion documented at `:1840-1842`.
+4. **ASGI wiring** (`main.py:104, 152, 167`).
+5. **`mcp.shared.auth` models** (`mcp_oauth.py:37`) used for dynamic-client-registration
+   round-trip (`model_validate` at `:185`, `model_dump` at `:200`).
+6. **`auth/mcp_auth.py`** — dead (see M1), but it still needs porting or deleting.
+
+Roughly five files, concentrated in `mcp_oauth.py`. Deleting the dead `mcp_auth.py` and
+folding its (correct) scope logic into the live path would shrink the migration and close
+M1 at the same time.
+
+## M7. Smaller MCP items (minor)
+
+- `_get_mcp_context`'s JWT branch (`server.py:207-227`) calls `verify_access_token` but not
+  `validate_access_session`, unlike both `dependencies.resolve_claims` (`:117`) and
+  `mcp_oauth.load_access_token` (`:403`). Currently covered because the transport already
+  validated, but the duplicated path itself does not re-check revocation.
+- `manage` overwrites `organization_id` unconditionally (`server.py:1731`) — correct — but
+  overwrites `user_id` only conditionally (`:1732-1733`, `if ctx.user_id:`). Same pattern
+  for `created_by` at `:681-682` and `:1116-1117`. When `ctx.user_id` is falsy, a
+  client-supplied `data["user_id"]` / `metadata["created_by"]` survives into core `manage`
+  (`:1758-1766`).
+- `_authorize_mcp_manage_action` returns `None` (`server.py:1259-1260`) for any action
+  outside `MCP_ENTITY_PROJECT_POLICY_ACTIONS` (`:95-110`) and `MCP_PROJECT_ID_POLICY_ACTIONS`
+  (`:111`), so `crawl`, `sync`, `refresh`, `link_graph`, and `link_graph_status` get **no
+  policy decision at all** and reach core `manage` with client-controlled `data`, protected
+  only by org isolation.
+
+---
+
+# Jobs and worker reliability
+
+## J1. `"auto"` never selects Redis, so the default is an in-memory queue (blocker, M)
+
+`src/sibyl/config.py:177-180` defaults `coordination_backend="auto"`. `config.py:799-801`:
+
+```python
+def resolved_coordination_backend(self) -> Literal["local", "redis"]:
+    return "redis" if self.coordination_backend == "redis" else "local"
+```
+
+`"auto"` maps to `"local"`. Redis is **never** auto-selected regardless of whether Redis is
+configured and reachable. Everything routes through this one value:
+`coordination/broker.py:414-434`, `scheduler.py:22-42`, `locks.py:58-78`, `pending.py:47-65`.
+
+That makes an in-process `asyncio.PriorityQueue` (`coordination/_local/broker.py:117`) the
+default job queue. It persists nothing. Every queued job dies with the process, with no
+record and no recovery. Combined with finding #1 (broker startup failures swallowed), a
+deployment can look entirely healthy while losing every background job.
+
+A setting named `auto` that ignores available infrastructure and always picks the weaker
+option is the wrong default, and the log line at `main.py:115-120` reports it as though a
+decision were made.
+
+## J2. Delivery semantics differ by backend and neither is documented (major, M)
+
+**Redis/arq — at-least-once, but only on crash.** The ack happens after the work
+(`arq/worker.py:588-660`), so a crash mid-job leaves the queue entry and another worker
+re-runs it once the `in_progress` TTL expires. But arq only retries on
+`Retry`/`RetryJob`/`CancelledError` (`arq/worker.py:613-625`); a plain `Exception` sets
+`finish=True` and fails permanently with zero retries (`arq/worker.py:629-635`). Nothing in
+`src/sibyl/jobs/` ever raises `arq.Retry`. `WorkerSettings` (`jobs/worker.py:337-341`) sets
+`max_jobs`, `job_timeout=3600`, `keep_result`, and `poll_delay` — never `max_tries`.
+
+**Local — at-most-once, with no retry and no timeout.** `_worker_loop` pops the id
+(`_local/broker.py:758`) and flips the record to `IN_PROGRESS` (`:764`) before running.
+Death between those points is unrecoverable. `_run_job` awaits the function unbounded
+(`:785`) — `job_timeout` is read only by arq; the local broker copies `max_jobs` and
+`keep_result` (`:95-96`) but not the timeout.
+
+## J3. A failed local job blocks its own retry for 24 hours (major, S)
+
+`coordination/_local/broker.py:799-811` — on exception, `_run_job` sets
+`record.status = JobStatus.COMPLETE` and stores the error string. `_enqueue_unique`
+(`:730-733`) then treats `COMPLETE` as already-done and returns `created=False` for any
+later enqueue with the same `job_id`, unless `clear_result=True`.
+
+`enqueue_create_entity` (`:273-283`) and `enqueue_update_entity` (`:296-303`) do not pass
+`clear_result`. So a failed `create_entity:{entity_id}` silently swallows every retry for
+`keep_result` = 86,400 seconds (`jobs/worker.py:340`, consumed at `_local/broker.py:96`).
+The caller receives the old job id and a success-shaped response.
+
+The Redis path has the same 24-hour window from the other direction: arq's
+`enqueue_job(_job_id=...)` returns `None` when either the job key or the result key exists
+(`arq/connections.py:156-159`), so `_redis/broker.py:231-239` (`enqueue_update_entity`),
+`:408-424`, and `:442-458` silently drop a re-enqueue within 24h and hand back a stale id.
+
+## J4. `run_backup` reports failure as a successful job (major, S)
+
+`src/sibyl/jobs/backup.py:430-462` catches every exception and **returns** a payload with
+`"success": False` instead of re-raising. Both brokers therefore record the job as
+succeeded (`_local/broker.py:813-823`; arq sets its own `success=True`), so it is never
+retried, and `job_end` telemetry records `status="ok"` because `worker.py:136-140` reads
+arq's flag rather than the payload's.
+
+A nightly backup can fail every night and every signal in the system says it worked.
+
+## J5. The local scheduler double-fires with more than one process (major, M)
+
+`coordination/_local/scheduler.py` keeps its entire dedup state in per-instance dicts:
+`self._last_fired` (`:35`, checked at `:80-81`) and `self._active_jobs` (`:34`, checked at
+`:83-87`). `RuntimeServices._startup_scheduler` (`runtime_services.py:72-84`) starts one per
+process.
+
+Firing goes `_run_spec` → `enqueue_scheduled_job(spec.name)` (`_local/scheduler.py:135-138`)
+→ `_enqueue_unique(job_id=f"scheduled:{function}", clear_result=True)`
+(`_local/broker.py:553-559`), and the broker's `self._jobs` dict is also per-process
+(`:106`). **N API processes run every cron job N times, every tick** — including
+`consolidate_all_orgs`, `run_reflection_dream_cycle_all_orgs`, and `run_scheduled_backups`
+(`jobs/worker.py:195-275`). `clear_result=True` additionally disables even the intra-process
+dedup.
+
+Redis mode is safe: `build_cron_jobs()` (`jobs/worker.py:82-95`) uses `arq.cron(unique=True)`,
+which derives the job id from the scheduled timestamp so exactly one worker wins, and
+`RedisScheduler` is a deliberate no-op (`_redis/scheduler.py:9-16`).
+
+Redis-mode caveat: `WorkerSettings.cron_jobs = build_cron_jobs()` is evaluated in the class
+body (`jobs/worker.py:329`), so the schedule is frozen at import and a runtime settings
+reload (`runtime_services.py:29`) cannot change it. `get_cron_jobs` (`worker.py:328`) is
+unused.
+
+## J6. Multi-process on the local backend breaks five coordination guarantees (major, M)
+
+Beyond the scheduler:
+
+1. **Dedup is per-process.** `self._jobs` (`_local/broker.py:106`) — `create_entity:{id}`
+   runs once per process, producing duplicate graph writes.
+2. **Locks do not cross processes.** `LocalLockManager` is a plain `asyncio.Lock`
+   (`_local/locks.py:17`) and `extend()` is a no-op (`:74-77`), so `entity_lock` in
+   `jobs/entities.py:1252` and `jobs/operational_distillation.py:78` provides no mutual
+   exclusion. This is also what backs `idempotency_lock` (finding #3).
+3. **The pending registry does not cross processes.** `_local/pending.py:20-23` — the
+   queue-until-materialized guarantee documented at `jobs/pending.py:6-13` is void.
+4. **Source-import run state does not cross processes.** `_SOURCE_IMPORT_RUNS` is a module
+   dict consulted before the Surreal fallback (`jobs/source_imports.py:138`, `:761-763`).
+5. **Job listing and status are per-process.** `list_jobs` reads `self._recent_job_ids`
+   (`_local/broker.py:571-575`), so the admin API shows only whichever process served the
+   request.
+
+## J7. Jobs missing org scope (major, S)
+
+Graph access is namespace-isolated per org, so a query without an org predicate is still
+contained *provided `group_id` is correct*. These are the ones where it is not:
+
+- **`sync_all_sources`** (`jobs/crawl.py:270-284`) — `list_sources()` at `:274` takes no org
+  argument and `sync_source(ctx, str(source.id))` at `:279` is called **without**
+  `organization_id`. One job iterates every source in every org.
+- **`poll_raw_capture_changefeed`** — org-scoped by argument, but the underlying read is
+  not: `SHOW CHANGES FOR TABLE raw_captures SINCE ... LIMIT $limit`
+  (`jobs/raw_changefeed.py:141-145`) runs against the **shared** content client
+  (`persistence/surreal/content.py:212-213`) with no org predicate. Every org's change
+  payload is read into the process and filtered in Python at `:299`. The `LIMIT` is shared
+  too, so a busy org consumes another org's poll budget.
+- **`_raw_capture_organization_ids`** (`jobs/raw_changefeed.py:222-237`) — cross-org
+  `SELECT ... GROUP BY organization_id`.
+- **`cleanup_old_backups`** (`jobs/backup.py:465-506`) — org-less by design; globs
+  `settings.backup_dir` across all orgs (`:144`) and unlinks by mtime.
+- **`purge_due_deleted_personal_memories`** (`jobs/privacy.py:15-34`) — purges globally,
+  then reads the org id back off each returned row (`:22`) for the audit log.
+
+Related visibility gap: `_JOB_ORG_ARGUMENT_INDEX` (`coordination/broker.py:21-31`) covers
+only 9 functions. `run_backup`, `promote_raw_captures`, `poll_raw_capture_changefeed`,
+`replay_memory_probes`, `create_learning_episode`, `create_learning_procedure`,
+`update_task`, and `drain_source_import` are absent, so `_job_visible_to_org`
+(`api/routes/jobs.py:40-79`) falls through to `return False` — those jobs are invisible to
+their own org in the jobs API. It fails closed, which is the right direction, but on the
+local backend it is total: `JobInfo.organization_id` is always `None`
+(`_local/broker.py:64-76`), so visibility depends entirely on that 9-entry map.
+
+## J8. Shutdown drains the backlog, then kills running work (minor, S)
+
+`LocalQueueBroker.shutdown` (`_local/broker.py:128-178`) sets `self._queue = None` (`:134`),
+then `await asyncio.wait_for(queue.join(), timeout=self._shutdown_grace_seconds)` (`:139`).
+
+`local_queue_shutdown_grace_seconds` **is** honored (`config.py:661-666`, read at
+`_local/broker.py:98-102`, applied at `:139`). Three problems around it:
+
+- `queue.join()` waits for the whole **backlog**, not just in-flight work. A deep queue means
+  the grace expires and running jobs are cancelled at `:164-165` even though they would have
+  finished in time.
+- Jobs still queued at timeout are lost. `_mark_queued_jobs_cancelled` (`:843-859`) only
+  mutates in-memory records; there is no drain-to-disk and nothing re-enqueues them.
+- Setting `self._queue = None` **before** draining (`:134`) poisons in-flight jobs that
+  enqueue follow-up work: `_require_queue()` (`:866-869`) raises
+  `RuntimeError("Local job broker is not running")`. `jobs/entities.py:716` and `:748`
+  swallow exactly that and return success.
+
+The arq shutdown hook is a bare log line (`jobs/worker.py:122-125`).
+
+## J9. Failure-looks-like-success is systemic across job bodies (major, M)
+
+Beyond J4, the pattern where an exception is logged and the job returns a success shape
+appears throughout. The highest-consequence instances:
+
+| Location | What is silently lost |
+|---|---|
+| `jobs/entities.py:716-721` | embedding-backfill job never enqueued; `create_entity` returns OK |
+| `jobs/entities.py:748-753` | memory-extraction job never enqueued; `create_entity` returns OK |
+| `jobs/source_imports.py:974-980` | raw promotion never enqueued; import reports COMPLETED |
+| `jobs/source_imports.py:341-346` | import run state never persisted; run continues in memory only |
+| `jobs/entities.py:533-534, 561-566, 619-620` | dedup link, explicit relationships, auto-links all dropped |
+| `jobs/entities.py:245-251` | inherited task-knowledge edges dropped |
+| `jobs/entities.py:274-284` | relationship writes dropped inside `_persist_job_relationships`; only the count differs |
+| `jobs/raw_promotion.py:466-476` | lineage edges lost, replaced with a metadata note |
+| `jobs/raw_promotion.py:668-673` | extraction enqueue failure recorded as metadata; job succeeds |
+| `jobs/memory_extraction.py:635-651` | projection failure returns `projection_state: "partial"` with 0 entities; job succeeds |
+| `jobs/pending.py:194-200, :203` | failed pending ops are recorded, then `clear_pending_operations` runs **unconditionally** and discards them |
+| `jobs/worker.py:148-151` | `_job_result_info` returning `None` makes `job_end` telemetry record `status="ok"` |
+| `jobs/backup.py:533, :585` | `except Exception: # noqa: S110` with bare `pass` on archive metadata reads |
+
+`jobs/probes.py:173-182` is the one place that deliberately guards against this — a `None`
+return from `update` is counted as a failure. It is the right model for the rest.
+
+Counted differently: `_safe_broadcast` swallows every WebSocket and pub/sub event at debug
+level in four separate modules (`jobs/entities.py:189-190`, `jobs/crawl.py:32-33`,
+`jobs/backup.py:164-166`, `jobs/source_imports.py:189-190`), so realtime UI updates can stop
+entirely with no signal above debug.
+
+---
+
+# Suggested order of attack
+
+1. **#1** (readiness blind to broker/scheduler/lock failure) and **J1** (`auto` never picks
+   Redis) — together these are the difference between a healthy-looking pod and one silently
+   dropping every background job. Neither fix is large.
+2. **M1** (no `api:read`/`api:write` on MCP) — the dead `auth/mcp_auth.py` already contains
+   the correct check; wiring it in and deleting the fallbacks at `mcp_oauth.py:98` and `:393`
+   closes it.
+3. **#2** (backups IDOR) and **#7** (route-auth coverage test) — the second prevents the
+   next instance of the first. Both are small.
+4. **#3** (`"unknown"` idempotency scope), **M2** (client project as authz input), **J3**
+   (failed job blocks its own retry), **J4** (`run_backup` fakes success) — four small,
+   independent correctness fixes.
+5. **#4** (inert rate limiting), **#5** (request-id bypass), **#12** (dead lifespan) — small,
+   and each currently has a green test or a passing probe telling you otherwise.
+6. **#6** (setup-mode bypass) and **#13** (membership check at the resolver) — medium,
+   security-structural.
+7. **#9** / **M4** — the large one. Moving the shared rules out of `api/routes/` into core is
+   what stops MCP and REST from drifting, and it is the root cause behind M2, M3, and most of
+   M4. Best done incrementally, starting with the memory policy helpers that already exist in
+   two diverged copies.
+

--- a/docs/architecture/AUDIT_2026-08-13/debt-api.md
+++ b/docs/architecture/AUDIT_2026-08-13/debt-api.md
@@ -1,88 +1,85 @@
 # apps/api tech-debt audit (sibyld server daemon)
 
-Repo: `/Users/bliss/dev/sibyl` @ `5388d986` (main, clean). Lane: `apps/api` only.
-Everything below was read in the tree as it stands today. Line numbers are from the
-current working copy. Findings the 2026-05-28 audit already fixed are not re-listed.
+Repo: `/Users/bliss/dev/sibyl` @ `5388d986` (main, clean). Lane: `apps/api` only. Everything below
+was read in the tree as it stands today. Line numbers are from the current working copy. Findings
+the 2026-05-28 audit already fixed are not re-listed.
 
-Scale of the surface: 390 Python files, ~151k lines including tests. 31 routers, 185
-REST routes, 204 route handlers and 332 module-private helpers inside
-`src/sibyl/api/routes/`.
+Scale of the surface: 390 Python files, ~151k lines including tests. 31 routers, 185 REST routes,
+204 route handlers and 332 module-private helpers inside `src/sibyl/api/routes/`.
 
 ---
 
 ## Severity index
 
-| # | Finding | Severity | Fix |
-|---|---|---|---|
-| 1 | Broker/scheduler/lock startup failures swallowed; readiness reports ready | blocker | M |
-| 2 | `GET /backups/jobs/{job_id}` is cross-org readable | major | S |
-| 3 | Idempotency lock scope defaults to the literal string `"unknown"` | major | S |
-| 4 | Rate limiting is inert outside 6 auth routes; tests assert the config dict | major | S |
-| 5 | `X-Request-ID` validation bypassed by middleware ordering | major | S |
-| 6 | Setup-mode auth bypass gates instance-wide settings on data presence | major | M |
-| 7 | No test asserts every mounted route carries an auth dependency | major | S |
-| 8 | API-key REST scope check depends on unpinned Starlette `Mount` behavior | major | S |
-| 9 | 6.5k lines of domain logic living in the route package | major | L |
-| 10 | Hand-rolled SurrealQL lexer as a security boundary in a route file | major | M |
-| 11 | Config lives in `os.environ`, mutated at startup and by route handlers | major | M |
-| 12 | The FastAPI app's `lifespan` never runs in the deployed process | major | S |
-| 13 | `get_current_organization` returns an org without checking membership | major | M |
-| 14 | Errors swallowed into 200 responses (5 sites) | minor | S |
-| 15 | Raw exception strings returned in 200 bodies, bypassing sanitization | minor | S |
-| 16 | Three auth-dependency families across two architectural layers | minor | M |
-| 17 | Two WebSocket endpoints, two hand-written auth paths, one via query param | minor | M |
-| 18 | WebSocket broadcast is serial; one slow client stalls the org | minor | S |
-| 19 | `is_setup_mode()` / readiness open an unpooled Surreal client per call | minor | S |
-| 20 | Duplicated config validators; dead `fully_surreal`; dead `auth/rls.py` | minor | S |
-| 21 | `enqueue_crawl`/`enqueue_sync` take an optional `organization_id` | minor | S |
-| 22 | 2.5k-line migration/cutover CLI ships in the daemon wheel | minor | M |
-| 23 | `disable_auth` is a half-implemented mode, resolved at import time | minor | S |
-| 24 | `SessionMiddleware` reuses the JWT signing secret | minor | S |
-| 25 | CORS allows `localhost:3337` in production | minor | S |
-| 26 | Six `BaseHTTPMiddleware` layers on every request | minor | M |
-| M1 | `api:read`/`api:write` never enforced on the MCP surface | blocker | M |
-| M2 | MCP accepts a client-supplied project as an authorization input | major | S |
-| M3 | MCP writes carry no org-role gate; VIEWER can write | major | M |
-| M4 | MCP re-implements REST handlers, with measured divergence | major | L |
-| M5 | Third verbatim copy of the REST scope check in the persistence layer | major | S |
-| M6 | mcp 2.0 migration surface (assessment) | n/a | M |
-| M7 | Conditional `user_id` overwrite; unpoliced `manage` actions | minor | S |
-| J1 | `coordination_backend="auto"` never selects Redis; default queue is in-memory | blocker | M |
-| J2 | Delivery semantics differ by backend; no `max_tries`, no local timeout | major | M |
-| J3 | A failed local job blocks its own retry for 24 hours | major | S |
-| J4 | `run_backup` reports failure as a successful job | major | S |
-| J5 | The local scheduler double-fires with more than one process | major | M |
-| J6 | Local backend breaks five coordination guarantees across processes | major | M |
-| J7 | Five jobs run without an org scope | major | S |
-| J8 | Shutdown drains the backlog, then kills running work | minor | S |
-| J9 | Failure-looks-like-success is systemic across job bodies | major | M |
+| #   | Finding                                                                       | Severity | Fix |
+| --- | ----------------------------------------------------------------------------- | -------- | --- |
+| 1   | Broker/scheduler/lock startup failures swallowed; readiness reports ready     | blocker  | M   |
+| 2   | `GET /backups/jobs/{job_id}` is cross-org readable                            | major    | S   |
+| 3   | Idempotency lock scope defaults to the literal string `"unknown"`             | major    | S   |
+| 4   | Rate limiting is inert outside 6 auth routes; tests assert the config dict    | major    | S   |
+| 5   | `X-Request-ID` validation bypassed by middleware ordering                     | major    | S   |
+| 6   | Setup-mode auth bypass gates instance-wide settings on data presence          | major    | M   |
+| 7   | No test asserts every mounted route carries an auth dependency                | major    | S   |
+| 8   | API-key REST scope check depends on unpinned Starlette `Mount` behavior       | major    | S   |
+| 9   | 6.5k lines of domain logic living in the route package                        | major    | L   |
+| 10  | Hand-rolled SurrealQL lexer as a security boundary in a route file            | major    | M   |
+| 11  | Config lives in `os.environ`, mutated at startup and by route handlers        | major    | M   |
+| 12  | The FastAPI app's `lifespan` never runs in the deployed process               | major    | S   |
+| 13  | `get_current_organization` returns an org without checking membership         | major    | M   |
+| 14  | Errors swallowed into 200 responses (5 sites)                                 | minor    | S   |
+| 15  | Raw exception strings returned in 200 bodies, bypassing sanitization          | minor    | S   |
+| 16  | Three auth-dependency families across two architectural layers                | minor    | M   |
+| 17  | Two WebSocket endpoints, two hand-written auth paths, one via query param     | minor    | M   |
+| 18  | WebSocket broadcast is serial; one slow client stalls the org                 | minor    | S   |
+| 19  | `is_setup_mode()` / readiness open an unpooled Surreal client per call        | minor    | S   |
+| 20  | Duplicated config validators; dead `fully_surreal`; dead `auth/rls.py`        | minor    | S   |
+| 21  | `enqueue_crawl`/`enqueue_sync` take an optional `organization_id`             | minor    | S   |
+| 22  | 2.5k-line migration/cutover CLI ships in the daemon wheel                     | minor    | M   |
+| 23  | `disable_auth` is a half-implemented mode, resolved at import time            | minor    | S   |
+| 24  | `SessionMiddleware` reuses the JWT signing secret                             | minor    | S   |
+| 25  | CORS allows `localhost:3337` in production                                    | minor    | S   |
+| 26  | Six `BaseHTTPMiddleware` layers on every request                              | minor    | M   |
+| M1  | `api:read`/`api:write` never enforced on the MCP surface                      | blocker  | M   |
+| M2  | MCP accepts a client-supplied project as an authorization input               | major    | S   |
+| M3  | MCP writes carry no org-role gate; VIEWER can write                           | major    | M   |
+| M4  | MCP re-implements REST handlers, with measured divergence                     | major    | L   |
+| M5  | Third verbatim copy of the REST scope check in the persistence layer          | major    | S   |
+| M6  | mcp 2.0 migration surface (assessment)                                        | n/a      | M   |
+| M7  | Conditional `user_id` overwrite; unpoliced `manage` actions                   | minor    | S   |
+| J1  | `coordination_backend="auto"` never selects Redis; default queue is in-memory | blocker  | M   |
+| J2  | Delivery semantics differ by backend; no `max_tries`, no local timeout        | major    | M   |
+| J3  | A failed local job blocks its own retry for 24 hours                          | major    | S   |
+| J4  | `run_backup` reports failure as a successful job                              | major    | S   |
+| J5  | The local scheduler double-fires with more than one process                   | major    | M   |
+| J6  | Local backend breaks five coordination guarantees across processes            | major    | M   |
+| J7  | Five jobs run without an org scope                                            | major    | S   |
+| J8  | Shutdown drains the backlog, then kills running work                          | minor    | S   |
+| J9  | Failure-looks-like-success is systemic across job bodies                      | major    | M   |
 
 ---
 
 ## 1. Startup failures are swallowed and readiness cannot see them (blocker, M)
 
 `src/sibyl/runtime_services.py:52-114`. Each of `_startup_broker`, `_startup_scheduler`,
-`_startup_pubsub`, and `_startup_locks` wraps its work in `try/except Exception` and
-downgrades any failure to a `log.warning`, then continues. `startup()` returns normally.
+`_startup_pubsub`, and `_startup_locks` wraps its work in `try/except Exception` and downgrades any
+failure to a `log.warning`, then continues. `startup()` returns normally.
 
-`src/sibyl/api/readiness.py:102-111` probes SurrealDB reachability and schema bootstrap,
-nothing else. `src/sibyl/api/app.py:339-354` `/health` returns `"healthy"`
-unconditionally.
+`src/sibyl/api/readiness.py:102-111` probes SurrealDB reachability and schema bootstrap, nothing
+else. `src/sibyl/api/app.py:339-354` `/health` returns `"healthy"` unconditionally.
 
-So a process that failed to connect its job broker, failed to start the scheduler, and
-failed to initialize distributed locks passes both probes and takes production traffic.
-Every enqueue against that process, every cron-scheduled backup, and every idempotency
-lock acquisition then fails or silently no-ops behind a warning line that nobody is
-paging on. This is the single highest-leverage finding in the lane: it converts a
-recoverable startup fault into silent data loss.
+So a process that failed to connect its job broker, failed to start the scheduler, and failed to
+initialize distributed locks passes both probes and takes production traffic. Every enqueue against
+that process, every cron-scheduled backup, and every idempotency lock acquisition then fails or
+silently no-ops behind a warning line that nobody is paging on. This is the single highest-leverage
+finding in the lane: it converts a recoverable startup fault into silent data loss.
 
-Fix: track which subsystems are required, record their status on the `RuntimeServices`
-instance (the flags already exist: `_broker_initialized`, `_scheduler_initialized`,
-`_locks_initialized`), and surface them as `DependencyStatus` entries in
-`check_readiness()`. Either fail startup outright or report not-ready.
+Fix: track which subsystems are required, record their status on the `RuntimeServices` instance (the
+flags already exist: `_broker_initialized`, `_scheduler_initialized`, `_locks_initialized`), and
+surface them as `DependencyStatus` entries in `check_readiness()`. Either fail startup outright or
+report not-ready.
 
-Related: `src/sibyl/api/app.py:161-166` calls `runtime_services.startup()` outside the
-`try`, so a partial startup leaks whatever did initialize.
+Related: `src/sibyl/api/app.py:161-166` calls `runtime_services.startup()` outside the `try`, so a
+partial startup leaks whatever did initialize.
 
 ## 2. `GET /backups/jobs/{job_id}` is cross-org readable (major, S)
 
@@ -98,17 +95,17 @@ async def get_backup_job_status(job_id: str) -> dict[str, Any]:
 
 It is the only route in the file with no `org: AuthOrganization = Depends(get_current_organization)`
 (compare `:184, :194, :225, :283, :318, :345, :370, :407`). The router-level
-`Depends(require_org_admin())` at `:76` only proves the caller administers *some* org, and
-the codebase itself documents that this is no privilege at all: `persistence/surreal/setup.py:154-156`
-notes "every user owns a personal organization with the OWNER role, so an org-scoped check
-gates nothing for instance-wide settings."
+`Depends(require_org_admin())` at `:76` only proves the caller administers _some_ org, and the
+codebase itself documents that this is no privilege at all: `persistence/surreal/setup.py:154-156`
+notes "every user owns a personal organization with the OWNER role, so an org-scoped check gates
+nothing for instance-wide settings."
 
-`info.result` for a backup job is the payload built at `src/sibyl/jobs/backup.py:455-462`,
-which carries `organization_id`, `backup_id`, and error text.
+`info.result` for a backup job is the payload built at `src/sibyl/jobs/backup.py:455-462`, which
+carries `organization_id`, `backup_id`, and error text.
 
 The correct pattern already exists one file over: `src/sibyl/api/routes/jobs.py:42-80`
-`_job_visible_to_org`, applied at `jobs.py:349-350` and `:373-374`, which 404s on mismatch.
-Fix is to reuse it.
+`_job_visible_to_org`, applied at `jobs.py:349-350` and `:373-374`, which 404s on mismatch. Fix is
+to reuse it.
 
 ## 3. Idempotency lock scope defaults to `"unknown"` (major, S)
 
@@ -121,72 +118,68 @@ actor = arguments.get("auth") or arguments.get("ctx") or arguments.get("user")
 principal_id = str(getattr(actor, "user_id", None) or ... or getattr(actor, "id", "unknown"))
 ```
 
-`serialize_idempotent_request` recovers the tenant by *introspecting the decorated
-handler's parameter names*. A handler that names its org parameter anything other than
-`org`, or its actor anything other than `auth`/`ctx`/`user`, silently falls back to the
-literal string `"unknown"` — and `idempotency_lock` then acquires the lock in a shared
-`"unknown"` scope (`idempotency.py:230`, `manager.acquire(organization_id, lock_id)`).
+`serialize_idempotent_request` recovers the tenant by _introspecting the decorated handler's
+parameter names_. A handler that names its org parameter anything other than `org`, or its actor
+anything other than `auth`/`ctx`/`user`, silently falls back to the literal string `"unknown"` — and
+`idempotency_lock` then acquires the lock in a shared `"unknown"` scope (`idempotency.py:230`,
+`manager.acquire(organization_id, lock_id)`).
 
-Two consequences. Cross-tenant contention: two orgs replaying the same `Idempotency-Key`
-against the same path serialize against each other. And divergence: the lock is scoped to
-`"unknown"` while the idempotency *record* is written with the real `organization_id`
-passed separately by the route (`replay_idempotent_response(organization_id=...)`), so the
-mutual exclusion the record's replay logic assumes is not the exclusion actually held.
+Two consequences. Cross-tenant contention: two orgs replaying the same `Idempotency-Key` against the
+same path serialize against each other. And divergence: the lock is scoped to `"unknown"` while the
+idempotency _record_ is written with the real `organization_id` passed separately by the route
+(`replay_idempotent_response(organization_id=...)`), so the mutual exclusion the record's replay
+logic assumes is not the exclusion actually held.
 
-This is the exact "group_id defaulted/confused" shape the multi-tenancy contract forbids.
-Fix: raise on a missing org/actor rather than defaulting, and make the resolution explicit
-rather than name-based.
+This is the exact "group_id defaulted/confused" shape the multi-tenancy contract forbids. Fix: raise
+on a missing org/actor rather than defaulting, and make the resolution explicit rather than
+name-based.
 
-Second defect in the same module, `idempotency.py:234-243`: when the lock lease cannot be
-extended, `renew_lease` logs `idempotency_lock_lease_lost` and returns. The critical
-section keeps executing without a lock, and `:252` then releases with a token that is no
-longer valid. Lease loss should abort the operation, not narrate it.
+Second defect in the same module, `idempotency.py:234-243`: when the lock lease cannot be extended,
+`renew_lease` logs `idempotency_lock_lease_lost` and returns. The critical section keeps executing
+without a lock, and `:252` then releases with a token that is no longer valid. Lease loss should
+abort the operation, not narrate it.
 
 ## 4. Rate limiting is inert on 179 of 185 routes (major, S)
 
 `src/sibyl/api/app.py:187-188` sets `app.state.limiter` and registers the 429 handler, but
-**`SlowAPIMiddleware` is never added**. In slowapi, `default_limits` are applied by that
-middleware; without it, only routes carrying an explicit `@limiter.limit(...)` decorator
-are limited. There are exactly six, all in `src/sibyl/api/routes/auth.py` (`:870, :961,
-:987, :1413, :1451, :1532`).
+**`SlowAPIMiddleware` is never added**. In slowapi, `default_limits` are applied by that middleware;
+without it, only routes carrying an explicit `@limiter.limit(...)` decorator are limited. There are
+exactly six, all in `src/sibyl/api/routes/auth.py` (`:870, :961, :987, :1413, :1451, :1532`).
 
-So `settings.rate_limit_default` ("100/minute", `config.py:374-377`) is advertised in
-config, documented, and enforced nowhere. `RATE_LIMITS` and `get_rate_limit()`
+So `settings.rate_limit_default` ("100/minute", `config.py:374-377`) is advertised in config,
+documented, and enforced nowhere. `RATE_LIMITS` and `get_rate_limit()`
 (`src/sibyl/api/rate_limit.py:36-54`) have no caller in `src/` at all.
 
-The test file makes this worse rather than catching it.
-`tests/test_rate_limiting.py:9-42` asserts that the `RATE_LIMITS` dict contains the
-expected string values and that `get_rate_limit("auth") == RATE_LIMITS["auth"]` — it
-tests a dictionary that nothing reads. No test issues N+1 requests and expects a 429.
-This is a green suite over an inert feature.
+The test file makes this worse rather than catching it. `tests/test_rate_limiting.py:9-42` asserts
+that the `RATE_LIMITS` dict contains the expected string values and that
+`get_rate_limit("auth") == RATE_LIMITS["auth"]` — it tests a dictionary that nothing reads. No test
+issues N+1 requests and expects a 429. This is a green suite over an inert feature.
 
 Two smaller issues in the same file. `_get_key` (`rate_limit.py:17-22`) reads
-`request.state.jwt_claims`, which `AuthMiddleware` only populates for JWTs, never for
-`sk_` API keys — so all API-key traffic from one egress IP shares a single bucket. And
-`limiter` is constructed at import time from `settings`, so `reload_settings_from_env()`
-cannot affect it.
+`request.state.jwt_claims`, which `AuthMiddleware` only populates for JWTs, never for `sk_` API keys
+— so all API-key traffic from one egress IP shares a single bucket. And `limiter` is constructed at
+import time from `settings`, so `reload_settings_from_env()` cannot affect it.
 
 ## 5. `X-Request-ID` validation is bypassed by middleware ordering (major, S)
 
-`src/sibyl/api/errors.py:259-266` `get_request_id` validates a caller-supplied header
-against `_REQUEST_ID_RE = ^[A-Za-z0-9_.:-]{1,128}$` — but only *after* checking
-`request.state.request_id` first and returning it if already set.
+`src/sibyl/api/errors.py:259-266` `get_request_id` validates a caller-supplied header against
+`_REQUEST_ID_RE = ^[A-Za-z0-9_.:-]{1,128}$` — but only _after_ checking `request.state.request_id`
+first and returning it if already set.
 
 `src/sibyl/api/app.py:130-131` `RequestIdMiddleware` sets
-`request.state.request_id = request.headers.get(REQUEST_ID_HEADER) or generate_request_id()`
-with no validation at all.
+`request.state.request_id = request.headers.get(REQUEST_ID_HEADER) or generate_request_id()` with no
+validation at all.
 
-Middleware order (`app.py:267-289`; `add_middleware` prepends, so last-added is outermost)
-is VersionHeader → RequestId → AccessLog → Auth → Session → CORS. `RequestIdMiddleware`
-therefore always runs first and always wins, and the regex in `errors.py` is dead for
-every real request. An arbitrary-length, arbitrary-content client string flows into the
-structlog context (`app.py:133`), into every error payload
-(`errors.py:281`, `safe_error_payload`), and back out in the response header
-(`app.py:136`).
+Middleware order (`app.py:267-289`; `add_middleware` prepends, so last-added is outermost) is
+VersionHeader → RequestId → AccessLog → Auth → Session → CORS. `RequestIdMiddleware` therefore
+always runs first and always wins, and the regex in `errors.py` is dead for every real request. An
+arbitrary-length, arbitrary-content client string flows into the structlog context (`app.py:133`),
+into every error payload (`errors.py:281`, `safe_error_payload`), and back out in the response
+header (`app.py:136`).
 
-Also note `AccessLogMiddleware` and `RequestIdMiddleware` both set `request.state.request_id`
-and both stamp the response header — duplicated responsibility across two layers with
-different rules. Collapse them into one.
+Also note `AccessLogMiddleware` and `RequestIdMiddleware` both set `request.state.request_id` and
+both stamp the response header — duplicated responsibility across two layers with different rules.
+Collapse them into one.
 
 ## 6. Setup mode is an unauthenticated bypass gated on data presence (major, M)
 
@@ -197,9 +190,8 @@ async def is_setup_mode() -> bool:
     return not (await get_setup_status()).setup_complete
 ```
 
-and `setup_complete` is `_has_records(payload["initialized_memberships"])`
-(`setup.py:57-71`) — i.e. "does at least one org_members row exist with role owner or
-admin".
+and `setup_complete` is `_has_records(payload["initialized_memberships"])` (`setup.py:57-71`) — i.e.
+"does at least one org_members row exist with role owner or admin".
 
 Four dependencies return with **zero authentication** when that is true:
 `require_setup_mode_or_auth` (`:107-113`), `require_setup_mode_or_admin` (`:116-138`),
@@ -207,38 +199,37 @@ Four dependencies return with **zero authentication** when that is true:
 
 What sits behind them:
 
-- `src/sibyl/api/routes/settings.py:174` `GET /settings`, `:205` `PATCH /settings` —
-  the PATCH writes provider API keys. Note both call `await require_settings_owner(request)`
-  *inside the handler body* (`:186`, `:217`) rather than as a `Depends`, so the gate is
-  invisible to the dependency graph and to the OpenAPI schema. `DELETE /settings/{key}`
-  (`:308`) is the only one that pre-blocks setup mode explicitly (`:319-320`).
-- `src/sibyl/ai/llm/routes.py:38` (`/settings/ai`, mounted at `app.py:303`) — all 8 routes
-  have no `Depends` whatsoever and call `require_settings_owner(request)` in the body
+- `src/sibyl/api/routes/settings.py:174` `GET /settings`, `:205` `PATCH /settings` — the PATCH
+  writes provider API keys. Note both call `await require_settings_owner(request)` _inside the
+  handler body_ (`:186`, `:217`) rather than as a `Depends`, so the gate is invisible to the
+  dependency graph and to the OpenAPI schema. `DELETE /settings/{key}` (`:308`) is the only one that
+  pre-blocks setup mode explicitly (`:319-320`).
+- `src/sibyl/ai/llm/routes.py:38` (`/settings/ai`, mounted at `app.py:303`) — all 8 routes have no
+  `Depends` whatsoever and call `require_settings_owner(request)` in the body
   (`:116, 133, 158, 182, 191, 203, 230`).
 - `src/sibyl/api/routes/setup.py:291` `POST /setup/config` — writes API keys.
 
-The risk is that the gate is derived from data rather than from state: an instance that
-loses its `organization_members` rows (bad restore, mid-migration, wrong namespace
-selected, a query that returns empty for a transport reason) re-opens the entire settings
-surface to anonymous writes. There is no explicit "setup completed" marker, no one-way
-latch, and no network restriction on the bypass.
+The risk is that the gate is derived from data rather than from state: an instance that loses its
+`organization_members` rows (bad restore, mid-migration, wrong namespace selected, a query that
+returns empty for a transport reason) re-opens the entire settings surface to anonymous writes.
+There is no explicit "setup completed" marker, no one-way latch, and no network restriction on the
+bypass.
 
-Fix: persist an explicit `setup_completed_at` marker that only ever transitions forward,
-and move the in-body `require_*` calls into route `dependencies=[...]` so the gate is
-declarative and auditable.
+Fix: persist an explicit `setup_completed_at` marker that only ever transitions forward, and move
+the in-body `require_*` calls into route `dependencies=[...]` so the gate is declarative and
+auditable.
 
 ## 7. Nothing tests that routes have auth (major, S)
 
-Finding #2 exists because the test suite cannot see it. `tests/test_wire_scope.py:1-8`
-is the closest thing to an end-to-end auth test and its own docstring says it "substitut[es]
-only the auth dependencies" — it overrides `get_auth_context`, `get_current_organization`,
-`get_current_org_role`, which means a route that *forgot* those dependencies is
-indistinguishable from one that has them. `tests/test_route_access_seams.py` calls the
-`_verify_*_access` helpers directly with mocks.
+Finding #2 exists because the test suite cannot see it. `tests/test_wire_scope.py:1-8` is the
+closest thing to an end-to-end auth test and its own docstring says it "substitut[es] only the auth
+dependencies" — it overrides `get_auth_context`, `get_current_organization`, `get_current_org_role`,
+which means a route that _forgot_ those dependencies is indistinguishable from one that has them.
+`tests/test_route_access_seams.py` calls the `_verify_*_access` helpers directly with mocks.
 
-There is no test that walks `create_api_app().routes` and asserts each non-allowlisted
-route resolves an auth dependency. That test is maybe 30 lines, it would have caught #2,
-and it is the cheapest durable guard in this report.
+There is no test that walks `create_api_app().routes` and asserts each non-allowlisted route
+resolves an auth dependency. That test is maybe 30 lines, it would have caught #2, and it is the
+cheapest durable guard in this report.
 
 ## 8. API-key REST scope enforcement rests on unpinned Starlette behavior (major, S)
 
@@ -249,205 +240,196 @@ def _is_rest_request(request: Request) -> bool:
     return request.url.path.startswith("/api/")
 ```
 
-This is the *only* thing that makes `api:read` / `api:write` scopes apply to REST
-(`dependencies.py:132-135`). The FastAPI app is mounted at `/api`
-(`src/sibyl/main.py:166`), so whether this predicate fires depends on whether
-`request.url.path` inside a mounted sub-app is the full path or the prefix-stripped one.
+This is the _only_ thing that makes `api:read` / `api:write` scopes apply to REST
+(`dependencies.py:132-135`). The FastAPI app is mounted at `/api` (`src/sibyl/main.py:166`), so
+whether this predicate fires depends on whether `request.url.path` inside a mounted sub-app is the
+full path or the prefix-stripped one.
 
-I verified it against the installed Starlette 1.6.0: `Mount.matches` builds `child_scope`
-with `root_path = root_path + matched_path` and deliberately does **not** rewrite
-`scope["path"]`, while `URL.__init__` uses bare `scope["path"]`. So today the predicate is
-correct and scopes are enforced.
+I verified it against the installed Starlette 1.6.0: `Mount.matches` builds `child_scope` with
+`root_path = root_path + matched_path` and deliberately does **not** rewrite `scope["path"]`, while
+`URL.__init__` uses bare `scope["path"]`. So today the predicate is correct and scopes are enforced.
 
-The debt is that nothing pins it. `tests/test_auth_api_key_scopes_rest.py:15-19`
-hand-constructs a scope dict with `"path": "/api/me"` and never drives the real mounted
-app. Older Starlette versions *did* strip the mount prefix from `scope["path"]`. If a
-future upgrade reverts to that, every API key silently gains unscoped read and write on
-the whole REST surface and this test stays green. One `TestClient(create_combined_app())`
-test that sends a read-only key at a POST and expects 403 closes it permanently.
+The debt is that nothing pins it. `tests/test_auth_api_key_scopes_rest.py:15-19` hand-constructs a
+scope dict with `"path": "/api/me"` and never drives the real mounted app. Older Starlette versions
+_did_ strip the mount prefix from `scope["path"]`. If a future upgrade reverts to that, every API
+key silently gains unscoped read and write on the whole REST surface and this test stays green. One
+`TestClient(create_combined_app())` test that sends a read-only key at a POST and expects 403 closes
+it permanently.
 
 ## 9. Domain logic lives in the route package (major, L)
 
-Measured by AST over `src/sibyl/api/routes/`: 204 route handlers totalling 9,096 lines,
-plus **332 module-private helper functions totalling 6,559 lines**. The helpers are not
-serialization glue; they are the domain.
+Measured by AST over `src/sibyl/api/routes/`: 204 route handlers totalling 9,096 lines, plus **332
+module-private helper functions totalling 6,559 lines**. The helpers are not serialization glue;
+they are the domain.
 
 Worst concentrations:
 
-- `src/sibyl/api/routes/memory.py` — 3,362 lines, of which the first ~1,690 are ~60
-  private helpers before a single route: authorization policy composition
-  (`_authorize_memory_policy:300`, `_authorize_project_scope_write:246`,
-  `_authorize_raw_promotion_api_key_scopes:1476`, `_authorize_share_api_key_scopes:1564`),
-  audit-event derivation (`_derived_records_from_audit:1169`, `_correction_history:1207`),
-  and promotion/share state machines (`_promotion_state:1237`, `_share_state:1253`).
+- `src/sibyl/api/routes/memory.py` — 3,362 lines, of which the first ~1,690 are ~60 private helpers
+  before a single route: authorization policy composition (`_authorize_memory_policy:300`,
+  `_authorize_project_scope_write:246`, `_authorize_raw_promotion_api_key_scopes:1476`,
+  `_authorize_share_api_key_scopes:1564`), audit-event derivation
+  (`_derived_records_from_audit:1169`, `_correction_history:1207`), and promotion/share state
+  machines (`_promotion_state:1237`, `_share_state:1253`).
 - `src/sibyl/api/routes/context.py:224-616` — retrieval fusion and refinement:
   `_fuse_context_evidence` (139 lines, `:251`), `_execute_context_refinement_round` (`:393`),
-  `_execute_accurate_context_evidence_search` (164 lines, `:449`), `_refinement_frontier`
-  (`:238`). This is core retrieval algorithm sitting behind an HTTP decorator.
+  `_execute_accurate_context_evidence_search` (164 lines, `:449`), `_refinement_frontier` (`:238`).
+  This is core retrieval algorithm sitting behind an HTTP decorator.
 - `src/sibyl/api/routes/entities.py:568-1190` — the whole entity visibility model
   (`_entity_visible_to_reader`, `_raw_capture_visible_to_reader`,
   `_resolve_entity_list_project_filter`, `_reader_memory_grants`).
-- `src/sibyl/api/routes/auth.py:1087-1387` — `_render_device_verify_page`, 300 lines of
-  inline HTML and CSS in a route module, in a repo that ships a Next.js frontend.
+- `src/sibyl/api/routes/auth.py:1087-1387` — `_render_device_verify_page`, 300 lines of inline HTML
+  and CSS in a route module, in a repo that ships a Next.js frontend.
 
 Individual handlers are correspondingly large: `entities.py:2076 create_entity` 237 lines,
 `entities.py:1655 create_entities_bulk` 195, `tasks.py:791 update_task` 194,
 `entities.py:1451 get_entity` 190.
 
-Consequence beyond aesthetics: this logic is only reachable through HTTP, so the MCP
-surface either duplicates it or silently diverges from it, and the tests that cover it are
-route tests with mocked dependencies rather than unit tests over the rule.
+Consequence beyond aesthetics: this logic is only reachable through HTTP, so the MCP surface either
+duplicates it or silently diverges from it, and the tests that cover it are route tests with mocked
+dependencies rather than unit tests over the rule.
 
 Six route modules also each define their own identical `get_entity_graph_runtime(group_id)`
-lazy-import wrapper: `entities.py:89`, `graph.py:39`, `rag.py:60`, `context.py:78`,
-`tasks.py:60`, plus `graph.py:45` for the query adapter. Same three lines, six copies.
+lazy-import wrapper: `entities.py:89`, `graph.py:39`, `rag.py:60`, `context.py:78`, `tasks.py:60`,
+plus `graph.py:45` for the query adapter. Same three lines, six copies.
 
 ## 10. A hand-rolled SurrealQL lexer is the security boundary on `/admin/debug/query` (major, M)
 
-`src/sibyl/api/routes/admin.py:726-1018` is roughly 290 lines of character-by-character
-SurrealQL scanning — `_skip_query_literal`, `_skip_query_comment`, `_skip_query_separators`,
+`src/sibyl/api/routes/admin.py:726-1018` is roughly 290 lines of character-by-character SurrealQL
+scanning — `_skip_query_literal`, `_skip_query_comment`, `_skip_query_separators`,
 `_has_identifier_boundary`, `_read_query_string_value`, `_query_has_dynamic_content_table`,
 `_query_has_additional_statement`, `_query_disallowed_namespace_call` — feeding
 `_is_supported_debug_dialect` (`:1009-1017`), which gates `debug_query` (`:1025`).
 
-The code is careful and clearly hard-won (the comment at `:987-988` about walking nested
-`::` chains shows real iteration). The debt is structural:
+The code is careful and clearly hard-won (the comment at `:987-988` about walking nested `::` chains
+shows real iteration). The debt is structural:
 
-- It is a **deny-list** (`_GRAPH_DEBUG_FORBIDDEN_TOKENS`, `:893-921`). Any SurrealQL
-  keyword added by a future server version defaults to permitted. `LET`, `RETURN`, `FOR`,
-  and `IF` are not in the list; today they are blocked only incidentally by the
-  "first token must be SELECT" rule.
-- It is a security boundary implemented as string parsing, in a route file, with no
-  fuzzing and no property tests.
-- It is the wrong layer. SurrealDB can express read-only access directly; a
-  scoped read-only session or a DEFINE-level permission would make the parser unnecessary.
+- It is a **deny-list** (`_GRAPH_DEBUG_FORBIDDEN_TOKENS`, `:893-921`). Any SurrealQL keyword added
+  by a future server version defaults to permitted. `LET`, `RETURN`, `FOR`, and `IF` are not in the
+  list; today they are blocked only incidentally by the "first token must be SELECT" rule.
+- It is a security boundary implemented as string parsing, in a route file, with no fuzzing and no
+  property tests.
+- It is the wrong layer. SurrealDB can express read-only access directly; a scoped read-only session
+  or a DEFINE-level permission would make the parser unnecessary.
 
-Blast radius is bounded — the endpoint is `_OWNER_ONLY` and executes against
-`str(org.id)`'s own namespace, with client-supplied `group_id`/`organization_id`/`org_id`
-params correctly rejected at `_debug_params_for_org` (`:881-890`). But a boundary this
-fragile should not live in a route module.
+Blast radius is bounded — the endpoint is `_OWNER_ONLY` and executes against `str(org.id)`'s own
+namespace, with client-supplied `group_id`/`organization_id`/`org_id` params correctly rejected at
+`_debug_params_for_org` (`:881-890`). But a boundary this fragile should not live in a route module.
 
-Same endpoint, second issue: `admin.py:1057-1067` catches every exception and returns
-**HTTP 200** with `error=str(e)` in the body. That path never touches
-`http_exception_payload`, so `sanitize_error_text` (`errors.py:350-358`) never runs and
-raw SurrealDB exception text — which can echo query fragments and internal identifiers —
-goes straight to the client. `_validate_content_debug_query`'s `ValueError` (`:868-878`)
-lands here too, so a validation failure returns 200 instead of 400.
+Same endpoint, second issue: `admin.py:1057-1067` catches every exception and returns **HTTP 200**
+with `error=str(e)` in the body. That path never touches `http_exception_payload`, so
+`sanitize_error_text` (`errors.py:350-358`) never runs and raw SurrealDB exception text — which can
+echo query fragments and internal identifiers — goes straight to the client.
+`_validate_content_debug_query`'s `ValueError` (`:868-878`) lands here too, so a validation failure
+returns 200 instead of 400.
 
 ## 11. Configuration is process environment, mutated at startup and by routes (major, M)
 
 Three separate mechanisms fight over the same state.
 
-`src/sibyl/config.py:805` instantiates a module-global `settings` at import. Modules
-capture values from it at import time (e.g. the security warning at
-`auth/dependencies.py:40`, the `limiter` at `rate_limit.py:26-31`, and the
-`require_org_role`/`require_org_admin` branch selection at `dependencies.py:206` and `:269`).
-`reload_settings_from_env()` (`config.py:808-812`) mutates `settings.__dict__` in place and
-none of those captured values move.
+`src/sibyl/config.py:805` instantiates a module-global `settings` at import. Modules capture values
+from it at import time (e.g. the security warning at `auth/dependencies.py:40`, the `limiter` at
+`rate_limit.py:26-31`, and the `require_org_role`/`require_org_admin` branch selection at
+`dependencies.py:206` and `:269`). `reload_settings_from_env()` (`config.py:808-812`) mutates
+`settings.__dict__` in place and none of those captured values move.
 
-`src/sibyl/services/settings.py:394-433` `load_runtime_settings_from_db` reads eleven
-settings out of SurrealDB at startup and writes them into `os.environ` via
-`os.environ.setdefault`. Provider keys, embedding models, and embedding dimensions are
-therefore transported through the process environment.
+`src/sibyl/services/settings.py:394-433` `load_runtime_settings_from_db` reads eleven settings out
+of SurrealDB at startup and writes them into `os.environ` via `os.environ.setdefault`. Provider
+keys, embedding models, and embedding dimensions are therefore transported through the process
+environment.
 
 `src/sibyl/api/routes/settings.py:170-171` does the same thing at request time:
 `os.environ[env_var] = str(value)` inside a route handler.
 
-Net effect: config is global mutable process state written from three places, one of which
-is an HTTP handler. `os.environ.setdefault` also makes it a one-way door — a value loaded
-at startup can never be cleared without a restart, which is why
-`DELETE /settings/{key}` has to hand-clear env vars (`settings.py:329-331`).
+Net effect: config is global mutable process state written from three places, one of which is an
+HTTP handler. `os.environ.setdefault` also makes it a one-way door — a value loaded at startup can
+never be cleared without a restart, which is why `DELETE /settings/{key}` has to hand-clear env vars
+(`settings.py:329-331`).
 
 Separately, `Settings` carries ~85 fields with three overlapping `model_validator(mode="after")`
 passes, two of which duplicate the same defaulting logic verbatim: `config.py:232-235` and
-`config.py:519-522` are identical four-line blocks setting `auth_store` and
-`local_auth_enabled`.
+`config.py:519-522` are identical four-line blocks setting `auth_store` and `local_auth_enabled`.
 
 ## 12. The FastAPI app's `lifespan` never runs in the deployed process (major, S)
 
-`src/sibyl/api/app.py:158-166` defines a `lifespan` that constructs `RuntimeServices` and
-calls `startup()`/`shutdown()`, and passes it to `FastAPI(lifespan=lifespan)` at `:183`.
+`src/sibyl/api/app.py:158-166` defines a `lifespan` that constructs `RuntimeServices` and calls
+`startup()`/`shutdown()`, and passes it to `FastAPI(lifespan=lifespan)` at `:183`.
 
 In the deployed process the API app is a **mounted sub-app** (`src/sibyl/main.py:166`,
-`Mount("/api", app=api_app)`). Starlette delivers `lifespan` scope only to the top-level
-router; mounted ASGI apps never receive it. The outer Starlette lifespan
-(`main.py:106-159`) does the real startup.
+`Mount("/api", app=api_app)`). Starlette delivers `lifespan` scope only to the top-level router;
+mounted ASGI apps never receive it. The outer Starlette lifespan (`main.py:106-159`) does the real
+startup.
 
-So `api/app.py`'s lifespan is dead in production and live only under
-`TestClient(create_api_app())`. Two failure modes follow: tests exercise a startup path
-production does not, and if the mounting ever changes to propagate lifespan,
-`RuntimeServices.startup()` runs twice with no guard against it. Delete the sub-app
-lifespan, or make `RuntimeServices` idempotent and say which one owns the lifecycle.
+So `api/app.py`'s lifespan is dead in production and live only under `TestClient(create_api_app())`.
+Two failure modes follow: tests exercise a startup path production does not, and if the mounting
+ever changes to propagate lifespan, `RuntimeServices.startup()` runs twice with no guard against it.
+Delete the sub-app lifespan, or make `RuntimeServices` idempotent and say which one owns the
+lifecycle.
 
-Adjacent dead branch in the same file: `main.py:142-159`. `worker_task` is initialized to
-`None` and never assigned — with `coordination_backend == "local"` it logs "runs
-in-process", otherwise it logs "Embedded worker disabled in surreal mode". So
-`SIBYL_RUN_WORKER=true` (`main.py:249`) does nothing on the redis backend while logging as
-though the decision were deliberate, and the cancellation block at `:156-159` is
-unreachable.
+Adjacent dead branch in the same file: `main.py:142-159`. `worker_task` is initialized to `None` and
+never assigned — with `coordination_backend == "local"` it logs "runs in-process", otherwise it logs
+"Embedded worker disabled in surreal mode". So `SIBYL_RUN_WORKER=true` (`main.py:249`) does nothing
+on the redis backend while logging as though the decision were deliberate, and the cancellation
+block at `:156-159` is unreachable.
 
 ## 13. `get_current_organization` does not verify membership (major, M)
 
-`src/sibyl/persistence/surreal/auth.py:702-774` `SurrealAuthContextResolver.resolve` runs
-one query returning `user`, `organization`, and `membership` independently (`:725-741`).
-`AuthContext.organization` is populated from the org row **whenever the `org` claim names a
-real organization**, regardless of whether the membership row exists — only `org_role`
-goes `None` (`:764-769`).
+`src/sibyl/persistence/surreal/auth.py:702-774` `SurrealAuthContextResolver.resolve` runs one query
+returning `user`, `organization`, and `membership` independently (`:725-741`).
+`AuthContext.organization` is populated from the org row **whenever the `org` claim names a real
+organization**, regardless of whether the membership row exists — only `org_role` goes `None`
+(`:764-769`).
 
 `src/sibyl/auth/dependencies.py:180-186` `get_current_organization` then checks only
-`ctx.organization is None`. So the dependency that every org-scoped route uses to obtain
-`group_id` — and that `get_entity_manager`/`get_graph_store`
-(`src/sibyl/api/dependencies.py:67-100`) use to open a client on that org's Surreal
-namespace — never asserts the caller is a member.
+`ctx.organization is None`. So the dependency that every org-scoped route uses to obtain `group_id`
+— and that `get_entity_manager`/`get_graph_store` (`src/sibyl/api/dependencies.py:67-100`) use to
+open a client on that org's Surreal namespace — never asserts the caller is a member.
 
-The tenancy invariant holds today only because the *separate* `require_org_role`
-dependency is present on the routers that matter, and because token issuance does check
-membership: `persistence/surreal/organization_runtime.py:760-768` (`switch_org`) 404s when
-`membership is None`. I checked the refresh path too — `api/routes/auth.py:1571-1584` takes
-the org from the signed refresh token's own claims, not from client input.
+The tenancy invariant holds today only because the _separate_ `require_org_role` dependency is
+present on the routers that matter, and because token issuance does check membership:
+`persistence/surreal/organization_runtime.py:760-768` (`switch_org`) 404s when `membership is None`.
+I checked the refresh path too — `api/routes/auth.py:1571-1584` takes the org from the signed
+refresh token's own claims, not from client input.
 
 Two residual gaps. Membership is never re-verified on refresh
 (`persistence/surreal/auth_runtime/sessions.py:241-256` mints a new access token from the
-caller-supplied `organization_id` without re-reading the session's org or the membership
-row), so a user removed from an org keeps refreshing into it until the session is revoked;
-they are stopped by `org_role is None` at the role check, not by the org resolution. And
-the WebSocket path (`src/sibyl/api/websocket.py:398-399`) scopes broadcasts purely on the
-`org` claim with no membership check at all.
+caller-supplied `organization_id` without re-reading the session's org or the membership row), so a
+user removed from an org keeps refreshing into it until the session is revoked; they are stopped by
+`org_role is None` at the role check, not by the org resolution. And the WebSocket path
+(`src/sibyl/api/websocket.py:398-399`) scopes broadcasts purely on the `org` claim with no
+membership check at all.
 
-Fix: make `resolve` refuse to populate `organization` without a membership row, so the
-invariant is enforced once at the chokepoint instead of 31 times at the routers.
+Fix: make `resolve` refuse to populate `organization` without a membership row, so the invariant is
+enforced once at the chokepoint instead of 31 times at the routers.
 
 ## 14. Errors swallowed into 200 responses (minor, S)
 
 - `src/sibyl/api/routes/crawler.py:291-350` `preview_url`: the handler raises
-  `HTTPException(400, "Invalid URL")` at `:299` **inside** a `try` whose `except Exception`
-  at `:347` catches it and returns HTTP 200 with `{"error": "Failed to preview URL"}`.
-  `HTTPException` is an `Exception`. So an invalid URL, an SSRF block, a timeout, and a
-  successful fetch are all 200s.
+  `HTTPException(400, "Invalid URL")` at `:299` **inside** a `try` whose `except Exception` at
+  `:347` catches it and returns HTTP 200 with `{"error": "Failed to preview URL"}`. `HTTPException`
+  is an `Exception`. So an invalid URL, an SSRF block, a timeout, and a successful fetch are all
+  200s.
 - `src/sibyl/api/routes/jobs.py:191-193` `list_jobs`: queue unreachable returns
-  `{"jobs": [], "total": 0, "error": ...}` with status 200 — a caller cannot distinguish
-  "no jobs" from "the queue is down".
+  `{"jobs": [], "total": 0, "error": ...}` with status 200 — a caller cannot distinguish "no jobs"
+  from "the queue is down".
 - `src/sibyl/api/routes/jobs.py:146-152` `jobs_health`: returns `status: "unhealthy"` at 200.
-- `src/sibyl/api/routes/rag.py:756-763`: graph search failure returns an empty related-entity
-  list at 200.
-- `src/sibyl/api/routes/admin.py:277-286` `health`: returns `HealthResponse(status="unhealthy",
-  errors=[str(e)])` at 200.
+- `src/sibyl/api/routes/rag.py:756-763`: graph search failure returns an empty related-entity list
+  at 200.
+- `src/sibyl/api/routes/admin.py:277-286` `health`: returns
+  `HealthResponse(status="unhealthy", errors=[str(e)])` at 200.
 
 ## 15. Raw exception text returned in 200 bodies (minor, S)
 
-`admin.py:1063-1066` (`error=str(e)`) and `admin.py:279-286` (`errors=[str(e)]`) return
-exception strings in successful responses, which bypasses the entire sanitization pipeline
-in `src/sibyl/api/errors.py`. That pipeline only runs for `HTTPException` and unhandled
-exceptions via the handlers at `app.py:209-258`.
+`admin.py:1063-1066` (`error=str(e)`) and `admin.py:279-286` (`errors=[str(e)]`) return exception
+strings in successful responses, which bypasses the entire sanitization pipeline in
+`src/sibyl/api/errors.py`. That pipeline only runs for `HTTPException` and unhandled exceptions via
+the handlers at `app.py:209-258`.
 
-Worth noting the sanitizer is also aggressive in the other direction:
-`sanitize_error_text` (`errors.py:350-358`) replaces any message longer than 200 chars, or
-containing two or more path-like segments, or matching
-`token|secret|password|credential|api_key`, with the generic "Invalid request data." A
-legitimate message like "Password reset token has expired" is destroyed. And `_safe_details`
-(`errors.py:376-385`) drops every detail key outside a 7-item allowlist, so
-`ProjectAuthorizationError`'s `project_id` (`auth/authorization.py:113`) never reaches the
-client.
+Worth noting the sanitizer is also aggressive in the other direction: `sanitize_error_text`
+(`errors.py:350-358`) replaces any message longer than 200 chars, or containing two or more
+path-like segments, or matching `token|secret|password|credential|api_key`, with the generic
+"Invalid request data." A legitimate message like "Password reset token has expired" is destroyed.
+And `_safe_details` (`errors.py:376-385`) drops every detail key outside a 7-item allowlist, so
+`ProjectAuthorizationError`'s `project_id` (`auth/authorization.py:113`) never reaches the client.
 
 ## 16. Three auth-dependency families across two layers (minor, M)
 
@@ -459,54 +441,53 @@ client.
   `require_settings_admin`, `require_settings_owner`, `require_setup_mode_or_admin`,
   `require_setup_mode_or_auth`.
 
-The third family is FastAPI dependency code living inside the **persistence** package,
-imported directly by routes (`api/routes/logs.py:18`, `api/routes/setup.py:19-20`). It
-imports back up into `sibyl.auth.dependencies` (`setup.py:12`), so the layering is circular
-in intent if not in module graph. `auth/authorization.py:97-119` also still carries a class
-explicitly marked `DEPRECATED` in its own docstring.
+The third family is FastAPI dependency code living inside the **persistence** package, imported
+directly by routes (`api/routes/logs.py:18`, `api/routes/setup.py:19-20`). It imports back up into
+`sibyl.auth.dependencies` (`setup.py:12`), so the layering is circular in intent if not in module
+graph. `auth/authorization.py:97-119` also still carries a class explicitly marked `DEPRECATED` in
+its own docstring.
 
 ## 17. Two WebSocket endpoints, two hand-written auth paths (minor, M)
 
 `src/sibyl/api/websocket.py:371-399` `_extract_org_from_token` and
-`src/sibyl/api/routes/logs.py:71-99` `_validate_owner_token` independently reimplement
-token extraction, JWT verification, and session validation. Neither reuses
-`resolve_claims`. Neither supports `sk_` API keys.
+`src/sibyl/api/routes/logs.py:71-99` `_validate_owner_token` independently reimplement token
+extraction, JWT verification, and session validation. Neither reuses `resolve_claims`. Neither
+supports `sk_` API keys.
 
-`logs.py:110-114` takes the token as a **query parameter** (`ws://host/api/logs/stream?token=<jwt>`),
-which puts a live access token into reverse-proxy access logs and browser history.
+`logs.py:110-114` takes the token as a **query parameter**
+(`ws://host/api/logs/stream?token=<jwt>`), which puts a live access token into reverse-proxy access
+logs and browser history.
 
-Both validate once at connect and never again, so revoking a session does not close an open
-socket — a revoked admin keeps streaming server logs until they disconnect.
+Both validate once at connect and never again, so revoking a session does not close an open socket —
+a revoked admin keeps streaming server logs until they disconnect.
 
 ## 18. WebSocket broadcast is serial (minor, S)
 
-`src/sibyl/api/websocket.py:122-130` awaits `conn.websocket.send_json(message)` in a loop
-over every connection in the org. One slow or backpressured client delays delivery for
-every other client in that organization and blocks the calling request handler that
-triggered the broadcast. `asyncio.gather` with per-connection exception capture is the
-straightforward fix.
+`src/sibyl/api/websocket.py:122-130` awaits `conn.websocket.send_json(message)` in a loop over every
+connection in the org. One slow or backpressured client delays delivery for every other client in
+that organization and blocks the calling request handler that triggered the broadcast.
+`asyncio.gather` with per-connection exception capture is the straightforward fix.
 
 ## 19. Unpooled Surreal clients on hot paths (minor, S)
 
 `src/sibyl/persistence/surreal/setup.py:47-74` `get_setup_status` calls
-`build_surreal_auth_client()` and `client.close()` on every invocation — and `is_setup_mode()`
-is called on **every request** to `/settings`, `/settings/ai`, and `/setup`. Same shape in
-`src/sibyl/api/readiness.py:63-78`, which connects and closes a fresh client per readiness
-probe (every few seconds under a k8s `readinessProbe`). Both bypass the pooling described
-in `CLAUDE.md`'s "Surreal Connection Pooling" section.
+`build_surreal_auth_client()` and `client.close()` on every invocation — and `is_setup_mode()` is
+called on **every request** to `/settings`, `/settings/ai`, and `/setup`. Same shape in
+`src/sibyl/api/readiness.py:63-78`, which connects and closes a fresh client per readiness probe
+(every few seconds under a k8s `readinessProbe`). Both bypass the pooling described in `CLAUDE.md`'s
+"Surreal Connection Pooling" section.
 
 ## 20. Dead and duplicated code (minor, S)
 
-- `src/sibyl/config.py:793-796` `fully_surreal` is `return True` with **zero callers** in
-  the repo.
+- `src/sibyl/config.py:793-796` `fully_surreal` is `return True` with **zero callers** in the repo.
 - `src/sibyl/auth/rls.py` (71 lines) — the whole module is a retired shim.
   `get_rls_session`/`require_rls_session` raise 501 and nothing in `src/` imports any of it.
-- `src/sibyl/config.py:232-235` and `:519-522` — the same four-line defaulting block
-  duplicated across two validators.
-- `src/sibyl/api/rate_limit.py:36-54` — `RATE_LIMITS` and `get_rate_limit`, referenced only
-  by the test that asserts their contents.
-- `src/sibyl/api/routes/logs.py`, `websocket.py`, `setup.py` all carry their own
-  `disable_auth` special case (`logs.py:74`, `websocket.py:379`, `websocket.py:420`).
+- `src/sibyl/config.py:232-235` and `:519-522` — the same four-line defaulting block duplicated
+  across two validators.
+- `src/sibyl/api/rate_limit.py:36-54` — `RATE_LIMITS` and `get_rate_limit`, referenced only by the
+  test that asserts their contents.
+- `src/sibyl/api/routes/logs.py`, `websocket.py`, `setup.py` all carry their own `disable_auth`
+  special case (`logs.py:74`, `websocket.py:379`, `websocket.py:420`).
 
 ## 21. `enqueue_crawl` / `enqueue_sync` take an optional org (minor, S)
 
@@ -514,94 +495,92 @@ in `CLAUDE.md`'s "Surreal Connection Pooling" section.
 `organization_id: str | None = None`; all fifteen others require it
 (`:105, 126, 134, 148, 170, 188, 204, 218, 233, 256, 274, 290, 317, 338, 352, 366, 380`).
 
-Every real caller passes it (`api/routes/crawler.py:546-553`,
-`core_runtime_ports.py:126-141` — the port even types it as required), so the optionality
-buys nothing and costs real complexity: `api/routes/jobs.py:59-79` has a whole fallback
-branch that re-derives the org for `crawl_source`/`sync_source` jobs by loading the source
-record, purely because those two jobs might not carry one. Tighten the signature and the
-fallback deletes itself.
+Every real caller passes it (`api/routes/crawler.py:546-553`, `core_runtime_ports.py:126-141` — the
+port even types it as required), so the optionality buys nothing and costs real complexity:
+`api/routes/jobs.py:59-79` has a whole fallback branch that re-derives the org for
+`crawl_source`/`sync_source` jobs by loading the source record, purely because those two jobs might
+not carry one. Tighten the signature and the fallback deletes itself.
 
 ## 22. Migration/cutover tooling ships in the daemon (minor, M)
 
-`src/sibyl/cli/migrate.py` is 2,548 lines — the second-largest file in `apps/api` — with 13
-commands including `rehearse` (`:1907`), `cutover` (`:2090`), `auth-flow-compare` (`:1833`),
-and `consolidate` (`:1362`). It shells out to `ssh`/`subprocess` (`:189, :228`), runs moon
-tasks (`:530`), and drives a full pre-cutover acceptance suite (`:599`).
+`src/sibyl/cli/migrate.py` is 2,548 lines — the second-largest file in `apps/api` — with 13 commands
+including `rehearse` (`:1907`), `cutover` (`:2090`), `auth-flow-compare` (`:1833`), and
+`consolidate` (`:1362`). It shells out to `ssh`/`subprocess` (`:189, :228`), runs moon tasks
+(`:530`), and drives a full pre-cutover acceptance suite (`:599`).
 
 This is one-time Neo4j-era migration rehearsal machinery. `settings.store` is now
 `Literal["surreal"]` (`config.py:169-172`) and `fully_surreal` is hardcoded `True`
-(`config.py:794-796`), so the alternative the cutover moves *from* no longer exists in the
-codebase. It ships in every `sibyld` wheel.
+(`config.py:794-796`), so the alternative the cutover moves _from_ no longer exists in the codebase.
+It ships in every `sibyld` wheel.
 
 ## 23. `disable_auth` is a half mode, resolved at import (minor, S)
 
-`require_org_role` and `require_org_admin` (`auth/dependencies.py:198-208`, `:258-271`)
-choose between the real check and a `_noop` **when the decorator is constructed**, i.e. at
-router-module import. `reload_settings_from_env()` cannot change it afterwards.
+`require_org_role` and `require_org_admin` (`auth/dependencies.py:198-208`, `:258-271`) choose
+between the real check and a `_noop` **when the decorator is constructed**, i.e. at router-module
+import. `reload_settings_from_env()` cannot change it afterwards.
 
 The mode is also incomplete: with `disable_auth=True` the role checks vanish, but
-`get_current_organization` still raises 401 because `resolve_claims` returns nothing, so
-most routes still fail. Production is protected (`config.py:237-241`), but as a dev mode it
-half-works, and each of `logs.py:74`, `websocket.py:379`, `websocket.py:420` handles it
-differently.
+`get_current_organization` still raises 401 because `resolve_claims` returns nothing, so most routes
+still fail. Production is protected (`config.py:237-241`), but as a dev mode it half-works, and each
+of `logs.py:74`, `websocket.py:379`, `websocket.py:420` handles it differently.
 
 ## 24-26. Middleware and transport hygiene (minor)
 
-- `src/sibyl/api/app.py:274-279`: `SessionMiddleware(secret_key=settings.jwt_secret.get_secret_value())`
-  reuses the JWT signing key for itsdangerous cookie signing. Two cryptographic purposes,
-  one key; rotating either forces rotating both.
+- `src/sibyl/api/app.py:274-279`:
+  `SessionMiddleware(secret_key=settings.jwt_secret.get_secret_value())` reuses the JWT signing key
+  for itsdangerous cookie signing. Two cryptographic purposes, one key; rotating either forces
+  rotating both.
 - `src/sibyl/api/app.py:261-273`: `cors_origins` hardcodes `http://localhost:3337` and
   `http://127.0.0.1:3337` alongside `public_url`, with `allow_credentials=True`, in every
   environment including production.
-- Six middleware layers on every request, four of them `BaseHTTPMiddleware`
-  (`VersionHeader`, `RequestId`, `AccessLog`, `Auth`) plus `SessionMiddleware` and CORS.
-  `BaseHTTPMiddleware` wraps each request in an anyio task group and is the known-costly
-  option; `AuthMiddleware` (`auth/middleware.py:22-35`) exists only to pre-decode a JWT that
-  `resolve_claims` re-verifies anyway (`auth/dependencies.py:102-115`), and its output feeds
-  exactly one other consumer, the rate-limit key function that finding #4 shows is inert on
-  almost every route. Pure ASGI middleware, or folding these into one layer, is the fix.
+- Six middleware layers on every request, four of them `BaseHTTPMiddleware` (`VersionHeader`,
+  `RequestId`, `AccessLog`, `Auth`) plus `SessionMiddleware` and CORS. `BaseHTTPMiddleware` wraps
+  each request in an anyio task group and is the known-costly option; `AuthMiddleware`
+  (`auth/middleware.py:22-35`) exists only to pre-decode a JWT that `resolve_claims` re-verifies
+  anyway (`auth/dependencies.py:102-115`), and its output feeds exactly one other consumer, the
+  rate-limit key function that finding #4 shows is inert on almost every route. Pure ASGI
+  middleware, or folding these into one layer, is the fix.
 
 ---
 
 # MCP surface
 
 `src/sibyl/server.py` (2,844 lines) registers 13 tools and 2 resources on
-`mcp.server.fastmcp.FastMCP`, mounted at `/` (`src/sibyl/main.py:167`) alongside REST at
-`/api`.
+`mcp.server.fastmcp.FastMCP`, mounted at `/` (`src/sibyl/main.py:167`) alongside REST at `/api`.
 
 ## M1. `api:read` / `api:write` are not enforced on MCP at all (blocker, M)
 
-I grepped `server.py`, `auth/mcp_auth.py`, and `auth/mcp_oauth.py` for `api:read` and
-`api:write`. **Zero hits.** Those scopes exist only in the two REST copies
-(`auth/dependencies.py:35-36` and `persistence/surreal/auth_runtime/_common.py:79-80`).
+I grepped `server.py`, `auth/mcp_auth.py`, and `auth/mcp_oauth.py` for `api:read` and `api:write`.
+**Zero hits.** Those scopes exist only in the two REST copies (`auth/dependencies.py:35-36` and
+`persistence/surreal/auth_runtime/_common.py:79-80`).
 
-The REST gate fires only for paths under `/api/` (`auth/dependencies.py:48-49`, finding #8),
-and MCP is mounted at `/`, so MCP requests never reach it. The result:
+The REST gate fires only for paths under `/api/` (`auth/dependencies.py:48-49`, finding #8), and MCP
+is mounted at `/`, so MCP requests never reach it. The result:
 
 - The default scope set for a newly created API key is `["mcp"]`
-  (`src/sibyl/api/routes/auth.py:117`; the allowlist is
-  `{"api:read", "api:write", "mcp"}` at `auth.py:111`).
-- That default key is correctly **refused** every mutating REST call
-  (`dependencies.py:132-135` → 403 `insufficient_api_scope`).
-- The same key is **fully accepted** by MCP `add` (`server.py:2436`), `remember`
-  (`server.py:2544`), and `manage` (`server.py:2677`) — including
-  `manage("complete_task")`, `manage("correct_memory")`, and `manage("crawl")`.
+  (`src/sibyl/api/routes/auth.py:117`; the allowlist is `{"api:read", "api:write", "mcp"}` at
+  `auth.py:111`).
+- That default key is correctly **refused** every mutating REST call (`dependencies.py:132-135` →
+  403 `insufficient_api_scope`).
+- The same key is **fully accepted** by MCP `add` (`server.py:2436`), `remember` (`server.py:2544`),
+  and `manage` (`server.py:2677`) — including `manage("complete_task")`, `manage("correct_memory")`,
+  and `manage("crawl")`.
 
 So `mcp` is a single all-or-nothing capability with no read/write distinction, and the
-least-privilege story the REST scopes tell is undone by the surface that most agents
-actually connect through. This is the most consequential finding in the MCP lane.
+least-privilege story the REST scopes tell is undone by the surface that most agents actually
+connect through. This is the most consequential finding in the MCP lane.
 
 Two scope fallbacks make it worse:
 
-- `auth/mcp_oauth.py:393`: `scopes = list(auth.scopes or []) or [OAUTH_SCOPE]` — an API key
-  with **zero** scopes is upgraded to `["mcp"]` and admitted.
-- `auth/mcp_oauth.py:98`: `_parse_scopes_from_claims` falls through to `return [OAUTH_SCOPE]`,
-  so a JWT carrying no `scope`/`scopes` claim is granted `mcp`.
+- `auth/mcp_oauth.py:393`: `scopes = list(auth.scopes or []) or [OAUTH_SCOPE]` — an API key with
+  **zero** scopes is upgraded to `["mcp"]` and admitted.
+- `auth/mcp_oauth.py:98`: `_parse_scopes_from_claims` falls through to `return [OAUTH_SCOPE]`, so a
+  JWT carrying no `scope`/`scopes` claim is granted `mcp`.
 
-`auth/mcp_auth.py` gets this right — `SibylMcpTokenVerifier` hard-rejects a missing `mcp`
-scope on both branches (`:43-44`, `:70-71`) with no fallback. It is dead code:
-`server.py:1822` leaves `token_verifier = None` and passes it as `None` at `server.py:1851`.
-81 lines of correct, unreachable enforcement.
+`auth/mcp_auth.py` gets this right — `SibylMcpTokenVerifier` hard-rejects a missing `mcp` scope on
+both branches (`:43-44`, `:70-71`) with no fallback. It is dead code: `server.py:1822` leaves
+`token_verifier = None` and passes it as `None` at `server.py:1851`. 81 lines of correct,
+unreachable enforcement.
 
 ## M2. MCP takes a client-supplied project as authorization input (major, S)
 
@@ -617,57 +596,54 @@ if accessible_projects is None:
 
 `_get_accessible_projects` returns `None` when `ctx.user_id` is falsy and
 `api_key_project_ids is None` (`server.py:296-301`), and also whenever
-`resolve_accessible_project_graph_ids` returns `None`. On that branch the caller's raw
-`project` string becomes the authoritative scope set with **no membership check and no
-existence check**, and is then passed as `accessible_projects` into the memory policy
-(`server.py:1104, 1256, 1269`) and into `authorize_memory_write`. Client input becomes an
-authorization input.
+`resolve_accessible_project_graph_ids` returns `None`. On that branch the caller's raw `project`
+string becomes the authoritative scope set with **no membership check and no existence check**, and
+is then passed as `accessible_projects` into the memory policy (`server.py:1104, 1256, 1269`) and
+into `authorize_memory_write`. Client input becomes an authorization input.
 
-The REST twins never do this: `api/routes/context.py:632-639` and
-`api/routes/search.py:391-399` always route a named project through
+The REST twins never do this: `api/routes/context.py:632-639` and `api/routes/search.py:391-399`
+always route a named project through
 `verify_entity_project_access(..., require_existing_project=True)` first.
 
 ## M3. MCP writes carry no org-role gate (major, M)
 
-REST write routes gate on `require_org_role(*_WRITE_ROLES)`
-(`api/routes/memory.py:1878`, `api/routes/entities.py:2072`) or an explicit role check
-(`api/routes/synthesis.py:121-122`). On MCP, `McpContext.org_role` defaults to `None`
-(`server.py:126`) and the API-key branch of `_get_mcp_context` (`server.py:184-201`) never
-populates it. It is forwarded into `MemoryPolicyContext.organization_role`
-(`server.py:143`) but no MCP tool ever compares it against a write-role set. The only role
-check on the entire MCP surface is `_require_owner_mcp_context` for the `logs` tool
-(`server.py:1796-1799`).
+REST write routes gate on `require_org_role(*_WRITE_ROLES)` (`api/routes/memory.py:1878`,
+`api/routes/entities.py:2072`) or an explicit role check (`api/routes/synthesis.py:121-122`). On
+MCP, `McpContext.org_role` defaults to `None` (`server.py:126`) and the API-key branch of
+`_get_mcp_context` (`server.py:184-201`) never populates it. It is forwarded into
+`MemoryPolicyContext.organization_role` (`server.py:143`) but no MCP tool ever compares it against a
+write-role set. The only role check on the entire MCP surface is `_require_owner_mcp_context` for
+the `logs` tool (`server.py:1796-1799`).
 
-Concretely: `_resolve_mcp_project_scope` does a plain set-membership test
-(`server.py:325-327`), so a project **VIEWER** can drive `remember` and `add` writes through
-MCP where REST demands CONTRIBUTOR.
+Concretely: `_resolve_mcp_project_scope` does a plain set-membership test (`server.py:325-327`), so
+a project **VIEWER** can drive `remember` and `add` writes through MCP where REST demands
+CONTRIBUTOR.
 
 `_add_mcp_entity` (`server.py:1068-1158`) also skips `_validate_related_to_targets_for_write`
-(`api/routes/entities.py:808`, applied at `:2112`), so `related_to` targets go from tool
-argument (`server.py:2443`) into core `add` (`server.py:1126`) unvalidated.
+(`api/routes/entities.py:808`, applied at `:2112`), so `related_to` targets go from tool argument
+(`server.py:2443`) into core `add` (`server.py:1126`) unvalidated.
 
 ## M4. MCP re-implements REST handlers rather than sharing them (major, L)
 
 Not stylistic duplication — the copies have measurably diverged:
 
 - **API-key memory-scope gate.** `server.py:437` vs `api/routes/memory.py:274`:
-  `effective = ctx.user_id if memory_scope == MemoryScope.PRIVATE.value else scope_key`
-  versus `... if memory_scope == "private" and not scope_key else scope_key`. MCP discards
-  an explicitly supplied `scope_key` on a private write; REST honours it. Same intent, two
-  answers.
+  `effective = ctx.user_id if memory_scope == MemoryScope.PRIVATE.value else scope_key` versus
+  `... if memory_scope == "private" and not scope_key else scope_key`. MCP discards an explicitly
+  supplied `scope_key` on a private write; REST honours it. Same intent, two answers.
 - **Active-task link resolution.** `_resolve_mcp_capture_links` (`server.py:532-571`) vs
   `_resolve_reflection_links` (`api/routes/context.py:644-683`) — same probe, but MCP passes
-  `allowed_memory_scope_keys=ctx.api_key_memory_scope_keys` (`server.py:557`) and REST omits
-  the argument entirely (`context.py:661-670`).
+  `allowed_memory_scope_keys=ctx.api_key_memory_scope_keys` (`server.py:557`) and REST omits the
+  argument entirely (`context.py:661-670`).
 - **Context pack.** `_compile_mcp_context_pack` (`server.py:333-411`) vs `context_pack`
   (`context.py:796-879`) — REST normalizes the query via `normalize_retrieval_question`
-  (`context.py:816`) and MCP never calls it, so an identical goal retrieves differently on
-  the two surfaces. REST also supports `record_exposure` and `knn_type_overfetch`
-  (`context.py:834-835`); MCP has neither.
+  (`context.py:816`) and MCP never calls it, so an identical goal retrieves differently on the two
+  surfaces. REST also supports `record_exposure` and `knn_type_overfetch` (`context.py:834-835`);
+  MCP has neither.
 - **Deny auditing.** REST writes `memory.policy_deny` audit rows on both denial paths
   (`memory.py:347-358`, `:371-382`); MCP raises a bare `ValueError(decision.reason)`
-  (`server.py:510`, `:485`) and writes nothing. Policy denials on the MCP surface are
-  invisible to the audit log.
+  (`server.py:510`, `:485`) and writes nothing. Policy denials on the MCP surface are invisible to
+  the audit log.
 - **Idempotency.** MCP hand-rolls reserve/replay/complete twice — `server.py:632-663` and
   `server.py:1688-1728` — including a duplicated "interrupted takeover" comment block
   (`server.py:646-655` ≡ `:1707-1717`). REST gets the same behavior from
@@ -677,49 +653,49 @@ Not stylistic duplication — the copies have measurably diverged:
 - Also `_log_mcp_policy_decision` (`server.py:414-430`) ≡ `_log_policy_decision`
   (`memory.py:167-183`); `_deny_mcp_api_key_memory_scope` (`server.py:465-485`) ≡
   `_api_key_memory_scope_denial` (`memory.py:279-297`); `_authorize_mcp_memory_write`
-  (`server.py:488-519`) ≡ `_authorize_memory_policy` (`memory.py:300-387`);
-  `_reflect_mcp_memory` (`server.py:784-889`) ≡ `reflect_context` (`context.py:925-1014`).
+  (`server.py:488-519`) ≡ `_authorize_memory_policy` (`memory.py:300-387`); `_reflect_mcp_memory`
+  (`server.py:784-889`) ≡ `reflect_context` (`context.py:925-1014`).
 
-`_manage_workflow_transition` (`server.py:1332-1491`) re-derives transition responses,
-message strings, revision validation, citation recording, and learning-job enqueue on top
-of the shared `transition_work_item` service. The comment at `server.py:1274-1277`
-acknowledges it was written to catch MCP up to REST — which is the diagnosis, not the fix.
+`_manage_workflow_transition` (`server.py:1332-1491`) re-derives transition responses, message
+strings, revision validation, citation recording, and learning-job enqueue on top of the shared
+`transition_work_item` service. The comment at `server.py:1274-1277` acknowledges it was written to
+catch MCP up to REST — which is the diagnosis, not the fix.
 
-Root cause is finding #9: the shared rule lives in the route package, so the only way to
-reach it from MCP is to copy it.
+Root cause is finding #9: the shared rule lives in the route package, so the only way to reach it
+from MCP is to copy it.
 
-Separately, `logs` uses `has_owner_membership` on MCP (`server.py:1796-1799`) while REST
-`/logs` uses `require_global_admin` (`api/routes/logs.py:31, 58`) — two different admin
-notions guarding the same data.
+Separately, `logs` uses `has_owner_membership` on MCP (`server.py:1796-1799`) while REST `/logs`
+uses `require_global_admin` (`api/routes/logs.py:31, 58`) — two different admin notions guarding the
+same data.
 
 ## M5. A third copy of the REST scope check lives in the persistence layer (major, S)
 
 `persistence/surreal/auth_runtime/_common.py:78-100` contains verbatim copies of
 `_SAFE_HTTP_METHODS`, `_REST_READ_SCOPES`, `_REST_WRITE_SCOPE`, `_is_rest_request`,
-`_api_key_allows_rest`, and `_insufficient_api_scope` from `auth/dependencies.py:34-73`.
-Both are live: the `_common` copy runs inside `resolve_request_claims`
+`_api_key_allows_rest`, and `_insufficient_api_scope` from `auth/dependencies.py:34-73`. Both are
+live: the `_common` copy runs inside `resolve_request_claims`
 (`persistence/surreal/auth_runtime/sessions.py:200-207`), reached from `logout`
 (`api/routes/auth.py:1613`) and `resolve_request_user`.
 
-A security check duplicated across the auth layer and the persistence layer will drift, and
-when it does one request path will enforce and the other will not.
+A security check duplicated across the auth layer and the persistence layer will drift, and when it
+does one request path will enforce and the other will not.
 
 ## M6. mcp 2.0 migration surface (assessment, not a defect)
 
 Every `mcp.` import in `src`:
 
-| file:line | symbols |
-|---|---|
-| `server.py:17` | `mcp.server.auth.middleware.auth_context.get_access_token` |
-| `server.py:18` | `mcp.server.fastmcp.FastMCP` |
-| `server.py:1824` | `mcp.server.auth.settings.AuthSettings`, `ClientRegistrationOptions` |
-| `auth/mcp_auth.py:16` | `mcp.server.auth.provider.AccessToken` |
+| file:line                 | symbols                                                                                                                     |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `server.py:17`            | `mcp.server.auth.middleware.auth_context.get_access_token`                                                                  |
+| `server.py:18`            | `mcp.server.fastmcp.FastMCP`                                                                                                |
+| `server.py:1824`          | `mcp.server.auth.settings.AuthSettings`, `ClientRegistrationOptions`                                                        |
+| `auth/mcp_auth.py:16`     | `mcp.server.auth.provider.AccessToken`                                                                                      |
 | `auth/mcp_oauth.py:29-36` | `AccessToken`, `AuthorizationCode`, `AuthorizationParams`, `OAuthAuthorizationServerProvider`, `RefreshToken`, `TokenError` |
-| `auth/mcp_oauth.py:37` | `mcp.shared.auth.OAuthClientInformationFull`, `OAuthToken` |
+| `auth/mcp_oauth.py:37`    | `mcp.shared.auth.OAuthClientInformationFull`, `OAuthToken`                                                                  |
 
-Plus tests (`test_mcp_oauth_multi_org_selection.py:10-11`,
-`test_mcp_oauth_session_refresh.py:9-10`, `test_server_accessible_projects.py:1799`) and
-client-side `mcp.ClientSession` in `tools/baselines/replay.py:10-11`.
+Plus tests (`test_mcp_oauth_multi_org_selection.py:10-11`, `test_mcp_oauth_session_refresh.py:9-10`,
+`test_server_accessible_projects.py:1799`) and client-side `mcp.ClientSession` in
+`tools/baselines/replay.py:10-11`.
 
 FastMCP surface actually used: constructor kwargs `host`/`port`/`stateless_http`/`auth`/
 `auth_server_provider`/`token_verifier` (`server.py:1844-1852`); `@mcp.tool()` ×13;
@@ -727,9 +703,9 @@ FastMCP surface actually used: constructor kwargs `host`/`port`/`stateless_http`
 `streamable_http_app()` (`main.py:104`); `session_manager.run()` (`main.py:152`);
 `run(transport="stdio")` (`main.py:212`). `sse_app` is unused.
 
-**The good news: the 13 tool bodies are decoupled.** No tool takes a `Context` parameter and
-no tool imports from `mcp`; signatures are plain Python types and returns are
-`dict[str, Any]` via `_to_dict` (`server.py:1877`). A 2.0 bump would not touch them.
+**The good news: the 13 tool bodies are decoupled.** No tool takes a `Context` parameter and no tool
+imports from `mcp`; signatures are plain Python types and returns are `dict[str, Any]` via
+`_to_dict` (`server.py:1877`). A 2.0 bump would not touch them.
 
 What it does touch, in cost order:
 
@@ -737,41 +713,37 @@ What it does touch, in cost order:
    `OAuthAuthorizationServerProvider[...]` and implements 9 abstract methods (`get_client:177`,
    `register_client:193`, `authorize:203`, `load_authorization_code:215`,
    `exchange_authorization_code:225`, `load_refresh_token:276`, `exchange_refresh_token:322`,
-   `load_access_token:388`, `revoke_token:423`) plus an `AuthorizationCode` subclass
-   (`:132-134`). A full protocol implementation pinned to the 1.x provider ABC. This is the
-   dominant cost.
-2. **`get_access_token()` ambient lookup** (`server.py:168`) — the entire MCP auth model
-   hangs off this contextvar. `_get_mcp_context` is the single identity source for every
-   tool via `_require_mcp_context` (`server.py:240-252`). If 2.0 changes ambient-token
-   retrieval, all 13 tools lose their identity source simultaneously.
+   `load_access_token:388`, `revoke_token:423`) plus an `AuthorizationCode` subclass (`:132-134`). A
+   full protocol implementation pinned to the 1.x provider ABC. This is the dominant cost.
+2. **`get_access_token()` ambient lookup** (`server.py:168`) — the entire MCP auth model hangs off
+   this contextvar. `_get_mcp_context` is the single identity source for every tool via
+   `_require_mcp_context` (`server.py:240-252`). If 2.0 changes ambient-token retrieval, all 13
+   tools lose their identity source simultaneously.
 3. **`create_mcp_server`** (`server.py:1802-1874`) — constructor kwargs, the
-   `AuthSettings`/`ClientRegistrationOptions` shape (`:1827-1836`), and the
-   `auth_server_provider` vs `token_verifier` mutual exclusion documented at `:1840-1842`.
+   `AuthSettings`/`ClientRegistrationOptions` shape (`:1827-1836`), and the `auth_server_provider`
+   vs `token_verifier` mutual exclusion documented at `:1840-1842`.
 4. **ASGI wiring** (`main.py:104, 152, 167`).
-5. **`mcp.shared.auth` models** (`mcp_oauth.py:37`) used for dynamic-client-registration
-   round-trip (`model_validate` at `:185`, `model_dump` at `:200`).
+5. **`mcp.shared.auth` models** (`mcp_oauth.py:37`) used for dynamic-client-registration round-trip
+   (`model_validate` at `:185`, `model_dump` at `:200`).
 6. **`auth/mcp_auth.py`** — dead (see M1), but it still needs porting or deleting.
 
-Roughly five files, concentrated in `mcp_oauth.py`. Deleting the dead `mcp_auth.py` and
-folding its (correct) scope logic into the live path would shrink the migration and close
-M1 at the same time.
+Roughly five files, concentrated in `mcp_oauth.py`. Deleting the dead `mcp_auth.py` and folding its
+(correct) scope logic into the live path would shrink the migration and close M1 at the same time.
 
 ## M7. Smaller MCP items (minor)
 
 - `_get_mcp_context`'s JWT branch (`server.py:207-227`) calls `verify_access_token` but not
   `validate_access_session`, unlike both `dependencies.resolve_claims` (`:117`) and
-  `mcp_oauth.load_access_token` (`:403`). Currently covered because the transport already
-  validated, but the duplicated path itself does not re-check revocation.
+  `mcp_oauth.load_access_token` (`:403`). Currently covered because the transport already validated,
+  but the duplicated path itself does not re-check revocation.
 - `manage` overwrites `organization_id` unconditionally (`server.py:1731`) — correct — but
-  overwrites `user_id` only conditionally (`:1732-1733`, `if ctx.user_id:`). Same pattern
-  for `created_by` at `:681-682` and `:1116-1117`. When `ctx.user_id` is falsy, a
-  client-supplied `data["user_id"]` / `metadata["created_by"]` survives into core `manage`
-  (`:1758-1766`).
-- `_authorize_mcp_manage_action` returns `None` (`server.py:1259-1260`) for any action
-  outside `MCP_ENTITY_PROJECT_POLICY_ACTIONS` (`:95-110`) and `MCP_PROJECT_ID_POLICY_ACTIONS`
-  (`:111`), so `crawl`, `sync`, `refresh`, `link_graph`, and `link_graph_status` get **no
-  policy decision at all** and reach core `manage` with client-controlled `data`, protected
-  only by org isolation.
+  overwrites `user_id` only conditionally (`:1732-1733`, `if ctx.user_id:`). Same pattern for
+  `created_by` at `:681-682` and `:1116-1117`. When `ctx.user_id` is falsy, a client-supplied
+  `data["user_id"]` / `metadata["created_by"]` survives into core `manage` (`:1758-1766`).
+- `_authorize_mcp_manage_action` returns `None` (`server.py:1259-1260`) for any action outside
+  `MCP_ENTITY_PROJECT_POLICY_ACTIONS` (`:95-110`) and `MCP_PROJECT_ID_POLICY_ACTIONS` (`:111`), so
+  `crawl`, `sync`, `refresh`, `link_graph`, and `link_graph_status` get **no policy decision at
+  all** and reach core `manage` with client-controlled `data`, protected only by org isolation.
 
 ---
 
@@ -790,55 +762,54 @@ def resolved_coordination_backend(self) -> Literal["local", "redis"]:
 configured and reachable. Everything routes through this one value:
 `coordination/broker.py:414-434`, `scheduler.py:22-42`, `locks.py:58-78`, `pending.py:47-65`.
 
-That makes an in-process `asyncio.PriorityQueue` (`coordination/_local/broker.py:117`) the
-default job queue. It persists nothing. Every queued job dies with the process, with no
-record and no recovery. Combined with finding #1 (broker startup failures swallowed), a
-deployment can look entirely healthy while losing every background job.
+That makes an in-process `asyncio.PriorityQueue` (`coordination/_local/broker.py:117`) the default
+job queue. It persists nothing. Every queued job dies with the process, with no record and no
+recovery. Combined with finding #1 (broker startup failures swallowed), a deployment can look
+entirely healthy while losing every background job.
 
-A setting named `auto` that ignores available infrastructure and always picks the weaker
-option is the wrong default, and the log line at `main.py:115-120` reports it as though a
-decision were made.
+A setting named `auto` that ignores available infrastructure and always picks the weaker option is
+the wrong default, and the log line at `main.py:115-120` reports it as though a decision were made.
 
 ## J2. Delivery semantics differ by backend and neither is documented (major, M)
 
 **Redis/arq — at-least-once, but only on crash.** The ack happens after the work
-(`arq/worker.py:588-660`), so a crash mid-job leaves the queue entry and another worker
-re-runs it once the `in_progress` TTL expires. But arq only retries on
-`Retry`/`RetryJob`/`CancelledError` (`arq/worker.py:613-625`); a plain `Exception` sets
-`finish=True` and fails permanently with zero retries (`arq/worker.py:629-635`). Nothing in
-`src/sibyl/jobs/` ever raises `arq.Retry`. `WorkerSettings` (`jobs/worker.py:337-341`) sets
-`max_jobs`, `job_timeout=3600`, `keep_result`, and `poll_delay` — never `max_tries`.
+(`arq/worker.py:588-660`), so a crash mid-job leaves the queue entry and another worker re-runs it
+once the `in_progress` TTL expires. But arq only retries on `Retry`/`RetryJob`/`CancelledError`
+(`arq/worker.py:613-625`); a plain `Exception` sets `finish=True` and fails permanently with zero
+retries (`arq/worker.py:629-635`). Nothing in `src/sibyl/jobs/` ever raises `arq.Retry`.
+`WorkerSettings` (`jobs/worker.py:337-341`) sets `max_jobs`, `job_timeout=3600`, `keep_result`, and
+`poll_delay` — never `max_tries`.
 
 **Local — at-most-once, with no retry and no timeout.** `_worker_loop` pops the id
-(`_local/broker.py:758`) and flips the record to `IN_PROGRESS` (`:764`) before running.
-Death between those points is unrecoverable. `_run_job` awaits the function unbounded
-(`:785`) — `job_timeout` is read only by arq; the local broker copies `max_jobs` and
-`keep_result` (`:95-96`) but not the timeout.
+(`_local/broker.py:758`) and flips the record to `IN_PROGRESS` (`:764`) before running. Death
+between those points is unrecoverable. `_run_job` awaits the function unbounded (`:785`) —
+`job_timeout` is read only by arq; the local broker copies `max_jobs` and `keep_result` (`:95-96`)
+but not the timeout.
 
 ## J3. A failed local job blocks its own retry for 24 hours (major, S)
 
 `coordination/_local/broker.py:799-811` — on exception, `_run_job` sets
-`record.status = JobStatus.COMPLETE` and stores the error string. `_enqueue_unique`
-(`:730-733`) then treats `COMPLETE` as already-done and returns `created=False` for any
-later enqueue with the same `job_id`, unless `clear_result=True`.
+`record.status = JobStatus.COMPLETE` and stores the error string. `_enqueue_unique` (`:730-733`)
+then treats `COMPLETE` as already-done and returns `created=False` for any later enqueue with the
+same `job_id`, unless `clear_result=True`.
 
 `enqueue_create_entity` (`:273-283`) and `enqueue_update_entity` (`:296-303`) do not pass
 `clear_result`. So a failed `create_entity:{entity_id}` silently swallows every retry for
-`keep_result` = 86,400 seconds (`jobs/worker.py:340`, consumed at `_local/broker.py:96`).
-The caller receives the old job id and a success-shaped response.
+`keep_result` = 86,400 seconds (`jobs/worker.py:340`, consumed at `_local/broker.py:96`). The caller
+receives the old job id and a success-shaped response.
 
 The Redis path has the same 24-hour window from the other direction: arq's
 `enqueue_job(_job_id=...)` returns `None` when either the job key or the result key exists
-(`arq/connections.py:156-159`), so `_redis/broker.py:231-239` (`enqueue_update_entity`),
-`:408-424`, and `:442-458` silently drop a re-enqueue within 24h and hand back a stale id.
+(`arq/connections.py:156-159`), so `_redis/broker.py:231-239` (`enqueue_update_entity`), `:408-424`,
+and `:442-458` silently drop a re-enqueue within 24h and hand back a stale id.
 
 ## J4. `run_backup` reports failure as a successful job (major, S)
 
 `src/sibyl/jobs/backup.py:430-462` catches every exception and **returns** a payload with
-`"success": False` instead of re-raising. Both brokers therefore record the job as
-succeeded (`_local/broker.py:813-823`; arq sets its own `success=True`), so it is never
-retried, and `job_end` telemetry records `status="ok"` because `worker.py:136-140` reads
-arq's flag rather than the payload's.
+`"success": False` instead of re-raising. Both brokers therefore record the job as succeeded
+(`_local/broker.py:813-823`; arq sets its own `success=True`), so it is never retried, and `job_end`
+telemetry records `status="ok"` because `worker.py:136-140` reads arq's flag rather than the
+payload's.
 
 A nightly backup can fail every night and every signal in the system says it worked.
 
@@ -849,141 +820,135 @@ A nightly backup can fail every night and every signal in the system says it wor
 `:83-87`). `RuntimeServices._startup_scheduler` (`runtime_services.py:72-84`) starts one per
 process.
 
-Firing goes `_run_spec` → `enqueue_scheduled_job(spec.name)` (`_local/scheduler.py:135-138`)
-→ `_enqueue_unique(job_id=f"scheduled:{function}", clear_result=True)`
-(`_local/broker.py:553-559`), and the broker's `self._jobs` dict is also per-process
-(`:106`). **N API processes run every cron job N times, every tick** — including
-`consolidate_all_orgs`, `run_reflection_dream_cycle_all_orgs`, and `run_scheduled_backups`
-(`jobs/worker.py:195-275`). `clear_result=True` additionally disables even the intra-process
-dedup.
+Firing goes `_run_spec` → `enqueue_scheduled_job(spec.name)` (`_local/scheduler.py:135-138`) →
+`_enqueue_unique(job_id=f"scheduled:{function}", clear_result=True)` (`_local/broker.py:553-559`),
+and the broker's `self._jobs` dict is also per-process (`:106`). **N API processes run every cron
+job N times, every tick** — including `consolidate_all_orgs`, `run_reflection_dream_cycle_all_orgs`,
+and `run_scheduled_backups` (`jobs/worker.py:195-275`). `clear_result=True` additionally disables
+even the intra-process dedup.
 
-Redis mode is safe: `build_cron_jobs()` (`jobs/worker.py:82-95`) uses `arq.cron(unique=True)`,
-which derives the job id from the scheduled timestamp so exactly one worker wins, and
-`RedisScheduler` is a deliberate no-op (`_redis/scheduler.py:9-16`).
+Redis mode is safe: `build_cron_jobs()` (`jobs/worker.py:82-95`) uses `arq.cron(unique=True)`, which
+derives the job id from the scheduled timestamp so exactly one worker wins, and `RedisScheduler` is
+a deliberate no-op (`_redis/scheduler.py:9-16`).
 
-Redis-mode caveat: `WorkerSettings.cron_jobs = build_cron_jobs()` is evaluated in the class
-body (`jobs/worker.py:329`), so the schedule is frozen at import and a runtime settings
-reload (`runtime_services.py:29`) cannot change it. `get_cron_jobs` (`worker.py:328`) is
-unused.
+Redis-mode caveat: `WorkerSettings.cron_jobs = build_cron_jobs()` is evaluated in the class body
+(`jobs/worker.py:329`), so the schedule is frozen at import and a runtime settings reload
+(`runtime_services.py:29`) cannot change it. `get_cron_jobs` (`worker.py:328`) is unused.
 
 ## J6. Multi-process on the local backend breaks five coordination guarantees (major, M)
 
 Beyond the scheduler:
 
-1. **Dedup is per-process.** `self._jobs` (`_local/broker.py:106`) — `create_entity:{id}`
-   runs once per process, producing duplicate graph writes.
+1. **Dedup is per-process.** `self._jobs` (`_local/broker.py:106`) — `create_entity:{id}` runs once
+   per process, producing duplicate graph writes.
 2. **Locks do not cross processes.** `LocalLockManager` is a plain `asyncio.Lock`
    (`_local/locks.py:17`) and `extend()` is a no-op (`:74-77`), so `entity_lock` in
-   `jobs/entities.py:1252` and `jobs/operational_distillation.py:78` provides no mutual
-   exclusion. This is also what backs `idempotency_lock` (finding #3).
+   `jobs/entities.py:1252` and `jobs/operational_distillation.py:78` provides no mutual exclusion.
+   This is also what backs `idempotency_lock` (finding #3).
 3. **The pending registry does not cross processes.** `_local/pending.py:20-23` — the
    queue-until-materialized guarantee documented at `jobs/pending.py:6-13` is void.
-4. **Source-import run state does not cross processes.** `_SOURCE_IMPORT_RUNS` is a module
-   dict consulted before the Surreal fallback (`jobs/source_imports.py:138`, `:761-763`).
+4. **Source-import run state does not cross processes.** `_SOURCE_IMPORT_RUNS` is a module dict
+   consulted before the Surreal fallback (`jobs/source_imports.py:138`, `:761-763`).
 5. **Job listing and status are per-process.** `list_jobs` reads `self._recent_job_ids`
-   (`_local/broker.py:571-575`), so the admin API shows only whichever process served the
-   request.
+   (`_local/broker.py:571-575`), so the admin API shows only whichever process served the request.
 
 ## J7. Jobs missing org scope (major, S)
 
-Graph access is namespace-isolated per org, so a query without an org predicate is still
-contained *provided `group_id` is correct*. These are the ones where it is not:
+Graph access is namespace-isolated per org, so a query without an org predicate is still contained
+_provided `group_id` is correct_. These are the ones where it is not:
 
 - **`sync_all_sources`** (`jobs/crawl.py:270-284`) — `list_sources()` at `:274` takes no org
-  argument and `sync_source(ctx, str(source.id))` at `:279` is called **without**
-  `organization_id`. One job iterates every source in every org.
-- **`poll_raw_capture_changefeed`** — org-scoped by argument, but the underlying read is
-  not: `SHOW CHANGES FOR TABLE raw_captures SINCE ... LIMIT $limit`
-  (`jobs/raw_changefeed.py:141-145`) runs against the **shared** content client
-  (`persistence/surreal/content.py:212-213`) with no org predicate. Every org's change
-  payload is read into the process and filtered in Python at `:299`. The `LIMIT` is shared
-  too, so a busy org consumes another org's poll budget.
+  argument and `sync_source(ctx, str(source.id))` at `:279` is called **without** `organization_id`.
+  One job iterates every source in every org.
+- **`poll_raw_capture_changefeed`** — org-scoped by argument, but the underlying read is not:
+  `SHOW CHANGES FOR TABLE raw_captures SINCE ... LIMIT $limit` (`jobs/raw_changefeed.py:141-145`)
+  runs against the **shared** content client (`persistence/surreal/content.py:212-213`) with no org
+  predicate. Every org's change payload is read into the process and filtered in Python at `:299`.
+  The `LIMIT` is shared too, so a busy org consumes another org's poll budget.
 - **`_raw_capture_organization_ids`** (`jobs/raw_changefeed.py:222-237`) — cross-org
   `SELECT ... GROUP BY organization_id`.
 - **`cleanup_old_backups`** (`jobs/backup.py:465-506`) — org-less by design; globs
   `settings.backup_dir` across all orgs (`:144`) and unlinks by mtime.
-- **`purge_due_deleted_personal_memories`** (`jobs/privacy.py:15-34`) — purges globally,
-  then reads the org id back off each returned row (`:22`) for the audit log.
+- **`purge_due_deleted_personal_memories`** (`jobs/privacy.py:15-34`) — purges globally, then reads
+  the org id back off each returned row (`:22`) for the audit log.
 
-Related visibility gap: `_JOB_ORG_ARGUMENT_INDEX` (`coordination/broker.py:21-31`) covers
-only 9 functions. `run_backup`, `promote_raw_captures`, `poll_raw_capture_changefeed`,
-`replay_memory_probes`, `create_learning_episode`, `create_learning_procedure`,
-`update_task`, and `drain_source_import` are absent, so `_job_visible_to_org`
-(`api/routes/jobs.py:40-79`) falls through to `return False` — those jobs are invisible to
-their own org in the jobs API. It fails closed, which is the right direction, but on the
-local backend it is total: `JobInfo.organization_id` is always `None`
-(`_local/broker.py:64-76`), so visibility depends entirely on that 9-entry map.
+Related visibility gap: `_JOB_ORG_ARGUMENT_INDEX` (`coordination/broker.py:21-31`) covers only 9
+functions. `run_backup`, `promote_raw_captures`, `poll_raw_capture_changefeed`,
+`replay_memory_probes`, `create_learning_episode`, `create_learning_procedure`, `update_task`, and
+`drain_source_import` are absent, so `_job_visible_to_org` (`api/routes/jobs.py:40-79`) falls
+through to `return False` — those jobs are invisible to their own org in the jobs API. It fails
+closed, which is the right direction, but on the local backend it is total:
+`JobInfo.organization_id` is always `None` (`_local/broker.py:64-76`), so visibility depends
+entirely on that 9-entry map.
 
 ## J8. Shutdown drains the backlog, then kills running work (minor, S)
 
-`LocalQueueBroker.shutdown` (`_local/broker.py:128-178`) sets `self._queue = None` (`:134`),
-then `await asyncio.wait_for(queue.join(), timeout=self._shutdown_grace_seconds)` (`:139`).
+`LocalQueueBroker.shutdown` (`_local/broker.py:128-178`) sets `self._queue = None` (`:134`), then
+`await asyncio.wait_for(queue.join(), timeout=self._shutdown_grace_seconds)` (`:139`).
 
 `local_queue_shutdown_grace_seconds` **is** honored (`config.py:661-666`, read at
 `_local/broker.py:98-102`, applied at `:139`). Three problems around it:
 
-- `queue.join()` waits for the whole **backlog**, not just in-flight work. A deep queue means
-  the grace expires and running jobs are cancelled at `:164-165` even though they would have
-  finished in time.
-- Jobs still queued at timeout are lost. `_mark_queued_jobs_cancelled` (`:843-859`) only
-  mutates in-memory records; there is no drain-to-disk and nothing re-enqueues them.
-- Setting `self._queue = None` **before** draining (`:134`) poisons in-flight jobs that
-  enqueue follow-up work: `_require_queue()` (`:866-869`) raises
-  `RuntimeError("Local job broker is not running")`. `jobs/entities.py:716` and `:748`
-  swallow exactly that and return success.
+- `queue.join()` waits for the whole **backlog**, not just in-flight work. A deep queue means the
+  grace expires and running jobs are cancelled at `:164-165` even though they would have finished in
+  time.
+- Jobs still queued at timeout are lost. `_mark_queued_jobs_cancelled` (`:843-859`) only mutates
+  in-memory records; there is no drain-to-disk and nothing re-enqueues them.
+- Setting `self._queue = None` **before** draining (`:134`) poisons in-flight jobs that enqueue
+  follow-up work: `_require_queue()` (`:866-869`) raises
+  `RuntimeError("Local job broker is not running")`. `jobs/entities.py:716` and `:748` swallow
+  exactly that and return success.
 
 The arq shutdown hook is a bare log line (`jobs/worker.py:122-125`).
 
 ## J9. Failure-looks-like-success is systemic across job bodies (major, M)
 
-Beyond J4, the pattern where an exception is logged and the job returns a success shape
-appears throughout. The highest-consequence instances:
+Beyond J4, the pattern where an exception is logged and the job returns a success shape appears
+throughout. The highest-consequence instances:
 
-| Location | What is silently lost |
-|---|---|
-| `jobs/entities.py:716-721` | embedding-backfill job never enqueued; `create_entity` returns OK |
-| `jobs/entities.py:748-753` | memory-extraction job never enqueued; `create_entity` returns OK |
-| `jobs/source_imports.py:974-980` | raw promotion never enqueued; import reports COMPLETED |
-| `jobs/source_imports.py:341-346` | import run state never persisted; run continues in memory only |
-| `jobs/entities.py:533-534, 561-566, 619-620` | dedup link, explicit relationships, auto-links all dropped |
-| `jobs/entities.py:245-251` | inherited task-knowledge edges dropped |
-| `jobs/entities.py:274-284` | relationship writes dropped inside `_persist_job_relationships`; only the count differs |
-| `jobs/raw_promotion.py:466-476` | lineage edges lost, replaced with a metadata note |
-| `jobs/raw_promotion.py:668-673` | extraction enqueue failure recorded as metadata; job succeeds |
-| `jobs/memory_extraction.py:635-651` | projection failure returns `projection_state: "partial"` with 0 entities; job succeeds |
-| `jobs/pending.py:194-200, :203` | failed pending ops are recorded, then `clear_pending_operations` runs **unconditionally** and discards them |
-| `jobs/worker.py:148-151` | `_job_result_info` returning `None` makes `job_end` telemetry record `status="ok"` |
-| `jobs/backup.py:533, :585` | `except Exception: # noqa: S110` with bare `pass` on archive metadata reads |
+| Location                                     | What is silently lost                                                                                       |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `jobs/entities.py:716-721`                   | embedding-backfill job never enqueued; `create_entity` returns OK                                           |
+| `jobs/entities.py:748-753`                   | memory-extraction job never enqueued; `create_entity` returns OK                                            |
+| `jobs/source_imports.py:974-980`             | raw promotion never enqueued; import reports COMPLETED                                                      |
+| `jobs/source_imports.py:341-346`             | import run state never persisted; run continues in memory only                                              |
+| `jobs/entities.py:533-534, 561-566, 619-620` | dedup link, explicit relationships, auto-links all dropped                                                  |
+| `jobs/entities.py:245-251`                   | inherited task-knowledge edges dropped                                                                      |
+| `jobs/entities.py:274-284`                   | relationship writes dropped inside `_persist_job_relationships`; only the count differs                     |
+| `jobs/raw_promotion.py:466-476`              | lineage edges lost, replaced with a metadata note                                                           |
+| `jobs/raw_promotion.py:668-673`              | extraction enqueue failure recorded as metadata; job succeeds                                               |
+| `jobs/memory_extraction.py:635-651`          | projection failure returns `projection_state: "partial"` with 0 entities; job succeeds                      |
+| `jobs/pending.py:194-200, :203`              | failed pending ops are recorded, then `clear_pending_operations` runs **unconditionally** and discards them |
+| `jobs/worker.py:148-151`                     | `_job_result_info` returning `None` makes `job_end` telemetry record `status="ok"`                          |
+| `jobs/backup.py:533, :585`                   | `except Exception: # noqa: S110` with bare `pass` on archive metadata reads                                 |
 
-`jobs/probes.py:173-182` is the one place that deliberately guards against this — a `None`
-return from `update` is counted as a failure. It is the right model for the rest.
+`jobs/probes.py:173-182` is the one place that deliberately guards against this — a `None` return
+from `update` is counted as a failure. It is the right model for the rest.
 
-Counted differently: `_safe_broadcast` swallows every WebSocket and pub/sub event at debug
-level in four separate modules (`jobs/entities.py:189-190`, `jobs/crawl.py:32-33`,
-`jobs/backup.py:164-166`, `jobs/source_imports.py:189-190`), so realtime UI updates can stop
-entirely with no signal above debug.
+Counted differently: `_safe_broadcast` swallows every WebSocket and pub/sub event at debug level in
+four separate modules (`jobs/entities.py:189-190`, `jobs/crawl.py:32-33`, `jobs/backup.py:164-166`,
+`jobs/source_imports.py:189-190`), so realtime UI updates can stop entirely with no signal above
+debug.
 
 ---
 
 # Suggested order of attack
 
-1. **#1** (readiness blind to broker/scheduler/lock failure) and **J1** (`auto` never picks
-   Redis) — together these are the difference between a healthy-looking pod and one silently
-   dropping every background job. Neither fix is large.
-2. **M1** (no `api:read`/`api:write` on MCP) — the dead `auth/mcp_auth.py` already contains
-   the correct check; wiring it in and deleting the fallbacks at `mcp_oauth.py:98` and `:393`
-   closes it.
-3. **#2** (backups IDOR) and **#7** (route-auth coverage test) — the second prevents the
-   next instance of the first. Both are small.
-4. **#3** (`"unknown"` idempotency scope), **M2** (client project as authz input), **J3**
-   (failed job blocks its own retry), **J4** (`run_backup` fakes success) — four small,
-   independent correctness fixes.
-5. **#4** (inert rate limiting), **#5** (request-id bypass), **#12** (dead lifespan) — small,
-   and each currently has a green test or a passing probe telling you otherwise.
+1. **#1** (readiness blind to broker/scheduler/lock failure) and **J1** (`auto` never picks Redis) —
+   together these are the difference between a healthy-looking pod and one silently dropping every
+   background job. Neither fix is large.
+2. **M1** (no `api:read`/`api:write` on MCP) — the dead `auth/mcp_auth.py` already contains the
+   correct check; wiring it in and deleting the fallbacks at `mcp_oauth.py:98` and `:393` closes it.
+3. **#2** (backups IDOR) and **#7** (route-auth coverage test) — the second prevents the next
+   instance of the first. Both are small.
+4. **#3** (`"unknown"` idempotency scope), **M2** (client project as authz input), **J3** (failed
+   job blocks its own retry), **J4** (`run_backup` fakes success) — four small, independent
+   correctness fixes.
+5. **#4** (inert rate limiting), **#5** (request-id bypass), **#12** (dead lifespan) — small, and
+   each currently has a green test or a passing probe telling you otherwise.
 6. **#6** (setup-mode bypass) and **#13** (membership check at the resolver) — medium,
    security-structural.
-7. **#9** / **M4** — the large one. Moving the shared rules out of `api/routes/` into core is
-   what stops MCP and REST from drifting, and it is the root cause behind M2, M3, and most of
-   M4. Best done incrementally, starting with the memory policy helpers that already exist in
-   two diverged copies.
-
+7. **#9** / **M4** — the large one. Moving the shared rules out of `api/routes/` into core is what
+   stops MCP and REST from drifting, and it is the root cause behind M2, M3, and most of M4. Best
+   done incrementally, starting with the memory policy helpers that already exist in two diverged
+   copies.

--- a/docs/architecture/AUDIT_2026-08-13/debt-core-graph.md
+++ b/docs/architecture/AUDIT_2026-08-13/debt-core-graph.md
@@ -1,0 +1,725 @@
+# Tech-debt audit: sibyl-core graph / persistence / models
+
+Scope: `packages/python/sibyl-core/src/sibyl_core/` — `models/`, `backends/surreal/`,
+`services/graph*.py`, `storage/`, `migrate/`, and multi-tenancy plumbing.
+Excluded by lane assignment: retrieval/ranking/ai/extraction, `apps/api`, `apps/web`.
+Every claim below was read in the source at the cited line. Commit `5388d986`, v1.2.0.
+
+Two historical facts named in the brief were re-checked and one has changed:
+
+- `entity.updated_at` is **no longer** `option<string>`. Graph schema migration v5
+  (`backends/surreal/schema.py:264-293`, `entity_updated_at_datetime`) converted it to
+  `option<datetime>`, and the current field definition at `schema.py:87` is
+  `option<datetime>`. The lexicographic-ORDER-BY hazard is retired. A runtime fallback
+  for un-migrated namespaces still exists (finding G7).
+- Dead Graphiti tables confirmed: `REMOVED_GRAPH_TABLES = ("community", "saga")` and
+  `REMOVED_GRAPH_EDGES = ("has_episode", "next_episode", "has_member")` at
+  `schema.py:575-577`, dropped by migration v4 and asserted empty before any migration
+  (`schema.py:897-910`). That cleanup is done. The `episode` table and `mentions` edge,
+  however, are still fully alive in the schema (finding S4).
+- Namespace-per-org isolation confirmed at `services/graph_client.py:117-122`.
+
+---
+
+## A. Findings that would fight a memory-representation redesign
+
+### A1. Every entity stores its metadata three times, and one copy goes stale by design
+`services/graph.py:3017-3025`, `graph.py:1982-2006`, `graph.py:3071-3081`
+
+`_entity_record` writes the same facts into three places on every full write:
+
+```python
+attributes: dict[str, object] = {
+    **metadata,                      # (1) flattened bag
+    "description": entity.description or "",
+    "updated_at": updated_at,
+    "_direct_insert": True,
+    "metadata": json.dumps(metadata),   # (2) JSON snapshot of the same bag
+    "entity_type": entity.entity_type.value,
+}
+```
+
+plus (3) ~20 promoted columns (`project_id`, `memory_scope`, `status`, `tags`,
+`retrieval_count`, …) on the record itself.
+
+The partial-update path (`_entity_update_patch`, `graph.py:3071`) builds an
+`attributes` patch that never contains a `metadata` key, and the write is
+`UPDATE entity MERGE $patch` (`graph.py:562`). A deep merge leaves
+`attributes.metadata` untouched, so from the first partial update onward the JSON
+snapshot is a stale copy of pre-update state. The read path
+(`entity_from_surreal_row`, `graph.py:2021`) layers `snapshot | flattened`, so the
+flattened copy wins for any key present in both — but a key an update **removed**
+resurrects from the snapshot. The code documents this and mitigates it with a
+hand-maintained allowlist of five keys (`_SNAPSHOT_SHADOWED_METADATA_KEYS`,
+`graph.py:1990-1998`).
+
+Why it matters: this is the single largest structural obstacle to a 1.3 memory
+representation. Any new metadata key with delete-semantics silently inherits the
+resurrection bug unless someone remembers to add it to a frozenset in a 3,475-line
+module. Storage is roughly tripled for metadata, and there is no single authority
+for what a row means.
+
+**Size L · Severity blocker (for the redesign; major as-is)**
+
+### A2. The write path is a blind full replace with per-field absence exceptions bolted on
+`services/graph.py:229-279` (`_ENTITY_BULK_UPSERT_QUERY`)
+
+`INSERT INTO entity $rows ON DUPLICATE KEY UPDATE ... attributes = $input.attributes`
+replaces the whole attributes bag with no revision guard and no `WHERE`. Two fields
+got rescued from that after it caused real data loss, each with its own inline
+special case and a paragraph of comment:
+
+- `memory_scope` (`graph.py:239-240`, `263-264`) — preserved on absence, cleared only
+  by a sentinel `CLEAR_MEMORY_SCOPE` string.
+- `retrieval_keys` / `retrieval_keys_normalized` (`graph.py:268-269`) — same rule.
+- `created_by` (`graph.py:249`) — `created_by ?? $input.created_by`, first-writer-wins.
+
+Every other metadata key still gets wiped by a reprojection or restore that rebuilds
+an `Entity` without carrying it forward. `EntityManager.create` / `create_direct`
+(`graph.py:450`, `331`) are therefore destructive upserts, not creates.
+
+Why it matters: the absence-vs-null distinction is being encoded ad hoc, one field at
+a time, in a SurrealQL string. A redesign needs it as a property of the model.
+
+**Size M · Severity major**
+
+### A3. Typed Entity subclasses are write-only; only two of twelve rehydrate
+`models/entities.py:147-267`, `services/graph.py:2213-2218`
+
+`Pattern`, `Rule`, `Template`, `Tool`, `Language`, `Topic`, `Episode`,
+`KnowledgeSource`, `ConfigFile`, `SlashCommand`, `Procedure` all declare typed
+fields. On write, `_entity_metadata` (`graph.py:3424-3444`) `model_dump`s every field
+not in its exclude-set into the untyped `metadata` bag. On read,
+`_coerce_native_entity` reconstructs only `Task` and `Procedure`:
+
+```python
+def _coerce_native_entity(entity: Entity) -> Entity:
+    if entity.entity_type == EntityType.TASK:
+        return _entity_to_task(entity)
+    if entity.entity_type == EntityType.PROCEDURE:
+        return _entity_to_procedure(entity)
+    return entity
+```
+
+So reading a `Pattern` yields a bare `Entity` whose `category` / `languages` /
+`confidence` live as untyped dict entries. The class hierarchy is decoration.
+
+**Size M · Severity major**
+
+### A4. The relationship model cannot express the temporal validity the schema already stores
+`models/entities.py:269-278` vs `backends/surreal/schema.py:190-193`
+
+The `relates_to` table defines `created_at`, `expired_at`, `valid_at`, `invalid_at`.
+The `Relationship` pydantic model has only `id`, `relationship_type`, `source_id`,
+`target_id`, `weight`, `metadata`, `created_at`. `_relationship_record`
+(`graph.py:3346-3348`) digs the three temporal columns out of the untyped metadata
+bag, accepting `valid_from`/`valid_to` aliases.
+
+The model also has no `organization_id`, no `revision`, and no `updated_at` — so
+edges have no optimistic-concurrency control at all, while entities do
+(`graph.py:565`, `models/entities.py:139`).
+
+Why it matters: "temporal validity" is named as a 1.3 goal. The storage layer already
+supports it; the typed model is the thing blocking it, and it is a small fix.
+
+**Size S · Severity major**
+
+### A5. Relation type is an open string in the database
+`backends/surreal/schema.py:182` vs `schema.py:385-388`
+
+`entity_type` got a DB-level enum assertion in migration v8, rendered from
+`EntityType` (`GRAPH_ENUM_ASSERTION_DEFINITIONS`). `relates_to.name` is
+`TYPE string` with no `ASSERT`, so any relation name can be written regardless of
+`RelationshipType`'s 40 members. Note also the comment at `schema.py:677-678`:
+widening the entity enum requires minting a new migration version to replay the
+assertion, so a typed-relations effort inherits a per-release migration tax.
+
+**Size S · Severity minor (correctness) / major (as a redesign constraint)**
+
+### A6. Timestamps are fabricated when absent
+`services/graph.py:2100-2103`
+
+```python
+created_at=_row_datetime(normalized_row.get("created_at") or metadata.get("created_at"))
+or datetime.now(UTC),
+updated_at=_row_datetime(normalized_row.get("updated_at") or metadata.get("updated_at"))
+or datetime.now(UTC),
+```
+
+A row with a missing or unparseable timestamp reads back as "just now". For a system
+whose ranking and recency logic run on these fields, and whose next release wants
+temporal validity, a silently invented timestamp is worse than a null.
+
+**Size S · Severity major**
+
+### A7. Three incompatible datetime conventions in one lane
+`backends/surreal/records.py:19-26` (naive UTC), `services/graph.py:555, 2896, 2981`
+(`datetime.now(UTC)`, aware), `services/graph.py:3410-3418` (`_metadata_datetime`
+returns whatever `fromisoformat` produces, naive or aware, unnormalized).
+
+`records.utcnow()` deliberately strips tzinfo with a docstring explaining that mixing
+aware and naive raises on comparison — and then `graph.py` writes aware datetimes
+into the same columns. `_metadata_datetime` passes both through untouched.
+
+**Size M · Severity major**
+
+---
+
+## B. Schema and migration integrity
+
+### S1. The graph plane is the one plane with no schema-invariant safety net
+`backends/surreal/schema_helpers.py:44-64`, `backends/surreal/schema_invariants.py:1-9`,
+`apps/api/src/sibyl/cli/db.py:706-756`
+
+`execute_schema_statement` swallows a failed `DEFINE INDEX ... UNIQUE` when the table
+already holds duplicates, logging only fingerprints:
+
+```python
+except Exception as exc:
+    if not is_duplicate_unique_index_error(statement, exc):
+        raise
+    fields = {"schema_scope": scope, "statement_hash": fingerprint_text(statement),
+              "error_hash": fingerprint_text(str(exc)), ...}
+    log.warning("surreal_schema_unique_index_skipped", **fields)
+```
+
+`apply_schema_migrations` then records the migration as applied. `schema_invariants.py`
+exists specifically to catch this, and says so in its module docstring. But:
+
+- `auth_schema.py:684` builds `auth_schema_invariant_plan()`.
+- `content_schema.py:737` builds `content_schema_invariant_plan()`.
+- **`backends/surreal/schema.py` builds no graph plan at all.** No
+  `graph_schema_invariant_plan`, and `bootstrap_schema` never calls
+  `ensure_schema_invariants`.
+- `sibyld db init` (`cli/db.py:713`, "Apply pending auth and content schema
+  migrations") runs `_init_plane` for auth and content only. The remediation loop —
+  `db duplicates` → `--collapse` → re-`init` — is likewise unreachable for graph.
+
+The unique indexes at stake are `idx_entity_uuid` (`schema.py:110`) and
+`idx_relates_uuid` (`schema.py:195`), i.e. the identity of every memory and every
+edge. A namespace that once held duplicate uuids loses entity uniqueness permanently,
+the log line carries no readable detail, and nothing reports it.
+
+**Size M · Severity blocker**
+
+### S2. Graph migrations run lazily, per-org, at request time, with no cross-process lock
+`services/graph_client.py:47-49, 102-115`, `backends/surreal/schema_version.py:137-173`
+
+`prepare_graph_schema` guards with a **process-local** `asyncio.Lock` and an
+in-memory `_prepared_groups` set. There is no advisory lock in the database. Two
+sibyld replicas (or api + worker) touching a cold org namespace concurrently both run
+`apply_schema_migrations`, which includes `DEFINE INDEX ... CONCURRENTLY` statements
+(`schema.py:281-292`, `346-381`, `537`) and whole-table `UPDATE` backfills
+(`schema.py:245-261`, `442-491`).
+
+Related: migrations are not transactional per version. A failure mid-migration leaves
+statements partially applied and the version unrecorded, so the next attempt replays
+from the first statement. Most statements are idempotent by construction
+(`IF NOT EXISTS` / `OVERWRITE` / `UPDATE ... WHERE`), but nothing enforces that
+property for new migrations.
+
+Also: eviction from the client LRU calls `mark_graph_schema_dirty`
+(`graph_client.py:84`), so the next touch of that org re-runs the entire bootstrap
+path. Past 64 active orgs (`surreal_graph_client_cache_size`), schema bootstrap
+thrashes.
+
+**Size M · Severity major**
+
+### S3. The SQL under test is not the SQL that ships
+`backends/surreal/schema.py:970-985`, `packages/python/sibyl-core/pyproject.toml:54`
+
+```python
+def render_surreal_compatible_sql(sql: str, *, url: str) -> str:
+    rendered = render_fulltext_compatible_sql(sql, url=url)   # FULLTEXT -> SEARCH for embedded
+    if not url.startswith(_EMBEDDED_SURREAL_SCHEMES):
+        rendered = (rendered.replace("type::is::string", "type::is_string")
+                    .replace("type::is::number", "type::is_number")
+                    .replace("type::is::datetime", "type::is_datetime")
+                    .replace("string::is::datetime", "string::is_datetime"))
+    return rendered
+```
+
+The SDK is pinned `surrealdb>=2.0.0,<3.0`, so `memory://` in tests runs the bundled
+2.x engine; every deployment pins server `v3.2.3` (`docker-compose.yml:12`,
+`infra/ansible/roles/sibyl/defaults/main.yml:12`). The bridge is four hardcoded string
+replacements plus one for `FULLTEXT`/`SEARCH`. Any new schema statement using a
+namespaced builtin outside that list ships the wrong dialect to production and passes
+every unit test. `tests/test_graph.py:1535` acknowledges the class of gap in a comment.
+
+**Size M · Severity major**
+
+### S4. The `episode` table and `mentions` edge are restore-only but fully maintained
+`backends/surreal/schema.py:142-158, 208-221, 232-261, 340-344, 374-381`;
+`services/graph.py:462-465`; `migrate/legacy_graph_archive.py:1-16`
+
+The only writer of the `episode` table is the archive-restore path
+(`tools/admin.py:890`, `_save_native_episode`), and the only writer of `mentions` is
+the same restore (`tools/admin.py:942-945`). Nothing in the live memory loop touches
+either. Note `EntityType.EPISODE` rows live in the **`entity`** table and are
+unrelated (`tasks/distillation.py:20-76`).
+
+Meanwhile every org namespace pays for: 12 field definitions, 3 `episode` indexes and
+5 `mentions` indexes, `RELATION_ENDPOINT_BACKFILL_DEFINITIONS` running a full
+`UPDATE mentions` on migrations v3 and v6, four `mentions` index rebuilds
+`CONCURRENTLY` in v7, and a `DELETE FROM mentions` statement inside every single
+entity delete transaction (`graph.py:462-465`).
+
+`migrate/legacy_graph_archive.py` (335 lines) exists solely to shape Graphiti-era
+episode payloads for that restore path.
+
+**Size M · Severity major** (removing it is the cheapest large win before a redesign)
+
+### S5. Schema definitions and data migrations are interleaved in the bootstrap blocks
+`backends/surreal/schema.py:132-135`, `162-175`, `418-439`
+
+`NODE_DEFINITIONS` — nominally the DDL block — ends with a whole-table
+`UPDATE entity SET description = description ?? attributes.description ...`, and
+`RELATION_EDGE_CLEANUP_DEFINITIONS` runs `DELETE FROM relates_to WHERE in NOT IN
+(SELECT VALUE id FROM entity)` — an anti-join over the whole graph — on every fresh
+bootstrap. Fresh namespaces run data repair against zero rows; the mixing makes it
+impossible to tell definition from repair when reading the file.
+
+**Size S · Severity minor**
+
+### S6. Field types ping-pong between strict and optional across migrations
+`backends/surreal/schema.py:407-412, 414-440, 493-497, 499-507, 540-561, 563-567`
+
+`ENTITY_REQUIRED_FIELD_OPTIONAL_DEFINITIONS` loosens `revision`, `retrieval_count`,
+`citation_count`, `misled_count` back to `option<int>`, and is prepended to
+migrations v11, v12, v13 and embedded in v14 and v15, each of which re-tightens them.
+Two further migrations (`entity_required_field_repair` v14,
+`entity_schema_drift_repair` v15) exist purely to repair what earlier migrations left
+inconsistent. The migration list is carrying its own bug history as permanent
+replayable state.
+
+**Size M · Severity minor** (works; costs every fresh namespace and every reader)
+
+### S7. Statement splitting is line-oriented and would break on multi-line string literals
+`backends/surreal/schema_helpers.py:14-30`
+
+`split_statements` splits on any line ending in `;`, ignoring quoting. Every current
+statement is safe, but the function is the sole gateway for all three schema planes
+and a future `DEFINE ... COMMENT 'text; with semicolon'` would silently split into
+two broken statements. Same class in
+`backends/surreal/connection.py:62, 72` (`query.split(";")` for retry classification).
+
+**Size S · Severity minor**
+
+---
+
+## C. Duplication and dead code
+
+### D1. Three divergent SurrealDB result normalizers, one claiming to be canonical
+`backends/surreal/records.py:1-7, 29-54`; `services/graph.py:2501-2541`;
+`services/surreal_content.py:643, 653, 671`
+
+`records.py` opens with:
+
+> "These were historically copy-pasted into every persistence module. Keeping a
+> single source of truth closes a real drift hazard… Every persistence module imports
+> from here."
+
+That is no longer true. `records.normalize_record` **drops** `id`
+(`records.py:35`). `graph.py:_normalize_record` **preserves** it as `record_id` and
+synthesizes a `uuid` from it (`graph.py:2507-2517`). `surreal_content.py` carries a
+third pair plus a fourth variant `_normalize_records_preserving_id`. The envelope
+detection differs between them (`graph.py:2526-2533` handles a shape
+`records.py:44` does not). The exact drift hazard the module was written to close is
+back, across three copies.
+
+Smaller instances of the same: `_metadata_str` is defined four times
+(`graph.py:3359`, `services/memory.py:2398`, `services/reflection.py:912`,
+`services/memory_autonomy.py:274`); `_optional_int` twice (`graph.py:2332`,
+`schema_version.py:254`); datetime coercion in `records.py:110`,
+`surreal_content.py:822`, and `graph.py:2349`/`3410`.
+
+**Size M · Severity major**
+
+### D2. `sibyl_core/storage/` is an unimplemented abstraction with zero production consumers
+`storage/__init__.py`, `storage/contracts.py:11-78`, `storage/models.py`
+
+`EntityStore`, `RelationshipStore`, `SearchIndex`, `GraphStore`, `EntityPatch`,
+`EntityBundle`, `GraphStats`, `SearchHit`, `Page`, `SearchFilters`,
+`RelationshipPatch` — 177 lines of "backend-agnostic graph storage contracts". The
+only importer anywhere in the repo is `tests/test_storage_contracts.py`, which
+constructs `FakeEntityStore` / `FakeGraphStore` and asserts the Protocols are
+satisfiable. No production class implements any of them; the real seam is
+`EntityManager` in a 3,475-line concrete module.
+
+Why it matters beyond the dead lines: this is a decoy. Anyone planning 1.3 who greps
+for the storage abstraction finds a clean Protocol package and reasonably concludes
+that is the seam to build against.
+
+**Size S to delete · Severity major** (as a redesign trap; minor as code)
+
+### D3. `graph_runtime.py` carries a duplicate runtime dataclass, an unreachable branch, and a Cypher-era guard
+`services/graph_runtime.py:36-42, 49-51, 101-132`
+
+- `ActiveGraphRuntime` (36-42) duplicates `GraphRuntime` (`graph.py:310-313`)
+  field-for-field; `get_graph_runtime` builds one from the other.
+- `count_entities_by_type` (93-154) has three paths. Path 1 uses
+  `getattr(entity_manager, "count_by_type")`, which `EntityManager` always has
+  (`graph.py:1323`), so it always wins. Path 2 reads
+  `getattr(entity_manager, "_driver")` — `EntityManager.__init__`
+  (`graph.py:320-329`) sets `_client`, `_group_id`, `_embedding_provider`, never
+  `_driver`, so that branch is unreachable. Path 3 paginates the whole org graph into
+  memory to count it.
+- `_assert_surreal_query_dialect` (49-51) rejects queries containing `CALL`, `MATCH`,
+  or `UNWIND` as "not SurrealQL" — a Neo4j/Cypher-era guard on a Surreal-only system,
+  and a token match that would reject a legitimate query with a field named `match`.
+
+**Size S · Severity minor**
+
+### D4. Vestigial per-row fields written on every entity
+`services/graph.py:3022, 3033, 3076`
+
+- `"_direct_insert": True` — a Graphiti-era marker written into `attributes` on every
+  create and every update. Nothing reads it as a signal; the only other production
+  reference strips it out again (`apps/api/src/sibyl/api/routes/entities.py:1990`).
+  It also rides inside the `attributes.metadata` JSON snapshot.
+- `"labels": [entity.entity_type.value, "Entity"]` — the literal `"Entity"` is a
+  Graphiti node label, and `entity_type` is duplicated from its own column. Both are
+  indexed by `idx_entity_labels` on `labels.*` (`schema.py:112`, rebuilt
+  `CONCURRENTLY` in migration v19), and `_entity_type_from_row` reads labels as a
+  fallback type source (`graph.py:2149-2151`).
+
+**Size S · Severity minor**
+
+### D5. Deleted graph contract suite left only stale bytecode
+`packages/python/sibyl-core/tests/graph/surreal/__pycache__/`
+
+The directory contains no tracked `.py` files (`git ls-files` returns nothing) — only
+`__pycache__` from commit `13f29fee` "delete the Graphiti compat layer and legacy
+graph". Among the deleted-but-cached names are dead-table suites
+(`test_saga_node_ops`, `test_community_edge_ops`, `test_next_episode_edge_ops`,
+`test_has_episode_edge_ops`, `test_episodic_edge_ops`) and live-surface suites
+(`test_entity_node_ops`, `test_search_interface`, `test_native_memory_contract`). The
+live-surface coverage went with them; whether it was re-homed into
+`tests/test_graph.py` was not verified.
+
+**Size S · Severity minor**
+
+### D6. `EntityType._missing_` handles exactly one type case-insensitively
+`models/entities.py:64-68`
+
+```python
+@classmethod
+def _missing_(cls, value: object) -> "EntityType | None":
+    if isinstance(value, str) and value.lower() == "guide":
+        return cls.GUIDE
+    return None
+```
+
+`EntityType("guide")` already resolves via StrEnum without `_missing_`, so the hook
+only fires for `"Guide"` / `"GUIDE"` — and does nothing for the other 34 members.
+Either all types should be case-insensitive or none.
+
+**Size S · Severity minor**
+
+---
+
+## D. Error handling that swallows or masks
+
+### G1. Bulk relationship write reports failure as "skipped"
+`services/graph.py:1465-1474`
+
+```python
+async def create_bulk(self, relationships) -> tuple[int, int]:
+    try:
+        created_ids = await self.create_direct_bulk(prepared, generate_embeddings=True)
+    except Exception:
+        return 0, len(prepared)
+```
+
+A bare `except Exception` with no logging turns a dead connection, a schema
+rejection, or a transaction conflict into `(0 created, N skipped)`. The caller cannot
+distinguish a write failure from a legitimate no-op. Edges vanish silently.
+
+**Size S · Severity major**
+
+### G2. Vector search failure degrades retrieval to zero candidates, silently
+`services/graph.py:840-845`
+
+```python
+except Exception as exc:
+    log.warning("entity_vector_search_failed", error_type=type(exc).__name__)
+    return []
+```
+
+Only the exception class name is logged — not the message — so an HNSW index that is
+missing, mid-rebuild, or dimension-mismatched produces `entity_vector_search_failed:
+SurrealQueryError` and an empty result the caller reads as "nothing matched". Given
+the embedding-dimension rebuild machinery (`schema.py:763-806`) can leave vectors
+cleared, this is a live failure mode.
+
+**Size S · Severity major**
+
+### G3. A broken graph renders as an empty graph
+`services/graph_communities.py:1948-1950, 1971-1973, 1993-1995`
+
+`count_graph_totals` → `return 0, 0`; `_fetch_graph_nodes` → `return [], set()`;
+`_fetch_graph_edges` → `return []`, each behind `except Exception as e:
+log.warning(...)`. Three independent failure paths all render as "your graph is
+empty" rather than "the query failed."
+
+**Size S · Severity major**
+
+### G4. Embedding failures are absorbed and the entity is written unembedded
+`services/graph.py:2700-2725`
+
+`_embed_texts_for_write` catches everything, logs `graph_embedding_failed`, returns
+`None`, and the write proceeds without a vector. There is a repair path
+(`backfill_embeddings_if_current`, `graph.py:377`), but the create call returns
+success and no caller can tell an embedded memory from an unembedded one.
+
+**Size M · Severity major**
+
+### G5. Unique-index skip logs only fingerprints
+`backends/surreal/schema_helpers.py:56-64` — see S1. The warning carries
+`statement_hash` and `error_hash`, not the statement or message, so the operator
+cannot tell which index was skipped or on what without re-deriving it.
+
+**Size S · Severity minor** (rolls up into S1)
+
+### G6. Bootstrap error is recorded then execution continues
+`apps/api/src/sibyl/cli/db.py:687-689` — `except Exception as exc: entry["error"] =
+str(exc)` then falls through to read the version and run invariants. Deliberate
+(it wants the post-mortem state) but worth naming: a bootstrap that threw is followed
+by an invariant repair attempt against a half-migrated plane.
+
+**Size S · Severity minor**
+
+### G7. Legacy `updated_at` string schema retried by matching an error message
+`services/graph.py:2930-2971`
+
+```python
+def _is_legacy_updated_at_string_schema_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return "coerce value for field `updated_at`" in message and (
+        "expected `none | string`" in message or "expected none | string" in message)
+```
+
+On match, the whole batch is rewritten with ISO strings and replayed. This is the
+compatibility tail of migration v5 — it fires only for namespaces still below graph
+schema v5. It is coupled to an exact SurrealDB error string across two phrasings,
+i.e. it breaks silently on a server upgrade and reverts to a hard write failure.
+Candidate for deletion once a floor version is declared.
+
+**Size S · Severity minor**
+
+---
+
+## E. Concurrency and pooling hazards
+
+### C1. Production code monkeypatches another module's globals on every call
+`services/graph.py:1929-1950`
+
+```python
+async def get_surreal_graph_client(group_id: str) -> SurrealGraphClient:
+    # Compatibility callers patch graph.SurrealGraphClient, not graph_client.
+    original_client_type = _graph_client.SurrealGraphClient
+    _graph_client.SurrealGraphClient = SurrealGraphClient
+    try:
+        return await _graph_client.get_surreal_graph_client(group_id)
+    finally:
+        _graph_client.SurrealGraphClient = original_client_type
+```
+
+`prepare_graph_schema` (1943-1950) does the same for `bootstrap_schema`. This is a
+test shim living in the hot path: every graph client acquisition mutates a module
+global, awaits, and restores it. Two concurrent coroutines interleave the save and
+restore, so the second one's `finally` writes back whatever the first had installed.
+Today both install the same value so the damage is bounded, but a test that patches
+`graph.SurrealGraphClient` while any real call is in flight gets its patch reverted
+mid-test — and the pattern is a live-lock waiting for a third writer.
+
+Same file, lines 98-99: `_clients = _graph_client._clients` and `_prepared_groups =
+_graph_client._prepared_groups` alias another module's private mutable state. It
+works only because every mutation is in-place (`.clear()`, `.discard()`); a single
+rebinding in `graph_client.py` silently desynchronizes the two views.
+
+**Size M · Severity major**
+
+### C2. Every write pays an extra round trip
+`backends/surreal/dedicated_client.py:287-310`
+
+For any non-retryable (write) query the client first sends `RETURN true;` on the
+connection as a liveness preflight, then sends the real statement. That is 2× the
+round trips for every entity create, update, delete, and bulk upsert. The intent is
+to avoid replaying a write on a dead socket, which is correct; the cost is unbounded
+and unmeasured.
+
+**Size M · Severity major** (perf; the fix is a connection-health signal rather than
+a probe query)
+
+### C3. Live queries bypass the pool
+`backends/surreal/dedicated_client.py:252-267`
+
+`live_table` calls `self._new_connection()` outside the pool on every invocation.
+Nothing bounds how many live subscriptions an org can hold open; each is a socket the
+pool does not know about.
+
+**Size S · Severity minor**
+
+### C4. Schema bootstrap is serialized globally across all orgs
+`services/graph_client.py:48, 106`
+
+`_prepare_lock` is one module-level `asyncio.Lock` for every organization. Org B's
+first request blocks behind Org A's full schema bootstrap (which on a cold namespace
+runs ~19 migrations including concurrent index builds). Should be per-`group_id`.
+
+**Size S · Severity minor**
+
+### C5. Whole-org graph loaded into Python memory, three times per render
+`services/graph_communities.py:202-235, 1940-1941, 1963-1964, 1989`
+
+`_list_all_entities` paginates every entity in the org into a list, uncapped by
+default (`max_items: int | None = None`). `count_graph_totals`, `_fetch_graph_nodes`,
+and `_fetch_graph_edges` each call it (and `_list_all_relationships`) independently,
+so a single graph view loads the entire org graph two to three times over and does
+the filtering, clustering, and counting in Python. Two more call sites at 2417/2423.
+
+This is the mechanism class behind the known `/graph` starfield behavior, and it is
+the "pull it all client-side" pattern a redesign has to kill rather than inherit.
+
+**Size L · Severity major**
+
+### C6. Per-query stack introspection
+`backends/surreal/dedicated_client.py:386-395`
+
+`_caller_origin()` calls `sys._getframe(2)` on every `execute_query` /
+`execute_query_raw` to build an origin string for the log line. Correct as written
+(the frame depth holds because it is evaluated as an argument inside the public
+method), but it is unconditional CPython frame introspection on the hottest path and
+it silently breaks if either wrapper is ever refactored to add a call level.
+
+**Size S · Severity minor**
+
+---
+
+## F. Multi-tenancy plumbing
+
+### T1. Namespace derivation is unvalidated and lossy
+`services/graph_client.py:117-122`
+
+```python
+def _namespace_for_group(prefix: str, group_id: str) -> str:
+    if not group_id:
+        raise ValueError(...)
+    sanitized = group_id.replace("-", "").lower()
+    return f"{prefix}{sanitized}"
+```
+
+Only emptiness is checked. `group_id` is never validated as a UUID or as a legal
+SurrealDB identifier, and stripping hyphens means `"ab-c"` and `"abc"` collide into
+the same namespace. In practice group_ids are UUIDs and the namespace reaches the
+server through `client.use(ns, db)` rather than string interpolation, so this is not
+an injection today. It is one refactor away from being one, and the collision is a
+silent cross-tenant merge.
+
+`validate_identifier` already exists at `schema_version.py:265-268` and is not used
+here.
+
+**Size S · Severity major**
+
+### T2. Redundant `group_id` predicates carry no index
+`services/graph.py` — 33 occurrences of `group_id = $group_id`; also
+`retrieval/search.py` (20), `graph_communities.py` (7), `retrieval/dedup.py` (3), and
+the migrate modules.
+
+Isolation is the namespace. Migration v7 (`GRAPH_INDEX_PRUNE_DEFINITIONS`,
+`schema.py:320-344`) removed every `group_id`-leading index precisely because they
+were redundant inside a per-org namespace — but the `WHERE group_id = $group_id`
+predicates stayed. They are now unindexed filters on every graph query, and they read
+as though they were the isolation mechanism, which they are not.
+
+Two options and both are fine, but the current state is the worst of them: either
+drop the predicates (isolation is the namespace) or keep them and say so.
+
+**Size M · Severity major**
+
+### T3. Cross-org guard applied in Python rather than in the query
+`services/graph.py:496-519`
+
+`get_many` runs `RETURN $uuids.map(|$u| (SELECT * FROM entity WHERE uuid = $u LIMIT 1)[0])`
+and filters `row.get("group_id") == self._group_id` afterward in Python, because —
+per the inline comment — the closure body silently drops every outer binding on at
+least one engine. The comment is honest and the mitigation is sound inside a namespace.
+Flagging it because the workaround is invisible from the call site and would break if
+anyone moved the graph to a shared namespace.
+
+**Size S · Severity minor**
+
+### T4. Raw query escape hatch binds `group_id` without enforcing it
+`services/graph_runtime.py:157-167`
+
+`execute_graph_query(group_id, query, **params)` executes an arbitrary caller-supplied
+SurrealQL string against the org client, passing `group_id=$group_id` as a bound
+param. Nothing checks that the query uses it.
+
+**Size S · Severity minor**
+
+---
+
+## G. Test gaps on load-bearing invariants
+
+- **Graph schema invariants are untested because they are unimplemented for graph.**
+  `tests/test_surreal_schema_invariants.py` exercises the machinery, but no test can
+  cover the graph plane because no graph invariant plan exists (S1).
+- **The unique-index swallow has no graph-level test.** Nothing asserts that a
+  namespace which failed to build `idx_entity_uuid` is detected.
+- **Concurrent bootstrap is untested.** No test starts two `prepare_graph_schema`
+  calls for the same org from different processes (S2).
+- **Dialect divergence is structurally untestable in unit tests.** Everything runs on
+  the embedded 2.x engine and takes the un-rewritten branch of
+  `render_surreal_compatible_sql` (S3). `tests/test_surreal_schema_syntax.py`
+  (1,705 lines) is the compensating control; whether it asserts the *rendered*
+  3.x form for every statement was not verified.
+- **`attributes.metadata` staleness has no regression test** for a key outside
+  `_SNAPSHOT_SHADOWED_METADATA_KEYS` (A1). Adding one would be S and would pin the
+  hazard.
+- **`storage/` Protocols are tested against Fakes only** (D2) — the test proves the
+  Protocol is satisfiable, not that anything satisfies it.
+- **Deleted per-operation graph suite** (D5) — coverage of entity node ops, search
+  interface, and the native memory contract left the tree in `13f29fee` and its
+  re-homing was not verified.
+
+---
+
+## Ranked summary
+
+| # | Finding | Where | Size | Severity |
+|---|---|---|---|---|
+| 1 | Metadata written three ways; JSON snapshot goes stale and resurrects deleted keys | graph.py:1982, 3017, 3071 | L | blocker |
+| 2 | Graph plane has no schema-invariant check; UNIQUE index failures silently swallowed | schema_helpers.py:44, cli/db.py:713 | M | blocker |
+| 3 | Blind full-replace upsert with per-field absence exceptions | graph.py:229-279 | M | major |
+| 4 | Whole-org graph loaded into memory three times per render | graph_communities.py:202, 1940 | L | major |
+| 5 | Three divergent Surreal normalizers; "canonical" module no longer canonical | records.py:1, graph.py:2521, surreal_content.py:653 | M | major |
+| 6 | Production code monkeypatches another module's globals per call | graph.py:1929-1950 | M | major |
+| 7 | Write failures reported as skips; vector-search and graph-render failures render as empty | graph.py:1469, 840; graph_communities.py:1948 | S each | major |
+| 8 | `Relationship` model cannot express the temporal validity the schema stores | entities.py:269 vs schema.py:190 | S | major |
+| 9 | Test engine (SDK 2.x embedded) differs from prod (3.2.3), bridged by 4 string replacements | schema.py:970 | M | major |
+| 10 | `episode`/`mentions` restore-only but fully indexed and migrated per namespace | schema.py:142, 208 | M | major |
+| 11 | Typed Entity subclasses are write-only; only Task/Procedure rehydrate | entities.py:147, graph.py:2213 | M | major |
+| 12 | `storage/` contracts: 177 lines, zero production consumers, decoy seam | storage/ | S | major |
+| 13 | Missing timestamps fabricated as `now()`; three datetime conventions | graph.py:2100, 3410; records.py:19 | M | major |
+| 14 | No cross-process migration lock; lazy per-org bootstrap at request time | graph_client.py:48, schema_version.py:137 | M | major |
+| 15 | Extra round trip on every write (preflight `RETURN true;`) | dedicated_client.py:287 | M | major |
+| 16 | Namespace derivation unvalidated, hyphen-stripping collides | graph_client.py:117 | S | major |
+| 17 | Redundant unindexed `group_id` predicates after v7 index prune | graph.py ×33, search.py ×20 | M | major |
+| 18 | `relates_to.name` has no enum assertion (entity_type does) | schema.py:182 vs 385 | S | minor |
+| 19 | Vestigial `_direct_insert` and `"Entity"` label on every row | graph.py:3022, 3033 | S | minor |
+| 20 | graph_runtime.py: duplicate dataclass, unreachable `_driver` branch, Cypher-era guard | graph_runtime.py:36, 49, 107 | S | minor |
+
+### Cheapest high-value moves before a 1.3 rearchitecture
+
+1. Add `graph_schema_invariant_plan()` and wire the graph plane into `sibyld db init`
+   alongside auth and content (S1). Mechanical — the pattern already exists twice.
+2. Delete `storage/` (D2) or implement it. Leaving it is the trap.
+3. Drop the `episode` table and `mentions` edge behind a restore-time-only schema
+   (S4), which also removes eight indexes, two backfill migrations, and a statement
+   from the entity-delete hot path.
+4. Give `Relationship` its temporal columns as typed fields (A4). One small model
+   change unlocks the stated 1.3 goal.
+5. Pin A1 with a regression test before touching anything else — the stale snapshot is
+   the invariant most likely to be silently broken by a representation change.

--- a/docs/architecture/AUDIT_2026-08-13/debt-core-graph.md
+++ b/docs/architecture/AUDIT_2026-08-13/debt-core-graph.md
@@ -1,22 +1,22 @@
 # Tech-debt audit: sibyl-core graph / persistence / models
 
 Scope: `packages/python/sibyl-core/src/sibyl_core/` — `models/`, `backends/surreal/`,
-`services/graph*.py`, `storage/`, `migrate/`, and multi-tenancy plumbing.
-Excluded by lane assignment: retrieval/ranking/ai/extraction, `apps/api`, `apps/web`.
-Every claim below was read in the source at the cited line. Commit `5388d986`, v1.2.0.
+`services/graph*.py`, `storage/`, `migrate/`, and multi-tenancy plumbing. Excluded by lane
+assignment: retrieval/ranking/ai/extraction, `apps/api`, `apps/web`. Every claim below was read in
+the source at the cited line. Commit `5388d986`, v1.2.0.
 
 Two historical facts named in the brief were re-checked and one has changed:
 
 - `entity.updated_at` is **no longer** `option<string>`. Graph schema migration v5
   (`backends/surreal/schema.py:264-293`, `entity_updated_at_datetime`) converted it to
-  `option<datetime>`, and the current field definition at `schema.py:87` is
-  `option<datetime>`. The lexicographic-ORDER-BY hazard is retired. A runtime fallback
-  for un-migrated namespaces still exists (finding G7).
+  `option<datetime>`, and the current field definition at `schema.py:87` is `option<datetime>`. The
+  lexicographic-ORDER-BY hazard is retired. A runtime fallback for un-migrated namespaces still
+  exists (finding G7).
 - Dead Graphiti tables confirmed: `REMOVED_GRAPH_TABLES = ("community", "saga")` and
-  `REMOVED_GRAPH_EDGES = ("has_episode", "next_episode", "has_member")` at
-  `schema.py:575-577`, dropped by migration v4 and asserted empty before any migration
-  (`schema.py:897-910`). That cleanup is done. The `episode` table and `mentions` edge,
-  however, are still fully alive in the schema (finding S4).
+  `REMOVED_GRAPH_EDGES = ("has_episode", "next_episode", "has_member")` at `schema.py:575-577`,
+  dropped by migration v4 and asserted empty before any migration (`schema.py:897-910`). That
+  cleanup is done. The `episode` table and `mentions` edge, however, are still fully alive in the
+  schema (finding S4).
 - Namespace-per-org isolation confirmed at `services/graph_client.py:117-122`.
 
 ---
@@ -24,6 +24,7 @@ Two historical facts named in the brief were re-checked and one has changed:
 ## A. Findings that would fight a memory-representation redesign
 
 ### A1. Every entity stores its metadata three times, and one copy goes stale by design
+
 `services/graph.py:3017-3025`, `graph.py:1982-2006`, `graph.py:3071-3081`
 
 `_entity_record` writes the same facts into three places on every full write:
@@ -39,58 +40,55 @@ attributes: dict[str, object] = {
 }
 ```
 
-plus (3) ~20 promoted columns (`project_id`, `memory_scope`, `status`, `tags`,
-`retrieval_count`, …) on the record itself.
+plus (3) ~20 promoted columns (`project_id`, `memory_scope`, `status`, `tags`, `retrieval_count`, …)
+on the record itself.
 
-The partial-update path (`_entity_update_patch`, `graph.py:3071`) builds an
-`attributes` patch that never contains a `metadata` key, and the write is
-`UPDATE entity MERGE $patch` (`graph.py:562`). A deep merge leaves
-`attributes.metadata` untouched, so from the first partial update onward the JSON
-snapshot is a stale copy of pre-update state. The read path
-(`entity_from_surreal_row`, `graph.py:2021`) layers `snapshot | flattened`, so the
-flattened copy wins for any key present in both — but a key an update **removed**
-resurrects from the snapshot. The code documents this and mitigates it with a
-hand-maintained allowlist of five keys (`_SNAPSHOT_SHADOWED_METADATA_KEYS`,
+The partial-update path (`_entity_update_patch`, `graph.py:3071`) builds an `attributes` patch that
+never contains a `metadata` key, and the write is `UPDATE entity MERGE $patch` (`graph.py:562`). A
+deep merge leaves `attributes.metadata` untouched, so from the first partial update onward the JSON
+snapshot is a stale copy of pre-update state. The read path (`entity_from_surreal_row`,
+`graph.py:2021`) layers `snapshot | flattened`, so the flattened copy wins for any key present in
+both — but a key an update **removed** resurrects from the snapshot. The code documents this and
+mitigates it with a hand-maintained allowlist of five keys (`_SNAPSHOT_SHADOWED_METADATA_KEYS`,
 `graph.py:1990-1998`).
 
-Why it matters: this is the single largest structural obstacle to a 1.3 memory
-representation. Any new metadata key with delete-semantics silently inherits the
-resurrection bug unless someone remembers to add it to a frozenset in a 3,475-line
-module. Storage is roughly tripled for metadata, and there is no single authority
-for what a row means.
+Why it matters: this is the single largest structural obstacle to a 1.3 memory representation. Any
+new metadata key with delete-semantics silently inherits the resurrection bug unless someone
+remembers to add it to a frozenset in a 3,475-line module. Storage is roughly tripled for metadata,
+and there is no single authority for what a row means.
 
 **Size L · Severity blocker (for the redesign; major as-is)**
 
 ### A2. The write path is a blind full replace with per-field absence exceptions bolted on
+
 `services/graph.py:229-279` (`_ENTITY_BULK_UPSERT_QUERY`)
 
-`INSERT INTO entity $rows ON DUPLICATE KEY UPDATE ... attributes = $input.attributes`
-replaces the whole attributes bag with no revision guard and no `WHERE`. Two fields
-got rescued from that after it caused real data loss, each with its own inline
-special case and a paragraph of comment:
+`INSERT INTO entity $rows ON DUPLICATE KEY UPDATE ... attributes = $input.attributes` replaces the
+whole attributes bag with no revision guard and no `WHERE`. Two fields got rescued from that after
+it caused real data loss, each with its own inline special case and a paragraph of comment:
 
-- `memory_scope` (`graph.py:239-240`, `263-264`) — preserved on absence, cleared only
-  by a sentinel `CLEAR_MEMORY_SCOPE` string.
+- `memory_scope` (`graph.py:239-240`, `263-264`) — preserved on absence, cleared only by a sentinel
+  `CLEAR_MEMORY_SCOPE` string.
 - `retrieval_keys` / `retrieval_keys_normalized` (`graph.py:268-269`) — same rule.
 - `created_by` (`graph.py:249`) — `created_by ?? $input.created_by`, first-writer-wins.
 
-Every other metadata key still gets wiped by a reprojection or restore that rebuilds
-an `Entity` without carrying it forward. `EntityManager.create` / `create_direct`
-(`graph.py:450`, `331`) are therefore destructive upserts, not creates.
+Every other metadata key still gets wiped by a reprojection or restore that rebuilds an `Entity`
+without carrying it forward. `EntityManager.create` / `create_direct` (`graph.py:450`, `331`) are
+therefore destructive upserts, not creates.
 
-Why it matters: the absence-vs-null distinction is being encoded ad hoc, one field at
-a time, in a SurrealQL string. A redesign needs it as a property of the model.
+Why it matters: the absence-vs-null distinction is being encoded ad hoc, one field at a time, in a
+SurrealQL string. A redesign needs it as a property of the model.
 
 **Size M · Severity major**
 
 ### A3. Typed Entity subclasses are write-only; only two of twelve rehydrate
+
 `models/entities.py:147-267`, `services/graph.py:2213-2218`
 
-`Pattern`, `Rule`, `Template`, `Tool`, `Language`, `Topic`, `Episode`,
-`KnowledgeSource`, `ConfigFile`, `SlashCommand`, `Procedure` all declare typed
-fields. On write, `_entity_metadata` (`graph.py:3424-3444`) `model_dump`s every field
-not in its exclude-set into the untyped `metadata` bag. On read,
-`_coerce_native_entity` reconstructs only `Task` and `Procedure`:
+`Pattern`, `Rule`, `Template`, `Tool`, `Language`, `Topic`, `Episode`, `KnowledgeSource`,
+`ConfigFile`, `SlashCommand`, `Procedure` all declare typed fields. On write, `_entity_metadata`
+(`graph.py:3424-3444`) `model_dump`s every field not in its exclude-set into the untyped `metadata`
+bag. On read, `_coerce_native_entity` reconstructs only `Task` and `Procedure`:
 
 ```python
 def _coerce_native_entity(entity: Entity) -> Entity:
@@ -101,42 +99,42 @@ def _coerce_native_entity(entity: Entity) -> Entity:
     return entity
 ```
 
-So reading a `Pattern` yields a bare `Entity` whose `category` / `languages` /
-`confidence` live as untyped dict entries. The class hierarchy is decoration.
+So reading a `Pattern` yields a bare `Entity` whose `category` / `languages` / `confidence` live as
+untyped dict entries. The class hierarchy is decoration.
 
 **Size M · Severity major**
 
 ### A4. The relationship model cannot express the temporal validity the schema already stores
+
 `models/entities.py:269-278` vs `backends/surreal/schema.py:190-193`
 
-The `relates_to` table defines `created_at`, `expired_at`, `valid_at`, `invalid_at`.
-The `Relationship` pydantic model has only `id`, `relationship_type`, `source_id`,
-`target_id`, `weight`, `metadata`, `created_at`. `_relationship_record`
-(`graph.py:3346-3348`) digs the three temporal columns out of the untyped metadata
-bag, accepting `valid_from`/`valid_to` aliases.
+The `relates_to` table defines `created_at`, `expired_at`, `valid_at`, `invalid_at`. The
+`Relationship` pydantic model has only `id`, `relationship_type`, `source_id`, `target_id`,
+`weight`, `metadata`, `created_at`. `_relationship_record` (`graph.py:3346-3348`) digs the three
+temporal columns out of the untyped metadata bag, accepting `valid_from`/`valid_to` aliases.
 
-The model also has no `organization_id`, no `revision`, and no `updated_at` — so
-edges have no optimistic-concurrency control at all, while entities do
-(`graph.py:565`, `models/entities.py:139`).
+The model also has no `organization_id`, no `revision`, and no `updated_at` — so edges have no
+optimistic-concurrency control at all, while entities do (`graph.py:565`, `models/entities.py:139`).
 
-Why it matters: "temporal validity" is named as a 1.3 goal. The storage layer already
-supports it; the typed model is the thing blocking it, and it is a small fix.
+Why it matters: "temporal validity" is named as a 1.3 goal. The storage layer already supports it;
+the typed model is the thing blocking it, and it is a small fix.
 
 **Size S · Severity major**
 
 ### A5. Relation type is an open string in the database
+
 `backends/surreal/schema.py:182` vs `schema.py:385-388`
 
-`entity_type` got a DB-level enum assertion in migration v8, rendered from
-`EntityType` (`GRAPH_ENUM_ASSERTION_DEFINITIONS`). `relates_to.name` is
-`TYPE string` with no `ASSERT`, so any relation name can be written regardless of
-`RelationshipType`'s 40 members. Note also the comment at `schema.py:677-678`:
-widening the entity enum requires minting a new migration version to replay the
+`entity_type` got a DB-level enum assertion in migration v8, rendered from `EntityType`
+(`GRAPH_ENUM_ASSERTION_DEFINITIONS`). `relates_to.name` is `TYPE string` with no `ASSERT`, so any
+relation name can be written regardless of `RelationshipType`'s 40 members. Note also the comment at
+`schema.py:677-678`: widening the entity enum requires minting a new migration version to replay the
 assertion, so a typed-relations effort inherits a per-release migration tax.
 
 **Size S · Severity minor (correctness) / major (as a redesign constraint)**
 
 ### A6. Timestamps are fabricated when absent
+
 `services/graph.py:2100-2103`
 
 ```python
@@ -146,20 +144,21 @@ updated_at=_row_datetime(normalized_row.get("updated_at") or metadata.get("updat
 or datetime.now(UTC),
 ```
 
-A row with a missing or unparseable timestamp reads back as "just now". For a system
-whose ranking and recency logic run on these fields, and whose next release wants
-temporal validity, a silently invented timestamp is worse than a null.
+A row with a missing or unparseable timestamp reads back as "just now". For a system whose ranking
+and recency logic run on these fields, and whose next release wants temporal validity, a silently
+invented timestamp is worse than a null.
 
 **Size S · Severity major**
 
 ### A7. Three incompatible datetime conventions in one lane
-`backends/surreal/records.py:19-26` (naive UTC), `services/graph.py:555, 2896, 2981`
-(`datetime.now(UTC)`, aware), `services/graph.py:3410-3418` (`_metadata_datetime`
-returns whatever `fromisoformat` produces, naive or aware, unnormalized).
 
-`records.utcnow()` deliberately strips tzinfo with a docstring explaining that mixing
-aware and naive raises on comparison — and then `graph.py` writes aware datetimes
-into the same columns. `_metadata_datetime` passes both through untouched.
+`backends/surreal/records.py:19-26` (naive UTC), `services/graph.py:555, 2896, 2981`
+(`datetime.now(UTC)`, aware), `services/graph.py:3410-3418` (`_metadata_datetime` returns whatever
+`fromisoformat` produces, naive or aware, unnormalized).
+
+`records.utcnow()` deliberately strips tzinfo with a docstring explaining that mixing aware and
+naive raises on comparison — and then `graph.py` writes aware datetimes into the same columns.
+`_metadata_datetime` passes both through untouched.
 
 **Size M · Severity major**
 
@@ -168,11 +167,12 @@ into the same columns. `_metadata_datetime` passes both through untouched.
 ## B. Schema and migration integrity
 
 ### S1. The graph plane is the one plane with no schema-invariant safety net
+
 `backends/surreal/schema_helpers.py:44-64`, `backends/surreal/schema_invariants.py:1-9`,
 `apps/api/src/sibyl/cli/db.py:706-756`
 
-`execute_schema_statement` swallows a failed `DEFINE INDEX ... UNIQUE` when the table
-already holds duplicates, logging only fingerprints:
+`execute_schema_statement` swallows a failed `DEFINE INDEX ... UNIQUE` when the table already holds
+duplicates, logging only fingerprints:
 
 ```python
 except Exception as exc:
@@ -183,49 +183,47 @@ except Exception as exc:
     log.warning("surreal_schema_unique_index_skipped", **fields)
 ```
 
-`apply_schema_migrations` then records the migration as applied. `schema_invariants.py`
-exists specifically to catch this, and says so in its module docstring. But:
+`apply_schema_migrations` then records the migration as applied. `schema_invariants.py` exists
+specifically to catch this, and says so in its module docstring. But:
 
 - `auth_schema.py:684` builds `auth_schema_invariant_plan()`.
 - `content_schema.py:737` builds `content_schema_invariant_plan()`.
-- **`backends/surreal/schema.py` builds no graph plan at all.** No
-  `graph_schema_invariant_plan`, and `bootstrap_schema` never calls
-  `ensure_schema_invariants`.
-- `sibyld db init` (`cli/db.py:713`, "Apply pending auth and content schema
-  migrations") runs `_init_plane` for auth and content only. The remediation loop —
-  `db duplicates` → `--collapse` → re-`init` — is likewise unreachable for graph.
+- **`backends/surreal/schema.py` builds no graph plan at all.** No `graph_schema_invariant_plan`,
+  and `bootstrap_schema` never calls `ensure_schema_invariants`.
+- `sibyld db init` (`cli/db.py:713`, "Apply pending auth and content schema migrations") runs
+  `_init_plane` for auth and content only. The remediation loop — `db duplicates` → `--collapse` →
+  re-`init` — is likewise unreachable for graph.
 
-The unique indexes at stake are `idx_entity_uuid` (`schema.py:110`) and
-`idx_relates_uuid` (`schema.py:195`), i.e. the identity of every memory and every
-edge. A namespace that once held duplicate uuids loses entity uniqueness permanently,
-the log line carries no readable detail, and nothing reports it.
+The unique indexes at stake are `idx_entity_uuid` (`schema.py:110`) and `idx_relates_uuid`
+(`schema.py:195`), i.e. the identity of every memory and every edge. A namespace that once held
+duplicate uuids loses entity uniqueness permanently, the log line carries no readable detail, and
+nothing reports it.
 
 **Size M · Severity blocker**
 
 ### S2. Graph migrations run lazily, per-org, at request time, with no cross-process lock
+
 `services/graph_client.py:47-49, 102-115`, `backends/surreal/schema_version.py:137-173`
 
-`prepare_graph_schema` guards with a **process-local** `asyncio.Lock` and an
-in-memory `_prepared_groups` set. There is no advisory lock in the database. Two
-sibyld replicas (or api + worker) touching a cold org namespace concurrently both run
-`apply_schema_migrations`, which includes `DEFINE INDEX ... CONCURRENTLY` statements
-(`schema.py:281-292`, `346-381`, `537`) and whole-table `UPDATE` backfills
-(`schema.py:245-261`, `442-491`).
+`prepare_graph_schema` guards with a **process-local** `asyncio.Lock` and an in-memory
+`_prepared_groups` set. There is no advisory lock in the database. Two sibyld replicas (or api +
+worker) touching a cold org namespace concurrently both run `apply_schema_migrations`, which
+includes `DEFINE INDEX ... CONCURRENTLY` statements (`schema.py:281-292`, `346-381`, `537`) and
+whole-table `UPDATE` backfills (`schema.py:245-261`, `442-491`).
 
-Related: migrations are not transactional per version. A failure mid-migration leaves
-statements partially applied and the version unrecorded, so the next attempt replays
-from the first statement. Most statements are idempotent by construction
-(`IF NOT EXISTS` / `OVERWRITE` / `UPDATE ... WHERE`), but nothing enforces that
-property for new migrations.
+Related: migrations are not transactional per version. A failure mid-migration leaves statements
+partially applied and the version unrecorded, so the next attempt replays from the first statement.
+Most statements are idempotent by construction (`IF NOT EXISTS` / `OVERWRITE` / `UPDATE ... WHERE`),
+but nothing enforces that property for new migrations.
 
-Also: eviction from the client LRU calls `mark_graph_schema_dirty`
-(`graph_client.py:84`), so the next touch of that org re-runs the entire bootstrap
-path. Past 64 active orgs (`surreal_graph_client_cache_size`), schema bootstrap
-thrashes.
+Also: eviction from the client LRU calls `mark_graph_schema_dirty` (`graph_client.py:84`), so the
+next touch of that org re-runs the entire bootstrap path. Past 64 active orgs
+(`surreal_graph_client_cache_size`), schema bootstrap thrashes.
 
 **Size M · Severity major**
 
 ### S3. The SQL under test is not the SQL that ships
+
 `backends/surreal/schema.py:970-985`, `packages/python/sibyl-core/pyproject.toml:54`
 
 ```python
@@ -239,69 +237,70 @@ def render_surreal_compatible_sql(sql: str, *, url: str) -> str:
     return rendered
 ```
 
-The SDK is pinned `surrealdb>=2.0.0,<3.0`, so `memory://` in tests runs the bundled
-2.x engine; every deployment pins server `v3.2.3` (`docker-compose.yml:12`,
-`infra/ansible/roles/sibyl/defaults/main.yml:12`). The bridge is four hardcoded string
-replacements plus one for `FULLTEXT`/`SEARCH`. Any new schema statement using a
-namespaced builtin outside that list ships the wrong dialect to production and passes
-every unit test. `tests/test_graph.py:1535` acknowledges the class of gap in a comment.
+The SDK is pinned `surrealdb>=2.0.0,<3.0`, so `memory://` in tests runs the bundled 2.x engine;
+every deployment pins server `v3.2.3` (`docker-compose.yml:12`,
+`infra/ansible/roles/sibyl/defaults/main.yml:12`). The bridge is four hardcoded string replacements
+plus one for `FULLTEXT`/`SEARCH`. Any new schema statement using a namespaced builtin outside that
+list ships the wrong dialect to production and passes every unit test. `tests/test_graph.py:1535`
+acknowledges the class of gap in a comment.
 
 **Size M · Severity major**
 
 ### S4. The `episode` table and `mentions` edge are restore-only but fully maintained
+
 `backends/surreal/schema.py:142-158, 208-221, 232-261, 340-344, 374-381`;
 `services/graph.py:462-465`; `migrate/legacy_graph_archive.py:1-16`
 
-The only writer of the `episode` table is the archive-restore path
-(`tools/admin.py:890`, `_save_native_episode`), and the only writer of `mentions` is
-the same restore (`tools/admin.py:942-945`). Nothing in the live memory loop touches
-either. Note `EntityType.EPISODE` rows live in the **`entity`** table and are
-unrelated (`tasks/distillation.py:20-76`).
+The only writer of the `episode` table is the archive-restore path (`tools/admin.py:890`,
+`_save_native_episode`), and the only writer of `mentions` is the same restore
+(`tools/admin.py:942-945`). Nothing in the live memory loop touches either. Note
+`EntityType.EPISODE` rows live in the **`entity`** table and are unrelated
+(`tasks/distillation.py:20-76`).
 
-Meanwhile every org namespace pays for: 12 field definitions, 3 `episode` indexes and
-5 `mentions` indexes, `RELATION_ENDPOINT_BACKFILL_DEFINITIONS` running a full
-`UPDATE mentions` on migrations v3 and v6, four `mentions` index rebuilds
-`CONCURRENTLY` in v7, and a `DELETE FROM mentions` statement inside every single
-entity delete transaction (`graph.py:462-465`).
+Meanwhile every org namespace pays for: 12 field definitions, 3 `episode` indexes and 5 `mentions`
+indexes, `RELATION_ENDPOINT_BACKFILL_DEFINITIONS` running a full `UPDATE mentions` on migrations v3
+and v6, four `mentions` index rebuilds `CONCURRENTLY` in v7, and a `DELETE FROM mentions` statement
+inside every single entity delete transaction (`graph.py:462-465`).
 
-`migrate/legacy_graph_archive.py` (335 lines) exists solely to shape Graphiti-era
-episode payloads for that restore path.
+`migrate/legacy_graph_archive.py` (335 lines) exists solely to shape Graphiti-era episode payloads
+for that restore path.
 
 **Size M · Severity major** (removing it is the cheapest large win before a redesign)
 
 ### S5. Schema definitions and data migrations are interleaved in the bootstrap blocks
+
 `backends/surreal/schema.py:132-135`, `162-175`, `418-439`
 
 `NODE_DEFINITIONS` — nominally the DDL block — ends with a whole-table
 `UPDATE entity SET description = description ?? attributes.description ...`, and
-`RELATION_EDGE_CLEANUP_DEFINITIONS` runs `DELETE FROM relates_to WHERE in NOT IN
-(SELECT VALUE id FROM entity)` — an anti-join over the whole graph — on every fresh
-bootstrap. Fresh namespaces run data repair against zero rows; the mixing makes it
-impossible to tell definition from repair when reading the file.
+`RELATION_EDGE_CLEANUP_DEFINITIONS` runs
+`DELETE FROM relates_to WHERE in NOT IN (SELECT VALUE id FROM entity)` — an anti-join over the whole
+graph — on every fresh bootstrap. Fresh namespaces run data repair against zero rows; the mixing
+makes it impossible to tell definition from repair when reading the file.
 
 **Size S · Severity minor**
 
 ### S6. Field types ping-pong between strict and optional across migrations
+
 `backends/surreal/schema.py:407-412, 414-440, 493-497, 499-507, 540-561, 563-567`
 
 `ENTITY_REQUIRED_FIELD_OPTIONAL_DEFINITIONS` loosens `revision`, `retrieval_count`,
-`citation_count`, `misled_count` back to `option<int>`, and is prepended to
-migrations v11, v12, v13 and embedded in v14 and v15, each of which re-tightens them.
-Two further migrations (`entity_required_field_repair` v14,
-`entity_schema_drift_repair` v15) exist purely to repair what earlier migrations left
-inconsistent. The migration list is carrying its own bug history as permanent
-replayable state.
+`citation_count`, `misled_count` back to `option<int>`, and is prepended to migrations v11, v12, v13
+and embedded in v14 and v15, each of which re-tightens them. Two further migrations
+(`entity_required_field_repair` v14, `entity_schema_drift_repair` v15) exist purely to repair what
+earlier migrations left inconsistent. The migration list is carrying its own bug history as
+permanent replayable state.
 
 **Size M · Severity minor** (works; costs every fresh namespace and every reader)
 
 ### S7. Statement splitting is line-oriented and would break on multi-line string literals
+
 `backends/surreal/schema_helpers.py:14-30`
 
-`split_statements` splits on any line ending in `;`, ignoring quoting. Every current
-statement is safe, but the function is the sole gateway for all three schema planes
-and a future `DEFINE ... COMMENT 'text; with semicolon'` would silently split into
-two broken statements. Same class in
-`backends/surreal/connection.py:62, 72` (`query.split(";")` for retry classification).
+`split_statements` splits on any line ending in `;`, ignoring quoting. Every current statement is
+safe, but the function is the sole gateway for all three schema planes and a future
+`DEFINE ... COMMENT 'text; with semicolon'` would silently split into two broken statements. Same
+class in `backends/surreal/connection.py:62, 72` (`query.split(";")` for retry classification).
 
 **Size S · Severity minor**
 
@@ -310,96 +309,94 @@ two broken statements. Same class in
 ## C. Duplication and dead code
 
 ### D1. Three divergent SurrealDB result normalizers, one claiming to be canonical
+
 `backends/surreal/records.py:1-7, 29-54`; `services/graph.py:2501-2541`;
 `services/surreal_content.py:643, 653, 671`
 
 `records.py` opens with:
 
-> "These were historically copy-pasted into every persistence module. Keeping a
-> single source of truth closes a real drift hazard… Every persistence module imports
-> from here."
+> "These were historically copy-pasted into every persistence module. Keeping a single source of
+> truth closes a real drift hazard… Every persistence module imports from here."
 
-That is no longer true. `records.normalize_record` **drops** `id`
-(`records.py:35`). `graph.py:_normalize_record` **preserves** it as `record_id` and
-synthesizes a `uuid` from it (`graph.py:2507-2517`). `surreal_content.py` carries a
-third pair plus a fourth variant `_normalize_records_preserving_id`. The envelope
-detection differs between them (`graph.py:2526-2533` handles a shape
-`records.py:44` does not). The exact drift hazard the module was written to close is
-back, across three copies.
+That is no longer true. `records.normalize_record` **drops** `id` (`records.py:35`).
+`graph.py:_normalize_record` **preserves** it as `record_id` and synthesizes a `uuid` from it
+(`graph.py:2507-2517`). `surreal_content.py` carries a third pair plus a fourth variant
+`_normalize_records_preserving_id`. The envelope detection differs between them
+(`graph.py:2526-2533` handles a shape `records.py:44` does not). The exact drift hazard the module
+was written to close is back, across three copies.
 
-Smaller instances of the same: `_metadata_str` is defined four times
-(`graph.py:3359`, `services/memory.py:2398`, `services/reflection.py:912`,
-`services/memory_autonomy.py:274`); `_optional_int` twice (`graph.py:2332`,
-`schema_version.py:254`); datetime coercion in `records.py:110`,
-`surreal_content.py:822`, and `graph.py:2349`/`3410`.
+Smaller instances of the same: `_metadata_str` is defined four times (`graph.py:3359`,
+`services/memory.py:2398`, `services/reflection.py:912`, `services/memory_autonomy.py:274`);
+`_optional_int` twice (`graph.py:2332`, `schema_version.py:254`); datetime coercion in
+`records.py:110`, `surreal_content.py:822`, and `graph.py:2349`/`3410`.
 
 **Size M · Severity major**
 
 ### D2. `sibyl_core/storage/` is an unimplemented abstraction with zero production consumers
+
 `storage/__init__.py`, `storage/contracts.py:11-78`, `storage/models.py`
 
-`EntityStore`, `RelationshipStore`, `SearchIndex`, `GraphStore`, `EntityPatch`,
-`EntityBundle`, `GraphStats`, `SearchHit`, `Page`, `SearchFilters`,
-`RelationshipPatch` — 177 lines of "backend-agnostic graph storage contracts". The
-only importer anywhere in the repo is `tests/test_storage_contracts.py`, which
-constructs `FakeEntityStore` / `FakeGraphStore` and asserts the Protocols are
-satisfiable. No production class implements any of them; the real seam is
+`EntityStore`, `RelationshipStore`, `SearchIndex`, `GraphStore`, `EntityPatch`, `EntityBundle`,
+`GraphStats`, `SearchHit`, `Page`, `SearchFilters`, `RelationshipPatch` — 177 lines of
+"backend-agnostic graph storage contracts". The only importer anywhere in the repo is
+`tests/test_storage_contracts.py`, which constructs `FakeEntityStore` / `FakeGraphStore` and asserts
+the Protocols are satisfiable. No production class implements any of them; the real seam is
 `EntityManager` in a 3,475-line concrete module.
 
-Why it matters beyond the dead lines: this is a decoy. Anyone planning 1.3 who greps
-for the storage abstraction finds a clean Protocol package and reasonably concludes
-that is the seam to build against.
+Why it matters beyond the dead lines: this is a decoy. Anyone planning 1.3 who greps for the storage
+abstraction finds a clean Protocol package and reasonably concludes that is the seam to build
+against.
 
 **Size S to delete · Severity major** (as a redesign trap; minor as code)
 
 ### D3. `graph_runtime.py` carries a duplicate runtime dataclass, an unreachable branch, and a Cypher-era guard
+
 `services/graph_runtime.py:36-42, 49-51, 101-132`
 
-- `ActiveGraphRuntime` (36-42) duplicates `GraphRuntime` (`graph.py:310-313`)
-  field-for-field; `get_graph_runtime` builds one from the other.
+- `ActiveGraphRuntime` (36-42) duplicates `GraphRuntime` (`graph.py:310-313`) field-for-field;
+  `get_graph_runtime` builds one from the other.
 - `count_entities_by_type` (93-154) has three paths. Path 1 uses
-  `getattr(entity_manager, "count_by_type")`, which `EntityManager` always has
-  (`graph.py:1323`), so it always wins. Path 2 reads
-  `getattr(entity_manager, "_driver")` — `EntityManager.__init__`
-  (`graph.py:320-329`) sets `_client`, `_group_id`, `_embedding_provider`, never
-  `_driver`, so that branch is unreachable. Path 3 paginates the whole org graph into
-  memory to count it.
-- `_assert_surreal_query_dialect` (49-51) rejects queries containing `CALL`, `MATCH`,
-  or `UNWIND` as "not SurrealQL" — a Neo4j/Cypher-era guard on a Surreal-only system,
-  and a token match that would reject a legitimate query with a field named `match`.
+  `getattr(entity_manager, "count_by_type")`, which `EntityManager` always has (`graph.py:1323`), so
+  it always wins. Path 2 reads `getattr(entity_manager, "_driver")` — `EntityManager.__init__`
+  (`graph.py:320-329`) sets `_client`, `_group_id`, `_embedding_provider`, never `_driver`, so that
+  branch is unreachable. Path 3 paginates the whole org graph into memory to count it.
+- `_assert_surreal_query_dialect` (49-51) rejects queries containing `CALL`, `MATCH`, or `UNWIND` as
+  "not SurrealQL" — a Neo4j/Cypher-era guard on a Surreal-only system, and a token match that would
+  reject a legitimate query with a field named `match`.
 
 **Size S · Severity minor**
 
 ### D4. Vestigial per-row fields written on every entity
+
 `services/graph.py:3022, 3033, 3076`
 
-- `"_direct_insert": True` — a Graphiti-era marker written into `attributes` on every
-  create and every update. Nothing reads it as a signal; the only other production
-  reference strips it out again (`apps/api/src/sibyl/api/routes/entities.py:1990`).
-  It also rides inside the `attributes.metadata` JSON snapshot.
-- `"labels": [entity.entity_type.value, "Entity"]` — the literal `"Entity"` is a
-  Graphiti node label, and `entity_type` is duplicated from its own column. Both are
-  indexed by `idx_entity_labels` on `labels.*` (`schema.py:112`, rebuilt
-  `CONCURRENTLY` in migration v19), and `_entity_type_from_row` reads labels as a
-  fallback type source (`graph.py:2149-2151`).
+- `"_direct_insert": True` — a Graphiti-era marker written into `attributes` on every create and
+  every update. Nothing reads it as a signal; the only other production reference strips it out
+  again (`apps/api/src/sibyl/api/routes/entities.py:1990`). It also rides inside the
+  `attributes.metadata` JSON snapshot.
+- `"labels": [entity.entity_type.value, "Entity"]` — the literal `"Entity"` is a Graphiti node
+  label, and `entity_type` is duplicated from its own column. Both are indexed by
+  `idx_entity_labels` on `labels.*` (`schema.py:112`, rebuilt `CONCURRENTLY` in migration v19), and
+  `_entity_type_from_row` reads labels as a fallback type source (`graph.py:2149-2151`).
 
 **Size S · Severity minor**
 
 ### D5. Deleted graph contract suite left only stale bytecode
+
 `packages/python/sibyl-core/tests/graph/surreal/__pycache__/`
 
-The directory contains no tracked `.py` files (`git ls-files` returns nothing) — only
-`__pycache__` from commit `13f29fee` "delete the Graphiti compat layer and legacy
-graph". Among the deleted-but-cached names are dead-table suites
-(`test_saga_node_ops`, `test_community_edge_ops`, `test_next_episode_edge_ops`,
-`test_has_episode_edge_ops`, `test_episodic_edge_ops`) and live-surface suites
-(`test_entity_node_ops`, `test_search_interface`, `test_native_memory_contract`). The
-live-surface coverage went with them; whether it was re-homed into
-`tests/test_graph.py` was not verified.
+The directory contains no tracked `.py` files (`git ls-files` returns nothing) — only `__pycache__`
+from commit `13f29fee` "delete the Graphiti compat layer and legacy graph". Among the
+deleted-but-cached names are dead-table suites (`test_saga_node_ops`, `test_community_edge_ops`,
+`test_next_episode_edge_ops`, `test_has_episode_edge_ops`, `test_episodic_edge_ops`) and
+live-surface suites (`test_entity_node_ops`, `test_search_interface`,
+`test_native_memory_contract`). The live-surface coverage went with them; whether it was re-homed
+into `tests/test_graph.py` was not verified.
 
 **Size S · Severity minor**
 
 ### D6. `EntityType._missing_` handles exactly one type case-insensitively
+
 `models/entities.py:64-68`
 
 ```python
@@ -410,9 +407,9 @@ def _missing_(cls, value: object) -> "EntityType | None":
     return None
 ```
 
-`EntityType("guide")` already resolves via StrEnum without `_missing_`, so the hook
-only fires for `"Guide"` / `"GUIDE"` — and does nothing for the other 34 members.
-Either all types should be case-insensitive or none.
+`EntityType("guide")` already resolves via StrEnum without `_missing_`, so the hook only fires for
+`"Guide"` / `"GUIDE"` — and does nothing for the other 34 members. Either all types should be
+case-insensitive or none.
 
 **Size S · Severity minor**
 
@@ -421,6 +418,7 @@ Either all types should be case-insensitive or none.
 ## D. Error handling that swallows or masks
 
 ### G1. Bulk relationship write reports failure as "skipped"
+
 `services/graph.py:1465-1474`
 
 ```python
@@ -431,13 +429,14 @@ async def create_bulk(self, relationships) -> tuple[int, int]:
         return 0, len(prepared)
 ```
 
-A bare `except Exception` with no logging turns a dead connection, a schema
-rejection, or a transaction conflict into `(0 created, N skipped)`. The caller cannot
-distinguish a write failure from a legitimate no-op. Edges vanish silently.
+A bare `except Exception` with no logging turns a dead connection, a schema rejection, or a
+transaction conflict into `(0 created, N skipped)`. The caller cannot distinguish a write failure
+from a legitimate no-op. Edges vanish silently.
 
 **Size S · Severity major**
 
 ### G2. Vector search failure degrades retrieval to zero candidates, silently
+
 `services/graph.py:840-845`
 
 ```python
@@ -446,50 +445,53 @@ except Exception as exc:
     return []
 ```
 
-Only the exception class name is logged — not the message — so an HNSW index that is
-missing, mid-rebuild, or dimension-mismatched produces `entity_vector_search_failed:
-SurrealQueryError` and an empty result the caller reads as "nothing matched". Given
-the embedding-dimension rebuild machinery (`schema.py:763-806`) can leave vectors
-cleared, this is a live failure mode.
+Only the exception class name is logged — not the message — so an HNSW index that is missing,
+mid-rebuild, or dimension-mismatched produces `entity_vector_search_failed: SurrealQueryError` and
+an empty result the caller reads as "nothing matched". Given the embedding-dimension rebuild
+machinery (`schema.py:763-806`) can leave vectors cleared, this is a live failure mode.
 
 **Size S · Severity major**
 
 ### G3. A broken graph renders as an empty graph
+
 `services/graph_communities.py:1948-1950, 1971-1973, 1993-1995`
 
 `count_graph_totals` → `return 0, 0`; `_fetch_graph_nodes` → `return [], set()`;
-`_fetch_graph_edges` → `return []`, each behind `except Exception as e:
-log.warning(...)`. Three independent failure paths all render as "your graph is
-empty" rather than "the query failed."
+`_fetch_graph_edges` → `return []`, each behind `except Exception as e: log.warning(...)`. Three
+independent failure paths all render as "your graph is empty" rather than "the query failed."
 
 **Size S · Severity major**
 
 ### G4. Embedding failures are absorbed and the entity is written unembedded
+
 `services/graph.py:2700-2725`
 
-`_embed_texts_for_write` catches everything, logs `graph_embedding_failed`, returns
-`None`, and the write proceeds without a vector. There is a repair path
-(`backfill_embeddings_if_current`, `graph.py:377`), but the create call returns
-success and no caller can tell an embedded memory from an unembedded one.
+`_embed_texts_for_write` catches everything, logs `graph_embedding_failed`, returns `None`, and the
+write proceeds without a vector. There is a repair path (`backfill_embeddings_if_current`,
+`graph.py:377`), but the create call returns success and no caller can tell an embedded memory from
+an unembedded one.
 
 **Size M · Severity major**
 
 ### G5. Unique-index skip logs only fingerprints
-`backends/surreal/schema_helpers.py:56-64` — see S1. The warning carries
-`statement_hash` and `error_hash`, not the statement or message, so the operator
-cannot tell which index was skipped or on what without re-deriving it.
+
+`backends/surreal/schema_helpers.py:56-64` — see S1. The warning carries `statement_hash` and
+`error_hash`, not the statement or message, so the operator cannot tell which index was skipped or
+on what without re-deriving it.
 
 **Size S · Severity minor** (rolls up into S1)
 
 ### G6. Bootstrap error is recorded then execution continues
-`apps/api/src/sibyl/cli/db.py:687-689` — `except Exception as exc: entry["error"] =
-str(exc)` then falls through to read the version and run invariants. Deliberate
-(it wants the post-mortem state) but worth naming: a bootstrap that threw is followed
-by an invariant repair attempt against a half-migrated plane.
+
+`apps/api/src/sibyl/cli/db.py:687-689` — `except Exception as exc: entry["error"] = str(exc)` then
+falls through to read the version and run invariants. Deliberate (it wants the post-mortem state)
+but worth naming: a bootstrap that threw is followed by an invariant repair attempt against a
+half-migrated plane.
 
 **Size S · Severity minor**
 
 ### G7. Legacy `updated_at` string schema retried by matching an error message
+
 `services/graph.py:2930-2971`
 
 ```python
@@ -499,11 +501,10 @@ def _is_legacy_updated_at_string_schema_error(exc: BaseException) -> bool:
         "expected `none | string`" in message or "expected none | string" in message)
 ```
 
-On match, the whole batch is rewritten with ISO strings and replayed. This is the
-compatibility tail of migration v5 — it fires only for namespaces still below graph
-schema v5. It is coupled to an exact SurrealDB error string across two phrasings,
-i.e. it breaks silently on a server upgrade and reverts to a hard write failure.
-Candidate for deletion once a floor version is declared.
+On match, the whole batch is rewritten with ISO strings and replayed. This is the compatibility tail
+of migration v5 — it fires only for namespaces still below graph schema v5. It is coupled to an
+exact SurrealDB error string across two phrasings, i.e. it breaks silently on a server upgrade and
+reverts to a hard write failure. Candidate for deletion once a floor version is declared.
 
 **Size S · Severity minor**
 
@@ -512,6 +513,7 @@ Candidate for deletion once a floor version is declared.
 ## E. Concurrency and pooling hazards
 
 ### C1. Production code monkeypatches another module's globals on every call
+
 `services/graph.py:1929-1950`
 
 ```python
@@ -525,73 +527,73 @@ async def get_surreal_graph_client(group_id: str) -> SurrealGraphClient:
         _graph_client.SurrealGraphClient = original_client_type
 ```
 
-`prepare_graph_schema` (1943-1950) does the same for `bootstrap_schema`. This is a
-test shim living in the hot path: every graph client acquisition mutates a module
-global, awaits, and restores it. Two concurrent coroutines interleave the save and
-restore, so the second one's `finally` writes back whatever the first had installed.
-Today both install the same value so the damage is bounded, but a test that patches
-`graph.SurrealGraphClient` while any real call is in flight gets its patch reverted
-mid-test — and the pattern is a live-lock waiting for a third writer.
+`prepare_graph_schema` (1943-1950) does the same for `bootstrap_schema`. This is a test shim living
+in the hot path: every graph client acquisition mutates a module global, awaits, and restores it.
+Two concurrent coroutines interleave the save and restore, so the second one's `finally` writes back
+whatever the first had installed. Today both install the same value so the damage is bounded, but a
+test that patches `graph.SurrealGraphClient` while any real call is in flight gets its patch
+reverted mid-test — and the pattern is a live-lock waiting for a third writer.
 
-Same file, lines 98-99: `_clients = _graph_client._clients` and `_prepared_groups =
-_graph_client._prepared_groups` alias another module's private mutable state. It
-works only because every mutation is in-place (`.clear()`, `.discard()`); a single
-rebinding in `graph_client.py` silently desynchronizes the two views.
+Same file, lines 98-99: `_clients = _graph_client._clients` and
+`_prepared_groups = _graph_client._prepared_groups` alias another module's private mutable state. It
+works only because every mutation is in-place (`.clear()`, `.discard()`); a single rebinding in
+`graph_client.py` silently desynchronizes the two views.
 
 **Size M · Severity major**
 
 ### C2. Every write pays an extra round trip
+
 `backends/surreal/dedicated_client.py:287-310`
 
-For any non-retryable (write) query the client first sends `RETURN true;` on the
-connection as a liveness preflight, then sends the real statement. That is 2× the
-round trips for every entity create, update, delete, and bulk upsert. The intent is
-to avoid replaying a write on a dead socket, which is correct; the cost is unbounded
-and unmeasured.
+For any non-retryable (write) query the client first sends `RETURN true;` on the connection as a
+liveness preflight, then sends the real statement. That is 2× the round trips for every entity
+create, update, delete, and bulk upsert. The intent is to avoid replaying a write on a dead socket,
+which is correct; the cost is unbounded and unmeasured.
 
-**Size M · Severity major** (perf; the fix is a connection-health signal rather than
-a probe query)
+**Size M · Severity major** (perf; the fix is a connection-health signal rather than a probe query)
 
 ### C3. Live queries bypass the pool
+
 `backends/surreal/dedicated_client.py:252-267`
 
-`live_table` calls `self._new_connection()` outside the pool on every invocation.
-Nothing bounds how many live subscriptions an org can hold open; each is a socket the
-pool does not know about.
+`live_table` calls `self._new_connection()` outside the pool on every invocation. Nothing bounds how
+many live subscriptions an org can hold open; each is a socket the pool does not know about.
 
 **Size S · Severity minor**
 
 ### C4. Schema bootstrap is serialized globally across all orgs
+
 `services/graph_client.py:48, 106`
 
-`_prepare_lock` is one module-level `asyncio.Lock` for every organization. Org B's
-first request blocks behind Org A's full schema bootstrap (which on a cold namespace
-runs ~19 migrations including concurrent index builds). Should be per-`group_id`.
+`_prepare_lock` is one module-level `asyncio.Lock` for every organization. Org B's first request
+blocks behind Org A's full schema bootstrap (which on a cold namespace runs ~19 migrations including
+concurrent index builds). Should be per-`group_id`.
 
 **Size S · Severity minor**
 
 ### C5. Whole-org graph loaded into Python memory, three times per render
+
 `services/graph_communities.py:202-235, 1940-1941, 1963-1964, 1989`
 
-`_list_all_entities` paginates every entity in the org into a list, uncapped by
-default (`max_items: int | None = None`). `count_graph_totals`, `_fetch_graph_nodes`,
-and `_fetch_graph_edges` each call it (and `_list_all_relationships`) independently,
-so a single graph view loads the entire org graph two to three times over and does
-the filtering, clustering, and counting in Python. Two more call sites at 2417/2423.
+`_list_all_entities` paginates every entity in the org into a list, uncapped by default
+(`max_items: int | None = None`). `count_graph_totals`, `_fetch_graph_nodes`, and
+`_fetch_graph_edges` each call it (and `_list_all_relationships`) independently, so a single graph
+view loads the entire org graph two to three times over and does the filtering, clustering, and
+counting in Python. Two more call sites at 2417/2423.
 
-This is the mechanism class behind the known `/graph` starfield behavior, and it is
-the "pull it all client-side" pattern a redesign has to kill rather than inherit.
+This is the mechanism class behind the known `/graph` starfield behavior, and it is the "pull it all
+client-side" pattern a redesign has to kill rather than inherit.
 
 **Size L · Severity major**
 
 ### C6. Per-query stack introspection
+
 `backends/surreal/dedicated_client.py:386-395`
 
-`_caller_origin()` calls `sys._getframe(2)` on every `execute_query` /
-`execute_query_raw` to build an origin string for the log line. Correct as written
-(the frame depth holds because it is evaluated as an argument inside the public
-method), but it is unconditional CPython frame introspection on the hottest path and
-it silently breaks if either wrapper is ever refactored to add a call level.
+`_caller_origin()` calls `sys._getframe(2)` on every `execute_query` / `execute_query_raw` to build
+an origin string for the log line. Correct as written (the frame depth holds because it is evaluated
+as an argument inside the public method), but it is unconditional CPython frame introspection on the
+hottest path and it silently breaks if either wrapper is ever refactored to add a call level.
 
 **Size S · Severity minor**
 
@@ -600,6 +602,7 @@ it silently breaks if either wrapper is ever refactored to add a call level.
 ## F. Multi-tenancy plumbing
 
 ### T1. Namespace derivation is unvalidated and lossy
+
 `services/graph_client.py:117-122`
 
 ```python
@@ -610,52 +613,50 @@ def _namespace_for_group(prefix: str, group_id: str) -> str:
     return f"{prefix}{sanitized}"
 ```
 
-Only emptiness is checked. `group_id` is never validated as a UUID or as a legal
-SurrealDB identifier, and stripping hyphens means `"ab-c"` and `"abc"` collide into
-the same namespace. In practice group_ids are UUIDs and the namespace reaches the
-server through `client.use(ns, db)` rather than string interpolation, so this is not
-an injection today. It is one refactor away from being one, and the collision is a
-silent cross-tenant merge.
+Only emptiness is checked. `group_id` is never validated as a UUID or as a legal SurrealDB
+identifier, and stripping hyphens means `"ab-c"` and `"abc"` collide into the same namespace. In
+practice group_ids are UUIDs and the namespace reaches the server through `client.use(ns, db)`
+rather than string interpolation, so this is not an injection today. It is one refactor away from
+being one, and the collision is a silent cross-tenant merge.
 
-`validate_identifier` already exists at `schema_version.py:265-268` and is not used
-here.
+`validate_identifier` already exists at `schema_version.py:265-268` and is not used here.
 
 **Size S · Severity major**
 
 ### T2. Redundant `group_id` predicates carry no index
-`services/graph.py` — 33 occurrences of `group_id = $group_id`; also
-`retrieval/search.py` (20), `graph_communities.py` (7), `retrieval/dedup.py` (3), and
-the migrate modules.
 
-Isolation is the namespace. Migration v7 (`GRAPH_INDEX_PRUNE_DEFINITIONS`,
-`schema.py:320-344`) removed every `group_id`-leading index precisely because they
-were redundant inside a per-org namespace — but the `WHERE group_id = $group_id`
-predicates stayed. They are now unindexed filters on every graph query, and they read
-as though they were the isolation mechanism, which they are not.
+`services/graph.py` — 33 occurrences of `group_id = $group_id`; also `retrieval/search.py` (20),
+`graph_communities.py` (7), `retrieval/dedup.py` (3), and the migrate modules.
 
-Two options and both are fine, but the current state is the worst of them: either
-drop the predicates (isolation is the namespace) or keep them and say so.
+Isolation is the namespace. Migration v7 (`GRAPH_INDEX_PRUNE_DEFINITIONS`, `schema.py:320-344`)
+removed every `group_id`-leading index precisely because they were redundant inside a per-org
+namespace — but the `WHERE group_id = $group_id` predicates stayed. They are now unindexed filters
+on every graph query, and they read as though they were the isolation mechanism, which they are not.
+
+Two options and both are fine, but the current state is the worst of them: either drop the
+predicates (isolation is the namespace) or keep them and say so.
 
 **Size M · Severity major**
 
 ### T3. Cross-org guard applied in Python rather than in the query
+
 `services/graph.py:496-519`
 
-`get_many` runs `RETURN $uuids.map(|$u| (SELECT * FROM entity WHERE uuid = $u LIMIT 1)[0])`
-and filters `row.get("group_id") == self._group_id` afterward in Python, because —
-per the inline comment — the closure body silently drops every outer binding on at
-least one engine. The comment is honest and the mitigation is sound inside a namespace.
-Flagging it because the workaround is invisible from the call site and would break if
-anyone moved the graph to a shared namespace.
+`get_many` runs `RETURN $uuids.map(|$u| (SELECT * FROM entity WHERE uuid = $u LIMIT 1)[0])` and
+filters `row.get("group_id") == self._group_id` afterward in Python, because — per the inline
+comment — the closure body silently drops every outer binding on at least one engine. The comment is
+honest and the mitigation is sound inside a namespace. Flagging it because the workaround is
+invisible from the call site and would break if anyone moved the graph to a shared namespace.
 
 **Size S · Severity minor**
 
 ### T4. Raw query escape hatch binds `group_id` without enforcing it
+
 `services/graph_runtime.py:157-167`
 
-`execute_graph_query(group_id, query, **params)` executes an arbitrary caller-supplied
-SurrealQL string against the org client, passing `group_id=$group_id` as a bound
-param. Nothing checks that the query uses it.
+`execute_graph_query(group_id, query, **params)` executes an arbitrary caller-supplied SurrealQL
+string against the org client, passing `group_id=$group_id` as a bound param. Nothing checks that
+the query uses it.
 
 **Size S · Severity minor**
 
@@ -664,62 +665,58 @@ param. Nothing checks that the query uses it.
 ## G. Test gaps on load-bearing invariants
 
 - **Graph schema invariants are untested because they are unimplemented for graph.**
-  `tests/test_surreal_schema_invariants.py` exercises the machinery, but no test can
-  cover the graph plane because no graph invariant plan exists (S1).
-- **The unique-index swallow has no graph-level test.** Nothing asserts that a
-  namespace which failed to build `idx_entity_uuid` is detected.
-- **Concurrent bootstrap is untested.** No test starts two `prepare_graph_schema`
-  calls for the same org from different processes (S2).
-- **Dialect divergence is structurally untestable in unit tests.** Everything runs on
-  the embedded 2.x engine and takes the un-rewritten branch of
-  `render_surreal_compatible_sql` (S3). `tests/test_surreal_schema_syntax.py`
-  (1,705 lines) is the compensating control; whether it asserts the *rendered*
-  3.x form for every statement was not verified.
+  `tests/test_surreal_schema_invariants.py` exercises the machinery, but no test can cover the graph
+  plane because no graph invariant plan exists (S1).
+- **The unique-index swallow has no graph-level test.** Nothing asserts that a namespace which
+  failed to build `idx_entity_uuid` is detected.
+- **Concurrent bootstrap is untested.** No test starts two `prepare_graph_schema` calls for the same
+  org from different processes (S2).
+- **Dialect divergence is structurally untestable in unit tests.** Everything runs on the embedded
+  2.x engine and takes the un-rewritten branch of `render_surreal_compatible_sql` (S3).
+  `tests/test_surreal_schema_syntax.py` (1,705 lines) is the compensating control; whether it
+  asserts the _rendered_ 3.x form for every statement was not verified.
 - **`attributes.metadata` staleness has no regression test** for a key outside
-  `_SNAPSHOT_SHADOWED_METADATA_KEYS` (A1). Adding one would be S and would pin the
-  hazard.
-- **`storage/` Protocols are tested against Fakes only** (D2) — the test proves the
-  Protocol is satisfiable, not that anything satisfies it.
-- **Deleted per-operation graph suite** (D5) — coverage of entity node ops, search
-  interface, and the native memory contract left the tree in `13f29fee` and its
-  re-homing was not verified.
+  `_SNAPSHOT_SHADOWED_METADATA_KEYS` (A1). Adding one would be S and would pin the hazard.
+- **`storage/` Protocols are tested against Fakes only** (D2) — the test proves the Protocol is
+  satisfiable, not that anything satisfies it.
+- **Deleted per-operation graph suite** (D5) — coverage of entity node ops, search interface, and
+  the native memory contract left the tree in `13f29fee` and its re-homing was not verified.
 
 ---
 
 ## Ranked summary
 
-| # | Finding | Where | Size | Severity |
-|---|---|---|---|---|
-| 1 | Metadata written three ways; JSON snapshot goes stale and resurrects deleted keys | graph.py:1982, 3017, 3071 | L | blocker |
-| 2 | Graph plane has no schema-invariant check; UNIQUE index failures silently swallowed | schema_helpers.py:44, cli/db.py:713 | M | blocker |
-| 3 | Blind full-replace upsert with per-field absence exceptions | graph.py:229-279 | M | major |
-| 4 | Whole-org graph loaded into memory three times per render | graph_communities.py:202, 1940 | L | major |
-| 5 | Three divergent Surreal normalizers; "canonical" module no longer canonical | records.py:1, graph.py:2521, surreal_content.py:653 | M | major |
-| 6 | Production code monkeypatches another module's globals per call | graph.py:1929-1950 | M | major |
-| 7 | Write failures reported as skips; vector-search and graph-render failures render as empty | graph.py:1469, 840; graph_communities.py:1948 | S each | major |
-| 8 | `Relationship` model cannot express the temporal validity the schema stores | entities.py:269 vs schema.py:190 | S | major |
-| 9 | Test engine (SDK 2.x embedded) differs from prod (3.2.3), bridged by 4 string replacements | schema.py:970 | M | major |
-| 10 | `episode`/`mentions` restore-only but fully indexed and migrated per namespace | schema.py:142, 208 | M | major |
-| 11 | Typed Entity subclasses are write-only; only Task/Procedure rehydrate | entities.py:147, graph.py:2213 | M | major |
-| 12 | `storage/` contracts: 177 lines, zero production consumers, decoy seam | storage/ | S | major |
-| 13 | Missing timestamps fabricated as `now()`; three datetime conventions | graph.py:2100, 3410; records.py:19 | M | major |
-| 14 | No cross-process migration lock; lazy per-org bootstrap at request time | graph_client.py:48, schema_version.py:137 | M | major |
-| 15 | Extra round trip on every write (preflight `RETURN true;`) | dedicated_client.py:287 | M | major |
-| 16 | Namespace derivation unvalidated, hyphen-stripping collides | graph_client.py:117 | S | major |
-| 17 | Redundant unindexed `group_id` predicates after v7 index prune | graph.py ×33, search.py ×20 | M | major |
-| 18 | `relates_to.name` has no enum assertion (entity_type does) | schema.py:182 vs 385 | S | minor |
-| 19 | Vestigial `_direct_insert` and `"Entity"` label on every row | graph.py:3022, 3033 | S | minor |
-| 20 | graph_runtime.py: duplicate dataclass, unreachable `_driver` branch, Cypher-era guard | graph_runtime.py:36, 49, 107 | S | minor |
+| #   | Finding                                                                                    | Where                                               | Size   | Severity |
+| --- | ------------------------------------------------------------------------------------------ | --------------------------------------------------- | ------ | -------- |
+| 1   | Metadata written three ways; JSON snapshot goes stale and resurrects deleted keys          | graph.py:1982, 3017, 3071                           | L      | blocker  |
+| 2   | Graph plane has no schema-invariant check; UNIQUE index failures silently swallowed        | schema_helpers.py:44, cli/db.py:713                 | M      | blocker  |
+| 3   | Blind full-replace upsert with per-field absence exceptions                                | graph.py:229-279                                    | M      | major    |
+| 4   | Whole-org graph loaded into memory three times per render                                  | graph_communities.py:202, 1940                      | L      | major    |
+| 5   | Three divergent Surreal normalizers; "canonical" module no longer canonical                | records.py:1, graph.py:2521, surreal_content.py:653 | M      | major    |
+| 6   | Production code monkeypatches another module's globals per call                            | graph.py:1929-1950                                  | M      | major    |
+| 7   | Write failures reported as skips; vector-search and graph-render failures render as empty  | graph.py:1469, 840; graph_communities.py:1948       | S each | major    |
+| 8   | `Relationship` model cannot express the temporal validity the schema stores                | entities.py:269 vs schema.py:190                    | S      | major    |
+| 9   | Test engine (SDK 2.x embedded) differs from prod (3.2.3), bridged by 4 string replacements | schema.py:970                                       | M      | major    |
+| 10  | `episode`/`mentions` restore-only but fully indexed and migrated per namespace             | schema.py:142, 208                                  | M      | major    |
+| 11  | Typed Entity subclasses are write-only; only Task/Procedure rehydrate                      | entities.py:147, graph.py:2213                      | M      | major    |
+| 12  | `storage/` contracts: 177 lines, zero production consumers, decoy seam                     | storage/                                            | S      | major    |
+| 13  | Missing timestamps fabricated as `now()`; three datetime conventions                       | graph.py:2100, 3410; records.py:19                  | M      | major    |
+| 14  | No cross-process migration lock; lazy per-org bootstrap at request time                    | graph_client.py:48, schema_version.py:137           | M      | major    |
+| 15  | Extra round trip on every write (preflight `RETURN true;`)                                 | dedicated_client.py:287                             | M      | major    |
+| 16  | Namespace derivation unvalidated, hyphen-stripping collides                                | graph_client.py:117                                 | S      | major    |
+| 17  | Redundant unindexed `group_id` predicates after v7 index prune                             | graph.py ×33, search.py ×20                         | M      | major    |
+| 18  | `relates_to.name` has no enum assertion (entity_type does)                                 | schema.py:182 vs 385                                | S      | minor    |
+| 19  | Vestigial `_direct_insert` and `"Entity"` label on every row                               | graph.py:3022, 3033                                 | S      | minor    |
+| 20  | graph_runtime.py: duplicate dataclass, unreachable `_driver` branch, Cypher-era guard      | graph_runtime.py:36, 49, 107                        | S      | minor    |
 
 ### Cheapest high-value moves before a 1.3 rearchitecture
 
-1. Add `graph_schema_invariant_plan()` and wire the graph plane into `sibyld db init`
-   alongside auth and content (S1). Mechanical — the pattern already exists twice.
+1. Add `graph_schema_invariant_plan()` and wire the graph plane into `sibyld db init` alongside auth
+   and content (S1). Mechanical — the pattern already exists twice.
 2. Delete `storage/` (D2) or implement it. Leaving it is the trap.
-3. Drop the `episode` table and `mentions` edge behind a restore-time-only schema
-   (S4), which also removes eight indexes, two backfill migrations, and a statement
-   from the entity-delete hot path.
-4. Give `Relationship` its temporal columns as typed fields (A4). One small model
-   change unlocks the stated 1.3 goal.
-5. Pin A1 with a regression test before touching anything else — the stale snapshot is
-   the invariant most likely to be silently broken by a representation change.
+3. Drop the `episode` table and `mentions` edge behind a restore-time-only schema (S4), which also
+   removes eight indexes, two backfill migrations, and a statement from the entity-delete hot path.
+4. Give `Relationship` its temporal columns as typed fields (A4). One small model change unlocks the
+   stated 1.3 goal.
+5. Pin A1 with a regression test before touching anything else — the stale snapshot is the invariant
+   most likely to be silently broken by a representation change.

--- a/docs/architecture/AUDIT_2026-08-13/debt-retrieval-ai.md
+++ b/docs/architecture/AUDIT_2026-08-13/debt-retrieval-ai.md
@@ -1,14 +1,14 @@
 # Sibyl tech-debt audit: retrieval, ranking, synthesis, ai/extraction
 
 Scope: `packages/python/sibyl-core/src/sibyl_core/` — `retrieval/`, `ai/`, `projection/`,
-`memory_pipeline/`, `embeddings/`, `query_anchors.py`, the search/synthesis/reflection
-services, and context-pack assembly in `tools/context.py` + `tools/search.py`.
-Out of scope (owned elsewhere): graph client/models/persistence, `apps/api`, `apps/web`.
+`memory_pipeline/`, `embeddings/`, `query_anchors.py`, the search/synthesis/reflection services, and
+context-pack assembly in `tools/context.py` + `tools/search.py`. Out of scope (owned elsewhere):
+graph client/models/persistence, `apps/api`, `apps/web`.
 
 Audit date 2026-08-13, against `main` at `5388d986`. Read-only; nothing mutated.
 
-All paths below are absolute. Every claim was checked by reading the file or by grep
-over the whole repo; call-site counts are stated where "dead" is claimed.
+All paths below are absolute. Every claim was checked by reading the file or by grep over the whole
+repo; call-site counts are stated where "dead" is claimed.
 
 ---
 
@@ -16,26 +16,25 @@ over the whole repo; call-site counts are stated where "dead" is claimed.
 
 Three numbers frame the rest of this document.
 
-**The ranker carries 51 hand-tuned numeric constants and 46 regex/term-set constants**
-in one file, `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py`
-(2016 lines). Counted with
-`grep -cE "^_[A-Z_]+ *(:[a-z ]*)?= *[0-9]"` and `grep -cE "^_[A-Z_]+ *(:.*)?= *(re\.compile|\{|frozenset|\()"`.
+**The ranker carries 51 hand-tuned numeric constants and 46 regex/term-set constants** in one file,
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py` (2016
+lines). Counted with `grep -cE "^_[A-Z_]+ *(:[a-z ]*)?= *[0-9]"` and
+`grep -cE "^_[A-Z_]+ *(:.*)?= *(re\.compile|\{|frozenset|\()"`.
 
-**Config for retrieval is spread across seven independent surfaces** that never
-reconcile: `CoreConfig` (pydantic-settings, env-driven), `RetrievalWeights` (8 fields),
-`CandidateLimits` (8), `RetrievalPlan` (16), `HybridConfig` (15), `FusionConfig` (3),
-`DedupConfig` (5), `TemporalConfig` (4), `CrossEncoderConfig` (7), plus 15 module
-constants in `retrieval/search.py` and the 97 in `query_ranking.py`. Three of those
-dataclasses have zero production readers (see 2.4).
+**Config for retrieval is spread across seven independent surfaces** that never reconcile:
+`CoreConfig` (pydantic-settings, env-driven), `RetrievalWeights` (8 fields), `CandidateLimits` (8),
+`RetrievalPlan` (16), `HybridConfig` (15), `FusionConfig` (3), `DedupConfig` (5), `TemporalConfig`
+(4), `CrossEncoderConfig` (7), plus 15 module constants in `retrieval/search.py` and the 97 in
+`query_ranking.py`. Three of those dataclasses have zero production readers (see 2.4).
 
-**Fusion discards every score magnitude the lanes compute.** `rrf_merge` binds the
-score to `_original_score` and never reads it
-(`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/fusion.py:126`).
-The coverage re-ranker then weights ordinal rank at 0.95 and the incoming prior at 0.04
-(`query_ranking.py:140-141`). The pipeline is ordinal end to end. Most of the
-carefully-tuned multiplicative constants downstream cannot change an outcome except by
-perturbing an ordering that is immediately re-flattened. This is the single most
-important thing to internalize before 1.3 tuning work.
+**Fusion discards every score magnitude the lanes compute.** `rrf_merge` binds the score to
+`_original_score` and never reads it
+(`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/fusion.py:126`). The
+coverage re-ranker then weights ordinal rank at 0.95 and the incoming prior at 0.04
+(`query_ranking.py:140-141`). The pipeline is ordinal end to end. Most of the carefully-tuned
+multiplicative constants downstream cannot change an outcome except by perturbing an ordering that
+is immediately re-flattened. This is the single most important thing to internalize before 1.3
+tuning work.
 
 ---
 
@@ -45,15 +44,15 @@ important thing to internalize before 1.3 tuning work.
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:337-705`
 
-`_CONCEPT_GROUPS` (561-705), `_CATEGORY_ALIASES` (480-510), and roughly twenty
-`_*_QUERY_PATTERN` / `_*_EVIDENCE_PATTERN` regex pairs (337-479) encode benchmark
-content directly as ranking signal. Verbatim examples:
+`_CONCEPT_GROUPS` (561-705), `_CATEGORY_ALIASES` (480-510), and roughly twenty `_*_QUERY_PATTERN` /
+`_*_EVIDENCE_PATTERN` regex pairs (337-479) encode benchmark content directly as ranking signal.
+Verbatim examples:
 
 - `query_ranking.py:698` — `"seattle"` is a member of a concept group.
-- `query_ranking.py:586-610` — a concept group containing `basil`, `airfryer`,
-  `tomatoes`, `mint`, `smoker`, `blender`.
-- `query_ranking.py:617` — `"buisiness"`, a **misspelling** sitting beside `"business"`
-  in the same frozenset. That is a dataset typo promoted into a shipped scoring table.
+- `query_ranking.py:586-610` — a concept group containing `basil`, `airfryer`, `tomatoes`, `mint`,
+  `smoker`, `blender`.
+- `query_ranking.py:617` — `"buisiness"`, a **misspelling** sitting beside `"business"` in the same
+  frozenset. That is a dataset typo promoted into a shipped scoring table.
 - `query_ranking.py:366-374` — `_HOMEGROWN_EVIDENCE_PATTERN` matching
   `basil|mint|tomatoes?|herbs?|pepper plants?`.
 - `query_ranking.py:425-437` — `_DOCTOR_VISIT_EVIDENCE_PATTERN` matching
@@ -61,21 +60,19 @@ content directly as ranking signal. Verbatim examples:
 - `query_ranking.py:385-395` — `_SPORTS_EVENT_EVIDENCE_PATTERN` matching
   `5k|triathlon|soccer tournament|bike ride`.
 
-These feed `_concept_overlap_score` (1647) and `_query_frame_score` (946), which enter
-the final score at `_CONCEPT_OVERLAP_WEIGHT` and `_QUERY_FRAME_WEIGHT` = 0.52
-(`query_ranking.py:1375-1378`) — the second-largest weight in the entire model after
-rank itself.
+These feed `_concept_overlap_score` (1647) and `_query_frame_score` (946), which enter the final
+score at `_CONCEPT_OVERLAP_WEIGHT` and `_QUERY_FRAME_WEIGHT` = 0.52 (`query_ranking.py:1375-1378`) —
+the second-largest weight in the entire model after rank itself.
 
-Why it matters: this is corpus overfitting shipped to every user of every org. A
-Sibyl user asking about a work incident gets scored against a table that rewards the
-token `airfryer`. It also poisons the benchmark: any LongMemEval delta measured while
-these tables are live is partly measuring the tables, not the architecture. The 30.38%
-anchor is not a clean read of the retrieval design.
+Why it matters: this is corpus overfitting shipped to every user of every org. A Sibyl user asking
+about a work incident gets scored against a table that rewards the token `airfryer`. It also poisons
+the benchmark: any LongMemEval delta measured while these tables are live is partly measuring the
+tables, not the architecture. The 30.38% anchor is not a clean read of the retrieval design.
 
-Fix: L. Not a delete-and-ship — the tables are load-bearing for the current benchmark
-number, so removing them will move it. The honest sequence is: measure with them
-removed, accept the drop as the true baseline, then rebuild the concept signal from
-something learned or embedded rather than enumerated.
+Fix: L. Not a delete-and-ship — the tables are load-bearing for the current benchmark number, so
+removing them will move it. The honest sequence is: measure with them removed, accept the drop as
+the true baseline, then rebuild the concept signal from something learned or embedded rather than
+enumerated.
 
 Severity: blocker. This is the finding that should gate 1.3 rearchitecture.
 
@@ -84,31 +81,29 @@ Severity: blocker. This is the finding that should gate 1.3 rearchitecture.
 There are two complete, separately-tuned retrieval paths:
 
 - `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:367`
-  `context_search` — 8 lanes, `RetrievalWeights`, `CandidateLimits`, Surreal-or-Python
-  RRF, `_boost_score` multipliers. Reached from `tools/context.py:1489` (context packs).
+  `context_search` — 8 lanes, `RetrievalWeights`, `CandidateLimits`, Surreal-or-Python RRF,
+  `_boost_score` multipliers. Reached from `tools/context.py:1489` (context packs).
 - `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py:584`
-  `hybrid_search` — 2 lanes, `HybridConfig`, weighted RRF, keyword boost, temporal
-  boost, cross-encoder hook. Reached from `tools/search.py:1074` (`/api/search`, CLI
-  `sibyl search`).
+  `hybrid_search` — 2 lanes, `HybridConfig`, weighted RRF, keyword boost, temporal boost,
+  cross-encoder hook. Reached from `tools/search.py:1074` (`/api/search`, CLI `sibyl search`).
 
-They share exactly one component: `rank_items_by_query_coverage`. Everything else is
-duplicated with different constants. The clearest instance is the graph relationship
-priority table, which exists twice with different scales and partially disjoint keys:
+They share exactly one component: `rank_items_by_query_coverage`. Everything else is duplicated with
+different constants. The clearest instance is the graph relationship priority table, which exists
+twice with different scales and partially disjoint keys:
 
-- `search.py:85-107` `_GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS`, range 0.58–1.0, includes
-  `DECIDES`, `SUPPORTS`, `TOUCHES`, `PRODUCES`, `ABOUT`, `SHARES_COMMUNITY`.
-- `hybrid.py:44-64` `DEFAULT_GRAPH_RELATIONSHIP_TYPE_WEIGHTS`, range 0.35–1.25,
-  includes `APPLIES_TO`, `ENABLES`, `BREAKS`, `CONFLICTS_WITH`.
+- `search.py:85-107` `_GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS`, range 0.58–1.0, includes `DECIDES`,
+  `SUPPORTS`, `TOUCHES`, `PRODUCES`, `ABOUT`, `SHARES_COMMUNITY`.
+- `hybrid.py:44-64` `DEFAULT_GRAPH_RELATIONSHIP_TYPE_WEIGHTS`, range 0.35–1.25, includes
+  `APPLIES_TO`, `ENABLES`, `BREAKS`, `CONFLICTS_WITH`.
 
-`MENTIONS` is 0.58 in one and 0.35 in the other. `RELATED_TO` is 0.64 vs 0.85. Nothing
-reconciles them, and no test asserts they agree.
+`MENTIONS` is 0.58 in one and 0.35 in the other. `RELATED_TO` is 0.64 vs 0.85. Nothing reconciles
+them, and no test asserts they agree.
 
-Consequence: a memory that surfaces in a context pack may not surface in `sibyl search`
-for the same query, and vice versa, for reasons nobody can predict from either file
-alone. Every ranking experiment has to be run twice or it only covers half the product.
+Consequence: a memory that surfaces in a context pack may not surface in `sibyl search` for the same
+query, and vice versa, for reasons nobody can predict from either file alone. Every ranking
+experiment has to be run twice or it only covers half the product.
 
-Fix: L. Severity: blocker for 1.3 (it is the reason lever screening keeps needing two
-harnesses).
+Fix: L. Severity: blocker for 1.3 (it is the reason lever screening keeps needing two harnesses).
 
 ### B3. The exact-name rescue lane is unreachable on the normal path
 
@@ -126,22 +121,21 @@ if (
 ```
 
 `enhanced_search_exhausted` is set at `tools/search.py:1099-1101` from
-`hybrid_result.metadata["entity_manager_search_completed"]`, which `hybrid.py:267`
-sets to `True` whenever the seed vector search *succeeded* — the normal case.
+`hybrid_result.metadata["entity_manager_search_completed"]`, which `hybrid.py:267` sets to `True`
+whenever the seed vector search _succeeded_ — the normal case.
 
-So the guard reads: run the exact-name rescue only when the seed search **failed**.
-The `_graph_results_contain_exact_name_match` check on the next line makes the intent
-unambiguous: this lane exists to rescue a query whose exact-name target is missing from
-an otherwise-successful result set. That is precisely the case where it never fires.
+So the guard reads: run the exact-name rescue only when the seed search **failed**. The
+`_graph_results_contain_exact_name_match` check on the next line makes the intent unambiguous: this
+lane exists to rescue a query whose exact-name target is missing from an otherwise-successful result
+set. That is precisely the case where it never fires.
 
-Why it matters: "search for the thing by its exact name" is the highest-precision
-query a memory system gets, and the lane built for it is dark in production. It also
-means any benchmark claim about exact-name behavior measured through `/api/search` is
-measuring a lane that did not run.
+Why it matters: "search for the thing by its exact name" is the highest-precision query a memory
+system gets, and the lane built for it is dark in production. It also means any benchmark claim
+about exact-name behavior measured through `/api/search` is measuring a lane that did not run.
 
-Fix: S (the guard should test `not raw_results`-style exhaustion, not seed success).
-Severity: blocker — confirm intent with whoever wrote it, but the current behavior does
-not match the surrounding code's own stated purpose.
+Fix: S (the guard should test `not raw_results`-style exhaustion, not seed success). Severity:
+blocker — confirm intent with whoever wrote it, but the current behavior does not match the
+surrounding code's own stated purpose.
 
 ---
 
@@ -159,81 +153,74 @@ for index in range(MAX_PASSAGES_PER_SOURCE):
     elif index > highest_kept: break
 ```
 
-The docstring at 589-590 asserts "the walk stops once it is past every kept index and
-has found an absence, which is where any previous run must have ended." That premise
-fails whenever a **previous** run skipped an index, and the module contains the code
-that produces such gaps: the oversize-leaf branch at `passages.py:222-227` `continue`s
-past an index it cannot store.
+The docstring at 589-590 asserts "the walk stops once it is past every kept index and has found an
+absence, which is where any previous run must have ended." That premise fails whenever a
+**previous** run skipped an index, and the module contains the code that produces such gaps: the
+oversize-leaf branch at `passages.py:222-227` `continue`s past an index it cannot store.
 
 Two concrete failures, both verified by reading the code path:
 
-**Stale span survives reprojection.** Run 1 writes `{0, 1, 3}` (index 2 was an
-unbreakable oversize line). The body is shortened; run 2 writes `{0, 1}`. Now
-`highest_kept = 1`, index 2 deletes nothing, `2 > 1` fires, loop breaks. Index 3
-survives holding the **previous revision's text** and keeps being served as current.
-`reproject_entity_passages`'s own docstring (`passages.py:391-397`) names this as the
-outcome it exists to prevent.
+**Stale span survives reprojection.** Run 1 writes `{0, 1, 3}` (index 2 was an unbreakable oversize
+line). The body is shortened; run 2 writes `{0, 1}`. Now `highest_kept = 1`, index 2 deletes
+nothing, `2 > 1` fires, loop breaks. Index 3 survives holding the **previous revision's text** and
+keeps being served as current. `reproject_entity_passages`'s own docstring (`passages.py:391-397`)
+names this as the outcome it exists to prevent.
 
-**Delete leaves every span alive.** `retire_entity_passages` (`passages.py:558-573`)
-calls the same helper with `kept_indices=frozenset()`, so `highest_kept = -1`. If
-index 0 was skipped as an oversize leaf, `delete(index 0)` returns falsy, `0 > -1`
-fires, and the loop breaks on its first iteration. Every span of the deleted memory
-survives, still serving the deleted text. The function's docstring (565-567) calls
-that "the one outcome a delete must not produce."
+**Delete leaves every span alive.** `retire_entity_passages` (`passages.py:558-573`) calls the same
+helper with `kept_indices=frozenset()`, so `highest_kept = -1`. If index 0 was skipped as an
+oversize leaf, `delete(index 0)` returns falsy, `0 > -1` fires, and the loop breaks on its first
+iteration. Every span of the deleted memory survives, still serving the deleted text. The function's
+docstring (565-567) calls that "the one outcome a delete must not produce."
 
-I read `passages.py:576-608` directly to confirm the control flow; the `elif` is exactly
-as quoted.
+I read `passages.py:576-608` directly to confirm the control flow; the `elif` is exactly as quoted.
 
-Fix: S. Either drop the `elif` and eat 64 deletes on the delete path (batchable), or
-bound the sweep by the parent's last-known `passage_total`.
+Fix: S. Either drop the `elif` and eat 64 deletes on the delete path (batchable), or bound the sweep
+by the parent's last-known `passage_total`.
 
-Severity: blocker — this is a correctness bug that serves deleted and superseded
-content as current, and it is silent.
+Severity: blocker — this is a correctness bug that serves deleted and superseded content as current,
+and it is silent.
 
 ### B5. The self-feeding-source guard runs only on sources that get thrown away
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py:1013,1023`
 vs `:566-672`
 
-`_without_self_feeding_sources` is applied to the searched sources (1013) and the
-neighborhood sources (1023) inside `plan_synthesis`. Then
-`materialize_synthesis_section_packs` rebuilds every pack from `context_fn` output in
-the loop at 566-656 — a loop that has **no** `_is_self_feeding_source` check anywhere —
-and returns `replace(run, source_packs=materialized_packs, ...)` at 667-672, replacing
-the plan-stage packs wholesale.
+`_without_self_feeding_sources` is applied to the searched sources (1013) and the neighborhood
+sources (1023) inside `plan_synthesis`. Then `materialize_synthesis_section_packs` rebuilds every
+pack from `context_fn` output in the loop at 566-656 — a loop that has **no**
+`_is_self_feeding_source` check anywhere — and returns
+`replace(run, source_packs=materialized_packs, ...)` at 667-672, replacing the plan-stage packs
+wholesale.
 
 Every production caller runs plan then materialize:
 `apps/api/src/sibyl/api/routes/synthesis.py:98-112` and
-`packages/python/sibyl-core/src/sibyl_core/tools/synthesis.py:90-104`. So the guard
-landed by `4bb5260d` ("never select synthesis or reflection output as a source", #354)
-protects only the sources that are discarded.
+`packages/python/sibyl-core/src/sibyl_core/tools/synthesis.py:90-104`. So the guard landed by
+`4bb5260d` ("never select synthesis or reflection output as a source", #354) protects only the
+sources that are discarded.
 
-The loop is closed and live. `remember_synthesis_artifact` (`synthesis.py:928-960`)
-stores the artifact via `remember_raw_memory` with `capture_surface="synthesis_artifact"`,
-and `compile_context` recalls raw memories (`tools/context.py:1519`). The signal is even
-deliberately preserved: `capture_surface` sits in `_ITEM_METADATA_KEYS`
-(`tools/context.py:600`) under a comment saying "synthesis render filters read these."
-Nothing reads it.
+The loop is closed and live. `remember_synthesis_artifact` (`synthesis.py:928-960`) stores the
+artifact via `remember_raw_memory` with `capture_surface="synthesis_artifact"`, and
+`compile_context` recalls raw memories (`tools/context.py:1519`). The signal is even deliberately
+preserved: `capture_surface` sits in `_ITEM_METADATA_KEYS` (`tools/context.py:600`) under a comment
+saying "synthesis render filters read these." Nothing reads it.
 
-I read `synthesis.py:560-672` directly and confirmed the materialize loop's filter set:
-hidden, render-authorization, correction-reason, redaction, and duplicate-source-id.
-No self-feeding check.
+I read `synthesis.py:560-672` directly and confirmed the materialize loop's filter set: hidden,
+render-authorization, correction-reason, redaction, and duplicate-source-id. No self-feeding check.
 
-Fix: S — one filter call in the materialize loop.
-Severity: blocker. It is the regeneration-loss loop the gate was written to close, and
-the fix landed one stage upstream of where it mattered.
+Fix: S — one filter call in the materialize loop. Severity: blocker. It is the regeneration-loss
+loop the gate was written to close, and the fix landed one stage upstream of where it mattered.
 
 ### B6. The handbook gate that "proved" B5 tests a stage production never renders
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/tests/test_handbook.py:70-77, 260-285`
 
-`_plan(...)` calls `plan_synthesis` alone, and **every** test in the file asserts on its
-output — including the byte-stability test at 221 and the line-tracing gate at 288.
-`materialize_synthesis_section_packs` never appears in the file. The handbook's entire
-test suite validates a pack shape the REST route does not render.
+`_plan(...)` calls `plan_synthesis` alone, and **every** test in the file asserts on its output —
+including the byte-stability test at 221 and the line-tracing gate at 288.
+`materialize_synthesis_section_packs` never appears in the file. The handbook's entire test suite
+validates a pack shape the REST route does not render.
 
-This is the mechanism by which B5 shipped green, and it generalizes: any future
-synthesis invariant asserted through `_plan` is asserting on discarded data.
+This is the mechanism by which B5 shipped green, and it generalizes: any future synthesis invariant
+asserted through `_plan` is asserting on discarded data.
 
 Fix: M (add a materialize stage to the gate fixtures). Severity: blocker.
 
@@ -254,40 +241,38 @@ temporal_multiplier = (
 boosted *= temporal_multiplier
 ```
 
-`_freshness_boost` (`search.py:3129-3137`) is `min(cap, 1 + 0.5/(1+age_days))` — a
-hyperbolic *boost* capped at 1.5. `temporal_decay_multiplier` (from
-`retrieval/temporal.py`) is exponential *decay* on a 365-day half-life. Both are
-functions of the same `created_at`, applied multiplicatively, configured by two
-unrelated knobs (`freshness_boost_cap` on the plan, `temporal_decay_days` on
-`CoreConfig`). Their product is a curve nobody designed.
+`_freshness_boost` (`search.py:3129-3137`) is `min(cap, 1 + 0.5/(1+age_days))` — a hyperbolic
+_boost_ capped at 1.5. `temporal_decay_multiplier` (from `retrieval/temporal.py`) is exponential
+_decay_ on a 365-day half-life. Both are functions of the same `created_at`, applied
+multiplicatively, configured by two unrelated knobs (`freshness_boost_cap` on the plan,
+`temporal_decay_days` on `CoreConfig`). Their product is a curve nobody designed.
 
-A second copy of `_freshness_boost` runs at `search.py:3147` with a **hardcoded**
-`cap=1.5` to populate the `freshness` receipt field, so if `plan.weights.freshness_boost_cap`
-is ever changed from its default the reported freshness will disagree with the applied one.
+A second copy of `_freshness_boost` runs at `search.py:3147` with a **hardcoded** `cap=1.5` to
+populate the `freshness` receipt field, so if `plan.weights.freshness_boost_cap` is ever changed
+from its default the reported freshness will disagree with the applied one.
 
-Fix: M (pick one decay model, delete the other, wire the receipt to the applied value).
-Severity: major.
+Fix: M (pick one decay model, delete the other, wire the receipt to the applied value). Severity:
+major.
 
 ### M2. The coverage ranker runs twice on every query, in Python, on the serving path
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:859-892`
 
-`rank_items_by_query_coverage` scores the full candidate set through
-`rank_by_query_coverage`, then unconditionally rebuilds the candidates and scores the
-whole set **again** (`refined = rank_by_query_coverage(...)` at 883), then throws the
-second pass away unless `should_accept_query_coverage_refinement` approves it (889).
+`rank_items_by_query_coverage` scores the full candidate set through `rank_by_query_coverage`, then
+unconditionally rebuilds the candidates and scores the whole set **again**
+(`refined = rank_by_query_coverage(...)` at 883), then throws the second pass away unless
+`should_accept_query_coverage_refinement` approves it (889).
 
-Each pass is pure-Python and per-candidate does: tokenization, three separate
-token-set extractions, sliding-window segment overlap at window 18 / stride 6
-(`_best_segment_overlap`, `_best_weighted_segment_overlap`), IDF weighting, ~20 regex
-searches through `_query_frame_score`, and fact-frame matching. It is offloaded to a
-thread (`search.py:568`, `hybrid.py:854`) which keeps the loop alive but does not make
-it cheaper — and under CPython the GIL means the thread competes with the event loop.
+Each pass is pure-Python and per-candidate does: tokenization, three separate token-set extractions,
+sliding-window segment overlap at window 18 / stride 6 (`_best_segment_overlap`,
+`_best_weighted_segment_overlap`), IDF weighting, ~20 regex searches through `_query_frame_score`,
+and fact-frame matching. It is offloaded to a thread (`search.py:568`, `hybrid.py:854`) which keeps
+the loop alive but does not make it cheaper — and under CPython the GIL means the thread competes
+with the event loop.
 
-Given the measured clean-server latency (ent ~32s, web ~18s against a 10s budget), this
-is a named, measurable, unconditional 2x on the one stage that is entirely local CPU.
-The refinement pass is a candidate for gating on a cheap precondition rather than
-running always.
+Given the measured clean-server latency (ent ~32s, web ~18s against a 10s budget), this is a named,
+measurable, unconditional 2x on the one stage that is entirely local CPU. The refinement pass is a
+candidate for gating on a cheap precondition rather than running always.
 
 Fix: M. Severity: major, and it is the cheapest latency win visible in this subsystem.
 
@@ -304,64 +289,61 @@ for item_index in range(per_facet_limit):
         remaining -= 1
 ```
 
-Selection takes item 0 from every facet, then item 1 from every facet, and so on until
-the pack budget is spent. Score never enters the loop. A top-scoring item sitting at
-rank 3 within a strong facet loses its slot to the rank-0 item of a weak facet.
+Selection takes item 0 from every facet, then item 1 from every facet, and so on until the pack
+budget is spent. Score never enters the loop. A top-scoring item sitting at rank 3 within a strong
+facet loses its slot to the rank-0 item of a weak facet.
 
-Everything upstream — RRF, four multiplicative boost classes, the 15-term coverage
-model, the seven stabilizer branches — feeds an ordering that this loop then reshuffles
-by facet position. Combined with `per_facet_limit = max(2, min(8, ...))` at
-`context.py:1540`, the pack cap is 8 per facet regardless of how much char budget is
-left, which matches the previously-diagnosed "8-item pack cap against a 1/3-spent char
-budget".
+Everything upstream — RRF, four multiplicative boost classes, the 15-term coverage model, the seven
+stabilizer branches — feeds an ordering that this loop then reshuffles by facet position. Combined
+with `per_facet_limit = max(2, min(8, ...))` at `context.py:1540`, the pack cap is 8 per facet
+regardless of how much char budget is left, which matches the previously-diagnosed "8-item pack cap
+against a 1/3-spent char budget".
 
-Fix: M (score-ordered selection with a per-facet floor, rather than strict round-robin).
-Severity: major.
+Fix: M (score-ordered selection with a per-facet floor, rather than strict round-robin). Severity:
+major.
 
 ### M4. Four expansion lanes issue sequential round trips, two of them against
+
 tables nothing in the write path populates
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:1693-1744`
 
-Per BFS depth level, `_node_bfs_records` awaits in strict sequence:
-`_mentioned_entity_hops` (1702), `_relation_target_hops` (1711), optionally
-`_relation_source_hops` (1722), optionally `_community_member_hops` (1737) — and
-`_community_member_hops` itself awaits `_community_ids_for_entities` first
-(`search.py:1935`), so it is two round trips. All four read from the same frozen
-`entity_frontier`/`episode_frontier` for that level; they are fully independent and
-could be one `asyncio.gather`. That is up to 5 serialized DB round trips where 1
-latency-unit would do.
+Per BFS depth level, `_node_bfs_records` awaits in strict sequence: `_mentioned_entity_hops` (1702),
+`_relation_target_hops` (1711), optionally `_relation_source_hops` (1722), optionally
+`_community_member_hops` (1737) — and `_community_member_hops` itself awaits
+`_community_ids_for_entities` first (`search.py:1935`), so it is two round trips. All four read from
+the same frozen `entity_frontier`/`episode_frontier` for that level; they are fully independent and
+could be one `asyncio.gather`. That is up to 5 serialized DB round trips where 1 latency-unit would
+do.
 
 Two of them cannot return anything on a live graph:
 
 - `_mentioned_entity_hops` (`search.py:1791`) queries `FROM mentions`. Grep across
-  `sibyl_core/graph`, `sibyl_core/services`, `sibyl_core/backends` finds no writer for
-  the `mentions` table outside `backends/surreal/schema.py` (definitions/indexes) and
-  the archive tuple `GRAPH_EDGES` at `schema.py:574`. `mentions` is restore-only.
-- `_community_member_hops` (`search.py:1925`) needs `entity_type = "community"` rows.
-  Community entities are created only by `store_communities`
-  (`services/graph_communities.py:2704`), and `detect_communities` /
-  `store_communities` have **zero callers** anywhere in `packages/` or `apps/` outside
-  their own module. No ingestion path, no worker, no job builds communities. The only
-  importers of `graph_communities` are three web-visualization helpers in
+  `sibyl_core/graph`, `sibyl_core/services`, `sibyl_core/backends` finds no writer for the
+  `mentions` table outside `backends/surreal/schema.py` (definitions/indexes) and the archive tuple
+  `GRAPH_EDGES` at `schema.py:574`. `mentions` is restore-only.
+- `_community_member_hops` (`search.py:1925`) needs `entity_type = "community"` rows. Community
+  entities are created only by `store_communities` (`services/graph_communities.py:2704`), and
+  `detect_communities` / `store_communities` have **zero callers** anywhere in `packages/` or
+  `apps/` outside their own module. No ingestion path, no worker, no job builds communities. The
+  only importers of `graph_communities` are three web-visualization helpers in
   `apps/api/src/sibyl/persistence/graph_runtime.py`.
 
-So every context-pack search pays three guaranteed-empty round trips (one `mentions`,
-two community) before the useful hops run.
+So every context-pack search pays three guaranteed-empty round trips (one `mentions`, two community)
+before the useful hops run.
 
-Fix: S for the gather; S for gating the two dead lanes behind a capability probe or
-deleting them. Severity: major (pure latency on the loudest budget miss).
+Fix: S for the gather; S for gating the two dead lanes behind a capability probe or deleting them.
+Severity: major (pure latency on the loudest budget miss).
 
 ### M5. `context_search`'s three retrieval phases are serialized
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:458, 472, 490`
 
-The critical path is: gather 4 lexical lanes (458) → **await** → embed query + gather 2
-vector lanes (472) → **await** → graph expansion (490). Only the third phase has a real
-data dependency (it seeds from the first two). The lexical gather and the
-vector gather are independent and are executed one after the other. The embedding call
-inside phase 2 (`search.py:1281`) is itself a network round trip that could overlap the
-entire lexical phase.
+The critical path is: gather 4 lexical lanes (458) → **await** → embed query + gather 2 vector lanes
+(472) → **await** → graph expansion (490). Only the third phase has a real data dependency (it seeds
+from the first two). The lexical gather and the vector gather are independent and are executed one
+after the other. The embedding call inside phase 2 (`search.py:1281`) is itself a network round trip
+that could overlap the entire lexical phase.
 
 Fix: S (gather phases 1 and 2, keep expansion downstream). Severity: major.
 
@@ -373,11 +355,10 @@ Fix: S (gather phases 1 and 2, keep expansion downstream). Severity: major.
 embeddings = await embedding_provider.embed_texts([plan.query], input_kind="query")
 ```
 
-Bare await, no `asyncio.wait_for`. `CoreConfig.graph_search_embedding_timeout_seconds`
-exists (`config.py:271`, default 5.0s) and **is** applied on the other path
-(`services/graph.py:783`), so the two retrieval pipelines disagree about whether a
-hung embedding provider can stall a request. On the context-pack path it can, up to
-whatever outer timeout the HTTP layer imposes.
+Bare await, no `asyncio.wait_for`. `CoreConfig.graph_search_embedding_timeout_seconds` exists
+(`config.py:271`, default 5.0s) and **is** applied on the other path (`services/graph.py:783`), so
+the two retrieval pipelines disagree about whether a hung embedding provider can stall a request. On
+the context-pack path it can, up to whatever outer timeout the HTTP layer imposes.
 
 Fix: S. Severity: major.
 
@@ -393,15 +374,14 @@ except Exception as exc:
     log.warning("context_native_search_failed", error_type=type(exc).__name__)
 ```
 
-A bug anywhere in the 3200-line native retrieval path becomes a `WARNING` line with the
-exception *type* only (no message, no traceback) and an empty or fallback-sourced pack.
-The `ContextPack` returned carries no field saying retrieval failed — `usage_metadata`
-only gets an exposure summary. A caller cannot distinguish "no relevant memories" from
-"retrieval crashed".
+A bug anywhere in the 3200-line native retrieval path becomes a `WARNING` line with the exception
+_type_ only (no message, no traceback) and an empty or fallback-sourced pack. The `ContextPack`
+returned carries no field saying retrieval failed — `usage_metadata` only gets an exposure summary.
+A caller cannot distinguish "no relevant memories" from "retrieval crashed".
 
 The contrast is instructive: the vector lane one level down does this correctly.
-`VectorCandidateFetch` (`retrieval/candidates.py:83-127`) carries `requested`,
-`attempted`, `reason`, `failures`, and surfaces them into `SearchResponse.filters` via
+`VectorCandidateFetch` (`retrieval/candidates.py:83-127`) carries `requested`, `attempted`,
+`reason`, `failures`, and surfaces them into `SearchResponse.filters` via
 `vector_fetch.as_metadata()` (`search.py:603`). That receipt discipline stops at the
 `compile_context` boundary.
 
@@ -411,33 +391,31 @@ Fix: S (propagate a `retrieval_failed` receipt into the pack). Severity: major.
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:1472-1497`
 
-Final ordering is chosen by an if/elif chain over regex query classifiers, selecting
-one of seven mutually exclusive stabilizers:
+Final ordering is chosen by an if/elif chain over regex query classifiers, selecting one of seven
+mutually exclusive stabilizers:
 
-| Stabilizer | Definition | Direct test coverage |
-| --- | --- | --- |
-| `_stabilize_fact_frame_ranking` | 1893 | none |
-| `_stabilize_preference_ranking` | 1839 | none |
-| `_stabilize_evidence_set_ranking` | 1850 | none |
-| `_stabilize_artifact_evidence_ranking` | 1872 | none |
-| `_stabilize_temporal_evidence_ranking` | 1862 | none |
-| `_rank_preserving_window` | 1789 | none |
-| `_stabilize_top_window_ranking` | 1943 | none |
-| `_apply_evidence_cluster_affinity` | 1682 | none |
-| `_stabilize_explicit_anchor_ranking` | 1798 | `tests/test_retrieval_advanced.py:429,449,471` |
+| Stabilizer                             | Definition | Direct test coverage                           |
+| -------------------------------------- | ---------- | ---------------------------------------------- |
+| `_stabilize_fact_frame_ranking`        | 1893       | none                                           |
+| `_stabilize_preference_ranking`        | 1839       | none                                           |
+| `_stabilize_evidence_set_ranking`      | 1850       | none                                           |
+| `_stabilize_artifact_evidence_ranking` | 1872       | none                                           |
+| `_stabilize_temporal_evidence_ranking` | 1862       | none                                           |
+| `_rank_preserving_window`              | 1789       | none                                           |
+| `_stabilize_top_window_ranking`        | 1943       | none                                           |
+| `_apply_evidence_cluster_affinity`     | 1682       | none                                           |
+| `_stabilize_explicit_anchor_ranking`   | 1798       | `tests/test_retrieval_advanced.py:429,449,471` |
 
-Verified by grepping each name across `packages/python/sibyl-core/tests`,
-`apps/*/tests`, and `tools/tests`. Only the explicit-anchor stabilizer has direct
-tests. The branch *selection* logic (which classifier wins when a query matches two
-patterns, e.g. a preference query that is also a temporal-instruction query) has no
-test at all. The only dedicated `query_ranking` test file,
-`tests/test_query_ranking_semantic_rescue.py` (104 lines), tests the dead experiment
-arm described in M9.
+Verified by grepping each name across `packages/python/sibyl-core/tests`, `apps/*/tests`, and
+`tools/tests`. Only the explicit-anchor stabilizer has direct tests. The branch _selection_ logic
+(which classifier wins when a query matches two patterns, e.g. a preference query that is also a
+temporal-instruction query) has no test at all. The only dedicated `query_ranking` test file,
+`tests/test_query_ranking_semantic_rescue.py` (104 lines), tests the dead experiment arm described
+in M9.
 
-Why it matters: these branches decide the final order of every search result in the
-product, and the invariants they encode ("a preference query must not let a generic
-assistant turn outrank the user's own statement") live only in the code. Any 1.3
-refactor will break them silently.
+Why it matters: these branches decide the final order of every search result in the product, and the
+invariants they encode ("a preference query must not let a generic assistant turn outrank the user's
+own statement") live only in the code. Any 1.3 refactor will break them silently.
 
 Fix: M (characterization tests per branch before any rewrite). Severity: major.
 
@@ -445,144 +423,135 @@ Fix: M (characterization tests per branch before any rewrite). Severity: major.
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:1148, 1395-1407`
 
-`rank_by_query_coverage(..., semantic_prior_rescue_weight: float = 0.0)` plus a
-13-line scoring block guarded by `if semantic_prior_rescue_weight > 0.0`.
+`rank_by_query_coverage(..., semantic_prior_rescue_weight: float = 0.0)` plus a 13-line scoring
+block guarded by `if semantic_prior_rescue_weight > 0.0`.
 
-`rank_items_by_query_coverage` — the *only* entry point used by either production
-pipeline (`search.py:41`, `hybrid.py:155`) — does not accept or forward the parameter
-(signature at `query_ranking.py:816-824`). The arm is therefore unreachable from every
-production caller. Every non-test reference is under `benchmarks/`
-(`longmemeval_v2_official.py:92,743,936`, `longmemeval_v2_live_retrieval.py:77,327`,
-`longmemeval_v2_memory/sibyl_memory.py` in eight places) plus
-`tests/test_query_ranking_semantic_rescue.py`.
+`rank_items_by_query_coverage` — the _only_ entry point used by either production pipeline
+(`search.py:41`, `hybrid.py:155`) — does not accept or forward the parameter (signature at
+`query_ranking.py:816-824`). The arm is therefore unreachable from every production caller. Every
+non-test reference is under `benchmarks/` (`longmemeval_v2_official.py:92,743,936`,
+`longmemeval_v2_live_retrieval.py:77,327`, `longmemeval_v2_memory/sibyl_memory.py` in eight places)
+plus `tests/test_query_ranking_semantic_rescue.py`.
 
-This matches the recorded verdict that the additive arm was NO-GO at reader level.
-The residue is a parameter, a scoring branch, and a 104-line test file living in the
-hottest function in the subsystem.
+This matches the recorded verdict that the additive arm was NO-GO at reader level. The residue is a
+parameter, a scoring branch, and a 104-line test file living in the hottest function in the
+subsystem.
 
-Fix: S. Severity: major (it is small, but it is exactly the accreted-arm class the
-1.3 map is meant to surface).
+Fix: S. Severity: major (it is small, but it is exactly the accreted-arm class the 1.3 map is meant
+to surface).
 
 ### M10. Cross-encoder reranking: 531 lines, off by default, one branch dead entirely
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/reranking.py`
 
-- `cohere_rerank` (`reranking.py:443-531`, ~88 lines) has **zero** call sites anywhere
-  in the repo — not in `packages/`, `apps/`, `benchmarks/`, `tools/`, or any test. It
-  also reads `COHERE_API_KEY` directly from `os.environ` (`reranking.py:469`),
-  bypassing `CoreConfig` entirely.
-- `rerank_results` / `cross_encoder_rerank` are reachable from exactly one production
-  site, `hybrid.py:797-807`, behind `config.apply_reranking`, which is fed from
-  `core_config.rerank_enabled` (`tools/search.py:1067`), default `False`
-  (`config.py:303`). Re-ranking was screened and refuted.
-- The feature-weighted reranker (`fit_feature_weighted_reranker`,
-  `rerank_by_feature_weights`, `FeatureWeightedRerankModel`) is used only by
-  `sibyl_core/evals/longmemeval_replay.py:221-577`. That is benchmark machinery
-  shipping inside the published `sibyl-core` package, not a dev-only tree.
-- The knob is declared three times: `CoreConfig.rerank_model` / `rerank_top_k`
-  (`config.py:311,315`) and again as `HybridConfig.rerank_model` / `rerank_top_k`
-  (`hybrid.py:191-192`) with an independently-hardcoded default model string.
+- `cohere_rerank` (`reranking.py:443-531`, ~88 lines) has **zero** call sites anywhere in the repo —
+  not in `packages/`, `apps/`, `benchmarks/`, `tools/`, or any test. It also reads `COHERE_API_KEY`
+  directly from `os.environ` (`reranking.py:469`), bypassing `CoreConfig` entirely.
+- `rerank_results` / `cross_encoder_rerank` are reachable from exactly one production site,
+  `hybrid.py:797-807`, behind `config.apply_reranking`, which is fed from
+  `core_config.rerank_enabled` (`tools/search.py:1067`), default `False` (`config.py:303`).
+  Re-ranking was screened and refuted.
+- The feature-weighted reranker (`fit_feature_weighted_reranker`, `rerank_by_feature_weights`,
+  `FeatureWeightedRerankModel`) is used only by `sibyl_core/evals/longmemeval_replay.py:221-577`.
+  That is benchmark machinery shipping inside the published `sibyl-core` package, not a dev-only
+  tree.
+- The knob is declared three times: `CoreConfig.rerank_model` / `rerank_top_k` (`config.py:311,315`)
+  and again as `HybridConfig.rerank_model` / `rerank_top_k` (`hybrid.py:191-192`) with an
+  independently-hardcoded default model string.
 
-Fix: M (delete `cohere_rerank` outright; decide whether the cross-encoder hook survives
-1.3; move `evals/` out of the shipped package or behind an extra). Severity: major.
+Fix: M (delete `cohere_rerank` outright; decide whether the cross-encoder hook survives 1.3; move
+`evals/` out of the shipped package or behind an extra). Severity: major.
 
 ### M11. Structure is fetched and persisted but never scored
 
 Three cases, each verified by grepping read sites:
 
-1. **Entity type never enters ranking.** `rank_by_query_coverage` receives only
-   `text`, `prior_score`, `original_rank`, `timestamp`
-   (`QueryCoverageCandidate`, `query_ranking.py:709-716`). The candidate's
-   `entity_type` is resolved at `search.py:2334` and `2621`, carried through
-   `RetrievalCandidate`, used for *filtering* (`_candidate_matches_types`, 2727) and
-   for facet assignment, and never for scoring. The only type-aware ranking in the
-   whole subsystem is `_LINEAGE_TYPE_RANK` (`tools/context.py:700-719`), which runs at
-   pack-assembly time for dedup, not retrieval.
-2. **Relationship weights never reach the fused score.**
-   `_graph_expansion_path_score` (`search.py:2181`) computes a score from the 23-entry
-   `_GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS` table times `_GRAPH_EXPANSION_DEPTH_DECAY`,
-   stores it on the candidate, and `rrf_merge` then ignores the magnitude
-   (`fusion.py:126`). The table only controls intra-lane ordering; any monotone
-   relabeling of those 23 numbers produces an identical fused result.
-3. **Vector cosine magnitude is discarded the same way.** A 0.95 match and a 0.31
-   match at the same rank in the vector lane contribute identically to fusion.
-   `RetrievalPlan.vector_min_score` (`search.py:225`) is the only magnitude gate, and
-   it is never set to anything but its `0.0` default (grep: the only writes are the
-   four read sites at `search.py:1413,1446,1497,1526`).
+1. **Entity type never enters ranking.** `rank_by_query_coverage` receives only `text`,
+   `prior_score`, `original_rank`, `timestamp` (`QueryCoverageCandidate`,
+   `query_ranking.py:709-716`). The candidate's `entity_type` is resolved at `search.py:2334` and
+   `2621`, carried through `RetrievalCandidate`, used for _filtering_
+   (`_candidate_matches_types`, 2727) and for facet assignment, and never for scoring. The only
+   type-aware ranking in the whole subsystem is `_LINEAGE_TYPE_RANK` (`tools/context.py:700-719`),
+   which runs at pack-assembly time for dedup, not retrieval.
+2. **Relationship weights never reach the fused score.** `_graph_expansion_path_score`
+   (`search.py:2181`) computes a score from the 23-entry `_GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS`
+   table times `_GRAPH_EXPANSION_DEPTH_DECAY`, stores it on the candidate, and `rrf_merge` then
+   ignores the magnitude (`fusion.py:126`). The table only controls intra-lane ordering; any
+   monotone relabeling of those 23 numbers produces an identical fused result.
+3. **Vector cosine magnitude is discarded the same way.** A 0.95 match and a 0.31 match at the same
+   rank in the vector lane contribute identically to fusion. `RetrievalPlan.vector_min_score`
+   (`search.py:225`) is the only magnitude gate, and it is never set to anything but its `0.0`
+   default (grep: the only writes are the four read sites at `search.py:1413,1446,1497,1526`).
 
-Fix: L (this is a design question for 1.3, not a patch). Severity: major — it is the
-mechanism by which "we have a knowledge graph" fails to become "the graph structure
-improves ranking".
+Fix: L (this is a design question for 1.3, not a patch). Severity: major — it is the mechanism by
+which "we have a knowledge graph" fails to become "the graph structure improves ranking".
 
 ### M12. RetrievalPlan fields frozen at their defaults
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:202-227`
 
-`build_context_retrieval_plan` (276-364) is the only plan constructor, and
-`context_search` mutates the plan only via
-`replace(plan, candidate_limits=...)` (`search.py:385-388`). Fields never set by any
-caller:
+`build_context_retrieval_plan` (276-364) is the only plan constructor, and `context_search` mutates
+the plan only via `replace(plan, candidate_limits=...)` (`search.py:385-388`). Fields never set by
+any caller:
 
 - `signals` (212) — always all 8 lanes; the per-lane disable path exists and is unused.
-- `graph_expansion_depth` (224) — always 1, so the `max_depth` loop in
-  `_node_bfs_records` always runs exactly one iteration and the BFS frontier logic
-  at `search.py:1765-1770` is unreachable.
+- `graph_expansion_depth` (224) — always 1, so the `max_depth` loop in `_node_bfs_records` always
+  runs exactly one iteration and the BFS frontier logic at `search.py:1765-1770` is unreachable.
 - `vector_min_score` (225) — always 0.0.
 - `filter_selectivity_threshold` (227) — always `DEFAULT_FILTER_SELECTIVITY_THRESHOLD`.
 
-Fix: S (either wire them or delete them). Severity: major — four knobs that read as
-tunable in every code review and are not.
+Fix: S (either wire them or delete them). Severity: major — four knobs that read as tunable in every
+code review and are not.
 
 ### M13. Operational passages never stamp `passage_covers_parent`, so parent
+
 suppression is inert for half the corpus
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/experience.py:490-506`
 against `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/context.py:1294`
 
-`_suppress_parents_of_passages` gates on
-`if not metadata.get(PASSAGE_COVERS_PARENT_KEY): continue`. Repo-wide grep for that key
-finds writes only in the **prose** projection (`passages.py:258` sets it `True`,
-`passages.py:289` sets it `False`). The operational projection's passage metadata block
+`_suppress_parents_of_passages` gates on `if not metadata.get(PASSAGE_COVERS_PARENT_KEY): continue`.
+Repo-wide grep for that key finds writes only in the **prose** projection (`passages.py:258` sets it
+`True`, `passages.py:289` sets it `False`). The operational projection's passage metadata block
 never writes it at all.
 
-Consequence: every operational passage fails the gate on line one, so the
-`raw_observation` parent it was cut from is never suppressed even when the whole part
-is present in the pack. Both copies of the same text spend the reader's char budget —
-the specific defect the slice substrate exists to kill, and a plausible contributor to
-the "1/3-spent char budget" symptom.
+Consequence: every operational passage fails the gate on line one, so the `raw_observation` parent
+it was cut from is never suppressed even when the whole part is present in the pack. Both copies of
+the same text spend the reader's char budget — the specific defect the slice substrate exists to
+kill, and a plausible contributor to the "1/3-spent char budget" symptom.
 
 The `/context` evidence-expansion path is unaffected: `_finest_granularity_units`
-(`retrieval/operational_sources.py:358-372`) dedupes correctly on its own. The leak is
-confined to search and context-pack assembly, which is the main read surface.
+(`retrieval/operational_sources.py:358-372`) dedupes correctly on its own. The leak is confined to
+search and context-pack assembly, which is the main read surface.
 
 Fix: M (stamp the key in `experience.py`, plus a backfill). Severity: major.
 
 ### M14. Passages do not inherit `retrieval_keys`, so the exact-key lane can only
+
 return the fat parent
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/passages.py:718-731`
 (`_inherited_scope_metadata`), copying the key list at `passages.py:85-93`
 
-`_SCOPE_METADATA_KEYS` covers memory scope only. `retrieval_keys` is stamped on the
-parent (`tools/add.py:493`) and promoted to the indexed column
-(`services/graph.py:3055-3057`). The exact-key lane queries
-`retrieval_keys_normalized CONTAINSANY $probe_keys` (`retrieval/search.py:1086`), and
-passages carry no value in that column, so a passage can never match a writer-declared
-key.
+`_SCOPE_METADATA_KEYS` covers memory scope only. `retrieval_keys` is stamped on the parent
+(`tools/add.py:493`) and promoted to the indexed column (`services/graph.py:3055-3057`). The
+exact-key lane queries `retrieval_keys_normalized CONTAINSANY $probe_keys`
+(`retrieval/search.py:1086`), and passages carry no value in that column, so a passage can never
+match a writer-declared key.
 
-Net effect: for the single highest-precision query class the system supports, retrieval
-returns the whole fat memory and the passage substrate contributes nothing. This
-directly undercuts the 1.2 headline. Zero test coverage on either side: no
-`retrieval_keys` occurrence in `tests/test_projection_passages.py`, no passage-shaped
-case in `tests/test_retrieval_exact_key_arm.py`.
+Net effect: for the single highest-precision query class the system supports, retrieval returns the
+whole fat memory and the passage substrate contributes nothing. This directly undercuts the 1.2
+headline. Zero test coverage on either side: no `retrieval_keys` occurrence in
+`tests/test_projection_passages.py`, no passage-shaped case in
+`tests/test_retrieval_exact_key_arm.py`.
 
-Fix: M. The interesting 1.3 design question is whether keys inherit wholesale or only
-onto the span whose text contains them. Severity: major.
+Fix: M. The interesting 1.3 design question is whether keys inherit wholesale or only onto the span
+whose text contains them. Severity: major.
 
 ### M15. Two divergent passage metadata contracts under one entity type
 
-`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py:138-141`
-papers over the split at the read site:
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py:138-141` papers
+over the split at the read site:
 
 ```python
 def _passage_total(metadata):
@@ -592,19 +561,19 @@ def _passage_total(metadata):
 
 The full divergence, all on rows of the same `EntityType.PASSAGE`:
 
-| concept | prose (`projection/passages.py`) | operational (`projection/experience.py`) |
-| --- | --- | --- |
-| total | `passage_total` (254) | `passage_count` (500) |
-| cut reason | `passage_cut_reason` (256) | `passage_reason` (502) |
-| trail | `passage_breadcrumb` (255) | absent |
-| coverage | `passage_covers_parent` (258) | absent |
-| plan provenance | `passage_plan` (257) | absent |
-| line offsets | absent | `passage_line_start`/`_end` (503-504) |
-| id scheme | `_generate_id` (117) | `_stable_id` (104) |
-| parent edge | `PART_OF` (269) | `DERIVED_FROM` (511) |
+| concept         | prose (`projection/passages.py`) | operational (`projection/experience.py`) |
+| --------------- | -------------------------------- | ---------------------------------------- |
+| total           | `passage_total` (254)            | `passage_count` (500)                    |
+| cut reason      | `passage_cut_reason` (256)       | `passage_reason` (502)                   |
+| trail           | `passage_breadcrumb` (255)       | absent                                   |
+| coverage        | `passage_covers_parent` (258)    | absent                                   |
+| plan provenance | `passage_plan` (257)             | absent                                   |
+| line offsets    | absent                           | `passage_line_start`/`_end` (503-504)    |
+| id scheme       | `_generate_id` (117)             | `_stable_id` (104)                       |
+| parent edge     | `PART_OF` (269)                  | `DERIVED_FROM` (511)                     |
 
-Every read-side consumer must know both shapes or silently handle one (M13 is exactly
-the case where a consumer handled one). No test pins the two schemas against each other.
+Every read-side consumer must know both shapes or silently handle one (M13 is exactly the case where
+a consumer handled one). No test pins the two schemas against each other.
 
 Fix: L. Severity: major — this is the largest single item on the 1.3 rearchitecture list.
 
@@ -619,73 +588,72 @@ if any(weights.values()): return weights
 return {term: 1 for term in query_terms}
 ```
 
-With a single group (`len(group_terms) == 1`), a **present** term scores `1 - 1 = 0`
-and an **absent** term scores `1 - 0 = 1`. A query mixing present and absent terms —
-the ordinary case — makes `any(weights.values())` true on the strength of the absent
-terms, so the uniform fallback never fires and every present term carries weight zero.
+With a single group (`len(group_terms) == 1`), a **present** term scores `1 - 1 = 0` and an
+**absent** term scores `1 - 0 = 1`. A query mixing present and absent terms — the ordinary case —
+makes `any(weights.values())` true on the strength of the absent terms, so the uniform fallback
+never fires and every present term carries weight zero.
 
-Downstream `_weighted_term_match` (`operational_sources.py:584-589`) returns 0 for every
-entity and `_select_window_entities` (536-546) falls through entirely to the positional
-tie-break: representative selection inside the window becomes query-blind. Absent terms
-also inflate the `total_weight` denominator in `_window_coverage_score` (573), diluting
-coverage by terms that could never match.
+Downstream `_weighted_term_match` (`operational_sources.py:584-589`) returns 0 for every entity and
+`_select_window_entities` (536-546) falls through entirely to the positional tie-break:
+representative selection inside the window becomes query-blind. Absent terms also inflate the
+`total_weight` denominator in `_window_coverage_score` (573), diluting coverage by terms that could
+never match.
 
-Fix: S (`len(group_terms) - df + 1`, or fall back to uniform when every *present* term
-weighs 0). Severity: major.
+Fix: S (`len(group_terms) - df + 1`, or fall back to uniform when every _present_ term weighs 0).
+Severity: major.
 
 ### M17. `restamp_entity_passages` does 64 sequential graph reads per scope-touching
+
 update, including on memories with no passages
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/passages.py:497-529`
 
-`for index in range(MAX_PASSAGES_PER_SOURCE)` with an `await get(passage_id)` inside and
-no early exit — deliberately, since the comment at 473-475 explains it must reach past
-an index gap. Sixty-four sequential round trips.
+`for index in range(MAX_PASSAGES_PER_SOURCE)` with an `await get(passage_id)` inside and no early
+exit — deliberately, since the comment at 473-475 explains it must reach past an index gap.
+Sixty-four sequential round trips.
 
 The two callers disagree about when to pay that:
 
 - Job path (`apps/api/src/sibyl/jobs/entities.py:1421-1432`) triggers on
-  `scope_bearing_entity_update(updates)` (`passages.py:427-439`), which is
-  **presence-based, not change-based**: any update mentioning one of seven keys,
-  including `project_id` and `source_id`, fires it. A 200-char note with zero passages
-  updated with a `project_id` in the patch pays 64 sequential reads.
+  `scope_bearing_entity_update(updates)` (`passages.py:427-439`), which is **presence-based, not
+  change-based**: any update mentioning one of seven keys, including `project_id` and `source_id`,
+  fires it. A 200-char note with zero passages updated with a `project_id` in the patch pays 64
+  sequential reads.
 - Route path (`apps/api/src/sibyl/api/routes/entities.py:2444`) diffs
   `entity_scope_stamps(existing) != entity_scope_stamps(updated)` first.
 
 Two cost profiles for the same function with no stated reason.
 
-Fix: M (batch through `get_many`; make the job trigger diff-based like the route).
-Severity: major.
+Fix: M (batch through `get_many`; make the job trigger diff-based like the route). Severity: major.
 
 ### M18. Ten passage/projection metadata keys are written on every row and read by nobody
 
 Each verified by grep for non-test read sites; every hit below is the write itself.
 
-| key | write site | reads |
-| --- | --- | --- |
-| `support_spans` | `experience.py:688,733,773` | 0 |
-| `passage_cut_reason` | `passages.py:256` | 0 |
-| `passage_plan` | `passages.py:257` | 0 |
-| `passage_cut_depth` | `experience.py:501` | 0 |
-| `passage_reason` | `experience.py:502` | 0 |
-| `passage_line_start` / `_end` | `experience.py:503-504` | 0 |
-| `ui_inventory_item_count` / `_truncated` | `experience.py:689-690` | 0 |
-| `evidence_part_count` | `experience.py:633` | 0 |
-| `procedure_part_count` | `experience.py:730` | 0 |
-| `resolution_status: "unknown"` | `experience.py:771` | 0 (literal constant) |
+| key                                      | write site                  | reads                |
+| ---------------------------------------- | --------------------------- | -------------------- |
+| `support_spans`                          | `experience.py:688,733,773` | 0                    |
+| `passage_cut_reason`                     | `passages.py:256`           | 0                    |
+| `passage_plan`                           | `passages.py:257`           | 0                    |
+| `passage_cut_depth`                      | `experience.py:501`         | 0                    |
+| `passage_reason`                         | `experience.py:502`         | 0                    |
+| `passage_line_start` / `_end`            | `experience.py:503-504`     | 0                    |
+| `ui_inventory_item_count` / `_truncated` | `experience.py:689-690`     | 0                    |
+| `evidence_part_count`                    | `experience.py:633`         | 0                    |
+| `procedure_part_count`                   | `experience.py:730`         | 0                    |
+| `resolution_status: "unknown"`           | `experience.py:771`         | 0 (literal constant) |
 
 `support_spans` is the fattest: a nested dict per observation carrying `image_refs` and
-`evidence_part_ids` lists, on every transition, procedure, and failure row. I confirmed
-its three writes and zero reads directly.
+`evidence_part_ids` lists, on every transition, procedure, and failure row. I confirmed its three
+writes and zero reads directly.
 
 `passage_plan` is worth calling out separately because the constant block's own comment
-(`passages.py:43-45`) justifies it as needed by "the replay job and any audit of
-retrievability" — and `apps/api/src/sibyl/jobs/probes.py` never mentions it.
+(`passages.py:43-45`) justifies it as needed by "the replay job and any audit of retrievability" —
+and `apps/api/src/sibyl/jobs/probes.py` never mentions it.
 
-Why it matters beyond tidiness: row size feeds lexical document length, and
-`_passage_description`'s own docstring (`experience.py:305-310`) names that as "the
-dilution mechanism Stage 1 named". These keys are paying a ranking cost for zero
-retrieval value.
+Why it matters beyond tidiness: row size feeds lexical document length, and `_passage_description`'s
+own docstring (`experience.py:305-310`) names that as "the dilution mechanism Stage 1 named". These
+keys are paying a ranking cost for zero retrieval value.
 
 Fix: S each, M as a sweep. Severity: major in aggregate.
 
@@ -693,80 +661,76 @@ Fix: S each, M as a sweep. Severity: major in aggregate.
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py:1013-1091`
 
-Plan runs four searches, up to 100 neighborhood expansions, and per-section scoring to
-build `source_packs` and `source_ids`. Materialize then overwrites `source_packs`
-wholesale (642-672) and overwrites each section's `source_ids` via
-`replace(section, source_ids=source_ids, ...)` (641). The only surviving product of all
-that work is the presence of a `no_source_supports_requested_section` gap — which
-materialize's own `no_materialized_sources` gap (628-635) already covers.
+Plan runs four searches, up to 100 neighborhood expansions, and per-section scoring to build
+`source_packs` and `source_ids`. Materialize then overwrites `source_packs` wholesale (642-672) and
+overwrites each section's `source_ids` via `replace(section, source_ids=source_ids, ...)` (641). The
+only surviving product of all that work is the presence of a `no_source_supports_requested_section`
+gap — which materialize's own `no_materialized_sources` gap (628-635) already covers.
 
-This is the largest single latency item in the synthesis slice: an expensive fan-out
-whose sole output is a duplicate gap flag.
+This is the largest single latency item in the synthesis slice: an expensive fan-out whose sole
+output is a duplicate gap flag.
 
-Fix: M, and it needs a decision rather than a patch — either delete plan's selection
-half, or make materialize merge instead of replace. Severity: major, and it gates M20.
+Fix: M, and it needs a decision rather than a patch — either delete plan's selection half, or make
+materialize merge instead of replace. Severity: major, and it gates M20.
 
 ### M20. 116 sequential round trips on one `/synthesis/draft`
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py`
 
 - `309-321` — 4 sequential `search_fn` calls.
-- `331-339` — one `related_fn` call per entity id, capped at 100
-  (`MAX_EXPLICIT_NEIGHBORHOOD_IDS`, line 134), fully serial.
-- `544-557` — one `context_fn` call per outline section, serial; up to 12 sections
-  (line 345), 5 for a handbook.
+- `331-339` — one `related_fn` call per entity id, capped at 100 (`MAX_EXPLICIT_NEIGHBORHOOD_IDS`,
+  line 134), fully serial.
+- `544-557` — one `context_fn` call per outline section, serial; up to 12 sections (line 345), 5 for
+  a handbook.
 
-Worst case 4 + 100 + 12 = 116 serialized round trips for a single draft. This sits
-directly behind the measured clean-server latency miss.
+Worst case 4 + 100 + 12 = 116 serialized round trips for a single draft. This sits directly behind
+the measured clean-server latency miss.
 
-Fix: S for the search and context loops (`asyncio.gather` with a semaphore); M for the
-neighborhood loop if bounded concurrency is wanted. Severity: major.
+Fix: S for the search and context loops (`asyncio.gather` with a semaphore); M for the neighborhood
+loop if bounded concurrency is wanted. Severity: major.
 
 ### M21. Untrusted web content is interpolated into the distillation prompt unfenced
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/operational_distillation.py:85-125`
 feeding the template at `:54-65`
 
-`build_operational_experience_digest` inlines `Goal:`, `Outcome:`, `Action:`,
-`Reasoning:`, and accessibility-tree node text straight into `_PROMPT_TEMPLATE` under a
-bare `Trajectory digest:` label. No delimiter, no escaping, no instruction-boundary
-marker. `_clean` (`:293`) only collapses whitespace.
+`build_operational_experience_digest` inlines `Goal:`, `Outcome:`, `Action:`, `Reasoning:`, and
+accessibility-tree node text straight into `_PROMPT_TEMPLATE` under a bare `Trajectory digest:`
+label. No delimiter, no escaping, no instruction-boundary marker. `_clean` (`:293`) only collapses
+whitespace.
 
-For a browsing agent that content is fully attacker-controlled, and the model's output
-lands in the graph as an `EntityType.NOTE` titled "Observed environment facts"
-(`:224`) that future agents read as ground truth. The `.format()` call at `:129` is
-safe (the digest is an argument, not the template), so the exposure is instruction
-injection, not brace injection.
+For a browsing agent that content is fully attacker-controlled, and the model's output lands in the
+graph as an `EntityType.NOTE` titled "Observed environment facts" (`:224`) that future agents read
+as ground truth. The `.format()` call at `:129` is safe (the digest is an argument, not the
+template), so the exposure is instruction injection, not brace injection.
 
-Fix: M — fence the digest and add an explicit data-not-instructions boundary. Worth a
-design conversation: fencing alone does not fully close indirect injection from browsed
-pages. Severity: major.
+Fix: M — fence the digest and add an explicit data-not-instructions boundary. Worth a design
+conversation: fencing alone does not fully close indirect injection from browsed pages. Severity:
+major.
 
 ### M22. Batch extraction prompt permits in-batch source attribution spoofing
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/memory_extraction.py:64-98`
 
-`build_memory_batch_entity_extraction_prompt` emits `source_id: X` / `content:` blocks
-separated by `\n\n---\n\n`, with raw unescaped content at line 84. A memory whose body
-contains its own `source_id: <other>` line can be attributed to a different source in
-the same batch. The consuming job's guard
-(`apps/api/src/sibyl/jobs/memory_extraction.py:275-284`) rejects only **unknown** source
+`build_memory_batch_entity_extraction_prompt` emits `source_id: X` / `content:` blocks separated by
+`\n\n---\n\n`, with raw unescaped content at line 84. A memory whose body contains its own
+`source_id: <other>` line can be attributed to a different source in the same batch. The consuming
+job's guard (`apps/api/src/sibyl/jobs/memory_extraction.py:275-284`) rejects only **unknown** source
 ids, so a swap between two ids that are both legitimately in the batch passes clean.
 
-Fix: S — escape or fence the content, or return per-block indices instead of echoing ids.
-Severity: major.
+Fix: S — escape or fence the content, or return per-block indices instead of echoing ids. Severity:
+major.
 
 ### M23. Distilled operational notes are truncated mid-sentence with no marker
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/operational_distillation.py:60-61`
 vs `:20, 226`
 
-The prompt authorizes up to 10 facts x 300 chars plus a 900-char workflow. Storage clips
-at `MAX_OPERATIONAL_NOTE_CHARS = 1_600` with a bare slice:
-`content=f"{header}\n\n{body}"[:MAX_OPERATIONAL_NOTE_CHARS]`. A full facts note runs
-header (~200) + 28 + ~3,020 ≈ 3,250 chars, so roughly half is dropped silently. The
-digest truncation at `:125` does mark itself; this one does not. The two budgets
-contradict each other by a factor of two.
+The prompt authorizes up to 10 facts x 300 chars plus a 900-char workflow. Storage clips at
+`MAX_OPERATIONAL_NOTE_CHARS = 1_600` with a bare slice:
+`content=f"{header}\n\n{body}"[:MAX_OPERATIONAL_NOTE_CHARS]`. A full facts note runs header (~200) +
+28 + ~3,020 ≈ 3,250 chars, so roughly half is dropped silently. The digest truncation at `:125` does
+mark itself; this one does not. The two budgets contradict each other by a factor of two.
 
 Fix: S. Severity: major.
 
@@ -775,9 +739,9 @@ Fix: S. Severity: major.
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py:489-492`
 
 Bare `except Exception`, log a warning, return `[]`. With an empty prior list,
-`apply_reflection_lifecycle_decisions` finds no duplicates, no supersessions, no stale
-targets, and no contradictions — so every candidate persists as clean and new. The
-`ReflectionPack` carries no degradation marker, so the caller cannot tell.
+`apply_reflection_lifecycle_decisions` finds no duplicates, no supersessions, no stale targets, and
+no contradictions — so every candidate persists as clean and new. The `ReflectionPack` carries no
+degradation marker, so the caller cannot tell.
 
 Same shape as M7 (`compile_context`) and the same fix: a receipt.
 
@@ -786,30 +750,31 @@ Fix: S (stamp `lifecycle_check_degraded` into candidate metadata). Severity: maj
 ### M25. LLM telemetry records literal placeholders instead of provider and model
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py:76-82, 88-94`
-and `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/llm/generator.py:49-55, 58-64, 83-89, 91-97`
+and
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/llm/generator.py:49-55, 58-64, 83-89, 91-97`
 
-Every metric records `provider="runtime"` and `model=self.model_override or "default"`.
-The extractor has the true values two lines later — `_extraction_usage` (`:139-149`)
-pulls `provider_name` and `model_name` off the responses. Per-model cost and latency
-breakdown is impossible from these metrics, on the only paid path in the system.
+Every metric records `provider="runtime"` and `model=self.model_override or "default"`. The
+extractor has the true values two lines later — `_extraction_usage` (`:139-149`) pulls
+`provider_name` and `model_name` off the responses. Per-model cost and latency breakdown is
+impossible from these metrics, on the only paid path in the system.
 
 Fix: S for the extractor. Severity: major.
 
 ### M26. Budget enforcement is a one-way estimate that is never reconciled
 
-`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/llm/budget.py:78-100`
-and `/Users/bliss/dev/sibyl/apps/api/src/sibyl/ai/llm/budget.py:37-101`
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/llm/budget.py:78-100` and
+`/Users/bliss/dev/sibyl/apps/api/src/sibyl/ai/llm/budget.py:37-101`
 
-`reserve_llm_budget` charges `estimate_llm_tokens` = `len(text)//4 + (output_token_limit
-or 0)`. `DBLLMBudgetEnforcer` increments the bucket and stops — there is no settle,
-commit, or refund anywhere in the protocol. Two consequences:
+`reserve_llm_budget` charges `estimate_llm_tokens` = `len(text)//4 + (output_token_limit or 0)`.
+`DBLLMBudgetEnforcer` increments the bucket and stops — there is no settle, commit, or refund
+anywhere in the protocol. Two consequences:
 
-- When `max_tokens is None` (the `Generator.generate` default, and any `Extractor`
-  without an explicit cap) the output side is charged **zero**.
+- When `max_tokens is None` (the `Generator.generate` default, and any `Extractor` without an
+  explicit cap) the output side is charged **zero**.
 - When `max_tokens` is set, the full cap is charged even if the model returns 20 tokens.
 
-`ExtractionUsage` carries the real counts and both jobs log them; nothing feeds them
-back. Drift is unbounded and monotonic in both directions depending on call shape.
+`ExtractionUsage` carries the real counts and both jobs log them; nothing feeds them back. Drift is
+unbounded and monotonic in both directions depending on call shape.
 
 Fix: M (add a `settle` hook to the `LLMBudgetEnforcer` protocol). Severity: major.
 
@@ -817,37 +782,36 @@ Fix: M (add a `settle` hook to the `LLMBudgetEnforcer` protocol). Severity: majo
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/models/synthesis.py:57,66`
 
-Both are threaded through the CLI (`apps/cli/src/sibyl_cli/client.py:1899`), the MCP
-server (`apps/api/src/sibyl/server.py:906,951,996`), the REST schema
+Both are threaded through the CLI (`apps/cli/src/sibyl_cli/client.py:1899`), the MCP server
+(`apps/api/src/sibyl/server.py:906,951,996`), the REST schema
 (`apps/api/src/sibyl/api/schemas/synthesis.py:33`), and the tool wrappers
-(`tools/synthesis.py:50,116,167,219`). The only read anywhere is the field-for-field
-copy inside `plan_synthesis` at `synthesis.py:986` and `:995` — I verified this by grep;
-no scoring, rendering, retrieval, or prompt code touches either.
+(`tools/synthesis.py:50,116,167,219`). The only read anywhere is the field-for-field copy inside
+`plan_synthesis` at `synthesis.py:986` and `:995` — I verified this by grep; no scoring, rendering,
+retrieval, or prompt code touches either.
 
-Both also feed `_run_id` (`synthesis.py:442-445`, `repr(asdict(request))`), so flipping
-`depth=deep` mints a fresh run id for byte-identical output — an advertised knob whose
-only observable effect is a cache miss.
+Both also feed `_run_id` (`synthesis.py:442-445`, `repr(asdict(request))`), so flipping `depth=deep`
+mints a fresh run id for byte-identical output — an advertised knob whose only observable effect is
+a cache miss.
 
-Fix: S (delete, or wire `depth` to `max_sections` and per-section limits).
-Severity: major — an advertised knob that does nothing is worse than a missing one.
+Fix: S (delete, or wire `depth` to `max_sections` and per-section limits). Severity: major — an
+advertised knob that does nothing is worse than a missing one.
 
 ### M28. `synthesis_plan` reports gaps for sections that have sources
 
-`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/synthesis.py:148-155`
-and `/Users/bliss/dev/sibyl/apps/api/src/sibyl/api/routes/synthesis.py:156`
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/synthesis.py:148-155` and
+`/Users/bliss/dev/sibyl/apps/api/src/sibyl/api/routes/synthesis.py:156`
 
 Both return the materialized run without calling `apply_synthesis_verification`.
-`materialize_synthesis_section_packs:658-666` carries `run.verification.gaps` forward
-unfiltered, and only `verify_synthesis_run:706-711` drops absence gaps for sourceful
-sections. `synthesis_verify` and `synthesis_draft` call it (`tools/synthesis.py:206,267`);
-`synthesis_plan` does not.
+`materialize_synthesis_section_packs:658-666` carries `run.verification.gaps` forward unfiltered,
+and only `verify_synthesis_run:706-711` drops absence gaps for sourceful sections.
+`synthesis_verify` and `synthesis_draft` call it (`tools/synthesis.py:206,267`); `synthesis_plan`
+does not.
 
-The related defect: stale plan-stage gaps are permanent in the outline.
-`synthesis.py:637-641` builds `section_gaps = [*section.gaps, *materialization_gaps]` —
-plan's gaps are never re-evaluated, and `verify_synthesis_run` only recomputes
-`run.verification`, never `outline.sections[*].gaps`. So `synthesis_run_to_dict` always
-ships outline sections claiming `no_source_supports_requested_section` beside a
-populated `source_ids` list.
+The related defect: stale plan-stage gaps are permanent in the outline. `synthesis.py:637-641`
+builds `section_gaps = [*section.gaps, *materialization_gaps]` — plan's gaps are never re-evaluated,
+and `verify_synthesis_run` only recomputes `run.verification`, never `outline.sections[*].gaps`. So
+`synthesis_run_to_dict` always ships outline sections claiming
+`no_source_supports_requested_section` beside a populated `source_ids` list.
 
 Fix: S each. Severity: major (the plan endpoint lies about its own coverage).
 
@@ -855,19 +819,18 @@ Fix: S each. Severity: major (the plan endpoint lies about its own coverage).
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/providers.py:79-85`
 
-`_pin_snapshots()` gates `resolve_provider_model_id`. Repo-wide grep for
-`SIBYL_LLM_PIN_SNAPSHOTS` outside its own definition returns exactly one hit:
-`docs/_archive/SIBYL_LLM_SUBSTRATE_PLAN.md:308`, which claims "CI uses this." It is set
-in no workflow, chart, compose file, or Ansible role, and no test exercises it — so both
-branches of `resolve_provider_model_id:58-60` are unexercised.
+`_pin_snapshots()` gates `resolve_provider_model_id`. Repo-wide grep for `SIBYL_LLM_PIN_SNAPSHOTS`
+outside its own definition returns exactly one hit: `docs/_archive/SIBYL_LLM_SUBSTRATE_PLAN.md:308`,
+which claims "CI uses this." It is set in no workflow, chart, compose file, or Ansible role, and no
+test exercises it — so both branches of `resolve_provider_model_id:58-60` are unexercised.
 
-Even when set it is a no-op for three of six models: `claude-sonnet-4-6`
-(`ai/registry.py:148-152`), `gpt-5.4-mini` (`:207-211`), and `gpt-5.4-nano` (`:230-234`)
-all have `snapshot == alias == provider_model_id`. Only `claude-haiku-4-5` and the two
-Gemini entries carry real snapshots.
+Even when set it is a no-op for three of six models: `claude-sonnet-4-6` (`ai/registry.py:148-152`),
+`gpt-5.4-mini` (`:207-211`), and `gpt-5.4-nano` (`:230-234`) all have
+`snapshot == alias == provider_model_id`. Only `claude-haiku-4-5` and the two Gemini entries carry
+real snapshots.
 
-A reproducibility guarantee that does not hold is worse than none, especially for a
-project that runs benchmark comparisons across weeks.
+A reproducibility guarantee that does not hold is worse than none, especially for a project that
+runs benchmark comparisons across weeks.
 
 Fix: S to set the env in CI; M to add real snapshot ids. Severity: major.
 
@@ -880,23 +843,22 @@ Fix: S to set the env in CI; M to add real snapshot ids. Severity: major.
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/query_anchors.py:7-31, 42-43`
 
 `_NORMALIZED_TOKEN_ALIASES` is a 25-entry hand-written stem table with unmistakably
-LongMemEval-shaped vocabulary (`weddings`, `volunteered`, `subscribed`, `serviced`,
-`attended`), and lines 42-43 hardcode a correction for one misspelling:
+LongMemEval-shaped vocabulary (`weddings`, `volunteered`, `subscribed`, `serviced`, `attended`), and
+lines 42-43 hardcode a correction for one misspelling:
 
 ```python
 if token == "buisiness":
     return "business"
 ```
 
-This is the same dataset typo that appears in `query_ranking.py:617` (B1), now fixed in
-a second place. `query_anchors` is live in production ranking — imported by
+This is the same dataset typo that appears in `query_ranking.py:617` (B1), now fixed in a second
+place. `query_anchors` is live in production ranking — imported by
 `retrieval/query_ranking.py:900,1092,1196`, `retrieval/hybrid.py:113`, and
-`services/graph.py:166-207` — so a benchmark artifact shapes token normalization for
-every real user query.
+`services/graph.py:166-207` — so a benchmark artifact shapes token normalization for every real user
+query.
 
-Fix: S to delete the typo line; M to replace the alias table with a real stemmer.
-Severity: minor on its own, but it is B1's evidence that the overfit is not confined to
-one file.
+Fix: S to delete the typo line; M to replace the alias table with a real stemmer. Severity: minor on
+its own, but it is B1's evidence that the overfit is not confined to one file.
 
 ### m1. Test-only exports presented as public API
 
@@ -910,8 +872,8 @@ Exported in `__all__`, zero production call sites (verified by repo-wide grep):
   `tests/test_retrieval.py` and `apps/api/tests/test_retrieval.py`.
 - `FusionConfig` (`fusion.py:28`, `__init__.py:90`) — instantiated only in
   `tests/test_retrieval.py:412`.
-- `_vector_candidate_sources` (`search.py:1244`) — a wrapper whose only callers are
-  three sites in `tests/test_search.py`.
+- `_vector_candidate_sources` (`search.py:1244`) — a wrapper whose only callers are three sites in
+  `tests/test_search.py`.
 
 Fix: S each. Severity: minor.
 
@@ -919,24 +881,23 @@ Fix: S each. Severity: minor.
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:2881,2889`
 
-`score_by_id` is a `defaultdict(float)` but line 2889 **assigns** rather than adds, and
-does so once per (lane, candidate) pair — so for a candidate found by four lanes the
-same value is written four times. The `defaultdict` and the repetition are both
-vestigial; the shape suggests this was an accumulating fusion before RRF moved into
-`rrf_merge`. Harmless today, actively misleading to read.
+`score_by_id` is a `defaultdict(float)` but line 2889 **assigns** rather than adds, and does so once
+per (lane, candidate) pair — so for a candidate found by four lanes the same value is written four
+times. The `defaultdict` and the repetition are both vestigial; the shape suggests this was an
+accumulating fusion before RRF moved into `rrf_merge`. Harmless today, actively misleading to read.
 
 Fix: S. Severity: minor.
 
 ### m3. Object identity used as a dictionary key across a re-ranking boundary
 
-`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:2999-3022`
-and `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:868-880`
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:2999-3022` and
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:868-880`
 
-Both `_apply_query_coverage_to_fused` and `rank_items_by_query_coverage` key metadata
-by `id(candidate)` and then look it up after the ranker has reordered the list. Correct
-today (the source list holds a strong reference for the whole window, so ids are
-stable and unique), but it silently breaks if the ranker ever copies, replaces, or
-re-wraps a candidate. The stable id is right there on the object.
+Both `_apply_query_coverage_to_fused` and `rank_items_by_query_coverage` key metadata by
+`id(candidate)` and then look it up after the ranker has reordered the list. Correct today (the
+source list holds a strong reference for the whole window, so ids are stable and unique), but it
+silently breaks if the ranker ever copies, replaces, or re-wraps a candidate. The stable id is right
+there on the object.
 
 Fix: S. Severity: minor.
 
@@ -949,11 +910,10 @@ reranked, _applied, _refined = rank_items_by_query_coverage(...)
 ```
 
 `hybrid_search` surfaces both flags as `query_coverage_rerank_applied` and
-`query_coverage_refinement_applied` in its metadata (`hybrid.py:881-882`).
-`context_search` throws them away, so the context-pack receipt cannot say whether the
-coverage rerank fired or whether the refinement pass was accepted. Given M2 (the pass
-always runs), this is the one receipt that would let you measure whether the second
-pass earns its cost.
+`query_coverage_refinement_applied` in its metadata (`hybrid.py:881-882`). `context_search` throws
+them away, so the context-pack receipt cannot say whether the coverage rerank fired or whether the
+refinement pass was accepted. Given M2 (the pass always runs), this is the one receipt that would
+let you measure whether the second pass earns its cost.
 
 Fix: S. Severity: minor, high leverage for the M2 decision.
 
@@ -961,68 +921,62 @@ Fix: S. Severity: minor, high leverage for the M2 decision.
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/embeddings/providers.py:606-617`
 
-Read straight from `os.getenv`, not through `CoreConfig`, so the
-`environment == "production"` validator in `config.py:220-232` (which does correctly
-forbid `memory://`) cannot see it. If the var leaks into a production process, every
-graph embedding becomes a SHA-256 derived vector and semantic retrieval degrades to
-noise while every health check stays green.
+Read straight from `os.getenv`, not through `CoreConfig`, so the `environment == "production"`
+validator in `config.py:220-232` (which does correctly forbid `memory://`) cannot see it. If the var
+leaks into a production process, every graph embedding becomes a SHA-256 derived vector and semantic
+retrieval degrades to noise while every health check stays green.
 
-The same module reads `SIBYL_GRAPH_EMBEDDING_PROVIDER`, `SIBYL_GRAPH_EMBEDDING_MODEL`,
-and `SIBYL_GRAPH_EMBEDDING_DIMENSIONS` directly (`providers.py:620,705,719`), each
-shadowing the corresponding `CoreConfig` field. `SIBYL_FUSION_BACKEND`
-(`search.py:266`) and `COHERE_API_KEY` (`reranking.py:469`) do the same. Six
-retrieval-relevant env vars bypass the settings object that validates the rest.
+The same module reads `SIBYL_GRAPH_EMBEDDING_PROVIDER`, `SIBYL_GRAPH_EMBEDDING_MODEL`, and
+`SIBYL_GRAPH_EMBEDDING_DIMENSIONS` directly (`providers.py:620,705,719`), each shadowing the
+corresponding `CoreConfig` field. `SIBYL_FUSION_BACKEND` (`search.py:266`) and `COHERE_API_KEY`
+(`reranking.py:469`) do the same. Six retrieval-relevant env vars bypass the settings object that
+validates the rest.
 
-Fix: S. Severity: minor (as a bug), major as a class if a production incident ever
-traces to it.
+Fix: S. Severity: minor (as a bug), major as a class if a production incident ever traces to it.
 
 ### m6. Embedding provider returns `None` on a missing key and logs at INFO
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/embeddings/providers.py:628-650`
 
-`configured_embedding_provider()` returns `None` for a missing dependency or a missing
-API key, logging `graph_embeddings_disabled` at INFO. Downstream,
-`_vector_candidate_sources_detailed` handles `None` correctly and emits a receipt
-(`search.py:1276-1277` sets `attempted=False`), so this one *is* observable in
-`SearchResponse.filters` — the degradation is honest at the retrieval layer. The debt
-is the log level: a whole retrieval modality going dark is not INFO, and the receipt
-does not survive into `ContextPack` (see M7).
+`configured_embedding_provider()` returns `None` for a missing dependency or a missing API key,
+logging `graph_embeddings_disabled` at INFO. Downstream, `_vector_candidate_sources_detailed`
+handles `None` correctly and emits a receipt (`search.py:1276-1277` sets `attempted=False`), so this
+one _is_ observable in `SearchResponse.filters` — the degradation is honest at the retrieval layer.
+The debt is the log level: a whole retrieval modality going dark is not INFO, and the receipt does
+not survive into `ContextPack` (see M7).
 
 Fix: S. Severity: minor.
 
 ### m7. Duplicated helpers and redeclared constants across the projection modules
 
-- **Scope-inheritance helper, verbatim twice**: `projection/memory.py:122-130` +
-  `1192-1198` and `projection/passages.py:85-93` + `718-731`. Same seven-key tuple,
-  same dict comprehension. `passages.py` additionally re-exports its copy as the public
-  `SCOPE_BEARING_UPDATE_KEYS`, so the two can drift with nothing catching it.
+- **Scope-inheritance helper, verbatim twice**: `projection/memory.py:122-130` + `1192-1198` and
+  `projection/passages.py:85-93` + `718-731`. Same seven-key tuple, same dict comprehension.
+  `passages.py` additionally re-exports its copy as the public `SCOPE_BEARING_UPDATE_KEYS`, so the
+  two can drift with nothing catching it.
 - **`PASSAGE_COVERS_PARENT_KEY` redeclared** at `tools/context.py:180`, duplicating
-  `projection/passages.py:52`. `tools/traverse.py:34` imports it properly, so the
-  codebase does both. Confirmed by grep.
-- **`PASSAGE_PROJECTION_KIND` redeclared** at `retrieval/operational_sources.py:17`,
-  duplicating `passages.py:41`.
-- **Trail-truncation block duplicated**: `passages.py:216-227` and
-  `experience.py:457-470` are the same three-step algorithm against two constants that
-  both equal `18_000` (`memory_pipeline/spans.py:46`, `experience.py:30`), with
-  near-identical comment prose.
+  `projection/passages.py:52`. `tools/traverse.py:34` imports it properly, so the codebase does
+  both. Confirmed by grep.
+- **`PASSAGE_PROJECTION_KIND` redeclared** at `retrieval/operational_sources.py:17`, duplicating
+  `passages.py:41`.
+- **Trail-truncation block duplicated**: `passages.py:216-227` and `experience.py:457-470` are the
+  same three-step algorithm against two constants that both equal `18_000`
+  (`memory_pipeline/spans.py:46`, `experience.py:30`), with near-identical comment prose.
 
 Fix: S each. Severity: minor.
 
 ### m8. `SliceStats` computed on every cut, discarded at every production call site
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/slicing.py:81-89`,
-incremented at 332, 353, 376, 390. Every non-test caller drops it:
-`passages.py:675`, `passages.py:687` (`mechanical, _ = slice_prose(content)`),
-`experience.py:448` (`slices, _ = slice_body(...)`). The only readers are
-`tests/test_projection_slicing.py` and the frozen
-`benchmarks/longmemeval_v2_chunk_geometry/` harness — the counters existed to compare
-`slicer.py` against `slicer_v2.py` during the killed geometry arm. `prepend_deferred`
-has exactly one increment and zero readers anywhere in `packages/`.
+incremented at 332, 353, 376, 390. Every non-test caller drops it: `passages.py:675`,
+`passages.py:687` (`mechanical, _ = slice_prose(content)`), `experience.py:448`
+(`slices, _ = slice_body(...)`). The only readers are `tests/test_projection_slicing.py` and the
+frozen `benchmarks/longmemeval_v2_chunk_geometry/` harness — the counters existed to compare
+`slicer.py` against `slicer_v2.py` during the killed geometry arm. `prepend_deferred` has exactly
+one increment and zero readers anywhere in `packages/`.
 
-Worth noting as a correction to the brief's premise: the geometry-reshaping arm is
-otherwise **not** in production code. `slicing.py` is the surviving v2 cutter and is
-live on both paths; the abandoned comparison harness lives entirely under
-`benchmarks/`. `SliceStats` is the only production residue.
+Worth noting as a correction to the brief's premise: the geometry-reshaping arm is otherwise **not**
+in production code. `slicing.py` is the surviving v2 cutter and is live on both paths; the abandoned
+comparison harness lives entirely under `benchmarks/`. `SliceStats` is the only production residue.
 
 Fix: S (keep it, but emit it on the structlog line so it stops floating). Severity: minor.
 
@@ -1030,32 +984,31 @@ Fix: S (keep it, but emit it on the structlog line so it stops floating). Severi
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/quality.py:32-67`
 
-`expand_memory_quality_storage_metadata` writes two importance shadows and four
-confidence shadows onto every entity, relationship, and raw capture
-(`services/graph.py:3327,3445`, `services/surreal_content.py:1151`,
-`apps/api/src/sibyl/persistence/surreal/content.py:590`). No application code reads
-them — grep finds only schema-migration `UPDATE` statements in
+`expand_memory_quality_storage_metadata` writes two importance shadows and four confidence shadows
+onto every entity, relationship, and raw capture (`services/graph.py:3327,3445`,
+`services/surreal_content.py:1151`, `apps/api/src/sibyl/persistence/surreal/content.py:590`). No
+application code reads them — grep finds only schema-migration `UPDATE` statements in
 `backends/surreal/schema.py:443-489` and `content_schema.py:511-533`.
 
-The sharper edge: `normalize_memory_quality_metadata` ranks the legacy names **above**
-the canonical ones (`quality.py:36` puts `retention_importance` before `importance`;
-41-45 put three legacy confidence names before `confidence`). The behavior is pinned by
-`tests/test_memory_pipeline_quality.py:8-24`: `{"importance": 0.8,
-"retention_importance": 0.3}` normalizes to `0.3`. So a partial metadata patch that
-sets `importance` without clearing the shadows is silently overridden by the stale value.
+The sharper edge: `normalize_memory_quality_metadata` ranks the legacy names **above** the canonical
+ones (`quality.py:36` puts `retention_importance` before `importance`; 41-45 put three legacy
+confidence names before `confidence`). The behavior is pinned by
+`tests/test_memory_pipeline_quality.py:8-24`: `{"importance": 0.8, "retention_importance": 0.3}`
+normalizes to `0.3`. So a partial metadata patch that sets `importance` without clearing the shadows
+is silently overridden by the stale value.
 
-Fix: S to invert precedence, M to drop the shadows. Severity: minor as written, but the
-precedence inversion is a live data-correctness trap.
+Fix: S to invert precedence, M to drop the shadows. Severity: minor as written, but the precedence
+inversion is a live data-correctness trap.
 
 ### m10. Positional `relationships[:created]` assumes failures are suffix-aligned
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/passages.py:660-661`
 and `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/memory.py:543-545`
 
-`create_bulk` returns a count; both sites slice the input list by it. If relationship 0
-fails and 1 succeeds, the reported "created" set names the wrong row. Ten lines up in
-the same function, `passages.py:648-658` gets this right by filtering on the returned
-id set — two contradictory assumptions about the same manager API in one file.
+`create_bulk` returns a count; both sites slice the input list by it. If relationship 0 fails and 1
+succeeds, the reported "created" set names the wrong row. Ten lines up in the same function,
+`passages.py:648-658` gets this right by filtering on the returned id set — two contradictory
+assumptions about the same manager API in one file.
 
 Fix: S. Severity: minor.
 
@@ -1064,24 +1017,22 @@ Fix: S. Severity: minor.
 `/Users/bliss/dev/sibyl/apps/api/src/sibyl/api/routes/entities.py:2424` and
 `/Users/bliss/dev/sibyl/apps/api/src/sibyl/jobs/entities.py:1405`
 
-Both guard on presence (`if update.content is not None`, `if "content" in updates`),
-never on change. `_resolve_structure_metadata` already computes `content_changed` at
-`routes/entities.py:243`, and the reprojection guard 2180 lines later does not use it.
-A client that PUTs an entity back unchanged pays a full re-cut and re-embed of every
-passage.
+Both guard on presence (`if update.content is not None`, `if "content" in updates`), never on
+change. `_resolve_structure_metadata` already computes `content_changed` at
+`routes/entities.py:243`, and the reprojection guard 2180 lines later does not use it. A client that
+PUTs an entity back unchanged pays a full re-cut and re-embed of every passage.
 
-Fix: S. Severity: minor (it is in `apps/api`, flagged here because the cost lands
-entirely in this subsystem).
+Fix: S. Severity: minor (it is in `apps/api`, flagged here because the cost lands entirely in this
+subsystem).
 
 ### m12. Per-query keyword extraction over the whole operational inventory, uncached
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py:486-513`
 
-`_source_discriminative_terms` runs `extract_keywords` over every entity of every group
-on every call to `select_operational_source_span`, then intersects group line sets.
-Nothing is memoized, so a source with 200 passages re-tokenizes 200 bodies per query.
-The inventory itself is fetched correctly in one `get_many` (line 179), so this is the
-remaining hot spot on that path.
+`_source_discriminative_terms` runs `extract_keywords` over every entity of every group on every
+call to `select_operational_source_span`, then intersects group line sets. Nothing is memoized, so a
+source with 200 passages re-tokenizes 200 bodies per query. The inventory itself is fetched
+correctly in one `get_many` (line 179), so this is the remaining hot spot on that path.
 
 Fix: M (cache term sets on the frozen inventory dataclass). Severity: minor.
 
@@ -1090,75 +1041,70 @@ Fix: M (cache term sets on the frozen inventory dataclass). Severity: minor.
 `/Users/bliss/dev/sibyl/apps/api/src/sibyl/jobs/probes.py:137-165`, with
 `DEFAULT_MAX_MEMORIES_PER_RUN = 200` (line 35) and up to `MAX_PROBES_PER_MEMORY = 5`
 (`memory_pipeline/structure.py:39`) live searches per memory, each awaited singly inside
-`rehearse_memory_probes` (`memory_pipeline/rehearsal.py:85-110`). Worst case 1000
-sequential fused searches per org, and `replay_memory_probes_all_orgs` (207-222) then
-loops orgs sequentially. The passage lookup on the same path *is* batched
-(`_PASSAGE_QUERY`, line 53), so the instinct is there; the probe loop never got it.
+`rehearse_memory_probes` (`memory_pipeline/rehearsal.py:85-110`). Worst case 1000 sequential fused
+searches per org, and `replay_memory_probes_all_orgs` (207-222) then loops orgs sequentially. The
+passage lookup on the same path _is_ batched (`_PASSAGE_QUERY`, line 53), so the instinct is there;
+the probe loop never got it.
 
 Fix: M. Severity: minor (background job, not serving path).
 
 ### m14. Rehearsal receipts are recorded and nothing acts on them
 
 `memory_pipeline/rehearsal.py` produces `REHEARSAL_STATUS_ABSENT` (line 185) and
-`jobs/probes.py:190` counts `probes_retrievable`, but nothing reads a stored
-`probe_rehearsal` / `probe_last_replay` receipt to alert, rank, re-project, or fail a
-gate. The only consumers are an API response field
-(`apps/api/src/sibyl/api/schemas/entities.py:191`) and a CLI pretty-printer
+`jobs/probes.py:190` counts `probes_retrievable`, but nothing reads a stored `probe_rehearsal` /
+`probe_last_replay` receipt to alert, rank, re-project, or fail a gate. The only consumers are an
+API response field (`apps/api/src/sibyl/api/schemas/entities.py:191`) and a CLI pretty-printer
 (`apps/cli/src/sibyl_cli/main.py:615-659`).
 
-The module docstring says probes exist "because this campaign was twice burned by
-features that passed their unit tests and did nothing in production." The measurement
-is real; nothing closes the loop on a failing one. Related: probes cannot be edited or
-withdrawn through the update route — `apps/api/src/sibyl/api/routes/entities.py:261`
-calls `build_memory_structure(content, spans=spans, atomic=atomic)` with no `probes`
-argument, so `memory_probes` never enters `declaration_keys` (line 269) and MERGE
-semantics preserve whatever was stored first.
+The module docstring says probes exist "because this campaign was twice burned by features that
+passed their unit tests and did nothing in production." The measurement is real; nothing closes the
+loop on a failing one. Related: probes cannot be edited or withdrawn through the update route —
+`apps/api/src/sibyl/api/routes/entities.py:261` calls
+`build_memory_structure(content, spans=spans, atomic=atomic)` with no `probes` argument, so
+`memory_probes` never enters `declaration_keys` (line 269) and MERGE semantics preserve whatever was
+stored first.
 
-Fix: S for the loop-closing counter, S for the probes argument. Severity: minor, but
-worth naming as a 1.3 design gap: the system's own anti-inert-feature instrument has no
-consumer.
+Fix: S for the loop-closing counter, S for the probes argument. Severity: minor, but worth naming as
+a 1.3 design gap: the system's own anti-inert-feature instrument has no consumer.
 
 ### m15. AI registry: most of the metadata surface has no reader
 
 `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/registry.py`
 
-Zero readers anywhere: `ModelCapability` (19-23) outside the export map,
-`deprecated_after` (42), `cost_source_url` (40), `last_verified_at` (41), the
-`is_custom` property (45-47), and `ModelRegistry.custom()` (97-115).
-`max_output_tokens`, `default_temperature`, and `input_cost_per_mtok_usd` are read only
-by `scripts/llm/smoke.py`. `recommended_for` (91, 265) is test-only.
+Zero readers anywhere: `ModelCapability` (19-23) outside the export map, `deprecated_after` (42),
+`cost_source_url` (40), `last_verified_at` (41), the `is_custom` property (45-47), and
+`ModelRegistry.custom()` (97-115). `max_output_tokens`, `default_temperature`, and
+`input_cost_per_mtok_usd` are read only by `scripts/llm/smoke.py`. `recommended_for` (91, 265) is
+test-only.
 
-Two sharper edges inside that: `_provider_output_type` (`ai/clients.py:100-103`)
-hardcodes `config.provider == "gemini"` instead of checking the `STRUCTURED_OUTPUT`
-capability the registry exists to express — so the capability model is bypassed at the
-one place it would matter. And `last_verified_at` is pinned to 2026-05-15 (`:50`) with
-no staleness gate, which is three months stale as of this audit.
+Two sharper edges inside that: `_provider_output_type` (`ai/clients.py:100-103`) hardcodes
+`config.provider == "gemini"` instead of checking the `STRUCTURED_OUTPUT` capability the registry
+exists to express — so the capability model is bypassed at the one place it would matter. And
+`last_verified_at` is pinned to 2026-05-15 (`:50`) with no staleness gate, which is three months
+stale as of this audit.
 
-The embedding half of the registry is scaffolding: all six `_DEFAULT_ENTRIES` are
-`ModelKind.LLM`, so `embedding_entries()` (261) always returns `[]` and
-`recommended_for(kind=EMBEDDING)` always raises. `tests/ai/test_registry.py:19` pins the
-emptiness. `ProviderName` (11) lists `cohere`, `voyageai`, and `bedrock`, none of which
-`build_model` (`ai/providers.py:25-43`) can construct — its `match` has no `case _`,
-so an unlisted provider falls through silently rather than raising.
+The embedding half of the registry is scaffolding: all six `_DEFAULT_ENTRIES` are `ModelKind.LLM`,
+so `embedding_entries()` (261) always returns `[]` and `recommended_for(kind=EMBEDDING)` always
+raises. `tests/ai/test_registry.py:19` pins the emptiness. `ProviderName` (11) lists `cohere`,
+`voyageai`, and `bedrock`, none of which `build_model` (`ai/providers.py:25-43`) can construct — its
+`match` has no `case _`, so an unlisted provider falls through silently rather than raising.
 
 Fix: S to prune, M to wire `STRUCTURED_OUTPUT`. Severity: minor.
 
 ### m16. Duplicated helpers across the synthesis and reflection services
 
 - **Three copies of the same text-compaction helper**: `_compact_text`
-  (`services/synthesis.py:200-207`), `_compact` (`services/reflection.py:881-888`) —
-  byte-identical algorithm, different defaults — and `_clean`
-  (`ai/operational_distillation.py:293`). A fourth, `_compact_text`, lives at
-  `tools/context.py:826`.
-- **Two functions named `_section_requests` with different jobs**:
-  `services/synthesis.py:343-351` (template expansion) and
-  `services/handbook.py:157-164` (outline reconstruction).
-- **Two functions named `_tags_for` with divergent behavior**:
-  `services/reflection.py:898-904` appends a `sensitive` tag,
-  `tools/reflect.py:40-44` does not. Both run inside the same reflect call.
+  (`services/synthesis.py:200-207`), `_compact` (`services/reflection.py:881-888`) — byte-identical
+  algorithm, different defaults — and `_clean` (`ai/operational_distillation.py:293`). A fourth,
+  `_compact_text`, lives at `tools/context.py:826`.
+- **Two functions named `_section_requests` with different jobs**: `services/synthesis.py:343-351`
+  (template expansion) and `services/handbook.py:157-164` (outline reconstruction).
+- **Two functions named `_tags_for` with divergent behavior**: `services/reflection.py:898-904`
+  appends a `sensitive` tag, `tools/reflect.py:40-44` does not. Both run inside the same reflect
+  call.
 - **Cross-module private imports**: `services/handbook.py:26-28` imports `_query_for`,
-  `_section_markdown`, and `_section_source_score` — three underscore-private symbols —
-  from `services/synthesis`.
+  `_section_markdown`, and `_section_source_score` — three underscore-private symbols — from
+  `services/synthesis`.
 
 Fix: S each. Severity: minor.
 
@@ -1166,59 +1112,56 @@ Fix: S each. Severity: minor.
 
 - **Class identity checked by string name**: `ai/validation.py:251`,
   `if error.__class__.__name__ == "LLMRateLimitError"`, two lines below a correct
-  `isinstance(exc, ModelHTTPError)` at 247. A rename or subclass silently breaks
-  rate-limit classification.
-- **Non-deterministic ids in a module documented as deterministic**: `ClaimRecord.id`
-  uses `uuid4` and `created_at` uses `_now_iso` (`models/reflection.py:121,131`), while
-  `services/reflection.py:1` is titled "deterministic providers". Re-reflecting
-  identical content mints new claim ids.
-- **O(n·m) re-normalization per reflect**: `_duplicate_prior`
-  (`services/reflection.py:729`) calls `_normalize_reflection_text` on prior content
-  inside the inner loop. 25 candidates against 100 priors (`tools/reflect.py:486`) is
-  2,500 full-body re-normalizations. `_prior_memory_snapshots` (682-700) already caches
-  the hash; caching the word set is the same edit.
+  `isinstance(exc, ModelHTTPError)` at 247. A rename or subclass silently breaks rate-limit
+  classification.
+- **Non-deterministic ids in a module documented as deterministic**: `ClaimRecord.id` uses `uuid4`
+  and `created_at` uses `_now_iso` (`models/reflection.py:121,131`), while
+  `services/reflection.py:1` is titled "deterministic providers". Re-reflecting identical content
+  mints new claim ids.
+- **O(n·m) re-normalization per reflect**: `_duplicate_prior` (`services/reflection.py:729`) calls
+  `_normalize_reflection_text` on prior content inside the inner loop. 25 candidates against 100
+  priors (`tools/reflect.py:486`) is 2,500 full-body re-normalizations. `_prior_memory_snapshots`
+  (682-700) already caches the hash; caching the word set is the same edit.
 - **Misleading empty-section text after argmax reassignment**: `cite_each_source_once`
-  (`services/handbook.py:117-154`) strips a source from every section but its best; the
-  emptied pack then renders "_No citable sources were available for this section._"
-  (`synthesis.py:824`). Sources were available; they went elsewhere. The section also
-  stays out of "Not Covered" (`handbook.py:103`) because verification saw it as sourceful.
+  (`services/handbook.py:117-154`) strips a source from every section but its best; the emptied pack
+  then renders "_No citable sources were available for this section._" (`synthesis.py:824`). Sources
+  were available; they went elsewhere. The section also stays out of "Not Covered"
+  (`handbook.py:103`) because verification saw it as sourceful.
 - **Handbook route over-reports sources**: `apps/api/src/sibyl/api/routes/synthesis.py:191-193`
-  builds `source_ids` from the full `run.source_packs` while the markdown at 190 renders
-  the deduped subset. The response claims citations the body does not contain.
-- **Stale comment narrating a fixed bug**: `services/synthesis.py:299-301` says the hint
-  families are types "none of which any bucket fetched" — the bucket at 306 fetches
-  exactly those types. Both landed in commit `2de35c41`.
-- **Obfuscated selection threshold**: `services/synthesis.py:411-415`,
-  `if score > source.score` where `score = overlap + hint_bonus + explicit_bonus +
-  source.score` — i.e. it means "any bonus at all". The `[:4]` cap and
-  `min(3, len(sources))` fallback at 417 are unexplained, as are the `+4.0` hint bonus
-  and `+1.5` explicit bonus at 383-387.
-- **Dead enum members**: `SynthesisRunStatus.DRAFTING` and `.FAILED`
-  (`models/synthesis.py:30-31`) have zero references — failures raise HTTP 500 instead.
-  `ReflectionFindingKind.EXCEPTION` (`models/reflection.py:50`) has zero references.
+  builds `source_ids` from the full `run.source_packs` while the markdown at 190 renders the deduped
+  subset. The response claims citations the body does not contain.
+- **Stale comment narrating a fixed bug**: `services/synthesis.py:299-301` says the hint families
+  are types "none of which any bucket fetched" — the bucket at 306 fetches exactly those types. Both
+  landed in commit `2de35c41`.
+- **Obfuscated selection threshold**: `services/synthesis.py:411-415`, `if score > source.score`
+  where `score = overlap + hint_bonus + explicit_bonus + source.score` — i.e. it means "any bonus at
+  all". The `[:4]` cap and `min(3, len(sources))` fallback at 417 are unexplained, as are the `+4.0`
+  hint bonus and `+1.5` explicit bonus at 383-387.
+- **Dead enum members**: `SynthesisRunStatus.DRAFTING` and `.FAILED` (`models/synthesis.py:30-31`)
+  have zero references — failures raise HTTP 500 instead. `ReflectionFindingKind.EXCEPTION`
+  (`models/reflection.py:50`) has zero references.
 - **Single-source memory extraction is production-dead**: `memory_entity_extractor`
-  (`ai/memory_extraction.py:101`) and `build_memory_entity_extraction_prompt` (44) have
-  no non-test callers — the job uses only the batch variants — yet both are still
-  exported from `ai/__init__.py:39,50`.
+  (`ai/memory_extraction.py:101`) and `build_memory_entity_extraction_prompt` (44) have no non-test
+  callers — the job uses only the batch variants — yet both are still exported from
+  `ai/__init__.py:39,50`.
 - **`get_budget_enforcer`** (`ai/llm/budget.py:40`) has zero callers outside the export map.
 - **Vestigial fan-out**: `apps/api/src/sibyl/jobs/memory_extraction.py:259` calls
-  `extract_many([prompt], max_concurrent=max_concurrent)` on a one-element list, then
-  unwraps `results[0]` — a semaphore and a gather over one item, left from the pre-batch
-  per-source design.
-- **`ReflectionExtractionRequest.source_ids` is production-dead**: `tools/reflect.py:104-111`
-  never sets it, so `HeuristicReflectionExtractor.extract:210` always validates with
+  `extract_many([prompt], max_concurrent=max_concurrent)` on a one-element list, then unwraps
+  `results[0]` — a semaphore and a gather over one item, left from the pre-batch per-source design.
+- **`ReflectionExtractionRequest.source_ids` is production-dead**: `tools/reflect.py:104-111` never
+  sets it, so `HeuristicReflectionExtractor.extract:210` always validates with
   `require_source_ids=False`, making the source-id checks in
   `validate_reflection_candidates:298-308` unreachable from that call site. Only
   `tests/test_reflection_extractor.py:49` sets it.
 - **Silent config fallback**: `coerce_write_mode` (`services/memory.py:251-261`) maps any
-  unrecognized value to `DISABLED`, so a typo in `SIBYL_NATIVE_WRITE` silently routes
-  reflection persistence down the legacy `add_fn` path (`tools/reflect.py:177-207,310-323`)
-  instead of the native one — two full persistence branches maintained in parallel.
-- **Streaming telemetry can never fire**: `Generator.stream` (`ai/llm/generator.py:67-98`)
-  records its success metric after the `async for` completes; an abandoned async
-  generator records neither success nor error.
-- **`_pin_snapshots` reads `os.environ` on every model resolution**
-  (`ai/providers.py:80`) rather than once at import or startup.
+  unrecognized value to `DISABLED`, so a typo in `SIBYL_NATIVE_WRITE` silently routes reflection
+  persistence down the legacy `add_fn` path (`tools/reflect.py:177-207,310-323`) instead of the
+  native one — two full persistence branches maintained in parallel.
+- **Streaming telemetry can never fire**: `Generator.stream` (`ai/llm/generator.py:67-98`) records
+  its success metric after the `async for` completes; an abandoned async generator records neither
+  success nor error.
+- **`_pin_snapshots` reads `os.environ` on every model resolution** (`ai/providers.py:80`) rather
+  than once at import or startup.
 
 Fix: S each. Severity: minor.
 
@@ -1229,130 +1172,117 @@ Fix: S each. Severity: minor.
 Beyond M8 (seven untested ranking stabilizers), the projection layer:
 
 1. **The B4 retire hole.** `tests/test_projection_passages.py:608`
-   (`test_reprojection_keeps_a_span_written_past_a_skipped_index`) covers a gap in the
-   *current* run. Nothing covers a gap left by a *previous* run, which is the case that
-   strands a stale span. Nothing covers `retire_entity_passages` when index 0 was
-   skipped — `test_deleting_a_memory_retires_every_span_cut_from_it` (line 449) uses
-   four contiguous indices and `test_retiring_a_memory_that_never_had_spans_is_a_no_op`
-   (line 464) uses zero.
-2. **Cross-projection metadata contract (M15).** No test asserts that a prose passage
-   and an operational passage present the fields their shared readers
-   (`traverse.py:138`, `context.py:1294`) need. `tests/test_memory_spans.py` pins the
-   *constants* against their sources and pins nothing about the two metadata schemas.
-3. **`passage_covers_parent` on operational passages (M13).**
-   `tests/test_context_pack.py:2311-2593` builds passage fixtures by hand with
-   prose-shaped metadata, so the operational shape's failure to suppress is invisible
-   to the suite.
+   (`test_reprojection_keeps_a_span_written_past_a_skipped_index`) covers a gap in the _current_
+   run. Nothing covers a gap left by a _previous_ run, which is the case that strands a stale span.
+   Nothing covers `retire_entity_passages` when index 0 was skipped —
+   `test_deleting_a_memory_retires_every_span_cut_from_it` (line 449) uses four contiguous indices
+   and `test_retiring_a_memory_that_never_had_spans_is_a_no_op` (line 464) uses zero.
+2. **Cross-projection metadata contract (M15).** No test asserts that a prose passage and an
+   operational passage present the fields their shared readers (`traverse.py:138`,
+   `context.py:1294`) need. `tests/test_memory_spans.py` pins the _constants_ against their sources
+   and pins nothing about the two metadata schemas.
+3. **`passage_covers_parent` on operational passages (M13).** `tests/test_context_pack.py:2311-2593`
+   builds passage fixtures by hand with prose-shaped metadata, so the operational shape's failure to
+   suppress is invisible to the suite.
 4. **Retrieval-key inheritance (M14).** Zero occurrences of `retrieval_keys` in
    `tests/test_projection_passages.py`; zero passage-shaped cases in
    `tests/test_retrieval_exact_key_arm.py`. Neither current nor intended behavior is pinned.
 5. **`_query_term_weights` degenerate case (M16).** None of the 25 tests in
-   `tests/test_operational_source_retrieval.py` exercises a single-group inventory with
-   a query mixing present and absent terms.
-6. **Quality round-trip (m9).** `tests/test_memory_pipeline_quality.py` asserts `expand`
-   writes the shadows and `normalize` prefers them, but never that
-   `normalize(expand(x)) == normalize(x)` — the invariant that stops the dual-write from
-   corrupting a canonical value.
-7. **Batching shape.** No test bounds the read count of `restamp_entity_passages`, so
-   the 64-round-trip behavior (M17) is free to persist.
-8. **`MemoryStructure.declared`** (`memory_pipeline/structure.py:74-76`) is both unused
-   (zero call sites across `packages/` and `apps/`) and untested.
+   `tests/test_operational_source_retrieval.py` exercises a single-group inventory with a query
+   mixing present and absent terms.
+6. **Quality round-trip (m9).** `tests/test_memory_pipeline_quality.py` asserts `expand` writes the
+   shadows and `normalize` prefers them, but never that `normalize(expand(x)) == normalize(x)` — the
+   invariant that stops the dual-write from corrupting a canonical value.
+7. **Batching shape.** No test bounds the read count of `restamp_entity_passages`, so the
+   64-round-trip behavior (M17) is free to persist.
+8. **`MemoryStructure.declared`** (`memory_pipeline/structure.py:74-76`) is both unused (zero call
+   sites across `packages/` and `apps/`) and untested.
 
 And the LLM/synthesis layer:
 
-9. **No test that materialize filters self-feeding sources (B5).**
-   `tests/test_synthesis.py` has six `materialize_synthesis_section_packs` tests
-   (369, 469, 537, 616, 729, 809) covering authorization, redaction, principal scoping,
-   and corrections. None covers `capture_surface`; grep for `self_feeding` or
-   `capture_surface` in that file returns only line 952, an assertion on what gets
-   *written*.
+9. **No test that materialize filters self-feeding sources (B5).** `tests/test_synthesis.py` has six
+   `materialize_synthesis_section_packs` tests (369, 469, 537, 616, 729, 809) covering
+   authorization, redaction, principal scoping, and corrections. None covers `capture_surface`; grep
+   for `self_feeding` or `capture_surface` in that file returns only line 952, an assertion on what
+   gets _written_.
 10. **All 13 handbook tests are plan-only (B6).**
 11. **`SIBYL_LLM_PIN_SNAPSHOTS` has zero test coverage (M29)**, so both branches of
     `resolve_provider_model_id:58-60` are unexercised.
-12. **No `tests/ai/test_providers.py` and no `tests/ai/test_errors.py`.**
-    `classify_llm_exception` is tested only at `tests/test_optional_dependencies.py:57-78`,
-    which covers the `ImportError` fallback. The 429 → `LLMRateLimitError` branch
-    (`ai/errors.py:103-110`), the timeout branch (88-95), and the
-    `ModelRetry`/`UnexpectedModelBehavior` branch (119-126) are untested.
+12. **No `tests/ai/test_providers.py` and no `tests/ai/test_errors.py`.** `classify_llm_exception`
+    is tested only at `tests/test_optional_dependencies.py:57-78`, which covers the `ImportError`
+    fallback. The 429 → `LLMRateLimitError` branch (`ai/errors.py:103-110`), the timeout branch
+    (88-95), and the `ModelRetry`/`UnexpectedModelBehavior` branch (119-126) are untested.
 13. **No test for the reflection lifecycle swallow path (M24).** The eleven tests in
-    `tests/test_reflect.py` cover extraction, dedup, scope policy, and both write modes;
-    none injects a lookup failure.
+    `tests/test_reflect.py` cover extraction, dedup, scope policy, and both write modes; none
+    injects a lookup failure.
 14. **No test for the 1,600-char note truncation (M23).**
-    `tests/ai/test_operational_distillation.py` (125 lines) never builds a payload large
-    enough to trip `operational_distillation.py:226`.
+    `tests/ai/test_operational_distillation.py` (125 lines) never builds a payload large enough to
+    trip `operational_distillation.py:226`.
 15. **No test for `require_note_content` against the retry budget.**
-    `DistilledOperationalNotes.require_note_content`
-    (`ai/operational_distillation.py:77-82`) raises on an honestly-empty trajectory;
-    with `output_retries=2` (`:147`) that burns three model calls and then fails the job.
-    Untested, and arguably wrong behavior for a trajectory with nothing to distill.
-16. **No test for batch source-id spoofing (M22).**
-    `apps/api/tests/test_jobs_memory_extraction.py` covers the unknown-source-id
-    rejection but not an in-batch swap.
+    `DistilledOperationalNotes.require_note_content` (`ai/operational_distillation.py:77-82`) raises
+    on an honestly-empty trajectory; with `output_retries=2` (`:147`) that burns three model calls
+    and then fails the job. Untested, and arguably wrong behavior for a trajectory with nothing to
+    distill.
+16. **No test for batch source-id spoofing (M22).** `apps/api/tests/test_jobs_memory_extraction.py`
+    covers the unknown-source-id rejection but not an in-batch swap.
 
 ---
 
 ## Suggested 1.3 ordering
 
-Small and paired, do first: **B5 with B6** (the guard and the gate that should have
-caught it), then **M28**, **M27**, and **M12** — all S, all visible in the public API
-surface.
+Small and paired, do first: **B5 with B6** (the guard and the gate that should have caught it), then
+**M28**, **M27**, and **M12** — all S, all visible in the public API surface.
 
 Then the correctness bug: **B4**. It is S and it is currently serving deleted text.
 
-Then the decisions that unblock everything else. **M19** (does plan's selection survive?)
-gates the synthesis latency work in **M20**. **B2** (two pipelines) gates every ranking
-experiment. **B1** (benchmark vocabulary in the ranker) gates any honest read of a
-benchmark number, and should be sequenced as: measure with the tables removed, accept
-the drop as the true baseline, then rebuild.
+Then the decisions that unblock everything else. **M19** (does plan's selection survive?) gates the
+synthesis latency work in **M20**. **B2** (two pipelines) gates every ranking experiment. **B1**
+(benchmark vocabulary in the ranker) gates any honest read of a benchmark number, and should be
+sequenced as: measure with the tables removed, accept the drop as the true baseline, then rebuild.
 
-Latency, roughly by ratio of win to effort: **M5** and **M4** (gather the retrieval
-phases and the expansion lanes, drop the two dead lanes), **M2** (stop running the
-coverage ranker twice), **M20** (gather the synthesis loops), **M17** (batch the
-64-read restamp), **M6** (add the missing embedding timeout).
+Latency, roughly by ratio of win to effort: **M5** and **M4** (gather the retrieval phases and the
+expansion lanes, drop the two dead lanes), **M2** (stop running the coverage ranker twice), **M20**
+(gather the synthesis loops), **M17** (batch the 64-read restamp), **M6** (add the missing embedding
+timeout).
 
-**M21** deserves a design conversation rather than a patch — fencing alone does not
-close indirect injection from browsed pages.
+**M21** deserves a design conversation rather than a patch — fencing alone does not close indirect
+injection from browsed pages.
 
 ---
 
 ## One structural observation worth carrying into planning
 
-There is **no LLM call anywhere in the synthesis or reflection path**.
-`services/synthesis.py`, `services/handbook.py`, and `services/reflection.py` are
-entirely deterministic: search, lexical scoring, template rendering. Only three surfaces
-call a model at all — `ai/memory_extraction.py`, `ai/operational_distillation.py`, and
-`apps/api/src/sibyl/generator/llm.py`.
+There is **no LLM call anywhere in the synthesis or reflection path**. `services/synthesis.py`,
+`services/handbook.py`, and `services/reflection.py` are entirely deterministic: search, lexical
+scoring, template rendering. Only three surfaces call a model at all — `ai/memory_extraction.py`,
+`ai/operational_distillation.py`, and `apps/api/src/sibyl/generator/llm.py`.
 
-That is not itself debt, and the determinism buys real things (byte-stable runs,
-testability). But several findings above (M25, M26, M29, m15) are LLM-shaped scaffolding
-built around code that never calls a model, and the budget/telemetry/pinning machinery
-is being maintained for a surface much smaller than its footprint suggests. Worth
-deciding deliberately in 1.3 whether synthesis stays deterministic or the scaffolding
-gets pruned to match.
+That is not itself debt, and the determinism buys real things (byte-stable runs, testability). But
+several findings above (M25, M26, M29, m15) are LLM-shaped scaffolding built around code that never
+calls a model, and the budget/telemetry/pinning machinery is being maintained for a surface much
+smaller than its footprint suggests. Worth deciding deliberately in 1.3 whether synthesis stays
+deterministic or the scaffolding gets pruned to match.
 
 ---
 
 ## What I did not audit
 
 - `retrieval/dedup.py` (1030 lines), `retrieval/refinement.py` internals, and
-  `services/graph_search.py` got call-graph treatment, not line-level review. One item
-  I did see in `dedup.py` and did not pursue: `_find_hnsw_candidates_for_seeds`
-  (`dedup.py:412-427`) falls back to a **sequential per-seed loop** when
-  `execute_query_raw` is absent, where the batched path issues one multi-statement
-  query. Grep found no non-test caller passing `execute_query_raw`, so which path
-  production takes depends on whether the live client exposes that method — worth one
+  `services/graph_search.py` got call-graph treatment, not line-level review. One item I did see in
+  `dedup.py` and did not pursue: `_find_hnsw_candidates_for_seeds` (`dedup.py:412-427`) falls back
+  to a **sequential per-seed loop** when `execute_query_raw` is absent, where the batched path
+  issues one multi-statement query. Grep found no non-test caller passing `execute_query_raw`, so
+  which path production takes depends on whether the live client exposes that method — worth one
   check before trusting the batched path.
 - `retrieval/identifier_query.py` was read only where the ranker touches it.
-- The graph client, models, and persistence layer; `apps/web`. Out of lane by
-  assignment. Where a finding's fix lands in `apps/api` (m11, M17's job path) I said so.
-- No tests were executed and no benchmarks were run. Every claim here is static: read
-  from source, or proved with grep whose command is stated. Nothing in this document
-  rests on a run I did not do.
-- Three findings originated with delegated readers on the projection and LLM slices. I
-  independently re-read and confirmed the three load-bearing ones before including them:
-  the retire-sweep control flow (B4, read `passages.py:576-608`), the materialize loop's
-  missing filter (B5, read `synthesis.py:560-672`), and the `passage_covers_parent`
-  write sites (M13, grep). The remainder carry their reporters' file:line and were not
-  independently re-verified.
+- The graph client, models, and persistence layer; `apps/web`. Out of lane by assignment. Where a
+  finding's fix lands in `apps/api` (m11, M17's job path) I said so.
+- No tests were executed and no benchmarks were run. Every claim here is static: read from source,
+  or proved with grep whose command is stated. Nothing in this document rests on a run I did not do.
+- Three findings originated with delegated readers on the projection and LLM slices. I independently
+  re-read and confirmed the three load-bearing ones before including them: the retire-sweep control
+  flow (B4, read `passages.py:576-608`), the materialize loop's missing filter (B5, read
+  `synthesis.py:560-672`), and the `passage_covers_parent` write sites (M13, grep). The remainder
+  carry their reporters' file:line and were not independently re-verified.
 
 ---

--- a/docs/architecture/AUDIT_2026-08-13/debt-retrieval-ai.md
+++ b/docs/architecture/AUDIT_2026-08-13/debt-retrieval-ai.md
@@ -1,0 +1,1358 @@
+# Sibyl tech-debt audit: retrieval, ranking, synthesis, ai/extraction
+
+Scope: `packages/python/sibyl-core/src/sibyl_core/` — `retrieval/`, `ai/`, `projection/`,
+`memory_pipeline/`, `embeddings/`, `query_anchors.py`, the search/synthesis/reflection
+services, and context-pack assembly in `tools/context.py` + `tools/search.py`.
+Out of scope (owned elsewhere): graph client/models/persistence, `apps/api`, `apps/web`.
+
+Audit date 2026-08-13, against `main` at `5388d986`. Read-only; nothing mutated.
+
+All paths below are absolute. Every claim was checked by reading the file or by grep
+over the whole repo; call-site counts are stated where "dead" is claimed.
+
+---
+
+## Section 0: the shape of the problem
+
+Three numbers frame the rest of this document.
+
+**The ranker carries 51 hand-tuned numeric constants and 46 regex/term-set constants**
+in one file, `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py`
+(2016 lines). Counted with
+`grep -cE "^_[A-Z_]+ *(:[a-z ]*)?= *[0-9]"` and `grep -cE "^_[A-Z_]+ *(:.*)?= *(re\.compile|\{|frozenset|\()"`.
+
+**Config for retrieval is spread across seven independent surfaces** that never
+reconcile: `CoreConfig` (pydantic-settings, env-driven), `RetrievalWeights` (8 fields),
+`CandidateLimits` (8), `RetrievalPlan` (16), `HybridConfig` (15), `FusionConfig` (3),
+`DedupConfig` (5), `TemporalConfig` (4), `CrossEncoderConfig` (7), plus 15 module
+constants in `retrieval/search.py` and the 97 in `query_ranking.py`. Three of those
+dataclasses have zero production readers (see 2.4).
+
+**Fusion discards every score magnitude the lanes compute.** `rrf_merge` binds the
+score to `_original_score` and never reads it
+(`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/fusion.py:126`).
+The coverage re-ranker then weights ordinal rank at 0.95 and the incoming prior at 0.04
+(`query_ranking.py:140-141`). The pipeline is ordinal end to end. Most of the
+carefully-tuned multiplicative constants downstream cannot change an outcome except by
+perturbing an ordering that is immediately re-flattened. This is the single most
+important thing to internalize before 1.3 tuning work.
+
+---
+
+## BLOCKER
+
+### B1. LongMemEval corpus vocabulary is hardcoded into the production ranker
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:337-705`
+
+`_CONCEPT_GROUPS` (561-705), `_CATEGORY_ALIASES` (480-510), and roughly twenty
+`_*_QUERY_PATTERN` / `_*_EVIDENCE_PATTERN` regex pairs (337-479) encode benchmark
+content directly as ranking signal. Verbatim examples:
+
+- `query_ranking.py:698` — `"seattle"` is a member of a concept group.
+- `query_ranking.py:586-610` — a concept group containing `basil`, `airfryer`,
+  `tomatoes`, `mint`, `smoker`, `blender`.
+- `query_ranking.py:617` — `"buisiness"`, a **misspelling** sitting beside `"business"`
+  in the same frozenset. That is a dataset typo promoted into a shipped scoring table.
+- `query_ranking.py:366-374` — `_HOMEGROWN_EVIDENCE_PATTERN` matching
+  `basil|mint|tomatoes?|herbs?|pepper plants?`.
+- `query_ranking.py:425-437` — `_DOCTOR_VISIT_EVIDENCE_PATTERN` matching
+  `dermatologist|dentist|optometrist`.
+- `query_ranking.py:385-395` — `_SPORTS_EVENT_EVIDENCE_PATTERN` matching
+  `5k|triathlon|soccer tournament|bike ride`.
+
+These feed `_concept_overlap_score` (1647) and `_query_frame_score` (946), which enter
+the final score at `_CONCEPT_OVERLAP_WEIGHT` and `_QUERY_FRAME_WEIGHT` = 0.52
+(`query_ranking.py:1375-1378`) — the second-largest weight in the entire model after
+rank itself.
+
+Why it matters: this is corpus overfitting shipped to every user of every org. A
+Sibyl user asking about a work incident gets scored against a table that rewards the
+token `airfryer`. It also poisons the benchmark: any LongMemEval delta measured while
+these tables are live is partly measuring the tables, not the architecture. The 30.38%
+anchor is not a clean read of the retrieval design.
+
+Fix: L. Not a delete-and-ship — the tables are load-bearing for the current benchmark
+number, so removing them will move it. The honest sequence is: measure with them
+removed, accept the drop as the true baseline, then rebuild the concept signal from
+something learned or embedded rather than enumerated.
+
+Severity: blocker. This is the finding that should gate 1.3 rearchitecture.
+
+### B2. Two mutually-unaware retrieval pipelines with divergent tuning
+
+There are two complete, separately-tuned retrieval paths:
+
+- `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:367`
+  `context_search` — 8 lanes, `RetrievalWeights`, `CandidateLimits`, Surreal-or-Python
+  RRF, `_boost_score` multipliers. Reached from `tools/context.py:1489` (context packs).
+- `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py:584`
+  `hybrid_search` — 2 lanes, `HybridConfig`, weighted RRF, keyword boost, temporal
+  boost, cross-encoder hook. Reached from `tools/search.py:1074` (`/api/search`, CLI
+  `sibyl search`).
+
+They share exactly one component: `rank_items_by_query_coverage`. Everything else is
+duplicated with different constants. The clearest instance is the graph relationship
+priority table, which exists twice with different scales and partially disjoint keys:
+
+- `search.py:85-107` `_GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS`, range 0.58–1.0, includes
+  `DECIDES`, `SUPPORTS`, `TOUCHES`, `PRODUCES`, `ABOUT`, `SHARES_COMMUNITY`.
+- `hybrid.py:44-64` `DEFAULT_GRAPH_RELATIONSHIP_TYPE_WEIGHTS`, range 0.35–1.25,
+  includes `APPLIES_TO`, `ENABLES`, `BREAKS`, `CONFLICTS_WITH`.
+
+`MENTIONS` is 0.58 in one and 0.35 in the other. `RELATED_TO` is 0.64 vs 0.85. Nothing
+reconciles them, and no test asserts they agree.
+
+Consequence: a memory that surfaces in a context pack may not surface in `sibyl search`
+for the same query, and vice versa, for reasons nobody can predict from either file
+alone. Every ranking experiment has to be run twice or it only covers half the product.
+
+Fix: L. Severity: blocker for 1.3 (it is the reason lever screening keeps needing two
+harnesses).
+
+### B3. The exact-name rescue lane is unreachable on the normal path
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/search.py:1144-1159`
+
+```python
+if (
+    query
+    and not graph_search_failed
+    and not enhanced_search_exhausted
+    and not _graph_results_contain_exact_name_match(raw_results, query)
+):
+    ...
+    exact_name_results = await ... entity_manager.search_exact_name(...)
+```
+
+`enhanced_search_exhausted` is set at `tools/search.py:1099-1101` from
+`hybrid_result.metadata["entity_manager_search_completed"]`, which `hybrid.py:267`
+sets to `True` whenever the seed vector search *succeeded* — the normal case.
+
+So the guard reads: run the exact-name rescue only when the seed search **failed**.
+The `_graph_results_contain_exact_name_match` check on the next line makes the intent
+unambiguous: this lane exists to rescue a query whose exact-name target is missing from
+an otherwise-successful result set. That is precisely the case where it never fires.
+
+Why it matters: "search for the thing by its exact name" is the highest-precision
+query a memory system gets, and the lane built for it is dark in production. It also
+means any benchmark claim about exact-name behavior measured through `/api/search` is
+measuring a lane that did not run.
+
+Fix: S (the guard should test `not raw_results`-style exhaustion, not seed success).
+Severity: blocker — confirm intent with whoever wrote it, but the current behavior does
+not match the surrounding code's own stated purpose.
+
+---
+
+### B4. The passage retire sweep breaks early and strands spans of deleted memories
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/passages.py:576-608`
+
+```python
+highest_kept = max(kept_indices, default=-1)
+for index in range(MAX_PASSAGES_PER_SOURCE):
+    if index in kept_indices: continue
+    try: removed = await delete(passage_entity_id(source_id, index))
+    except Exception: break
+    if removed: retired += 1
+    elif index > highest_kept: break
+```
+
+The docstring at 589-590 asserts "the walk stops once it is past every kept index and
+has found an absence, which is where any previous run must have ended." That premise
+fails whenever a **previous** run skipped an index, and the module contains the code
+that produces such gaps: the oversize-leaf branch at `passages.py:222-227` `continue`s
+past an index it cannot store.
+
+Two concrete failures, both verified by reading the code path:
+
+**Stale span survives reprojection.** Run 1 writes `{0, 1, 3}` (index 2 was an
+unbreakable oversize line). The body is shortened; run 2 writes `{0, 1}`. Now
+`highest_kept = 1`, index 2 deletes nothing, `2 > 1` fires, loop breaks. Index 3
+survives holding the **previous revision's text** and keeps being served as current.
+`reproject_entity_passages`'s own docstring (`passages.py:391-397`) names this as the
+outcome it exists to prevent.
+
+**Delete leaves every span alive.** `retire_entity_passages` (`passages.py:558-573`)
+calls the same helper with `kept_indices=frozenset()`, so `highest_kept = -1`. If
+index 0 was skipped as an oversize leaf, `delete(index 0)` returns falsy, `0 > -1`
+fires, and the loop breaks on its first iteration. Every span of the deleted memory
+survives, still serving the deleted text. The function's docstring (565-567) calls
+that "the one outcome a delete must not produce."
+
+I read `passages.py:576-608` directly to confirm the control flow; the `elif` is exactly
+as quoted.
+
+Fix: S. Either drop the `elif` and eat 64 deletes on the delete path (batchable), or
+bound the sweep by the parent's last-known `passage_total`.
+
+Severity: blocker — this is a correctness bug that serves deleted and superseded
+content as current, and it is silent.
+
+### B5. The self-feeding-source guard runs only on sources that get thrown away
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py:1013,1023`
+vs `:566-672`
+
+`_without_self_feeding_sources` is applied to the searched sources (1013) and the
+neighborhood sources (1023) inside `plan_synthesis`. Then
+`materialize_synthesis_section_packs` rebuilds every pack from `context_fn` output in
+the loop at 566-656 — a loop that has **no** `_is_self_feeding_source` check anywhere —
+and returns `replace(run, source_packs=materialized_packs, ...)` at 667-672, replacing
+the plan-stage packs wholesale.
+
+Every production caller runs plan then materialize:
+`apps/api/src/sibyl/api/routes/synthesis.py:98-112` and
+`packages/python/sibyl-core/src/sibyl_core/tools/synthesis.py:90-104`. So the guard
+landed by `4bb5260d` ("never select synthesis or reflection output as a source", #354)
+protects only the sources that are discarded.
+
+The loop is closed and live. `remember_synthesis_artifact` (`synthesis.py:928-960`)
+stores the artifact via `remember_raw_memory` with `capture_surface="synthesis_artifact"`,
+and `compile_context` recalls raw memories (`tools/context.py:1519`). The signal is even
+deliberately preserved: `capture_surface` sits in `_ITEM_METADATA_KEYS`
+(`tools/context.py:600`) under a comment saying "synthesis render filters read these."
+Nothing reads it.
+
+I read `synthesis.py:560-672` directly and confirmed the materialize loop's filter set:
+hidden, render-authorization, correction-reason, redaction, and duplicate-source-id.
+No self-feeding check.
+
+Fix: S — one filter call in the materialize loop.
+Severity: blocker. It is the regeneration-loss loop the gate was written to close, and
+the fix landed one stage upstream of where it mattered.
+
+### B6. The handbook gate that "proved" B5 tests a stage production never renders
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/tests/test_handbook.py:70-77, 260-285`
+
+`_plan(...)` calls `plan_synthesis` alone, and **every** test in the file asserts on its
+output — including the byte-stability test at 221 and the line-tracing gate at 288.
+`materialize_synthesis_section_packs` never appears in the file. The handbook's entire
+test suite validates a pack shape the REST route does not render.
+
+This is the mechanism by which B5 shipped green, and it generalizes: any future
+synthesis invariant asserted through `_plan` is asserting on discarded data.
+
+Fix: M (add a materialize stage to the gate fixtures). Severity: blocker.
+
+---
+
+## MAJOR
+
+### M1. Two age-decay functions stacked on the same candidate, pulling opposite ways
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:3115-3123`
+
+```python
+boosted *= _freshness_boost(candidate.created_at, cap=plan.weights.freshness_boost_cap)
+temporal_multiplier = (
+    1.0 if temporal_target is not None
+    else temporal_decay_multiplier(candidate, decay_days=core_config.temporal_decay_days)
+)
+boosted *= temporal_multiplier
+```
+
+`_freshness_boost` (`search.py:3129-3137`) is `min(cap, 1 + 0.5/(1+age_days))` — a
+hyperbolic *boost* capped at 1.5. `temporal_decay_multiplier` (from
+`retrieval/temporal.py`) is exponential *decay* on a 365-day half-life. Both are
+functions of the same `created_at`, applied multiplicatively, configured by two
+unrelated knobs (`freshness_boost_cap` on the plan, `temporal_decay_days` on
+`CoreConfig`). Their product is a curve nobody designed.
+
+A second copy of `_freshness_boost` runs at `search.py:3147` with a **hardcoded**
+`cap=1.5` to populate the `freshness` receipt field, so if `plan.weights.freshness_boost_cap`
+is ever changed from its default the reported freshness will disagree with the applied one.
+
+Fix: M (pick one decay model, delete the other, wire the receipt to the applied value).
+Severity: major.
+
+### M2. The coverage ranker runs twice on every query, in Python, on the serving path
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:859-892`
+
+`rank_items_by_query_coverage` scores the full candidate set through
+`rank_by_query_coverage`, then unconditionally rebuilds the candidates and scores the
+whole set **again** (`refined = rank_by_query_coverage(...)` at 883), then throws the
+second pass away unless `should_accept_query_coverage_refinement` approves it (889).
+
+Each pass is pure-Python and per-candidate does: tokenization, three separate
+token-set extractions, sliding-window segment overlap at window 18 / stride 6
+(`_best_segment_overlap`, `_best_weighted_segment_overlap`), IDF weighting, ~20 regex
+searches through `_query_frame_score`, and fact-frame matching. It is offloaded to a
+thread (`search.py:568`, `hybrid.py:854`) which keeps the loop alive but does not make
+it cheaper — and under CPython the GIL means the thread competes with the event loop.
+
+Given the measured clean-server latency (ent ~32s, web ~18s against a 10s budget), this
+is a named, measurable, unconditional 2x on the one stage that is entirely local CPU.
+The refinement pass is a candidate for gating on a cheap precondition rather than
+running always.
+
+Fix: M. Severity: major, and it is the cheapest latency win visible in this subsystem.
+
+### M3. Round-robin facet interleaving discards the global ranking
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/context.py:790-804`
+
+```python
+for item_index in range(per_facet_limit):
+    for section_index, section in enumerate(unique_sections):
+        ...
+        item = section.items[item_index]
+        selected[section_index].append(item)
+        remaining -= 1
+```
+
+Selection takes item 0 from every facet, then item 1 from every facet, and so on until
+the pack budget is spent. Score never enters the loop. A top-scoring item sitting at
+rank 3 within a strong facet loses its slot to the rank-0 item of a weak facet.
+
+Everything upstream — RRF, four multiplicative boost classes, the 15-term coverage
+model, the seven stabilizer branches — feeds an ordering that this loop then reshuffles
+by facet position. Combined with `per_facet_limit = max(2, min(8, ...))` at
+`context.py:1540`, the pack cap is 8 per facet regardless of how much char budget is
+left, which matches the previously-diagnosed "8-item pack cap against a 1/3-spent char
+budget".
+
+Fix: M (score-ordered selection with a per-facet floor, rather than strict round-robin).
+Severity: major.
+
+### M4. Four expansion lanes issue sequential round trips, two of them against
+tables nothing in the write path populates
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:1693-1744`
+
+Per BFS depth level, `_node_bfs_records` awaits in strict sequence:
+`_mentioned_entity_hops` (1702), `_relation_target_hops` (1711), optionally
+`_relation_source_hops` (1722), optionally `_community_member_hops` (1737) — and
+`_community_member_hops` itself awaits `_community_ids_for_entities` first
+(`search.py:1935`), so it is two round trips. All four read from the same frozen
+`entity_frontier`/`episode_frontier` for that level; they are fully independent and
+could be one `asyncio.gather`. That is up to 5 serialized DB round trips where 1
+latency-unit would do.
+
+Two of them cannot return anything on a live graph:
+
+- `_mentioned_entity_hops` (`search.py:1791`) queries `FROM mentions`. Grep across
+  `sibyl_core/graph`, `sibyl_core/services`, `sibyl_core/backends` finds no writer for
+  the `mentions` table outside `backends/surreal/schema.py` (definitions/indexes) and
+  the archive tuple `GRAPH_EDGES` at `schema.py:574`. `mentions` is restore-only.
+- `_community_member_hops` (`search.py:1925`) needs `entity_type = "community"` rows.
+  Community entities are created only by `store_communities`
+  (`services/graph_communities.py:2704`), and `detect_communities` /
+  `store_communities` have **zero callers** anywhere in `packages/` or `apps/` outside
+  their own module. No ingestion path, no worker, no job builds communities. The only
+  importers of `graph_communities` are three web-visualization helpers in
+  `apps/api/src/sibyl/persistence/graph_runtime.py`.
+
+So every context-pack search pays three guaranteed-empty round trips (one `mentions`,
+two community) before the useful hops run.
+
+Fix: S for the gather; S for gating the two dead lanes behind a capability probe or
+deleting them. Severity: major (pure latency on the loudest budget miss).
+
+### M5. `context_search`'s three retrieval phases are serialized
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:458, 472, 490`
+
+The critical path is: gather 4 lexical lanes (458) → **await** → embed query + gather 2
+vector lanes (472) → **await** → graph expansion (490). Only the third phase has a real
+data dependency (it seeds from the first two). The lexical gather and the
+vector gather are independent and are executed one after the other. The embedding call
+inside phase 2 (`search.py:1281`) is itself a network round trip that could overlap the
+entire lexical phase.
+
+Fix: S (gather phases 1 and 2, keep expansion downstream). Severity: major.
+
+### M6. The context-pack vector lane has no embedding timeout
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:1281`
+
+```python
+embeddings = await embedding_provider.embed_texts([plan.query], input_kind="query")
+```
+
+Bare await, no `asyncio.wait_for`. `CoreConfig.graph_search_embedding_timeout_seconds`
+exists (`config.py:271`, default 5.0s) and **is** applied on the other path
+(`services/graph.py:783`), so the two retrieval pipelines disagree about whether a
+hung embedding provider can stall a request. On the context-pack path it can, up to
+whatever outer timeout the HTTP layer imposes.
+
+Fix: S. Severity: major.
+
+### M7. `compile_context` swallows every retrieval exception into a warning
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/context.py:1557-1571`
+
+```python
+try:
+    sections = await _compile_native_sections(...)
+except Exception as exc:
+    retrieval_failed = True
+    log.warning("context_native_search_failed", error_type=type(exc).__name__)
+```
+
+A bug anywhere in the 3200-line native retrieval path becomes a `WARNING` line with the
+exception *type* only (no message, no traceback) and an empty or fallback-sourced pack.
+The `ContextPack` returned carries no field saying retrieval failed — `usage_metadata`
+only gets an exposure summary. A caller cannot distinguish "no relevant memories" from
+"retrieval crashed".
+
+The contrast is instructive: the vector lane one level down does this correctly.
+`VectorCandidateFetch` (`retrieval/candidates.py:83-127`) carries `requested`,
+`attempted`, `reason`, `failures`, and surfaces them into `SearchResponse.filters` via
+`vector_fetch.as_metadata()` (`search.py:603`). That receipt discipline stops at the
+`compile_context` boundary.
+
+Fix: S (propagate a `retrieval_failed` receipt into the pack). Severity: major.
+
+### M8. Seven ranking stabilizer branches, one of them tested
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:1472-1497`
+
+Final ordering is chosen by an if/elif chain over regex query classifiers, selecting
+one of seven mutually exclusive stabilizers:
+
+| Stabilizer | Definition | Direct test coverage |
+| --- | --- | --- |
+| `_stabilize_fact_frame_ranking` | 1893 | none |
+| `_stabilize_preference_ranking` | 1839 | none |
+| `_stabilize_evidence_set_ranking` | 1850 | none |
+| `_stabilize_artifact_evidence_ranking` | 1872 | none |
+| `_stabilize_temporal_evidence_ranking` | 1862 | none |
+| `_rank_preserving_window` | 1789 | none |
+| `_stabilize_top_window_ranking` | 1943 | none |
+| `_apply_evidence_cluster_affinity` | 1682 | none |
+| `_stabilize_explicit_anchor_ranking` | 1798 | `tests/test_retrieval_advanced.py:429,449,471` |
+
+Verified by grepping each name across `packages/python/sibyl-core/tests`,
+`apps/*/tests`, and `tools/tests`. Only the explicit-anchor stabilizer has direct
+tests. The branch *selection* logic (which classifier wins when a query matches two
+patterns, e.g. a preference query that is also a temporal-instruction query) has no
+test at all. The only dedicated `query_ranking` test file,
+`tests/test_query_ranking_semantic_rescue.py` (104 lines), tests the dead experiment
+arm described in M9.
+
+Why it matters: these branches decide the final order of every search result in the
+product, and the invariants they encode ("a preference query must not let a generic
+assistant turn outrank the user's own statement") live only in the code. Any 1.3
+refactor will break them silently.
+
+Fix: M (characterization tests per branch before any rewrite). Severity: major.
+
+### M9. Dead experiment arm wired into the production ranker
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:1148, 1395-1407`
+
+`rank_by_query_coverage(..., semantic_prior_rescue_weight: float = 0.0)` plus a
+13-line scoring block guarded by `if semantic_prior_rescue_weight > 0.0`.
+
+`rank_items_by_query_coverage` — the *only* entry point used by either production
+pipeline (`search.py:41`, `hybrid.py:155`) — does not accept or forward the parameter
+(signature at `query_ranking.py:816-824`). The arm is therefore unreachable from every
+production caller. Every non-test reference is under `benchmarks/`
+(`longmemeval_v2_official.py:92,743,936`, `longmemeval_v2_live_retrieval.py:77,327`,
+`longmemeval_v2_memory/sibyl_memory.py` in eight places) plus
+`tests/test_query_ranking_semantic_rescue.py`.
+
+This matches the recorded verdict that the additive arm was NO-GO at reader level.
+The residue is a parameter, a scoring branch, and a 104-line test file living in the
+hottest function in the subsystem.
+
+Fix: S. Severity: major (it is small, but it is exactly the accreted-arm class the
+1.3 map is meant to surface).
+
+### M10. Cross-encoder reranking: 531 lines, off by default, one branch dead entirely
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/reranking.py`
+
+- `cohere_rerank` (`reranking.py:443-531`, ~88 lines) has **zero** call sites anywhere
+  in the repo — not in `packages/`, `apps/`, `benchmarks/`, `tools/`, or any test. It
+  also reads `COHERE_API_KEY` directly from `os.environ` (`reranking.py:469`),
+  bypassing `CoreConfig` entirely.
+- `rerank_results` / `cross_encoder_rerank` are reachable from exactly one production
+  site, `hybrid.py:797-807`, behind `config.apply_reranking`, which is fed from
+  `core_config.rerank_enabled` (`tools/search.py:1067`), default `False`
+  (`config.py:303`). Re-ranking was screened and refuted.
+- The feature-weighted reranker (`fit_feature_weighted_reranker`,
+  `rerank_by_feature_weights`, `FeatureWeightedRerankModel`) is used only by
+  `sibyl_core/evals/longmemeval_replay.py:221-577`. That is benchmark machinery
+  shipping inside the published `sibyl-core` package, not a dev-only tree.
+- The knob is declared three times: `CoreConfig.rerank_model` / `rerank_top_k`
+  (`config.py:311,315`) and again as `HybridConfig.rerank_model` / `rerank_top_k`
+  (`hybrid.py:191-192`) with an independently-hardcoded default model string.
+
+Fix: M (delete `cohere_rerank` outright; decide whether the cross-encoder hook survives
+1.3; move `evals/` out of the shipped package or behind an extra). Severity: major.
+
+### M11. Structure is fetched and persisted but never scored
+
+Three cases, each verified by grepping read sites:
+
+1. **Entity type never enters ranking.** `rank_by_query_coverage` receives only
+   `text`, `prior_score`, `original_rank`, `timestamp`
+   (`QueryCoverageCandidate`, `query_ranking.py:709-716`). The candidate's
+   `entity_type` is resolved at `search.py:2334` and `2621`, carried through
+   `RetrievalCandidate`, used for *filtering* (`_candidate_matches_types`, 2727) and
+   for facet assignment, and never for scoring. The only type-aware ranking in the
+   whole subsystem is `_LINEAGE_TYPE_RANK` (`tools/context.py:700-719`), which runs at
+   pack-assembly time for dedup, not retrieval.
+2. **Relationship weights never reach the fused score.**
+   `_graph_expansion_path_score` (`search.py:2181`) computes a score from the 23-entry
+   `_GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS` table times `_GRAPH_EXPANSION_DEPTH_DECAY`,
+   stores it on the candidate, and `rrf_merge` then ignores the magnitude
+   (`fusion.py:126`). The table only controls intra-lane ordering; any monotone
+   relabeling of those 23 numbers produces an identical fused result.
+3. **Vector cosine magnitude is discarded the same way.** A 0.95 match and a 0.31
+   match at the same rank in the vector lane contribute identically to fusion.
+   `RetrievalPlan.vector_min_score` (`search.py:225`) is the only magnitude gate, and
+   it is never set to anything but its `0.0` default (grep: the only writes are the
+   four read sites at `search.py:1413,1446,1497,1526`).
+
+Fix: L (this is a design question for 1.3, not a patch). Severity: major — it is the
+mechanism by which "we have a knowledge graph" fails to become "the graph structure
+improves ranking".
+
+### M12. RetrievalPlan fields frozen at their defaults
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:202-227`
+
+`build_context_retrieval_plan` (276-364) is the only plan constructor, and
+`context_search` mutates the plan only via
+`replace(plan, candidate_limits=...)` (`search.py:385-388`). Fields never set by any
+caller:
+
+- `signals` (212) — always all 8 lanes; the per-lane disable path exists and is unused.
+- `graph_expansion_depth` (224) — always 1, so the `max_depth` loop in
+  `_node_bfs_records` always runs exactly one iteration and the BFS frontier logic
+  at `search.py:1765-1770` is unreachable.
+- `vector_min_score` (225) — always 0.0.
+- `filter_selectivity_threshold` (227) — always `DEFAULT_FILTER_SELECTIVITY_THRESHOLD`.
+
+Fix: S (either wire them or delete them). Severity: major — four knobs that read as
+tunable in every code review and are not.
+
+### M13. Operational passages never stamp `passage_covers_parent`, so parent
+suppression is inert for half the corpus
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/experience.py:490-506`
+against `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/context.py:1294`
+
+`_suppress_parents_of_passages` gates on
+`if not metadata.get(PASSAGE_COVERS_PARENT_KEY): continue`. Repo-wide grep for that key
+finds writes only in the **prose** projection (`passages.py:258` sets it `True`,
+`passages.py:289` sets it `False`). The operational projection's passage metadata block
+never writes it at all.
+
+Consequence: every operational passage fails the gate on line one, so the
+`raw_observation` parent it was cut from is never suppressed even when the whole part
+is present in the pack. Both copies of the same text spend the reader's char budget —
+the specific defect the slice substrate exists to kill, and a plausible contributor to
+the "1/3-spent char budget" symptom.
+
+The `/context` evidence-expansion path is unaffected: `_finest_granularity_units`
+(`retrieval/operational_sources.py:358-372`) dedupes correctly on its own. The leak is
+confined to search and context-pack assembly, which is the main read surface.
+
+Fix: M (stamp the key in `experience.py`, plus a backfill). Severity: major.
+
+### M14. Passages do not inherit `retrieval_keys`, so the exact-key lane can only
+return the fat parent
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/passages.py:718-731`
+(`_inherited_scope_metadata`), copying the key list at `passages.py:85-93`
+
+`_SCOPE_METADATA_KEYS` covers memory scope only. `retrieval_keys` is stamped on the
+parent (`tools/add.py:493`) and promoted to the indexed column
+(`services/graph.py:3055-3057`). The exact-key lane queries
+`retrieval_keys_normalized CONTAINSANY $probe_keys` (`retrieval/search.py:1086`), and
+passages carry no value in that column, so a passage can never match a writer-declared
+key.
+
+Net effect: for the single highest-precision query class the system supports, retrieval
+returns the whole fat memory and the passage substrate contributes nothing. This
+directly undercuts the 1.2 headline. Zero test coverage on either side: no
+`retrieval_keys` occurrence in `tests/test_projection_passages.py`, no passage-shaped
+case in `tests/test_retrieval_exact_key_arm.py`.
+
+Fix: M. The interesting 1.3 design question is whether keys inherit wholesale or only
+onto the span whose text contains them. Severity: major.
+
+### M15. Two divergent passage metadata contracts under one entity type
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/traverse.py:138-141`
+papers over the split at the read site:
+
+```python
+def _passage_total(metadata):
+    # The prose projection stamps passage_total, the operational one stamps passage_count
+    return _int_metadata(metadata, "passage_total") or _int_metadata(metadata, "passage_count")
+```
+
+The full divergence, all on rows of the same `EntityType.PASSAGE`:
+
+| concept | prose (`projection/passages.py`) | operational (`projection/experience.py`) |
+| --- | --- | --- |
+| total | `passage_total` (254) | `passage_count` (500) |
+| cut reason | `passage_cut_reason` (256) | `passage_reason` (502) |
+| trail | `passage_breadcrumb` (255) | absent |
+| coverage | `passage_covers_parent` (258) | absent |
+| plan provenance | `passage_plan` (257) | absent |
+| line offsets | absent | `passage_line_start`/`_end` (503-504) |
+| id scheme | `_generate_id` (117) | `_stable_id` (104) |
+| parent edge | `PART_OF` (269) | `DERIVED_FROM` (511) |
+
+Every read-side consumer must know both shapes or silently handle one (M13 is exactly
+the case where a consumer handled one). No test pins the two schemas against each other.
+
+Fix: L. Severity: major — this is the largest single item on the 1.3 rearchitecture list.
+
+### M16. `_query_term_weights` zeroes every term the source actually contains
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py:516-525`
+
+```python
+weights = {term: len(group_terms) - sum(term in terms for terms in group_terms)
+           for term in query_terms}
+if any(weights.values()): return weights
+return {term: 1 for term in query_terms}
+```
+
+With a single group (`len(group_terms) == 1`), a **present** term scores `1 - 1 = 0`
+and an **absent** term scores `1 - 0 = 1`. A query mixing present and absent terms —
+the ordinary case — makes `any(weights.values())` true on the strength of the absent
+terms, so the uniform fallback never fires and every present term carries weight zero.
+
+Downstream `_weighted_term_match` (`operational_sources.py:584-589`) returns 0 for every
+entity and `_select_window_entities` (536-546) falls through entirely to the positional
+tie-break: representative selection inside the window becomes query-blind. Absent terms
+also inflate the `total_weight` denominator in `_window_coverage_score` (573), diluting
+coverage by terms that could never match.
+
+Fix: S (`len(group_terms) - df + 1`, or fall back to uniform when every *present* term
+weighs 0). Severity: major.
+
+### M17. `restamp_entity_passages` does 64 sequential graph reads per scope-touching
+update, including on memories with no passages
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/passages.py:497-529`
+
+`for index in range(MAX_PASSAGES_PER_SOURCE)` with an `await get(passage_id)` inside and
+no early exit — deliberately, since the comment at 473-475 explains it must reach past
+an index gap. Sixty-four sequential round trips.
+
+The two callers disagree about when to pay that:
+
+- Job path (`apps/api/src/sibyl/jobs/entities.py:1421-1432`) triggers on
+  `scope_bearing_entity_update(updates)` (`passages.py:427-439`), which is
+  **presence-based, not change-based**: any update mentioning one of seven keys,
+  including `project_id` and `source_id`, fires it. A 200-char note with zero passages
+  updated with a `project_id` in the patch pays 64 sequential reads.
+- Route path (`apps/api/src/sibyl/api/routes/entities.py:2444`) diffs
+  `entity_scope_stamps(existing) != entity_scope_stamps(updated)` first.
+
+Two cost profiles for the same function with no stated reason.
+
+Fix: M (batch through `get_many`; make the job trigger diff-based like the route).
+Severity: major.
+
+### M18. Ten passage/projection metadata keys are written on every row and read by nobody
+
+Each verified by grep for non-test read sites; every hit below is the write itself.
+
+| key | write site | reads |
+| --- | --- | --- |
+| `support_spans` | `experience.py:688,733,773` | 0 |
+| `passage_cut_reason` | `passages.py:256` | 0 |
+| `passage_plan` | `passages.py:257` | 0 |
+| `passage_cut_depth` | `experience.py:501` | 0 |
+| `passage_reason` | `experience.py:502` | 0 |
+| `passage_line_start` / `_end` | `experience.py:503-504` | 0 |
+| `ui_inventory_item_count` / `_truncated` | `experience.py:689-690` | 0 |
+| `evidence_part_count` | `experience.py:633` | 0 |
+| `procedure_part_count` | `experience.py:730` | 0 |
+| `resolution_status: "unknown"` | `experience.py:771` | 0 (literal constant) |
+
+`support_spans` is the fattest: a nested dict per observation carrying `image_refs` and
+`evidence_part_ids` lists, on every transition, procedure, and failure row. I confirmed
+its three writes and zero reads directly.
+
+`passage_plan` is worth calling out separately because the constant block's own comment
+(`passages.py:43-45`) justifies it as needed by "the replay job and any audit of
+retrievability" — and `apps/api/src/sibyl/jobs/probes.py` never mentions it.
+
+Why it matters beyond tidiness: row size feeds lexical document length, and
+`_passage_description`'s own docstring (`experience.py:305-310`) names that as "the
+dilution mechanism Stage 1 named". These keys are paying a ranking cost for zero
+retrieval value.
+
+Fix: S each, M as a sweep. Severity: major in aggregate.
+
+### M19. `plan_synthesis`'s whole source-selection pipeline is dead work
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py:1013-1091`
+
+Plan runs four searches, up to 100 neighborhood expansions, and per-section scoring to
+build `source_packs` and `source_ids`. Materialize then overwrites `source_packs`
+wholesale (642-672) and overwrites each section's `source_ids` via
+`replace(section, source_ids=source_ids, ...)` (641). The only surviving product of all
+that work is the presence of a `no_source_supports_requested_section` gap — which
+materialize's own `no_materialized_sources` gap (628-635) already covers.
+
+This is the largest single latency item in the synthesis slice: an expensive fan-out
+whose sole output is a duplicate gap flag.
+
+Fix: M, and it needs a decision rather than a patch — either delete plan's selection
+half, or make materialize merge instead of replace. Severity: major, and it gates M20.
+
+### M20. 116 sequential round trips on one `/synthesis/draft`
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py`
+
+- `309-321` — 4 sequential `search_fn` calls.
+- `331-339` — one `related_fn` call per entity id, capped at 100
+  (`MAX_EXPLICIT_NEIGHBORHOOD_IDS`, line 134), fully serial.
+- `544-557` — one `context_fn` call per outline section, serial; up to 12 sections
+  (line 345), 5 for a handbook.
+
+Worst case 4 + 100 + 12 = 116 serialized round trips for a single draft. This sits
+directly behind the measured clean-server latency miss.
+
+Fix: S for the search and context loops (`asyncio.gather` with a semaphore); M for the
+neighborhood loop if bounded concurrency is wanted. Severity: major.
+
+### M21. Untrusted web content is interpolated into the distillation prompt unfenced
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/operational_distillation.py:85-125`
+feeding the template at `:54-65`
+
+`build_operational_experience_digest` inlines `Goal:`, `Outcome:`, `Action:`,
+`Reasoning:`, and accessibility-tree node text straight into `_PROMPT_TEMPLATE` under a
+bare `Trajectory digest:` label. No delimiter, no escaping, no instruction-boundary
+marker. `_clean` (`:293`) only collapses whitespace.
+
+For a browsing agent that content is fully attacker-controlled, and the model's output
+lands in the graph as an `EntityType.NOTE` titled "Observed environment facts"
+(`:224`) that future agents read as ground truth. The `.format()` call at `:129` is
+safe (the digest is an argument, not the template), so the exposure is instruction
+injection, not brace injection.
+
+Fix: M — fence the digest and add an explicit data-not-instructions boundary. Worth a
+design conversation: fencing alone does not fully close indirect injection from browsed
+pages. Severity: major.
+
+### M22. Batch extraction prompt permits in-batch source attribution spoofing
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/memory_extraction.py:64-98`
+
+`build_memory_batch_entity_extraction_prompt` emits `source_id: X` / `content:` blocks
+separated by `\n\n---\n\n`, with raw unescaped content at line 84. A memory whose body
+contains its own `source_id: <other>` line can be attributed to a different source in
+the same batch. The consuming job's guard
+(`apps/api/src/sibyl/jobs/memory_extraction.py:275-284`) rejects only **unknown** source
+ids, so a swap between two ids that are both legitimately in the batch passes clean.
+
+Fix: S — escape or fence the content, or return per-block indices instead of echoing ids.
+Severity: major.
+
+### M23. Distilled operational notes are truncated mid-sentence with no marker
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/operational_distillation.py:60-61`
+vs `:20, 226`
+
+The prompt authorizes up to 10 facts x 300 chars plus a 900-char workflow. Storage clips
+at `MAX_OPERATIONAL_NOTE_CHARS = 1_600` with a bare slice:
+`content=f"{header}\n\n{body}"[:MAX_OPERATIONAL_NOTE_CHARS]`. A full facts note runs
+header (~200) + 28 + ~3,020 ≈ 3,250 chars, so roughly half is dropped silently. The
+digest truncation at `:125` does mark itself; this one does not. The two budgets
+contradict each other by a factor of two.
+
+Fix: S. Severity: major.
+
+### M24. Reflection lifecycle decisions silently no-op on any lookup error
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py:489-492`
+
+Bare `except Exception`, log a warning, return `[]`. With an empty prior list,
+`apply_reflection_lifecycle_decisions` finds no duplicates, no supersessions, no stale
+targets, and no contradictions — so every candidate persists as clean and new. The
+`ReflectionPack` carries no degradation marker, so the caller cannot tell.
+
+Same shape as M7 (`compile_context`) and the same fix: a receipt.
+
+Fix: S (stamp `lifecycle_check_degraded` into candidate metadata). Severity: major.
+
+### M25. LLM telemetry records literal placeholders instead of provider and model
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py:76-82, 88-94`
+and `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/llm/generator.py:49-55, 58-64, 83-89, 91-97`
+
+Every metric records `provider="runtime"` and `model=self.model_override or "default"`.
+The extractor has the true values two lines later — `_extraction_usage` (`:139-149`)
+pulls `provider_name` and `model_name` off the responses. Per-model cost and latency
+breakdown is impossible from these metrics, on the only paid path in the system.
+
+Fix: S for the extractor. Severity: major.
+
+### M26. Budget enforcement is a one-way estimate that is never reconciled
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/llm/budget.py:78-100`
+and `/Users/bliss/dev/sibyl/apps/api/src/sibyl/ai/llm/budget.py:37-101`
+
+`reserve_llm_budget` charges `estimate_llm_tokens` = `len(text)//4 + (output_token_limit
+or 0)`. `DBLLMBudgetEnforcer` increments the bucket and stops — there is no settle,
+commit, or refund anywhere in the protocol. Two consequences:
+
+- When `max_tokens is None` (the `Generator.generate` default, and any `Extractor`
+  without an explicit cap) the output side is charged **zero**.
+- When `max_tokens` is set, the full cap is charged even if the model returns 20 tokens.
+
+`ExtractionUsage` carries the real counts and both jobs log them; nothing feeds them
+back. Drift is unbounded and monotonic in both directions depending on call shape.
+
+Fix: M (add a `settle` hook to the `LLMBudgetEnforcer` protocol). Severity: major.
+
+### M27. `depth` and `constraints` are dead knobs exposed through the public API
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/models/synthesis.py:57,66`
+
+Both are threaded through the CLI (`apps/cli/src/sibyl_cli/client.py:1899`), the MCP
+server (`apps/api/src/sibyl/server.py:906,951,996`), the REST schema
+(`apps/api/src/sibyl/api/schemas/synthesis.py:33`), and the tool wrappers
+(`tools/synthesis.py:50,116,167,219`). The only read anywhere is the field-for-field
+copy inside `plan_synthesis` at `synthesis.py:986` and `:995` — I verified this by grep;
+no scoring, rendering, retrieval, or prompt code touches either.
+
+Both also feed `_run_id` (`synthesis.py:442-445`, `repr(asdict(request))`), so flipping
+`depth=deep` mints a fresh run id for byte-identical output — an advertised knob whose
+only observable effect is a cache miss.
+
+Fix: S (delete, or wire `depth` to `max_sections` and per-section limits).
+Severity: major — an advertised knob that does nothing is worse than a missing one.
+
+### M28. `synthesis_plan` reports gaps for sections that have sources
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/tools/synthesis.py:148-155`
+and `/Users/bliss/dev/sibyl/apps/api/src/sibyl/api/routes/synthesis.py:156`
+
+Both return the materialized run without calling `apply_synthesis_verification`.
+`materialize_synthesis_section_packs:658-666` carries `run.verification.gaps` forward
+unfiltered, and only `verify_synthesis_run:706-711` drops absence gaps for sourceful
+sections. `synthesis_verify` and `synthesis_draft` call it (`tools/synthesis.py:206,267`);
+`synthesis_plan` does not.
+
+The related defect: stale plan-stage gaps are permanent in the outline.
+`synthesis.py:637-641` builds `section_gaps = [*section.gaps, *materialization_gaps]` —
+plan's gaps are never re-evaluated, and `verify_synthesis_run` only recomputes
+`run.verification`, never `outline.sections[*].gaps`. So `synthesis_run_to_dict` always
+ships outline sections claiming `no_source_supports_requested_section` beside a
+populated `source_ids` list.
+
+Fix: S each. Severity: major (the plan endpoint lies about its own coverage).
+
+### M29. Model snapshot pinning is unreachable, untested, and a no-op for half the registry
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/providers.py:79-85`
+
+`_pin_snapshots()` gates `resolve_provider_model_id`. Repo-wide grep for
+`SIBYL_LLM_PIN_SNAPSHOTS` outside its own definition returns exactly one hit:
+`docs/_archive/SIBYL_LLM_SUBSTRATE_PLAN.md:308`, which claims "CI uses this." It is set
+in no workflow, chart, compose file, or Ansible role, and no test exercises it — so both
+branches of `resolve_provider_model_id:58-60` are unexercised.
+
+Even when set it is a no-op for three of six models: `claude-sonnet-4-6`
+(`ai/registry.py:148-152`), `gpt-5.4-mini` (`:207-211`), and `gpt-5.4-nano` (`:230-234`)
+all have `snapshot == alias == provider_model_id`. Only `claude-haiku-4-5` and the two
+Gemini entries carry real snapshots.
+
+A reproducibility guarantee that does not hold is worse than none, especially for a
+project that runs benchmark comparisons across weeks.
+
+Fix: S to set the env in CI; M to add real snapshot ids. Severity: major.
+
+---
+
+## MINOR
+
+### m0. Benchmark overfit in the production tokenizer, second instance
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/query_anchors.py:7-31, 42-43`
+
+`_NORMALIZED_TOKEN_ALIASES` is a 25-entry hand-written stem table with unmistakably
+LongMemEval-shaped vocabulary (`weddings`, `volunteered`, `subscribed`, `serviced`,
+`attended`), and lines 42-43 hardcode a correction for one misspelling:
+
+```python
+if token == "buisiness":
+    return "business"
+```
+
+This is the same dataset typo that appears in `query_ranking.py:617` (B1), now fixed in
+a second place. `query_anchors` is live in production ranking — imported by
+`retrieval/query_ranking.py:900,1092,1196`, `retrieval/hybrid.py:113`, and
+`services/graph.py:166-207` — so a benchmark artifact shapes token normalization for
+every real user query.
+
+Fix: S to delete the typo line; M to replace the alias table with a real stemmer.
+Severity: minor on its own, but it is B1's evidence that the overfit is not confined to
+one file.
+
+### m1. Test-only exports presented as public API
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/__init__.py`
+
+Exported in `__all__`, zero production call sites (verified by repo-wide grep):
+
+- `simple_hybrid_search` (`hybrid.py:918`, `__init__.py:118`) — referenced only by
+  `tests/test_retrieval_advanced.py` and `tests/test_retrieval_benchmarks.py`.
+- `weighted_score_merge` (`fusion.py:246`, `__init__.py:122`) — referenced only by
+  `tests/test_retrieval.py` and `apps/api/tests/test_retrieval.py`.
+- `FusionConfig` (`fusion.py:28`, `__init__.py:90`) — instantiated only in
+  `tests/test_retrieval.py:412`.
+- `_vector_candidate_sources` (`search.py:1244`) — a wrapper whose only callers are
+  three sites in `tests/test_search.py`.
+
+Fix: S each. Severity: minor.
+
+### m2. `defaultdict(float)` accumulator that never accumulates
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:2881,2889`
+
+`score_by_id` is a `defaultdict(float)` but line 2889 **assigns** rather than adds, and
+does so once per (lane, candidate) pair — so for a candidate found by four lanes the
+same value is written four times. The `defaultdict` and the repetition are both
+vestigial; the shape suggests this was an accumulating fusion before RRF moved into
+`rrf_merge`. Harmless today, actively misleading to read.
+
+Fix: S. Severity: minor.
+
+### m3. Object identity used as a dictionary key across a re-ranking boundary
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:2999-3022`
+and `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py:868-880`
+
+Both `_apply_query_coverage_to_fused` and `rank_items_by_query_coverage` key metadata
+by `id(candidate)` and then look it up after the ranker has reordered the list. Correct
+today (the source list holds a strong reference for the whole window, so ids are
+stable and unique), but it silently breaks if the ranker ever copies, replaces, or
+re-wraps a candidate. The stable id is right there on the object.
+
+Fix: S. Severity: minor.
+
+### m4. The coverage rerank result flag is discarded on the context path
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py:3011`
+
+```python
+reranked, _applied, _refined = rank_items_by_query_coverage(...)
+```
+
+`hybrid_search` surfaces both flags as `query_coverage_rerank_applied` and
+`query_coverage_refinement_applied` in its metadata (`hybrid.py:881-882`).
+`context_search` throws them away, so the context-pack receipt cannot say whether the
+coverage rerank fired or whether the refinement pass was accepted. Given M2 (the pass
+always runs), this is the one receipt that would let you measure whether the second
+pass earns its cost.
+
+Fix: S. Severity: minor, high leverage for the M2 decision.
+
+### m5. `SIBYL_MOCK_LLM` silently swaps in hash-based embeddings, with no production guard
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/embeddings/providers.py:606-617`
+
+Read straight from `os.getenv`, not through `CoreConfig`, so the
+`environment == "production"` validator in `config.py:220-232` (which does correctly
+forbid `memory://`) cannot see it. If the var leaks into a production process, every
+graph embedding becomes a SHA-256 derived vector and semantic retrieval degrades to
+noise while every health check stays green.
+
+The same module reads `SIBYL_GRAPH_EMBEDDING_PROVIDER`, `SIBYL_GRAPH_EMBEDDING_MODEL`,
+and `SIBYL_GRAPH_EMBEDDING_DIMENSIONS` directly (`providers.py:620,705,719`), each
+shadowing the corresponding `CoreConfig` field. `SIBYL_FUSION_BACKEND`
+(`search.py:266`) and `COHERE_API_KEY` (`reranking.py:469`) do the same. Six
+retrieval-relevant env vars bypass the settings object that validates the rest.
+
+Fix: S. Severity: minor (as a bug), major as a class if a production incident ever
+traces to it.
+
+### m6. Embedding provider returns `None` on a missing key and logs at INFO
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/embeddings/providers.py:628-650`
+
+`configured_embedding_provider()` returns `None` for a missing dependency or a missing
+API key, logging `graph_embeddings_disabled` at INFO. Downstream,
+`_vector_candidate_sources_detailed` handles `None` correctly and emits a receipt
+(`search.py:1276-1277` sets `attempted=False`), so this one *is* observable in
+`SearchResponse.filters` — the degradation is honest at the retrieval layer. The debt
+is the log level: a whole retrieval modality going dark is not INFO, and the receipt
+does not survive into `ContextPack` (see M7).
+
+Fix: S. Severity: minor.
+
+### m7. Duplicated helpers and redeclared constants across the projection modules
+
+- **Scope-inheritance helper, verbatim twice**: `projection/memory.py:122-130` +
+  `1192-1198` and `projection/passages.py:85-93` + `718-731`. Same seven-key tuple,
+  same dict comprehension. `passages.py` additionally re-exports its copy as the public
+  `SCOPE_BEARING_UPDATE_KEYS`, so the two can drift with nothing catching it.
+- **`PASSAGE_COVERS_PARENT_KEY` redeclared** at `tools/context.py:180`, duplicating
+  `projection/passages.py:52`. `tools/traverse.py:34` imports it properly, so the
+  codebase does both. Confirmed by grep.
+- **`PASSAGE_PROJECTION_KIND` redeclared** at `retrieval/operational_sources.py:17`,
+  duplicating `passages.py:41`.
+- **Trail-truncation block duplicated**: `passages.py:216-227` and
+  `experience.py:457-470` are the same three-step algorithm against two constants that
+  both equal `18_000` (`memory_pipeline/spans.py:46`, `experience.py:30`), with
+  near-identical comment prose.
+
+Fix: S each. Severity: minor.
+
+### m8. `SliceStats` computed on every cut, discarded at every production call site
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/slicing.py:81-89`,
+incremented at 332, 353, 376, 390. Every non-test caller drops it:
+`passages.py:675`, `passages.py:687` (`mechanical, _ = slice_prose(content)`),
+`experience.py:448` (`slices, _ = slice_body(...)`). The only readers are
+`tests/test_projection_slicing.py` and the frozen
+`benchmarks/longmemeval_v2_chunk_geometry/` harness — the counters existed to compare
+`slicer.py` against `slicer_v2.py` during the killed geometry arm. `prepend_deferred`
+has exactly one increment and zero readers anywhere in `packages/`.
+
+Worth noting as a correction to the brief's premise: the geometry-reshaping arm is
+otherwise **not** in production code. `slicing.py` is the surviving v2 cutter and is
+live on both paths; the abandoned comparison harness lives entirely under
+`benchmarks/`. `SliceStats` is the only production residue.
+
+Fix: S (keep it, but emit it on the structlog line so it stops floating). Severity: minor.
+
+### m9. Legacy quality keys are dual-written and take precedence over the canonical ones
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/quality.py:32-67`
+
+`expand_memory_quality_storage_metadata` writes two importance shadows and four
+confidence shadows onto every entity, relationship, and raw capture
+(`services/graph.py:3327,3445`, `services/surreal_content.py:1151`,
+`apps/api/src/sibyl/persistence/surreal/content.py:590`). No application code reads
+them — grep finds only schema-migration `UPDATE` statements in
+`backends/surreal/schema.py:443-489` and `content_schema.py:511-533`.
+
+The sharper edge: `normalize_memory_quality_metadata` ranks the legacy names **above**
+the canonical ones (`quality.py:36` puts `retention_importance` before `importance`;
+41-45 put three legacy confidence names before `confidence`). The behavior is pinned by
+`tests/test_memory_pipeline_quality.py:8-24`: `{"importance": 0.8,
+"retention_importance": 0.3}` normalizes to `0.3`. So a partial metadata patch that
+sets `importance` without clearing the shadows is silently overridden by the stale value.
+
+Fix: S to invert precedence, M to drop the shadows. Severity: minor as written, but the
+precedence inversion is a live data-correctness trap.
+
+### m10. Positional `relationships[:created]` assumes failures are suffix-aligned
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/passages.py:660-661`
+and `/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/projection/memory.py:543-545`
+
+`create_bulk` returns a count; both sites slice the input list by it. If relationship 0
+fails and 1 succeeds, the reported "created" set names the wrong row. Ten lines up in
+the same function, `passages.py:648-658` gets this right by filtering on the returned
+id set — two contradictory assumptions about the same manager API in one file.
+
+Fix: S. Severity: minor.
+
+### m11. Reprojection fires on unchanged content
+
+`/Users/bliss/dev/sibyl/apps/api/src/sibyl/api/routes/entities.py:2424` and
+`/Users/bliss/dev/sibyl/apps/api/src/sibyl/jobs/entities.py:1405`
+
+Both guard on presence (`if update.content is not None`, `if "content" in updates`),
+never on change. `_resolve_structure_metadata` already computes `content_changed` at
+`routes/entities.py:243`, and the reprojection guard 2180 lines later does not use it.
+A client that PUTs an entity back unchanged pays a full re-cut and re-embed of every
+passage.
+
+Fix: S. Severity: minor (it is in `apps/api`, flagged here because the cost lands
+entirely in this subsystem).
+
+### m12. Per-query keyword extraction over the whole operational inventory, uncached
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py:486-513`
+
+`_source_discriminative_terms` runs `extract_keywords` over every entity of every group
+on every call to `select_operational_source_span`, then intersects group line sets.
+Nothing is memoized, so a source with 200 passages re-tokenizes 200 bodies per query.
+The inventory itself is fetched correctly in one `get_many` (line 179), so this is the
+remaining hot spot on that path.
+
+Fix: M (cache term sets on the frozen inventory dataclass). Severity: minor.
+
+### m13. Sequential probe replay across memories and orgs
+
+`/Users/bliss/dev/sibyl/apps/api/src/sibyl/jobs/probes.py:137-165`, with
+`DEFAULT_MAX_MEMORIES_PER_RUN = 200` (line 35) and up to `MAX_PROBES_PER_MEMORY = 5`
+(`memory_pipeline/structure.py:39`) live searches per memory, each awaited singly inside
+`rehearse_memory_probes` (`memory_pipeline/rehearsal.py:85-110`). Worst case 1000
+sequential fused searches per org, and `replay_memory_probes_all_orgs` (207-222) then
+loops orgs sequentially. The passage lookup on the same path *is* batched
+(`_PASSAGE_QUERY`, line 53), so the instinct is there; the probe loop never got it.
+
+Fix: M. Severity: minor (background job, not serving path).
+
+### m14. Rehearsal receipts are recorded and nothing acts on them
+
+`memory_pipeline/rehearsal.py` produces `REHEARSAL_STATUS_ABSENT` (line 185) and
+`jobs/probes.py:190` counts `probes_retrievable`, but nothing reads a stored
+`probe_rehearsal` / `probe_last_replay` receipt to alert, rank, re-project, or fail a
+gate. The only consumers are an API response field
+(`apps/api/src/sibyl/api/schemas/entities.py:191`) and a CLI pretty-printer
+(`apps/cli/src/sibyl_cli/main.py:615-659`).
+
+The module docstring says probes exist "because this campaign was twice burned by
+features that passed their unit tests and did nothing in production." The measurement
+is real; nothing closes the loop on a failing one. Related: probes cannot be edited or
+withdrawn through the update route — `apps/api/src/sibyl/api/routes/entities.py:261`
+calls `build_memory_structure(content, spans=spans, atomic=atomic)` with no `probes`
+argument, so `memory_probes` never enters `declaration_keys` (line 269) and MERGE
+semantics preserve whatever was stored first.
+
+Fix: S for the loop-closing counter, S for the probes argument. Severity: minor, but
+worth naming as a 1.3 design gap: the system's own anti-inert-feature instrument has no
+consumer.
+
+### m15. AI registry: most of the metadata surface has no reader
+
+`/Users/bliss/dev/sibyl/packages/python/sibyl-core/src/sibyl_core/ai/registry.py`
+
+Zero readers anywhere: `ModelCapability` (19-23) outside the export map,
+`deprecated_after` (42), `cost_source_url` (40), `last_verified_at` (41), the
+`is_custom` property (45-47), and `ModelRegistry.custom()` (97-115).
+`max_output_tokens`, `default_temperature`, and `input_cost_per_mtok_usd` are read only
+by `scripts/llm/smoke.py`. `recommended_for` (91, 265) is test-only.
+
+Two sharper edges inside that: `_provider_output_type` (`ai/clients.py:100-103`)
+hardcodes `config.provider == "gemini"` instead of checking the `STRUCTURED_OUTPUT`
+capability the registry exists to express — so the capability model is bypassed at the
+one place it would matter. And `last_verified_at` is pinned to 2026-05-15 (`:50`) with
+no staleness gate, which is three months stale as of this audit.
+
+The embedding half of the registry is scaffolding: all six `_DEFAULT_ENTRIES` are
+`ModelKind.LLM`, so `embedding_entries()` (261) always returns `[]` and
+`recommended_for(kind=EMBEDDING)` always raises. `tests/ai/test_registry.py:19` pins the
+emptiness. `ProviderName` (11) lists `cohere`, `voyageai`, and `bedrock`, none of which
+`build_model` (`ai/providers.py:25-43`) can construct — its `match` has no `case _`,
+so an unlisted provider falls through silently rather than raising.
+
+Fix: S to prune, M to wire `STRUCTURED_OUTPUT`. Severity: minor.
+
+### m16. Duplicated helpers across the synthesis and reflection services
+
+- **Three copies of the same text-compaction helper**: `_compact_text`
+  (`services/synthesis.py:200-207`), `_compact` (`services/reflection.py:881-888`) —
+  byte-identical algorithm, different defaults — and `_clean`
+  (`ai/operational_distillation.py:293`). A fourth, `_compact_text`, lives at
+  `tools/context.py:826`.
+- **Two functions named `_section_requests` with different jobs**:
+  `services/synthesis.py:343-351` (template expansion) and
+  `services/handbook.py:157-164` (outline reconstruction).
+- **Two functions named `_tags_for` with divergent behavior**:
+  `services/reflection.py:898-904` appends a `sensitive` tag,
+  `tools/reflect.py:40-44` does not. Both run inside the same reflect call.
+- **Cross-module private imports**: `services/handbook.py:26-28` imports `_query_for`,
+  `_section_markdown`, and `_section_source_score` — three underscore-private symbols —
+  from `services/synthesis`.
+
+Fix: S each. Severity: minor.
+
+### m17. Assorted correctness and hygiene items in synthesis/reflection
+
+- **Class identity checked by string name**: `ai/validation.py:251`,
+  `if error.__class__.__name__ == "LLMRateLimitError"`, two lines below a correct
+  `isinstance(exc, ModelHTTPError)` at 247. A rename or subclass silently breaks
+  rate-limit classification.
+- **Non-deterministic ids in a module documented as deterministic**: `ClaimRecord.id`
+  uses `uuid4` and `created_at` uses `_now_iso` (`models/reflection.py:121,131`), while
+  `services/reflection.py:1` is titled "deterministic providers". Re-reflecting
+  identical content mints new claim ids.
+- **O(n·m) re-normalization per reflect**: `_duplicate_prior`
+  (`services/reflection.py:729`) calls `_normalize_reflection_text` on prior content
+  inside the inner loop. 25 candidates against 100 priors (`tools/reflect.py:486`) is
+  2,500 full-body re-normalizations. `_prior_memory_snapshots` (682-700) already caches
+  the hash; caching the word set is the same edit.
+- **Misleading empty-section text after argmax reassignment**: `cite_each_source_once`
+  (`services/handbook.py:117-154`) strips a source from every section but its best; the
+  emptied pack then renders "_No citable sources were available for this section._"
+  (`synthesis.py:824`). Sources were available; they went elsewhere. The section also
+  stays out of "Not Covered" (`handbook.py:103`) because verification saw it as sourceful.
+- **Handbook route over-reports sources**: `apps/api/src/sibyl/api/routes/synthesis.py:191-193`
+  builds `source_ids` from the full `run.source_packs` while the markdown at 190 renders
+  the deduped subset. The response claims citations the body does not contain.
+- **Stale comment narrating a fixed bug**: `services/synthesis.py:299-301` says the hint
+  families are types "none of which any bucket fetched" — the bucket at 306 fetches
+  exactly those types. Both landed in commit `2de35c41`.
+- **Obfuscated selection threshold**: `services/synthesis.py:411-415`,
+  `if score > source.score` where `score = overlap + hint_bonus + explicit_bonus +
+  source.score` — i.e. it means "any bonus at all". The `[:4]` cap and
+  `min(3, len(sources))` fallback at 417 are unexplained, as are the `+4.0` hint bonus
+  and `+1.5` explicit bonus at 383-387.
+- **Dead enum members**: `SynthesisRunStatus.DRAFTING` and `.FAILED`
+  (`models/synthesis.py:30-31`) have zero references — failures raise HTTP 500 instead.
+  `ReflectionFindingKind.EXCEPTION` (`models/reflection.py:50`) has zero references.
+- **Single-source memory extraction is production-dead**: `memory_entity_extractor`
+  (`ai/memory_extraction.py:101`) and `build_memory_entity_extraction_prompt` (44) have
+  no non-test callers — the job uses only the batch variants — yet both are still
+  exported from `ai/__init__.py:39,50`.
+- **`get_budget_enforcer`** (`ai/llm/budget.py:40`) has zero callers outside the export map.
+- **Vestigial fan-out**: `apps/api/src/sibyl/jobs/memory_extraction.py:259` calls
+  `extract_many([prompt], max_concurrent=max_concurrent)` on a one-element list, then
+  unwraps `results[0]` — a semaphore and a gather over one item, left from the pre-batch
+  per-source design.
+- **`ReflectionExtractionRequest.source_ids` is production-dead**: `tools/reflect.py:104-111`
+  never sets it, so `HeuristicReflectionExtractor.extract:210` always validates with
+  `require_source_ids=False`, making the source-id checks in
+  `validate_reflection_candidates:298-308` unreachable from that call site. Only
+  `tests/test_reflection_extractor.py:49` sets it.
+- **Silent config fallback**: `coerce_write_mode` (`services/memory.py:251-261`) maps any
+  unrecognized value to `DISABLED`, so a typo in `SIBYL_NATIVE_WRITE` silently routes
+  reflection persistence down the legacy `add_fn` path (`tools/reflect.py:177-207,310-323`)
+  instead of the native one — two full persistence branches maintained in parallel.
+- **Streaming telemetry can never fire**: `Generator.stream` (`ai/llm/generator.py:67-98`)
+  records its success metric after the `async for` completes; an abandoned async
+  generator records neither success nor error.
+- **`_pin_snapshots` reads `os.environ` on every model resolution**
+  (`ai/providers.py:80`) rather than once at import or startup.
+
+Fix: S each. Severity: minor.
+
+---
+
+## Test gaps on load-bearing invariants
+
+Beyond M8 (seven untested ranking stabilizers), the projection layer:
+
+1. **The B4 retire hole.** `tests/test_projection_passages.py:608`
+   (`test_reprojection_keeps_a_span_written_past_a_skipped_index`) covers a gap in the
+   *current* run. Nothing covers a gap left by a *previous* run, which is the case that
+   strands a stale span. Nothing covers `retire_entity_passages` when index 0 was
+   skipped — `test_deleting_a_memory_retires_every_span_cut_from_it` (line 449) uses
+   four contiguous indices and `test_retiring_a_memory_that_never_had_spans_is_a_no_op`
+   (line 464) uses zero.
+2. **Cross-projection metadata contract (M15).** No test asserts that a prose passage
+   and an operational passage present the fields their shared readers
+   (`traverse.py:138`, `context.py:1294`) need. `tests/test_memory_spans.py` pins the
+   *constants* against their sources and pins nothing about the two metadata schemas.
+3. **`passage_covers_parent` on operational passages (M13).**
+   `tests/test_context_pack.py:2311-2593` builds passage fixtures by hand with
+   prose-shaped metadata, so the operational shape's failure to suppress is invisible
+   to the suite.
+4. **Retrieval-key inheritance (M14).** Zero occurrences of `retrieval_keys` in
+   `tests/test_projection_passages.py`; zero passage-shaped cases in
+   `tests/test_retrieval_exact_key_arm.py`. Neither current nor intended behavior is pinned.
+5. **`_query_term_weights` degenerate case (M16).** None of the 25 tests in
+   `tests/test_operational_source_retrieval.py` exercises a single-group inventory with
+   a query mixing present and absent terms.
+6. **Quality round-trip (m9).** `tests/test_memory_pipeline_quality.py` asserts `expand`
+   writes the shadows and `normalize` prefers them, but never that
+   `normalize(expand(x)) == normalize(x)` — the invariant that stops the dual-write from
+   corrupting a canonical value.
+7. **Batching shape.** No test bounds the read count of `restamp_entity_passages`, so
+   the 64-round-trip behavior (M17) is free to persist.
+8. **`MemoryStructure.declared`** (`memory_pipeline/structure.py:74-76`) is both unused
+   (zero call sites across `packages/` and `apps/`) and untested.
+
+And the LLM/synthesis layer:
+
+9. **No test that materialize filters self-feeding sources (B5).**
+   `tests/test_synthesis.py` has six `materialize_synthesis_section_packs` tests
+   (369, 469, 537, 616, 729, 809) covering authorization, redaction, principal scoping,
+   and corrections. None covers `capture_surface`; grep for `self_feeding` or
+   `capture_surface` in that file returns only line 952, an assertion on what gets
+   *written*.
+10. **All 13 handbook tests are plan-only (B6).**
+11. **`SIBYL_LLM_PIN_SNAPSHOTS` has zero test coverage (M29)**, so both branches of
+    `resolve_provider_model_id:58-60` are unexercised.
+12. **No `tests/ai/test_providers.py` and no `tests/ai/test_errors.py`.**
+    `classify_llm_exception` is tested only at `tests/test_optional_dependencies.py:57-78`,
+    which covers the `ImportError` fallback. The 429 → `LLMRateLimitError` branch
+    (`ai/errors.py:103-110`), the timeout branch (88-95), and the
+    `ModelRetry`/`UnexpectedModelBehavior` branch (119-126) are untested.
+13. **No test for the reflection lifecycle swallow path (M24).** The eleven tests in
+    `tests/test_reflect.py` cover extraction, dedup, scope policy, and both write modes;
+    none injects a lookup failure.
+14. **No test for the 1,600-char note truncation (M23).**
+    `tests/ai/test_operational_distillation.py` (125 lines) never builds a payload large
+    enough to trip `operational_distillation.py:226`.
+15. **No test for `require_note_content` against the retry budget.**
+    `DistilledOperationalNotes.require_note_content`
+    (`ai/operational_distillation.py:77-82`) raises on an honestly-empty trajectory;
+    with `output_retries=2` (`:147`) that burns three model calls and then fails the job.
+    Untested, and arguably wrong behavior for a trajectory with nothing to distill.
+16. **No test for batch source-id spoofing (M22).**
+    `apps/api/tests/test_jobs_memory_extraction.py` covers the unknown-source-id
+    rejection but not an in-batch swap.
+
+---
+
+## Suggested 1.3 ordering
+
+Small and paired, do first: **B5 with B6** (the guard and the gate that should have
+caught it), then **M28**, **M27**, and **M12** — all S, all visible in the public API
+surface.
+
+Then the correctness bug: **B4**. It is S and it is currently serving deleted text.
+
+Then the decisions that unblock everything else. **M19** (does plan's selection survive?)
+gates the synthesis latency work in **M20**. **B2** (two pipelines) gates every ranking
+experiment. **B1** (benchmark vocabulary in the ranker) gates any honest read of a
+benchmark number, and should be sequenced as: measure with the tables removed, accept
+the drop as the true baseline, then rebuild.
+
+Latency, roughly by ratio of win to effort: **M5** and **M4** (gather the retrieval
+phases and the expansion lanes, drop the two dead lanes), **M2** (stop running the
+coverage ranker twice), **M20** (gather the synthesis loops), **M17** (batch the
+64-read restamp), **M6** (add the missing embedding timeout).
+
+**M21** deserves a design conversation rather than a patch — fencing alone does not
+close indirect injection from browsed pages.
+
+---
+
+## One structural observation worth carrying into planning
+
+There is **no LLM call anywhere in the synthesis or reflection path**.
+`services/synthesis.py`, `services/handbook.py`, and `services/reflection.py` are
+entirely deterministic: search, lexical scoring, template rendering. Only three surfaces
+call a model at all — `ai/memory_extraction.py`, `ai/operational_distillation.py`, and
+`apps/api/src/sibyl/generator/llm.py`.
+
+That is not itself debt, and the determinism buys real things (byte-stable runs,
+testability). But several findings above (M25, M26, M29, m15) are LLM-shaped scaffolding
+built around code that never calls a model, and the budget/telemetry/pinning machinery
+is being maintained for a surface much smaller than its footprint suggests. Worth
+deciding deliberately in 1.3 whether synthesis stays deterministic or the scaffolding
+gets pruned to match.
+
+---
+
+## What I did not audit
+
+- `retrieval/dedup.py` (1030 lines), `retrieval/refinement.py` internals, and
+  `services/graph_search.py` got call-graph treatment, not line-level review. One item
+  I did see in `dedup.py` and did not pursue: `_find_hnsw_candidates_for_seeds`
+  (`dedup.py:412-427`) falls back to a **sequential per-seed loop** when
+  `execute_query_raw` is absent, where the batched path issues one multi-statement
+  query. Grep found no non-test caller passing `execute_query_raw`, so which path
+  production takes depends on whether the live client exposes that method — worth one
+  check before trusting the batched path.
+- `retrieval/identifier_query.py` was read only where the ranker touches it.
+- The graph client, models, and persistence layer; `apps/web`. Out of lane by
+  assignment. Where a finding's fix lands in `apps/api` (m11, M17's job path) I said so.
+- No tests were executed and no benchmarks were run. Every claim here is static: read
+  from source, or proved with grep whose command is stated. Nothing in this document
+  rests on a run I did not do.
+- Three findings originated with delegated readers on the projection and LLM slices. I
+  independently re-read and confirmed the three load-bearing ones before including them:
+  the retire-sweep control flow (B4, read `passages.py:576-608`), the materialize loop's
+  missing filter (B5, read `synthesis.py:560-672`), and the `passage_covers_parent`
+  write sites (M13, grep). The remainder carry their reporters' file:line and were not
+  independently re-verified.
+
+---

--- a/docs/architecture/AUDIT_2026-08-13/debt-web-cli-infra.md
+++ b/docs/architecture/AUDIT_2026-08-13/debt-web-cli-infra.md
@@ -1,0 +1,1014 @@
+# Tech debt audit: apps/web, apps/cli, apps/e2e, infra
+
+Read-only audit at commit `5388d986` (main, clean). Every finding below was verified by
+reading the code; hypotheses that did not survive a check are recorded in the
+"Checked and clean" sections so nobody re-investigates them.
+
+Severity: **blocker** (ship-stopping or data-integrity), **major** (real user or
+maintainer cost, fix soon), **minor** (hygiene, fix opportunistically).
+Size: **S** (< half day), **M** (1-3 days), **L** (a week or more).
+
+---
+
+## Top findings, ranked
+
+| # | Finding | Where | Sev | Size |
+|---|---|---|---|---|
+| 1 | `sibyl auth login` writes the token under a key no command reads; login exits 0 | C1 | blocker | S |
+| 2 | CI classifier ignores `uv.lock`, `pyproject.toml`, `charts/`, `VERSION`, Dockerfiles — whole pipeline no-ops | I1 | blocker | S |
+| 3 | Stock `helm install` ships production-labelled with MCP auth disabled | I3 | blocker | S |
+| 4 | Every browser e2e test asserts the login page; Playwright declared and never imported | E1, E2 | blocker | M |
+| 5 | ~32 gate suites run for the first time at RC cut, never in CI | I2 | blocker | S |
+| 6 | `sibyl entity delete` destroys data with no confirmation; its `--yes` is dead | C2 | blocker | S |
+| 7 | Worker crash-loops under the chart's own defaults; Surreal password regenerates per upgrade | I4, I5 | blocker | S/M |
+| 8 | 19 CLI failure paths exit 0; failed writes buffer to disk silently | C3, C4 | major | S |
+| 9 | Realtime give-up kills the only freshness signal (focus + reconnect refetch both off) | W1 | major | M |
+| 10 | 1 of 185 GitHub Actions is SHA-pinned, incl. a mutable branch ref on the PyPI publish job | I7 | major | M |
+
+The three themes worth naming: **a green check that proves nothing** (2, 4, 5, plus I11's
+nonexistent lockfile path and I12's cacheable gate), **silent failure** (1, 6, 8, 9, plus
+W4's swallowed SSR errors), and **defaults that only work by accident** (3, 7, plus I14
+and I15's unreachable config).
+
+---
+
+## apps/web (Next.js 16)
+
+222 non-test TypeScript files, 124 of them client components. Biome config is strict
+and genuinely enforced (8 suppressions repo-wide, exactly 1 `any`).
+
+### W1. Realtime give-up silently breaks the only freshness signal — major, M
+
+`components/providers.tsx:51-52` disables both `refetchOnWindowFocus` and
+`refetchOnReconnect`, with the comment at lines 47-50 stating plainly that
+"Realtime/websocket invalidation is the primary freshness signal."
+
+`lib/websocket.ts:344-347` gives up permanently after `maxReconnectAttempts = 10`
+(`websocket.ts:192`), returning early without calling `setStatus('disconnected')`. The
+last status written was `'reconnecting'` at line 351, so the client parks in
+`'reconnecting'` forever. `reconnectAttempts` resets only on a successful connect
+(line 273) or `destroy()` (line 340), and no UI offers a manual reconnect.
+
+The two decisions are each defensible alone and destructive together. After roughly
+17 minutes of cumulative backoff on a flaky connection, the app has no websocket, no
+focus refetch, and no reconnect refetch. Hooks with a polling fallback survive
+(`useMemorySourceImport` at `hooks.ts:680-686`, `useBackups` at `hooks.ts:2099`,
+`useBackupJobStatus` at `hooks.ts:2101-2110` all poll when status is not `'connected'`),
+but the primary data hooks have no `refetchInterval` at all: `useTasks`
+(`hooks.ts:1293-1299`), `useEntities` (`hooks.ts:568-574`), `useProjects`, `useEpics`.
+Those views then serve stale cache indefinitely until a hard reload or a mutation, with
+no indication anything is wrong.
+
+Confirmed at `hooks.ts:1050-1135`: `useRealtimeUpdates` is the sole invalidation driver
+for `entity_created`, `entity_pending`, `entity_updated`, and `entity_deleted`, all of
+which route through `invalidateByEntityType` to reach `tasks.all`, `projects.all`,
+`entities.all`, and `sources.all`. None of those has a polling fallback, so all four
+primary list views are affected.
+
+Fix: transition to `'disconnected'` on give-up, and either re-enable
+`refetchOnReconnect` or add a reconnect affordance. The status transition alone is S;
+the full freshness-contract repair is M.
+
+### W2. Entity detail queries with params are never invalidated — major, S
+
+`queryKeys.entities.detail` (`hooks.ts:55-56`) takes an optional trailing `params`
+object that becomes part of the key. `EntityDetailPanel` uses it: `entity-detail-panel.tsx:92-96`
+calls `useEntity(entityId, undefined, { include_summary: false, related_limit: 0 })`
+when `queryMode === 'graph'`, producing key
+`['entities','detail',id,{include_summary:false,related_limit:0}]`.
+
+Every invalidation site omits the params. `invalidateByEntityType` at `hooks.ts:224`
+calls `invalidateQueries({ queryKey: queryKeys.entities.detail(entityId) })`, which
+builds `['entities','detail',id,undefined]`. React Query's `partialMatchKey` compares
+index 3 as `partialMatchKey({include_summary:false,...}, undefined)`, and the `typeof`
+guard rejects it — so the graph panel's cached entity is never invalidated after an
+update or delete.
+
+The same key shape breaks `useDeleteEntity` at `hooks.ts:843`:
+`getQueryData(queryKeys.entities.detail(id))` misses the params-bearing entry, so
+`entityType` resolves `undefined` and the mutation falls through to the `default`
+branch of the switch (`hooks.ts:219-226`) — wrong invalidation set for tasks, projects,
+and sources deleted from the graph panel.
+
+Fix: split the registry into an exact key and a prefix key (`detail(id)` for
+invalidation, `detailWith(id, params)` for the query), the standard TanStack pattern.
+
+### W3. No route-level error boundaries; three routes have none at all — major, S
+
+`find app -name 'error.tsx'` returns nothing: there are zero Next.js error boundary
+files. The only boundary is a single `AsyncBoundary` in `components/layout/main-shell.tsx:50`,
+which `app/(main)/layout.tsx:10` applies to the `(main)` group.
+
+That leaves `app/login/page.tsx` (523 lines of client code), `app/setup/page.tsx`, and
+`app/reset-password/page.tsx` with no boundary whatsoever — a render throw on the login
+or first-run setup page produces Next's default error screen. Inside `(main)`, the
+single page-level boundary means any error in any segment blanks the entire shell
+rather than the failing panel, despite `loading.tsx` files existing for 15 routes.
+
+Fix: an `error.tsx` per route group, plus segment boundaries around the heavy panels.
+
+### W4. Server-side prefetch failures are silent — major, S
+
+Four server components swallow fetch errors with no logging and no user signal:
+`app/(main)/entities/page.tsx:53-54`, `app/(main)/search/page.tsx:31-33`,
+`app/(main)/projects/page.tsx:15-21`. Each is a bare `.catch(() => undefined)` (or
+`.catch(() => ({...}))`), so a backend outage or a timeout degrades to a client-side
+refetch with nothing recorded.
+
+`lib/api-server.ts` is otherwise well built — a 5s `AbortSignal.timeout`
+(`api-server.ts:25-32`), cookie forwarding (`api-server.ts:61-72`), and a distinct
+timeout error message (`api-server.ts:78-80`). All of that diagnostic value is
+discarded at the call site. `lib/logger.ts` exists and is not used here.
+
+Fix: log the swallowed error server-side; keep the UI degradation.
+
+### W5. Two architectures for the same job — major, M
+
+Nine pages use the server-component shell that prefetches in parallel and hands
+`initialData` to a client child — `app/(main)/entities/page.tsx:44-68` is the
+reference implementation, joined by `page.tsx`, `settings/page.tsx`, `memory/page.tsx`,
+`archive/page.tsx`, `projects/page.tsx`, `search/page.tsx`, `memory/captures/page.tsx`,
+`entities/[id]/page.tsx`.
+
+Twenty-four pages are wholesale `'use client'` with no SSR prefetch, including the
+heaviest ones: `tasks/page.tsx:1`, `graph/page.tsx`, `sources/page.tsx`,
+`epics/page.tsx`, and all seven `settings/*` pages. `tasks/page.tsx:48-52` fires four
+client queries on mount with nothing server-rendered.
+
+Neither pattern is wrong, but which one a route uses is unpredictable, so every new
+page is a coin flip and the SSR path's `initialData` plumbing rots on the routes that
+skipped it. Fix: pick one, document it, migrate the high-traffic routes.
+
+### W6. `lib/api.ts` is a 3,040-line god-module — major, M
+
+One file holds 169 exported interfaces (the entire API type surface) plus the `api`
+object with 26 namespaces (`api.ts:2065-3000`: `entities`, `rawCaptures`, `memory`,
+`sourceImports`, `synthesis`, `search`, `graph`, `admin`, `telemetry`, `jobs`,
+`backups`, `auth`, `security`, `preferences`, `profile`, `session`, `orgs`, `tasks`,
+`projects`, `epics`, `sources`, `rag`, `metrics`, `setup`, `settings`).
+
+Nearly every component imports from it, so any type edit invalidates the module for the
+whole graph on every typecheck and rebuild. `lib/hooks.ts` at 2,135 lines has the same
+shape one layer up. Fix: split into `lib/api/<domain>.ts` with a barrel, mirroring the
+existing `lib/constants/` split which already does this well.
+
+### W7. `graph/page.tsx` is 1,764 lines holding seven components — major, M
+
+`app/(main)/graph/page.tsx` defines `MobileEntitySheet` (:94), `ClusterLegend` (:169),
+`StatsOverlay` (:271), `GraphToolbar` (:317), and `GraphPageContent` (:786) — the last
+alone runs ~970 lines with 11 `useState`, 9 `useEffect`, and 14 `useCallback`/`useMemo`
+hooks. The canvas paint path (`paintNode`, :1206-1390) is 185 lines inline.
+
+Nothing here is broken; it is the single hardest file in the app to modify safely, and
+`components/graph/` already exists as the natural home (it currently holds only
+`entity-detail-panel.tsx`).
+
+### W8. Priority constants duplicated five times, with a latent divergence — minor, S
+
+`lib/constants/tasks.ts:55-57` already defines `TASK_PRIORITIES` (including `someday`)
+and `TASK_PRIORITY_CONFIG` as the canonical source. Five local redefinitions ignore it:
+
+- `PRIORITY_ORDER` at `app/(main)/epics/page.tsx:29`, `components/tasks/task-list-mobile.tsx:23`,
+  `components/tasks/kanban-board.tsx:30`
+- `PRIORITY_LABELS` at `components/tasks/task-card.tsx:76` and `components/epics/epic-card.tsx:53`
+  (byte-identical)
+- `PRIORITY_STYLES` at `components/tasks/task-card.tsx:40` and `components/epics/epic-card.tsx:17`
+
+The epics copy omits `someday`, so at `epics/page.tsx:137-138` a `someday` epic takes
+the `?? 99` fallback. To be precise: with today's five priorities that still sorts it
+last, identical to the `someday: 4` the task copies use — **this is a latent
+divergence, not a live bug**. It becomes one the moment a sixth priority is added to
+`TASK_PRIORITIES` and only three of the five copies are updated.
+
+### W9. Six dead query-key registry entries — minor, S
+
+Defined in `hooks.ts` and referenced nowhere: `projects.members` (:136),
+`epics.tasks` (:152), `epics.progress` (:153), `metrics.projectsSummary` (:165),
+`session.all` (:74), `rag.all` (:83). They imply cache surfaces that do not exist.
+
+Three keys also bypass the registry entirely with raw literals: `['metrics']`
+(`hooks.ts:198,206`, where the registry has `metrics.org`/`metrics.project` but no
+`metrics.all` prefix to use), and `['crawl_progress', source_id]`
+(`hooks.ts:1133,1184`) — the only snake_case key in a kebab-case registry. A registry
+that the code routes around in three places is one rename away from a silent cache miss.
+
+### W10. Five exported Suspense wrappers with zero consumers — minor, S
+
+`components/suspense-boundary.tsx` exports `SuspenseBoundary` (:97), `PageSuspense`
+(:117), `SectionSuspense` (:126), `CardGridSuspense` (:135), and `ListSuspense` (:144).
+None is imported anywhere in the app; only the 15 `*Skeleton` exports below them are
+used, and those go through `loading.tsx` files directly. `StatusIndicator`
+(`components/ui/icons.tsx:294`) is likewise unused and is visibly the component built
+for W1's missing offline state — its `status` union even omits `'reconnecting'`.
+
+### W11. Stale nav entry for a redirect stub — minor, S
+
+`lib/constants/navigation.ts:43` registers `archive: { label: 'Memory Captures',
+href: '/archive' }`. `app/(main)/archive/page.tsx:24` is a pure redirect to
+`/memory/captures`, and every real link in the app already points at the new route
+(`dashboard-content.tsx:894`, `memory-home.tsx:457,710,745,764`,
+`search-result.tsx:72`). The stub also carries a `loading.tsx` rendering `ArchiveSkeleton`
+for a page that never renders, and `archive/page.test.tsx`.
+
+Related naming collision: `/sources/[id]` (docs-crawl RAG sources,
+`app/(main)/sources/[id]/page.tsx`) and `/memory/sources/[sourceId]` (memory provenance,
+`app/(main)/memory/sources/[sourceId]/page.tsx`) are unrelated concepts sharing a noun.
+
+### W12. Query-key factory type understates its own key — minor, S
+
+`queryKeys.graph.hierarchical` (`hooks.ts:93-94`) is typed
+`(params?: { max_nodes?, max_edges?, refresh? })`, but `useHierarchicalGraph`
+(`hooks.ts:968-980`) passes seven fields including `projects`, `types`, `resolution`,
+and `cluster_id`. Because the argument is a variable rather than a literal, excess
+property checking does not fire, so it compiles. Caching is correct at runtime (the
+whole object lands in the key); the type is simply a lie that would mislead the next
+person reasoning about invalidation.
+
+### W13. Minor a11y residuals — minor, S
+
+Biome disables `noStaticElementInteractions`, `useSemanticElements`, and
+`useKeyWithClickEvents` globally (`apps/web/biome.json:19-21`), so clickable-div
+correctness is unenforced. In practice the code is disciplined — all five
+`<div onClick>` sites carry `role`, `tabIndex`, and `onKeyDown`. Two residuals:
+
+- `components/tasks/task-card.tsx:150-171` has `role="button"` and a key handler but no
+  `aria-label` and no `focus-visible` ring, while its sibling `epic-card.tsx:118-136`
+  has both. Keyboard users get no visible focus on the kanban board.
+- `components/layout/project-selector.tsx:159-170` handles `Enter` but not `Space`
+  (ARIA requires both for `role="button"`), and nests a real `<button>` (:174) inside
+  the `role="button"` div — nested interactive controls.
+
+### Checked and clean (do not re-investigate)
+
+- **Charts are theme-aware.** `components/metrics/charts.tsx:82-97` reads SilkCircuit
+  CSS custom properties off `document.documentElement` and re-reads on every theme
+  flip. The hex block at :52-62 is an explicitly labelled SSR fallback, not a dark-only
+  palette.
+- **Canvas colors are theme-aware.** `lib/constants/graph.ts:45-51` provides
+  `canvasNodeColor`/`canvasClusterColor` with a documented dawn-theme darkening pass,
+  because canvas cannot read CSS variables.
+- **The graph starfield redesign landed.** The historical finding is resolved on the web
+  side: `GRAPH_DEFAULTS.MAX_NODES` is now 500 with a comment explaining the legibility
+  tradeoff (`constants/graph.ts:56-59`), overview/detail resolution modes exist, the
+  server sends `recommended_resolution` and the client honours it
+  (`graph/page.tsx:884-902`), clusters are labelled and colored, and `StatsOverlay`
+  (`graph/page.tsx:271-306`) surfaces displayed-vs-total counts. The 1000/5000
+  truncation still lives in `apps/api/src/sibyl/persistence/graph_runtime.py:1140-1141`
+  and `graph_communities.py` (not this lane), but the client no longer requests it.
+- **No polling freeze from W1.** Every `useWebSocketStatus` gate is
+  `status === 'connected' ? false : poll`, so a stuck `'reconnecting'` still polls. W1's
+  impact is confined to hooks with no polling fallback.
+- **Both `dangerouslySetInnerHTML` sites are sound** — a static theme FOUC script
+  (`app/layout.tsx:53`) and Shiki's own escaped output (`components/ui/markdown.tsx:67`).
+- **`AsyncBoundary` is not dead** (used at `main-shell.tsx:50`); the gap is coverage, not
+  existence.
+- **Lint hygiene is excellent**: 8 `biome-ignore` suppressions and 1 `any` across 222
+  files, `noExplicitAny`/`noNonNullAssertion`/`noFloatingPromises` all at `error`.
+
+One config note: `apps/web/biome.json:73-76` puts `noFloatingPromises` and
+`noMisusedPromises` in `nursery`. Nursery rules are renamed or promoted between Biome
+minors, so a routine bump can silently drop both checks with no lint error. Worth
+pinning awareness to the dependency-bump checklist. (minor, S)
+
+---
+
+## apps/e2e
+
+27 tests across five files. The auth and CLI-runner fixtures are well built, bounded
+waits are used correctly everywhere, and two tests (archive round-trip, context recall)
+are genuine end-to-end proofs. The problems are coverage and vacuity, not flakiness.
+
+### E1. The entire browser suite cannot fail — blocker, M
+
+`tests/browser/test_smoke.py:28-57`: all five tests issue
+`httpx.get(path, follow_redirects=True)` and assert the status is in
+`(200, 301, 302, 307, 308)`. `apps/web/src/proxy.ts:35-43` redirects every
+unauthenticated request to `/login`, and the matcher at `proxy.ts:52` covers `/`,
+`/tasks`, `/graph`, `/settings`. The tests send no cookies, so all four
+protected-route tests follow the redirect and assert that the login page returned 200.
+They are five copies of `test_login_page`.
+
+Deleting `apps/web/src/app/(main)/tasks/page.tsx` would not fail `test_tasks_page`. When
+the frontend is down the autouse fixture at :22-26 skips the class, so the suite has
+exactly two outcomes: skip or pass. CI spends minutes building and booting the frontend
+(`ci.yml:649-651`, `:678-690`) to prove nothing.
+
+### E2. Playwright is declared, installed, documented, and never imported — blocker, S
+
+`apps/e2e/pyproject.toml:22-24,29` declares `playwright>=1.40` as both an optional extra
+and a dev dependency, `apps/e2e/moon.yml:36-38` defines `playwright-install`, and
+`README.md:79-85` documents the setup. Zero playwright imports exist under `tests/`. The
+`browser` marker (`pyproject.toml:59`, described as "requires playwright") is attached to
+a pure-httpx suite. This is what makes E1 look acceptable at a glance.
+
+### E3. Zero coverage of org/tenant isolation — blocker, M
+
+`CLAUDE.md` names namespace-per-org as the load-bearing invariant. No e2e test creates
+two users in two orgs and asserts that user A cannot read user B's entities, tasks, or
+captures. Every existing test shares one session-scoped user (`conftest.py:359`), so
+none could detect a leak. A regression here is cross-tenant data disclosure.
+
+### E4. e2e is excluded from CI's task graph and re-declared by hand — major, S
+
+Every task in `apps/e2e/moon.yml` (lines 12, 19, 28, 35, 38, 51) carries `preset: server`.
+Verified against the installed moon 2.2.6: `moon task e2e:test` reports
+`Mode: persistent / Runs in CI: No`, while `api:test`, `core:test`, and `cli:test` all
+report `Runs in CI: Yes`. Root `moon.yml:212-254` omits `e2e:` from `:check`.
+
+CI works around this by bypassing moon entirely — `ci.yml:696-703` runs
+`cd apps/e2e && uv run pytest -v` with `SIBYL_E2E_CLI_COMMAND` re-declared inline. So the
+moon task definitions and the CI invocation are two configurations that drift silently:
+editing `apps/e2e/moon.yml` has no CI effect, and the CI run ignores the `-m` marker
+filters.
+
+### E5. Assertions that cannot fail — major, S each
+
+- `tests/api/test_health.py:31,37` — `assert status_code in (200, 401, 403)`; only a 500 fails.
+- `tests/api/test_health.py:41` — `assert "total_entities" in data or "entities" in data
+  or isinstance(data, dict)`; the third disjunct is unconditionally true, making the
+  first two decorative.
+- `tests/api/test_endpoints.py:81` — `isinstance(data, dict)` is the whole test body.
+- `tests/api/test_endpoints.py:108,116` — `isinstance(data, (dict, list))`.
+- `tests/api/test_endpoints.py:70-73` — loops over returned entities to check a type
+  filter; an empty result passes having verified nothing.
+- `tests/cli/test_tasks.py:27-38` — creates a task, lists by status, then asserts only
+  `isinstance(tasks, list)`. The creation is decorative and the named behavior (status
+  filtering) is untested. Same shape at `tests/cli/test_entities.py:50-56,74-82`.
+
+### E6. A test that passes when the command is broken — major, S
+
+`tests/cli/test_projects.py:52-64` runs `project show --json`, and on failure falls
+through to re-verifying `project list` (comment: "may not be implemented"). If
+`sibyl project show` regresses or is deleted, the test still passes.
+
+### E7. Mock-only unit tests gated behind a live server — major, S
+
+All five tests in `tests/test_cli_runner.py` are pure `unittest.mock` tests of argument
+construction and touch no network, but `conftest.py:468-470` makes `require_services`
+`autouse=True`, pulling in a session-scoped `wait_for_services` that raises `TimeoutError`
+after 30s without a backend. They also carry no marker, so both `e2e:test-api` and
+`e2e:test-browser` skip them.
+
+### E8. The perf gate is off by default and never runs — major, S
+
+`tools/perf/multi_user.py:26` sets `DEFAULT_ERROR_RATE = 0.0` (correct), but `max_p95_ms`
+defaults to `_env_optional_float("SIBYL_PERF_MAX_P95_MS")` with no fallback (:324-326),
+and `check_thresholds` short-circuits on `is not None` (:196). `apps/e2e/moon.yml:20-28`
+does not set it, so the suite measures p95, prints it, and asserts nothing. Load is
+4 users x 3 iterations x 5 operations = 60 requests
+(`tests/perf/test_multi_user_performance.py:47-49`).
+
+It also never runs at any cadence: `skipif SIBYL_E2E_PERF != 1` (:28-32), no `test-perf`
+in any workflow, and `nightly-regression.yml` has only `baseline-parity`, `live-graph`,
+and `restore-to-scratch`. Root `:check` runs `multi-user-perf-test` (`moon.yml:770`), but
+that targets `tools/tests/test_multi_user_perf.py` — unit tests of the harness, not a
+live run.
+
+Spot-checked independently and confirmed: `apps/web/src/proxy.ts:36-43` redirects every
+unauthenticated request to `/login` and the matcher at :50-55 covers all four tested
+paths; `grep -rn playwright apps/e2e/tests/` returns nothing; all six `apps/e2e/moon.yml`
+tasks carry `preset: server`.
+
+While confirming E4 I also found `apps/e2e/moon.yml:47-51`: the `format` task carries
+`preset: server`, marking a one-shot `ruff format` as a persistent server task. Its
+sibling `lint` (:44-46) correctly does not. Copy-paste slip. (minor, S)
+
+### E9. Coverage gaps, ranked
+
+- **Web: 33 routes, 0 meaningfully covered.** Highest value missing: login → dashboard
+  (nothing proves a user can sign in through the UI), `/setup` first-run (a broken
+  wizard bricks every new install), `/search`.
+- **CLI: 26 registered sub-apps, 8 covered.** No coverage for `login`/`logout`/`whoami`/`auth`
+  (`apps/cli/src/sibyl_cli/main.py:134,157-158,164`), `epic`, `team`, `org`, `synthesis`,
+  `explore`, `export`, `ingest`, `crawl`, `session`, `pending-writes`, `admin`, `skill`,
+  `docs`, `debug`, `logs`, `doctor`, `update`, `config`, `note`, `brief`, `init`.
+  Highest value: the auth commands, the first thing every user touches.
+- **API: 31 route modules, 5 endpoints touched.** Untouched and high value: `backups`
+  (a silently broken restore is unrecoverable), `setup`, `context`/`memory` (the core
+  read path, currently exercised only indirectly through the CLI).
+- **Auth flows:** login is a fixture (`conftest.py:359-394`), so a failure surfaces as a
+  collection error rather than a named test. No test for logout, refresh, invalid
+  credentials, expired-token rejection, or password reset.
+
+### E10. Shared session user with no cleanup — minor, M
+
+`e2e_auth_token` is session-scoped (`conftest.py:359`); no test deletes what it creates.
+`test_projects.py` creates four projects per run, `test_tasks.py` five tasks plus four
+projects. Names are uniquified (`conftest.py:478-495`) so runs do not collide, but the
+org accretes permanently. Ephemeral in CI; unbounded growth when run locally against the
+dev DB per `README.md:9-11`. Defaults at `conftest.py:22-23` (`localhost:3334`,
+`localhost:3337`) collide with a running `moon run dev` stack, which is what makes the
+accidental-pollution path easy to hit.
+
+### E11. Undeclared dependency on a pre-seeded corpus — minor, S
+
+`ci.yml:698-700` authenticates as `baseline-corpus@sibyl.dev`, whose org is populated by
+`moon run baseline-seed` + `baseline-replay-runtime` (`ci.yml:677-680`). Tests like
+`test_entities_with_type_filter` read whatever that seed produced, but nothing in
+`conftest.py` or `README.md` mentions the dependency, so a local run against a fresh org
+exercises different paths than CI.
+
+Boundary worth naming: `ci.yml:589` sets `SIBYL_MOCK_LLM: true`, so no e2e test covers
+any LLM-dependent extraction, synthesis, or reflection path.
+
+### Checked and clean
+
+- **No committed junk.** `git ls-files apps/e2e` returns 20 files, all source.
+  `.pytest_cache/`, `.ruff_cache/`, `.venv/`, `__pycache__/` are covered by root
+  `.gitignore` (lines 2, 24, 46, 57) and are untracked local artifacts.
+- **No unbounded waits.** All three `time.sleep` sites sit inside bounded deadline loops
+  (`conftest.py:280-296`, `:337-351`, `:460-465`) that raise on expiry.
+- **No order dependence.** Every test builds its own fixtures with UUID-suffixed names.
+- **No suppressed failures.** The two `skip` sites are environment gates; no `xfail`
+  anywhere. `--strict-markers` and `--strict-config` are both on
+  (`pyproject.toml:50`).
+
+---
+
+## apps/cli
+
+44 source modules, 38 test files. Findings below were produced with live probes against
+a sandboxed `HOME`; I independently re-verified the two blockers and C6 by reading the
+cited lines.
+
+### C1. `sibyl auth login` writes the token under a key no other command reads — blocker, S
+
+`auth.py:43-55` and `client.py:54-94` resolve the API base URL with inverted priority.
+The client ranks the active context above `SIBYL_API_URL` (`client.py:78-83`, priorities
+2 and 3); auth checks `SIBYL_API_URL` first (`auth.py:51-53`) and only falls back to
+`SibylClient().base_url` (`auth.py:55`) when the env var is empty.
+
+The precondition is precise: an active context **and** `SIBYL_API_URL` set to a
+different host. With context `prod → https://sibyl.example.com` and
+`SIBYL_API_URL=http://localhost:3334/api`, login stores the token under the localhost
+key while every command reads the context key. The credential *scope* matches
+(`context:prod:org:default` both sides); only the server key diverges.
+
+Login prints `✓ Login complete` and exits 0. Every later command sees no token, takes a
+401, and per C4 silently buffers its writes. The failure presents as a server-side auth
+problem. This is the mechanism behind the known "sibyl auth still needs login +
+pending-writes flush" symptom.
+
+Fix: have `_compute_api_url` delegate to the client resolver for the no-explicit-server
+case instead of reading the env var itself.
+
+### C2. `sibyl entity delete` destroys data with no confirmation and a dead `--yes` — blocker, S
+
+`entity.py:270` declares `yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip
+confirmation")] = False`. The body (`entity.py:276-299`) never references it and
+contains no prompt — it goes straight to `await client.delete_entity(entity_id)` at
+:285. Verified by reading the full command.
+
+The flag actively misleads: anyone reading `--help` concludes a guard exists. An AST
+sweep found exactly two dead Typer parameters in the package, both named `yes` — this
+one and `epic.py:583` (`archive_epic`).
+
+### C3. Nineteen command failure paths exit 0 — major, S
+
+The `else: error("Failed to ...")` tail sits at the end of a `@run_async` coroutine with
+no `raise typer.Exit(1)`, so the process exits 0 on a refused write. Probed:
+`task start`, `task create`, `task complete`, and `epic start` all print `✗ Failed to
+...` and exit 0.
+
+Sites: `task.py:589,631,672,726,815,1044,1162,1246`; `epic.py:492,531,574,614,685`;
+`entity.py:261`; `project.py:275`; `crawl.py:299`; `crawl_shared.py:50`; `local.py:431`;
+`main.py:2085`. Any CI job, hook, or agent checking `$?` reads a refused write as
+success — and Sibyl's own session hooks are exactly such callers.
+
+### C4. Failed writes are buffered to disk with nothing telling the user — major, S
+
+`client.py:631-641` files every POST/PATCH/DELETE into `~/.config/sibyl/pending_writes/`
+before sending. On connection failure `client.py:739-744` raises with no remediation
+string. Probed against a dead port: three writes queued, user saw only "Is the server
+running?", queue depth 3.
+
+`sibyl doctor` never checks the queue (`doctor.py:509-531` covers config, health, port,
+embedded-lock, write-probe, and agent checks only). Depth is exposed solely by
+`sibyl debug status` (`debug.py:345`), which requires OWNER role. No age or size bound
+on the queue either.
+
+The buffer mechanism is sound — `_should_keep_pending_write` (`client.py:282-286`) errs
+in the safe direction and the metric-sum invariant is documented
+(`pending_writes.py:14-19`). The gap is purely surfacing. Combined with C1, this is how
+memories go missing: login silently no-ops, writes silently queue, nothing reports it.
+
+### C5. Error output goes to stdout and corrupts `--json` — major, S
+
+`common.py:38` builds one console on stdout; `error()` (:183) and `warn()` (:188) both
+print to it, while `pagination_hint()` (:148-170) writes to stderr. The streams are
+backwards: machine-readable output shares stdout with human errors, and a purely
+informational hint gets stderr. `sibyl <cmd> --json | jq` breaks on any error — the same
+hazard `print_json`'s own docstring warns about (`common.py:52-61`).
+
+### C6. The 401 handler recommends a command that does not exist — major, S
+
+`main.py:1348-1350` prints `sibyl auth signup` as the "Create account" remediation.
+Verified: `auth.py` registers `status` (:653), `set-token` (:701), `clear-token` (:717),
+`login` (:744), `local-signup` (:833), and the `api-key` group. There is no `signup`.
+This sits on the most frequently hit error path in the CLI.
+
+### C7. The refresh-revoked recovery path is permanently dead — major, S to delete
+
+`client.py:416-420` (`_silent_local_relogin`) reads `local_login_email` and
+`local_login_password` from stored credentials. A repo-wide grep finds
+`local_login_password` at exactly one location: that read. Nothing writes it.
+
+So a revoked refresh token always takes the failure branch at `client.py:549-555` and
+appends `Silent re-login failed: No stored local login credentials are available.` The
+user is told a credential store is empty for a feature that was never wired up.
+
+### C8. Login swallows the real failure behind bare `except Exception` — major, S
+
+`auth.py:594-596` and `auth.py:633-636` catch bare `Exception` during the device-flow and
+OAuth fallbacks and report only `type(e).__name__`. A TLS failure, a DNS error, and a bug
+in our own code all degrade to `Device login unavailable (SSLError); trying OAuth login`,
+ending at the generic `No supported login methods detected for this server`
+(`auth.py:638-641`). Field login failures become undiagnosable from CLI output.
+
+Adjacent dead branch: `auth.py:627-632` has an `if e.payload is not None:` / `else:`
+where both branches emit the identical string and `e.payload` (the server's diagnostic)
+is discarded either way.
+
+### C9. `--password` accepted on the command line — major, S
+
+`auth.py:769-771` (`login`) and `auth.py:836` (`local-signup`) accept `--password` as a
+Typer option, putting passwords in shell history and in `ps` output for every other user
+on the box. Typer supports `prompt=True, hide_input=True`.
+
+### C10. `main.py` is a 3,945-line god-module with four clean seams — major, M
+
+| Range | Contents | Extract to |
+|---|---|---|
+| 590-1330 | 23 `_print_*` renderers, zero command definitions | `memory_views.py` (~740 lines) |
+| 2611-3354 | memory admin (audit, cite, inspect, blame, correct, promote, review, share, space) | `memory_admin.py` (744) |
+| 2127-2420 | four synthesis commands | `synthesis.py` (294) |
+| 3355-3514 | seven team commands | `team.py` (160) |
+
+Those four cuts remove ~1,900 lines. The 590-1330 renderer block is the highest-value
+one: pure presentation, no Typer coupling, no interleaved commands.
+
+### C11. Thirteen near-identical mutation bodies, and the helper for them is dead — major, M
+
+Every state-changing command in `task.py` and `epic.py` repeats the same six-beat body.
+Mechanical proof: `task.py:611-636` (block) vs `task.py:652-677` (unblock) is 26 lines
+each with 5 differing; `epic.py:510-536` vs `epic.py:593-619` is 27 each with 8
+differing. Roughly 515 lines carrying ~182 lines of invariant scaffolding across
+`task.py:562-594,611-636,652-677,700-731,771-823,992-1049,1097-1167,1213-1254` and
+`epic.py:456-497,510-536,551-579,593-619,642-690`.
+
+`task.py:51-58` defines `_output_response` — the exact helper this pattern wants — with
+zero call sites. The abstraction was written and then every site was copy-pasted anyway.
+The copies have already drifted: some echo the unresolved argument
+(`task.py:579,628,669,723,803`; `epic.py:529,570`), others the resolved ID
+(`task.py:912,1158`; `epic.py:612,682`), so an ID prefix yields inconsistent output.
+
+Also dead: `_validate_task_id` (`task.py:108-138`) and `_validate_epic_id`
+(`epic.py:60-84`) are referenced only by their own tests; live commands use the
+`_resolve_*` variants.
+
+### C12. Two implementations of `show`, and they disagree — major, M
+
+`main.py:1408-1457` and `entity.py:175-210` both dispatch raw-memory-versus-entity,
+sharing renderers but not dispatch. `main.py:1412-1428` tries `resolve_id_prefix` →
+`get_entity`, catches 404, retries as raw memory. `entity.py:189-198` gates the raw path
+solely on `is_raw_memory_reference`, a bare `raw_memory_` prefix test
+(`memory_display.py:15-17`). A raw memory addressed by bare UUID resolves under
+`sibyl show <uuid>` and 404s under `sibyl entity show <uuid>`.
+
+Same shape in `sibyl note` vs `sibyl task note`: `main.py:2068-2086` re-implements
+`task.py:1230-1246`, and only the latter calls `print_mutation_receipt`, so `sibyl note`
+silently drops the revision receipt its sibling prints.
+
+### C13. `epic tasks` is a verbatim copy of the task table that lost a feature — major, S
+
+`epic.py:1003-1022` reproduces `task.py:272-296` character-for-character modulo
+indentation, including a trailing `# Full title, no truncation` comment, but omits
+`task.py:273-281`, which widens columns on wide terminals and non-TTY pipes. So
+`sibyl task list` reflows titles and `sibyl epic tasks` never does. A function-local
+`from sibyl_cli.common import format_status` at `epic.py:1001`, while `format_priority`
+is imported at module top (`epic.py:21`), marks this as a later paste.
+
+### C14. `org.py` opts out of the shared error handler in all seven commands — major, S
+
+`org.py:15` imports only `error, print_json, run_async, success`, and every command ends
+with a hand-rolled `except SibylClientError` at `org.py:51-53,85-87,114-116,164-166,
+186-188,212-214,234-236`. Bypassing `common.py:301-330` means `sibyl org *` never
+surfaces `request_id`, `remediation`, `error_code`, or the 404/400/409 labels that every
+other lane module gets. `org.py:21` also shadows the shared console with a bare
+`Console()`, losing the `width=160` non-TTY setting.
+
+### C15. Four modules with zero test references — major, M
+
+| Module | Lines | Untested surface |
+|---|---|---|
+| `explore.py` | 305 | all four commands: `related`, `traverse`, `dependencies`, `path` |
+| `config_cmd.py` | 157 | seven commands including `set`, `reset`, `edit` |
+| `project_refs.py` | 102 | `resolve_project_reference`, used by `main.py:78` |
+| `view_shared.py` | 43 | shared render helpers |
+
+`explore.py` and `config_cmd.py` are the real holes — an entire user-facing sub-app
+each, one of which mutates config and includes a destructive `reset`.
+(`memory_display.py` has no direct test module but is covered indirectly via
+`test_main_capture.py` and `test_entity.py`.)
+
+### C16. Formatting and palette drift — minor, S each
+
+- **Palette bypasses** of `sibyl_core.logging.colors`: `epic.py:52-56` mixes imported
+  constants with the same values inlined as hex (`"#ff6363"`, `"#50fa7b"`), plus a
+  `"#888888"` fallback that is not in the palette at all; `logs.py:57-60` hardcodes all
+  four hexes in comments naming the constants it declined to import; `org.py:149-152`
+  and `pending.py:92` use generic Rich names.
+- **Table factory bypassed** by `config_cmd.py:55`, `debug.py:138`, `dev.py:215`,
+  `local.py:460`, `org.py:148`, `update.py:407` instead of `common.create_table`
+  (:209-222). `org.py:148` sets no box or header style at all.
+- **`pagination_hint` has one call site** (`task.py:451`) while ten sites hand-roll the
+  same footer (`task.py:304,307`; `project.py:125`; `entity.py:167,345,461`;
+  `epic.py:169,1022`; `document.py:353,488`).
+- **`--json` coverage is uneven**: `org.py` 1 of 7 (and `list`/`create`/`switch` dump raw
+  JSON unconditionally, the inverse of every other list command), `pending.py` 1 of 3,
+  `project.py` 4 of 8, `context.py` 6 of 10, `epic.py` 8 of 9; `auth.py` has none.
+- **Duplicated helpers**: `_parse_csv_ids` byte-identical at `task.py:161-164` and
+  `main.py:345-348`; the CSV row emitter at `entity.py:137-152` and `project.py:92-108`;
+  `document.py:109-113` vs `main.py:876-880`, which differ by one token
+  (`or "project"` vs `or "private"`) — a semantic split hiding inside a copy.
+
+### C17. `search` and `add` are hidden from help but documented as the core workflow — minor, S
+
+`main.py:2607-2608` registers `recall` and `search` with `hidden=True`, `main.py:3774`
+hides `add`, and `graph-search` (:1607) and `graph-add` (:1737) are hidden too. Rendered
+`sibyl --help` shows no search command. The project's own `CLAUDE.md` documents
+`/sibyl search "topic"` and `sibyl add "Pattern Title" "..."` as the standard cycle.
+
+### C18. `epic` is deprecated with no deprecation path — minor, S
+
+The sub-app help carries `DEPRECATED: an epic is just a task with subtasks...`, but no
+epic command emits a runtime warning and no removal version is named. The only runtime
+deprecation warning in the package is `main.py:201` for entity-type aliases.
+
+### C19. Client lifecycle inconsistency — minor, M
+
+Thirty-five sites use bare `client = get_client()` and never close, while
+`document.py:230,295,331`, `session.py:119` and `main.py` use `async with`. Not a
+correctness bug (`client.py:458` recreates the httpx client lazily), but every command
+leaves an open `AsyncClient` at `asyncio.run()` teardown. Separately, `pending.py:193`
+and `doctor.py:315` reach through to the private `client._request(...)` to pass
+`_buffer_pending`/`_pending_write_id`; both uses are legitimate and want a public
+replay/probe API.
+
+### Checked and clean
+
+`auth_store.py` is genuinely well built: 0600 file mode via `os.fchmod` before any
+content is written (:83-114), 0700 directory enforcement with umask (:54-81), atomic
+rename, and `fcntl.flock` exclusion (:34-51). No token is logged anywhere in the
+package. `read_content_file` (`common.py:83-122`) defends against symlinks with
+`O_NOFOLLOW`, plus size limits and binary detection.
+
+---
+
+## infra / CI
+
+Nine workflows (5,195 lines), two Helm charts, ten `moon.yml` files. I independently
+re-verified I1, I7, and I11 against the repo; all three reproduced exactly.
+
+### I1. The CI change classifier ignores `uv.lock`, `pyproject.toml`, `charts/`, `VERSION`, and Dockerfiles — blocker, S
+
+`.github/workflows/ci.yml:125`. The `runtime_changed` case list is
+`apps/api/*|apps/cli/*|apps/e2e/*|packages/python/sibyl-core/*|tools/*|benchmarks/*|
+baselines/*|moon.yml|.moon/*|.prototools|pnpm-lock.yaml|compose.e2e.yml|docker-compose*.yml`.
+
+Verified by grepping the whole classify step (lines 46-165): `uv.lock` 0 hits,
+`pyproject` 0, `charts` 0, `VERSION` 0, `Dockerfile` 0. Only `pnpm-lock` appears.
+
+Every classifier flag stays false, so `run_static`, `run_build`, `run_tests`, and
+`run_e2e` are all false and the pipeline no-ops. The concrete exposure: Dependabot runs a
+weekly `uv` update (`dependabot.yml:4-7`), and any bump confined to `uv.lock` plus the
+root `pyproject.toml` merges green with zero test coverage. That root `pyproject.toml` is
+where the security pins live — the lxml CVE-2026-41066 override at :9-12 and
+`cryptography>=48.0.1` at :30. Chart, Dockerfile, and `publish.yml` edits likewise
+trigger nothing.
+
+### I2. CI never runs the root gate suite; ~32 gate tests are release-time-only — blocker, S
+
+`ci.yml` runs `:lint`, `:typecheck`, the four `test-cov` tasks, `bench-gate`,
+`api:test-live`, the baseline replay, e2e pytest, and the storybook build. It never runs
+`moon run :check`. That target appears only in `release.yml:289`, `publish.yml:68`, and
+`publish-dogfood-images.yml:113`.
+
+Root `check` (`moon.yml:212-254`) carries 41 deps, so roughly 32 gate suites run for the
+first time at RC cut: `inventory-check`, `sync-versions-check`, `dev-script-test`,
+`chaos-test`, `storage-access-check`, `baseline-test`, and the whole `*-gate-test` family
+(memory-trust, usage-loop, trust-control, context-quality, workspace-trust, autonomy,
+reflection-quality, forgetting, write-path-integrity, team-scope, auth-session,
+overview-perf, synthesis, adapter-ingest, large-corpus-rehearsal, okf-export, doc-claim,
+backup-restore, enterprise-readiness-evidence), plus `release-workflow-test`.
+
+Combined with I1 this closes a loop: `release-workflow-test` declares `release.yml` and
+`publish.yml` as inputs (`moon.yml:568-575`), but editing `publish.yml` neither trips the
+classifier nor reaches a workflow that runs the test. The gate guarding the release
+workflow cannot see edits to the release workflow.
+
+### I3. Stock `helm install` yields a production-labelled deploy with MCP auth disabled — blocker, S
+
+`charts/sibyl/values.yaml:168` (`existingSecret: ""`) with `:155`
+(`SIBYL_ENVIRONMENT: "production"`). The `{{- if .Values.backend.existingSecret }}` guard
+at `charts/sibyl/templates/backend-deployment.yaml:71` skips the secret block, so
+`SIBYL_JWT_SECRET` is never set, and the dev auto-generation branch at
+`apps/api/src/sibyl/config.py:557` is `elif self.environment != "production"`, so it does
+not fire. The process runs with `jwt_secret == ""`.
+
+MCP auth then disables itself: `auth_enabled = auth_mode == "on" or (auth_mode == "auto"
+and jwt_secret_set)` (`server.py:1818`) with `mcp_auth_mode` defaulting to `"auto"`
+(`config.py:364-367`). Startup logs it at INFO and continues (`main.py:133-137`), and
+`SessionMiddleware` is built with `secret_key=""` (`api/app.py:276`). The production
+validator (`config.py:229-276`) checks `disable_auth`, memory URLs, `cookie_secure`, and
+default Surreal credentials, but never a JWT secret. The values comment at :166-167
+states the requirement; a comment is not a guard.
+
+Unverified: whether tokens signed with an empty HMAC key also verify, which would make
+sessions forgeable rather than merely unauthenticated.
+
+### I4. The worker crash-loops under the chart's own defaults — blocker, S
+
+`charts/sibyl/values.yaml:361` (`worker.enabled: true`) with `:15`
+(`coordinationBackend: "auto"`). `resolved_coordination_backend` returns `"redis"` only
+on a literal `"redis"` (`config.py:799-801`), so `auto` resolves to `local`, and the
+worker CLI prints a message and returns immediately (`cli/main.py:258-263`). The
+container exits 0, the Deployment restarts it, and the pod settles into CrashLoopBackOff
+with a Completed container. The chart guards only the opposite direction
+(`redis-secret.yaml:4`).
+
+### I5. The SurrealDB root password regenerates on every `helm upgrade` — blocker, M
+
+`charts/sibyl/templates/surreal-secret.yaml:14` renders `randAlphaNum 24` with no
+`lookup` guard, so each upgrade writes a new password. The Deployments checksum only the
+ConfigMap (`backend-deployment.yaml:17`, `worker-deployment.yaml:18`), never the Secret,
+so running pods do not roll and keep serving on the old value until an unrelated restart
+picks up a password the database has never seen. Separately the generated value never
+reaches SurrealDB at all: the wrapper resolves its credentials secret to
+`<upstream-fullname>-root` (`charts/surrealdb/templates/_helpers.tpl:71-73`), a different
+object from `<release>-surreal`. A delayed fuse — the upgrade reports success and auth
+breaks later, far from the cause.
+
+### I6. SurrealDB mounts a 100Gi PVC with no `fsGroup` against a nonroot image — blocker, S
+
+`charts/surrealdb/values.yaml:21-26` enables persistence at 100Gi with
+`path: rocksdb:/data/db` (:14), and the `surrealdb:` block (:7-31) sets no
+`podSecurityContext`. Upstream defaults it to `{}` and warns twice that the official
+image runs as `USER nonroot` (65532) and that provisioners creating the volume
+root-owned fail with Permission denied without `fsGroup: 65532` (vendored
+`surrealdb-0.5.0.tgz` → `values.yaml:120-127`, :274-278). The asymmetry is the tell: the
+same file sets `fsGroup: 1000` for the wrapper's own jobs at :59-63. Blocker on affected
+storage classes, no impact on ones that chown the mount.
+
+### I7. One of 185 external action references is SHA-pinned — major, M
+
+Verified by counting across all nine workflows plus `.github/actions/`: **185 external
+`uses:` references, exactly 1 SHA-pinned** — `KSXGitHub/github-actions-deploy-aur@084b0d9b...`
+at `publish.yml:354`, which handles `AUR_SSH_KEY`. The security reasoning was applied
+once and never generalized.
+
+The two that matter most, both confirmed:
+
+- `publish.yml:162` uses `pypa/gh-action-pypi-publish@release/v1` — a **mutable branch
+  ref**, not even a tag, in the job holding `id-token: write` for PyPI trusted publishing
+  (:126-127).
+- `release.yml:247` uses `hyperb1iss/git-iris@v2`, a mutable major tag, handed
+  `secrets.ANTHROPIC_API_KEY` (:256) inside a workflow whose top-level permissions are
+  `actions: write` and `contents: write` (:29-31). Own org, so lower risk, but that token
+  can write to the repo and dispatch `publish.yml`.
+
+Remaining third-party tag pins: `moonrepo/setup-toolchain@v0.6` (23x),
+`docker/login-action@v4` (10x), `docker/setup-buildx-action@v4` (5x),
+`docker/build-push-action@v7` (2x), `aquasecurity/trivy-action@v0.36.0` (2x),
+`azure/setup-helm@v5.0.1` (2x), `softprops/action-gh-release@v3` (2x), plus
+`codecov/codecov-action@v7`, `pnpm/action-setup@v6.0.10`, `astral-sh/setup-uv@v9.0.0`,
+`sigstore/cosign-installer@v4.1.2`. First-party `actions/*` accounts for 132 of the rest.
+
+Dependabot already has a `github-actions` entry (`dependabot.yml:76-90`) and updates SHA
+pins while preserving the trailing version comment, so pinning adds no maintenance cost.
+
+### I8. Dependabot has no `docker` ecosystem — major, S
+
+`dependabot.yml` covers `uv`, `npm`, and `github-actions` only. Four Dockerfiles carry
+floating base tags: `apps/api/Dockerfile:7,30` (`python:3.13-slim-bookworm`),
+`apps/web/Dockerfile:8,24,53` (`node:24-alpine`), `.devcontainer/Dockerfile:1`, and
+`infra/ansible/roles/sibyl/files/caddy/Dockerfile:4,7` (`caddy:2`). Base image CVEs
+surface only when Trivy scans the built image during publish (`publish.yml:592`, :624).
+
+The repo already knows this shape of bug: the comment above `dependency-audit` names it
+for the npm side — "The image scan in publish only speaks once a release is already under
+way, which is how a HIGH postcss advisory reached two tagged releases"
+(`ci.yml:186-190`). Same gap, still open for base images.
+
+### I9. 102 duplicated setup step instances across 727 YAML lines — major, M
+
+Counted by parsing every workflow: `Setup moonrepo toolchain` 23, `Cache moon outputs`
+18, `Cache uv` 18, `Install system dependencies` 17, `Verify toolchain` 12, `Install Node
+dependencies` 8, `Cache pnpm store` 6. The pattern is already proven here —
+`.github/actions/start-surrealdb/action.yml` is a composite action used at 10 call sites.
+The setup block is the obvious second extraction and was never done.
+
+### I10. Caches fragmented into 13 uv and 12 moon namespaces on identical hash inputs — major, S
+
+Every `Cache uv` step keys on `hashFiles('**/uv.lock')` but under 13 distinct prefixes
+(`uv-`, `uv-eval-`, `uv-live-`, `uv-longmemeval-`, `uv-longmemeval-compare-`,
+`uv-longmemeval-local-`, `uv-longmemeval-v2-`, `uv-longmemeval-v2-official-`,
+`uv-longmemeval-v2-package-`, `uv-nightly-`, `uv-okf-memory-`, `uv-release-`,
+`uv-restore-`). The `restore-keys` fall back to their own prefix only (e.g.
+`eval.yml:218-220`), so no namespace can read another's entry. `Cache moon outputs` has
+the same shape across 12 prefixes. Thirteen near-identical copies compete for the 10GB
+repository cache budget and evict each other.
+
+### I11. Six cache keys hash a lockfile path that does not exist — major, S
+
+`ci.yml:292,397,469,626,745` and `release.yml:83` read
+`hashFiles('.prototools', 'uv.lock', 'apps/web/pnpm-lock.yaml')`. Verified:
+`find . -name pnpm-lock.yaml` returns exactly one file, the root `./pnpm-lock.yaml`, and
+6 workflow lines reference the `apps/web/` path. This is a pnpm workspace, so a member
+lockfile has never existed.
+
+`hashFiles` silently omits patterns matching nothing, so the key resolves from
+`.prototools` and `uv.lock` alone. The cached paths include `apps/web/.next/cache`
+(`ci.yml:288-290`), meaning the Next build cache is invalidated by no JavaScript
+dependency change at all.
+
+### I12. `bench-gate` is the only cacheable gate, and it gates files outside its inputs — major, S
+
+18 of 19 `*-gate` and rehearsal tasks set `options: cache: false`; `bench-gate`
+(`moon.yml:666-673`) alone does not. It is also the only one invoked repeatedly within a
+single CI job against runtime files outside its declared inputs — `eval.yml:295,465,665,778`
+each pass a different report under `.moon/cache/evals/`, while the declared inputs are
+`tools/**/*.py`, `benchmarks/**/*.py`, `benchmarks/context_pack_cases.json`,
+`benchmarks/results/ai-memory/**/*.json`, and `pyproject.toml`. The gated file is not an
+input, so its content cannot influence the cache decision. Whether that produces a false
+PASS depends on whether moon folds `--` passthrough args into the task hash, which was
+not verified; the asymmetry against 18 siblings is verified and is reason enough.
+
+### I13. The RC gate skips `apps/e2e` entirely — major, S
+
+`apps/e2e/moon.yml` has no `check` and no `typecheck`, the only project with a test suite
+lacking one. Root `lint` (`moon.yml:181-192`) and root `check` (:212-254) both list core,
+api, cli, web, hooks, docs, skills, infra — never e2e. So `moon run :check`, the RC gate
+at `release.yml:289`, `publish.yml:68`, and `publish-dogfood-images.yml:113`, never lints
+or tests e2e. `ci.yml:328` runs `moon run :lint`, whose colon-prefix form does reach
+`e2e:lint`, so PR lint is covered; the release path is the gap. This compounds E4 above.
+
+### I14. No chart value reaches `SIBYL_PUBLIC_URL` — major, S
+
+The variable appears nowhere under `charts/`. Without it `public_url` keeps its default
+`http://localhost:3337` (`config.py:310-313`), and because the chart sets
+`SIBYL_SERVER_HOST: "0.0.0.0"` (`values.yaml:153`) the `server_url` derivation
+(`config.py:332-335`) rewrites the bind host to `localhost` and yields
+`http://localhost:3334`.
+
+Those two feed the MCP OAuth issuer and resource-server URLs (`server.py:1826-1829`), the
+OIDC redirect base (`auth/oidc.py:76`), the CORS allowlist (`api/app.py:260-266`),
+organization invitation links (`organization_runtime.py:166`), and password reset links
+(`auth_runtime/password_reset.py:116`). The repo's own reference values file sets it by
+hand and comments it as the single source of truth
+(`infra/local/sibyl-values.yaml:36-38`); the shipped chart omits it. Settable through the
+free-form `backend.env` map, which is the only reason this is not a blocker.
+
+### I15. Graph embedding config is unreachable, and the exposed key looks like it covers it — major, S
+
+The chart exposes `SIBYL_EMBEDDING_MODEL` and `SIBYL_EMBEDDING_DIMENSIONS`
+(`values.yaml:158-159`), which map to the **document chunk** pair (`config.py:592-601`).
+The graph pair is separate, defaults to 1024 rather than 1536 (`config.py:602-615`), and
+`graph_embedding_dimensions` sizes the Surreal vector field and HNSW index at schema
+definition time (`sibyl_core/backends/surreal/schema.py:52`). No chart value reaches it.
+
+The provider side compounds it: `embedding_provider` and `graph_embedding_provider` both
+default to `openai` while the chart defaults `SIBYL_LLM_PROVIDER: "anthropic"`
+(`values.yaml:156`) and wires the OpenAI key `optional: true`
+(`backend-deployment.yaml:82-87`). A deployment given only an Anthropic key extracts
+entities and fails every embedding call.
+
+### I16. SurrealDB runs BestEffort while every application pod has limits — major, S
+
+`charts/surrealdb/values.yaml:7-31` sets no `surrealdb.resources` and upstream defaults to
+`{}` (vendored tgz `values.yaml:201`). Backend (`charts/sibyl/values.yaml:124-130`),
+frontend (:294-300), and worker (:404-410) all set limits and requests. The only stateful
+component gets BestEffort QoS, making it the first eviction target under node memory
+pressure.
+
+### I17. `podSecurity.enforceRestricted` would reject the chart's own pods — major, S
+
+`charts/sibyl/values.yaml:513` (default off). The three security contexts set
+`allowPrivilegeEscalation`, `readOnlyRootFilesystem`, and `capabilities.drop` but no
+`seccompProfile` (:212-224, :335-347, :417-429), which the restricted profile requires as
+`RuntimeDefault` or `Localhost`; `enforce-version: "latest"` (:514) applies the newest
+semantics. Separately, `charts/sibyl/templates/podsecurity.yaml:3-12` renders a
+`Namespace` as a release resource, so installing into an existing namespace fails Helm
+ownership validation and `helm uninstall` deletes the namespace with everything in it,
+including a co-located SurrealDB PVC.
+
+### I18. Local Tilt runs SurrealDB 2.6.5 while all 14 other pins are v3.2.3 — major, S
+
+`Tiltfile:331-341` installs `surrealdb-helm/surrealdb` at `--version=0.5.0` with
+`infra/local/surrealdb-values.yaml`, which sets no `image.tag`. The upstream chart's
+`appVersion` is **2.6.5**. Every other surface pins v3.2.3:
+`charts/surrealdb/values.yaml:10`, `docker-compose.yml:12`, `compose.e2e.yml:12`,
+`docker-compose.prod.yml:163`, `docker-compose.quickstart.yml:186`,
+`infra/ansible/roles/sibyl/defaults/main.yml:12`,
+`infra/ansible/roles/sibyl/files/docker-compose.yml:22`, `apps/cli/.../docker.py:83`,
+`apps/cli/.../local.py:138`.
+
+This lands directly on a known trap: the recorded 2.x-versus-3.x divergence class where
+code passes on the lenient 2.x engine and 500s live on 3.x. Validating local Kubernetes
+against 2.6.5 is a hole in exactly that net.
+
+### I19. `sync-versions-check` inputs are a hand-maintained duplicate, already missing two — major, S
+
+`moon.yml:297-312` declares 11 of the 13 targets in `_targets()`
+(`tools/release/sync_versions.py:55-109`), missing `apps/api/pyproject.toml` and
+`apps/cli/pyproject.toml`. The task is cacheable with no outputs (two consecutive runs:
+`9s 528ms, 3dc51e09` then `cached, 3dc51e09`), and `release.yml:76-85` restores
+`.moon/cache` across runs, so a change confined to an undeclared input leaves the hash
+unchanged and the gate reports a green it did not compute.
+
+Nothing ships stale today — `release-workflow-test` covers both missing files
+(`moon.yml:576-577`, `test_release_workflow.py:439-451`). The structural hole is that no
+test asserts `set(_targets()) == inputs`, so the next pin added inherits a blind gate.
+
+### I20. Hardcoded fallback image tag in the CLI, two minor releases stale — major, S
+
+`apps/cli/src/sibyl_cli/local.py:60-70` returns `"1.0.0-rc.8"` when package metadata is
+unavailable. `DEFAULT_IMAGE_TAG` feeds the generated compose files (`local.py:77`, :115)
+and the `--tag` default for `sibyl docker init` (`docker.py:230`). The happy path resolves
+correctly, so this fires only when the CLI runs without installed metadata — at which
+point a 1.2.0 CLI silently writes a compose file pulling `sibyl-api:1.0.0-rc.8`. No test
+exercises the branch and `sync_versions.py` does not target the file.
+
+### I21. Minor infra findings
+
+- **`publish.yml` and `publish-dogfood-images.yml` have no top-level `permissions:`.**
+  Every job declares its own (12 of 12 and 4 of 4, all tightly scoped), but a newly added
+  job silently inherits the repository default token instead of default-deny. Every other
+  workflow sets a top-level `contents: read`.
+- **`longmemeval-v2.yml` duplicates a 33-item path list verbatim** for `push` (:6-38) and
+  `pull_request` (:42-74), byte-identical after strip. YAML anchors collapse it.
+- **Five checks are cacheable while all 18 sibling gates are not**: `bench-gate`
+  (`moon.yml:666`), `sync-versions-check` (:297), `inventory-check` (:323),
+  `storage-access-check` (:793), `fmt-check` (:172). `sync-versions` (:291) is a pure
+  side-effect writer with no declared outputs and caching on.
+- **`infra:lint` and `skills:lint` shell out to `npx prettier`** (`infra/moon.yml:7`,
+  `skills/moon.yml:22`) inside the RC gate. Prettier is a root devDependency at `^3.9.6`,
+  so `npx` resolves it locally when present and silently downloads an arbitrary version
+  from the network when not. `pnpm exec prettier` is the deterministic form.
+- **`skills/moon.yml:24-28` declares `**/*.yaml` in `sources`** but the lint command checks
+  only `'**/*.md' '**/*.yml'`. Latent — no `.yaml` exists under `skills/` today.
+- **The worker has no probes** while backend (`backend-deployment.yaml:118-121`) and
+  frontend (`frontend-deployment.yaml:81-84`) both do. A wedged arq worker stays Ready
+  forever, and its HPA scales on CPU and memory (`worker-hpa.yaml:15-31`), so stuck reads
+  as underutilized and scales down.
+- **SurrealDB chart jobs inherit empty resources** (`charts/surrealdb/values.yaml:70`,
+  consumed by `bootstrap-job.yaml:68-69`, `export-cronjob.yaml:86-87`,
+  `snapshot-cronjob.yaml:86-87`, `restore-drill-cronjob.yaml:159-160`). The export and
+  restore-drill jobs stream a full database export with no memory ceiling on a node also
+  running the database.
+- **Wrapper `appVersion` lacks the `v` prefix its own fallback needs.**
+  `charts/surrealdb/Chart.yaml:6` is `"3.2.3"` and `_helpers.tpl:115` falls back to
+  `.Chart.AppVersion`, producing `surrealdb/surrealdb:3.2.3`; upstream publishes
+  v-prefixed tags, so that path is an ImagePullBackOff. Latent only because
+  `values.yaml:10` sets `v3.2.3` explicitly.
+- **`okf-memory-changelog.yml` guards one artifact upload and not its sibling** (:94 gated
+  on `hashFiles(...) != ''`, :101 has `if-no-files-found: error` and no guard). Whether
+  the weekly cron fails depends on an unreadable repo secret; the intra-workflow
+  inconsistency is verified.
+- **`publish-dogfood-images.yml` is `workflow_dispatch`-only** and nothing dispatches it.
+  A legitimate manual tool worth confirming is still wanted.
+- **Nothing tests `sync_versions.py` itself.** `"moon run sync-versions"` and
+  `"moon run sync-versions-check"` are absent from `RELEASE_WORKFLOW_REQUIRED_FRAGMENTS`
+  (`test_release_workflow.py:32-68`), so deleting `release.yml:171-172` still passes the
+  allowlist proof. No test asserts every target exists, and the docstring at
+  `sync_versions.py:36-39` claims a `_pep440` parity check that no test performs.
+- **The SurrealDB version is duplicated across 14 sites with no sync tool** (I18's list
+  plus `charts/surrealdb/Chart.yaml:6`, `docs/deployment/ansible.md:12`,
+  `docs/deployment/docker-compose.md:62,90,214`). Only the two CLI sites have tests
+  pinning the literal. Extending `sync_versions.py` with a second source of truth folds it
+  into the existing gate. (M)
+- **`infra/local/tidb-cluster.yaml:17` pins `alpine:3.16.0`** (2022-era) as the TiKV helper
+  image, in a path documented as the local backing store.
+
+### Checked and clean
+
+No `pull_request_target` anywhere. No secret is echoed, written to `$GITHUB_OUTPUT`, or
+used in an `if:` expression. Every top-level `permissions:` block is `contents: read`
+except `docs.yml` (pages deploy, correctly scoped) and `release.yml` (`actions: write` for
+the publish dispatch, `contents: write` for the tag). All 16 `workflow_dispatch` inputs in
+`eval.yml` are defined and referenced. `infra/local/secrets.yaml` is gitignored.
+
+Version pins are currently in sync: `sync_versions.py --check` exits 0 with "All
+deployment pins match VERSION (1.2.0)", all 13 targets exist, all 17 patterns match. The
+three published Python packages carry no version literal (`dynamic = ["version"]` reading
+the root `VERSION`), the web version is injected at build time
+(`apps/web/next.config.ts:13,43,61`), and no Dockerfile holds a literal. The chart
+subchart chain has no drift: `Chart.yaml` 0.5.0, `Chart.lock` 0.5.0, vendored tgz 0.5.0.
+Every chart env var maps to a live setting. No image in either chart uses `:latest`.
+`.prototools` (moon 2.2.6, python 3.13, node 24, pnpm 11.5.2, uv 0.9) matches what CI
+installs.
+
+Not run: no `helm template`, `helm lint`, or cluster operation, so every chart rendering
+claim comes from reading templates rather than rendered output. No workflow was executed.
+Moon's passthrough-argument hashing was not tested, which is why I12 is scoped to the
+asymmetry rather than a claimed false PASS.

--- a/docs/architecture/AUDIT_2026-08-13/debt-web-cli-infra.md
+++ b/docs/architecture/AUDIT_2026-08-13/debt-web-cli-infra.md
@@ -1,109 +1,105 @@
 # Tech debt audit: apps/web, apps/cli, apps/e2e, infra
 
-Read-only audit at commit `5388d986` (main, clean). Every finding below was verified by
-reading the code; hypotheses that did not survive a check are recorded in the
-"Checked and clean" sections so nobody re-investigates them.
+Read-only audit at commit `5388d986` (main, clean). Every finding below was verified by reading the
+code; hypotheses that did not survive a check are recorded in the "Checked and clean" sections so
+nobody re-investigates them.
 
-Severity: **blocker** (ship-stopping or data-integrity), **major** (real user or
-maintainer cost, fix soon), **minor** (hygiene, fix opportunistically).
-Size: **S** (< half day), **M** (1-3 days), **L** (a week or more).
+Severity: **blocker** (ship-stopping or data-integrity), **major** (real user or maintainer cost,
+fix soon), **minor** (hygiene, fix opportunistically). Size: **S** (< half day), **M** (1-3 days),
+**L** (a week or more).
 
 ---
 
 ## Top findings, ranked
 
-| # | Finding | Where | Sev | Size |
-|---|---|---|---|---|
-| 1 | `sibyl auth login` writes the token under a key no command reads; login exits 0 | C1 | blocker | S |
-| 2 | CI classifier ignores `uv.lock`, `pyproject.toml`, `charts/`, `VERSION`, Dockerfiles — whole pipeline no-ops | I1 | blocker | S |
-| 3 | Stock `helm install` ships production-labelled with MCP auth disabled | I3 | blocker | S |
-| 4 | Every browser e2e test asserts the login page; Playwright declared and never imported | E1, E2 | blocker | M |
-| 5 | ~32 gate suites run for the first time at RC cut, never in CI | I2 | blocker | S |
-| 6 | `sibyl entity delete` destroys data with no confirmation; its `--yes` is dead | C2 | blocker | S |
-| 7 | Worker crash-loops under the chart's own defaults; Surreal password regenerates per upgrade | I4, I5 | blocker | S/M |
-| 8 | 19 CLI failure paths exit 0; failed writes buffer to disk silently | C3, C4 | major | S |
-| 9 | Realtime give-up kills the only freshness signal (focus + reconnect refetch both off) | W1 | major | M |
-| 10 | 1 of 185 GitHub Actions is SHA-pinned, incl. a mutable branch ref on the PyPI publish job | I7 | major | M |
+| #   | Finding                                                                                                      | Where  | Sev     | Size |
+| --- | ------------------------------------------------------------------------------------------------------------ | ------ | ------- | ---- |
+| 1   | `sibyl auth login` writes the token under a key no command reads; login exits 0                              | C1     | blocker | S    |
+| 2   | CI classifier ignores `uv.lock`, `pyproject.toml`, `charts/`, `VERSION`, Dockerfiles — whole pipeline no-ops | I1     | blocker | S    |
+| 3   | Stock `helm install` ships production-labelled with MCP auth disabled                                        | I3     | blocker | S    |
+| 4   | Every browser e2e test asserts the login page; Playwright declared and never imported                        | E1, E2 | blocker | M    |
+| 5   | ~32 gate suites run for the first time at RC cut, never in CI                                                | I2     | blocker | S    |
+| 6   | `sibyl entity delete` destroys data with no confirmation; its `--yes` is dead                                | C2     | blocker | S    |
+| 7   | Worker crash-loops under the chart's own defaults; Surreal password regenerates per upgrade                  | I4, I5 | blocker | S/M  |
+| 8   | 19 CLI failure paths exit 0; failed writes buffer to disk silently                                           | C3, C4 | major   | S    |
+| 9   | Realtime give-up kills the only freshness signal (focus + reconnect refetch both off)                        | W1     | major   | M    |
+| 10  | 1 of 185 GitHub Actions is SHA-pinned, incl. a mutable branch ref on the PyPI publish job                    | I7     | major   | M    |
 
 The three themes worth naming: **a green check that proves nothing** (2, 4, 5, plus I11's
-nonexistent lockfile path and I12's cacheable gate), **silent failure** (1, 6, 8, 9, plus
-W4's swallowed SSR errors), and **defaults that only work by accident** (3, 7, plus I14
-and I15's unreachable config).
+nonexistent lockfile path and I12's cacheable gate), **silent failure** (1, 6, 8, 9, plus W4's
+swallowed SSR errors), and **defaults that only work by accident** (3, 7, plus I14 and I15's
+unreachable config).
 
 ---
 
 ## apps/web (Next.js 16)
 
-222 non-test TypeScript files, 124 of them client components. Biome config is strict
-and genuinely enforced (8 suppressions repo-wide, exactly 1 `any`).
+222 non-test TypeScript files, 124 of them client components. Biome config is strict and genuinely
+enforced (8 suppressions repo-wide, exactly 1 `any`).
 
 ### W1. Realtime give-up silently breaks the only freshness signal — major, M
 
-`components/providers.tsx:51-52` disables both `refetchOnWindowFocus` and
-`refetchOnReconnect`, with the comment at lines 47-50 stating plainly that
-"Realtime/websocket invalidation is the primary freshness signal."
+`components/providers.tsx:51-52` disables both `refetchOnWindowFocus` and `refetchOnReconnect`, with
+the comment at lines 47-50 stating plainly that "Realtime/websocket invalidation is the primary
+freshness signal."
 
 `lib/websocket.ts:344-347` gives up permanently after `maxReconnectAttempts = 10`
-(`websocket.ts:192`), returning early without calling `setStatus('disconnected')`. The
-last status written was `'reconnecting'` at line 351, so the client parks in
-`'reconnecting'` forever. `reconnectAttempts` resets only on a successful connect
-(line 273) or `destroy()` (line 340), and no UI offers a manual reconnect.
+(`websocket.ts:192`), returning early without calling `setStatus('disconnected')`. The last status
+written was `'reconnecting'` at line 351, so the client parks in `'reconnecting'` forever.
+`reconnectAttempts` resets only on a successful connect (line 273) or `destroy()` (line 340), and no
+UI offers a manual reconnect.
 
-The two decisions are each defensible alone and destructive together. After roughly
-17 minutes of cumulative backoff on a flaky connection, the app has no websocket, no
-focus refetch, and no reconnect refetch. Hooks with a polling fallback survive
-(`useMemorySourceImport` at `hooks.ts:680-686`, `useBackups` at `hooks.ts:2099`,
-`useBackupJobStatus` at `hooks.ts:2101-2110` all poll when status is not `'connected'`),
-but the primary data hooks have no `refetchInterval` at all: `useTasks`
-(`hooks.ts:1293-1299`), `useEntities` (`hooks.ts:568-574`), `useProjects`, `useEpics`.
-Those views then serve stale cache indefinitely until a hard reload or a mutation, with
+The two decisions are each defensible alone and destructive together. After roughly 17 minutes of
+cumulative backoff on a flaky connection, the app has no websocket, no focus refetch, and no
+reconnect refetch. Hooks with a polling fallback survive (`useMemorySourceImport` at
+`hooks.ts:680-686`, `useBackups` at `hooks.ts:2099`, `useBackupJobStatus` at `hooks.ts:2101-2110`
+all poll when status is not `'connected'`), but the primary data hooks have no `refetchInterval` at
+all: `useTasks` (`hooks.ts:1293-1299`), `useEntities` (`hooks.ts:568-574`), `useProjects`,
+`useEpics`. Those views then serve stale cache indefinitely until a hard reload or a mutation, with
 no indication anything is wrong.
 
-Confirmed at `hooks.ts:1050-1135`: `useRealtimeUpdates` is the sole invalidation driver
-for `entity_created`, `entity_pending`, `entity_updated`, and `entity_deleted`, all of
-which route through `invalidateByEntityType` to reach `tasks.all`, `projects.all`,
-`entities.all`, and `sources.all`. None of those has a polling fallback, so all four
-primary list views are affected.
+Confirmed at `hooks.ts:1050-1135`: `useRealtimeUpdates` is the sole invalidation driver for
+`entity_created`, `entity_pending`, `entity_updated`, and `entity_deleted`, all of which route
+through `invalidateByEntityType` to reach `tasks.all`, `projects.all`, `entities.all`, and
+`sources.all`. None of those has a polling fallback, so all four primary list views are affected.
 
-Fix: transition to `'disconnected'` on give-up, and either re-enable
-`refetchOnReconnect` or add a reconnect affordance. The status transition alone is S;
-the full freshness-contract repair is M.
+Fix: transition to `'disconnected'` on give-up, and either re-enable `refetchOnReconnect` or add a
+reconnect affordance. The status transition alone is S; the full freshness-contract repair is M.
 
 ### W2. Entity detail queries with params are never invalidated — major, S
 
-`queryKeys.entities.detail` (`hooks.ts:55-56`) takes an optional trailing `params`
-object that becomes part of the key. `EntityDetailPanel` uses it: `entity-detail-panel.tsx:92-96`
-calls `useEntity(entityId, undefined, { include_summary: false, related_limit: 0 })`
-when `queryMode === 'graph'`, producing key
+`queryKeys.entities.detail` (`hooks.ts:55-56`) takes an optional trailing `params` object that
+becomes part of the key. `EntityDetailPanel` uses it: `entity-detail-panel.tsx:92-96` calls
+`useEntity(entityId, undefined, { include_summary: false, related_limit: 0 })` when
+`queryMode === 'graph'`, producing key
 `['entities','detail',id,{include_summary:false,related_limit:0}]`.
 
-Every invalidation site omits the params. `invalidateByEntityType` at `hooks.ts:224`
-calls `invalidateQueries({ queryKey: queryKeys.entities.detail(entityId) })`, which
-builds `['entities','detail',id,undefined]`. React Query's `partialMatchKey` compares
-index 3 as `partialMatchKey({include_summary:false,...}, undefined)`, and the `typeof`
-guard rejects it — so the graph panel's cached entity is never invalidated after an
-update or delete.
+Every invalidation site omits the params. `invalidateByEntityType` at `hooks.ts:224` calls
+`invalidateQueries({ queryKey: queryKeys.entities.detail(entityId) })`, which builds
+`['entities','detail',id,undefined]`. React Query's `partialMatchKey` compares index 3 as
+`partialMatchKey({include_summary:false,...}, undefined)`, and the `typeof` guard rejects it — so
+the graph panel's cached entity is never invalidated after an update or delete.
 
 The same key shape breaks `useDeleteEntity` at `hooks.ts:843`:
-`getQueryData(queryKeys.entities.detail(id))` misses the params-bearing entry, so
-`entityType` resolves `undefined` and the mutation falls through to the `default`
-branch of the switch (`hooks.ts:219-226`) — wrong invalidation set for tasks, projects,
-and sources deleted from the graph panel.
+`getQueryData(queryKeys.entities.detail(id))` misses the params-bearing entry, so `entityType`
+resolves `undefined` and the mutation falls through to the `default` branch of the switch
+(`hooks.ts:219-226`) — wrong invalidation set for tasks, projects, and sources deleted from the
+graph panel.
 
-Fix: split the registry into an exact key and a prefix key (`detail(id)` for
-invalidation, `detailWith(id, params)` for the query), the standard TanStack pattern.
+Fix: split the registry into an exact key and a prefix key (`detail(id)` for invalidation,
+`detailWith(id, params)` for the query), the standard TanStack pattern.
 
 ### W3. No route-level error boundaries; three routes have none at all — major, S
 
-`find app -name 'error.tsx'` returns nothing: there are zero Next.js error boundary
-files. The only boundary is a single `AsyncBoundary` in `components/layout/main-shell.tsx:50`,
-which `app/(main)/layout.tsx:10` applies to the `(main)` group.
+`find app -name 'error.tsx'` returns nothing: there are zero Next.js error boundary files. The only
+boundary is a single `AsyncBoundary` in `components/layout/main-shell.tsx:50`, which
+`app/(main)/layout.tsx:10` applies to the `(main)` group.
 
 That leaves `app/login/page.tsx` (523 lines of client code), `app/setup/page.tsx`, and
-`app/reset-password/page.tsx` with no boundary whatsoever — a render throw on the login
-or first-run setup page produces Next's default error screen. Inside `(main)`, the
-single page-level boundary means any error in any segment blanks the entire shell
-rather than the failing panel, despite `loading.tsx` files existing for 15 routes.
+`app/reset-password/page.tsx` with no boundary whatsoever — a render throw on the login or first-run
+setup page produces Next's default error screen. Inside `(main)`, the single page-level boundary
+means any error in any segment blanks the entire shell rather than the failing panel, despite
+`loading.tsx` files existing for 15 routes.
 
 Fix: an `error.tsx` per route group, plus segment boundaries around the heavy panels.
 
@@ -112,52 +108,51 @@ Fix: an `error.tsx` per route group, plus segment boundaries around the heavy pa
 Four server components swallow fetch errors with no logging and no user signal:
 `app/(main)/entities/page.tsx:53-54`, `app/(main)/search/page.tsx:31-33`,
 `app/(main)/projects/page.tsx:15-21`. Each is a bare `.catch(() => undefined)` (or
-`.catch(() => ({...}))`), so a backend outage or a timeout degrades to a client-side
-refetch with nothing recorded.
+`.catch(() => ({...}))`), so a backend outage or a timeout degrades to a client-side refetch with
+nothing recorded.
 
-`lib/api-server.ts` is otherwise well built — a 5s `AbortSignal.timeout`
-(`api-server.ts:25-32`), cookie forwarding (`api-server.ts:61-72`), and a distinct
-timeout error message (`api-server.ts:78-80`). All of that diagnostic value is
-discarded at the call site. `lib/logger.ts` exists and is not used here.
+`lib/api-server.ts` is otherwise well built — a 5s `AbortSignal.timeout` (`api-server.ts:25-32`),
+cookie forwarding (`api-server.ts:61-72`), and a distinct timeout error message
+(`api-server.ts:78-80`). All of that diagnostic value is discarded at the call site. `lib/logger.ts`
+exists and is not used here.
 
 Fix: log the swallowed error server-side; keep the UI degradation.
 
 ### W5. Two architectures for the same job — major, M
 
-Nine pages use the server-component shell that prefetches in parallel and hands
-`initialData` to a client child — `app/(main)/entities/page.tsx:44-68` is the
-reference implementation, joined by `page.tsx`, `settings/page.tsx`, `memory/page.tsx`,
-`archive/page.tsx`, `projects/page.tsx`, `search/page.tsx`, `memory/captures/page.tsx`,
-`entities/[id]/page.tsx`.
+Nine pages use the server-component shell that prefetches in parallel and hands `initialData` to a
+client child — `app/(main)/entities/page.tsx:44-68` is the reference implementation, joined by
+`page.tsx`, `settings/page.tsx`, `memory/page.tsx`, `archive/page.tsx`, `projects/page.tsx`,
+`search/page.tsx`, `memory/captures/page.tsx`, `entities/[id]/page.tsx`.
 
-Twenty-four pages are wholesale `'use client'` with no SSR prefetch, including the
-heaviest ones: `tasks/page.tsx:1`, `graph/page.tsx`, `sources/page.tsx`,
-`epics/page.tsx`, and all seven `settings/*` pages. `tasks/page.tsx:48-52` fires four
-client queries on mount with nothing server-rendered.
+Twenty-four pages are wholesale `'use client'` with no SSR prefetch, including the heaviest ones:
+`tasks/page.tsx:1`, `graph/page.tsx`, `sources/page.tsx`, `epics/page.tsx`, and all seven
+`settings/*` pages. `tasks/page.tsx:48-52` fires four client queries on mount with nothing
+server-rendered.
 
-Neither pattern is wrong, but which one a route uses is unpredictable, so every new
-page is a coin flip and the SSR path's `initialData` plumbing rots on the routes that
-skipped it. Fix: pick one, document it, migrate the high-traffic routes.
+Neither pattern is wrong, but which one a route uses is unpredictable, so every new page is a coin
+flip and the SSR path's `initialData` plumbing rots on the routes that skipped it. Fix: pick one,
+document it, migrate the high-traffic routes.
 
 ### W6. `lib/api.ts` is a 3,040-line god-module — major, M
 
-One file holds 169 exported interfaces (the entire API type surface) plus the `api`
-object with 26 namespaces (`api.ts:2065-3000`: `entities`, `rawCaptures`, `memory`,
-`sourceImports`, `synthesis`, `search`, `graph`, `admin`, `telemetry`, `jobs`,
-`backups`, `auth`, `security`, `preferences`, `profile`, `session`, `orgs`, `tasks`,
-`projects`, `epics`, `sources`, `rag`, `metrics`, `setup`, `settings`).
+One file holds 169 exported interfaces (the entire API type surface) plus the `api` object with 26
+namespaces (`api.ts:2065-3000`: `entities`, `rawCaptures`, `memory`, `sourceImports`, `synthesis`,
+`search`, `graph`, `admin`, `telemetry`, `jobs`, `backups`, `auth`, `security`, `preferences`,
+`profile`, `session`, `orgs`, `tasks`, `projects`, `epics`, `sources`, `rag`, `metrics`, `setup`,
+`settings`).
 
-Nearly every component imports from it, so any type edit invalidates the module for the
-whole graph on every typecheck and rebuild. `lib/hooks.ts` at 2,135 lines has the same
-shape one layer up. Fix: split into `lib/api/<domain>.ts` with a barrel, mirroring the
-existing `lib/constants/` split which already does this well.
+Nearly every component imports from it, so any type edit invalidates the module for the whole graph
+on every typecheck and rebuild. `lib/hooks.ts` at 2,135 lines has the same shape one layer up. Fix:
+split into `lib/api/<domain>.ts` with a barrel, mirroring the existing `lib/constants/` split which
+already does this well.
 
 ### W7. `graph/page.tsx` is 1,764 lines holding seven components — major, M
 
 `app/(main)/graph/page.tsx` defines `MobileEntitySheet` (:94), `ClusterLegend` (:169),
-`StatsOverlay` (:271), `GraphToolbar` (:317), and `GraphPageContent` (:786) — the last
-alone runs ~970 lines with 11 `useState`, 9 `useEffect`, and 14 `useCallback`/`useMemo`
-hooks. The canvas paint path (`paintNode`, :1206-1390) is 185 lines inline.
+`StatsOverlay` (:271), `GraphToolbar` (:317), and `GraphPageContent` (:786) — the last alone runs
+~970 lines with 11 `useState`, 9 `useEffect`, and 14 `useCallback`/`useMemo` hooks. The canvas paint
+path (`paintNode`, :1206-1390) is 185 lines inline.
 
 Nothing here is broken; it is the single hardest file in the app to modify safely, and
 `components/graph/` already exists as the natural home (it currently holds only
@@ -165,8 +160,8 @@ Nothing here is broken; it is the single hardest file in the app to modify safel
 
 ### W8. Priority constants duplicated five times, with a latent divergence — minor, S
 
-`lib/constants/tasks.ts:55-57` already defines `TASK_PRIORITIES` (including `someday`)
-and `TASK_PRIORITY_CONFIG` as the canonical source. Five local redefinitions ignore it:
+`lib/constants/tasks.ts:55-57` already defines `TASK_PRIORITIES` (including `someday`) and
+`TASK_PRIORITY_CONFIG` as the canonical source. Five local redefinitions ignore it:
 
 - `PRIORITY_ORDER` at `app/(main)/epics/page.tsx:29`, `components/tasks/task-list-mobile.tsx:23`,
   `components/tasks/kanban-board.tsx:30`
@@ -174,41 +169,41 @@ and `TASK_PRIORITY_CONFIG` as the canonical source. Five local redefinitions ign
   (byte-identical)
 - `PRIORITY_STYLES` at `components/tasks/task-card.tsx:40` and `components/epics/epic-card.tsx:17`
 
-The epics copy omits `someday`, so at `epics/page.tsx:137-138` a `someday` epic takes
-the `?? 99` fallback. To be precise: with today's five priorities that still sorts it
-last, identical to the `someday: 4` the task copies use — **this is a latent
-divergence, not a live bug**. It becomes one the moment a sixth priority is added to
-`TASK_PRIORITIES` and only three of the five copies are updated.
+The epics copy omits `someday`, so at `epics/page.tsx:137-138` a `someday` epic takes the `?? 99`
+fallback. To be precise: with today's five priorities that still sorts it last, identical to the
+`someday: 4` the task copies use — **this is a latent divergence, not a live bug**. It becomes one
+the moment a sixth priority is added to `TASK_PRIORITIES` and only three of the five copies are
+updated.
 
 ### W9. Six dead query-key registry entries — minor, S
 
-Defined in `hooks.ts` and referenced nowhere: `projects.members` (:136),
-`epics.tasks` (:152), `epics.progress` (:153), `metrics.projectsSummary` (:165),
-`session.all` (:74), `rag.all` (:83). They imply cache surfaces that do not exist.
+Defined in `hooks.ts` and referenced nowhere: `projects.members` (:136), `epics.tasks` (:152),
+`epics.progress` (:153), `metrics.projectsSummary` (:165), `session.all` (:74), `rag.all` (:83).
+They imply cache surfaces that do not exist.
 
-Three keys also bypass the registry entirely with raw literals: `['metrics']`
-(`hooks.ts:198,206`, where the registry has `metrics.org`/`metrics.project` but no
-`metrics.all` prefix to use), and `['crawl_progress', source_id]`
-(`hooks.ts:1133,1184`) — the only snake_case key in a kebab-case registry. A registry
-that the code routes around in three places is one rename away from a silent cache miss.
+Three keys also bypass the registry entirely with raw literals: `['metrics']` (`hooks.ts:198,206`,
+where the registry has `metrics.org`/`metrics.project` but no `metrics.all` prefix to use), and
+`['crawl_progress', source_id]` (`hooks.ts:1133,1184`) — the only snake_case key in a kebab-case
+registry. A registry that the code routes around in three places is one rename away from a silent
+cache miss.
 
 ### W10. Five exported Suspense wrappers with zero consumers — minor, S
 
-`components/suspense-boundary.tsx` exports `SuspenseBoundary` (:97), `PageSuspense`
-(:117), `SectionSuspense` (:126), `CardGridSuspense` (:135), and `ListSuspense` (:144).
-None is imported anywhere in the app; only the 15 `*Skeleton` exports below them are
-used, and those go through `loading.tsx` files directly. `StatusIndicator`
-(`components/ui/icons.tsx:294`) is likewise unused and is visibly the component built
-for W1's missing offline state — its `status` union even omits `'reconnecting'`.
+`components/suspense-boundary.tsx` exports `SuspenseBoundary` (:97), `PageSuspense` (:117),
+`SectionSuspense` (:126), `CardGridSuspense` (:135), and `ListSuspense` (:144). None is imported
+anywhere in the app; only the 15 `*Skeleton` exports below them are used, and those go through
+`loading.tsx` files directly. `StatusIndicator` (`components/ui/icons.tsx:294`) is likewise unused
+and is visibly the component built for W1's missing offline state — its `status` union even omits
+`'reconnecting'`.
 
 ### W11. Stale nav entry for a redirect stub — minor, S
 
-`lib/constants/navigation.ts:43` registers `archive: { label: 'Memory Captures',
-href: '/archive' }`. `app/(main)/archive/page.tsx:24` is a pure redirect to
-`/memory/captures`, and every real link in the app already points at the new route
-(`dashboard-content.tsx:894`, `memory-home.tsx:457,710,745,764`,
-`search-result.tsx:72`). The stub also carries a `loading.tsx` rendering `ArchiveSkeleton`
-for a page that never renders, and `archive/page.test.tsx`.
+`lib/constants/navigation.ts:43` registers
+`archive: { label: 'Memory Captures', href: '/archive' }`. `app/(main)/archive/page.tsx:24` is a
+pure redirect to `/memory/captures`, and every real link in the app already points at the new route
+(`dashboard-content.tsx:894`, `memory-home.tsx:457,710,745,764`, `search-result.tsx:72`). The stub
+also carries a `loading.tsx` rendering `ArchiveSkeleton` for a page that never renders, and
+`archive/page.test.tsx`.
 
 Related naming collision: `/sources/[id]` (docs-crawl RAG sources,
 `app/(main)/sources/[id]/page.tsx`) and `/memory/sources/[sourceId]` (memory provenance,
@@ -217,798 +212,758 @@ Related naming collision: `/sources/[id]` (docs-crawl RAG sources,
 ### W12. Query-key factory type understates its own key — minor, S
 
 `queryKeys.graph.hierarchical` (`hooks.ts:93-94`) is typed
-`(params?: { max_nodes?, max_edges?, refresh? })`, but `useHierarchicalGraph`
-(`hooks.ts:968-980`) passes seven fields including `projects`, `types`, `resolution`,
-and `cluster_id`. Because the argument is a variable rather than a literal, excess
-property checking does not fire, so it compiles. Caching is correct at runtime (the
-whole object lands in the key); the type is simply a lie that would mislead the next
-person reasoning about invalidation.
+`(params?: { max_nodes?, max_edges?, refresh? })`, but `useHierarchicalGraph` (`hooks.ts:968-980`)
+passes seven fields including `projects`, `types`, `resolution`, and `cluster_id`. Because the
+argument is a variable rather than a literal, excess property checking does not fire, so it
+compiles. Caching is correct at runtime (the whole object lands in the key); the type is simply a
+lie that would mislead the next person reasoning about invalidation.
 
 ### W13. Minor a11y residuals — minor, S
 
-Biome disables `noStaticElementInteractions`, `useSemanticElements`, and
-`useKeyWithClickEvents` globally (`apps/web/biome.json:19-21`), so clickable-div
-correctness is unenforced. In practice the code is disciplined — all five
-`<div onClick>` sites carry `role`, `tabIndex`, and `onKeyDown`. Two residuals:
+Biome disables `noStaticElementInteractions`, `useSemanticElements`, and `useKeyWithClickEvents`
+globally (`apps/web/biome.json:19-21`), so clickable-div correctness is unenforced. In practice the
+code is disciplined — all five `<div onClick>` sites carry `role`, `tabIndex`, and `onKeyDown`. Two
+residuals:
 
-- `components/tasks/task-card.tsx:150-171` has `role="button"` and a key handler but no
-  `aria-label` and no `focus-visible` ring, while its sibling `epic-card.tsx:118-136`
-  has both. Keyboard users get no visible focus on the kanban board.
-- `components/layout/project-selector.tsx:159-170` handles `Enter` but not `Space`
-  (ARIA requires both for `role="button"`), and nests a real `<button>` (:174) inside
-  the `role="button"` div — nested interactive controls.
+- `components/tasks/task-card.tsx:150-171` has `role="button"` and a key handler but no `aria-label`
+  and no `focus-visible` ring, while its sibling `epic-card.tsx:118-136` has both. Keyboard users
+  get no visible focus on the kanban board.
+- `components/layout/project-selector.tsx:159-170` handles `Enter` but not `Space` (ARIA requires
+  both for `role="button"`), and nests a real `<button>` (:174) inside the `role="button"` div —
+  nested interactive controls.
 
 ### Checked and clean (do not re-investigate)
 
-- **Charts are theme-aware.** `components/metrics/charts.tsx:82-97` reads SilkCircuit
-  CSS custom properties off `document.documentElement` and re-reads on every theme
-  flip. The hex block at :52-62 is an explicitly labelled SSR fallback, not a dark-only
-  palette.
+- **Charts are theme-aware.** `components/metrics/charts.tsx:82-97` reads SilkCircuit CSS custom
+  properties off `document.documentElement` and re-reads on every theme flip. The hex block at
+  :52-62 is an explicitly labelled SSR fallback, not a dark-only palette.
 - **Canvas colors are theme-aware.** `lib/constants/graph.ts:45-51` provides
-  `canvasNodeColor`/`canvasClusterColor` with a documented dawn-theme darkening pass,
-  because canvas cannot read CSS variables.
-- **The graph starfield redesign landed.** The historical finding is resolved on the web
-  side: `GRAPH_DEFAULTS.MAX_NODES` is now 500 with a comment explaining the legibility
-  tradeoff (`constants/graph.ts:56-59`), overview/detail resolution modes exist, the
-  server sends `recommended_resolution` and the client honours it
-  (`graph/page.tsx:884-902`), clusters are labelled and colored, and `StatsOverlay`
-  (`graph/page.tsx:271-306`) surfaces displayed-vs-total counts. The 1000/5000
-  truncation still lives in `apps/api/src/sibyl/persistence/graph_runtime.py:1140-1141`
-  and `graph_communities.py` (not this lane), but the client no longer requests it.
+  `canvasNodeColor`/`canvasClusterColor` with a documented dawn-theme darkening pass, because canvas
+  cannot read CSS variables.
+- **The graph starfield redesign landed.** The historical finding is resolved on the web side:
+  `GRAPH_DEFAULTS.MAX_NODES` is now 500 with a comment explaining the legibility tradeoff
+  (`constants/graph.ts:56-59`), overview/detail resolution modes exist, the server sends
+  `recommended_resolution` and the client honours it (`graph/page.tsx:884-902`), clusters are
+  labelled and colored, and `StatsOverlay` (`graph/page.tsx:271-306`) surfaces displayed-vs-total
+  counts. The 1000/5000 truncation still lives in
+  `apps/api/src/sibyl/persistence/graph_runtime.py:1140-1141` and `graph_communities.py` (not this
+  lane), but the client no longer requests it.
 - **No polling freeze from W1.** Every `useWebSocketStatus` gate is
-  `status === 'connected' ? false : poll`, so a stuck `'reconnecting'` still polls. W1's
-  impact is confined to hooks with no polling fallback.
+  `status === 'connected' ? false : poll`, so a stuck `'reconnecting'` still polls. W1's impact is
+  confined to hooks with no polling fallback.
 - **Both `dangerouslySetInnerHTML` sites are sound** — a static theme FOUC script
   (`app/layout.tsx:53`) and Shiki's own escaped output (`components/ui/markdown.tsx:67`).
-- **`AsyncBoundary` is not dead** (used at `main-shell.tsx:50`); the gap is coverage, not
-  existence.
-- **Lint hygiene is excellent**: 8 `biome-ignore` suppressions and 1 `any` across 222
-  files, `noExplicitAny`/`noNonNullAssertion`/`noFloatingPromises` all at `error`.
+- **`AsyncBoundary` is not dead** (used at `main-shell.tsx:50`); the gap is coverage, not existence.
+- **Lint hygiene is excellent**: 8 `biome-ignore` suppressions and 1 `any` across 222 files,
+  `noExplicitAny`/`noNonNullAssertion`/`noFloatingPromises` all at `error`.
 
-One config note: `apps/web/biome.json:73-76` puts `noFloatingPromises` and
-`noMisusedPromises` in `nursery`. Nursery rules are renamed or promoted between Biome
-minors, so a routine bump can silently drop both checks with no lint error. Worth
-pinning awareness to the dependency-bump checklist. (minor, S)
+One config note: `apps/web/biome.json:73-76` puts `noFloatingPromises` and `noMisusedPromises` in
+`nursery`. Nursery rules are renamed or promoted between Biome minors, so a routine bump can
+silently drop both checks with no lint error. Worth pinning awareness to the dependency-bump
+checklist. (minor, S)
 
 ---
 
 ## apps/e2e
 
-27 tests across five files. The auth and CLI-runner fixtures are well built, bounded
-waits are used correctly everywhere, and two tests (archive round-trip, context recall)
-are genuine end-to-end proofs. The problems are coverage and vacuity, not flakiness.
+27 tests across five files. The auth and CLI-runner fixtures are well built, bounded waits are used
+correctly everywhere, and two tests (archive round-trip, context recall) are genuine end-to-end
+proofs. The problems are coverage and vacuity, not flakiness.
 
 ### E1. The entire browser suite cannot fail — blocker, M
 
-`tests/browser/test_smoke.py:28-57`: all five tests issue
-`httpx.get(path, follow_redirects=True)` and assert the status is in
-`(200, 301, 302, 307, 308)`. `apps/web/src/proxy.ts:35-43` redirects every
-unauthenticated request to `/login`, and the matcher at `proxy.ts:52` covers `/`,
-`/tasks`, `/graph`, `/settings`. The tests send no cookies, so all four
-protected-route tests follow the redirect and assert that the login page returned 200.
-They are five copies of `test_login_page`.
+`tests/browser/test_smoke.py:28-57`: all five tests issue `httpx.get(path, follow_redirects=True)`
+and assert the status is in `(200, 301, 302, 307, 308)`. `apps/web/src/proxy.ts:35-43` redirects
+every unauthenticated request to `/login`, and the matcher at `proxy.ts:52` covers `/`, `/tasks`,
+`/graph`, `/settings`. The tests send no cookies, so all four protected-route tests follow the
+redirect and assert that the login page returned 200. They are five copies of `test_login_page`.
 
-Deleting `apps/web/src/app/(main)/tasks/page.tsx` would not fail `test_tasks_page`. When
-the frontend is down the autouse fixture at :22-26 skips the class, so the suite has
-exactly two outcomes: skip or pass. CI spends minutes building and booting the frontend
-(`ci.yml:649-651`, `:678-690`) to prove nothing.
+Deleting `apps/web/src/app/(main)/tasks/page.tsx` would not fail `test_tasks_page`. When the
+frontend is down the autouse fixture at :22-26 skips the class, so the suite has exactly two
+outcomes: skip or pass. CI spends minutes building and booting the frontend (`ci.yml:649-651`,
+`:678-690`) to prove nothing.
 
 ### E2. Playwright is declared, installed, documented, and never imported — blocker, S
 
-`apps/e2e/pyproject.toml:22-24,29` declares `playwright>=1.40` as both an optional extra
-and a dev dependency, `apps/e2e/moon.yml:36-38` defines `playwright-install`, and
-`README.md:79-85` documents the setup. Zero playwright imports exist under `tests/`. The
-`browser` marker (`pyproject.toml:59`, described as "requires playwright") is attached to
-a pure-httpx suite. This is what makes E1 look acceptable at a glance.
+`apps/e2e/pyproject.toml:22-24,29` declares `playwright>=1.40` as both an optional extra and a dev
+dependency, `apps/e2e/moon.yml:36-38` defines `playwright-install`, and `README.md:79-85` documents
+the setup. Zero playwright imports exist under `tests/`. The `browser` marker (`pyproject.toml:59`,
+described as "requires playwright") is attached to a pure-httpx suite. This is what makes E1 look
+acceptable at a glance.
 
 ### E3. Zero coverage of org/tenant isolation — blocker, M
 
-`CLAUDE.md` names namespace-per-org as the load-bearing invariant. No e2e test creates
-two users in two orgs and asserts that user A cannot read user B's entities, tasks, or
-captures. Every existing test shares one session-scoped user (`conftest.py:359`), so
-none could detect a leak. A regression here is cross-tenant data disclosure.
+`CLAUDE.md` names namespace-per-org as the load-bearing invariant. No e2e test creates two users in
+two orgs and asserts that user A cannot read user B's entities, tasks, or captures. Every existing
+test shares one session-scoped user (`conftest.py:359`), so none could detect a leak. A regression
+here is cross-tenant data disclosure.
 
 ### E4. e2e is excluded from CI's task graph and re-declared by hand — major, S
 
-Every task in `apps/e2e/moon.yml` (lines 12, 19, 28, 35, 38, 51) carries `preset: server`.
-Verified against the installed moon 2.2.6: `moon task e2e:test` reports
-`Mode: persistent / Runs in CI: No`, while `api:test`, `core:test`, and `cli:test` all
-report `Runs in CI: Yes`. Root `moon.yml:212-254` omits `e2e:` from `:check`.
+Every task in `apps/e2e/moon.yml` (lines 12, 19, 28, 35, 38, 51) carries `preset: server`. Verified
+against the installed moon 2.2.6: `moon task e2e:test` reports `Mode: persistent / Runs in CI: No`,
+while `api:test`, `core:test`, and `cli:test` all report `Runs in CI: Yes`. Root `moon.yml:212-254`
+omits `e2e:` from `:check`.
 
 CI works around this by bypassing moon entirely — `ci.yml:696-703` runs
-`cd apps/e2e && uv run pytest -v` with `SIBYL_E2E_CLI_COMMAND` re-declared inline. So the
-moon task definitions and the CI invocation are two configurations that drift silently:
-editing `apps/e2e/moon.yml` has no CI effect, and the CI run ignores the `-m` marker
-filters.
+`cd apps/e2e && uv run pytest -v` with `SIBYL_E2E_CLI_COMMAND` re-declared inline. So the moon task
+definitions and the CI invocation are two configurations that drift silently: editing
+`apps/e2e/moon.yml` has no CI effect, and the CI run ignores the `-m` marker filters.
 
 ### E5. Assertions that cannot fail — major, S each
 
 - `tests/api/test_health.py:31,37` — `assert status_code in (200, 401, 403)`; only a 500 fails.
-- `tests/api/test_health.py:41` — `assert "total_entities" in data or "entities" in data
-  or isinstance(data, dict)`; the third disjunct is unconditionally true, making the
-  first two decorative.
+- `tests/api/test_health.py:41` —
+  `assert "total_entities" in data or "entities" in data or isinstance(data, dict)`; the third
+  disjunct is unconditionally true, making the first two decorative.
 - `tests/api/test_endpoints.py:81` — `isinstance(data, dict)` is the whole test body.
 - `tests/api/test_endpoints.py:108,116` — `isinstance(data, (dict, list))`.
-- `tests/api/test_endpoints.py:70-73` — loops over returned entities to check a type
-  filter; an empty result passes having verified nothing.
+- `tests/api/test_endpoints.py:70-73` — loops over returned entities to check a type filter; an
+  empty result passes having verified nothing.
 - `tests/cli/test_tasks.py:27-38` — creates a task, lists by status, then asserts only
-  `isinstance(tasks, list)`. The creation is decorative and the named behavior (status
-  filtering) is untested. Same shape at `tests/cli/test_entities.py:50-56,74-82`.
+  `isinstance(tasks, list)`. The creation is decorative and the named behavior (status filtering) is
+  untested. Same shape at `tests/cli/test_entities.py:50-56,74-82`.
 
 ### E6. A test that passes when the command is broken — major, S
 
-`tests/cli/test_projects.py:52-64` runs `project show --json`, and on failure falls
-through to re-verifying `project list` (comment: "may not be implemented"). If
-`sibyl project show` regresses or is deleted, the test still passes.
+`tests/cli/test_projects.py:52-64` runs `project show --json`, and on failure falls through to
+re-verifying `project list` (comment: "may not be implemented"). If `sibyl project show` regresses
+or is deleted, the test still passes.
 
 ### E7. Mock-only unit tests gated behind a live server — major, S
 
-All five tests in `tests/test_cli_runner.py` are pure `unittest.mock` tests of argument
-construction and touch no network, but `conftest.py:468-470` makes `require_services`
-`autouse=True`, pulling in a session-scoped `wait_for_services` that raises `TimeoutError`
-after 30s without a backend. They also carry no marker, so both `e2e:test-api` and
-`e2e:test-browser` skip them.
+All five tests in `tests/test_cli_runner.py` are pure `unittest.mock` tests of argument construction
+and touch no network, but `conftest.py:468-470` makes `require_services` `autouse=True`, pulling in
+a session-scoped `wait_for_services` that raises `TimeoutError` after 30s without a backend. They
+also carry no marker, so both `e2e:test-api` and `e2e:test-browser` skip them.
 
 ### E8. The perf gate is off by default and never runs — major, S
 
-`tools/perf/multi_user.py:26` sets `DEFAULT_ERROR_RATE = 0.0` (correct), but `max_p95_ms`
-defaults to `_env_optional_float("SIBYL_PERF_MAX_P95_MS")` with no fallback (:324-326),
-and `check_thresholds` short-circuits on `is not None` (:196). `apps/e2e/moon.yml:20-28`
-does not set it, so the suite measures p95, prints it, and asserts nothing. Load is
-4 users x 3 iterations x 5 operations = 60 requests
-(`tests/perf/test_multi_user_performance.py:47-49`).
+`tools/perf/multi_user.py:26` sets `DEFAULT_ERROR_RATE = 0.0` (correct), but `max_p95_ms` defaults
+to `_env_optional_float("SIBYL_PERF_MAX_P95_MS")` with no fallback (:324-326), and
+`check_thresholds` short-circuits on `is not None` (:196). `apps/e2e/moon.yml:20-28` does not set
+it, so the suite measures p95, prints it, and asserts nothing. Load is 4 users x 3 iterations x 5
+operations = 60 requests (`tests/perf/test_multi_user_performance.py:47-49`).
 
-It also never runs at any cadence: `skipif SIBYL_E2E_PERF != 1` (:28-32), no `test-perf`
-in any workflow, and `nightly-regression.yml` has only `baseline-parity`, `live-graph`,
-and `restore-to-scratch`. Root `:check` runs `multi-user-perf-test` (`moon.yml:770`), but
-that targets `tools/tests/test_multi_user_perf.py` — unit tests of the harness, not a
-live run.
+It also never runs at any cadence: `skipif SIBYL_E2E_PERF != 1` (:28-32), no `test-perf` in any
+workflow, and `nightly-regression.yml` has only `baseline-parity`, `live-graph`, and
+`restore-to-scratch`. Root `:check` runs `multi-user-perf-test` (`moon.yml:770`), but that targets
+`tools/tests/test_multi_user_perf.py` — unit tests of the harness, not a live run.
 
 Spot-checked independently and confirmed: `apps/web/src/proxy.ts:36-43` redirects every
-unauthenticated request to `/login` and the matcher at :50-55 covers all four tested
-paths; `grep -rn playwright apps/e2e/tests/` returns nothing; all six `apps/e2e/moon.yml`
-tasks carry `preset: server`.
+unauthenticated request to `/login` and the matcher at :50-55 covers all four tested paths;
+`grep -rn playwright apps/e2e/tests/` returns nothing; all six `apps/e2e/moon.yml` tasks carry
+`preset: server`.
 
 While confirming E4 I also found `apps/e2e/moon.yml:47-51`: the `format` task carries
-`preset: server`, marking a one-shot `ruff format` as a persistent server task. Its
-sibling `lint` (:44-46) correctly does not. Copy-paste slip. (minor, S)
+`preset: server`, marking a one-shot `ruff format` as a persistent server task. Its sibling `lint`
+(:44-46) correctly does not. Copy-paste slip. (minor, S)
 
 ### E9. Coverage gaps, ranked
 
-- **Web: 33 routes, 0 meaningfully covered.** Highest value missing: login → dashboard
-  (nothing proves a user can sign in through the UI), `/setup` first-run (a broken
-  wizard bricks every new install), `/search`.
+- **Web: 33 routes, 0 meaningfully covered.** Highest value missing: login → dashboard (nothing
+  proves a user can sign in through the UI), `/setup` first-run (a broken wizard bricks every new
+  install), `/search`.
 - **CLI: 26 registered sub-apps, 8 covered.** No coverage for `login`/`logout`/`whoami`/`auth`
-  (`apps/cli/src/sibyl_cli/main.py:134,157-158,164`), `epic`, `team`, `org`, `synthesis`,
-  `explore`, `export`, `ingest`, `crawl`, `session`, `pending-writes`, `admin`, `skill`,
-  `docs`, `debug`, `logs`, `doctor`, `update`, `config`, `note`, `brief`, `init`.
-  Highest value: the auth commands, the first thing every user touches.
-- **API: 31 route modules, 5 endpoints touched.** Untouched and high value: `backups`
-  (a silently broken restore is unrecoverable), `setup`, `context`/`memory` (the core
-  read path, currently exercised only indirectly through the CLI).
-- **Auth flows:** login is a fixture (`conftest.py:359-394`), so a failure surfaces as a
-  collection error rather than a named test. No test for logout, refresh, invalid
-  credentials, expired-token rejection, or password reset.
+  (`apps/cli/src/sibyl_cli/main.py:134,157-158,164`), `epic`, `team`, `org`, `synthesis`, `explore`,
+  `export`, `ingest`, `crawl`, `session`, `pending-writes`, `admin`, `skill`, `docs`, `debug`,
+  `logs`, `doctor`, `update`, `config`, `note`, `brief`, `init`. Highest value: the auth commands,
+  the first thing every user touches.
+- **API: 31 route modules, 5 endpoints touched.** Untouched and high value: `backups` (a silently
+  broken restore is unrecoverable), `setup`, `context`/`memory` (the core read path, currently
+  exercised only indirectly through the CLI).
+- **Auth flows:** login is a fixture (`conftest.py:359-394`), so a failure surfaces as a collection
+  error rather than a named test. No test for logout, refresh, invalid credentials, expired-token
+  rejection, or password reset.
 
 ### E10. Shared session user with no cleanup — minor, M
 
 `e2e_auth_token` is session-scoped (`conftest.py:359`); no test deletes what it creates.
-`test_projects.py` creates four projects per run, `test_tasks.py` five tasks plus four
-projects. Names are uniquified (`conftest.py:478-495`) so runs do not collide, but the
-org accretes permanently. Ephemeral in CI; unbounded growth when run locally against the
-dev DB per `README.md:9-11`. Defaults at `conftest.py:22-23` (`localhost:3334`,
-`localhost:3337`) collide with a running `moon run dev` stack, which is what makes the
-accidental-pollution path easy to hit.
+`test_projects.py` creates four projects per run, `test_tasks.py` five tasks plus four projects.
+Names are uniquified (`conftest.py:478-495`) so runs do not collide, but the org accretes
+permanently. Ephemeral in CI; unbounded growth when run locally against the dev DB per
+`README.md:9-11`. Defaults at `conftest.py:22-23` (`localhost:3334`, `localhost:3337`) collide with
+a running `moon run dev` stack, which is what makes the accidental-pollution path easy to hit.
 
 ### E11. Undeclared dependency on a pre-seeded corpus — minor, S
 
 `ci.yml:698-700` authenticates as `baseline-corpus@sibyl.dev`, whose org is populated by
 `moon run baseline-seed` + `baseline-replay-runtime` (`ci.yml:677-680`). Tests like
-`test_entities_with_type_filter` read whatever that seed produced, but nothing in
-`conftest.py` or `README.md` mentions the dependency, so a local run against a fresh org
-exercises different paths than CI.
+`test_entities_with_type_filter` read whatever that seed produced, but nothing in `conftest.py` or
+`README.md` mentions the dependency, so a local run against a fresh org exercises different paths
+than CI.
 
-Boundary worth naming: `ci.yml:589` sets `SIBYL_MOCK_LLM: true`, so no e2e test covers
-any LLM-dependent extraction, synthesis, or reflection path.
+Boundary worth naming: `ci.yml:589` sets `SIBYL_MOCK_LLM: true`, so no e2e test covers any
+LLM-dependent extraction, synthesis, or reflection path.
 
 ### Checked and clean
 
-- **No committed junk.** `git ls-files apps/e2e` returns 20 files, all source.
-  `.pytest_cache/`, `.ruff_cache/`, `.venv/`, `__pycache__/` are covered by root
-  `.gitignore` (lines 2, 24, 46, 57) and are untracked local artifacts.
+- **No committed junk.** `git ls-files apps/e2e` returns 20 files, all source. `.pytest_cache/`,
+  `.ruff_cache/`, `.venv/`, `__pycache__/` are covered by root `.gitignore` (lines 2, 24, 46, 57)
+  and are untracked local artifacts.
 - **No unbounded waits.** All three `time.sleep` sites sit inside bounded deadline loops
   (`conftest.py:280-296`, `:337-351`, `:460-465`) that raise on expiry.
 - **No order dependence.** Every test builds its own fixtures with UUID-suffixed names.
-- **No suppressed failures.** The two `skip` sites are environment gates; no `xfail`
-  anywhere. `--strict-markers` and `--strict-config` are both on
-  (`pyproject.toml:50`).
+- **No suppressed failures.** The two `skip` sites are environment gates; no `xfail` anywhere.
+  `--strict-markers` and `--strict-config` are both on (`pyproject.toml:50`).
 
 ---
 
 ## apps/cli
 
-44 source modules, 38 test files. Findings below were produced with live probes against
-a sandboxed `HOME`; I independently re-verified the two blockers and C6 by reading the
-cited lines.
+44 source modules, 38 test files. Findings below were produced with live probes against a sandboxed
+`HOME`; I independently re-verified the two blockers and C6 by reading the cited lines.
 
 ### C1. `sibyl auth login` writes the token under a key no other command reads — blocker, S
 
-`auth.py:43-55` and `client.py:54-94` resolve the API base URL with inverted priority.
-The client ranks the active context above `SIBYL_API_URL` (`client.py:78-83`, priorities
-2 and 3); auth checks `SIBYL_API_URL` first (`auth.py:51-53`) and only falls back to
-`SibylClient().base_url` (`auth.py:55`) when the env var is empty.
+`auth.py:43-55` and `client.py:54-94` resolve the API base URL with inverted priority. The client
+ranks the active context above `SIBYL_API_URL` (`client.py:78-83`, priorities 2 and 3); auth checks
+`SIBYL_API_URL` first (`auth.py:51-53`) and only falls back to `SibylClient().base_url`
+(`auth.py:55`) when the env var is empty.
 
-The precondition is precise: an active context **and** `SIBYL_API_URL` set to a
-different host. With context `prod → https://sibyl.example.com` and
-`SIBYL_API_URL=http://localhost:3334/api`, login stores the token under the localhost
-key while every command reads the context key. The credential *scope* matches
-(`context:prod:org:default` both sides); only the server key diverges.
+The precondition is precise: an active context **and** `SIBYL_API_URL` set to a different host. With
+context `prod → https://sibyl.example.com` and `SIBYL_API_URL=http://localhost:3334/api`, login
+stores the token under the localhost key while every command reads the context key. The credential
+_scope_ matches (`context:prod:org:default` both sides); only the server key diverges.
 
-Login prints `✓ Login complete` and exits 0. Every later command sees no token, takes a
-401, and per C4 silently buffers its writes. The failure presents as a server-side auth
-problem. This is the mechanism behind the known "sibyl auth still needs login +
-pending-writes flush" symptom.
+Login prints `✓ Login complete` and exits 0. Every later command sees no token, takes a 401, and per
+C4 silently buffers its writes. The failure presents as a server-side auth problem. This is the
+mechanism behind the known "sibyl auth still needs login + pending-writes flush" symptom.
 
-Fix: have `_compute_api_url` delegate to the client resolver for the no-explicit-server
-case instead of reading the env var itself.
+Fix: have `_compute_api_url` delegate to the client resolver for the no-explicit-server case instead
+of reading the env var itself.
 
 ### C2. `sibyl entity delete` destroys data with no confirmation and a dead `--yes` — blocker, S
 
-`entity.py:270` declares `yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip
-confirmation")] = False`. The body (`entity.py:276-299`) never references it and
-contains no prompt — it goes straight to `await client.delete_entity(entity_id)` at
-:285. Verified by reading the full command.
+`entity.py:270` declares
+`yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False`. The body
+(`entity.py:276-299`) never references it and contains no prompt — it goes straight to
+`await client.delete_entity(entity_id)` at :285. Verified by reading the full command.
 
-The flag actively misleads: anyone reading `--help` concludes a guard exists. An AST
-sweep found exactly two dead Typer parameters in the package, both named `yes` — this
-one and `epic.py:583` (`archive_epic`).
+The flag actively misleads: anyone reading `--help` concludes a guard exists. An AST sweep found
+exactly two dead Typer parameters in the package, both named `yes` — this one and `epic.py:583`
+(`archive_epic`).
 
 ### C3. Nineteen command failure paths exit 0 — major, S
 
-The `else: error("Failed to ...")` tail sits at the end of a `@run_async` coroutine with
-no `raise typer.Exit(1)`, so the process exits 0 on a refused write. Probed:
-`task start`, `task create`, `task complete`, and `epic start` all print `✗ Failed to
-...` and exit 0.
+The `else: error("Failed to ...")` tail sits at the end of a `@run_async` coroutine with no
+`raise typer.Exit(1)`, so the process exits 0 on a refused write. Probed: `task start`,
+`task create`, `task complete`, and `epic start` all print `✗ Failed to ...` and exit 0.
 
-Sites: `task.py:589,631,672,726,815,1044,1162,1246`; `epic.py:492,531,574,614,685`;
-`entity.py:261`; `project.py:275`; `crawl.py:299`; `crawl_shared.py:50`; `local.py:431`;
-`main.py:2085`. Any CI job, hook, or agent checking `$?` reads a refused write as
-success — and Sibyl's own session hooks are exactly such callers.
+Sites: `task.py:589,631,672,726,815,1044,1162,1246`; `epic.py:492,531,574,614,685`; `entity.py:261`;
+`project.py:275`; `crawl.py:299`; `crawl_shared.py:50`; `local.py:431`; `main.py:2085`. Any CI job,
+hook, or agent checking `$?` reads a refused write as success — and Sibyl's own session hooks are
+exactly such callers.
 
 ### C4. Failed writes are buffered to disk with nothing telling the user — major, S
 
-`client.py:631-641` files every POST/PATCH/DELETE into `~/.config/sibyl/pending_writes/`
-before sending. On connection failure `client.py:739-744` raises with no remediation
-string. Probed against a dead port: three writes queued, user saw only "Is the server
-running?", queue depth 3.
+`client.py:631-641` files every POST/PATCH/DELETE into `~/.config/sibyl/pending_writes/` before
+sending. On connection failure `client.py:739-744` raises with no remediation string. Probed against
+a dead port: three writes queued, user saw only "Is the server running?", queue depth 3.
 
 `sibyl doctor` never checks the queue (`doctor.py:509-531` covers config, health, port,
-embedded-lock, write-probe, and agent checks only). Depth is exposed solely by
-`sibyl debug status` (`debug.py:345`), which requires OWNER role. No age or size bound
-on the queue either.
+embedded-lock, write-probe, and agent checks only). Depth is exposed solely by `sibyl debug status`
+(`debug.py:345`), which requires OWNER role. No age or size bound on the queue either.
 
-The buffer mechanism is sound — `_should_keep_pending_write` (`client.py:282-286`) errs
-in the safe direction and the metric-sum invariant is documented
-(`pending_writes.py:14-19`). The gap is purely surfacing. Combined with C1, this is how
-memories go missing: login silently no-ops, writes silently queue, nothing reports it.
+The buffer mechanism is sound — `_should_keep_pending_write` (`client.py:282-286`) errs in the safe
+direction and the metric-sum invariant is documented (`pending_writes.py:14-19`). The gap is purely
+surfacing. Combined with C1, this is how memories go missing: login silently no-ops, writes silently
+queue, nothing reports it.
 
 ### C5. Error output goes to stdout and corrupts `--json` — major, S
 
-`common.py:38` builds one console on stdout; `error()` (:183) and `warn()` (:188) both
-print to it, while `pagination_hint()` (:148-170) writes to stderr. The streams are
-backwards: machine-readable output shares stdout with human errors, and a purely
-informational hint gets stderr. `sibyl <cmd> --json | jq` breaks on any error — the same
-hazard `print_json`'s own docstring warns about (`common.py:52-61`).
+`common.py:38` builds one console on stdout; `error()` (:183) and `warn()` (:188) both print to it,
+while `pagination_hint()` (:148-170) writes to stderr. The streams are backwards: machine-readable
+output shares stdout with human errors, and a purely informational hint gets stderr.
+`sibyl <cmd> --json | jq` breaks on any error — the same hazard `print_json`'s own docstring warns
+about (`common.py:52-61`).
 
 ### C6. The 401 handler recommends a command that does not exist — major, S
 
-`main.py:1348-1350` prints `sibyl auth signup` as the "Create account" remediation.
-Verified: `auth.py` registers `status` (:653), `set-token` (:701), `clear-token` (:717),
-`login` (:744), `local-signup` (:833), and the `api-key` group. There is no `signup`.
-This sits on the most frequently hit error path in the CLI.
+`main.py:1348-1350` prints `sibyl auth signup` as the "Create account" remediation. Verified:
+`auth.py` registers `status` (:653), `set-token` (:701), `clear-token` (:717), `login` (:744),
+`local-signup` (:833), and the `api-key` group. There is no `signup`. This sits on the most
+frequently hit error path in the CLI.
 
 ### C7. The refresh-revoked recovery path is permanently dead — major, S to delete
 
-`client.py:416-420` (`_silent_local_relogin`) reads `local_login_email` and
-`local_login_password` from stored credentials. A repo-wide grep finds
-`local_login_password` at exactly one location: that read. Nothing writes it.
+`client.py:416-420` (`_silent_local_relogin`) reads `local_login_email` and `local_login_password`
+from stored credentials. A repo-wide grep finds `local_login_password` at exactly one location: that
+read. Nothing writes it.
 
-So a revoked refresh token always takes the failure branch at `client.py:549-555` and
-appends `Silent re-login failed: No stored local login credentials are available.` The
-user is told a credential store is empty for a feature that was never wired up.
+So a revoked refresh token always takes the failure branch at `client.py:549-555` and appends
+`Silent re-login failed: No stored local login credentials are available.` The user is told a
+credential store is empty for a feature that was never wired up.
 
 ### C8. Login swallows the real failure behind bare `except Exception` — major, S
 
-`auth.py:594-596` and `auth.py:633-636` catch bare `Exception` during the device-flow and
-OAuth fallbacks and report only `type(e).__name__`. A TLS failure, a DNS error, and a bug
-in our own code all degrade to `Device login unavailable (SSLError); trying OAuth login`,
-ending at the generic `No supported login methods detected for this server`
-(`auth.py:638-641`). Field login failures become undiagnosable from CLI output.
+`auth.py:594-596` and `auth.py:633-636` catch bare `Exception` during the device-flow and OAuth
+fallbacks and report only `type(e).__name__`. A TLS failure, a DNS error, and a bug in our own code
+all degrade to `Device login unavailable (SSLError); trying OAuth login`, ending at the generic
+`No supported login methods detected for this server` (`auth.py:638-641`). Field login failures
+become undiagnosable from CLI output.
 
-Adjacent dead branch: `auth.py:627-632` has an `if e.payload is not None:` / `else:`
-where both branches emit the identical string and `e.payload` (the server's diagnostic)
-is discarded either way.
+Adjacent dead branch: `auth.py:627-632` has an `if e.payload is not None:` / `else:` where both
+branches emit the identical string and `e.payload` (the server's diagnostic) is discarded either
+way.
 
 ### C9. `--password` accepted on the command line — major, S
 
-`auth.py:769-771` (`login`) and `auth.py:836` (`local-signup`) accept `--password` as a
-Typer option, putting passwords in shell history and in `ps` output for every other user
-on the box. Typer supports `prompt=True, hide_input=True`.
+`auth.py:769-771` (`login`) and `auth.py:836` (`local-signup`) accept `--password` as a Typer
+option, putting passwords in shell history and in `ps` output for every other user on the box. Typer
+supports `prompt=True, hide_input=True`.
 
 ### C10. `main.py` is a 3,945-line god-module with four clean seams — major, M
 
-| Range | Contents | Extract to |
-|---|---|---|
-| 590-1330 | 23 `_print_*` renderers, zero command definitions | `memory_views.py` (~740 lines) |
-| 2611-3354 | memory admin (audit, cite, inspect, blame, correct, promote, review, share, space) | `memory_admin.py` (744) |
-| 2127-2420 | four synthesis commands | `synthesis.py` (294) |
-| 3355-3514 | seven team commands | `team.py` (160) |
+| Range     | Contents                                                                           | Extract to                     |
+| --------- | ---------------------------------------------------------------------------------- | ------------------------------ |
+| 590-1330  | 23 `_print_*` renderers, zero command definitions                                  | `memory_views.py` (~740 lines) |
+| 2611-3354 | memory admin (audit, cite, inspect, blame, correct, promote, review, share, space) | `memory_admin.py` (744)        |
+| 2127-2420 | four synthesis commands                                                            | `synthesis.py` (294)           |
+| 3355-3514 | seven team commands                                                                | `team.py` (160)                |
 
-Those four cuts remove ~1,900 lines. The 590-1330 renderer block is the highest-value
-one: pure presentation, no Typer coupling, no interleaved commands.
+Those four cuts remove ~1,900 lines. The 590-1330 renderer block is the highest-value one: pure
+presentation, no Typer coupling, no interleaved commands.
 
 ### C11. Thirteen near-identical mutation bodies, and the helper for them is dead — major, M
 
-Every state-changing command in `task.py` and `epic.py` repeats the same six-beat body.
-Mechanical proof: `task.py:611-636` (block) vs `task.py:652-677` (unblock) is 26 lines
-each with 5 differing; `epic.py:510-536` vs `epic.py:593-619` is 27 each with 8
-differing. Roughly 515 lines carrying ~182 lines of invariant scaffolding across
+Every state-changing command in `task.py` and `epic.py` repeats the same six-beat body. Mechanical
+proof: `task.py:611-636` (block) vs `task.py:652-677` (unblock) is 26 lines each with 5 differing;
+`epic.py:510-536` vs `epic.py:593-619` is 27 each with 8 differing. Roughly 515 lines carrying ~182
+lines of invariant scaffolding across
 `task.py:562-594,611-636,652-677,700-731,771-823,992-1049,1097-1167,1213-1254` and
 `epic.py:456-497,510-536,551-579,593-619,642-690`.
 
-`task.py:51-58` defines `_output_response` — the exact helper this pattern wants — with
-zero call sites. The abstraction was written and then every site was copy-pasted anyway.
-The copies have already drifted: some echo the unresolved argument
-(`task.py:579,628,669,723,803`; `epic.py:529,570`), others the resolved ID
-(`task.py:912,1158`; `epic.py:612,682`), so an ID prefix yields inconsistent output.
+`task.py:51-58` defines `_output_response` — the exact helper this pattern wants — with zero call
+sites. The abstraction was written and then every site was copy-pasted anyway. The copies have
+already drifted: some echo the unresolved argument (`task.py:579,628,669,723,803`;
+`epic.py:529,570`), others the resolved ID (`task.py:912,1158`; `epic.py:612,682`), so an ID prefix
+yields inconsistent output.
 
-Also dead: `_validate_task_id` (`task.py:108-138`) and `_validate_epic_id`
-(`epic.py:60-84`) are referenced only by their own tests; live commands use the
-`_resolve_*` variants.
+Also dead: `_validate_task_id` (`task.py:108-138`) and `_validate_epic_id` (`epic.py:60-84`) are
+referenced only by their own tests; live commands use the `_resolve_*` variants.
 
 ### C12. Two implementations of `show`, and they disagree — major, M
 
-`main.py:1408-1457` and `entity.py:175-210` both dispatch raw-memory-versus-entity,
-sharing renderers but not dispatch. `main.py:1412-1428` tries `resolve_id_prefix` →
-`get_entity`, catches 404, retries as raw memory. `entity.py:189-198` gates the raw path
-solely on `is_raw_memory_reference`, a bare `raw_memory_` prefix test
-(`memory_display.py:15-17`). A raw memory addressed by bare UUID resolves under
-`sibyl show <uuid>` and 404s under `sibyl entity show <uuid>`.
+`main.py:1408-1457` and `entity.py:175-210` both dispatch raw-memory-versus-entity, sharing
+renderers but not dispatch. `main.py:1412-1428` tries `resolve_id_prefix` → `get_entity`, catches
+404, retries as raw memory. `entity.py:189-198` gates the raw path solely on
+`is_raw_memory_reference`, a bare `raw_memory_` prefix test (`memory_display.py:15-17`). A raw
+memory addressed by bare UUID resolves under `sibyl show <uuid>` and 404s under
+`sibyl entity show <uuid>`.
 
 Same shape in `sibyl note` vs `sibyl task note`: `main.py:2068-2086` re-implements
-`task.py:1230-1246`, and only the latter calls `print_mutation_receipt`, so `sibyl note`
-silently drops the revision receipt its sibling prints.
+`task.py:1230-1246`, and only the latter calls `print_mutation_receipt`, so `sibyl note` silently
+drops the revision receipt its sibling prints.
 
 ### C13. `epic tasks` is a verbatim copy of the task table that lost a feature — major, S
 
-`epic.py:1003-1022` reproduces `task.py:272-296` character-for-character modulo
-indentation, including a trailing `# Full title, no truncation` comment, but omits
-`task.py:273-281`, which widens columns on wide terminals and non-TTY pipes. So
-`sibyl task list` reflows titles and `sibyl epic tasks` never does. A function-local
-`from sibyl_cli.common import format_status` at `epic.py:1001`, while `format_priority`
-is imported at module top (`epic.py:21`), marks this as a later paste.
+`epic.py:1003-1022` reproduces `task.py:272-296` character-for-character modulo indentation,
+including a trailing `# Full title, no truncation` comment, but omits `task.py:273-281`, which
+widens columns on wide terminals and non-TTY pipes. So `sibyl task list` reflows titles and
+`sibyl epic tasks` never does. A function-local `from sibyl_cli.common import format_status` at
+`epic.py:1001`, while `format_priority` is imported at module top (`epic.py:21`), marks this as a
+later paste.
 
 ### C14. `org.py` opts out of the shared error handler in all seven commands — major, S
 
-`org.py:15` imports only `error, print_json, run_async, success`, and every command ends
-with a hand-rolled `except SibylClientError` at `org.py:51-53,85-87,114-116,164-166,
-186-188,212-214,234-236`. Bypassing `common.py:301-330` means `sibyl org *` never
-surfaces `request_id`, `remediation`, `error_code`, or the 404/400/409 labels that every
-other lane module gets. `org.py:21` also shadows the shared console with a bare
+`org.py:15` imports only `error, print_json, run_async, success`, and every command ends with a
+hand-rolled `except SibylClientError` at
+`org.py:51-53,85-87,114-116,164-166, 186-188,212-214,234-236`. Bypassing `common.py:301-330` means
+`sibyl org *` never surfaces `request_id`, `remediation`, `error_code`, or the 404/400/409 labels
+that every other lane module gets. `org.py:21` also shadows the shared console with a bare
 `Console()`, losing the `width=160` non-TTY setting.
 
 ### C15. Four modules with zero test references — major, M
 
-| Module | Lines | Untested surface |
-|---|---|---|
-| `explore.py` | 305 | all four commands: `related`, `traverse`, `dependencies`, `path` |
-| `config_cmd.py` | 157 | seven commands including `set`, `reset`, `edit` |
-| `project_refs.py` | 102 | `resolve_project_reference`, used by `main.py:78` |
-| `view_shared.py` | 43 | shared render helpers |
+| Module            | Lines | Untested surface                                                 |
+| ----------------- | ----- | ---------------------------------------------------------------- |
+| `explore.py`      | 305   | all four commands: `related`, `traverse`, `dependencies`, `path` |
+| `config_cmd.py`   | 157   | seven commands including `set`, `reset`, `edit`                  |
+| `project_refs.py` | 102   | `resolve_project_reference`, used by `main.py:78`                |
+| `view_shared.py`  | 43    | shared render helpers                                            |
 
-`explore.py` and `config_cmd.py` are the real holes — an entire user-facing sub-app
-each, one of which mutates config and includes a destructive `reset`.
-(`memory_display.py` has no direct test module but is covered indirectly via
-`test_main_capture.py` and `test_entity.py`.)
+`explore.py` and `config_cmd.py` are the real holes — an entire user-facing sub-app each, one of
+which mutates config and includes a destructive `reset`. (`memory_display.py` has no direct test
+module but is covered indirectly via `test_main_capture.py` and `test_entity.py`.)
 
 ### C16. Formatting and palette drift — minor, S each
 
-- **Palette bypasses** of `sibyl_core.logging.colors`: `epic.py:52-56` mixes imported
-  constants with the same values inlined as hex (`"#ff6363"`, `"#50fa7b"`), plus a
-  `"#888888"` fallback that is not in the palette at all; `logs.py:57-60` hardcodes all
-  four hexes in comments naming the constants it declined to import; `org.py:149-152`
-  and `pending.py:92` use generic Rich names.
-- **Table factory bypassed** by `config_cmd.py:55`, `debug.py:138`, `dev.py:215`,
-  `local.py:460`, `org.py:148`, `update.py:407` instead of `common.create_table`
-  (:209-222). `org.py:148` sets no box or header style at all.
-- **`pagination_hint` has one call site** (`task.py:451`) while ten sites hand-roll the
-  same footer (`task.py:304,307`; `project.py:125`; `entity.py:167,345,461`;
-  `epic.py:169,1022`; `document.py:353,488`).
-- **`--json` coverage is uneven**: `org.py` 1 of 7 (and `list`/`create`/`switch` dump raw
-  JSON unconditionally, the inverse of every other list command), `pending.py` 1 of 3,
-  `project.py` 4 of 8, `context.py` 6 of 10, `epic.py` 8 of 9; `auth.py` has none.
+- **Palette bypasses** of `sibyl_core.logging.colors`: `epic.py:52-56` mixes imported constants with
+  the same values inlined as hex (`"#ff6363"`, `"#50fa7b"`), plus a `"#888888"` fallback that is not
+  in the palette at all; `logs.py:57-60` hardcodes all four hexes in comments naming the constants
+  it declined to import; `org.py:149-152` and `pending.py:92` use generic Rich names.
+- **Table factory bypassed** by `config_cmd.py:55`, `debug.py:138`, `dev.py:215`, `local.py:460`,
+  `org.py:148`, `update.py:407` instead of `common.create_table` (:209-222). `org.py:148` sets no
+  box or header style at all.
+- **`pagination_hint` has one call site** (`task.py:451`) while ten sites hand-roll the same footer
+  (`task.py:304,307`; `project.py:125`; `entity.py:167,345,461`; `epic.py:169,1022`;
+  `document.py:353,488`).
+- **`--json` coverage is uneven**: `org.py` 1 of 7 (and `list`/`create`/`switch` dump raw JSON
+  unconditionally, the inverse of every other list command), `pending.py` 1 of 3, `project.py` 4 of
+  8, `context.py` 6 of 10, `epic.py` 8 of 9; `auth.py` has none.
 - **Duplicated helpers**: `_parse_csv_ids` byte-identical at `task.py:161-164` and
   `main.py:345-348`; the CSV row emitter at `entity.py:137-152` and `project.py:92-108`;
-  `document.py:109-113` vs `main.py:876-880`, which differ by one token
-  (`or "project"` vs `or "private"`) — a semantic split hiding inside a copy.
+  `document.py:109-113` vs `main.py:876-880`, which differ by one token (`or "project"` vs
+  `or "private"`) — a semantic split hiding inside a copy.
 
 ### C17. `search` and `add` are hidden from help but documented as the core workflow — minor, S
 
-`main.py:2607-2608` registers `recall` and `search` with `hidden=True`, `main.py:3774`
-hides `add`, and `graph-search` (:1607) and `graph-add` (:1737) are hidden too. Rendered
-`sibyl --help` shows no search command. The project's own `CLAUDE.md` documents
-`/sibyl search "topic"` and `sibyl add "Pattern Title" "..."` as the standard cycle.
+`main.py:2607-2608` registers `recall` and `search` with `hidden=True`, `main.py:3774` hides `add`,
+and `graph-search` (:1607) and `graph-add` (:1737) are hidden too. Rendered `sibyl --help` shows no
+search command. The project's own `CLAUDE.md` documents `/sibyl search "topic"` and
+`sibyl add "Pattern Title" "..."` as the standard cycle.
 
 ### C18. `epic` is deprecated with no deprecation path — minor, S
 
-The sub-app help carries `DEPRECATED: an epic is just a task with subtasks...`, but no
-epic command emits a runtime warning and no removal version is named. The only runtime
-deprecation warning in the package is `main.py:201` for entity-type aliases.
+The sub-app help carries `DEPRECATED: an epic is just a task with subtasks...`, but no epic command
+emits a runtime warning and no removal version is named. The only runtime deprecation warning in the
+package is `main.py:201` for entity-type aliases.
 
 ### C19. Client lifecycle inconsistency — minor, M
 
-Thirty-five sites use bare `client = get_client()` and never close, while
-`document.py:230,295,331`, `session.py:119` and `main.py` use `async with`. Not a
-correctness bug (`client.py:458` recreates the httpx client lazily), but every command
-leaves an open `AsyncClient` at `asyncio.run()` teardown. Separately, `pending.py:193`
-and `doctor.py:315` reach through to the private `client._request(...)` to pass
-`_buffer_pending`/`_pending_write_id`; both uses are legitimate and want a public
-replay/probe API.
+Thirty-five sites use bare `client = get_client()` and never close, while `document.py:230,295,331`,
+`session.py:119` and `main.py` use `async with`. Not a correctness bug (`client.py:458` recreates
+the httpx client lazily), but every command leaves an open `AsyncClient` at `asyncio.run()`
+teardown. Separately, `pending.py:193` and `doctor.py:315` reach through to the private
+`client._request(...)` to pass `_buffer_pending`/`_pending_write_id`; both uses are legitimate and
+want a public replay/probe API.
 
 ### Checked and clean
 
-`auth_store.py` is genuinely well built: 0600 file mode via `os.fchmod` before any
-content is written (:83-114), 0700 directory enforcement with umask (:54-81), atomic
-rename, and `fcntl.flock` exclusion (:34-51). No token is logged anywhere in the
-package. `read_content_file` (`common.py:83-122`) defends against symlinks with
-`O_NOFOLLOW`, plus size limits and binary detection.
+`auth_store.py` is genuinely well built: 0600 file mode via `os.fchmod` before any content is
+written (:83-114), 0700 directory enforcement with umask (:54-81), atomic rename, and `fcntl.flock`
+exclusion (:34-51). No token is logged anywhere in the package. `read_content_file`
+(`common.py:83-122`) defends against symlinks with `O_NOFOLLOW`, plus size limits and binary
+detection.
 
 ---
 
 ## infra / CI
 
-Nine workflows (5,195 lines), two Helm charts, ten `moon.yml` files. I independently
-re-verified I1, I7, and I11 against the repo; all three reproduced exactly.
+Nine workflows (5,195 lines), two Helm charts, ten `moon.yml` files. I independently re-verified I1,
+I7, and I11 against the repo; all three reproduced exactly.
 
 ### I1. The CI change classifier ignores `uv.lock`, `pyproject.toml`, `charts/`, `VERSION`, and Dockerfiles — blocker, S
 
 `.github/workflows/ci.yml:125`. The `runtime_changed` case list is
-`apps/api/*|apps/cli/*|apps/e2e/*|packages/python/sibyl-core/*|tools/*|benchmarks/*|
-baselines/*|moon.yml|.moon/*|.prototools|pnpm-lock.yaml|compose.e2e.yml|docker-compose*.yml`.
+`apps/api/*|apps/cli/*|apps/e2e/*|packages/python/sibyl-core/*|tools/*|benchmarks/*| baselines/*|moon.yml|.moon/*|.prototools|pnpm-lock.yaml|compose.e2e.yml|docker-compose*.yml`.
 
-Verified by grepping the whole classify step (lines 46-165): `uv.lock` 0 hits,
-`pyproject` 0, `charts` 0, `VERSION` 0, `Dockerfile` 0. Only `pnpm-lock` appears.
+Verified by grepping the whole classify step (lines 46-165): `uv.lock` 0 hits, `pyproject` 0,
+`charts` 0, `VERSION` 0, `Dockerfile` 0. Only `pnpm-lock` appears.
 
-Every classifier flag stays false, so `run_static`, `run_build`, `run_tests`, and
-`run_e2e` are all false and the pipeline no-ops. The concrete exposure: Dependabot runs a
-weekly `uv` update (`dependabot.yml:4-7`), and any bump confined to `uv.lock` plus the
-root `pyproject.toml` merges green with zero test coverage. That root `pyproject.toml` is
-where the security pins live — the lxml CVE-2026-41066 override at :9-12 and
-`cryptography>=48.0.1` at :30. Chart, Dockerfile, and `publish.yml` edits likewise
-trigger nothing.
+Every classifier flag stays false, so `run_static`, `run_build`, `run_tests`, and `run_e2e` are all
+false and the pipeline no-ops. The concrete exposure: Dependabot runs a weekly `uv` update
+(`dependabot.yml:4-7`), and any bump confined to `uv.lock` plus the root `pyproject.toml` merges
+green with zero test coverage. That root `pyproject.toml` is where the security pins live — the lxml
+CVE-2026-41066 override at :9-12 and `cryptography>=48.0.1` at :30. Chart, Dockerfile, and
+`publish.yml` edits likewise trigger nothing.
 
 ### I2. CI never runs the root gate suite; ~32 gate tests are release-time-only — blocker, S
 
-`ci.yml` runs `:lint`, `:typecheck`, the four `test-cov` tasks, `bench-gate`,
-`api:test-live`, the baseline replay, e2e pytest, and the storybook build. It never runs
-`moon run :check`. That target appears only in `release.yml:289`, `publish.yml:68`, and
-`publish-dogfood-images.yml:113`.
+`ci.yml` runs `:lint`, `:typecheck`, the four `test-cov` tasks, `bench-gate`, `api:test-live`, the
+baseline replay, e2e pytest, and the storybook build. It never runs `moon run :check`. That target
+appears only in `release.yml:289`, `publish.yml:68`, and `publish-dogfood-images.yml:113`.
 
-Root `check` (`moon.yml:212-254`) carries 41 deps, so roughly 32 gate suites run for the
-first time at RC cut: `inventory-check`, `sync-versions-check`, `dev-script-test`,
-`chaos-test`, `storage-access-check`, `baseline-test`, and the whole `*-gate-test` family
-(memory-trust, usage-loop, trust-control, context-quality, workspace-trust, autonomy,
-reflection-quality, forgetting, write-path-integrity, team-scope, auth-session,
-overview-perf, synthesis, adapter-ingest, large-corpus-rehearsal, okf-export, doc-claim,
-backup-restore, enterprise-readiness-evidence), plus `release-workflow-test`.
+Root `check` (`moon.yml:212-254`) carries 41 deps, so roughly 32 gate suites run for the first time
+at RC cut: `inventory-check`, `sync-versions-check`, `dev-script-test`, `chaos-test`,
+`storage-access-check`, `baseline-test`, and the whole `*-gate-test` family (memory-trust,
+usage-loop, trust-control, context-quality, workspace-trust, autonomy, reflection-quality,
+forgetting, write-path-integrity, team-scope, auth-session, overview-perf, synthesis,
+adapter-ingest, large-corpus-rehearsal, okf-export, doc-claim, backup-restore,
+enterprise-readiness-evidence), plus `release-workflow-test`.
 
 Combined with I1 this closes a loop: `release-workflow-test` declares `release.yml` and
-`publish.yml` as inputs (`moon.yml:568-575`), but editing `publish.yml` neither trips the
-classifier nor reaches a workflow that runs the test. The gate guarding the release
-workflow cannot see edits to the release workflow.
+`publish.yml` as inputs (`moon.yml:568-575`), but editing `publish.yml` neither trips the classifier
+nor reaches a workflow that runs the test. The gate guarding the release workflow cannot see edits
+to the release workflow.
 
 ### I3. Stock `helm install` yields a production-labelled deploy with MCP auth disabled — blocker, S
 
 `charts/sibyl/values.yaml:168` (`existingSecret: ""`) with `:155`
-(`SIBYL_ENVIRONMENT: "production"`). The `{{- if .Values.backend.existingSecret }}` guard
-at `charts/sibyl/templates/backend-deployment.yaml:71` skips the secret block, so
-`SIBYL_JWT_SECRET` is never set, and the dev auto-generation branch at
-`apps/api/src/sibyl/config.py:557` is `elif self.environment != "production"`, so it does
-not fire. The process runs with `jwt_secret == ""`.
+(`SIBYL_ENVIRONMENT: "production"`). The `{{- if .Values.backend.existingSecret }}` guard at
+`charts/sibyl/templates/backend-deployment.yaml:71` skips the secret block, so `SIBYL_JWT_SECRET` is
+never set, and the dev auto-generation branch at `apps/api/src/sibyl/config.py:557` is
+`elif self.environment != "production"`, so it does not fire. The process runs with
+`jwt_secret == ""`.
 
-MCP auth then disables itself: `auth_enabled = auth_mode == "on" or (auth_mode == "auto"
-and jwt_secret_set)` (`server.py:1818`) with `mcp_auth_mode` defaulting to `"auto"`
-(`config.py:364-367`). Startup logs it at INFO and continues (`main.py:133-137`), and
-`SessionMiddleware` is built with `secret_key=""` (`api/app.py:276`). The production
-validator (`config.py:229-276`) checks `disable_auth`, memory URLs, `cookie_secure`, and
-default Surreal credentials, but never a JWT secret. The values comment at :166-167
-states the requirement; a comment is not a guard.
+MCP auth then disables itself:
+`auth_enabled = auth_mode == "on" or (auth_mode == "auto" and jwt_secret_set)` (`server.py:1818`)
+with `mcp_auth_mode` defaulting to `"auto"` (`config.py:364-367`). Startup logs it at INFO and
+continues (`main.py:133-137`), and `SessionMiddleware` is built with `secret_key=""`
+(`api/app.py:276`). The production validator (`config.py:229-276`) checks `disable_auth`, memory
+URLs, `cookie_secure`, and default Surreal credentials, but never a JWT secret. The values comment
+at :166-167 states the requirement; a comment is not a guard.
 
-Unverified: whether tokens signed with an empty HMAC key also verify, which would make
-sessions forgeable rather than merely unauthenticated.
+Unverified: whether tokens signed with an empty HMAC key also verify, which would make sessions
+forgeable rather than merely unauthenticated.
 
 ### I4. The worker crash-loops under the chart's own defaults — blocker, S
 
-`charts/sibyl/values.yaml:361` (`worker.enabled: true`) with `:15`
-(`coordinationBackend: "auto"`). `resolved_coordination_backend` returns `"redis"` only
-on a literal `"redis"` (`config.py:799-801`), so `auto` resolves to `local`, and the
-worker CLI prints a message and returns immediately (`cli/main.py:258-263`). The
-container exits 0, the Deployment restarts it, and the pod settles into CrashLoopBackOff
-with a Completed container. The chart guards only the opposite direction
+`charts/sibyl/values.yaml:361` (`worker.enabled: true`) with `:15` (`coordinationBackend: "auto"`).
+`resolved_coordination_backend` returns `"redis"` only on a literal `"redis"` (`config.py:799-801`),
+so `auto` resolves to `local`, and the worker CLI prints a message and returns immediately
+(`cli/main.py:258-263`). The container exits 0, the Deployment restarts it, and the pod settles into
+CrashLoopBackOff with a Completed container. The chart guards only the opposite direction
 (`redis-secret.yaml:4`).
 
 ### I5. The SurrealDB root password regenerates on every `helm upgrade` — blocker, M
 
-`charts/sibyl/templates/surreal-secret.yaml:14` renders `randAlphaNum 24` with no
-`lookup` guard, so each upgrade writes a new password. The Deployments checksum only the
-ConfigMap (`backend-deployment.yaml:17`, `worker-deployment.yaml:18`), never the Secret,
-so running pods do not roll and keep serving on the old value until an unrelated restart
-picks up a password the database has never seen. Separately the generated value never
-reaches SurrealDB at all: the wrapper resolves its credentials secret to
-`<upstream-fullname>-root` (`charts/surrealdb/templates/_helpers.tpl:71-73`), a different
-object from `<release>-surreal`. A delayed fuse — the upgrade reports success and auth
-breaks later, far from the cause.
+`charts/sibyl/templates/surreal-secret.yaml:14` renders `randAlphaNum 24` with no `lookup` guard, so
+each upgrade writes a new password. The Deployments checksum only the ConfigMap
+(`backend-deployment.yaml:17`, `worker-deployment.yaml:18`), never the Secret, so running pods do
+not roll and keep serving on the old value until an unrelated restart picks up a password the
+database has never seen. Separately the generated value never reaches SurrealDB at all: the wrapper
+resolves its credentials secret to `<upstream-fullname>-root`
+(`charts/surrealdb/templates/_helpers.tpl:71-73`), a different object from `<release>-surreal`. A
+delayed fuse — the upgrade reports success and auth breaks later, far from the cause.
 
 ### I6. SurrealDB mounts a 100Gi PVC with no `fsGroup` against a nonroot image — blocker, S
 
-`charts/surrealdb/values.yaml:21-26` enables persistence at 100Gi with
-`path: rocksdb:/data/db` (:14), and the `surrealdb:` block (:7-31) sets no
-`podSecurityContext`. Upstream defaults it to `{}` and warns twice that the official
-image runs as `USER nonroot` (65532) and that provisioners creating the volume
-root-owned fail with Permission denied without `fsGroup: 65532` (vendored
-`surrealdb-0.5.0.tgz` → `values.yaml:120-127`, :274-278). The asymmetry is the tell: the
-same file sets `fsGroup: 1000` for the wrapper's own jobs at :59-63. Blocker on affected
-storage classes, no impact on ones that chown the mount.
+`charts/surrealdb/values.yaml:21-26` enables persistence at 100Gi with `path: rocksdb:/data/db`
+(:14), and the `surrealdb:` block (:7-31) sets no `podSecurityContext`. Upstream defaults it to `{}`
+and warns twice that the official image runs as `USER nonroot` (65532) and that provisioners
+creating the volume root-owned fail with Permission denied without `fsGroup: 65532` (vendored
+`surrealdb-0.5.0.tgz` → `values.yaml:120-127`, :274-278). The asymmetry is the tell: the same file
+sets `fsGroup: 1000` for the wrapper's own jobs at :59-63. Blocker on affected storage classes, no
+impact on ones that chown the mount.
 
 ### I7. One of 185 external action references is SHA-pinned — major, M
 
-Verified by counting across all nine workflows plus `.github/actions/`: **185 external
-`uses:` references, exactly 1 SHA-pinned** — `KSXGitHub/github-actions-deploy-aur@084b0d9b...`
-at `publish.yml:354`, which handles `AUR_SSH_KEY`. The security reasoning was applied
-once and never generalized.
+Verified by counting across all nine workflows plus `.github/actions/`: **185 external `uses:`
+references, exactly 1 SHA-pinned** — `KSXGitHub/github-actions-deploy-aur@084b0d9b...` at
+`publish.yml:354`, which handles `AUR_SSH_KEY`. The security reasoning was applied once and never
+generalized.
 
 The two that matter most, both confirmed:
 
-- `publish.yml:162` uses `pypa/gh-action-pypi-publish@release/v1` — a **mutable branch
-  ref**, not even a tag, in the job holding `id-token: write` for PyPI trusted publishing
-  (:126-127).
+- `publish.yml:162` uses `pypa/gh-action-pypi-publish@release/v1` — a **mutable branch ref**, not
+  even a tag, in the job holding `id-token: write` for PyPI trusted publishing (:126-127).
 - `release.yml:247` uses `hyperb1iss/git-iris@v2`, a mutable major tag, handed
   `secrets.ANTHROPIC_API_KEY` (:256) inside a workflow whose top-level permissions are
-  `actions: write` and `contents: write` (:29-31). Own org, so lower risk, but that token
-  can write to the repo and dispatch `publish.yml`.
+  `actions: write` and `contents: write` (:29-31). Own org, so lower risk, but that token can write
+  to the repo and dispatch `publish.yml`.
 
-Remaining third-party tag pins: `moonrepo/setup-toolchain@v0.6` (23x),
-`docker/login-action@v4` (10x), `docker/setup-buildx-action@v4` (5x),
-`docker/build-push-action@v7` (2x), `aquasecurity/trivy-action@v0.36.0` (2x),
-`azure/setup-helm@v5.0.1` (2x), `softprops/action-gh-release@v3` (2x), plus
-`codecov/codecov-action@v7`, `pnpm/action-setup@v6.0.10`, `astral-sh/setup-uv@v9.0.0`,
-`sigstore/cosign-installer@v4.1.2`. First-party `actions/*` accounts for 132 of the rest.
+Remaining third-party tag pins: `moonrepo/setup-toolchain@v0.6` (23x), `docker/login-action@v4`
+(10x), `docker/setup-buildx-action@v4` (5x), `docker/build-push-action@v7` (2x),
+`aquasecurity/trivy-action@v0.36.0` (2x), `azure/setup-helm@v5.0.1` (2x),
+`softprops/action-gh-release@v3` (2x), plus `codecov/codecov-action@v7`,
+`pnpm/action-setup@v6.0.10`, `astral-sh/setup-uv@v9.0.0`, `sigstore/cosign-installer@v4.1.2`.
+First-party `actions/*` accounts for 132 of the rest.
 
-Dependabot already has a `github-actions` entry (`dependabot.yml:76-90`) and updates SHA
-pins while preserving the trailing version comment, so pinning adds no maintenance cost.
+Dependabot already has a `github-actions` entry (`dependabot.yml:76-90`) and updates SHA pins while
+preserving the trailing version comment, so pinning adds no maintenance cost.
 
 ### I8. Dependabot has no `docker` ecosystem — major, S
 
-`dependabot.yml` covers `uv`, `npm`, and `github-actions` only. Four Dockerfiles carry
-floating base tags: `apps/api/Dockerfile:7,30` (`python:3.13-slim-bookworm`),
-`apps/web/Dockerfile:8,24,53` (`node:24-alpine`), `.devcontainer/Dockerfile:1`, and
-`infra/ansible/roles/sibyl/files/caddy/Dockerfile:4,7` (`caddy:2`). Base image CVEs
-surface only when Trivy scans the built image during publish (`publish.yml:592`, :624).
+`dependabot.yml` covers `uv`, `npm`, and `github-actions` only. Four Dockerfiles carry floating base
+tags: `apps/api/Dockerfile:7,30` (`python:3.13-slim-bookworm`), `apps/web/Dockerfile:8,24,53`
+(`node:24-alpine`), `.devcontainer/Dockerfile:1`, and
+`infra/ansible/roles/sibyl/files/caddy/Dockerfile:4,7` (`caddy:2`). Base image CVEs surface only
+when Trivy scans the built image during publish (`publish.yml:592`, :624).
 
-The repo already knows this shape of bug: the comment above `dependency-audit` names it
-for the npm side — "The image scan in publish only speaks once a release is already under
-way, which is how a HIGH postcss advisory reached two tagged releases"
-(`ci.yml:186-190`). Same gap, still open for base images.
+The repo already knows this shape of bug: the comment above `dependency-audit` names it for the npm
+side — "The image scan in publish only speaks once a release is already under way, which is how a
+HIGH postcss advisory reached two tagged releases" (`ci.yml:186-190`). Same gap, still open for base
+images.
 
 ### I9. 102 duplicated setup step instances across 727 YAML lines — major, M
 
-Counted by parsing every workflow: `Setup moonrepo toolchain` 23, `Cache moon outputs`
-18, `Cache uv` 18, `Install system dependencies` 17, `Verify toolchain` 12, `Install Node
-dependencies` 8, `Cache pnpm store` 6. The pattern is already proven here —
-`.github/actions/start-surrealdb/action.yml` is a composite action used at 10 call sites.
-The setup block is the obvious second extraction and was never done.
+Counted by parsing every workflow: `Setup moonrepo toolchain` 23, `Cache moon outputs` 18,
+`Cache uv` 18, `Install system dependencies` 17, `Verify toolchain` 12, `Install Node dependencies`
+8, `Cache pnpm store` 6. The pattern is already proven here —
+`.github/actions/start-surrealdb/action.yml` is a composite action used at 10 call sites. The setup
+block is the obvious second extraction and was never done.
 
 ### I10. Caches fragmented into 13 uv and 12 moon namespaces on identical hash inputs — major, S
 
-Every `Cache uv` step keys on `hashFiles('**/uv.lock')` but under 13 distinct prefixes
-(`uv-`, `uv-eval-`, `uv-live-`, `uv-longmemeval-`, `uv-longmemeval-compare-`,
-`uv-longmemeval-local-`, `uv-longmemeval-v2-`, `uv-longmemeval-v2-official-`,
-`uv-longmemeval-v2-package-`, `uv-nightly-`, `uv-okf-memory-`, `uv-release-`,
-`uv-restore-`). The `restore-keys` fall back to their own prefix only (e.g.
-`eval.yml:218-220`), so no namespace can read another's entry. `Cache moon outputs` has
-the same shape across 12 prefixes. Thirteen near-identical copies compete for the 10GB
-repository cache budget and evict each other.
+Every `Cache uv` step keys on `hashFiles('**/uv.lock')` but under 13 distinct prefixes (`uv-`,
+`uv-eval-`, `uv-live-`, `uv-longmemeval-`, `uv-longmemeval-compare-`, `uv-longmemeval-local-`,
+`uv-longmemeval-v2-`, `uv-longmemeval-v2-official-`, `uv-longmemeval-v2-package-`, `uv-nightly-`,
+`uv-okf-memory-`, `uv-release-`, `uv-restore-`). The `restore-keys` fall back to their own prefix
+only (e.g. `eval.yml:218-220`), so no namespace can read another's entry. `Cache moon outputs` has
+the same shape across 12 prefixes. Thirteen near-identical copies compete for the 10GB repository
+cache budget and evict each other.
 
 ### I11. Six cache keys hash a lockfile path that does not exist — major, S
 
 `ci.yml:292,397,469,626,745` and `release.yml:83` read
 `hashFiles('.prototools', 'uv.lock', 'apps/web/pnpm-lock.yaml')`. Verified:
-`find . -name pnpm-lock.yaml` returns exactly one file, the root `./pnpm-lock.yaml`, and
-6 workflow lines reference the `apps/web/` path. This is a pnpm workspace, so a member
-lockfile has never existed.
+`find . -name pnpm-lock.yaml` returns exactly one file, the root `./pnpm-lock.yaml`, and 6 workflow
+lines reference the `apps/web/` path. This is a pnpm workspace, so a member lockfile has never
+existed.
 
-`hashFiles` silently omits patterns matching nothing, so the key resolves from
-`.prototools` and `uv.lock` alone. The cached paths include `apps/web/.next/cache`
-(`ci.yml:288-290`), meaning the Next build cache is invalidated by no JavaScript
-dependency change at all.
+`hashFiles` silently omits patterns matching nothing, so the key resolves from `.prototools` and
+`uv.lock` alone. The cached paths include `apps/web/.next/cache` (`ci.yml:288-290`), meaning the
+Next build cache is invalidated by no JavaScript dependency change at all.
 
 ### I12. `bench-gate` is the only cacheable gate, and it gates files outside its inputs — major, S
 
-18 of 19 `*-gate` and rehearsal tasks set `options: cache: false`; `bench-gate`
-(`moon.yml:666-673`) alone does not. It is also the only one invoked repeatedly within a
-single CI job against runtime files outside its declared inputs — `eval.yml:295,465,665,778`
-each pass a different report under `.moon/cache/evals/`, while the declared inputs are
-`tools/**/*.py`, `benchmarks/**/*.py`, `benchmarks/context_pack_cases.json`,
-`benchmarks/results/ai-memory/**/*.json`, and `pyproject.toml`. The gated file is not an
-input, so its content cannot influence the cache decision. Whether that produces a false
-PASS depends on whether moon folds `--` passthrough args into the task hash, which was
-not verified; the asymmetry against 18 siblings is verified and is reason enough.
+18 of 19 `*-gate` and rehearsal tasks set `options: cache: false`; `bench-gate` (`moon.yml:666-673`)
+alone does not. It is also the only one invoked repeatedly within a single CI job against runtime
+files outside its declared inputs — `eval.yml:295,465,665,778` each pass a different report under
+`.moon/cache/evals/`, while the declared inputs are `tools/**/*.py`, `benchmarks/**/*.py`,
+`benchmarks/context_pack_cases.json`, `benchmarks/results/ai-memory/**/*.json`, and
+`pyproject.toml`. The gated file is not an input, so its content cannot influence the cache
+decision. Whether that produces a false PASS depends on whether moon folds `--` passthrough args
+into the task hash, which was not verified; the asymmetry against 18 siblings is verified and is
+reason enough.
 
 ### I13. The RC gate skips `apps/e2e` entirely — major, S
 
-`apps/e2e/moon.yml` has no `check` and no `typecheck`, the only project with a test suite
-lacking one. Root `lint` (`moon.yml:181-192`) and root `check` (:212-254) both list core,
-api, cli, web, hooks, docs, skills, infra — never e2e. So `moon run :check`, the RC gate
-at `release.yml:289`, `publish.yml:68`, and `publish-dogfood-images.yml:113`, never lints
-or tests e2e. `ci.yml:328` runs `moon run :lint`, whose colon-prefix form does reach
-`e2e:lint`, so PR lint is covered; the release path is the gap. This compounds E4 above.
+`apps/e2e/moon.yml` has no `check` and no `typecheck`, the only project with a test suite lacking
+one. Root `lint` (`moon.yml:181-192`) and root `check` (:212-254) both list core, api, cli, web,
+hooks, docs, skills, infra — never e2e. So `moon run :check`, the RC gate at `release.yml:289`,
+`publish.yml:68`, and `publish-dogfood-images.yml:113`, never lints or tests e2e. `ci.yml:328` runs
+`moon run :lint`, whose colon-prefix form does reach `e2e:lint`, so PR lint is covered; the release
+path is the gap. This compounds E4 above.
 
 ### I14. No chart value reaches `SIBYL_PUBLIC_URL` — major, S
 
 The variable appears nowhere under `charts/`. Without it `public_url` keeps its default
 `http://localhost:3337` (`config.py:310-313`), and because the chart sets
-`SIBYL_SERVER_HOST: "0.0.0.0"` (`values.yaml:153`) the `server_url` derivation
-(`config.py:332-335`) rewrites the bind host to `localhost` and yields
-`http://localhost:3334`.
+`SIBYL_SERVER_HOST: "0.0.0.0"` (`values.yaml:153`) the `server_url` derivation (`config.py:332-335`)
+rewrites the bind host to `localhost` and yields `http://localhost:3334`.
 
-Those two feed the MCP OAuth issuer and resource-server URLs (`server.py:1826-1829`), the
-OIDC redirect base (`auth/oidc.py:76`), the CORS allowlist (`api/app.py:260-266`),
-organization invitation links (`organization_runtime.py:166`), and password reset links
-(`auth_runtime/password_reset.py:116`). The repo's own reference values file sets it by
-hand and comments it as the single source of truth
-(`infra/local/sibyl-values.yaml:36-38`); the shipped chart omits it. Settable through the
-free-form `backend.env` map, which is the only reason this is not a blocker.
+Those two feed the MCP OAuth issuer and resource-server URLs (`server.py:1826-1829`), the OIDC
+redirect base (`auth/oidc.py:76`), the CORS allowlist (`api/app.py:260-266`), organization
+invitation links (`organization_runtime.py:166`), and password reset links
+(`auth_runtime/password_reset.py:116`). The repo's own reference values file sets it by hand and
+comments it as the single source of truth (`infra/local/sibyl-values.yaml:36-38`); the shipped chart
+omits it. Settable through the free-form `backend.env` map, which is the only reason this is not a
+blocker.
 
 ### I15. Graph embedding config is unreachable, and the exposed key looks like it covers it — major, S
 
-The chart exposes `SIBYL_EMBEDDING_MODEL` and `SIBYL_EMBEDDING_DIMENSIONS`
-(`values.yaml:158-159`), which map to the **document chunk** pair (`config.py:592-601`).
-The graph pair is separate, defaults to 1024 rather than 1536 (`config.py:602-615`), and
-`graph_embedding_dimensions` sizes the Surreal vector field and HNSW index at schema
-definition time (`sibyl_core/backends/surreal/schema.py:52`). No chart value reaches it.
+The chart exposes `SIBYL_EMBEDDING_MODEL` and `SIBYL_EMBEDDING_DIMENSIONS` (`values.yaml:158-159`),
+which map to the **document chunk** pair (`config.py:592-601`). The graph pair is separate, defaults
+to 1024 rather than 1536 (`config.py:602-615`), and `graph_embedding_dimensions` sizes the Surreal
+vector field and HNSW index at schema definition time (`sibyl_core/backends/surreal/schema.py:52`).
+No chart value reaches it.
 
-The provider side compounds it: `embedding_provider` and `graph_embedding_provider` both
-default to `openai` while the chart defaults `SIBYL_LLM_PROVIDER: "anthropic"`
-(`values.yaml:156`) and wires the OpenAI key `optional: true`
-(`backend-deployment.yaml:82-87`). A deployment given only an Anthropic key extracts
-entities and fails every embedding call.
+The provider side compounds it: `embedding_provider` and `graph_embedding_provider` both default to
+`openai` while the chart defaults `SIBYL_LLM_PROVIDER: "anthropic"` (`values.yaml:156`) and wires
+the OpenAI key `optional: true` (`backend-deployment.yaml:82-87`). A deployment given only an
+Anthropic key extracts entities and fails every embedding call.
 
 ### I16. SurrealDB runs BestEffort while every application pod has limits — major, S
 
-`charts/surrealdb/values.yaml:7-31` sets no `surrealdb.resources` and upstream defaults to
-`{}` (vendored tgz `values.yaml:201`). Backend (`charts/sibyl/values.yaml:124-130`),
-frontend (:294-300), and worker (:404-410) all set limits and requests. The only stateful
-component gets BestEffort QoS, making it the first eviction target under node memory
-pressure.
+`charts/surrealdb/values.yaml:7-31` sets no `surrealdb.resources` and upstream defaults to `{}`
+(vendored tgz `values.yaml:201`). Backend (`charts/sibyl/values.yaml:124-130`), frontend (:294-300),
+and worker (:404-410) all set limits and requests. The only stateful component gets BestEffort QoS,
+making it the first eviction target under node memory pressure.
 
 ### I17. `podSecurity.enforceRestricted` would reject the chart's own pods — major, S
 
 `charts/sibyl/values.yaml:513` (default off). The three security contexts set
 `allowPrivilegeEscalation`, `readOnlyRootFilesystem`, and `capabilities.drop` but no
 `seccompProfile` (:212-224, :335-347, :417-429), which the restricted profile requires as
-`RuntimeDefault` or `Localhost`; `enforce-version: "latest"` (:514) applies the newest
-semantics. Separately, `charts/sibyl/templates/podsecurity.yaml:3-12` renders a
-`Namespace` as a release resource, so installing into an existing namespace fails Helm
-ownership validation and `helm uninstall` deletes the namespace with everything in it,
-including a co-located SurrealDB PVC.
+`RuntimeDefault` or `Localhost`; `enforce-version: "latest"` (:514) applies the newest semantics.
+Separately, `charts/sibyl/templates/podsecurity.yaml:3-12` renders a `Namespace` as a release
+resource, so installing into an existing namespace fails Helm ownership validation and
+`helm uninstall` deletes the namespace with everything in it, including a co-located SurrealDB PVC.
 
 ### I18. Local Tilt runs SurrealDB 2.6.5 while all 14 other pins are v3.2.3 — major, S
 
 `Tiltfile:331-341` installs `surrealdb-helm/surrealdb` at `--version=0.5.0` with
-`infra/local/surrealdb-values.yaml`, which sets no `image.tag`. The upstream chart's
-`appVersion` is **2.6.5**. Every other surface pins v3.2.3:
-`charts/surrealdb/values.yaml:10`, `docker-compose.yml:12`, `compose.e2e.yml:12`,
-`docker-compose.prod.yml:163`, `docker-compose.quickstart.yml:186`,
-`infra/ansible/roles/sibyl/defaults/main.yml:12`,
+`infra/local/surrealdb-values.yaml`, which sets no `image.tag`. The upstream chart's `appVersion` is
+**2.6.5**. Every other surface pins v3.2.3: `charts/surrealdb/values.yaml:10`,
+`docker-compose.yml:12`, `compose.e2e.yml:12`, `docker-compose.prod.yml:163`,
+`docker-compose.quickstart.yml:186`, `infra/ansible/roles/sibyl/defaults/main.yml:12`,
 `infra/ansible/roles/sibyl/files/docker-compose.yml:22`, `apps/cli/.../docker.py:83`,
 `apps/cli/.../local.py:138`.
 
-This lands directly on a known trap: the recorded 2.x-versus-3.x divergence class where
-code passes on the lenient 2.x engine and 500s live on 3.x. Validating local Kubernetes
-against 2.6.5 is a hole in exactly that net.
+This lands directly on a known trap: the recorded 2.x-versus-3.x divergence class where code passes
+on the lenient 2.x engine and 500s live on 3.x. Validating local Kubernetes against 2.6.5 is a hole
+in exactly that net.
 
 ### I19. `sync-versions-check` inputs are a hand-maintained duplicate, already missing two — major, S
 
 `moon.yml:297-312` declares 11 of the 13 targets in `_targets()`
 (`tools/release/sync_versions.py:55-109`), missing `apps/api/pyproject.toml` and
 `apps/cli/pyproject.toml`. The task is cacheable with no outputs (two consecutive runs:
-`9s 528ms, 3dc51e09` then `cached, 3dc51e09`), and `release.yml:76-85` restores
-`.moon/cache` across runs, so a change confined to an undeclared input leaves the hash
-unchanged and the gate reports a green it did not compute.
+`9s 528ms, 3dc51e09` then `cached, 3dc51e09`), and `release.yml:76-85` restores `.moon/cache` across
+runs, so a change confined to an undeclared input leaves the hash unchanged and the gate reports a
+green it did not compute.
 
-Nothing ships stale today — `release-workflow-test` covers both missing files
-(`moon.yml:576-577`, `test_release_workflow.py:439-451`). The structural hole is that no
-test asserts `set(_targets()) == inputs`, so the next pin added inherits a blind gate.
+Nothing ships stale today — `release-workflow-test` covers both missing files (`moon.yml:576-577`,
+`test_release_workflow.py:439-451`). The structural hole is that no test asserts
+`set(_targets()) == inputs`, so the next pin added inherits a blind gate.
 
 ### I20. Hardcoded fallback image tag in the CLI, two minor releases stale — major, S
 
-`apps/cli/src/sibyl_cli/local.py:60-70` returns `"1.0.0-rc.8"` when package metadata is
-unavailable. `DEFAULT_IMAGE_TAG` feeds the generated compose files (`local.py:77`, :115)
-and the `--tag` default for `sibyl docker init` (`docker.py:230`). The happy path resolves
-correctly, so this fires only when the CLI runs without installed metadata — at which
-point a 1.2.0 CLI silently writes a compose file pulling `sibyl-api:1.0.0-rc.8`. No test
-exercises the branch and `sync_versions.py` does not target the file.
+`apps/cli/src/sibyl_cli/local.py:60-70` returns `"1.0.0-rc.8"` when package metadata is unavailable.
+`DEFAULT_IMAGE_TAG` feeds the generated compose files (`local.py:77`, :115) and the `--tag` default
+for `sibyl docker init` (`docker.py:230`). The happy path resolves correctly, so this fires only
+when the CLI runs without installed metadata — at which point a 1.2.0 CLI silently writes a compose
+file pulling `sibyl-api:1.0.0-rc.8`. No test exercises the branch and `sync_versions.py` does not
+target the file.
 
 ### I21. Minor infra findings
 
-- **`publish.yml` and `publish-dogfood-images.yml` have no top-level `permissions:`.**
-  Every job declares its own (12 of 12 and 4 of 4, all tightly scoped), but a newly added
-  job silently inherits the repository default token instead of default-deny. Every other
-  workflow sets a top-level `contents: read`.
+- **`publish.yml` and `publish-dogfood-images.yml` have no top-level `permissions:`.** Every job
+  declares its own (12 of 12 and 4 of 4, all tightly scoped), but a newly added job silently
+  inherits the repository default token instead of default-deny. Every other workflow sets a
+  top-level `contents: read`.
 - **`longmemeval-v2.yml` duplicates a 33-item path list verbatim** for `push` (:6-38) and
   `pull_request` (:42-74), byte-identical after strip. YAML anchors collapse it.
-- **Five checks are cacheable while all 18 sibling gates are not**: `bench-gate`
-  (`moon.yml:666`), `sync-versions-check` (:297), `inventory-check` (:323),
-  `storage-access-check` (:793), `fmt-check` (:172). `sync-versions` (:291) is a pure
-  side-effect writer with no declared outputs and caching on.
+- **Five checks are cacheable while all 18 sibling gates are not**: `bench-gate` (`moon.yml:666`),
+  `sync-versions-check` (:297), `inventory-check` (:323), `storage-access-check` (:793), `fmt-check`
+  (:172). `sync-versions` (:291) is a pure side-effect writer with no declared outputs and caching
+  on.
 - **`infra:lint` and `skills:lint` shell out to `npx prettier`** (`infra/moon.yml:7`,
-  `skills/moon.yml:22`) inside the RC gate. Prettier is a root devDependency at `^3.9.6`,
-  so `npx` resolves it locally when present and silently downloads an arbitrary version
-  from the network when not. `pnpm exec prettier` is the deterministic form.
-- **`skills/moon.yml:24-28` declares `**/*.yaml` in `sources`** but the lint command checks
-  only `'**/*.md' '**/*.yml'`. Latent — no `.yaml` exists under `skills/` today.
-- **The worker has no probes** while backend (`backend-deployment.yaml:118-121`) and
-  frontend (`frontend-deployment.yaml:81-84`) both do. A wedged arq worker stays Ready
-  forever, and its HPA scales on CPU and memory (`worker-hpa.yaml:15-31`), so stuck reads
-  as underutilized and scales down.
-- **SurrealDB chart jobs inherit empty resources** (`charts/surrealdb/values.yaml:70`,
-  consumed by `bootstrap-job.yaml:68-69`, `export-cronjob.yaml:86-87`,
-  `snapshot-cronjob.yaml:86-87`, `restore-drill-cronjob.yaml:159-160`). The export and
-  restore-drill jobs stream a full database export with no memory ceiling on a node also
-  running the database.
+  `skills/moon.yml:22`) inside the RC gate. Prettier is a root devDependency at `^3.9.6`, so `npx`
+  resolves it locally when present and silently downloads an arbitrary version from the network when
+  not. `pnpm exec prettier` is the deterministic form.
+- **`skills/moon.yml:24-28` declares `**/*.yaml` in `sources`** but the lint command checks only
+  `'**/*.md' '**/*.yml'`. Latent — no `.yaml` exists under `skills/` today.
+- **The worker has no probes** while backend (`backend-deployment.yaml:118-121`) and frontend
+  (`frontend-deployment.yaml:81-84`) both do. A wedged arq worker stays Ready forever, and its HPA
+  scales on CPU and memory (`worker-hpa.yaml:15-31`), so stuck reads as underutilized and scales
+  down.
+- **SurrealDB chart jobs inherit empty resources** (`charts/surrealdb/values.yaml:70`, consumed by
+  `bootstrap-job.yaml:68-69`, `export-cronjob.yaml:86-87`, `snapshot-cronjob.yaml:86-87`,
+  `restore-drill-cronjob.yaml:159-160`). The export and restore-drill jobs stream a full database
+  export with no memory ceiling on a node also running the database.
 - **Wrapper `appVersion` lacks the `v` prefix its own fallback needs.**
   `charts/surrealdb/Chart.yaml:6` is `"3.2.3"` and `_helpers.tpl:115` falls back to
-  `.Chart.AppVersion`, producing `surrealdb/surrealdb:3.2.3`; upstream publishes
-  v-prefixed tags, so that path is an ImagePullBackOff. Latent only because
-  `values.yaml:10` sets `v3.2.3` explicitly.
-- **`okf-memory-changelog.yml` guards one artifact upload and not its sibling** (:94 gated
-  on `hashFiles(...) != ''`, :101 has `if-no-files-found: error` and no guard). Whether
-  the weekly cron fails depends on an unreadable repo secret; the intra-workflow
-  inconsistency is verified.
-- **`publish-dogfood-images.yml` is `workflow_dispatch`-only** and nothing dispatches it.
-  A legitimate manual tool worth confirming is still wanted.
+  `.Chart.AppVersion`, producing `surrealdb/surrealdb:3.2.3`; upstream publishes v-prefixed tags, so
+  that path is an ImagePullBackOff. Latent only because `values.yaml:10` sets `v3.2.3` explicitly.
+- **`okf-memory-changelog.yml` guards one artifact upload and not its sibling** (:94 gated on
+  `hashFiles(...) != ''`, :101 has `if-no-files-found: error` and no guard). Whether the weekly cron
+  fails depends on an unreadable repo secret; the intra-workflow inconsistency is verified.
+- **`publish-dogfood-images.yml` is `workflow_dispatch`-only** and nothing dispatches it. A
+  legitimate manual tool worth confirming is still wanted.
 - **Nothing tests `sync_versions.py` itself.** `"moon run sync-versions"` and
   `"moon run sync-versions-check"` are absent from `RELEASE_WORKFLOW_REQUIRED_FRAGMENTS`
-  (`test_release_workflow.py:32-68`), so deleting `release.yml:171-172` still passes the
-  allowlist proof. No test asserts every target exists, and the docstring at
-  `sync_versions.py:36-39` claims a `_pep440` parity check that no test performs.
-- **The SurrealDB version is duplicated across 14 sites with no sync tool** (I18's list
-  plus `charts/surrealdb/Chart.yaml:6`, `docs/deployment/ansible.md:12`,
-  `docs/deployment/docker-compose.md:62,90,214`). Only the two CLI sites have tests
-  pinning the literal. Extending `sync_versions.py` with a second source of truth folds it
-  into the existing gate. (M)
-- **`infra/local/tidb-cluster.yaml:17` pins `alpine:3.16.0`** (2022-era) as the TiKV helper
-  image, in a path documented as the local backing store.
+  (`test_release_workflow.py:32-68`), so deleting `release.yml:171-172` still passes the allowlist
+  proof. No test asserts every target exists, and the docstring at `sync_versions.py:36-39` claims a
+  `_pep440` parity check that no test performs.
+- **The SurrealDB version is duplicated across 14 sites with no sync tool** (I18's list plus
+  `charts/surrealdb/Chart.yaml:6`, `docs/deployment/ansible.md:12`,
+  `docs/deployment/docker-compose.md:62,90,214`). Only the two CLI sites have tests pinning the
+  literal. Extending `sync_versions.py` with a second source of truth folds it into the existing
+  gate. (M)
+- **`infra/local/tidb-cluster.yaml:17` pins `alpine:3.16.0`** (2022-era) as the TiKV helper image,
+  in a path documented as the local backing store.
 
 ### Checked and clean
 
-No `pull_request_target` anywhere. No secret is echoed, written to `$GITHUB_OUTPUT`, or
-used in an `if:` expression. Every top-level `permissions:` block is `contents: read`
-except `docs.yml` (pages deploy, correctly scoped) and `release.yml` (`actions: write` for
-the publish dispatch, `contents: write` for the tag). All 16 `workflow_dispatch` inputs in
-`eval.yml` are defined and referenced. `infra/local/secrets.yaml` is gitignored.
+No `pull_request_target` anywhere. No secret is echoed, written to `$GITHUB_OUTPUT`, or used in an
+`if:` expression. Every top-level `permissions:` block is `contents: read` except `docs.yml` (pages
+deploy, correctly scoped) and `release.yml` (`actions: write` for the publish dispatch,
+`contents: write` for the tag). All 16 `workflow_dispatch` inputs in `eval.yml` are defined and
+referenced. `infra/local/secrets.yaml` is gitignored.
 
-Version pins are currently in sync: `sync_versions.py --check` exits 0 with "All
-deployment pins match VERSION (1.2.0)", all 13 targets exist, all 17 patterns match. The
-three published Python packages carry no version literal (`dynamic = ["version"]` reading
-the root `VERSION`), the web version is injected at build time
-(`apps/web/next.config.ts:13,43,61`), and no Dockerfile holds a literal. The chart
-subchart chain has no drift: `Chart.yaml` 0.5.0, `Chart.lock` 0.5.0, vendored tgz 0.5.0.
-Every chart env var maps to a live setting. No image in either chart uses `:latest`.
-`.prototools` (moon 2.2.6, python 3.13, node 24, pnpm 11.5.2, uv 0.9) matches what CI
-installs.
+Version pins are currently in sync: `sync_versions.py --check` exits 0 with "All deployment pins
+match VERSION (1.2.0)", all 13 targets exist, all 17 patterns match. The three published Python
+packages carry no version literal (`dynamic = ["version"]` reading the root `VERSION`), the web
+version is injected at build time (`apps/web/next.config.ts:13,43,61`), and no Dockerfile holds a
+literal. The chart subchart chain has no drift: `Chart.yaml` 0.5.0, `Chart.lock` 0.5.0, vendored tgz
+0.5.0. Every chart env var maps to a live setting. No image in either chart uses `:latest`.
+`.prototools` (moon 2.2.6, python 3.13, node 24, pnpm 11.5.2, uv 0.9) matches what CI installs.
 
-Not run: no `helm template`, `helm lint`, or cluster operation, so every chart rendering
-claim comes from reading templates rather than rendered output. No workflow was executed.
-Moon's passthrough-argument hashing was not tested, which is why I12 is scoped to the
-asymmetry rather than a claimed false PASS.
+Not run: no `helm template`, `helm lint`, or cluster operation, so every chart rendering claim comes
+from reading templates rather than rendered output. No workflow was executed. Moon's
+passthrough-argument hashing was not tested, which is why I12 is scoped to the asymmetry rather than
+a claimed false PASS.

--- a/docs/architecture/AUDIT_2026-08-13/expressiveness-map.md
+++ b/docs/architecture/AUDIT_2026-08-13/expressiveness-map.md
@@ -1,0 +1,565 @@
+# Sibyl Expressiveness Surface Map
+
+What an agent can express when it stores a memory, and how much of that expressed
+structure retrieval actually consumes. All receipts are `file:line` against
+`/Users/bliss/dev/sibyl` at commit `5388d986`. Read-only survey; nothing mutated.
+
+---
+
+## 0. Two substrates and two retrieval paths
+
+Two structural facts govern everything below. Both are easy to miss and both
+change how you read the matrix.
+
+### 0.1 Every memory is stored twice
+
+| Substrate | Table | Schema receipt | Character |
+| --- | --- | --- | --- |
+| Content / raw | `raw_captures` (+ `supersedes`, `derived_from` relations) | `packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql:121-175` | Verbatim capture, shared org namespace, carries a real `review_state` lifecycle |
+| Graph | `entity` + `relates_to` | `packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py:75-205` | Projected/typed node, per-org namespace, **no lifecycle column** |
+
+`MemoryCaptureService.capture` writes raw first, then graph, copying a metadata
+bag across the seam
+(`packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py:104-154`).
+
+Nearly all correction and supersession expressiveness lives on the raw side.
+Nearly all retrieval scoring reads the graph side. Gap G1 is the consequence.
+
+### 0.2 Two live search entry points, not one
+
+- `sibyl_core/tools/search.py::search` — the MCP `search` tool, the `sibyl
+  search` CLI, probe rehearsal (`memory_pipeline/rehearsal.py:51`), and synthesis
+  (`services/synthesis.py:138`). Delegates to `retrieval/hybrid.py::hybrid_search`
+  at `tools/search.py:1074`.
+- `sibyl_core/retrieval/search.py::context_search` — the context-pack / `recall`
+  path, called from `tools/context.py:1489`.
+
+These have **different scoring code**. `hybrid.py` is not dead: it is the legacy
+lane still serving `search`. Where the two disagree, the matrix says so.
+
+---
+
+## 1. Write surface
+
+### 1.1 The capture contract
+
+`MemoryCaptureRequest`
+(`packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py:16-46`) is
+the shape every graph-memory write funnels into:
+
+| Field | Type | Default | Validation |
+| --- | --- | --- | --- |
+| `title` | `str` | required | length-capped downstream |
+| `content` | `str` | required | stripped; `stored_content` is the span-addressable string (`capture.py:49-57`) |
+| `entity_type` | `str` | `"episode"` | coerced to `EntityType`; **no DB constraint** |
+| `domain` | `str \| None` | `None` | freeform |
+| `tags` | `Sequence[str] \| None` | `None` | **freeform, no vocabulary** |
+| `related_to` | `Sequence[str] \| None` | `None` | entity ids → untyped `RELATED_TO` (§1.3) |
+| `languages` | `Sequence[str] \| None` | `None` | freeform |
+| `retrieval_keys` | `Sequence[str] \| None` | `None` | strict: ≤16 keys, ≤200 chars (`retrieval_keys.py:34-38, 67-110`) |
+| `metadata` | `Mapping` | `{}` | free bag, minus server-owned structure keys |
+| `provenance` | `Mapping` | `{}` | free bag, raw side only |
+| `source_id` | `str \| None` | `None` | |
+| `memory_scope` | `str` | `"private"` | **enum-asserted in DB**, raw table only (`content_schema.py:170-171`) |
+| `scope_key` | `str \| None` | `None` | |
+| `principal_id` | `str \| None` | `None` | server-stamped, not caller-forgeable (`capture.py:126-134`) |
+| `capture_surface` | `str` | `"cli"` | |
+| `wait_searchable` | `bool` | `False` | forces sync write |
+| `skip_conflicts` | `bool` | `False` | |
+| `diary` | `bool` | `False` | |
+| `agent_id` | `str \| None` | `None` | |
+| `project_id` | `str \| None` | `None` | |
+| `spans` | `Sequence[Mapping] \| None` | `None` | strict, §1.4 |
+| `atomic` | `bool` | `False` | strict, §1.4 |
+| `probes` | `Sequence[str] \| None` | `None` | strict, ≤5 × ≤500 chars (`structure.py:39-46`) |
+
+Two CLI-only fields ride in as untyped metadata rather than contract fields:
+
+- `--pin` → `capture_metadata["pinned"] = True`
+  (`apps/cli/src/sibyl_cli/main.py:3601, 3672`). Read only by the retention job
+  (`apps/api/src/sibyl/jobs/consolidation.py:370-376`).
+- `--basis` → `capture_metadata["basis"]`, normalized to one of
+  `observed | inferred | told | assumed`
+  (`apps/cli/src/sibyl_cli/main.py:225, 3602-3606, 3678-3679`). This is the only
+  epistemic-status axis in the entire system, and its **sole reader is a blame
+  display** (`apps/api/src/sibyl/api/routes/memory.py:1978`). Nothing in
+  retrieval, ranking, synthesis, or retention consults it.
+
+Absent from the contract entirely: `importance`, `confidence`,
+`valid_from`/`valid_to`, any typed-relationship parameter, any `supersedes`
+parameter. Importance and confidence enter only as untyped metadata keys, where
+`normalize_memory_quality_metadata` canonicalizes them
+(`memory_pipeline/quality.py:32-54`).
+
+### 1.2 Surface coverage for the 1.2 structure params
+
+| Surface | spans | atomic | probes | retrieval_keys |
+| --- | --- | --- | --- | --- |
+| MCP `remember` (`apps/api/src/sibyl/server.py:2544-2560`) | yes | yes | yes | yes |
+| MCP `add` (`server.py:2436-2458`) | no | no | no | no |
+| CLI `sibyl remember` / `sibyl add` (`main.py:3614, 3622, 3627, 3558`) | `--spans-json` | `--atomic` | `--probe` | `--key` |
+| CLI `sibyl capture` / `note` (`main.py:1866, 1989`) | no | no | no | no |
+| CLI `sibyl entity create` (`entity.py:213`) | no | no | no | no |
+| `POST /entities` (`apps/api/src/sibyl/api/schemas/entities.py:39, 47, 69, 90`) | yes | yes | yes | yes |
+| `PATCH /entities/{id}` (`schemas/entities.py:155, 160`) | yes | yes | no | no |
+| `POST /memory/raw` (`schemas/memory.py:17`) | no | no | no | no |
+
+`sibyl add` is a hidden alias for the same function as `sibyl remember`
+(`main.py:3774`). The MCP `add` tool is a different, older tool that carries none
+of the structure params.
+
+### 1.3 Entity type vocabulary
+
+`EntityType` (`models/entities.py:10-68`) — 34 members: `pattern, rule, template,
+guide, tool, language, topic, episode, knowledge_source, config_file,
+slash_command, project, epic, task, team, error_pattern, milestone, source,
+document, procedure, community, note, domain, artifact, decision, plan, idea,
+claim, preference, person, place, event, session, passage`.
+
+The `entity_type` column is bare `TYPE string` with **no ASSERT**
+(`backends/surreal/schema.py:79`) — the enum is a Python convention, not a
+database constraint. MCP `remember` narrows further to an 11-value `MemoryKind`
+literal (`apps/api/src/sibyl/server.py:69-81`), and the LLM extractor to a
+12-value subset (`models/memory_extraction.py:15-31`).
+
+### 1.4 Relationships: what a writer can declare
+
+`RelationshipType` (`models/entities.py:71-116`) declares 40 predicates,
+including `SUPERSEDES`, `CONFLICTS_WITH`, `CONTRADICTS`, `SUPPORTS`, `DECIDES`,
+`BREAKS`, `ENABLES`, `REQUIRES`.
+
+**A writing agent can select none of them.** The only relationship parameter on
+any write surface is `related_to`, and both write paths hardcode the predicate:
+
+- `tools/add.py:712-725` — `"type": "RELATED_TO"` as a literal at `add.py:720`.
+- `services/memory.py:3196-3205` — `RelationshipType.RELATED_TO` for every id.
+
+There is no `relationship_type` parameter on `add()` (`add.py:222-256`), on
+`EntityCreate` (`schemas/entities.py:65-99`), on the MCP `add`/`remember` tools,
+or on `MemoryCaptureRequest`. There is also no relationship-create HTTP endpoint:
+`apps/api/src/sibyl/api/routes/graph.py` exposes reads plus `POST /subgraph`
+(`graph.py:524`), whose `relationship_types` field
+(`apps/api/src/sibyl/api/schemas/graph.py:48`) is a filter, not a writer.
+
+The complete live predicate vocabulary — **7 of 40**:
+
+| Predicate | Producer | Receipt |
+| --- | --- | --- |
+| `RELATED_TO` | `related_to` param; also auto-discovered links at similarity ≥0.75 | `tools/add.py:712-725, 748, 756-768` |
+| `BELONGS_TO` | project association | `services/memory.py:3176-3183`, `tools/add.py:693` |
+| `DEPENDS_ON` | `add` tool `depends_on` param (tasks) | `tools/add.py:699-711` |
+| `DERIVED_FROM` | promotion, experience projection | `services/memory.py:3185-3193`, `projection/experience.py:511, 698, 741, 780` |
+| `SUPERSEDES` | reflection promotion only | `services/memory.py:3207-3226` |
+| `MENTIONS` | LLM entity projection | `projection/memory.py:991-1047` |
+| `PART_OF` | passage + experience projection | `projection/passages.py:266-269`, `projection/experience.py:794` |
+
+The remaining 33 enum members have no writer at all.
+
+`SUPERSEDES` deserves its own note because it is the one semantically loaded edge
+the system can produce. It comes only from reflection-candidate metadata keys
+`("supersedes", "supersedes_ids", "superseded_ids", "supersedes_entity_ids")`
+(`services/memory.py:2468-2474`), and every target is re-authorized:
+`_authorized_superseded_entity_ids` drops targets the principal cannot write
+(`memory.py:2799-2811`) and `_with_authorized_supersedes` **overwrites** any
+caller-supplied list with the authorized set (`memory.py:2480-2489`). So even
+planting the key in metadata cannot forge a supersession.
+
+A regex `RelationshipBuilder` (`apps/api/src/sibyl/ingestion/relationships.py:38-120`)
+can infer `REQUIRES`, `CONFLICTS_WITH`, `SUPERSEDES`, `APPLIES_TO`,
+`DOCUMENTED_IN`, `WARNS_ABOUT` from text — and is **dead on the memory path**.
+Its only importer is a test (`packages/python/sibyl-core/tests/test_default_memory_loop.py:54`).
+It also carries a divergent `RelationType` enum whose `WARNS_ABOUT` does not
+exist in `RelationshipType`.
+
+### 1.5 Spans, atomicity, probes
+
+Three declarations, all server-validated and unforgeable through the metadata bag
+(`memory_pipeline/structure.py:55-63`; `strip_structure_metadata` applied at
+`tools/add.py:377-378`, re-stamped at `add.py:477`):
+
+- **`spans`** — half-open `[start, end)` offsets into `content.strip()` with an
+  optional ≤120-char label (`spans.py:92-108`). Must tile the whole body: no gap
+  (`spans.py:194-199`), no overlap (`spans.py:188-193`), ≥2 spans
+  (`spans.py:170-174`), ≤64 spans (`spans.py:49`), each ≤17,648 chars
+  (`spans.py:66-67`), covering every character (`spans.py:215-220`). Never
+  repaired, never partially honored (`spans.py:159-163`). Accepted spans become
+  `passage` entities with `PART_OF` edges (`projection/passages.py:266-269`).
+- **`atomic`** — "this body is one retrievable unit." Mutually exclusive with
+  spans (`structure.py:131-133`); refused above 18,000 chars (`spans.py:224-232`).
+  Survives a content edit unless restated, while a stale span plan is dropped
+  (`apps/api/src/sibyl/api/routes/entities.py:214-222`).
+- **`probes`** — up to 5 queries the memory must answer (`structure.py:39-46`).
+  Each is run through the **live fused retrieval path** at write time and its rank
+  (or absence) recorded (`memory_pipeline/rehearsal.py:56-131`). Raw recall and
+  exposure recording are disabled so the measurement can actually fail
+  (`rehearsal.py:8-13, 157-160`). Rehearsal runs after passages exist so a probe
+  landing on a span counts (`tools/add.py:834-835`). Supplying probes forces a
+  synchronous write (`tools/add.py:380-384`, `routes/entities.py:2154`). A failing
+  probe never fails the write (`rehearsal.py:14-16`).
+
+### 1.6 Retrieval keys
+
+An identifier the writer asserts the memory answers to, **not derived from the
+content** — so a key may name something the body never spells out
+(`retrieval_keys.py:1-23`). Compared by casefold plus whitespace-collapse and
+nothing else: no stemming, no punctuation stripping (`retrieval_keys.py:51-54`).
+The write boundary is strict and the storage edge lenient by design
+(`retrieval_keys.py:18-22`, strict at `:93-109`, lenient at `:113-148`). `None`
+means "this write does not speak to keys" and preserves existing ones
+(`retrieval_keys.py:118-120`).
+
+---
+
+## 2. Extraction and enrichment
+
+### 2.1 Entity extraction
+
+`ExtractedMemoryEntity` (`models/memory_extraction.py:33-48`): `name`,
+`entity_type` (12-value subset), `summary`, optional `confidence` 0-1,
+`evidence` ≤400 chars. Max 12 per source (`memory_extraction.py:11`).
+
+At projection (`projection/memory.py:819-858`) confidence defaults to 0.75 when
+omitted, is clamped, gates admission via `min_confidence`, and orders/dedupes
+candidates. Dedup key is `f"{type}:{name.lower()}"` (`projection/memory.py:849`),
+scoped to a single batch.
+
+### 2.2 There is no relation extraction
+
+`MemoryEntityExtractionResult` holds only `entities`
+(`models/memory_extraction.py:51-57`) — the extraction contract has no relation
+field. The pipeline emits exactly one edge type from extraction: `MENTIONS`
+(`projection/memory.py:991-1047`).
+
+The reflection layer has a typed relationship dataclass,
+`ReflectionRelationshipRecord`, carrying a `relationship_type: str`
+(`models/reflection.py:237-245`). It is populated in exactly one place, with one
+hardcoded predicate: `_relationship_records_for_project` emits
+`relationship_type="BELONGS_TO"` pointing at the project
+(`services/reflection.py:506-524`). The records are serialized into metadata
+(`reflection.py:266-268`) and **never become graph edges** — promotion builds
+edges from `_relationships_for_promotion` (`services/memory.py:3165-3226`), which
+never reads `relationship_records`.
+
+So the pipeline can say *"this memory mentions Redis"* and nothing else. It
+cannot say *"Redis TTL expiry causes the JWT refresh failure."*
+
+### 2.3 What lands on `relates_to`
+
+Built at `services/graph.py:3326-3349`:
+
+| Column | Source |
+| --- | --- |
+| `name` | `relationship.relationship_type.value` — the predicate |
+| `fact` | `metadata["fact"]`, else auto-generated `"<src> <predicate> <tgt>"` (`graph.py:3352-3357`) |
+| `fact_embedding` | `metadata["fact_embedding" \| "embedding"]` |
+| `source_id` / `target_id` | model fields |
+| `episodes` | `metadata["episodes"]` |
+| `attributes` | the whole remaining metadata bag (FLEXIBLE) |
+| `created_at`, `expired_at`, `valid_at`, `invalid_at` | model field + metadata (`valid_from`/`valid_to` accepted as aliases) |
+
+**`Relationship.weight` is not persisted.** The model declares it
+(`models/entities.py:276`) and `_relationship_record` omits it. There is no
+`weight` column on `relates_to` (full field list: `schema.py:181-193`). It exists
+only if a caller puts `weight` into metadata, which lands in `attributes` and is
+hydrated back at `graph.py:2442, 2494-2497`. Nothing does:
+grepping `"weight"` across `sibyl-core/src` and `apps/api/src` finds readers
+(`hybrid.py:559`, `graph.py:2495`, export, community layout) and **no writer**.
+`_metadata_weight` therefore always returns its 1.0 default.
+
+There is no provenance column and no confidence column on the edge. Both can only
+exist as `attributes` sub-keys.
+
+---
+
+## 3. Taxonomy: four axes, four contracts
+
+| Axis | Storage | Validation | Role |
+| --- | --- | --- | --- |
+| `entity_type` | `entity.entity_type` string (`schema.py:79`), indexed (`:111`) | Python enum only, **no DB ASSERT** | Kind of thing; drives facet routing |
+| `tags` | `entity.tags option<array<string>>` (`schema.py:104`), **no index** | none, freeform | Ad-hoc labeling |
+| `labels` | `entity.labels array<string>` (`schema.py:83`), indexed on `labels.*` (`:112`) | **not writer-settable**: always `[entity_type, "Entity"]` (`graph.py:3033`) | Legacy Graphiti compat shape |
+| `memory_scope` | `entity.memory_scope` (`schema.py:105`) + `idx_entity_memory_scope` (`:117`); `raw_captures.memory_scope` with **ASSERT** (`content_schema.py:170-171`) | enum-enforced on the raw side only | Authorization partition |
+| `project_id` | `entity.project_id` (`schema.py:96`), in 4 indexes | freeform string | Second partition axis |
+
+`labels` is not a writer axis despite looking like one — it is a derived
+duplicate of `entity_type`. `memory_scope` is the only axis with a real database
+constraint, and only on the raw table.
+
+---
+
+## 4. THE STORED-VS-USED MATRIX
+
+"Used" means read by retrieval, ranking, fusion, or context-pack assembly in a
+way that changes what comes back or in what order. Display pass-through does not
+count. Where the two search paths (§0.2) differ, both are named.
+
+| Axis | Stored | Verdict | Receipt |
+| --- | --- | --- | --- |
+| `entity_type` | `entity.entity_type` | **USED** — filter, request pools, tie-rank, boost | SQL filter `retrieval/search.py:1602-1604`, applied to vector (`:1436`), exact-key (`:1084`), BFS (`:2152`); KNN overfetch lifts the predicate out of the HNSW bracket and reapplies it (`:1384-1407`). Request pools `tools/context.py:77-90, 1221-1239`. Lineage tie-rank `context.py:700-720, 739`. Boosts: `type == "task"` + active → `search.py:3110`; `type == "raw_memory"` → `:3114-3115`. **No global type-prior table exists.** |
+| `entity_type` facet coverage | as above | **PARTIAL** — 8 types unreachable by recall | `FACET_TYPES` (`context.py:77-90`) omits `person, place, language, team, milestone, community, knowledge_source, slash_command`; `_types_for_facets` (`:1221-1239`) builds the requested-type list from that map, so those 8 are never requested by any intent |
+| `tags` | `entity.tags` (unindexed) | **STORED, UNREAD by search** | In `retrieval/`, two lines, both pass-through: `search.py:2383, 2455`. `list_by_type` accepts `tags=` (`graph.py:1104`) but emits **no SQL clause** (`graph.py:1143-1186`); filtering is a Python post-filter (`graph_search.py:99-100`) whose only caller is `tools/explore.py:241` — a browse surface. Neither `tools/search.py:343` nor `context.py:1414` passes tags |
+| `labels` | `entity.labels`, indexed | **PARTIAL** — used as type fallback; the label filter is dead | Live read: `search.py:2348-2352, 2632-2636` (third fallback for deriving candidate type). Dead filter: `search.py:1605-1607, 1628-1630` gate on `SearchFilter.node_labels`, declared `:233` with default `()` and **never populated by any production caller** (constructions at `:899, 1214, 2081`). `idx_entity_labels` is never exercised |
+| `memory_scope` | `entity.memory_scope` column **and** `attributes.memory_scope` | **USED as a hard gate — via attributes, not the column** | Gate `search.py:2710-2724` → `auth/memory_policy.py:643, 657, 660`, reading `metadata["memory_scope" / "scope_key" / "principal_id"]`, which arrive via the whole-attributes splat at `search.py:2211-2212`. Plan side `search.py:287-336, 623-635, 951`. Pack side `context.py:439-447, 1426-1434`. The **column** appears in no retrieval WHERE clause; `idx_entity_memory_scope` is dead weight and the two copies can drift |
+| `project_id` | `entity.project_id` + `attributes.project_id` | **USED** — filter, boost, gate | Node filter `search.py:1608-1610` (checks both column and attribute); edge filter is a 5-way disjunction across endpoints `:1631-1641`; boost `:3112-3113`; post-filter gates `:2693-2707`; selectivity signal `:919-927`; episode lane skipped entirely when project filtering is on `:1143-1144` |
+| `status` | `entity.status` | **USED** — filter, boost, facet suppression | SQL `graph.py:1170-1172, 1186`, reached from the pack at `context.py:1414-1419`; boost `search.py:3109-3111`; `archived` dropped and `done` demoted at `context.py:216-234`; lineage rank `-1` for in-flight `context.py:735-738` |
+| `priority` | `entity.priority`, indexed | **STORED, UNREAD by retrieval** | Exactly one hit in `retrieval/`: `search.py:2380`, a pass-through key. SQL clause exists at `graph.py:1174-1177` but its only caller is `tools/explore.py:418-427` (browse). `idx_entity_priority` serves browse only. A high-priority memory does not rank higher |
+| `retrieval_keys_normalized` | `entity.retrieval_keys_normalized`, element-indexed | **USED** — dedicated high-precision lane | `CONTAINSANY $probe_keys` at `search.py:1086`, index-served by `idx_entity_retrieval_keys ON ... retrieval_keys_normalized.*` (`schema.py:118`); the `.*` is load-bearing (`search.py:1071-1077`). Overlap scoring `:1126-1133, 1111, 1119`; fusion multiplier `_exact_key_signal_multiplier` `:3052-3074`; probes minted from query identifiers `retrieval/identifier_query.py:47-49, 184`; inert without an identifier `:1067-1068` |
+| `retrieval_keys` (display form) | column | **STORED, UNREAD** — matching always uses the normalized form | `search.py:2384` |
+| `attributes` (FLEXIBLE) | `entity.attributes` | **USED** — splatted whole, ~14 sub-keys read by name | Splat `search.py:2211-2212, 2290-2291, 2591`. Named: `project_id` (`:1609, 1634-1638, 2202`), `entity_type` (`:2339, 2623`), `content`/`description` (`:2366-2367`), `source*` (`:2205-2208`), endpoint project ids (`:2575, 2578`), scope trio (→ `memory_policy.py:643-660`), `status` (→ `:3109`), usage counters (→ `temporal.py:144-146, 199-201`), `source_entity_type` (`context.py:201`), `projection_kind` (`apps/api/src/sibyl/api/routes/context.py:502-511`), `parent_entity_id`/`passage_index`/`passage_total` (`context.py:1296-1298`), `operational_source_id` (`context.py:394-396`) |
+| `attributes.importance` | `entity.attributes` | **UNREAD by retrieval; USED by retention** | Only reader: `apps/api/src/sibyl/jobs/consolidation.py:339-345`, feeding `importance × 0.5^(age/half_life)` at `:319-331`. Zero hits in `retrieval/` |
+| `attributes.confidence` | `entity.attributes` | **STORED, UNREAD** | Display projections only: `search.py:2390, 2416` |
+| `attributes.pinned` / `retention` | `entity.attributes` | **UNREAD by retrieval; USED by retention** | `jobs/consolidation.py:370-376` |
+| `attributes.basis` | `entity.attributes` | **STORED, UNREAD** | Written `apps/cli/src/sibyl_cli/main.py:3678-3679`; sole reader is a blame display `apps/api/src/sibyl/api/routes/memory.py:1978` |
+| edge `name` (predicate) | `relates_to.name`, indexed | **USED** — filter, traversal weight, candidate identity | Filter `search.py:1626-1627, 1481, 1491`; traversal filter `:1837, 1890`; hardcoded `name = "BELONGS_TO"` `:1950, 1992`; **per-predicate scoring** `:1859, 1865, 1912, 1918` → `_graph_expansion_path_score`; becomes `candidate.name` `:2307` and gates `_candidate_matches_types` `:2735` |
+| edge `fact` | `relates_to.fact`, FT-indexed | **USED** — BM25 target and candidate content | `search.py:1179, 1188-1194, 2308, 2587` |
+| edge `fact_embedding` | `relates_to.fact_embedding`, HNSW | **USED** — edge vector lane | `search.py:1489, 1518`; index `schema.py:205` |
+| edge `weight` | **not a column**; only `attributes.weight` | **Effectively unread — and always 1.0** | Read on the legacy path only: `hybrid.py:558-562 _relationship_weight`. `context_search` ignores it entirely and uses the hardcoded table instead. No writer anywhere sets it, so `_metadata_weight` (`graph.py:2494-2497`) always returns 1.0. `_relationship_type_multiplier` (`hybrid.py:565-579`) needs `relationship_type_weights`, which no production `HybridConfig` supplies (`tools/search.py:1063-1071`) |
+| edge `valid_at` | `relates_to.valid_at` | **USED indirectly** — decay anchor; never a WHERE | Projected `search.py:1661`, carried `:2391, 2417`, read first in the `"auto"` chain `retrieval/temporal.py:113` (`valid_at → valid_from → created_at`), driving `temporal_decay_multiplier` at `search.py:3120-3122` |
+| edge `invalid_at` | `relates_to.invalid_at` | **STORED, UNREAD by retrieval** | Three hits in `retrieval/`, all key lists: `search.py:1661, 2394, 2420`. The traversal queries `_relation_target_hops` (`:1826-1868`) and `_relation_source_hops` (`:1871-1922`) carry no temporal predicate. An invalidated edge is walked and ranked exactly like a live one |
+| edge `expired_at` | `relates_to.expired_at` | **STORED, UNREAD by retrieval** | `retrieval/` hits are `search.py:1661, 2421` only. Sole real readers are `tools/temporal.py:64, 296-333, 549` — a separate opt-in tool `context_search` never calls |
+| edge `episodes` | `relates_to.episodes` | **STORED, UNREAD** | `search.py:1660, 2424` only. The `mentions` traversal at `:1794-1799` walks the separate `mentions` table, not this array |
+| Graph traversal | `relates_to` | **USED and predicate-aware; outgoing-only** | `_graph_expansion_candidates` `search.py:1556-1591` → `_node_bfs_records` `:1670-1778`. 21-entry predicate weight table `:85-107` (`DECIDES` 1.0 … `MENTIONS` 0.58, unknown → 0.64); depth decay 0.72 at `:2181-2185`; highest-scoring predicate wins on hop dedup `:2171-2178`; fusion multiplier `:3077-3098`, applied only to candidates that also carry a non-expansion signal `:3085-3086`. **Incoming edges are off by default** (`include_incoming=False`, `:1680`), so "the tasks that depend on this one" is invisible to `context_search`. The `relationship_names` filter is reachable only from `tools/traverse.py`; the retrieval walk passes none (`:1575-1583`) and discriminates purely by weight |
+| `last_used_at`, `last_recalled_at` | entity columns, indexed | **USED in retrieval scoring** | `get_entity_decay_timestamp` `retrieval/temporal.py:138-173`: `last_used_at` at full weight (`:144, 149-150`), `last_recalled_at` discounted by `EXPOSURE_DECAY_TIMESTAMP_WEIGHT` (`:145, 151-158`) — being shown is worth less than being used. Result shifts the decay anchor, consumed at `search.py:3117-3125` |
+| `retrieval_count`, `citation_count`, `misled_count` | entity columns | **USED in retrieval scoring** | `usage_retention_multiplier` `temporal.py:197-205`: `+0.02×min(retrieval,50)`, `+0.12×min(citation,20)`, `−0.6×min(misled,5)`, clamped `[0.1, 4.0]`; applied as `decay_days × multiplier` at `:226`. A heavily cited memory decays up to 4× slower; `misled_count ≥ 5` decays 10× faster. **`misled_count` is a live negative-feedback channel** |
+| `created_at` | entity column, indexed | **USED** — freshness boost, decay anchor, tiebreak | `_freshness_boost` `search.py:3116, 3129-3136` = `min(cap, 1 + 0.5/(1+age_days))`; last resort in the decay chain `temporal.py:113`; `ORDER BY … created_at DESC, uuid DESC` in every lane (`:1030, 1155, 1194, 1408, 1441, 1492, 1521`) |
+| `updated_at` | entity column, in 5 indexes | **STORED, UNREAD by retrieval** | One hit in `retrieval/`: `dedup.py:307`, inside a maintenance scan. `_freshness_boost` takes `created_at` only; `updated_at` is not in the decay chain and not in `_selected_record_metadata` (`search.py:2376-2407`), so it never reaches a candidate. Its 5 indexes (`schema.py:120, 123-126`) serve `list_by_type` only. **An edited memory does not become fresher to the ranker** |
+| `spans` (`attributes.agent_spans`) | entity attributes | **USED indirectly** | Consumed at projection to mint `passage` rows (`projection/passages.py`); passages are first-class retrieval targets and collapse into their parent at `context.py:1296-1298` |
+| `atomic` (`attributes.agent_atomic`) | entity attributes | **USED indirectly** | Suppresses mechanical cutting, keeping the memory one retrievable unit |
+| `probes` (`attributes.memory_probes`) | entity attributes | **STORED, UNREAD** | Write-time diagnostic only (`rehearsal.py:113-121`). No retrieval lane reads `memory_probes`: not query expansions, not alternate embeddings, not synonyms |
+| Raw lifecycle (`review_state`, `superseded_by_*`) | `raw_captures` | **USED on the raw lane; UNENFORCED on the graph lane** | Raw: `raw_memory_recallable` (`memory_pipeline/lifecycle.py:62-85`, wired `services/surreal_content.py:545-550`, called `:606, 1892, 2173`). Synthesis re-filters at render (`services/synthesis.py:116-119, 481-492, 555-580`). The graph lane has no equivalent |
+
+### 4.1 The short version
+
+**Read by retrieval:** `memory_scope` (via attributes), `project_id`, `status`,
+`retrieval_keys_normalized`, edge predicate `name`, edge `fact` and
+`fact_embedding`, `entity_type` (filter/pools/tie-rank/two boosts), `created_at`,
+all five usage counters and timestamps, spans and `atomic` via passages.
+
+**Stored and never read by retrieval:** `tags`, `priority`, `updated_at`,
+`probes`, `basis`, `confidence`, edge `weight`, edge `invalid_at`, edge
+`expired_at`, edge `episodes`, the `node_labels` filter, and the
+`entity.memory_scope` column itself.
+
+**Read only by the retention job:** `importance`, `pinned`, `retention`.
+
+---
+
+## 5. Temporal, provenance, correction
+
+### 5.1 Temporal expressiveness
+
+On the **edge**: a genuine bi-temporal model exists —
+`valid_at`/`invalid_at` (valid time) and `created_at`/`expired_at` (transaction
+time) (`schema.py:190-193`), queryable through
+`temporal_query(mode=history|timeline|conflicts)` (`tools/temporal.py:36-120`)
+and `/search` conflicts mode (`apps/api/src/sibyl/api/routes/search.py:553-558`).
+
+On the **node**: nothing. `entity` has no `valid_at`/`invalid_at` columns. The
+`Episode` model declares `valid_from`/`valid_to` (`models/entities.py:204-209`)
+and the storage edge does not write them (`graph.py:3026-3051`), so they land in
+`attributes` as untyped metadata.
+
+And a writer cannot set edge temporal bounds anyway, because a writer cannot
+create a typed edge (§1.4). `valid_at` is populated only by reflection promotion
+(`services/memory.py:3213-3222`).
+
+### 5.2 Provenance
+
+Raw side: a dedicated `provenance` FLEXIBLE column
+(`10_tables.surql:139`) plus `principal_id`, `agent_id`, `capture_surface`,
+`created_by_user_id`, and a `derived_from` relation to `source_imports`.
+
+Graph side: `created_by`/`modified_by` (`schema.py:88-89`), `source_file`, and
+`attributes`. `native_write_path` is stamped on generated relationships
+(`services/memory.py:3180, 3190, 3204`). There is **no provenance column on
+`relates_to`** — an edge cannot say who asserted it or on what evidence except
+through `attributes` and `episodes`, and `episodes` is unread (§4).
+
+### 5.3 What `sibyl correct` actually does
+
+Ten actions (`services/memory.py:186-205`, literal type at
+`apps/api/src/sibyl/api/schemas/common.py:20-31`): `delete`, `mark_duplicate`,
+`mark_stale`, `mark_wrong`, `restore`, `supersede`, `hide`, `mark_sensitive`,
+`redact`, `revise`. Aliases `duplicate | stale | superseded | wrong`
+(`memory.py:200-205`). `delete` and `redact` are irreversible (`memory.py:216`).
+
+**What it touches:** `apply_memory_correction` (`services/memory.py:1652-1732`)
+builds a `replace(memory, ...)` and calls `save_raw_memory`. It mutates three
+things on the **raw** row: `raw_content` (revise only), `review_state`, and
+`metadata` — writing `metadata["superseded_by_source_id"]` (`memory.py:1598`), a
+`MemoryLifecycle` record (`:1607`), a correction-history entry (`:1621`), and a
+`ReflectionFinding` (`:1637-1640`). On `supersede` it passes
+`superseded_by_memory_id`, which can materialize the content-layer `supersedes`
+relation (`content_schema.py:301-312`).
+
+**What it does not touch:** the graph. No `relates_to` write, no `entity` update,
+no reprojection job. The route reports `affected_records=[f"raw_captures:{id}"]`
+only (`apps/api/src/sibyl/api/routes/memory.py:2585-2591`).
+`_correction_derived_ids` (`memory.py:1236-1250`) *lists* the promoted entity and
+relationship ids and nothing mutates them. `_correction_impact`
+(`memory.py:1333-1352`) returns `{"excluded_from_recall": ...}` — a **declaration
+about** exclusion, not an enforcement of it.
+
+Note also that the physical `supersedes` table is materialized only by
+`_materialize_supersedes_lineage` (`services/surreal_content.py:1485, 1508,
+1518-1526`) reading `metadata.supersedes_raw_memory_id`, whose only writer is the
+source-import job (`apps/api/src/sibyl/jobs/source_imports.py:542`). No
+agent-facing parameter sets that key.
+
+Enforcement is split three ways: the raw recall lane honors lifecycle
+(`surreal_content.py:545-550`); synthesis re-filters at render
+(`synthesis.py:481-492`); the graph retrieval lane honors nothing (G1).
+
+### 5.4 Contradiction and consolidation
+
+Contradiction detection exists in exactly one form: a regex over an 11-word
+polarity vocabulary (`services/reflection.py:145-161` — enabled/disabled,
+allowed/blocked, required/forbidden, use/avoid/skip/disable/enable) firing a
+`ReflectionFindingKind.CONTRADICTION` when two candidates share a subject with
+opposite polarity (`reflection.py:664-678`, reason
+`"same_subject_opposite_polarity"`, confidence 0.82). The action is
+`route_to_review` — it resolves nothing. Supersession and staleness detection are
+explicit-signal-driven (`reflection.py:631-663`).
+
+`ClaimRecord` (`models/reflection.py:121-181`) is the richest structure in the
+codebase for this: `supports_source_ids`, `contradicts_source_ids`,
+`supersedes_source_ids`, `superseded_by_source_id`, `validity`, `freshness`,
+`confidence`. Only `supersedes_source_ids` ever becomes a graph edge
+(`services/memory.py:3207-3226`). `contradicts_source_ids` and
+`supports_source_ids` never become `CONTRADICTS` or `SUPPORTS` edges, though both
+predicates exist in the enum and both carry high expansion weights (0.64 default
+and 0.94 respectively).
+
+---
+
+## 6. Gaps an agent hits
+
+### G1. A correction cannot reach the memory retrieval serves
+
+`sibyl correct <id> --action mark_wrong` corrects the `raw_captures` row. The
+projected `entity` row keeps its capture-time metadata, has no `review_state` or
+`lifecycle_state` column (`schema.py:75-108`), and is never reprojected. Nothing
+in `retrieval/` joins a graph row back to its raw memory: `raw_memory_id` and
+`raw_source_id` are written into graph metadata at `capture.py:137-140`, and
+grepping either name across `retrieval/` and `tools/` returns zero hits. The
+wrong memory keeps ranking, keeps its embedding, keeps being expanded into. The
+only backstop is the synthesis render filter, which reads metadata the graph row
+does not carry.
+
+The system has a correction verb whose blast radius stops at the substrate
+retrieval mostly does not read.
+
+### G2. No typed edge between two memories at write time
+
+An agent that knows "this supersedes that" or "this claim contradicts that
+decision" has one channel: `related_to`, which becomes `RELATED_TO`
+unconditionally (`tools/add.py:720`, `services/memory.py:3196-3205`).
+`CONTRADICTS`, `SUPPORTS`, `CONFLICTS_WITH`, `DECIDES`, `BREAKS`, `ENABLES`,
+`REQUIRES` have no writer at all.
+
+The sharp edge: retrieval *would* use it. The expansion weight table
+(`search.py:85-107`) already assigns `DECIDES` 1.0, `REQUIRES` 0.98, `SUPERSEDES`
+0.95, `SUPPORTS` 0.94 — a tuned scoring table for predicates the write surface
+cannot produce. Traversal is typed; the write surface is not. The one typed
+relationship dataclass in the codebase
+(`ReflectionRelationshipRecord`, `models/reflection.py:237-245`) is populated
+with a single hardcoded `BELONGS_TO` (`services/reflection.py:506-524`) and never
+reaches the graph.
+
+### G3. Supersession is expressible, unenforced, and inverted in ranking
+
+Three compounding problems. The traversal queries carry no temporal predicate
+(`search.py:1826-1868, 1871-1922`), so an edge with `invalid_at` set is walked
+like a live one. `invalid_at` and `expired_at` are projected all the way into
+`SearchResult.metadata` (`:2394, 2420-2421`) and consulted by nothing in the
+fusion or boost path. And `SUPERSEDES` carries a weight of **0.95**, one of the
+highest in the table — so following a supersession edge *boosts* its target,
+which is the superseded memory. Retrieval treats "X replaced Y" as a strong
+reason to also surface Y.
+
+### G4. Confidence and epistemic basis have nowhere to live and nothing to read them
+
+Per-item confidence is produced in four places — the extractor
+(`models/memory_extraction.py:39`), `ClaimRecord` (`models/reflection.py:125`),
+`ReflectionFinding` (`:189`), and `Pattern` (`models/entities.py:153`) — and
+reaches no column. `entity` has no `confidence`; `relates_to` has no
+`confidence`. It survives only in `attributes`, where the only readers are
+display projections (`search.py:2390, 2416`). A low-confidence memory ranks
+identically to a certain one.
+
+`--basis` is worse, because it is a well-designed axis with a validated
+four-value vocabulary (`main.py:225`) that an agent can use to distinguish what
+it *observed* from what it *assumed* — and its only consumer in the entire system
+is a blame view (`routes/memory.py:1978`).
+
+Same shape for edge weight: not persisted, no column, always 1.0 (§2.3).
+
+### G5. Tags are a write-only axis on the retrieval path
+
+`tags` is the most natural thing for an agent to set and the least load-bearing
+thing it can set. Unindexed (`schema.py:104`), absent from every search WHERE
+clause, absent from every scoring term. `list_by_type` accepts a `tags` argument
+and emits no SQL for it (`graph.py:1104, 1143-1186`); the only real filter is a
+Python post-filter reached from `explore()` (`graph_search.py:99-100`,
+`tools/explore.py:241`). An agent tagging a memory `gotcha` and later searching
+for gotchas gets zero lift — the tag helps only if the reader already knows to
+*browse* by it.
+
+### G6. Eight entity types can never appear in a context pack
+
+`FACET_TYPES` (`tools/context.py:77-90`) maps 12 facets to entity types and
+`_types_for_facets` (`:1221-1239`) builds the requested-type list from exactly
+that map plus `passage`. Absent from every facet: `person`, `place`, `language`,
+`team`, `milestone`, `community`, `knowledge_source`, `slash_command`. `person`
+and `place` are the pointed ones — they were added deliberately for
+domain-general personal memory (`models/entities.py:54-55`) and `recall` can
+never request them.
+
+### G7. Structural expressiveness the schema lacks outright
+
+- **N-ary relations.** `relates_to` is `IN entity OUT entity` (`schema.py:179`).
+  "We decided X, in meeting Y, because of constraint Z" must be decomposed into
+  pairwise edges or flattened into prose.
+- **Negation.** No polarity field on node or edge. "Redis is *not* the
+  bottleneck" is stored as text and embeds close to "Redis is the bottleneck".
+  The only negation-aware machinery in the system is the 11-word regex vocabulary
+  in reflection (`services/reflection.py:145-161`).
+- **Entity aliasing / merge.** No `same_as` predicate, no merge verb, no
+  canonical-id indirection. Extraction dedupes only within a single batch by
+  `f"{type}:{name.lower()}"` (`projection/memory.py:849`), so "Bliss",
+  "Stefanie", and "stef@gradial.com" become three permanent nodes.
+- **TTL / explicit decay.** `raw_captures` has `purge_after`
+  (`10_tables.surql:145`); `entity` has none. Decay is job-driven
+  (`jobs/consolidation.py:319-331`) with no writer-facing knob beyond untyped
+  `attributes.importance` or `attributes.pinned`.
+- **Probes as retrieval assets.** The single most direct statement an agent can
+  make about *how this memory should be found* is rehearsed once at write time
+  and then inert. Not indexed, not embedded, not used as query expansions
+  (`rehearsal.py`).
+- **Edit-time freshness.** `updated_at` is written and indexed five ways and read
+  by no ranker (`search.py:3129` takes `created_at` only). Revising a memory
+  cannot make it more current to retrieval.
+
+---
+
+## 7. Summary judgement
+
+The write surface is asymmetric in a specific way: **rich about the shape of a
+single memory, nearly mute about relations between memories.** Spans, atomicity,
+probes, retrieval keys, and scope are first-class, validated, unforgeable
+declarations with real server-side enforcement. Predicates, confidence, validity
+intervals, epistemic basis, and supersession are either absent from the contract
+or reachable only through internal code paths.
+
+Retrieval mirrors the asymmetry from the other side, and is better than the write
+surface deserves in two places and worse in three. Better: the graph expansion
+lane is genuinely predicate-aware with a tuned 21-entry weight table, and the
+usage-feedback loop is real — citations stretch a memory's half-life up to 4×
+and `misled_count` collapses it 10×, both feeding live ranking. Worse: no type
+prior, no tag signal, no confidence term, no temporal filter on edges, and no
+path from a corrected raw memory to the graph row that answers for it.
+
+The clearest single statement of the gap: **the predicate weight table
+(`search.py:85-107`) is a wish list.** It scores `DECIDES`, `SUPPORTS`,
+`REQUIRES`, `BLOCKS`, and `VALIDATED_BY` — five predicates no agent, and no
+extractor, can ever write.

--- a/docs/architecture/AUDIT_2026-08-13/expressiveness-map.md
+++ b/docs/architecture/AUDIT_2026-08-13/expressiveness-map.md
@@ -1,41 +1,39 @@
 # Sibyl Expressiveness Surface Map
 
-What an agent can express when it stores a memory, and how much of that expressed
-structure retrieval actually consumes. All receipts are `file:line` against
-`/Users/bliss/dev/sibyl` at commit `5388d986`. Read-only survey; nothing mutated.
+What an agent can express when it stores a memory, and how much of that expressed structure
+retrieval actually consumes. All receipts are `file:line` against `/Users/bliss/dev/sibyl` at commit
+`5388d986`. Read-only survey; nothing mutated.
 
 ---
 
 ## 0. Two substrates and two retrieval paths
 
-Two structural facts govern everything below. Both are easy to miss and both
-change how you read the matrix.
+Two structural facts govern everything below. Both are easy to miss and both change how you read the
+matrix.
 
 ### 0.1 Every memory is stored twice
 
-| Substrate | Table | Schema receipt | Character |
-| --- | --- | --- | --- |
+| Substrate     | Table                                                     | Schema receipt                                                                                       | Character                                                                       |
+| ------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | Content / raw | `raw_captures` (+ `supersedes`, `derived_from` relations) | `packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql:121-175` | Verbatim capture, shared org namespace, carries a real `review_state` lifecycle |
-| Graph | `entity` + `relates_to` | `packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py:75-205` | Projected/typed node, per-org namespace, **no lifecycle column** |
+| Graph         | `entity` + `relates_to`                                   | `packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py:75-205`                        | Projected/typed node, per-org namespace, **no lifecycle column**                |
 
-`MemoryCaptureService.capture` writes raw first, then graph, copying a metadata
-bag across the seam
+`MemoryCaptureService.capture` writes raw first, then graph, copying a metadata bag across the seam
 (`packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py:104-154`).
 
-Nearly all correction and supersession expressiveness lives on the raw side.
-Nearly all retrieval scoring reads the graph side. Gap G1 is the consequence.
+Nearly all correction and supersession expressiveness lives on the raw side. Nearly all retrieval
+scoring reads the graph side. Gap G1 is the consequence.
 
 ### 0.2 Two live search entry points, not one
 
-- `sibyl_core/tools/search.py::search` — the MCP `search` tool, the `sibyl
-  search` CLI, probe rehearsal (`memory_pipeline/rehearsal.py:51`), and synthesis
-  (`services/synthesis.py:138`). Delegates to `retrieval/hybrid.py::hybrid_search`
-  at `tools/search.py:1074`.
-- `sibyl_core/retrieval/search.py::context_search` — the context-pack / `recall`
-  path, called from `tools/context.py:1489`.
+- `sibyl_core/tools/search.py::search` — the MCP `search` tool, the `sibyl search` CLI, probe
+  rehearsal (`memory_pipeline/rehearsal.py:51`), and synthesis (`services/synthesis.py:138`).
+  Delegates to `retrieval/hybrid.py::hybrid_search` at `tools/search.py:1074`.
+- `sibyl_core/retrieval/search.py::context_search` — the context-pack / `recall` path, called from
+  `tools/context.py:1489`.
 
-These have **different scoring code**. `hybrid.py` is not dead: it is the legacy
-lane still serving `search`. Where the two disagree, the matrix says so.
+These have **different scoring code**. `hybrid.py` is not dead: it is the legacy lane still serving
+`search`. Where the two disagree, the matrix says so.
 
 ---
 
@@ -44,169 +42,154 @@ lane still serving `search`. Where the two disagree, the matrix says so.
 ### 1.1 The capture contract
 
 `MemoryCaptureRequest`
-(`packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py:16-46`) is
-the shape every graph-memory write funnels into:
+(`packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py:16-46`) is the shape every
+graph-memory write funnels into:
 
-| Field | Type | Default | Validation |
-| --- | --- | --- | --- |
-| `title` | `str` | required | length-capped downstream |
-| `content` | `str` | required | stripped; `stored_content` is the span-addressable string (`capture.py:49-57`) |
-| `entity_type` | `str` | `"episode"` | coerced to `EntityType`; **no DB constraint** |
-| `domain` | `str \| None` | `None` | freeform |
-| `tags` | `Sequence[str] \| None` | `None` | **freeform, no vocabulary** |
-| `related_to` | `Sequence[str] \| None` | `None` | entity ids → untyped `RELATED_TO` (§1.3) |
-| `languages` | `Sequence[str] \| None` | `None` | freeform |
-| `retrieval_keys` | `Sequence[str] \| None` | `None` | strict: ≤16 keys, ≤200 chars (`retrieval_keys.py:34-38, 67-110`) |
-| `metadata` | `Mapping` | `{}` | free bag, minus server-owned structure keys |
-| `provenance` | `Mapping` | `{}` | free bag, raw side only |
-| `source_id` | `str \| None` | `None` | |
-| `memory_scope` | `str` | `"private"` | **enum-asserted in DB**, raw table only (`content_schema.py:170-171`) |
-| `scope_key` | `str \| None` | `None` | |
-| `principal_id` | `str \| None` | `None` | server-stamped, not caller-forgeable (`capture.py:126-134`) |
-| `capture_surface` | `str` | `"cli"` | |
-| `wait_searchable` | `bool` | `False` | forces sync write |
-| `skip_conflicts` | `bool` | `False` | |
-| `diary` | `bool` | `False` | |
-| `agent_id` | `str \| None` | `None` | |
-| `project_id` | `str \| None` | `None` | |
-| `spans` | `Sequence[Mapping] \| None` | `None` | strict, §1.4 |
-| `atomic` | `bool` | `False` | strict, §1.4 |
-| `probes` | `Sequence[str] \| None` | `None` | strict, ≤5 × ≤500 chars (`structure.py:39-46`) |
+| Field             | Type                        | Default     | Validation                                                                     |
+| ----------------- | --------------------------- | ----------- | ------------------------------------------------------------------------------ |
+| `title`           | `str`                       | required    | length-capped downstream                                                       |
+| `content`         | `str`                       | required    | stripped; `stored_content` is the span-addressable string (`capture.py:49-57`) |
+| `entity_type`     | `str`                       | `"episode"` | coerced to `EntityType`; **no DB constraint**                                  |
+| `domain`          | `str \| None`               | `None`      | freeform                                                                       |
+| `tags`            | `Sequence[str] \| None`     | `None`      | **freeform, no vocabulary**                                                    |
+| `related_to`      | `Sequence[str] \| None`     | `None`      | entity ids → untyped `RELATED_TO` (§1.3)                                       |
+| `languages`       | `Sequence[str] \| None`     | `None`      | freeform                                                                       |
+| `retrieval_keys`  | `Sequence[str] \| None`     | `None`      | strict: ≤16 keys, ≤200 chars (`retrieval_keys.py:34-38, 67-110`)               |
+| `metadata`        | `Mapping`                   | `{}`        | free bag, minus server-owned structure keys                                    |
+| `provenance`      | `Mapping`                   | `{}`        | free bag, raw side only                                                        |
+| `source_id`       | `str \| None`               | `None`      |                                                                                |
+| `memory_scope`    | `str`                       | `"private"` | **enum-asserted in DB**, raw table only (`content_schema.py:170-171`)          |
+| `scope_key`       | `str \| None`               | `None`      |                                                                                |
+| `principal_id`    | `str \| None`               | `None`      | server-stamped, not caller-forgeable (`capture.py:126-134`)                    |
+| `capture_surface` | `str`                       | `"cli"`     |                                                                                |
+| `wait_searchable` | `bool`                      | `False`     | forces sync write                                                              |
+| `skip_conflicts`  | `bool`                      | `False`     |                                                                                |
+| `diary`           | `bool`                      | `False`     |                                                                                |
+| `agent_id`        | `str \| None`               | `None`      |                                                                                |
+| `project_id`      | `str \| None`               | `None`      |                                                                                |
+| `spans`           | `Sequence[Mapping] \| None` | `None`      | strict, §1.4                                                                   |
+| `atomic`          | `bool`                      | `False`     | strict, §1.4                                                                   |
+| `probes`          | `Sequence[str] \| None`     | `None`      | strict, ≤5 × ≤500 chars (`structure.py:39-46`)                                 |
 
 Two CLI-only fields ride in as untyped metadata rather than contract fields:
 
-- `--pin` → `capture_metadata["pinned"] = True`
-  (`apps/cli/src/sibyl_cli/main.py:3601, 3672`). Read only by the retention job
-  (`apps/api/src/sibyl/jobs/consolidation.py:370-376`).
+- `--pin` → `capture_metadata["pinned"] = True` (`apps/cli/src/sibyl_cli/main.py:3601, 3672`). Read
+  only by the retention job (`apps/api/src/sibyl/jobs/consolidation.py:370-376`).
 - `--basis` → `capture_metadata["basis"]`, normalized to one of
   `observed | inferred | told | assumed`
-  (`apps/cli/src/sibyl_cli/main.py:225, 3602-3606, 3678-3679`). This is the only
-  epistemic-status axis in the entire system, and its **sole reader is a blame
-  display** (`apps/api/src/sibyl/api/routes/memory.py:1978`). Nothing in
-  retrieval, ranking, synthesis, or retention consults it.
+  (`apps/cli/src/sibyl_cli/main.py:225, 3602-3606, 3678-3679`). This is the only epistemic-status
+  axis in the entire system, and its **sole reader is a blame display**
+  (`apps/api/src/sibyl/api/routes/memory.py:1978`). Nothing in retrieval, ranking, synthesis, or
+  retention consults it.
 
-Absent from the contract entirely: `importance`, `confidence`,
-`valid_from`/`valid_to`, any typed-relationship parameter, any `supersedes`
-parameter. Importance and confidence enter only as untyped metadata keys, where
-`normalize_memory_quality_metadata` canonicalizes them
+Absent from the contract entirely: `importance`, `confidence`, `valid_from`/`valid_to`, any
+typed-relationship parameter, any `supersedes` parameter. Importance and confidence enter only as
+untyped metadata keys, where `normalize_memory_quality_metadata` canonicalizes them
 (`memory_pipeline/quality.py:32-54`).
 
 ### 1.2 Surface coverage for the 1.2 structure params
 
-| Surface | spans | atomic | probes | retrieval_keys |
-| --- | --- | --- | --- | --- |
-| MCP `remember` (`apps/api/src/sibyl/server.py:2544-2560`) | yes | yes | yes | yes |
-| MCP `add` (`server.py:2436-2458`) | no | no | no | no |
-| CLI `sibyl remember` / `sibyl add` (`main.py:3614, 3622, 3627, 3558`) | `--spans-json` | `--atomic` | `--probe` | `--key` |
-| CLI `sibyl capture` / `note` (`main.py:1866, 1989`) | no | no | no | no |
-| CLI `sibyl entity create` (`entity.py:213`) | no | no | no | no |
-| `POST /entities` (`apps/api/src/sibyl/api/schemas/entities.py:39, 47, 69, 90`) | yes | yes | yes | yes |
-| `PATCH /entities/{id}` (`schemas/entities.py:155, 160`) | yes | yes | no | no |
-| `POST /memory/raw` (`schemas/memory.py:17`) | no | no | no | no |
+| Surface                                                                        | spans          | atomic     | probes    | retrieval_keys |
+| ------------------------------------------------------------------------------ | -------------- | ---------- | --------- | -------------- |
+| MCP `remember` (`apps/api/src/sibyl/server.py:2544-2560`)                      | yes            | yes        | yes       | yes            |
+| MCP `add` (`server.py:2436-2458`)                                              | no             | no         | no        | no             |
+| CLI `sibyl remember` / `sibyl add` (`main.py:3614, 3622, 3627, 3558`)          | `--spans-json` | `--atomic` | `--probe` | `--key`        |
+| CLI `sibyl capture` / `note` (`main.py:1866, 1989`)                            | no             | no         | no        | no             |
+| CLI `sibyl entity create` (`entity.py:213`)                                    | no             | no         | no        | no             |
+| `POST /entities` (`apps/api/src/sibyl/api/schemas/entities.py:39, 47, 69, 90`) | yes            | yes        | yes       | yes            |
+| `PATCH /entities/{id}` (`schemas/entities.py:155, 160`)                        | yes            | yes        | no        | no             |
+| `POST /memory/raw` (`schemas/memory.py:17`)                                    | no             | no         | no        | no             |
 
-`sibyl add` is a hidden alias for the same function as `sibyl remember`
-(`main.py:3774`). The MCP `add` tool is a different, older tool that carries none
-of the structure params.
+`sibyl add` is a hidden alias for the same function as `sibyl remember` (`main.py:3774`). The MCP
+`add` tool is a different, older tool that carries none of the structure params.
 
 ### 1.3 Entity type vocabulary
 
-`EntityType` (`models/entities.py:10-68`) — 34 members: `pattern, rule, template,
-guide, tool, language, topic, episode, knowledge_source, config_file,
-slash_command, project, epic, task, team, error_pattern, milestone, source,
-document, procedure, community, note, domain, artifact, decision, plan, idea,
-claim, preference, person, place, event, session, passage`.
+`EntityType` (`models/entities.py:10-68`) — 34 members:
+`pattern, rule, template, guide, tool, language, topic, episode, knowledge_source, config_file, slash_command, project, epic, task, team, error_pattern, milestone, source, document, procedure, community, note, domain, artifact, decision, plan, idea, claim, preference, person, place, event, session, passage`.
 
-The `entity_type` column is bare `TYPE string` with **no ASSERT**
-(`backends/surreal/schema.py:79`) — the enum is a Python convention, not a
-database constraint. MCP `remember` narrows further to an 11-value `MemoryKind`
-literal (`apps/api/src/sibyl/server.py:69-81`), and the LLM extractor to a
+The `entity_type` column is bare `TYPE string` with **no ASSERT** (`backends/surreal/schema.py:79`)
+— the enum is a Python convention, not a database constraint. MCP `remember` narrows further to an
+11-value `MemoryKind` literal (`apps/api/src/sibyl/server.py:69-81`), and the LLM extractor to a
 12-value subset (`models/memory_extraction.py:15-31`).
 
 ### 1.4 Relationships: what a writer can declare
 
-`RelationshipType` (`models/entities.py:71-116`) declares 40 predicates,
-including `SUPERSEDES`, `CONFLICTS_WITH`, `CONTRADICTS`, `SUPPORTS`, `DECIDES`,
-`BREAKS`, `ENABLES`, `REQUIRES`.
+`RelationshipType` (`models/entities.py:71-116`) declares 40 predicates, including `SUPERSEDES`,
+`CONFLICTS_WITH`, `CONTRADICTS`, `SUPPORTS`, `DECIDES`, `BREAKS`, `ENABLES`, `REQUIRES`.
 
-**A writing agent can select none of them.** The only relationship parameter on
-any write surface is `related_to`, and both write paths hardcode the predicate:
+**A writing agent can select none of them.** The only relationship parameter on any write surface is
+`related_to`, and both write paths hardcode the predicate:
 
 - `tools/add.py:712-725` — `"type": "RELATED_TO"` as a literal at `add.py:720`.
 - `services/memory.py:3196-3205` — `RelationshipType.RELATED_TO` for every id.
 
-There is no `relationship_type` parameter on `add()` (`add.py:222-256`), on
-`EntityCreate` (`schemas/entities.py:65-99`), on the MCP `add`/`remember` tools,
-or on `MemoryCaptureRequest`. There is also no relationship-create HTTP endpoint:
-`apps/api/src/sibyl/api/routes/graph.py` exposes reads plus `POST /subgraph`
-(`graph.py:524`), whose `relationship_types` field
+There is no `relationship_type` parameter on `add()` (`add.py:222-256`), on `EntityCreate`
+(`schemas/entities.py:65-99`), on the MCP `add`/`remember` tools, or on `MemoryCaptureRequest`.
+There is also no relationship-create HTTP endpoint: `apps/api/src/sibyl/api/routes/graph.py` exposes
+reads plus `POST /subgraph` (`graph.py:524`), whose `relationship_types` field
 (`apps/api/src/sibyl/api/schemas/graph.py:48`) is a filter, not a writer.
 
 The complete live predicate vocabulary — **7 of 40**:
 
-| Predicate | Producer | Receipt |
-| --- | --- | --- |
-| `RELATED_TO` | `related_to` param; also auto-discovered links at similarity ≥0.75 | `tools/add.py:712-725, 748, 756-768` |
-| `BELONGS_TO` | project association | `services/memory.py:3176-3183`, `tools/add.py:693` |
-| `DEPENDS_ON` | `add` tool `depends_on` param (tasks) | `tools/add.py:699-711` |
-| `DERIVED_FROM` | promotion, experience projection | `services/memory.py:3185-3193`, `projection/experience.py:511, 698, 741, 780` |
-| `SUPERSEDES` | reflection promotion only | `services/memory.py:3207-3226` |
-| `MENTIONS` | LLM entity projection | `projection/memory.py:991-1047` |
-| `PART_OF` | passage + experience projection | `projection/passages.py:266-269`, `projection/experience.py:794` |
+| Predicate      | Producer                                                           | Receipt                                                                       |
+| -------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `RELATED_TO`   | `related_to` param; also auto-discovered links at similarity ≥0.75 | `tools/add.py:712-725, 748, 756-768`                                          |
+| `BELONGS_TO`   | project association                                                | `services/memory.py:3176-3183`, `tools/add.py:693`                            |
+| `DEPENDS_ON`   | `add` tool `depends_on` param (tasks)                              | `tools/add.py:699-711`                                                        |
+| `DERIVED_FROM` | promotion, experience projection                                   | `services/memory.py:3185-3193`, `projection/experience.py:511, 698, 741, 780` |
+| `SUPERSEDES`   | reflection promotion only                                          | `services/memory.py:3207-3226`                                                |
+| `MENTIONS`     | LLM entity projection                                              | `projection/memory.py:991-1047`                                               |
+| `PART_OF`      | passage + experience projection                                    | `projection/passages.py:266-269`, `projection/experience.py:794`              |
 
 The remaining 33 enum members have no writer at all.
 
-`SUPERSEDES` deserves its own note because it is the one semantically loaded edge
-the system can produce. It comes only from reflection-candidate metadata keys
+`SUPERSEDES` deserves its own note because it is the one semantically loaded edge the system can
+produce. It comes only from reflection-candidate metadata keys
 `("supersedes", "supersedes_ids", "superseded_ids", "supersedes_entity_ids")`
 (`services/memory.py:2468-2474`), and every target is re-authorized:
-`_authorized_superseded_entity_ids` drops targets the principal cannot write
-(`memory.py:2799-2811`) and `_with_authorized_supersedes` **overwrites** any
-caller-supplied list with the authorized set (`memory.py:2480-2489`). So even
-planting the key in metadata cannot forge a supersession.
+`_authorized_superseded_entity_ids` drops targets the principal cannot write (`memory.py:2799-2811`)
+and `_with_authorized_supersedes` **overwrites** any caller-supplied list with the authorized set
+(`memory.py:2480-2489`). So even planting the key in metadata cannot forge a supersession.
 
-A regex `RelationshipBuilder` (`apps/api/src/sibyl/ingestion/relationships.py:38-120`)
-can infer `REQUIRES`, `CONFLICTS_WITH`, `SUPERSEDES`, `APPLIES_TO`,
-`DOCUMENTED_IN`, `WARNS_ABOUT` from text — and is **dead on the memory path**.
-Its only importer is a test (`packages/python/sibyl-core/tests/test_default_memory_loop.py:54`).
-It also carries a divergent `RelationType` enum whose `WARNS_ABOUT` does not
-exist in `RelationshipType`.
+A regex `RelationshipBuilder` (`apps/api/src/sibyl/ingestion/relationships.py:38-120`) can infer
+`REQUIRES`, `CONFLICTS_WITH`, `SUPERSEDES`, `APPLIES_TO`, `DOCUMENTED_IN`, `WARNS_ABOUT` from text —
+and is **dead on the memory path**. Its only importer is a test
+(`packages/python/sibyl-core/tests/test_default_memory_loop.py:54`). It also carries a divergent
+`RelationType` enum whose `WARNS_ABOUT` does not exist in `RelationshipType`.
 
 ### 1.5 Spans, atomicity, probes
 
 Three declarations, all server-validated and unforgeable through the metadata bag
-(`memory_pipeline/structure.py:55-63`; `strip_structure_metadata` applied at
-`tools/add.py:377-378`, re-stamped at `add.py:477`):
+(`memory_pipeline/structure.py:55-63`; `strip_structure_metadata` applied at `tools/add.py:377-378`,
+re-stamped at `add.py:477`):
 
-- **`spans`** — half-open `[start, end)` offsets into `content.strip()` with an
-  optional ≤120-char label (`spans.py:92-108`). Must tile the whole body: no gap
-  (`spans.py:194-199`), no overlap (`spans.py:188-193`), ≥2 spans
-  (`spans.py:170-174`), ≤64 spans (`spans.py:49`), each ≤17,648 chars
-  (`spans.py:66-67`), covering every character (`spans.py:215-220`). Never
-  repaired, never partially honored (`spans.py:159-163`). Accepted spans become
-  `passage` entities with `PART_OF` edges (`projection/passages.py:266-269`).
-- **`atomic`** — "this body is one retrievable unit." Mutually exclusive with
-  spans (`structure.py:131-133`); refused above 18,000 chars (`spans.py:224-232`).
-  Survives a content edit unless restated, while a stale span plan is dropped
+- **`spans`** — half-open `[start, end)` offsets into `content.strip()` with an optional ≤120-char
+  label (`spans.py:92-108`). Must tile the whole body: no gap (`spans.py:194-199`), no overlap
+  (`spans.py:188-193`), ≥2 spans (`spans.py:170-174`), ≤64 spans (`spans.py:49`), each ≤17,648 chars
+  (`spans.py:66-67`), covering every character (`spans.py:215-220`). Never repaired, never partially
+  honored (`spans.py:159-163`). Accepted spans become `passage` entities with `PART_OF` edges
+  (`projection/passages.py:266-269`).
+- **`atomic`** — "this body is one retrievable unit." Mutually exclusive with spans
+  (`structure.py:131-133`); refused above 18,000 chars (`spans.py:224-232`). Survives a content edit
+  unless restated, while a stale span plan is dropped
   (`apps/api/src/sibyl/api/routes/entities.py:214-222`).
-- **`probes`** — up to 5 queries the memory must answer (`structure.py:39-46`).
-  Each is run through the **live fused retrieval path** at write time and its rank
-  (or absence) recorded (`memory_pipeline/rehearsal.py:56-131`). Raw recall and
-  exposure recording are disabled so the measurement can actually fail
-  (`rehearsal.py:8-13, 157-160`). Rehearsal runs after passages exist so a probe
-  landing on a span counts (`tools/add.py:834-835`). Supplying probes forces a
-  synchronous write (`tools/add.py:380-384`, `routes/entities.py:2154`). A failing
-  probe never fails the write (`rehearsal.py:14-16`).
+- **`probes`** — up to 5 queries the memory must answer (`structure.py:39-46`). Each is run through
+  the **live fused retrieval path** at write time and its rank (or absence) recorded
+  (`memory_pipeline/rehearsal.py:56-131`). Raw recall and exposure recording are disabled so the
+  measurement can actually fail (`rehearsal.py:8-13, 157-160`). Rehearsal runs after passages exist
+  so a probe landing on a span counts (`tools/add.py:834-835`). Supplying probes forces a
+  synchronous write (`tools/add.py:380-384`, `routes/entities.py:2154`). A failing probe never fails
+  the write (`rehearsal.py:14-16`).
 
 ### 1.6 Retrieval keys
 
-An identifier the writer asserts the memory answers to, **not derived from the
-content** — so a key may name something the body never spells out
-(`retrieval_keys.py:1-23`). Compared by casefold plus whitespace-collapse and
-nothing else: no stemming, no punctuation stripping (`retrieval_keys.py:51-54`).
-The write boundary is strict and the storage edge lenient by design
-(`retrieval_keys.py:18-22`, strict at `:93-109`, lenient at `:113-148`). `None`
-means "this write does not speak to keys" and preserves existing ones
-(`retrieval_keys.py:118-120`).
+An identifier the writer asserts the memory answers to, **not derived from the content** — so a key
+may name something the body never spells out (`retrieval_keys.py:1-23`). Compared by casefold plus
+whitespace-collapse and nothing else: no stemming, no punctuation stripping
+(`retrieval_keys.py:51-54`). The write boundary is strict and the storage edge lenient by design
+(`retrieval_keys.py:18-22`, strict at `:93-109`, lenient at `:113-148`). `None` means "this write
+does not speak to keys" and preserves existing ones (`retrieval_keys.py:118-120`).
 
 ---
 
@@ -214,131 +197,123 @@ means "this write does not speak to keys" and preserves existing ones
 
 ### 2.1 Entity extraction
 
-`ExtractedMemoryEntity` (`models/memory_extraction.py:33-48`): `name`,
-`entity_type` (12-value subset), `summary`, optional `confidence` 0-1,
-`evidence` ≤400 chars. Max 12 per source (`memory_extraction.py:11`).
+`ExtractedMemoryEntity` (`models/memory_extraction.py:33-48`): `name`, `entity_type` (12-value
+subset), `summary`, optional `confidence` 0-1, `evidence` ≤400 chars. Max 12 per source
+(`memory_extraction.py:11`).
 
-At projection (`projection/memory.py:819-858`) confidence defaults to 0.75 when
-omitted, is clamped, gates admission via `min_confidence`, and orders/dedupes
-candidates. Dedup key is `f"{type}:{name.lower()}"` (`projection/memory.py:849`),
-scoped to a single batch.
+At projection (`projection/memory.py:819-858`) confidence defaults to 0.75 when omitted, is clamped,
+gates admission via `min_confidence`, and orders/dedupes candidates. Dedup key is
+`f"{type}:{name.lower()}"` (`projection/memory.py:849`), scoped to a single batch.
 
 ### 2.2 There is no relation extraction
 
-`MemoryEntityExtractionResult` holds only `entities`
-(`models/memory_extraction.py:51-57`) — the extraction contract has no relation
-field. The pipeline emits exactly one edge type from extraction: `MENTIONS`
-(`projection/memory.py:991-1047`).
+`MemoryEntityExtractionResult` holds only `entities` (`models/memory_extraction.py:51-57`) — the
+extraction contract has no relation field. The pipeline emits exactly one edge type from extraction:
+`MENTIONS` (`projection/memory.py:991-1047`).
 
-The reflection layer has a typed relationship dataclass,
-`ReflectionRelationshipRecord`, carrying a `relationship_type: str`
-(`models/reflection.py:237-245`). It is populated in exactly one place, with one
-hardcoded predicate: `_relationship_records_for_project` emits
-`relationship_type="BELONGS_TO"` pointing at the project
-(`services/reflection.py:506-524`). The records are serialized into metadata
-(`reflection.py:266-268`) and **never become graph edges** — promotion builds
-edges from `_relationships_for_promotion` (`services/memory.py:3165-3226`), which
+The reflection layer has a typed relationship dataclass, `ReflectionRelationshipRecord`, carrying a
+`relationship_type: str` (`models/reflection.py:237-245`). It is populated in exactly one place,
+with one hardcoded predicate: `_relationship_records_for_project` emits
+`relationship_type="BELONGS_TO"` pointing at the project (`services/reflection.py:506-524`). The
+records are serialized into metadata (`reflection.py:266-268`) and **never become graph edges** —
+promotion builds edges from `_relationships_for_promotion` (`services/memory.py:3165-3226`), which
 never reads `relationship_records`.
 
-So the pipeline can say *"this memory mentions Redis"* and nothing else. It
-cannot say *"Redis TTL expiry causes the JWT refresh failure."*
+So the pipeline can say _"this memory mentions Redis"_ and nothing else. It cannot say _"Redis TTL
+expiry causes the JWT refresh failure."_
 
 ### 2.3 What lands on `relates_to`
 
 Built at `services/graph.py:3326-3349`:
 
-| Column | Source |
-| --- | --- |
-| `name` | `relationship.relationship_type.value` — the predicate |
-| `fact` | `metadata["fact"]`, else auto-generated `"<src> <predicate> <tgt>"` (`graph.py:3352-3357`) |
-| `fact_embedding` | `metadata["fact_embedding" \| "embedding"]` |
-| `source_id` / `target_id` | model fields |
-| `episodes` | `metadata["episodes"]` |
-| `attributes` | the whole remaining metadata bag (FLEXIBLE) |
-| `created_at`, `expired_at`, `valid_at`, `invalid_at` | model field + metadata (`valid_from`/`valid_to` accepted as aliases) |
+| Column                                               | Source                                                                                     |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `name`                                               | `relationship.relationship_type.value` — the predicate                                     |
+| `fact`                                               | `metadata["fact"]`, else auto-generated `"<src> <predicate> <tgt>"` (`graph.py:3352-3357`) |
+| `fact_embedding`                                     | `metadata["fact_embedding" \| "embedding"]`                                                |
+| `source_id` / `target_id`                            | model fields                                                                               |
+| `episodes`                                           | `metadata["episodes"]`                                                                     |
+| `attributes`                                         | the whole remaining metadata bag (FLEXIBLE)                                                |
+| `created_at`, `expired_at`, `valid_at`, `invalid_at` | model field + metadata (`valid_from`/`valid_to` accepted as aliases)                       |
 
-**`Relationship.weight` is not persisted.** The model declares it
-(`models/entities.py:276`) and `_relationship_record` omits it. There is no
-`weight` column on `relates_to` (full field list: `schema.py:181-193`). It exists
-only if a caller puts `weight` into metadata, which lands in `attributes` and is
-hydrated back at `graph.py:2442, 2494-2497`. Nothing does:
-grepping `"weight"` across `sibyl-core/src` and `apps/api/src` finds readers
-(`hybrid.py:559`, `graph.py:2495`, export, community layout) and **no writer**.
-`_metadata_weight` therefore always returns its 1.0 default.
+**`Relationship.weight` is not persisted.** The model declares it (`models/entities.py:276`) and
+`_relationship_record` omits it. There is no `weight` column on `relates_to` (full field list:
+`schema.py:181-193`). It exists only if a caller puts `weight` into metadata, which lands in
+`attributes` and is hydrated back at `graph.py:2442, 2494-2497`. Nothing does: grepping `"weight"`
+across `sibyl-core/src` and `apps/api/src` finds readers (`hybrid.py:559`, `graph.py:2495`, export,
+community layout) and **no writer**. `_metadata_weight` therefore always returns its 1.0 default.
 
-There is no provenance column and no confidence column on the edge. Both can only
-exist as `attributes` sub-keys.
+There is no provenance column and no confidence column on the edge. Both can only exist as
+`attributes` sub-keys.
 
 ---
 
 ## 3. Taxonomy: four axes, four contracts
 
-| Axis | Storage | Validation | Role |
-| --- | --- | --- | --- |
-| `entity_type` | `entity.entity_type` string (`schema.py:79`), indexed (`:111`) | Python enum only, **no DB ASSERT** | Kind of thing; drives facet routing |
-| `tags` | `entity.tags option<array<string>>` (`schema.py:104`), **no index** | none, freeform | Ad-hoc labeling |
-| `labels` | `entity.labels array<string>` (`schema.py:83`), indexed on `labels.*` (`:112`) | **not writer-settable**: always `[entity_type, "Entity"]` (`graph.py:3033`) | Legacy Graphiti compat shape |
-| `memory_scope` | `entity.memory_scope` (`schema.py:105`) + `idx_entity_memory_scope` (`:117`); `raw_captures.memory_scope` with **ASSERT** (`content_schema.py:170-171`) | enum-enforced on the raw side only | Authorization partition |
-| `project_id` | `entity.project_id` (`schema.py:96`), in 4 indexes | freeform string | Second partition axis |
+| Axis           | Storage                                                                                                                                                 | Validation                                                                  | Role                                |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------- |
+| `entity_type`  | `entity.entity_type` string (`schema.py:79`), indexed (`:111`)                                                                                          | Python enum only, **no DB ASSERT**                                          | Kind of thing; drives facet routing |
+| `tags`         | `entity.tags option<array<string>>` (`schema.py:104`), **no index**                                                                                     | none, freeform                                                              | Ad-hoc labeling                     |
+| `labels`       | `entity.labels array<string>` (`schema.py:83`), indexed on `labels.*` (`:112`)                                                                          | **not writer-settable**: always `[entity_type, "Entity"]` (`graph.py:3033`) | Legacy Graphiti compat shape        |
+| `memory_scope` | `entity.memory_scope` (`schema.py:105`) + `idx_entity_memory_scope` (`:117`); `raw_captures.memory_scope` with **ASSERT** (`content_schema.py:170-171`) | enum-enforced on the raw side only                                          | Authorization partition             |
+| `project_id`   | `entity.project_id` (`schema.py:96`), in 4 indexes                                                                                                      | freeform string                                                             | Second partition axis               |
 
-`labels` is not a writer axis despite looking like one — it is a derived
-duplicate of `entity_type`. `memory_scope` is the only axis with a real database
-constraint, and only on the raw table.
+`labels` is not a writer axis despite looking like one — it is a derived duplicate of `entity_type`.
+`memory_scope` is the only axis with a real database constraint, and only on the raw table.
 
 ---
 
 ## 4. THE STORED-VS-USED MATRIX
 
-"Used" means read by retrieval, ranking, fusion, or context-pack assembly in a
-way that changes what comes back or in what order. Display pass-through does not
-count. Where the two search paths (§0.2) differ, both are named.
+"Used" means read by retrieval, ranking, fusion, or context-pack assembly in a way that changes what
+comes back or in what order. Display pass-through does not count. Where the two search paths (§0.2)
+differ, both are named.
 
-| Axis | Stored | Verdict | Receipt |
-| --- | --- | --- | --- |
-| `entity_type` | `entity.entity_type` | **USED** — filter, request pools, tie-rank, boost | SQL filter `retrieval/search.py:1602-1604`, applied to vector (`:1436`), exact-key (`:1084`), BFS (`:2152`); KNN overfetch lifts the predicate out of the HNSW bracket and reapplies it (`:1384-1407`). Request pools `tools/context.py:77-90, 1221-1239`. Lineage tie-rank `context.py:700-720, 739`. Boosts: `type == "task"` + active → `search.py:3110`; `type == "raw_memory"` → `:3114-3115`. **No global type-prior table exists.** |
-| `entity_type` facet coverage | as above | **PARTIAL** — 8 types unreachable by recall | `FACET_TYPES` (`context.py:77-90`) omits `person, place, language, team, milestone, community, knowledge_source, slash_command`; `_types_for_facets` (`:1221-1239`) builds the requested-type list from that map, so those 8 are never requested by any intent |
-| `tags` | `entity.tags` (unindexed) | **STORED, UNREAD by search** | In `retrieval/`, two lines, both pass-through: `search.py:2383, 2455`. `list_by_type` accepts `tags=` (`graph.py:1104`) but emits **no SQL clause** (`graph.py:1143-1186`); filtering is a Python post-filter (`graph_search.py:99-100`) whose only caller is `tools/explore.py:241` — a browse surface. Neither `tools/search.py:343` nor `context.py:1414` passes tags |
-| `labels` | `entity.labels`, indexed | **PARTIAL** — used as type fallback; the label filter is dead | Live read: `search.py:2348-2352, 2632-2636` (third fallback for deriving candidate type). Dead filter: `search.py:1605-1607, 1628-1630` gate on `SearchFilter.node_labels`, declared `:233` with default `()` and **never populated by any production caller** (constructions at `:899, 1214, 2081`). `idx_entity_labels` is never exercised |
-| `memory_scope` | `entity.memory_scope` column **and** `attributes.memory_scope` | **USED as a hard gate — via attributes, not the column** | Gate `search.py:2710-2724` → `auth/memory_policy.py:643, 657, 660`, reading `metadata["memory_scope" / "scope_key" / "principal_id"]`, which arrive via the whole-attributes splat at `search.py:2211-2212`. Plan side `search.py:287-336, 623-635, 951`. Pack side `context.py:439-447, 1426-1434`. The **column** appears in no retrieval WHERE clause; `idx_entity_memory_scope` is dead weight and the two copies can drift |
-| `project_id` | `entity.project_id` + `attributes.project_id` | **USED** — filter, boost, gate | Node filter `search.py:1608-1610` (checks both column and attribute); edge filter is a 5-way disjunction across endpoints `:1631-1641`; boost `:3112-3113`; post-filter gates `:2693-2707`; selectivity signal `:919-927`; episode lane skipped entirely when project filtering is on `:1143-1144` |
-| `status` | `entity.status` | **USED** — filter, boost, facet suppression | SQL `graph.py:1170-1172, 1186`, reached from the pack at `context.py:1414-1419`; boost `search.py:3109-3111`; `archived` dropped and `done` demoted at `context.py:216-234`; lineage rank `-1` for in-flight `context.py:735-738` |
-| `priority` | `entity.priority`, indexed | **STORED, UNREAD by retrieval** | Exactly one hit in `retrieval/`: `search.py:2380`, a pass-through key. SQL clause exists at `graph.py:1174-1177` but its only caller is `tools/explore.py:418-427` (browse). `idx_entity_priority` serves browse only. A high-priority memory does not rank higher |
-| `retrieval_keys_normalized` | `entity.retrieval_keys_normalized`, element-indexed | **USED** — dedicated high-precision lane | `CONTAINSANY $probe_keys` at `search.py:1086`, index-served by `idx_entity_retrieval_keys ON ... retrieval_keys_normalized.*` (`schema.py:118`); the `.*` is load-bearing (`search.py:1071-1077`). Overlap scoring `:1126-1133, 1111, 1119`; fusion multiplier `_exact_key_signal_multiplier` `:3052-3074`; probes minted from query identifiers `retrieval/identifier_query.py:47-49, 184`; inert without an identifier `:1067-1068` |
-| `retrieval_keys` (display form) | column | **STORED, UNREAD** — matching always uses the normalized form | `search.py:2384` |
-| `attributes` (FLEXIBLE) | `entity.attributes` | **USED** — splatted whole, ~14 sub-keys read by name | Splat `search.py:2211-2212, 2290-2291, 2591`. Named: `project_id` (`:1609, 1634-1638, 2202`), `entity_type` (`:2339, 2623`), `content`/`description` (`:2366-2367`), `source*` (`:2205-2208`), endpoint project ids (`:2575, 2578`), scope trio (→ `memory_policy.py:643-660`), `status` (→ `:3109`), usage counters (→ `temporal.py:144-146, 199-201`), `source_entity_type` (`context.py:201`), `projection_kind` (`apps/api/src/sibyl/api/routes/context.py:502-511`), `parent_entity_id`/`passage_index`/`passage_total` (`context.py:1296-1298`), `operational_source_id` (`context.py:394-396`) |
-| `attributes.importance` | `entity.attributes` | **UNREAD by retrieval; USED by retention** | Only reader: `apps/api/src/sibyl/jobs/consolidation.py:339-345`, feeding `importance × 0.5^(age/half_life)` at `:319-331`. Zero hits in `retrieval/` |
-| `attributes.confidence` | `entity.attributes` | **STORED, UNREAD** | Display projections only: `search.py:2390, 2416` |
-| `attributes.pinned` / `retention` | `entity.attributes` | **UNREAD by retrieval; USED by retention** | `jobs/consolidation.py:370-376` |
-| `attributes.basis` | `entity.attributes` | **STORED, UNREAD** | Written `apps/cli/src/sibyl_cli/main.py:3678-3679`; sole reader is a blame display `apps/api/src/sibyl/api/routes/memory.py:1978` |
-| edge `name` (predicate) | `relates_to.name`, indexed | **USED** — filter, traversal weight, candidate identity | Filter `search.py:1626-1627, 1481, 1491`; traversal filter `:1837, 1890`; hardcoded `name = "BELONGS_TO"` `:1950, 1992`; **per-predicate scoring** `:1859, 1865, 1912, 1918` → `_graph_expansion_path_score`; becomes `candidate.name` `:2307` and gates `_candidate_matches_types` `:2735` |
-| edge `fact` | `relates_to.fact`, FT-indexed | **USED** — BM25 target and candidate content | `search.py:1179, 1188-1194, 2308, 2587` |
-| edge `fact_embedding` | `relates_to.fact_embedding`, HNSW | **USED** — edge vector lane | `search.py:1489, 1518`; index `schema.py:205` |
-| edge `weight` | **not a column**; only `attributes.weight` | **Effectively unread — and always 1.0** | Read on the legacy path only: `hybrid.py:558-562 _relationship_weight`. `context_search` ignores it entirely and uses the hardcoded table instead. No writer anywhere sets it, so `_metadata_weight` (`graph.py:2494-2497`) always returns 1.0. `_relationship_type_multiplier` (`hybrid.py:565-579`) needs `relationship_type_weights`, which no production `HybridConfig` supplies (`tools/search.py:1063-1071`) |
-| edge `valid_at` | `relates_to.valid_at` | **USED indirectly** — decay anchor; never a WHERE | Projected `search.py:1661`, carried `:2391, 2417`, read first in the `"auto"` chain `retrieval/temporal.py:113` (`valid_at → valid_from → created_at`), driving `temporal_decay_multiplier` at `search.py:3120-3122` |
-| edge `invalid_at` | `relates_to.invalid_at` | **STORED, UNREAD by retrieval** | Three hits in `retrieval/`, all key lists: `search.py:1661, 2394, 2420`. The traversal queries `_relation_target_hops` (`:1826-1868`) and `_relation_source_hops` (`:1871-1922`) carry no temporal predicate. An invalidated edge is walked and ranked exactly like a live one |
-| edge `expired_at` | `relates_to.expired_at` | **STORED, UNREAD by retrieval** | `retrieval/` hits are `search.py:1661, 2421` only. Sole real readers are `tools/temporal.py:64, 296-333, 549` — a separate opt-in tool `context_search` never calls |
-| edge `episodes` | `relates_to.episodes` | **STORED, UNREAD** | `search.py:1660, 2424` only. The `mentions` traversal at `:1794-1799` walks the separate `mentions` table, not this array |
-| Graph traversal | `relates_to` | **USED and predicate-aware; outgoing-only** | `_graph_expansion_candidates` `search.py:1556-1591` → `_node_bfs_records` `:1670-1778`. 21-entry predicate weight table `:85-107` (`DECIDES` 1.0 … `MENTIONS` 0.58, unknown → 0.64); depth decay 0.72 at `:2181-2185`; highest-scoring predicate wins on hop dedup `:2171-2178`; fusion multiplier `:3077-3098`, applied only to candidates that also carry a non-expansion signal `:3085-3086`. **Incoming edges are off by default** (`include_incoming=False`, `:1680`), so "the tasks that depend on this one" is invisible to `context_search`. The `relationship_names` filter is reachable only from `tools/traverse.py`; the retrieval walk passes none (`:1575-1583`) and discriminates purely by weight |
-| `last_used_at`, `last_recalled_at` | entity columns, indexed | **USED in retrieval scoring** | `get_entity_decay_timestamp` `retrieval/temporal.py:138-173`: `last_used_at` at full weight (`:144, 149-150`), `last_recalled_at` discounted by `EXPOSURE_DECAY_TIMESTAMP_WEIGHT` (`:145, 151-158`) — being shown is worth less than being used. Result shifts the decay anchor, consumed at `search.py:3117-3125` |
-| `retrieval_count`, `citation_count`, `misled_count` | entity columns | **USED in retrieval scoring** | `usage_retention_multiplier` `temporal.py:197-205`: `+0.02×min(retrieval,50)`, `+0.12×min(citation,20)`, `−0.6×min(misled,5)`, clamped `[0.1, 4.0]`; applied as `decay_days × multiplier` at `:226`. A heavily cited memory decays up to 4× slower; `misled_count ≥ 5` decays 10× faster. **`misled_count` is a live negative-feedback channel** |
-| `created_at` | entity column, indexed | **USED** — freshness boost, decay anchor, tiebreak | `_freshness_boost` `search.py:3116, 3129-3136` = `min(cap, 1 + 0.5/(1+age_days))`; last resort in the decay chain `temporal.py:113`; `ORDER BY … created_at DESC, uuid DESC` in every lane (`:1030, 1155, 1194, 1408, 1441, 1492, 1521`) |
-| `updated_at` | entity column, in 5 indexes | **STORED, UNREAD by retrieval** | One hit in `retrieval/`: `dedup.py:307`, inside a maintenance scan. `_freshness_boost` takes `created_at` only; `updated_at` is not in the decay chain and not in `_selected_record_metadata` (`search.py:2376-2407`), so it never reaches a candidate. Its 5 indexes (`schema.py:120, 123-126`) serve `list_by_type` only. **An edited memory does not become fresher to the ranker** |
-| `spans` (`attributes.agent_spans`) | entity attributes | **USED indirectly** | Consumed at projection to mint `passage` rows (`projection/passages.py`); passages are first-class retrieval targets and collapse into their parent at `context.py:1296-1298` |
-| `atomic` (`attributes.agent_atomic`) | entity attributes | **USED indirectly** | Suppresses mechanical cutting, keeping the memory one retrievable unit |
-| `probes` (`attributes.memory_probes`) | entity attributes | **STORED, UNREAD** | Write-time diagnostic only (`rehearsal.py:113-121`). No retrieval lane reads `memory_probes`: not query expansions, not alternate embeddings, not synonyms |
-| Raw lifecycle (`review_state`, `superseded_by_*`) | `raw_captures` | **USED on the raw lane; UNENFORCED on the graph lane** | Raw: `raw_memory_recallable` (`memory_pipeline/lifecycle.py:62-85`, wired `services/surreal_content.py:545-550`, called `:606, 1892, 2173`). Synthesis re-filters at render (`services/synthesis.py:116-119, 481-492, 555-580`). The graph lane has no equivalent |
+| Axis                                                | Stored                                                         | Verdict                                                       | Receipt                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entity_type`                                       | `entity.entity_type`                                           | **USED** — filter, request pools, tie-rank, boost             | SQL filter `retrieval/search.py:1602-1604`, applied to vector (`:1436`), exact-key (`:1084`), BFS (`:2152`); KNN overfetch lifts the predicate out of the HNSW bracket and reapplies it (`:1384-1407`). Request pools `tools/context.py:77-90, 1221-1239`. Lineage tie-rank `context.py:700-720, 739`. Boosts: `type == "task"` + active → `search.py:3110`; `type == "raw_memory"` → `:3114-3115`. **No global type-prior table exists.**                                                                                                                                                                                                                                                                        |
+| `entity_type` facet coverage                        | as above                                                       | **PARTIAL** — 8 types unreachable by recall                   | `FACET_TYPES` (`context.py:77-90`) omits `person, place, language, team, milestone, community, knowledge_source, slash_command`; `_types_for_facets` (`:1221-1239`) builds the requested-type list from that map, so those 8 are never requested by any intent                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `tags`                                              | `entity.tags` (unindexed)                                      | **STORED, UNREAD by search**                                  | In `retrieval/`, two lines, both pass-through: `search.py:2383, 2455`. `list_by_type` accepts `tags=` (`graph.py:1104`) but emits **no SQL clause** (`graph.py:1143-1186`); filtering is a Python post-filter (`graph_search.py:99-100`) whose only caller is `tools/explore.py:241` — a browse surface. Neither `tools/search.py:343` nor `context.py:1414` passes tags                                                                                                                                                                                                                                                                                                                                          |
+| `labels`                                            | `entity.labels`, indexed                                       | **PARTIAL** — used as type fallback; the label filter is dead | Live read: `search.py:2348-2352, 2632-2636` (third fallback for deriving candidate type). Dead filter: `search.py:1605-1607, 1628-1630` gate on `SearchFilter.node_labels`, declared `:233` with default `()` and **never populated by any production caller** (constructions at `:899, 1214, 2081`). `idx_entity_labels` is never exercised                                                                                                                                                                                                                                                                                                                                                                      |
+| `memory_scope`                                      | `entity.memory_scope` column **and** `attributes.memory_scope` | **USED as a hard gate — via attributes, not the column**      | Gate `search.py:2710-2724` → `auth/memory_policy.py:643, 657, 660`, reading `metadata["memory_scope" / "scope_key" / "principal_id"]`, which arrive via the whole-attributes splat at `search.py:2211-2212`. Plan side `search.py:287-336, 623-635, 951`. Pack side `context.py:439-447, 1426-1434`. The **column** appears in no retrieval WHERE clause; `idx_entity_memory_scope` is dead weight and the two copies can drift                                                                                                                                                                                                                                                                                   |
+| `project_id`                                        | `entity.project_id` + `attributes.project_id`                  | **USED** — filter, boost, gate                                | Node filter `search.py:1608-1610` (checks both column and attribute); edge filter is a 5-way disjunction across endpoints `:1631-1641`; boost `:3112-3113`; post-filter gates `:2693-2707`; selectivity signal `:919-927`; episode lane skipped entirely when project filtering is on `:1143-1144`                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `status`                                            | `entity.status`                                                | **USED** — filter, boost, facet suppression                   | SQL `graph.py:1170-1172, 1186`, reached from the pack at `context.py:1414-1419`; boost `search.py:3109-3111`; `archived` dropped and `done` demoted at `context.py:216-234`; lineage rank `-1` for in-flight `context.py:735-738`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `priority`                                          | `entity.priority`, indexed                                     | **STORED, UNREAD by retrieval**                               | Exactly one hit in `retrieval/`: `search.py:2380`, a pass-through key. SQL clause exists at `graph.py:1174-1177` but its only caller is `tools/explore.py:418-427` (browse). `idx_entity_priority` serves browse only. A high-priority memory does not rank higher                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `retrieval_keys_normalized`                         | `entity.retrieval_keys_normalized`, element-indexed            | **USED** — dedicated high-precision lane                      | `CONTAINSANY $probe_keys` at `search.py:1086`, index-served by `idx_entity_retrieval_keys ON ... retrieval_keys_normalized.*` (`schema.py:118`); the `.*` is load-bearing (`search.py:1071-1077`). Overlap scoring `:1126-1133, 1111, 1119`; fusion multiplier `_exact_key_signal_multiplier` `:3052-3074`; probes minted from query identifiers `retrieval/identifier_query.py:47-49, 184`; inert without an identifier `:1067-1068`                                                                                                                                                                                                                                                                             |
+| `retrieval_keys` (display form)                     | column                                                         | **STORED, UNREAD** — matching always uses the normalized form | `search.py:2384`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `attributes` (FLEXIBLE)                             | `entity.attributes`                                            | **USED** — splatted whole, ~14 sub-keys read by name          | Splat `search.py:2211-2212, 2290-2291, 2591`. Named: `project_id` (`:1609, 1634-1638, 2202`), `entity_type` (`:2339, 2623`), `content`/`description` (`:2366-2367`), `source*` (`:2205-2208`), endpoint project ids (`:2575, 2578`), scope trio (→ `memory_policy.py:643-660`), `status` (→ `:3109`), usage counters (→ `temporal.py:144-146, 199-201`), `source_entity_type` (`context.py:201`), `projection_kind` (`apps/api/src/sibyl/api/routes/context.py:502-511`), `parent_entity_id`/`passage_index`/`passage_total` (`context.py:1296-1298`), `operational_source_id` (`context.py:394-396`)                                                                                                             |
+| `attributes.importance`                             | `entity.attributes`                                            | **UNREAD by retrieval; USED by retention**                    | Only reader: `apps/api/src/sibyl/jobs/consolidation.py:339-345`, feeding `importance × 0.5^(age/half_life)` at `:319-331`. Zero hits in `retrieval/`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `attributes.confidence`                             | `entity.attributes`                                            | **STORED, UNREAD**                                            | Display projections only: `search.py:2390, 2416`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `attributes.pinned` / `retention`                   | `entity.attributes`                                            | **UNREAD by retrieval; USED by retention**                    | `jobs/consolidation.py:370-376`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `attributes.basis`                                  | `entity.attributes`                                            | **STORED, UNREAD**                                            | Written `apps/cli/src/sibyl_cli/main.py:3678-3679`; sole reader is a blame display `apps/api/src/sibyl/api/routes/memory.py:1978`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| edge `name` (predicate)                             | `relates_to.name`, indexed                                     | **USED** — filter, traversal weight, candidate identity       | Filter `search.py:1626-1627, 1481, 1491`; traversal filter `:1837, 1890`; hardcoded `name = "BELONGS_TO"` `:1950, 1992`; **per-predicate scoring** `:1859, 1865, 1912, 1918` → `_graph_expansion_path_score`; becomes `candidate.name` `:2307` and gates `_candidate_matches_types` `:2735`                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| edge `fact`                                         | `relates_to.fact`, FT-indexed                                  | **USED** — BM25 target and candidate content                  | `search.py:1179, 1188-1194, 2308, 2587`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| edge `fact_embedding`                               | `relates_to.fact_embedding`, HNSW                              | **USED** — edge vector lane                                   | `search.py:1489, 1518`; index `schema.py:205`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| edge `weight`                                       | **not a column**; only `attributes.weight`                     | **Effectively unread — and always 1.0**                       | Read on the legacy path only: `hybrid.py:558-562 _relationship_weight`. `context_search` ignores it entirely and uses the hardcoded table instead. No writer anywhere sets it, so `_metadata_weight` (`graph.py:2494-2497`) always returns 1.0. `_relationship_type_multiplier` (`hybrid.py:565-579`) needs `relationship_type_weights`, which no production `HybridConfig` supplies (`tools/search.py:1063-1071`)                                                                                                                                                                                                                                                                                                |
+| edge `valid_at`                                     | `relates_to.valid_at`                                          | **USED indirectly** — decay anchor; never a WHERE             | Projected `search.py:1661`, carried `:2391, 2417`, read first in the `"auto"` chain `retrieval/temporal.py:113` (`valid_at → valid_from → created_at`), driving `temporal_decay_multiplier` at `search.py:3120-3122`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| edge `invalid_at`                                   | `relates_to.invalid_at`                                        | **STORED, UNREAD by retrieval**                               | Three hits in `retrieval/`, all key lists: `search.py:1661, 2394, 2420`. The traversal queries `_relation_target_hops` (`:1826-1868`) and `_relation_source_hops` (`:1871-1922`) carry no temporal predicate. An invalidated edge is walked and ranked exactly like a live one                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| edge `expired_at`                                   | `relates_to.expired_at`                                        | **STORED, UNREAD by retrieval**                               | `retrieval/` hits are `search.py:1661, 2421` only. Sole real readers are `tools/temporal.py:64, 296-333, 549` — a separate opt-in tool `context_search` never calls                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| edge `episodes`                                     | `relates_to.episodes`                                          | **STORED, UNREAD**                                            | `search.py:1660, 2424` only. The `mentions` traversal at `:1794-1799` walks the separate `mentions` table, not this array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Graph traversal                                     | `relates_to`                                                   | **USED and predicate-aware; outgoing-only**                   | `_graph_expansion_candidates` `search.py:1556-1591` → `_node_bfs_records` `:1670-1778`. 21-entry predicate weight table `:85-107` (`DECIDES` 1.0 … `MENTIONS` 0.58, unknown → 0.64); depth decay 0.72 at `:2181-2185`; highest-scoring predicate wins on hop dedup `:2171-2178`; fusion multiplier `:3077-3098`, applied only to candidates that also carry a non-expansion signal `:3085-3086`. **Incoming edges are off by default** (`include_incoming=False`, `:1680`), so "the tasks that depend on this one" is invisible to `context_search`. The `relationship_names` filter is reachable only from `tools/traverse.py`; the retrieval walk passes none (`:1575-1583`) and discriminates purely by weight |
+| `last_used_at`, `last_recalled_at`                  | entity columns, indexed                                        | **USED in retrieval scoring**                                 | `get_entity_decay_timestamp` `retrieval/temporal.py:138-173`: `last_used_at` at full weight (`:144, 149-150`), `last_recalled_at` discounted by `EXPOSURE_DECAY_TIMESTAMP_WEIGHT` (`:145, 151-158`) — being shown is worth less than being used. Result shifts the decay anchor, consumed at `search.py:3117-3125`                                                                                                                                                                                                                                                                                                                                                                                                |
+| `retrieval_count`, `citation_count`, `misled_count` | entity columns                                                 | **USED in retrieval scoring**                                 | `usage_retention_multiplier` `temporal.py:197-205`: `+0.02×min(retrieval,50)`, `+0.12×min(citation,20)`, `−0.6×min(misled,5)`, clamped `[0.1, 4.0]`; applied as `decay_days × multiplier` at `:226`. A heavily cited memory decays up to 4× slower; `misled_count ≥ 5` decays 10× faster. **`misled_count` is a live negative-feedback channel**                                                                                                                                                                                                                                                                                                                                                                  |
+| `created_at`                                        | entity column, indexed                                         | **USED** — freshness boost, decay anchor, tiebreak            | `_freshness_boost` `search.py:3116, 3129-3136` = `min(cap, 1 + 0.5/(1+age_days))`; last resort in the decay chain `temporal.py:113`; `ORDER BY … created_at DESC, uuid DESC` in every lane (`:1030, 1155, 1194, 1408, 1441, 1492, 1521`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `updated_at`                                        | entity column, in 5 indexes                                    | **STORED, UNREAD by retrieval**                               | One hit in `retrieval/`: `dedup.py:307`, inside a maintenance scan. `_freshness_boost` takes `created_at` only; `updated_at` is not in the decay chain and not in `_selected_record_metadata` (`search.py:2376-2407`), so it never reaches a candidate. Its 5 indexes (`schema.py:120, 123-126`) serve `list_by_type` only. **An edited memory does not become fresher to the ranker**                                                                                                                                                                                                                                                                                                                            |
+| `spans` (`attributes.agent_spans`)                  | entity attributes                                              | **USED indirectly**                                           | Consumed at projection to mint `passage` rows (`projection/passages.py`); passages are first-class retrieval targets and collapse into their parent at `context.py:1296-1298`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `atomic` (`attributes.agent_atomic`)                | entity attributes                                              | **USED indirectly**                                           | Suppresses mechanical cutting, keeping the memory one retrievable unit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `probes` (`attributes.memory_probes`)               | entity attributes                                              | **STORED, UNREAD**                                            | Write-time diagnostic only (`rehearsal.py:113-121`). No retrieval lane reads `memory_probes`: not query expansions, not alternate embeddings, not synonyms                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| Raw lifecycle (`review_state`, `superseded_by_*`)   | `raw_captures`                                                 | **USED on the raw lane; UNENFORCED on the graph lane**        | Raw: `raw_memory_recallable` (`memory_pipeline/lifecycle.py:62-85`, wired `services/surreal_content.py:545-550`, called `:606, 1892, 2173`). Synthesis re-filters at render (`services/synthesis.py:116-119, 481-492, 555-580`). The graph lane has no equivalent                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 ### 4.1 The short version
 
 **Read by retrieval:** `memory_scope` (via attributes), `project_id`, `status`,
-`retrieval_keys_normalized`, edge predicate `name`, edge `fact` and
-`fact_embedding`, `entity_type` (filter/pools/tie-rank/two boosts), `created_at`,
-all five usage counters and timestamps, spans and `atomic` via passages.
+`retrieval_keys_normalized`, edge predicate `name`, edge `fact` and `fact_embedding`, `entity_type`
+(filter/pools/tie-rank/two boosts), `created_at`, all five usage counters and timestamps, spans and
+`atomic` via passages.
 
-**Stored and never read by retrieval:** `tags`, `priority`, `updated_at`,
-`probes`, `basis`, `confidence`, edge `weight`, edge `invalid_at`, edge
-`expired_at`, edge `episodes`, the `node_labels` filter, and the
-`entity.memory_scope` column itself.
+**Stored and never read by retrieval:** `tags`, `priority`, `updated_at`, `probes`, `basis`,
+`confidence`, edge `weight`, edge `invalid_at`, edge `expired_at`, edge `episodes`, the
+`node_labels` filter, and the `entity.memory_scope` column itself.
 
 **Read only by the retention job:** `importance`, `pinned`, `retention`.
 
@@ -348,87 +323,76 @@ all five usage counters and timestamps, spans and `atomic` via passages.
 
 ### 5.1 Temporal expressiveness
 
-On the **edge**: a genuine bi-temporal model exists —
-`valid_at`/`invalid_at` (valid time) and `created_at`/`expired_at` (transaction
-time) (`schema.py:190-193`), queryable through
-`temporal_query(mode=history|timeline|conflicts)` (`tools/temporal.py:36-120`)
-and `/search` conflicts mode (`apps/api/src/sibyl/api/routes/search.py:553-558`).
+On the **edge**: a genuine bi-temporal model exists — `valid_at`/`invalid_at` (valid time) and
+`created_at`/`expired_at` (transaction time) (`schema.py:190-193`), queryable through
+`temporal_query(mode=history|timeline|conflicts)` (`tools/temporal.py:36-120`) and `/search`
+conflicts mode (`apps/api/src/sibyl/api/routes/search.py:553-558`).
 
-On the **node**: nothing. `entity` has no `valid_at`/`invalid_at` columns. The
-`Episode` model declares `valid_from`/`valid_to` (`models/entities.py:204-209`)
-and the storage edge does not write them (`graph.py:3026-3051`), so they land in
-`attributes` as untyped metadata.
+On the **node**: nothing. `entity` has no `valid_at`/`invalid_at` columns. The `Episode` model
+declares `valid_from`/`valid_to` (`models/entities.py:204-209`) and the storage edge does not write
+them (`graph.py:3026-3051`), so they land in `attributes` as untyped metadata.
 
-And a writer cannot set edge temporal bounds anyway, because a writer cannot
-create a typed edge (§1.4). `valid_at` is populated only by reflection promotion
-(`services/memory.py:3213-3222`).
+And a writer cannot set edge temporal bounds anyway, because a writer cannot create a typed edge
+(§1.4). `valid_at` is populated only by reflection promotion (`services/memory.py:3213-3222`).
 
 ### 5.2 Provenance
 
-Raw side: a dedicated `provenance` FLEXIBLE column
-(`10_tables.surql:139`) plus `principal_id`, `agent_id`, `capture_surface`,
-`created_by_user_id`, and a `derived_from` relation to `source_imports`.
+Raw side: a dedicated `provenance` FLEXIBLE column (`10_tables.surql:139`) plus `principal_id`,
+`agent_id`, `capture_surface`, `created_by_user_id`, and a `derived_from` relation to
+`source_imports`.
 
-Graph side: `created_by`/`modified_by` (`schema.py:88-89`), `source_file`, and
-`attributes`. `native_write_path` is stamped on generated relationships
-(`services/memory.py:3180, 3190, 3204`). There is **no provenance column on
-`relates_to`** — an edge cannot say who asserted it or on what evidence except
-through `attributes` and `episodes`, and `episodes` is unread (§4).
+Graph side: `created_by`/`modified_by` (`schema.py:88-89`), `source_file`, and `attributes`.
+`native_write_path` is stamped on generated relationships (`services/memory.py:3180, 3190, 3204`).
+There is **no provenance column on `relates_to`** — an edge cannot say who asserted it or on what
+evidence except through `attributes` and `episodes`, and `episodes` is unread (§4).
 
 ### 5.3 What `sibyl correct` actually does
 
 Ten actions (`services/memory.py:186-205`, literal type at
-`apps/api/src/sibyl/api/schemas/common.py:20-31`): `delete`, `mark_duplicate`,
-`mark_stale`, `mark_wrong`, `restore`, `supersede`, `hide`, `mark_sensitive`,
-`redact`, `revise`. Aliases `duplicate | stale | superseded | wrong`
-(`memory.py:200-205`). `delete` and `redact` are irreversible (`memory.py:216`).
+`apps/api/src/sibyl/api/schemas/common.py:20-31`): `delete`, `mark_duplicate`, `mark_stale`,
+`mark_wrong`, `restore`, `supersede`, `hide`, `mark_sensitive`, `redact`, `revise`. Aliases
+`duplicate | stale | superseded | wrong` (`memory.py:200-205`). `delete` and `redact` are
+irreversible (`memory.py:216`).
 
-**What it touches:** `apply_memory_correction` (`services/memory.py:1652-1732`)
-builds a `replace(memory, ...)` and calls `save_raw_memory`. It mutates three
-things on the **raw** row: `raw_content` (revise only), `review_state`, and
-`metadata` — writing `metadata["superseded_by_source_id"]` (`memory.py:1598`), a
-`MemoryLifecycle` record (`:1607`), a correction-history entry (`:1621`), and a
-`ReflectionFinding` (`:1637-1640`). On `supersede` it passes
-`superseded_by_memory_id`, which can materialize the content-layer `supersedes`
-relation (`content_schema.py:301-312`).
+**What it touches:** `apply_memory_correction` (`services/memory.py:1652-1732`) builds a
+`replace(memory, ...)` and calls `save_raw_memory`. It mutates three things on the **raw** row:
+`raw_content` (revise only), `review_state`, and `metadata` — writing
+`metadata["superseded_by_source_id"]` (`memory.py:1598`), a `MemoryLifecycle` record (`:1607`), a
+correction-history entry (`:1621`), and a `ReflectionFinding` (`:1637-1640`). On `supersede` it
+passes `superseded_by_memory_id`, which can materialize the content-layer `supersedes` relation
+(`content_schema.py:301-312`).
 
-**What it does not touch:** the graph. No `relates_to` write, no `entity` update,
-no reprojection job. The route reports `affected_records=[f"raw_captures:{id}"]`
-only (`apps/api/src/sibyl/api/routes/memory.py:2585-2591`).
-`_correction_derived_ids` (`memory.py:1236-1250`) *lists* the promoted entity and
-relationship ids and nothing mutates them. `_correction_impact`
-(`memory.py:1333-1352`) returns `{"excluded_from_recall": ...}` — a **declaration
-about** exclusion, not an enforcement of it.
+**What it does not touch:** the graph. No `relates_to` write, no `entity` update, no reprojection
+job. The route reports `affected_records=[f"raw_captures:{id}"]` only
+(`apps/api/src/sibyl/api/routes/memory.py:2585-2591`). `_correction_derived_ids`
+(`memory.py:1236-1250`) _lists_ the promoted entity and relationship ids and nothing mutates them.
+`_correction_impact` (`memory.py:1333-1352`) returns `{"excluded_from_recall": ...}` — a
+**declaration about** exclusion, not an enforcement of it.
 
 Note also that the physical `supersedes` table is materialized only by
-`_materialize_supersedes_lineage` (`services/surreal_content.py:1485, 1508,
-1518-1526`) reading `metadata.supersedes_raw_memory_id`, whose only writer is the
-source-import job (`apps/api/src/sibyl/jobs/source_imports.py:542`). No
-agent-facing parameter sets that key.
+`_materialize_supersedes_lineage` (`services/surreal_content.py:1485, 1508, 1518-1526`) reading
+`metadata.supersedes_raw_memory_id`, whose only writer is the source-import job
+(`apps/api/src/sibyl/jobs/source_imports.py:542`). No agent-facing parameter sets that key.
 
 Enforcement is split three ways: the raw recall lane honors lifecycle
-(`surreal_content.py:545-550`); synthesis re-filters at render
-(`synthesis.py:481-492`); the graph retrieval lane honors nothing (G1).
+(`surreal_content.py:545-550`); synthesis re-filters at render (`synthesis.py:481-492`); the graph
+retrieval lane honors nothing (G1).
 
 ### 5.4 Contradiction and consolidation
 
-Contradiction detection exists in exactly one form: a regex over an 11-word
-polarity vocabulary (`services/reflection.py:145-161` — enabled/disabled,
-allowed/blocked, required/forbidden, use/avoid/skip/disable/enable) firing a
-`ReflectionFindingKind.CONTRADICTION` when two candidates share a subject with
-opposite polarity (`reflection.py:664-678`, reason
-`"same_subject_opposite_polarity"`, confidence 0.82). The action is
-`route_to_review` — it resolves nothing. Supersession and staleness detection are
-explicit-signal-driven (`reflection.py:631-663`).
+Contradiction detection exists in exactly one form: a regex over an 11-word polarity vocabulary
+(`services/reflection.py:145-161` — enabled/disabled, allowed/blocked, required/forbidden,
+use/avoid/skip/disable/enable) firing a `ReflectionFindingKind.CONTRADICTION` when two candidates
+share a subject with opposite polarity (`reflection.py:664-678`, reason
+`"same_subject_opposite_polarity"`, confidence 0.82). The action is `route_to_review` — it resolves
+nothing. Supersession and staleness detection are explicit-signal-driven (`reflection.py:631-663`).
 
-`ClaimRecord` (`models/reflection.py:121-181`) is the richest structure in the
-codebase for this: `supports_source_ids`, `contradicts_source_ids`,
-`supersedes_source_ids`, `superseded_by_source_id`, `validity`, `freshness`,
-`confidence`. Only `supersedes_source_ids` ever becomes a graph edge
-(`services/memory.py:3207-3226`). `contradicts_source_ids` and
-`supports_source_ids` never become `CONTRADICTS` or `SUPPORTS` edges, though both
-predicates exist in the enum and both carry high expansion weights (0.64 default
-and 0.94 respectively).
+`ClaimRecord` (`models/reflection.py:121-181`) is the richest structure in the codebase for this:
+`supports_source_ids`, `contradicts_source_ids`, `supersedes_source_ids`, `superseded_by_source_id`,
+`validity`, `freshness`, `confidence`. Only `supersedes_source_ids` ever becomes a graph edge
+(`services/memory.py:3207-3226`). `contradicts_source_ids` and `supports_source_ids` never become
+`CONTRADICTS` or `SUPPORTS` edges, though both predicates exist in the enum and both carry high
+expansion weights (0.64 default and 0.94 respectively).
 
 ---
 
@@ -436,130 +400,111 @@ and 0.94 respectively).
 
 ### G1. A correction cannot reach the memory retrieval serves
 
-`sibyl correct <id> --action mark_wrong` corrects the `raw_captures` row. The
-projected `entity` row keeps its capture-time metadata, has no `review_state` or
-`lifecycle_state` column (`schema.py:75-108`), and is never reprojected. Nothing
-in `retrieval/` joins a graph row back to its raw memory: `raw_memory_id` and
-`raw_source_id` are written into graph metadata at `capture.py:137-140`, and
-grepping either name across `retrieval/` and `tools/` returns zero hits. The
-wrong memory keeps ranking, keeps its embedding, keeps being expanded into. The
-only backstop is the synthesis render filter, which reads metadata the graph row
-does not carry.
+`sibyl correct <id> --action mark_wrong` corrects the `raw_captures` row. The projected `entity` row
+keeps its capture-time metadata, has no `review_state` or `lifecycle_state` column
+(`schema.py:75-108`), and is never reprojected. Nothing in `retrieval/` joins a graph row back to
+its raw memory: `raw_memory_id` and `raw_source_id` are written into graph metadata at
+`capture.py:137-140`, and grepping either name across `retrieval/` and `tools/` returns zero hits.
+The wrong memory keeps ranking, keeps its embedding, keeps being expanded into. The only backstop is
+the synthesis render filter, which reads metadata the graph row does not carry.
 
-The system has a correction verb whose blast radius stops at the substrate
-retrieval mostly does not read.
+The system has a correction verb whose blast radius stops at the substrate retrieval mostly does not
+read.
 
 ### G2. No typed edge between two memories at write time
 
-An agent that knows "this supersedes that" or "this claim contradicts that
-decision" has one channel: `related_to`, which becomes `RELATED_TO`
-unconditionally (`tools/add.py:720`, `services/memory.py:3196-3205`).
-`CONTRADICTS`, `SUPPORTS`, `CONFLICTS_WITH`, `DECIDES`, `BREAKS`, `ENABLES`,
-`REQUIRES` have no writer at all.
+An agent that knows "this supersedes that" or "this claim contradicts that decision" has one
+channel: `related_to`, which becomes `RELATED_TO` unconditionally (`tools/add.py:720`,
+`services/memory.py:3196-3205`). `CONTRADICTS`, `SUPPORTS`, `CONFLICTS_WITH`, `DECIDES`, `BREAKS`,
+`ENABLES`, `REQUIRES` have no writer at all.
 
-The sharp edge: retrieval *would* use it. The expansion weight table
-(`search.py:85-107`) already assigns `DECIDES` 1.0, `REQUIRES` 0.98, `SUPERSEDES`
-0.95, `SUPPORTS` 0.94 — a tuned scoring table for predicates the write surface
-cannot produce. Traversal is typed; the write surface is not. The one typed
-relationship dataclass in the codebase
-(`ReflectionRelationshipRecord`, `models/reflection.py:237-245`) is populated
-with a single hardcoded `BELONGS_TO` (`services/reflection.py:506-524`) and never
-reaches the graph.
+The sharp edge: retrieval _would_ use it. The expansion weight table (`search.py:85-107`) already
+assigns `DECIDES` 1.0, `REQUIRES` 0.98, `SUPERSEDES` 0.95, `SUPPORTS` 0.94 — a tuned scoring table
+for predicates the write surface cannot produce. Traversal is typed; the write surface is not. The
+one typed relationship dataclass in the codebase (`ReflectionRelationshipRecord`,
+`models/reflection.py:237-245`) is populated with a single hardcoded `BELONGS_TO`
+(`services/reflection.py:506-524`) and never reaches the graph.
 
 ### G3. Supersession is expressible, unenforced, and inverted in ranking
 
 Three compounding problems. The traversal queries carry no temporal predicate
-(`search.py:1826-1868, 1871-1922`), so an edge with `invalid_at` set is walked
-like a live one. `invalid_at` and `expired_at` are projected all the way into
-`SearchResult.metadata` (`:2394, 2420-2421`) and consulted by nothing in the
-fusion or boost path. And `SUPERSEDES` carries a weight of **0.95**, one of the
-highest in the table — so following a supersession edge *boosts* its target,
-which is the superseded memory. Retrieval treats "X replaced Y" as a strong
-reason to also surface Y.
+(`search.py:1826-1868, 1871-1922`), so an edge with `invalid_at` set is walked like a live one.
+`invalid_at` and `expired_at` are projected all the way into `SearchResult.metadata`
+(`:2394, 2420-2421`) and consulted by nothing in the fusion or boost path. And `SUPERSEDES` carries
+a weight of **0.95**, one of the highest in the table — so following a supersession edge _boosts_
+its target, which is the superseded memory. Retrieval treats "X replaced Y" as a strong reason to
+also surface Y.
 
 ### G4. Confidence and epistemic basis have nowhere to live and nothing to read them
 
-Per-item confidence is produced in four places — the extractor
-(`models/memory_extraction.py:39`), `ClaimRecord` (`models/reflection.py:125`),
-`ReflectionFinding` (`:189`), and `Pattern` (`models/entities.py:153`) — and
-reaches no column. `entity` has no `confidence`; `relates_to` has no
-`confidence`. It survives only in `attributes`, where the only readers are
-display projections (`search.py:2390, 2416`). A low-confidence memory ranks
-identically to a certain one.
+Per-item confidence is produced in four places — the extractor (`models/memory_extraction.py:39`),
+`ClaimRecord` (`models/reflection.py:125`), `ReflectionFinding` (`:189`), and `Pattern`
+(`models/entities.py:153`) — and reaches no column. `entity` has no `confidence`; `relates_to` has
+no `confidence`. It survives only in `attributes`, where the only readers are display projections
+(`search.py:2390, 2416`). A low-confidence memory ranks identically to a certain one.
 
-`--basis` is worse, because it is a well-designed axis with a validated
-four-value vocabulary (`main.py:225`) that an agent can use to distinguish what
-it *observed* from what it *assumed* — and its only consumer in the entire system
-is a blame view (`routes/memory.py:1978`).
+`--basis` is worse, because it is a well-designed axis with a validated four-value vocabulary
+(`main.py:225`) that an agent can use to distinguish what it _observed_ from what it _assumed_ — and
+its only consumer in the entire system is a blame view (`routes/memory.py:1978`).
 
 Same shape for edge weight: not persisted, no column, always 1.0 (§2.3).
 
 ### G5. Tags are a write-only axis on the retrieval path
 
-`tags` is the most natural thing for an agent to set and the least load-bearing
-thing it can set. Unindexed (`schema.py:104`), absent from every search WHERE
-clause, absent from every scoring term. `list_by_type` accepts a `tags` argument
-and emits no SQL for it (`graph.py:1104, 1143-1186`); the only real filter is a
-Python post-filter reached from `explore()` (`graph_search.py:99-100`,
-`tools/explore.py:241`). An agent tagging a memory `gotcha` and later searching
-for gotchas gets zero lift — the tag helps only if the reader already knows to
-*browse* by it.
+`tags` is the most natural thing for an agent to set and the least load-bearing thing it can set.
+Unindexed (`schema.py:104`), absent from every search WHERE clause, absent from every scoring term.
+`list_by_type` accepts a `tags` argument and emits no SQL for it (`graph.py:1104, 1143-1186`); the
+only real filter is a Python post-filter reached from `explore()` (`graph_search.py:99-100`,
+`tools/explore.py:241`). An agent tagging a memory `gotcha` and later searching for gotchas gets
+zero lift — the tag helps only if the reader already knows to _browse_ by it.
 
 ### G6. Eight entity types can never appear in a context pack
 
-`FACET_TYPES` (`tools/context.py:77-90`) maps 12 facets to entity types and
-`_types_for_facets` (`:1221-1239`) builds the requested-type list from exactly
-that map plus `passage`. Absent from every facet: `person`, `place`, `language`,
-`team`, `milestone`, `community`, `knowledge_source`, `slash_command`. `person`
-and `place` are the pointed ones — they were added deliberately for
-domain-general personal memory (`models/entities.py:54-55`) and `recall` can
-never request them.
+`FACET_TYPES` (`tools/context.py:77-90`) maps 12 facets to entity types and `_types_for_facets`
+(`:1221-1239`) builds the requested-type list from exactly that map plus `passage`. Absent from
+every facet: `person`, `place`, `language`, `team`, `milestone`, `community`, `knowledge_source`,
+`slash_command`. `person` and `place` are the pointed ones — they were added deliberately for
+domain-general personal memory (`models/entities.py:54-55`) and `recall` can never request them.
 
 ### G7. Structural expressiveness the schema lacks outright
 
-- **N-ary relations.** `relates_to` is `IN entity OUT entity` (`schema.py:179`).
-  "We decided X, in meeting Y, because of constraint Z" must be decomposed into
-  pairwise edges or flattened into prose.
-- **Negation.** No polarity field on node or edge. "Redis is *not* the
-  bottleneck" is stored as text and embeds close to "Redis is the bottleneck".
-  The only negation-aware machinery in the system is the 11-word regex vocabulary
-  in reflection (`services/reflection.py:145-161`).
-- **Entity aliasing / merge.** No `same_as` predicate, no merge verb, no
-  canonical-id indirection. Extraction dedupes only within a single batch by
-  `f"{type}:{name.lower()}"` (`projection/memory.py:849`), so "Bliss",
-  "Stefanie", and "stef@gradial.com" become three permanent nodes.
-- **TTL / explicit decay.** `raw_captures` has `purge_after`
-  (`10_tables.surql:145`); `entity` has none. Decay is job-driven
-  (`jobs/consolidation.py:319-331`) with no writer-facing knob beyond untyped
-  `attributes.importance` or `attributes.pinned`.
-- **Probes as retrieval assets.** The single most direct statement an agent can
-  make about *how this memory should be found* is rehearsed once at write time
-  and then inert. Not indexed, not embedded, not used as query expansions
-  (`rehearsal.py`).
-- **Edit-time freshness.** `updated_at` is written and indexed five ways and read
-  by no ranker (`search.py:3129` takes `created_at` only). Revising a memory
-  cannot make it more current to retrieval.
+- **N-ary relations.** `relates_to` is `IN entity OUT entity` (`schema.py:179`). "We decided X, in
+  meeting Y, because of constraint Z" must be decomposed into pairwise edges or flattened into
+  prose.
+- **Negation.** No polarity field on node or edge. "Redis is _not_ the bottleneck" is stored as text
+  and embeds close to "Redis is the bottleneck". The only negation-aware machinery in the system is
+  the 11-word regex vocabulary in reflection (`services/reflection.py:145-161`).
+- **Entity aliasing / merge.** No `same_as` predicate, no merge verb, no canonical-id indirection.
+  Extraction dedupes only within a single batch by `f"{type}:{name.lower()}"`
+  (`projection/memory.py:849`), so "Bliss", "Stefanie", and "stef@gradial.com" become three
+  permanent nodes.
+- **TTL / explicit decay.** `raw_captures` has `purge_after` (`10_tables.surql:145`); `entity` has
+  none. Decay is job-driven (`jobs/consolidation.py:319-331`) with no writer-facing knob beyond
+  untyped `attributes.importance` or `attributes.pinned`.
+- **Probes as retrieval assets.** The single most direct statement an agent can make about _how this
+  memory should be found_ is rehearsed once at write time and then inert. Not indexed, not embedded,
+  not used as query expansions (`rehearsal.py`).
+- **Edit-time freshness.** `updated_at` is written and indexed five ways and read by no ranker
+  (`search.py:3129` takes `created_at` only). Revising a memory cannot make it more current to
+  retrieval.
 
 ---
 
 ## 7. Summary judgement
 
-The write surface is asymmetric in a specific way: **rich about the shape of a
-single memory, nearly mute about relations between memories.** Spans, atomicity,
-probes, retrieval keys, and scope are first-class, validated, unforgeable
-declarations with real server-side enforcement. Predicates, confidence, validity
-intervals, epistemic basis, and supersession are either absent from the contract
-or reachable only through internal code paths.
+The write surface is asymmetric in a specific way: **rich about the shape of a single memory, nearly
+mute about relations between memories.** Spans, atomicity, probes, retrieval keys, and scope are
+first-class, validated, unforgeable declarations with real server-side enforcement. Predicates,
+confidence, validity intervals, epistemic basis, and supersession are either absent from the
+contract or reachable only through internal code paths.
 
-Retrieval mirrors the asymmetry from the other side, and is better than the write
-surface deserves in two places and worse in three. Better: the graph expansion
-lane is genuinely predicate-aware with a tuned 21-entry weight table, and the
-usage-feedback loop is real — citations stretch a memory's half-life up to 4×
-and `misled_count` collapses it 10×, both feeding live ranking. Worse: no type
-prior, no tag signal, no confidence term, no temporal filter on edges, and no
-path from a corrected raw memory to the graph row that answers for it.
+Retrieval mirrors the asymmetry from the other side, and is better than the write surface deserves
+in two places and worse in three. Better: the graph expansion lane is genuinely predicate-aware with
+a tuned 21-entry weight table, and the usage-feedback loop is real — citations stretch a memory's
+half-life up to 4× and `misled_count` collapses it 10×, both feeding live ranking. Worse: no type
+prior, no tag signal, no confidence term, no temporal filter on edges, and no path from a corrected
+raw memory to the graph row that answers for it.
 
-The clearest single statement of the gap: **the predicate weight table
-(`search.py:85-107`) is a wish list.** It scores `DECIDES`, `SUPPORTS`,
-`REQUIRES`, `BLOCKS`, and `VALIDATED_BY` — five predicates no agent, and no
-extractor, can ever write.
+The clearest single statement of the gap: **the predicate weight table (`search.py:85-107`) is a
+wish list.** It scores `DECIDES`, `SUPPORTS`, `REQUIRES`, `BLOCKS`, and `VALIDATED_BY` — five
+predicates no agent, and no extractor, can ever write.

--- a/docs/architecture/AUDIT_2026-08-13/sota-research.md
+++ b/docs/architecture/AUDIT_2026-08-13/sota-research.md
@@ -1,8 +1,11 @@
 # Agent Memory Research SOTA — August 2026
 
-Research-side survey (papers, benchmarks, empirical findings) for Sibyl 1.3 representation/retrieval decisions. Products are covered by a sibling report. Compiled 2026-08-13.
+Research-side survey (papers, benchmarks, empirical findings) for Sibyl 1.3 representation/retrieval
+decisions. Products are covered by a sibling report. Compiled 2026-08-13.
 
-Reading key: [REALISTIC] = evaluated on realistic agent workloads (long trajectories, tool use, latency budgets). [CHAT] = long-conversation QA benchmarks (LoCoMo, LongMemEval-S/M). [TOY] = synthetic or narrow probes.
+Reading key: [REALISTIC] = evaluated on realistic agent workloads (long trajectories, tool use,
+latency budgets). [CHAT] = long-conversation QA benchmarks (LoCoMo, LongMemEval-S/M). [TOY] =
+synthetic or narrow probes.
 
 ---
 
@@ -10,53 +13,150 @@ Reading key: [REALISTIC] = evaluated on realistic agent workloads (long trajecto
 
 ### Temporal knowledge graphs: the Zep/Graphiti lineage
 
-- **Zep: A Temporal Knowledge Graph Architecture for Agent Memory** (Rasmussen et al., arXiv:2501.13956) remains the canonical TKG-memory paper: bi-temporal edges (valid time + transaction time), episodic/entity/community node types. Graphiti crossed 20K GitHub stars in 2026. But its headline numbers have aged badly: on LongMemEval-V1, Zep scores 71.2% while a plain RAG pipeline with reranking hits 86% (Emergence AI, below). https://arxiv.org/abs/2501.13956
-- **HippoRAG 2 — "From RAG to Memory: Non-Parametric Continual Learning for LLMs"** (Gutierrez et al., OSU, arXiv:2502.14802) is the strongest graph-retrieval result with a controlled story: dual-node KG (phrase nodes + passage nodes), Personalized PageRank seeded by embedding scores, LLM triple filtering. +7 F1 on associative (multi-hop) QA over SOTA dense retrievers. Critically, HippoRAG 2 names "context loss during indexing" as the fatal flaw of HippoRAG 1 — the graph works only because passage nodes keep verbatim text in the loop. [CHAT/multi-hop QA] https://arxiv.org/pdf/2502.14802
-- Successors in the graph lane: **GAAMA: Graph Augmented Associative Memory** (arXiv:2603.27910), **Synapse** (arXiv:2601.02744, Feb 2026) which models memory as a dynamic graph where relevance emerges from *spreading activation* rather than pre-computed links, and **"Implicit Graph, Explicit Retrieval"** (arXiv:2601.03417) arguing the graph should be latent while retrieval stays cheap and interpretable. Direction of travel: away from expensive explicit triple extraction, toward graphs as a traversal/activation structure over preserved text.
-- **Association Is Not Similarity** (arXiv:2604.20850) — learns corpus-specific association weights for multi-hop retrieval; relevant if we ever score edges for traversal.
+- **Zep: A Temporal Knowledge Graph Architecture for Agent Memory** (Rasmussen et al.,
+  arXiv:2501.13956) remains the canonical TKG-memory paper: bi-temporal edges (valid time +
+  transaction time), episodic/entity/community node types. Graphiti crossed 20K GitHub stars
+  in 2026. But its headline numbers have aged badly: on LongMemEval-V1, Zep scores 71.2% while a
+  plain RAG pipeline with reranking hits 86% (Emergence AI, below). https://arxiv.org/abs/2501.13956
+- **HippoRAG 2 — "From RAG to Memory: Non-Parametric Continual Learning for LLMs"** (Gutierrez et
+  al., OSU, arXiv:2502.14802) is the strongest graph-retrieval result with a controlled story:
+  dual-node KG (phrase nodes + passage nodes), Personalized PageRank seeded by embedding scores, LLM
+  triple filtering. +7 F1 on associative (multi-hop) QA over SOTA dense retrievers. Critically,
+  HippoRAG 2 names "context loss during indexing" as the fatal flaw of HippoRAG 1 — the graph works
+  only because passage nodes keep verbatim text in the loop. [CHAT/multi-hop QA]
+  https://arxiv.org/pdf/2502.14802
+- Successors in the graph lane: **GAAMA: Graph Augmented Associative Memory** (arXiv:2603.27910),
+  **Synapse** (arXiv:2601.02744, Feb 2026) which models memory as a dynamic graph where relevance
+  emerges from _spreading activation_ rather than pre-computed links, and **"Implicit Graph,
+  Explicit Retrieval"** (arXiv:2601.03417) arguing the graph should be latent while retrieval stays
+  cheap and interpretable. Direction of travel: away from expensive explicit triple extraction,
+  toward graphs as a traversal/activation structure over preserved text.
+- **Association Is Not Similarity** (arXiv:2604.20850) — learns corpus-specific association weights
+  for multi-hop retrieval; relevant if we ever score edges for traversal.
 
 ### Typed vs untyped structure — what the controlled evidence actually says
 
 Two different claims get conflated; the evidence splits cleanly:
 
-- **Typed STORE separation (episodic/semantic/procedural routing) has strong evidence.** **ENGRAM: Effective, Lightweight Memory Orchestration for Conversational Agents** (arXiv:2511.12960, also OpenReview): routes conversation into three canonical memory types with a single router+retriever. LoCoMo LLM-judge 77.55%, beating Mem0, MemOS, LangMem, Zep. The ablation is the money shot: collapsing the three stores into one undifferentiated store drops to **46.56%** (−31 points). [CHAT] https://arxiv.org/abs/2511.12960
-- **Memanto: Typed Semantic Memory with Information-Theoretic Retrieval** (Abtahi et al., arXiv:2604.22085, Apr 2026) extends this to 13 semantic categories (facts, preferences, decisions, commitments, goals, events, instructions, relationships, context, learning, observations, errors, artifacts), each with distinct retrieval semantics and priority weighting. LongMemEval 89.8%, LoCoMo 87.1%. No direct typed-vs-untyped ablation of its own; leans on ENGRAM's. [CHAT] https://arxiv.org/html/2604.22085v1
-- **Typed EDGES/ontologies: evidence is thinner and conditional.** **Ontology Learning and KG Construction: A Comparison of Approaches and Their Impact on RAG Performance** (arXiv:2511.05991) is the best controlled comparison: vector RAG vs GraphRAG vs several ontology-grounded KGs, holding corpus/retrieval/eval constant. Ontology-grounded approaches win — but specifically the variants **that keep textual chunk information attached**; the win is interpretability + hallucination reduction, and DB-derived ontologies match text-extracted ones at far lower LLM cost. [CHAT/QA corpora] https://arxiv.org/abs/2511.05991
-- **OntoKG** (arXiv:2604.02618) isolates type annotations on controlled mentions (same candidate entities both arms): type annotations, not candidate coverage, drive the accuracy difference. [TOY-leaning, entity-linking probe]
-- **For code specifically**: **"Reliable Graph-RAG for Codebases: AST-Derived Graphs vs LLM-Extracted Knowledge Graphs"** (arXiv:2601.08773) — deterministic AST-derived structure beats LLM-extracted KGs for codebase QA. Structure you can compute exactly beats structure you hallucinate. [REALISTIC for coding]
+- **Typed STORE separation (episodic/semantic/procedural routing) has strong evidence.** **ENGRAM:
+  Effective, Lightweight Memory Orchestration for Conversational Agents** (arXiv:2511.12960, also
+  OpenReview): routes conversation into three canonical memory types with a single router+retriever.
+  LoCoMo LLM-judge 77.55%, beating Mem0, MemOS, LangMem, Zep. The ablation is the money shot:
+  collapsing the three stores into one undifferentiated store drops to **46.56%** (−31 points).
+  [CHAT] https://arxiv.org/abs/2511.12960
+- **Memanto: Typed Semantic Memory with Information-Theoretic Retrieval** (Abtahi et al.,
+  arXiv:2604.22085, Apr 2026) extends this to 13 semantic categories (facts, preferences, decisions,
+  commitments, goals, events, instructions, relationships, context, learning, observations, errors,
+  artifacts), each with distinct retrieval semantics and priority weighting. LongMemEval 89.8%,
+  LoCoMo 87.1%. No direct typed-vs-untyped ablation of its own; leans on ENGRAM's. [CHAT]
+  https://arxiv.org/html/2604.22085v1
+- **Typed EDGES/ontologies: evidence is thinner and conditional.** **Ontology Learning and KG
+  Construction: A Comparison of Approaches and Their Impact on RAG Performance** (arXiv:2511.05991)
+  is the best controlled comparison: vector RAG vs GraphRAG vs several ontology-grounded KGs,
+  holding corpus/retrieval/eval constant. Ontology-grounded approaches win — but specifically the
+  variants **that keep textual chunk information attached**; the win is interpretability +
+  hallucination reduction, and DB-derived ontologies match text-extracted ones at far lower LLM
+  cost. [CHAT/QA corpora] https://arxiv.org/abs/2511.05991
+- **OntoKG** (arXiv:2604.02618) isolates type annotations on controlled mentions (same candidate
+  entities both arms): type annotations, not candidate coverage, drive the accuracy difference.
+  [TOY-leaning, entity-linking probe]
+- **For code specifically**: **"Reliable Graph-RAG for Codebases: AST-Derived Graphs vs
+  LLM-Extracted Knowledge Graphs"** (arXiv:2601.08773) — deterministic AST-derived structure beats
+  LLM-extracted KGs for codebase QA. Structure you can compute exactly beats structure you
+  hallucinate. [REALISTIC for coding]
 
-Net: no paper shows that *typed relations on a memory graph* improve end-task accuracy over untyped edges in a controlled way. What is shown: typed top-level stores/categories with type-aware retrieval semantics help a lot; ontology structure helps when it augments rather than replaces text.
+Net: no paper shows that _typed relations on a memory graph_ improve end-task accuracy over untyped
+edges in a controlled way. What is shown: typed top-level stores/categories with type-aware
+retrieval semantics help a lot; ontology structure helps when it augments rather than replaces text.
 
 ### Ontology-free / atomic-note approaches
 
-- **A-Mem: Agentic Memory for LLM Agents** (Xu et al., arXiv:2502.12110; NeurIPS/OpenReview) — Zettelkasten-style atomic notes with LLM-generated contextual descriptions and links, memory evolution on write. Up to 2x GPT-4o-mini multi-hop on LoCoMo, 85–93% fewer memory-operation tokens than MemGPT. [CHAT] https://arxiv.org/pdf/2502.12110
-- **AtomMem** (arXiv:2606.19847, Jun 2026) — "simple and effective memory via atomic facts"; the minimalist counterpoint arguing atomic facts + good retrieval match heavyweight systems. [CHAT]
-- **Schema-constrained middle ground**: **"To Know is to Construct: Schema-Constrained Generation for Agent Memory"** (arXiv:2604.20117) and **"From Unstructured Recall to Schema-Grounded Memory: Reliable AI Memory via Iterative, Schema-Aware Extraction"** (arXiv:2604.27906) — extraction reliability improves when a schema constrains generation; the failure mode they target is exactly the lossy/hallucinated extraction that Fidelity-Before-Structure (Section 2) measures.
+- **A-Mem: Agentic Memory for LLM Agents** (Xu et al., arXiv:2502.12110; NeurIPS/OpenReview) —
+  Zettelkasten-style atomic notes with LLM-generated contextual descriptions and links, memory
+  evolution on write. Up to 2x GPT-4o-mini multi-hop on LoCoMo, 85–93% fewer memory-operation tokens
+  than MemGPT. [CHAT] https://arxiv.org/pdf/2502.12110
+- **AtomMem** (arXiv:2606.19847, Jun 2026) — "simple and effective memory via atomic facts"; the
+  minimalist counterpoint arguing atomic facts + good retrieval match heavyweight systems. [CHAT]
+- **Schema-constrained middle ground**: **"To Know is to Construct: Schema-Constrained Generation
+  for Agent Memory"** (arXiv:2604.20117) and **"From Unstructured Recall to Schema-Grounded Memory:
+  Reliable AI Memory via Iterative, Schema-Aware Extraction"** (arXiv:2604.27906) — extraction
+  reliability improves when a schema constrains generation; the failure mode they target is exactly
+  the lossy/hallucinated extraction that Fidelity-Before-Structure (Section 2) measures.
 
 ### Episodic vs semantic splits, consolidation, sleep-time compute
 
-- **SYNAPSE** (arXiv:2601.02744) — episodic-semantic memory via spreading activation; minimal activated subsets beat strong baselines. **E-mem** (arXiv:2601.21714) — multi-agent episodic context reconstruction. **Episodic-Semantic Memory for Long-Horizon Scientific Agents** (arXiv:2605.17625) — retains semantic knowledge from old topics while discarding dated episodic detail. [CHAT/agent-sim]
-- **Sleep-time compute lineage**: Letta's **"Sleep-time Compute: Beyond Inference Scaling at Test-time"** (arXiv:2504.13171, 2025) established the framing (pre-compute representations off the critical path). 2026 successors: **SCM: Sleep-Consolidated Memory** (arXiv:2604.20943) with multi-stage sleep cycles (consolidation, dreaming, intentional forgetting); **"Language Models Need Sleep: Learning to Self-Modify and Consolidate Memories"** (arXiv:2606.03979) — distill fragile short-term memory into stable long-term knowledge with replay; **TiMem: Temporal-Hierarchical Memory Consolidation** (arXiv:2601.02845) — 76.9–79.0% on LongMemEval-S depending on reader. [CHAT, some TOY]
-- **"Sleep-Like Memory Consolidation in LLMs"** (arXiv:2605.26099) — periodic conversion of recent context into persistent fast weights; longer "sleep" decouples memory capacity from reasoning compute. [TOY + real benchmarks, weight-space so not directly applicable to an external store]
+- **SYNAPSE** (arXiv:2601.02744) — episodic-semantic memory via spreading activation; minimal
+  activated subsets beat strong baselines. **E-mem** (arXiv:2601.21714) — multi-agent episodic
+  context reconstruction. **Episodic-Semantic Memory for Long-Horizon Scientific Agents**
+  (arXiv:2605.17625) — retains semantic knowledge from old topics while discarding dated episodic
+  detail. [CHAT/agent-sim]
+- **Sleep-time compute lineage**: Letta's **"Sleep-time Compute: Beyond Inference Scaling at
+  Test-time"** (arXiv:2504.13171, 2025) established the framing (pre-compute representations off the
+  critical path). 2026 successors: **SCM: Sleep-Consolidated Memory** (arXiv:2604.20943) with
+  multi-stage sleep cycles (consolidation, dreaming, intentional forgetting); **"Language Models
+  Need Sleep: Learning to Self-Modify and Consolidate Memories"** (arXiv:2606.03979) — distill
+  fragile short-term memory into stable long-term knowledge with replay; **TiMem:
+  Temporal-Hierarchical Memory Consolidation** (arXiv:2601.02845) — 76.9–79.0% on LongMemEval-S
+  depending on reader. [CHAT, some TOY]
+- **"Sleep-Like Memory Consolidation in LLMs"** (arXiv:2605.26099) — periodic conversion of recent
+  context into persistent fast weights; longer "sleep" decouples memory capacity from reasoning
+  compute. [TOY + real benchmarks, weight-space so not directly applicable to an external store]
 
 ---
 
 ## 2. Storage-time vs retrieval-time intelligence
 
-This is the most decisive cluster of 2026 results, and it cuts against expensive write-time structuring **when structure replaces raw text**:
+This is the most decisive cluster of 2026 results, and it cuts against expensive write-time
+structuring **when structure replaces raw text**:
 
-- **"Diagnosing Retrieval vs. Utilization Bottlenecks in LLM Agent Memory"** (Yuan, Su, Yao; MemAgents Workshop @ ICLR 2026; arXiv:2603.02473). 3x3 factorial: write strategies {raw chunks, Mem0-style fact extraction, MemGPT-style summarization} x retrieval {cosine, BM25, hybrid+rerank} on LoCoMo. **Retrieval method spans 20 points (57.1%→77.2%); write strategy spans 3–8 points.** Raw chunks (zero LLM calls at write time) match or beat both lossy alternatives. Failures manifest at the retrieval stage, not utilization, in their decomposition. Conclusion verbatim: "improving retrieval quality yields larger gains than increasing write-time sophistication." [CHAT] https://arxiv.org/abs/2603.02473
-- **"Fidelity Before Structure: Verbatim Chunks Beat Lossy Artifact Extraction in Long-Conversation LLM Memory"** (Tao An, arXiv:2601.00821v4, Jul 2026). Same retrieval pipeline, storage varied: LoCoMo chunks 43.9% vs artifacts 28.0% (−15.9); LongMemEval-S chunks 67.4% vs artifacts 45.4% (−22.0). Extracted artifacts fail to beat naive RAG at all (p=0.89). **Union storage (chunks + artifacts) recovers chunk-level accuracy (42.5%)** — the damage is *replacement*, not coexistence. Mechanism: accuracy tracks how much source text survives storage ("lossy distillation"). Six confound controls. Recommendation: "structure should augment verbatim text, not replace it." [CHAT] https://arxiv.org/html/2601.00821
-- **Emergence AI, "SOTA on LongMemEval with RAG"** (blog, engineering result not peer-reviewed): 86% on LongMemEval-V1 (vs Zep 71.2%, vs Oracle GPT-4o 82.4%) with turn-level matching → session-level retrieval → cross-encoder rerank → CoT-before-answer. No query decomposition, no graph, no temporal module. Their own conclusion: "advanced memory architecture appears to be overkill for LongMemEval." [CHAT] https://www.emergence.ai/blog/sota-on-longmemeval-with-rag
-- **Counterweight — write-time work that DOES pay**: ENGRAM/Memanto typed routing (cheap classification, not lossy rewriting); **"Beyond Static Summarization: Proactive Memory Extraction"** (arXiv:2601.04463); MemGuard write-time contamination filtering (Section 6); and Infini Memory's write-time recency rewriting for single-hop knowledge updates (Section 6). Pattern: cheap write-time *routing, tagging, verification, and superseding* pays; expensive write-time *rewriting that discards source text* does not.
+- **"Diagnosing Retrieval vs. Utilization Bottlenecks in LLM Agent Memory"** (Yuan, Su, Yao;
+  MemAgents Workshop @ ICLR 2026; arXiv:2603.02473). 3x3 factorial: write strategies {raw chunks,
+  Mem0-style fact extraction, MemGPT-style summarization} x retrieval {cosine, BM25, hybrid+rerank}
+  on LoCoMo. **Retrieval method spans 20 points (57.1%→77.2%); write strategy spans 3–8 points.**
+  Raw chunks (zero LLM calls at write time) match or beat both lossy alternatives. Failures manifest
+  at the retrieval stage, not utilization, in their decomposition. Conclusion verbatim: "improving
+  retrieval quality yields larger gains than increasing write-time sophistication." [CHAT]
+  https://arxiv.org/abs/2603.02473
+- **"Fidelity Before Structure: Verbatim Chunks Beat Lossy Artifact Extraction in Long-Conversation
+  LLM Memory"** (Tao An, arXiv:2601.00821v4, Jul 2026). Same retrieval pipeline, storage varied:
+  LoCoMo chunks 43.9% vs artifacts 28.0% (−15.9); LongMemEval-S chunks 67.4% vs artifacts 45.4%
+  (−22.0). Extracted artifacts fail to beat naive RAG at all (p=0.89). **Union storage (chunks +
+  artifacts) recovers chunk-level accuracy (42.5%)** — the damage is _replacement_, not coexistence.
+  Mechanism: accuracy tracks how much source text survives storage ("lossy distillation"). Six
+  confound controls. Recommendation: "structure should augment verbatim text, not replace it."
+  [CHAT] https://arxiv.org/html/2601.00821
+- **Emergence AI, "SOTA on LongMemEval with RAG"** (blog, engineering result not peer-reviewed): 86%
+  on LongMemEval-V1 (vs Zep 71.2%, vs Oracle GPT-4o 82.4%) with turn-level matching → session-level
+  retrieval → cross-encoder rerank → CoT-before-answer. No query decomposition, no graph, no
+  temporal module. Their own conclusion: "advanced memory architecture appears to be overkill for
+  LongMemEval." [CHAT] https://www.emergence.ai/blog/sota-on-longmemeval-with-rag
+- **Counterweight — write-time work that DOES pay**: ENGRAM/Memanto typed routing (cheap
+  classification, not lossy rewriting); **"Beyond Static Summarization: Proactive Memory
+  Extraction"** (arXiv:2601.04463); MemGuard write-time contamination filtering (Section 6); and
+  Infini Memory's write-time recency rewriting for single-hop knowledge updates (Section 6).
+  Pattern: cheap write-time _routing, tagging, verification, and superseding_ pays; expensive
+  write-time _rewriting that discards source text_ does not.
 
 ### Long-context vs RAG as of mid-2026
 
-- **"Long Context vs. RAG for LLMs: An Evaluation and Revisits"** (arXiv:2501.01880) and **LongBench v2** (arXiv:2412.15204): long context wins when the corpus fits and the model is frontier-class; RAG wins on cost and on mid-window content. Position sensitivity persists: relevant content buried mid-window still costs 30%+ accuracy in 2026 practice write-ups.
-- **"Context Length Alone Hurts LLM Performance Despite Perfect Retrieval"** (arXiv:2510.05381, EMNLP 2025 Findings): even with perfect retrieval, sheer input length degrades answers — independent of distraction. This is a reader-side result with direct implications for pack sizing. [Controlled, semi-TOY]
-- **ConvoMem** (Pakhomov, Nijkamp, Xiong — Salesforce; arXiv:2511.10523): "why your first 150 conversations don't need RAG" — full-context is competitive up to ~150 conversations; memory systems only earn their keep beyond that. Implication: memory-system evaluation must be at scale or it measures nothing. [CHAT]
-- **BEAM** (Mem0's benchmark line, 1M and 10M token scales): designed to be unsaturated; Mem0 self-reports 64.1 (BEAM-1M) and 48.6 (BEAM-10M) vs 94.4 on LongMemEval-V1 — the headroom benchmark. Vendor-reported. https://mem0.ai/blog/ai-memory-benchmarks-in-2026
-- 2026 consensus pattern (multiple industry write-ups): hybrid — retrieval to narrow, long window to reason across what survived. Nobody serious argues pure long-context for persistent multi-month memory.
+- **"Long Context vs. RAG for LLMs: An Evaluation and Revisits"** (arXiv:2501.01880) and **LongBench
+  v2** (arXiv:2412.15204): long context wins when the corpus fits and the model is frontier-class;
+  RAG wins on cost and on mid-window content. Position sensitivity persists: relevant content buried
+  mid-window still costs 30%+ accuracy in 2026 practice write-ups.
+- **"Context Length Alone Hurts LLM Performance Despite Perfect Retrieval"** (arXiv:2510.05381,
+  EMNLP 2025 Findings): even with perfect retrieval, sheer input length degrades answers —
+  independent of distraction. This is a reader-side result with direct implications for pack sizing.
+  [Controlled, semi-TOY]
+- **ConvoMem** (Pakhomov, Nijkamp, Xiong — Salesforce; arXiv:2511.10523): "why your first 150
+  conversations don't need RAG" — full-context is competitive up to ~150 conversations; memory
+  systems only earn their keep beyond that. Implication: memory-system evaluation must be at scale
+  or it measures nothing. [CHAT]
+- **BEAM** (Mem0's benchmark line, 1M and 10M token scales): designed to be unsaturated; Mem0
+  self-reports 64.1 (BEAM-1M) and 48.6 (BEAM-10M) vs 94.4 on LongMemEval-V1 — the headroom
+  benchmark. Vendor-reported. https://mem0.ai/blog/ai-memory-benchmarks-in-2026
+- 2026 consensus pattern (multiple industry write-ups): hybrid — retrieval to narrow, long window to
+  reason across what survived. Nobody serious argues pure long-context for persistent multi-month
+  memory.
 
 ---
 
@@ -64,28 +164,60 @@ This is the most decisive cluster of 2026 results, and it cuts against expensive
 
 ### LongMemEval-V1 (500 q, ~115K-token histories) [CHAT]
 
-Saturating. Reported numbers (mix of peer-reviewed and vendor): OMEGA 95.4% (vendor), Mem0 94.4% (vendor), Memanto 89.8%, Emergence RAG 86%, MemForest 79.8% (30B model), TiMem 76.9–79.0%, Zep 71.2%. The spread between "simple RAG done well" (86%) and the top vendor claims (~90–95%) is within eval-protocol noise given LLM-judge variance; treat vendor deltas above ~85% as marketing precision. The Emergence result plus the bottleneck-diagnosis paper make the method-family story clear: **hybrid sparse+dense retrieval, session/document-scope expansion, cross-encoder reranking, and CoT-before-answer account for nearly all of the win**; graph traversal and heavyweight write pipelines account for little on this benchmark.
+Saturating. Reported numbers (mix of peer-reviewed and vendor): OMEGA 95.4% (vendor), Mem0 94.4%
+(vendor), Memanto 89.8%, Emergence RAG 86%, MemForest 79.8% (30B model), TiMem 76.9–79.0%, Zep
+71.2%. The spread between "simple RAG done well" (86%) and the top vendor claims (~90–95%) is within
+eval-protocol noise given LLM-judge variance; treat vendor deltas above ~85% as marketing precision.
+The Emergence result plus the bottleneck-diagnosis paper make the method-family story clear:
+**hybrid sparse+dense retrieval, session/document-scope expansion, cross-encoder reranking, and
+CoT-before-answer account for nearly all of the win**; graph traversal and heavyweight write
+pipelines account for little on this benchmark.
 
 ### LongMemEval-V2 (Wu, Ji, Kawatkar, Kwan, Gu, Peng, Chang; arXiv:2605.12493) [REALISTIC]
 
-- 451 manually curated questions over agent trajectories (up to 115M-token haystacks, up to 500 trajectories/haystack); five abilities: static state recall, dynamic state tracking, workflow knowledge, environment gotchas, premise awareness. Scored on accuracy AND latency (LAFS: latency-accuracy frontier score). Naive RAG small-tier baseline: 42.8%. Readers pinned (Qwen3.5-9B reader, Qwen3-Embedding-8B).
-- The paper's own failure decomposition splits errors into retrieval failures vs reader failures and concludes systems need advances in both — some methods win via retrieval, others via reading. No public leaderboard results table yet (repo confirms entries measure LAFS gain over the released baseline frontier; the board remains effectively open as of this week). https://github.com/xiaowu0162/LongMemEval-V2
-- This is the one benchmark in the set that matches Sibyl's actual workload (coding-agent trajectories, latency budget). Everything scoring 90%+ above is scoring on V1-style chat QA, not this.
+- 451 manually curated questions over agent trajectories (up to 115M-token haystacks, up to 500
+  trajectories/haystack); five abilities: static state recall, dynamic state tracking, workflow
+  knowledge, environment gotchas, premise awareness. Scored on accuracy AND latency (LAFS:
+  latency-accuracy frontier score). Naive RAG small-tier baseline: 42.8%. Readers pinned (Qwen3.5-9B
+  reader, Qwen3-Embedding-8B).
+- The paper's own failure decomposition splits errors into retrieval failures vs reader failures and
+  concludes systems need advances in both — some methods win via retrieval, others via reading. No
+  public leaderboard results table yet (repo confirms entries measure LAFS gain over the released
+  baseline frontier; the board remains effectively open as of this week).
+  https://github.com/xiaowu0162/LongMemEval-V2
+- This is the one benchmark in the set that matches Sibyl's actual workload (coding-agent
+  trajectories, latency budget). Everything scoring 90%+ above is scoring on V1-style chat QA, not
+  this.
 
 ### LoCoMo — increasingly distrusted [CHAT, flawed]
 
-- **Locomo-Plus** (arXiv:2602.10715) documents gold-answer errors (e.g., "Graphic Design" evidence keyed to a "Political science" gold), task-disclosed prompting artifacts, and string-matching metric distortion.
-- Statistical power is weak: 10 conversations; LongMemEval-V1 has only 30 preference questions (per benchmark-methodology critiques). Simple filesystem operations hit 74% on LoCoMo, matching sophisticated systems — the benchmark barely separates trivial from intelligent memory.
-- **MemoryAgentBench** (arXiv:2507.05257 lineage): four capabilities — accurate retrieval, test-time learning, long-range understanding, **selective forgetting**. No current system masters all four; most fail conspicuously on selective forgetting.
-- **AMA-Bench** (arXiv:2602.22769) and **"Agent Memory: Characterization and System Implications of Stateful Long-Horizon Workloads"** (arXiv:2606.06448) push evaluation toward real agentic workloads (the latter is a systems-side characterization worth reading for storage design).
+- **Locomo-Plus** (arXiv:2602.10715) documents gold-answer errors (e.g., "Graphic Design" evidence
+  keyed to a "Political science" gold), task-disclosed prompting artifacts, and string-matching
+  metric distortion.
+- Statistical power is weak: 10 conversations; LongMemEval-V1 has only 30 preference questions (per
+  benchmark-methodology critiques). Simple filesystem operations hit 74% on LoCoMo, matching
+  sophisticated systems — the benchmark barely separates trivial from intelligent memory.
+- **MemoryAgentBench** (arXiv:2507.05257 lineage): four capabilities — accurate retrieval, test-time
+  learning, long-range understanding, **selective forgetting**. No current system masters all four;
+  most fail conspicuously on selective forgetting.
+- **AMA-Bench** (arXiv:2602.22769) and **"Agent Memory: Characterization and System Implications of
+  Stateful Long-Horizon Workloads"** (arXiv:2606.06448) push evaluation toward real agentic
+  workloads (the latter is a systems-side characterization worth reading for storage design).
 
 ### Method families
 
-- **Hybrid sparse+dense + rerank**: dominant, per Section 2. BM25 alone often beats cosine alone on conversational memory.
-- **Graph traversal**: HippoRAG 2's PPR-over-phrase/passage-graph is the validated pattern; wins concentrated on multi-hop/associative questions (+7 F1), roughly neutral elsewhere.
-- **Query decomposition**: notably absent from the winning LongMemEval pipelines; Emergence explicitly skipped it. Survives mainly in multi-hop QA literature.
-- **Note-taking/distillation**: helps as an *additional* retrieval surface (union storage, trajectory notes — LME-V2's own rag+notes baseline), hurts as a replacement (Section 2).
-- **Navigation as retrieval**: HORMA (Section 5) — agentic filesystem navigation instead of embedding search; also **"From Passive Retrieval to Active Memory Navigation"** (arXiv:2607.05794) and **"Beyond RAG for Agent Memory: Retrieval by Decoupling and Aggregation"** (arXiv:2602.02007). This family trades latency for temporal/causal grounding.
+- **Hybrid sparse+dense + rerank**: dominant, per Section 2. BM25 alone often beats cosine alone on
+  conversational memory.
+- **Graph traversal**: HippoRAG 2's PPR-over-phrase/passage-graph is the validated pattern; wins
+  concentrated on multi-hop/associative questions (+7 F1), roughly neutral elsewhere.
+- **Query decomposition**: notably absent from the winning LongMemEval pipelines; Emergence
+  explicitly skipped it. Survives mainly in multi-hop QA literature.
+- **Note-taking/distillation**: helps as an _additional_ retrieval surface (union storage,
+  trajectory notes — LME-V2's own rag+notes baseline), hurts as a replacement (Section 2).
+- **Navigation as retrieval**: HORMA (Section 5) — agentic filesystem navigation instead of
+  embedding search; also **"From Passive Retrieval to Active Memory Navigation"** (arXiv:2607.05794)
+  and **"Beyond RAG for Agent Memory: Retrieval by Decoupling and Aggregation"** (arXiv:2602.02007).
+  This family trades latency for temporal/causal grounding.
 
 ---
 
@@ -93,16 +225,36 @@ Saturating. Reported numbers (mix of peer-reviewed and vendor): OMEGA 95.4% (ven
 
 The field now formally recognizes this as a separate loss bucket:
 
-- **"Sufficient Context: A New Lens on RAG Systems"** (Joren et al., Google; arXiv:2411.06037, ICLR 2025) — the foundational decomposition. An autorater classifies whether context sufficed; frontier models (GPT-4o, Gemini 1.5 Pro, Claude 3.5) still answer wrong on a non-trivial fraction of *sufficient-context* instances, and hallucinate rather than abstain on insufficient ones. Conclusion: open-book QA cannot be solved by retrieval improvements alone. Their selective-generation trick (sufficiency signal + self-confidence gating) improves correct-when-answering by 2–10%. [Controlled, realistic corpora]
-- **"Context Length Alone Hurts LLM Performance Despite Perfect Retrieval"** (arXiv:2510.05381) — length itself is a reader tax, no distractors needed. Directly supports tight packs over big packs at fixed recall.
-- **ActMem** (Zhang, Sun, Yang, Jin, Zhang, Hu; arXiv:2603.00026, Jun 2026) — names the "reader-conversion gap" explicitly and couples retrieval with active reasoning over retrieved memories rather than one-shot stuffing. Evaluated on LongMemEval/BABILong-family tasks. [CHAT]
-- **LongMemEval-V2's own error decomposition** (Section 3) institutionalizes retrieval-vs-reader failure attribution in the benchmark harness.
+- **"Sufficient Context: A New Lens on RAG Systems"** (Joren et al., Google; arXiv:2411.06037,
+  ICLR 2025) — the foundational decomposition. An autorater classifies whether context sufficed;
+  frontier models (GPT-4o, Gemini 1.5 Pro, Claude 3.5) still answer wrong on a non-trivial fraction
+  of _sufficient-context_ instances, and hallucinate rather than abstain on insufficient ones.
+  Conclusion: open-book QA cannot be solved by retrieval improvements alone. Their
+  selective-generation trick (sufficiency signal + self-confidence gating) improves
+  correct-when-answering by 2–10%. [Controlled, realistic corpora]
+- **"Context Length Alone Hurts LLM Performance Despite Perfect Retrieval"** (arXiv:2510.05381) —
+  length itself is a reader tax, no distractors needed. Directly supports tight packs over big packs
+  at fixed recall.
+- **ActMem** (Zhang, Sun, Yang, Jin, Zhang, Hu; arXiv:2603.00026, Jun 2026) — names the
+  "reader-conversion gap" explicitly and couples retrieval with active reasoning over retrieved
+  memories rather than one-shot stuffing. Evaluated on LongMemEval/BABILong-family tasks. [CHAT]
+- **LongMemEval-V2's own error decomposition** (Section 3) institutionalizes retrieval-vs-reader
+  failure attribution in the benchmark harness.
 - **What measurably helps the reader**:
   - **CoT-before-answer**: part of Emergence's 86% pipeline; the cheapest validated lever.
-  - **Two-stage read (extract facts → answer)**: Emergence's "Simple Fast" variant, 79% at 3.59s — a latency-friendly conversion booster.
-  - **Citation forcing**: FRONT-style fine-grained grounded citations (arXiv:2408.04568) and cite-before-you-speak (arXiv:2503.04830) improve grounding ~13.8% in e-commerce agents; GopherCite lineage. **Caveat**: "Are Finer Citations Always Better?" (arXiv:2604.01432) shows over-fine citation granularity *fractures semantic dependencies* and degrades both retrieval and faithful generation — force citations at span/passage level, not sentence-shard level.
-  - **Verifiable-reward training for groundedness** (arXiv:2506.15522) — post-training lever, not applicable to us directly but explains reader-model drift across versions.
-- **Interference as a reader failure**: **"Transformers Remember First, Forget Last: Dual-Process Interference in LLMs"** (arXiv:2603.00270) and SleepGate (Section 6): stale associations in context degrade retrieval of current values **log-linearly** as they accumulate — packing superseded memory versions actively poisons the reader.
+  - **Two-stage read (extract facts → answer)**: Emergence's "Simple Fast" variant, 79% at 3.59s — a
+    latency-friendly conversion booster.
+  - **Citation forcing**: FRONT-style fine-grained grounded citations (arXiv:2408.04568) and
+    cite-before-you-speak (arXiv:2503.04830) improve grounding ~13.8% in e-commerce agents;
+    GopherCite lineage. **Caveat**: "Are Finer Citations Always Better?" (arXiv:2604.01432) shows
+    over-fine citation granularity _fractures semantic dependencies_ and degrades both retrieval and
+    faithful generation — force citations at span/passage level, not sentence-shard level.
+  - **Verifiable-reward training for groundedness** (arXiv:2506.15522) — post-training lever, not
+    applicable to us directly but explains reader-model drift across versions.
+- **Interference as a reader failure**: **"Transformers Remember First, Forget Last: Dual-Process
+  Interference in LLMs"** (arXiv:2603.00270) and SleepGate (Section 6): stale associations in
+  context degrade retrieval of current values **log-linearly** as they accumulate — packing
+  superseded memory versions actively poisons the reader.
 
 ---
 
@@ -110,27 +262,73 @@ The field now formally recognizes this as a separate loss bucket:
 
 No paper directly tests user-style tags vs flat embeddings. The adjacent evidence:
 
-- **Typed-store routing** (ENGRAM, Section 1): the strongest categorization result — 3-way canonical typing with type-aware retrieval beats flat storage by 31 points on LoCoMo. This is category-as-retrieval-semantics, not category-as-label.
-- **HORMA — "Organize then Retrieve: Hierarchical Memory Navigation for Efficient Agents"** (Hsu, Kuang, Liu, Yao, He; Duke/Snowflake; arXiv:2606.11680, Jun 2026): filesystem-like hierarchy (timestamped directories, synthesized notes linked to raw traces) navigated by an agent with ls/grep/cd/cat. Beats embedding retrieval on ALFWorld (56.7%→73.9% by context size), LoCoMo LLM-judge 51.6 vs 32.2 truncation at 3–22% of baseline tokens, LongMemEval 55.9 best-overall at 1.2–16% tokens. Wins concentrate on **temporal consistency and staleness avoidance** — exactly where similarity search fails. Cost: agentic navigation latency. [Mixed CHAT/agent-sim]
-- **xMemory** (per survey arXiv:2602.06052) and **"Filesystem-Based Memory for LLM Agents"** (arXiv:2607.26637): hierarchy that disentangles episodic traces into semantic components, drill-down retrieval shrinking search space.
-- The sober caveat, stated in the hierarchical-memory literature itself: **simple retrieval outperforms complex hierarchies on standard benchmarks**; adopt hierarchy only for retrieval failures flat search demonstrably can't solve (temporal ordering, causal chains, scope narrowing).
-- Read across ENGRAM + HORMA + Memanto: categories earn accuracy only when they change retrieval behavior (routing, priority weighting, navigation paths, temporal scoping). Labels that are only filters at query time have no published accuracy evidence behind them.
+- **Typed-store routing** (ENGRAM, Section 1): the strongest categorization result — 3-way canonical
+  typing with type-aware retrieval beats flat storage by 31 points on LoCoMo. This is
+  category-as-retrieval-semantics, not category-as-label.
+- **HORMA — "Organize then Retrieve: Hierarchical Memory Navigation for Efficient Agents"** (Hsu,
+  Kuang, Liu, Yao, He; Duke/Snowflake; arXiv:2606.11680, Jun 2026): filesystem-like hierarchy
+  (timestamped directories, synthesized notes linked to raw traces) navigated by an agent with
+  ls/grep/cd/cat. Beats embedding retrieval on ALFWorld (56.7%→73.9% by context size), LoCoMo
+  LLM-judge 51.6 vs 32.2 truncation at 3–22% of baseline tokens, LongMemEval 55.9 best-overall at
+  1.2–16% tokens. Wins concentrate on **temporal consistency and staleness avoidance** — exactly
+  where similarity search fails. Cost: agentic navigation latency. [Mixed CHAT/agent-sim]
+- **xMemory** (per survey arXiv:2602.06052) and **"Filesystem-Based Memory for LLM Agents"**
+  (arXiv:2607.26637): hierarchy that disentangles episodic traces into semantic components,
+  drill-down retrieval shrinking search space.
+- The sober caveat, stated in the hierarchical-memory literature itself: **simple retrieval
+  outperforms complex hierarchies on standard benchmarks**; adopt hierarchy only for retrieval
+  failures flat search demonstrably can't solve (temporal ordering, causal chains, scope narrowing).
+- Read across ENGRAM + HORMA + Memanto: categories earn accuracy only when they change retrieval
+  behavior (routing, priority weighting, navigation paths, temporal scoping). Labels that are only
+  filters at query time have no published accuracy evidence behind them.
 
 ## 6. What the research says matters that Sibyl likely ignores
 
-1. **Selective forgetting / knowledge updates as a first-class operation.** MemoryAgentBench: the capability most systems conspicuously fail. **Infini Memory** (arXiv:2606.10677): single-hop forgetting is settled cheaply at *write time* via recency-override rewriting within a topic; multi-hop forgetting (chains across documents updated at different times) cannot be, and remains open. **TOKI** (arXiv:2606.06240) gives a bitemporal operator algebra for contradiction resolution — the formal version of what Graphiti's edge invalidation gestures at.
-2. **Proactive interference.** SleepGate — **"Learning to Forget: Sleep-Inspired Memory Consolidation for Resolving Proactive Interference"** (arXiv:2603.14517): stale associations degrade retrieval log-linearly; conflict-aware temporal tagging + eviction/consolidation fixes it. A memory system that never supersedes gets *worse* with age, not just bigger.
-3. **Write-time self-verification.** **MemGuard** (Ha, Kim, Qian, ..., Hakkani-Tur, Ji; arXiv:2605.28009): contamination (irrelevant/outdated/erroneous writes) accumulates and degrades long-horizon accuracy; verification gates at write time beat retrieval-time compensation. Evaluated on LongMemEval, PerLTQA, AgentBoard.
-4. **Reconsolidation / memory rewriting on retrieval.** ACT-R-inspired architectures (HAI 2025, dl.acm.org/10.1145/3765766.3765803) and the sleep-cycle papers implement retrieval-triggered re-encoding; nothing in our loop touches a memory after it's written except manual edits.
-5. **Procedural memory as a separate lane.** **ReasoningBank** (Google; arXiv:2509.25140): distills transferable reasoning strategies from both successes AND failures, self-judged without ground truth; **Memp** (procedural instructions + script abstractions with build/retrieve/update phases); **"Managing Procedural Memory in LLM Agents"** (arXiv:2606.23127); **"Compiling User Corrections into Runtime Enforcement for Coding Agents"** (arXiv:2606.13174) — user corrections as compiled enforcement rules, very close to our standing-grants/no-touch-zone capture. [REALISTIC — web/SWE agent workloads]
-6. **Benchmark hygiene.** LoCoMo gold errors and 74%-via-filesystem; ConvoMem's finding that memory systems only differentiate past ~150 conversations; BEAM as the unsaturated headroom line. Chat-benchmark wins do not transfer claims to trajectory-scale workloads — LME-V2 is the only public benchmark in our shape.
+1. **Selective forgetting / knowledge updates as a first-class operation.** MemoryAgentBench: the
+   capability most systems conspicuously fail. **Infini Memory** (arXiv:2606.10677): single-hop
+   forgetting is settled cheaply at _write time_ via recency-override rewriting within a topic;
+   multi-hop forgetting (chains across documents updated at different times) cannot be, and remains
+   open. **TOKI** (arXiv:2606.06240) gives a bitemporal operator algebra for contradiction
+   resolution — the formal version of what Graphiti's edge invalidation gestures at.
+2. **Proactive interference.** SleepGate — **"Learning to Forget: Sleep-Inspired Memory
+   Consolidation for Resolving Proactive Interference"** (arXiv:2603.14517): stale associations
+   degrade retrieval log-linearly; conflict-aware temporal tagging + eviction/consolidation fixes
+   it. A memory system that never supersedes gets _worse_ with age, not just bigger.
+3. **Write-time self-verification.** **MemGuard** (Ha, Kim, Qian, ..., Hakkani-Tur, Ji;
+   arXiv:2605.28009): contamination (irrelevant/outdated/erroneous writes) accumulates and degrades
+   long-horizon accuracy; verification gates at write time beat retrieval-time compensation.
+   Evaluated on LongMemEval, PerLTQA, AgentBoard.
+4. **Reconsolidation / memory rewriting on retrieval.** ACT-R-inspired architectures (HAI 2025,
+   dl.acm.org/10.1145/3765766.3765803) and the sleep-cycle papers implement retrieval-triggered
+   re-encoding; nothing in our loop touches a memory after it's written except manual edits.
+5. **Procedural memory as a separate lane.** **ReasoningBank** (Google; arXiv:2509.25140): distills
+   transferable reasoning strategies from both successes AND failures, self-judged without ground
+   truth; **Memp** (procedural instructions + script abstractions with build/retrieve/update
+   phases); **"Managing Procedural Memory in LLM Agents"** (arXiv:2606.23127); **"Compiling User
+   Corrections into Runtime Enforcement for Coding Agents"** (arXiv:2606.13174) — user corrections
+   as compiled enforcement rules, very close to our standing-grants/no-touch-zone capture.
+   [REALISTIC — web/SWE agent workloads]
+6. **Benchmark hygiene.** LoCoMo gold errors and 74%-via-filesystem; ConvoMem's finding that memory
+   systems only differentiate past ~150 conversations; BEAM as the unsaturated headroom line.
+   Chat-benchmark wins do not transfer claims to trajectory-scale workloads — LME-V2 is the only
+   public benchmark in our shape.
 
 ---
 
 ## Cross-cutting synthesis for Sibyl 1.3
 
-- Our own measurements (selection ceiling 82.6% vs best render 65.2%; reader-conversion loss bucket) reproduce the field's central 2026 finding: retrieval selection and reader conversion dominate; write-time representation sophistication is third.
-- Passage projection is on the right side of the Fidelity-Before-Structure result *if* projected spans preserve verbatim source text and coexist with any distilled note (union, never replacement). The 42.5%-recovery number is the design rule.
-- Mostly-untyped edges: no evidence we're leaving accuracy on the table with untyped *relations*. Type-aware *retrieval semantics* over our existing type enum (ENGRAM/Memanto pattern: per-type priority weighting, temporal scoping) is the evidenced upgrade, and it's a retrieval-side change, not a schema migration.
-- Reader levers with receipts: CoT-before-answer, extract-then-answer two-stage, span-level citation forcing, sufficiency-gated abstention, and *not* packing superseded versions (interference is log-linear in stale entries).
-- Biggest ignored-by-us lane: supersede/forget as a write-path operation with temporal tagging, plus write-time contamination gating.
+- Our own measurements (selection ceiling 82.6% vs best render 65.2%; reader-conversion loss bucket)
+  reproduce the field's central 2026 finding: retrieval selection and reader conversion dominate;
+  write-time representation sophistication is third.
+- Passage projection is on the right side of the Fidelity-Before-Structure result _if_ projected
+  spans preserve verbatim source text and coexist with any distilled note (union, never
+  replacement). The 42.5%-recovery number is the design rule.
+- Mostly-untyped edges: no evidence we're leaving accuracy on the table with untyped _relations_.
+  Type-aware _retrieval semantics_ over our existing type enum (ENGRAM/Memanto pattern: per-type
+  priority weighting, temporal scoping) is the evidenced upgrade, and it's a retrieval-side change,
+  not a schema migration.
+- Reader levers with receipts: CoT-before-answer, extract-then-answer two-stage, span-level citation
+  forcing, sufficiency-gated abstention, and _not_ packing superseded versions (interference is
+  log-linear in stale entries).
+- Biggest ignored-by-us lane: supersede/forget as a write-path operation with temporal tagging, plus
+  write-time contamination gating.

--- a/docs/architecture/AUDIT_2026-08-13/sota-research.md
+++ b/docs/architecture/AUDIT_2026-08-13/sota-research.md
@@ -1,0 +1,136 @@
+# Agent Memory Research SOTA — August 2026
+
+Research-side survey (papers, benchmarks, empirical findings) for Sibyl 1.3 representation/retrieval decisions. Products are covered by a sibling report. Compiled 2026-08-13.
+
+Reading key: [REALISTIC] = evaluated on realistic agent workloads (long trajectories, tool use, latency budgets). [CHAT] = long-conversation QA benchmarks (LoCoMo, LongMemEval-S/M). [TOY] = synthetic or narrow probes.
+
+---
+
+## 1. Representation research
+
+### Temporal knowledge graphs: the Zep/Graphiti lineage
+
+- **Zep: A Temporal Knowledge Graph Architecture for Agent Memory** (Rasmussen et al., arXiv:2501.13956) remains the canonical TKG-memory paper: bi-temporal edges (valid time + transaction time), episodic/entity/community node types. Graphiti crossed 20K GitHub stars in 2026. But its headline numbers have aged badly: on LongMemEval-V1, Zep scores 71.2% while a plain RAG pipeline with reranking hits 86% (Emergence AI, below). https://arxiv.org/abs/2501.13956
+- **HippoRAG 2 — "From RAG to Memory: Non-Parametric Continual Learning for LLMs"** (Gutierrez et al., OSU, arXiv:2502.14802) is the strongest graph-retrieval result with a controlled story: dual-node KG (phrase nodes + passage nodes), Personalized PageRank seeded by embedding scores, LLM triple filtering. +7 F1 on associative (multi-hop) QA over SOTA dense retrievers. Critically, HippoRAG 2 names "context loss during indexing" as the fatal flaw of HippoRAG 1 — the graph works only because passage nodes keep verbatim text in the loop. [CHAT/multi-hop QA] https://arxiv.org/pdf/2502.14802
+- Successors in the graph lane: **GAAMA: Graph Augmented Associative Memory** (arXiv:2603.27910), **Synapse** (arXiv:2601.02744, Feb 2026) which models memory as a dynamic graph where relevance emerges from *spreading activation* rather than pre-computed links, and **"Implicit Graph, Explicit Retrieval"** (arXiv:2601.03417) arguing the graph should be latent while retrieval stays cheap and interpretable. Direction of travel: away from expensive explicit triple extraction, toward graphs as a traversal/activation structure over preserved text.
+- **Association Is Not Similarity** (arXiv:2604.20850) — learns corpus-specific association weights for multi-hop retrieval; relevant if we ever score edges for traversal.
+
+### Typed vs untyped structure — what the controlled evidence actually says
+
+Two different claims get conflated; the evidence splits cleanly:
+
+- **Typed STORE separation (episodic/semantic/procedural routing) has strong evidence.** **ENGRAM: Effective, Lightweight Memory Orchestration for Conversational Agents** (arXiv:2511.12960, also OpenReview): routes conversation into three canonical memory types with a single router+retriever. LoCoMo LLM-judge 77.55%, beating Mem0, MemOS, LangMem, Zep. The ablation is the money shot: collapsing the three stores into one undifferentiated store drops to **46.56%** (−31 points). [CHAT] https://arxiv.org/abs/2511.12960
+- **Memanto: Typed Semantic Memory with Information-Theoretic Retrieval** (Abtahi et al., arXiv:2604.22085, Apr 2026) extends this to 13 semantic categories (facts, preferences, decisions, commitments, goals, events, instructions, relationships, context, learning, observations, errors, artifacts), each with distinct retrieval semantics and priority weighting. LongMemEval 89.8%, LoCoMo 87.1%. No direct typed-vs-untyped ablation of its own; leans on ENGRAM's. [CHAT] https://arxiv.org/html/2604.22085v1
+- **Typed EDGES/ontologies: evidence is thinner and conditional.** **Ontology Learning and KG Construction: A Comparison of Approaches and Their Impact on RAG Performance** (arXiv:2511.05991) is the best controlled comparison: vector RAG vs GraphRAG vs several ontology-grounded KGs, holding corpus/retrieval/eval constant. Ontology-grounded approaches win — but specifically the variants **that keep textual chunk information attached**; the win is interpretability + hallucination reduction, and DB-derived ontologies match text-extracted ones at far lower LLM cost. [CHAT/QA corpora] https://arxiv.org/abs/2511.05991
+- **OntoKG** (arXiv:2604.02618) isolates type annotations on controlled mentions (same candidate entities both arms): type annotations, not candidate coverage, drive the accuracy difference. [TOY-leaning, entity-linking probe]
+- **For code specifically**: **"Reliable Graph-RAG for Codebases: AST-Derived Graphs vs LLM-Extracted Knowledge Graphs"** (arXiv:2601.08773) — deterministic AST-derived structure beats LLM-extracted KGs for codebase QA. Structure you can compute exactly beats structure you hallucinate. [REALISTIC for coding]
+
+Net: no paper shows that *typed relations on a memory graph* improve end-task accuracy over untyped edges in a controlled way. What is shown: typed top-level stores/categories with type-aware retrieval semantics help a lot; ontology structure helps when it augments rather than replaces text.
+
+### Ontology-free / atomic-note approaches
+
+- **A-Mem: Agentic Memory for LLM Agents** (Xu et al., arXiv:2502.12110; NeurIPS/OpenReview) — Zettelkasten-style atomic notes with LLM-generated contextual descriptions and links, memory evolution on write. Up to 2x GPT-4o-mini multi-hop on LoCoMo, 85–93% fewer memory-operation tokens than MemGPT. [CHAT] https://arxiv.org/pdf/2502.12110
+- **AtomMem** (arXiv:2606.19847, Jun 2026) — "simple and effective memory via atomic facts"; the minimalist counterpoint arguing atomic facts + good retrieval match heavyweight systems. [CHAT]
+- **Schema-constrained middle ground**: **"To Know is to Construct: Schema-Constrained Generation for Agent Memory"** (arXiv:2604.20117) and **"From Unstructured Recall to Schema-Grounded Memory: Reliable AI Memory via Iterative, Schema-Aware Extraction"** (arXiv:2604.27906) — extraction reliability improves when a schema constrains generation; the failure mode they target is exactly the lossy/hallucinated extraction that Fidelity-Before-Structure (Section 2) measures.
+
+### Episodic vs semantic splits, consolidation, sleep-time compute
+
+- **SYNAPSE** (arXiv:2601.02744) — episodic-semantic memory via spreading activation; minimal activated subsets beat strong baselines. **E-mem** (arXiv:2601.21714) — multi-agent episodic context reconstruction. **Episodic-Semantic Memory for Long-Horizon Scientific Agents** (arXiv:2605.17625) — retains semantic knowledge from old topics while discarding dated episodic detail. [CHAT/agent-sim]
+- **Sleep-time compute lineage**: Letta's **"Sleep-time Compute: Beyond Inference Scaling at Test-time"** (arXiv:2504.13171, 2025) established the framing (pre-compute representations off the critical path). 2026 successors: **SCM: Sleep-Consolidated Memory** (arXiv:2604.20943) with multi-stage sleep cycles (consolidation, dreaming, intentional forgetting); **"Language Models Need Sleep: Learning to Self-Modify and Consolidate Memories"** (arXiv:2606.03979) — distill fragile short-term memory into stable long-term knowledge with replay; **TiMem: Temporal-Hierarchical Memory Consolidation** (arXiv:2601.02845) — 76.9–79.0% on LongMemEval-S depending on reader. [CHAT, some TOY]
+- **"Sleep-Like Memory Consolidation in LLMs"** (arXiv:2605.26099) — periodic conversion of recent context into persistent fast weights; longer "sleep" decouples memory capacity from reasoning compute. [TOY + real benchmarks, weight-space so not directly applicable to an external store]
+
+---
+
+## 2. Storage-time vs retrieval-time intelligence
+
+This is the most decisive cluster of 2026 results, and it cuts against expensive write-time structuring **when structure replaces raw text**:
+
+- **"Diagnosing Retrieval vs. Utilization Bottlenecks in LLM Agent Memory"** (Yuan, Su, Yao; MemAgents Workshop @ ICLR 2026; arXiv:2603.02473). 3x3 factorial: write strategies {raw chunks, Mem0-style fact extraction, MemGPT-style summarization} x retrieval {cosine, BM25, hybrid+rerank} on LoCoMo. **Retrieval method spans 20 points (57.1%→77.2%); write strategy spans 3–8 points.** Raw chunks (zero LLM calls at write time) match or beat both lossy alternatives. Failures manifest at the retrieval stage, not utilization, in their decomposition. Conclusion verbatim: "improving retrieval quality yields larger gains than increasing write-time sophistication." [CHAT] https://arxiv.org/abs/2603.02473
+- **"Fidelity Before Structure: Verbatim Chunks Beat Lossy Artifact Extraction in Long-Conversation LLM Memory"** (Tao An, arXiv:2601.00821v4, Jul 2026). Same retrieval pipeline, storage varied: LoCoMo chunks 43.9% vs artifacts 28.0% (−15.9); LongMemEval-S chunks 67.4% vs artifacts 45.4% (−22.0). Extracted artifacts fail to beat naive RAG at all (p=0.89). **Union storage (chunks + artifacts) recovers chunk-level accuracy (42.5%)** — the damage is *replacement*, not coexistence. Mechanism: accuracy tracks how much source text survives storage ("lossy distillation"). Six confound controls. Recommendation: "structure should augment verbatim text, not replace it." [CHAT] https://arxiv.org/html/2601.00821
+- **Emergence AI, "SOTA on LongMemEval with RAG"** (blog, engineering result not peer-reviewed): 86% on LongMemEval-V1 (vs Zep 71.2%, vs Oracle GPT-4o 82.4%) with turn-level matching → session-level retrieval → cross-encoder rerank → CoT-before-answer. No query decomposition, no graph, no temporal module. Their own conclusion: "advanced memory architecture appears to be overkill for LongMemEval." [CHAT] https://www.emergence.ai/blog/sota-on-longmemeval-with-rag
+- **Counterweight — write-time work that DOES pay**: ENGRAM/Memanto typed routing (cheap classification, not lossy rewriting); **"Beyond Static Summarization: Proactive Memory Extraction"** (arXiv:2601.04463); MemGuard write-time contamination filtering (Section 6); and Infini Memory's write-time recency rewriting for single-hop knowledge updates (Section 6). Pattern: cheap write-time *routing, tagging, verification, and superseding* pays; expensive write-time *rewriting that discards source text* does not.
+
+### Long-context vs RAG as of mid-2026
+
+- **"Long Context vs. RAG for LLMs: An Evaluation and Revisits"** (arXiv:2501.01880) and **LongBench v2** (arXiv:2412.15204): long context wins when the corpus fits and the model is frontier-class; RAG wins on cost and on mid-window content. Position sensitivity persists: relevant content buried mid-window still costs 30%+ accuracy in 2026 practice write-ups.
+- **"Context Length Alone Hurts LLM Performance Despite Perfect Retrieval"** (arXiv:2510.05381, EMNLP 2025 Findings): even with perfect retrieval, sheer input length degrades answers — independent of distraction. This is a reader-side result with direct implications for pack sizing. [Controlled, semi-TOY]
+- **ConvoMem** (Pakhomov, Nijkamp, Xiong — Salesforce; arXiv:2511.10523): "why your first 150 conversations don't need RAG" — full-context is competitive up to ~150 conversations; memory systems only earn their keep beyond that. Implication: memory-system evaluation must be at scale or it measures nothing. [CHAT]
+- **BEAM** (Mem0's benchmark line, 1M and 10M token scales): designed to be unsaturated; Mem0 self-reports 64.1 (BEAM-1M) and 48.6 (BEAM-10M) vs 94.4 on LongMemEval-V1 — the headroom benchmark. Vendor-reported. https://mem0.ai/blog/ai-memory-benchmarks-in-2026
+- 2026 consensus pattern (multiple industry write-ups): hybrid — retrieval to narrow, long window to reason across what survived. Nobody serious argues pure long-context for persistent multi-month memory.
+
+---
+
+## 3. Retrieval research: what's winning on the benchmarks
+
+### LongMemEval-V1 (500 q, ~115K-token histories) [CHAT]
+
+Saturating. Reported numbers (mix of peer-reviewed and vendor): OMEGA 95.4% (vendor), Mem0 94.4% (vendor), Memanto 89.8%, Emergence RAG 86%, MemForest 79.8% (30B model), TiMem 76.9–79.0%, Zep 71.2%. The spread between "simple RAG done well" (86%) and the top vendor claims (~90–95%) is within eval-protocol noise given LLM-judge variance; treat vendor deltas above ~85% as marketing precision. The Emergence result plus the bottleneck-diagnosis paper make the method-family story clear: **hybrid sparse+dense retrieval, session/document-scope expansion, cross-encoder reranking, and CoT-before-answer account for nearly all of the win**; graph traversal and heavyweight write pipelines account for little on this benchmark.
+
+### LongMemEval-V2 (Wu, Ji, Kawatkar, Kwan, Gu, Peng, Chang; arXiv:2605.12493) [REALISTIC]
+
+- 451 manually curated questions over agent trajectories (up to 115M-token haystacks, up to 500 trajectories/haystack); five abilities: static state recall, dynamic state tracking, workflow knowledge, environment gotchas, premise awareness. Scored on accuracy AND latency (LAFS: latency-accuracy frontier score). Naive RAG small-tier baseline: 42.8%. Readers pinned (Qwen3.5-9B reader, Qwen3-Embedding-8B).
+- The paper's own failure decomposition splits errors into retrieval failures vs reader failures and concludes systems need advances in both — some methods win via retrieval, others via reading. No public leaderboard results table yet (repo confirms entries measure LAFS gain over the released baseline frontier; the board remains effectively open as of this week). https://github.com/xiaowu0162/LongMemEval-V2
+- This is the one benchmark in the set that matches Sibyl's actual workload (coding-agent trajectories, latency budget). Everything scoring 90%+ above is scoring on V1-style chat QA, not this.
+
+### LoCoMo — increasingly distrusted [CHAT, flawed]
+
+- **Locomo-Plus** (arXiv:2602.10715) documents gold-answer errors (e.g., "Graphic Design" evidence keyed to a "Political science" gold), task-disclosed prompting artifacts, and string-matching metric distortion.
+- Statistical power is weak: 10 conversations; LongMemEval-V1 has only 30 preference questions (per benchmark-methodology critiques). Simple filesystem operations hit 74% on LoCoMo, matching sophisticated systems — the benchmark barely separates trivial from intelligent memory.
+- **MemoryAgentBench** (arXiv:2507.05257 lineage): four capabilities — accurate retrieval, test-time learning, long-range understanding, **selective forgetting**. No current system masters all four; most fail conspicuously on selective forgetting.
+- **AMA-Bench** (arXiv:2602.22769) and **"Agent Memory: Characterization and System Implications of Stateful Long-Horizon Workloads"** (arXiv:2606.06448) push evaluation toward real agentic workloads (the latter is a systems-side characterization worth reading for storage design).
+
+### Method families
+
+- **Hybrid sparse+dense + rerank**: dominant, per Section 2. BM25 alone often beats cosine alone on conversational memory.
+- **Graph traversal**: HippoRAG 2's PPR-over-phrase/passage-graph is the validated pattern; wins concentrated on multi-hop/associative questions (+7 F1), roughly neutral elsewhere.
+- **Query decomposition**: notably absent from the winning LongMemEval pipelines; Emergence explicitly skipped it. Survives mainly in multi-hop QA literature.
+- **Note-taking/distillation**: helps as an *additional* retrieval surface (union storage, trajectory notes — LME-V2's own rag+notes baseline), hurts as a replacement (Section 2).
+- **Navigation as retrieval**: HORMA (Section 5) — agentic filesystem navigation instead of embedding search; also **"From Passive Retrieval to Active Memory Navigation"** (arXiv:2607.05794) and **"Beyond RAG for Agent Memory: Retrieval by Decoupling and Aggregation"** (arXiv:2602.02007). This family trades latency for temporal/causal grounding.
+
+---
+
+## 4. Reader conversion (evidence present, answer wrong)
+
+The field now formally recognizes this as a separate loss bucket:
+
+- **"Sufficient Context: A New Lens on RAG Systems"** (Joren et al., Google; arXiv:2411.06037, ICLR 2025) — the foundational decomposition. An autorater classifies whether context sufficed; frontier models (GPT-4o, Gemini 1.5 Pro, Claude 3.5) still answer wrong on a non-trivial fraction of *sufficient-context* instances, and hallucinate rather than abstain on insufficient ones. Conclusion: open-book QA cannot be solved by retrieval improvements alone. Their selective-generation trick (sufficiency signal + self-confidence gating) improves correct-when-answering by 2–10%. [Controlled, realistic corpora]
+- **"Context Length Alone Hurts LLM Performance Despite Perfect Retrieval"** (arXiv:2510.05381) — length itself is a reader tax, no distractors needed. Directly supports tight packs over big packs at fixed recall.
+- **ActMem** (Zhang, Sun, Yang, Jin, Zhang, Hu; arXiv:2603.00026, Jun 2026) — names the "reader-conversion gap" explicitly and couples retrieval with active reasoning over retrieved memories rather than one-shot stuffing. Evaluated on LongMemEval/BABILong-family tasks. [CHAT]
+- **LongMemEval-V2's own error decomposition** (Section 3) institutionalizes retrieval-vs-reader failure attribution in the benchmark harness.
+- **What measurably helps the reader**:
+  - **CoT-before-answer**: part of Emergence's 86% pipeline; the cheapest validated lever.
+  - **Two-stage read (extract facts → answer)**: Emergence's "Simple Fast" variant, 79% at 3.59s — a latency-friendly conversion booster.
+  - **Citation forcing**: FRONT-style fine-grained grounded citations (arXiv:2408.04568) and cite-before-you-speak (arXiv:2503.04830) improve grounding ~13.8% in e-commerce agents; GopherCite lineage. **Caveat**: "Are Finer Citations Always Better?" (arXiv:2604.01432) shows over-fine citation granularity *fractures semantic dependencies* and degrades both retrieval and faithful generation — force citations at span/passage level, not sentence-shard level.
+  - **Verifiable-reward training for groundedness** (arXiv:2506.15522) — post-training lever, not applicable to us directly but explains reader-model drift across versions.
+- **Interference as a reader failure**: **"Transformers Remember First, Forget Last: Dual-Process Interference in LLMs"** (arXiv:2603.00270) and SleepGate (Section 6): stale associations in context degrade retrieval of current values **log-linearly** as they accumulate — packing superseded memory versions actively poisons the reader.
+
+---
+
+## 5. Tagging / categorization vs flat embeddings
+
+No paper directly tests user-style tags vs flat embeddings. The adjacent evidence:
+
+- **Typed-store routing** (ENGRAM, Section 1): the strongest categorization result — 3-way canonical typing with type-aware retrieval beats flat storage by 31 points on LoCoMo. This is category-as-retrieval-semantics, not category-as-label.
+- **HORMA — "Organize then Retrieve: Hierarchical Memory Navigation for Efficient Agents"** (Hsu, Kuang, Liu, Yao, He; Duke/Snowflake; arXiv:2606.11680, Jun 2026): filesystem-like hierarchy (timestamped directories, synthesized notes linked to raw traces) navigated by an agent with ls/grep/cd/cat. Beats embedding retrieval on ALFWorld (56.7%→73.9% by context size), LoCoMo LLM-judge 51.6 vs 32.2 truncation at 3–22% of baseline tokens, LongMemEval 55.9 best-overall at 1.2–16% tokens. Wins concentrate on **temporal consistency and staleness avoidance** — exactly where similarity search fails. Cost: agentic navigation latency. [Mixed CHAT/agent-sim]
+- **xMemory** (per survey arXiv:2602.06052) and **"Filesystem-Based Memory for LLM Agents"** (arXiv:2607.26637): hierarchy that disentangles episodic traces into semantic components, drill-down retrieval shrinking search space.
+- The sober caveat, stated in the hierarchical-memory literature itself: **simple retrieval outperforms complex hierarchies on standard benchmarks**; adopt hierarchy only for retrieval failures flat search demonstrably can't solve (temporal ordering, causal chains, scope narrowing).
+- Read across ENGRAM + HORMA + Memanto: categories earn accuracy only when they change retrieval behavior (routing, priority weighting, navigation paths, temporal scoping). Labels that are only filters at query time have no published accuracy evidence behind them.
+
+## 6. What the research says matters that Sibyl likely ignores
+
+1. **Selective forgetting / knowledge updates as a first-class operation.** MemoryAgentBench: the capability most systems conspicuously fail. **Infini Memory** (arXiv:2606.10677): single-hop forgetting is settled cheaply at *write time* via recency-override rewriting within a topic; multi-hop forgetting (chains across documents updated at different times) cannot be, and remains open. **TOKI** (arXiv:2606.06240) gives a bitemporal operator algebra for contradiction resolution — the formal version of what Graphiti's edge invalidation gestures at.
+2. **Proactive interference.** SleepGate — **"Learning to Forget: Sleep-Inspired Memory Consolidation for Resolving Proactive Interference"** (arXiv:2603.14517): stale associations degrade retrieval log-linearly; conflict-aware temporal tagging + eviction/consolidation fixes it. A memory system that never supersedes gets *worse* with age, not just bigger.
+3. **Write-time self-verification.** **MemGuard** (Ha, Kim, Qian, ..., Hakkani-Tur, Ji; arXiv:2605.28009): contamination (irrelevant/outdated/erroneous writes) accumulates and degrades long-horizon accuracy; verification gates at write time beat retrieval-time compensation. Evaluated on LongMemEval, PerLTQA, AgentBoard.
+4. **Reconsolidation / memory rewriting on retrieval.** ACT-R-inspired architectures (HAI 2025, dl.acm.org/10.1145/3765766.3765803) and the sleep-cycle papers implement retrieval-triggered re-encoding; nothing in our loop touches a memory after it's written except manual edits.
+5. **Procedural memory as a separate lane.** **ReasoningBank** (Google; arXiv:2509.25140): distills transferable reasoning strategies from both successes AND failures, self-judged without ground truth; **Memp** (procedural instructions + script abstractions with build/retrieve/update phases); **"Managing Procedural Memory in LLM Agents"** (arXiv:2606.23127); **"Compiling User Corrections into Runtime Enforcement for Coding Agents"** (arXiv:2606.13174) — user corrections as compiled enforcement rules, very close to our standing-grants/no-touch-zone capture. [REALISTIC — web/SWE agent workloads]
+6. **Benchmark hygiene.** LoCoMo gold errors and 74%-via-filesystem; ConvoMem's finding that memory systems only differentiate past ~150 conversations; BEAM as the unsaturated headroom line. Chat-benchmark wins do not transfer claims to trajectory-scale workloads — LME-V2 is the only public benchmark in our shape.
+
+---
+
+## Cross-cutting synthesis for Sibyl 1.3
+
+- Our own measurements (selection ceiling 82.6% vs best render 65.2%; reader-conversion loss bucket) reproduce the field's central 2026 finding: retrieval selection and reader conversion dominate; write-time representation sophistication is third.
+- Passage projection is on the right side of the Fidelity-Before-Structure result *if* projected spans preserve verbatim source text and coexist with any distilled note (union, never replacement). The 42.5%-recovery number is the design rule.
+- Mostly-untyped edges: no evidence we're leaving accuracy on the table with untyped *relations*. Type-aware *retrieval semantics* over our existing type enum (ENGRAM/Memanto pattern: per-type priority weighting, temporal scoping) is the evidenced upgrade, and it's a retrieval-side change, not a schema migration.
+- Reader levers with receipts: CoT-before-answer, extract-then-answer two-stage, span-level citation forcing, sufficiency-gated abstention, and *not* packing superseded versions (interference is log-linear in stale entries).
+- Biggest ignored-by-us lane: supersede/forget as a write-path operation with temporal tagging, plus write-time contamination gating.

--- a/docs/architecture/AUDIT_2026-08-13/sota-systems.md
+++ b/docs/architecture/AUDIT_2026-08-13/sota-systems.md
@@ -29,21 +29,20 @@ remains open, 3 weeks after our July read said the same.
   (docs → structured pages with link graphs), Code-Graph (symbols/calls/impact paths). Retrieval:
   BM25 + vector + RRF under strict token/character budgets. Governance: private/team/restricted/
   agent-targeted visibility, "private is owner-only, not readable even by team admins," explicit
-  sharing. Self-reported PersonaMem 48%→76%; no independent reproduction.
-  Repo: github.com/TencentCloud/TencentDB-Agent-Memory.
-  **This is our scope ladder, our budgeted packs, and our team story, shipped by Tencent with a
-  20k-star megaphone.** What it does NOT have: a knowledge graph, provenance-per-write semantics,
-  or (apparently) an LLM-free write path.
+  sharing. Self-reported PersonaMem 48%→76%; no independent reproduction. Repo:
+  github.com/TencentCloud/TencentDB-Agent-Memory. **This is our scope ladder, our budgeted packs,
+  and our team story, shipped by Tencent with a 20k-star megaphone.** What it does NOT have: a
+  knowledge graph, provenance-per-write semantics, or (apparently) an LLM-free write path.
 - **Hindsight went after coding agents.** v0.9.0 (2026-08-07, verified release notes): a
   `hindsight-coding-agents` package — "harness-pluggable long-term memory for coding agents" — plus
   transcript readers for Copilot CLI and Devin, OpenClaw plugins, Obsidian vault ingestion,
-  client-managed Knowledge Pages, and "Mental Models" (consolidated per-scope syntheses with
-  dry-run refresh). 19,898 stars (verified). Release cadence is ~weekly.
-- **Mem0 published its "State of AI Agent Memory 2026" report today (2026-08-13)** and it contains
-  a load-bearing architecture confession: Mem0 moved from external graph stores (Neo4j) to
-  "built-in entity linking" — the `relations` field is **removed**, there is "no longer a queryable
-  graph interface," entities influence retrieval ranking but cannot be traversed. Their own words:
-  for teams needing traversable graphs this is "a regression." (Fetched from
+  client-managed Knowledge Pages, and "Mental Models" (consolidated per-scope syntheses with dry-run
+  refresh). 19,898 stars (verified). Release cadence is ~weekly.
+- **Mem0 published its "State of AI Agent Memory 2026" report today (2026-08-13)** and it contains a
+  load-bearing architecture confession: Mem0 moved from external graph stores (Neo4j) to "built-in
+  entity linking" — the `relations` field is **removed**, there is "no longer a queryable graph
+  interface," entities influence retrieval ranking but cannot be traversed. Their own words: for
+  teams needing traversable graphs this is "a regression." (Fetched from
   mem0.ai/blog/state-of-ai-agent-memory-2026.)
 - **Elastic entered** (missed by the July sweep): Atlas agent memory, open-sourced 2026-06-30
   (InfoQ). Cognitive-science triad — episodic / semantic / procedural memories in separate
@@ -68,13 +67,14 @@ remains open, 3 weeks after our July read said the same.
 ## 2. System profiles
 
 ### Zep / Graphiti — the typed-relations flagship
+
 - **Representation** (verified from help.getzep.com custom-entity-and-edge-types doc): temporal
   knowledge graph. Facts are edges with `valid_at`/`invalid_at` bitemporal handling (invalidation
   preserves history + provenance). Custom entity AND edge types are **Pydantic models with typed
   attributes** (e.g. an `Employment` edge carrying `position`, `start_date`, `salary`,
   `is_current`). An `edge_type_map` constrains which edge types may form between entity-type pairs,
   e.g. `("Person","Company"): ["Employment"]`. Untyped pairs fall back to **generic RELATES_TO** —
-  the default graph is exactly Sibyl's shape; typing is opt-in schema work by the *developer*, not
+  the default graph is exactly Sibyl's shape; typing is opt-in schema work by the _developer_, not
   the writing agent. Extraction pipeline: LLM detects → classifies against the map → populates
   attributes → Pydantic validates.
 - **Tagging**: no user-facing tag system; typing IS the categorization. Group graphs for scoping.
@@ -88,14 +88,15 @@ remains open, 3 weeks after our July read said the same.
 - **Benchmarks**: old LongMemEval-v1 claims (71.2–90.2 across eras); nothing new since July.
 
 ### Mem0 — volume leader, retreating from structure
+
 - **Representation** (their Aug 13 report, fetched): extracted **facts** as flat text, single-pass
   ADD-only extraction at `add()` time; agent-generated facts now first-class alongside user facts.
   Graph memory: **removed as a queryable surface** (see delta above). Temporal: admits "temporal
   abstraction at scale" is a weakness (25% drop from BEAM-1M to BEAM-10M).
 - **Tagging** (verified from docs.mem0.ai custom-categories): 15 default categories
-  (`personal_details`, `food`, `travel`, ... `misc`), replaceable with custom lists;
-  auto-classified asynchronously post-ingestion. Docs show no filter-by-category retrieval —
-  categories are for reporting/organization. **Vestigial for retrieval.**
+  (`personal_details`, `food`, `travel`, ... `misc`), replaceable with custom lists; auto-classified
+  asynchronously post-ingestion. Docs show no filter-by-category retrieval — categories are for
+  reporting/organization. **Vestigial for retrieval.**
 - **Retrieval**: multi-signal — semantic + BM25 + entity matching; entity links boost ranking only.
 - **Numbers** (self-published, Aug 13 report): LoCoMo 92.5 @~6,956 tok/query, LongMemEval-v1 94.4
   @~6,787, BEAM-1M 64.1, BEAM-10M 48.6. Admitted open problems: identity resolution, staleness,
@@ -103,12 +104,13 @@ remains open, 3 weeks after our July read said the same.
 - **Releases**: v2.0.18 (2026-08-11, verified). 63.2k stars.
 
 ### cognee — the ontology camp
+
 - **Representation** (verified via docs + search): semantic graph of **Pydantic DataPoint** typed
   nodes; optional **OWL ontology grounding** (RDF/XML): entity types fuzzy-matched to OWL classes
   (80% cutoff), individuals matched, names canonicalized to URI-derived forms (killing
   cross-document duplicates), then BFS injects `rdfs:subClassOf` hierarchies and
-  `owl:ObjectProperty` edges into the graph; every node tagged `ontology_valid` true/false.
-  This is the deepest writer/developer-declared structure in the field.
+  `owl:ObjectProperty` edges into the graph; every node tagged `ontology_valid` true/false. This is
+  the deepest writer/developer-declared structure in the field.
 - **Retrieval**: graph-completion retrievers (GRAPH_COMPLETION_COT), tunable graph construction.
 - **Numbers** (self-published): BEAM-100k 79% vs prior SOTA 73.4%; BEAM-10M 67% vs Hindsight's
   64.1%, flat token usage. Jan 2026 head-to-head (24 HotPotQA q, 45 runs): cognee 0.85 DeepEval
@@ -117,27 +119,28 @@ remains open, 3 weeks after our July read said the same.
 - **Cadence**: v1.4.2 (2026-08-08, verified), near-weekly. 30.0k stars, passed Graphiti this month.
 
 ### Hindsight (Vectorize) — typed epistemic categories, benchmark-marketing crown
+
 - **Representation** (verified via docs/search + arXiv 2512.12818): memory **banks** organized into
   four networks by epistemic role — **World** (objective facts), **Experience** (first-person agent
   biography), **Opinion** (subjective judgments with confidence scores + formation timestamps),
-  **Observation** (preference-neutral entity summaries consolidated from the other networks).
-  Facts are structured text with entity resolution (pg_trgm fuzzy matching, configurable threshold)
-  and temporal extraction — NOT triples, NOT a relation vocabulary. Notably v0.9.0 **removed** the
+  **Observation** (preference-neutral entity summaries consolidated from the other networks). Facts
+  are structured text with entity resolution (pg_trgm fuzzy matching, configurable threshold) and
+  temporal extraction — NOT triples, NOT a relation vocabulary. Notably v0.9.0 **removed** the
   "deprecated entity schema from memory_links" — they simplified link structure. Banks carry
   mission/directives/disposition traits that steer Reflect.
 - **Tagging**: a tags column exists (referenced in v0.9.0 changelog) but consolidation was just
-  fixed to key on resolved scope "not the tags column" — tags look secondary; scope is
-  load-bearing.
+  fixed to key on resolved scope "not the tags column" — tags look secondary; scope is load-bearing.
 - **Retrieval**: Recall = parallel semantic + BM25 + **graph traversal** + temporal strategies,
   cross-encoder rerank (now with reranker failover chains); fact-type filters on recall (invalid
   types 422). Reflect = agentic reasoning over recalled memories.
-- **Numbers**: LongMemEval-v1 94.6% "independently reproduced by Virginia Tech's Sanghani Center
-  and The Washington Post" (their claim; reproduction reports not fetched); BEAM-10M 64.1% #1 claim
-  from April. New blog "How to Actually Evaluate an Agent-Memory System" — they're playing the
-  integrity discourse too.
+- **Numbers**: LongMemEval-v1 94.6% "independently reproduced by Virginia Tech's Sanghani Center and
+  The Washington Post" (their claim; reproduction reports not fetched); BEAM-10M 64.1% #1 claim from
+  April. New blog "How to Actually Evaluate an Agent-Memory System" — they're playing the integrity
+  discourse too.
 - **Direction**: hard pivot into coding-agent memory (see delta). Postgres-native, MIT, 19.9k stars.
 
 ### Letta / Letta Code — memory blocks + git-backed files
+
 - **Representation**: memory **blocks** — labeled, always-in-context, agent-editable sections
   (structured prompt real estate, not a datastore); Letta Code adds git-tracked context rewriting,
   markdown **skill files**, and `/init`, `/remember` learning commands. New `ai-memory-sdk`
@@ -152,30 +155,35 @@ remains open, 3 weeks after our July read said the same.
   the memory layer.
 
 ### MemOS (MemTensor) — "memory OS," Chinese ecosystem
+
 - **Representation** (verified README): MemOS 2.0 "Stardust"; graph-structured unified memory API
   ("inspectable and editable by design, not a black-box embedding store"), multi-modal (text,
   images, tool traces, personas), **MemCube** composable knowledge bases, layered self-evolving
-  memory (L1 traces → L2 policies → L3 world models → crystallized Skills). Neo4j + Qdrant
-  self-host stack.
+  memory (L1 traces → L2 policies → L3 world models → crystallized Skills). Neo4j + Qdrant self-host
+  stack.
 - **Numbers** (self-published via their own OmniMemEval harness, 14 commercial products, 10
   datasets): LoCoMo 88.83, LongMemEval-v1 89.20, BEAM-10M 56.75, PersonaMem-v2 40.58; OpenClaw task
   completion 36.63%→50.87%. 10.7k stars, Apache-2.0, active daily.
 
 ### Elastic Atlas — cognitive triad, new entrant
-Covered in delta. The notable part is WHO: Elastic productizing episodic/semantic/procedural
-memory over Elasticsearch legitimizes the typed-category (not typed-relation) representation for
-enterprise buyers.
+
+Covered in delta. The notable part is WHO: Elastic productizing episodic/semantic/procedural memory
+over Elasticsearch legitimizes the typed-category (not typed-relation) representation for enterprise
+buyers.
 
 ### EverMind EverOS — Markdown as source of truth
+
 - **Representation** (verified README): canonical `.md` files (readable, diffable, git-versioned)
-  + synced SQLite + LanceDB indexes; separate user tracks (episodes/profile) and agent tracks
-  (cases/skills); an editable "Knowledge Wiki" with taxonomy. Orthogonal retrieval keyed by
-  user/agent/app/project/session ids. 12.0k stars, Apache-2.0. Claims LoCoMo 93.05% / LongMemEval-S
-  83.00% (self-published; their blog also runs a rankings content mill — treat as marketing).
-- The star/commit anomaly flagged in July persists as a credibility question, but the repo is
-  active daily.
+  - synced SQLite + LanceDB indexes; separate user tracks (episodes/profile) and agent tracks
+    (cases/skills); an editable "Knowledge Wiki" with taxonomy. Orthogonal retrieval keyed by
+    user/agent/app/project/session ids. 12.0k stars, Apache-2.0. Claims LoCoMo 93.05% /
+    LongMemEval-S 83.00% (self-published; their blog also runs a rankings content mill — treat as
+    marketing).
+- The star/commit anomaly flagged in July persists as a credibility question, but the repo is active
+  daily.
 
 ### Supermemory — consumer/API memory with an internal graph
+
 - **Representation** (their docs/blog): documents → Chunks + derived Memories + Profile; "Memory
   Graph" on a custom vector-graph engine with "ontology-aware edges," contradiction resolution,
   temporal reasoning — all system-extracted, zero writer declaration. "Dreaming" ingestion param
@@ -183,25 +191,27 @@ enterprise buyers.
   28.9k stars, MIT. Marketing-heavy; internals unverified.
 
 ### Smaller/other OSS
+
 - **MemMachine** (3.3k stars): arXiv 2604.04853, "ground-truth-preserving" memory; episodic +
   profile; modest traction.
-- **CaviraOSS OpenMemory** (4.4k stars, verified README): "cognitive memory engine," flat
-  add/search API, explainable recall traces; **entire project mid-rewrite** on a branch — unstable.
+- **CaviraOSS OpenMemory** (4.4k stars, verified README): "cognitive memory engine," flat add/search
+  API, explainable recall traces; **entire project mid-rewrite** on a branch — unstable.
 - **LangMem** (1.6k stars, v0.0.30 still latest from Oct 2025): alive but frozen; it's a thin
   extraction layer over LangGraph's BaseStore (flat namespaced JSON docs + semantic search).
   LangChain's answer to memory is the store primitive, not a memory product.
 
 ### Platform-native (the silos)
-- **Anthropic**: Managed Agents memory public beta (2026-04-23; `agent-memory-2026-07-22` header
-  for memory-store endpoints — a July revision): memories are **files** in a managed store,
+
+- **Anthropic**: Managed Agents memory public beta (2026-04-23; `agent-memory-2026-07-22` header for
+  memory-store endpoints — a July revision): memories are **files** in a managed store,
   export/edit/delete via API + Console, full audit trails. Claude Code auto-memory (on by default
   since v2.1.59): `~/.claude/projects/<proj>/memory/` with MEMORY.md index (first 200 lines/25KB
   auto-loaded) + topic files on demand. Flat markdown, agent-written, greppable. Not synced across
   machines.
 - **OpenAI**: ChatGPT "Dreaming" GA'd broadly (announced 2026-06-04): background consolidation,
   automatic capture, **self-updating temporal rewrites** ("you are going to Singapore" → "you went
-  to Singapore in July 2026") — the most user-visible temporal-validity feature anywhere. Agents
-  SDK evolution continues (sandboxed long-horizon agents); memory primitives remain per-platform
+  to Singapore in July 2026") — the most user-visible temporal-validity feature anywhere. Agents SDK
+  evolution continues (sandboxed long-horizon agents); memory primitives remain per-platform
   files/summaries.
 - **Cursor**: Memories feature REMOVED (~v2.1.x); Rules (static curated text) are the only native
   persistence. **Windsurf**: Cascade Memories persist snippets across sessions but contextual
@@ -216,9 +226,9 @@ enterprise buyers.
 
 - **LME-V2: zero entries, both tiers, verified today.** Every vendor still markets LongMemEval-v1
   and LoCoMo numbers despite v1 saturation (94.x claims from Mem0 AND Hindsight simultaneously) and
-  the Penfield LoCoMo audit. Nobody has touched the agentic-tier benchmark publicly. Sibyl's
-  ~30.4% (new 3-pass anchor) against RAG-51.0/AgentRunbook-74.9 frontier remains unflattering in
-  absolute terms but would still be the FIRST leaderboard number in existence.
+  the Penfield LoCoMo audit. Nobody has touched the agentic-tier benchmark publicly. Sibyl's ~30.4%
+  (new 3-pass anchor) against RAG-51.0/AgentRunbook-74.9 frontier remains unflattering in absolute
+  terms but would still be the FIRST leaderboard number in existence.
 - **BEAM is the new marketing battleground** (10M-token tier): Hindsight 64.1 → cognee claims 67 →
   MemOS 56.75 → Mem0 admits 48.6. All self-run.
 - **OmniMemEval** (MemTensor) is a new cross-product harness (14 products, 10 datasets) — worth
@@ -228,10 +238,9 @@ enterprise buyers.
 
 ## 4. Tagging/categorization across the field
 
-- **Load-bearing**: Letta block labels (routing), Hindsight banks + four networks (epistemic
-  routing at write AND recall filter), Elastic Atlas memory types (separate indices + lifecycles),
-  TencentDB asset types (four products essentially), Graphiti node_labels/edge_types (retrieval
-  filters).
+- **Load-bearing**: Letta block labels (routing), Hindsight banks + four networks (epistemic routing
+  at write AND recall filter), Elastic Atlas memory types (separate indices + lifecycles), TencentDB
+  asset types (four products essentially), Graphiti node_labels/edge_types (retrieval filters).
 - **Vestigial**: Mem0 categories (auto-assigned, reporting-only, no retrieval filter documented),
   Hindsight's literal tags column (consolidation just moved OFF it onto scope).
 - Pattern: **coarse enumerated type systems (4–15 values) with retrieval consequences win; freeform
@@ -246,22 +255,21 @@ Is richer writer-side expressiveness paying off? **Mostly no — with one precis
   system by adoption measured graph maintenance cost against ranking benefit and kept only entity
   links). Hindsight removed entity schema from memory_links. Cursor removed auto-memories in favor
   of flat rules. Letta left the memory-layer market for pinned flat blocks + markdown skills.
-- The **holds**: Graphiti's typed edges survive because they're *developer-declared schema*
+- The **holds**: Graphiti's typed edges survive because they're _developer-declared schema_
   (Pydantic, per-deployment) validated at extraction — not agent-declared at write time — and
   because they cash out as retrieval filters. cognee's OWL grounding survives for the same reason:
   the ontology is an input artifact that canonicalizes entities (dedup) and injects hierarchy;
   agents never author triples.
-- **Nobody ships agent-authored typed relations.** In every surveyed system the writer (agent)
-  emits text; structure is either extracted by LLM pipeline (Graphiti, cognee, Mem0, Hindsight,
+- **Nobody ships agent-authored typed relations.** In every surveyed system the writer (agent) emits
+  text; structure is either extracted by LLM pipeline (Graphiti, cognee, Mem0, Hindsight,
   Supermemory) or declared by the developer as schema/config (Graphiti Pydantic, cognee OWL, Letta
   block labels, TencentDB asset types). Sibyl's writer-declared retrieval keys are already more
   writer-side structure than anyone else's product asks for.
-- What actually correlates with benchmark wins in 2026: (a) multi-signal retrieval with rerank,
-  (b) coarse epistemic typing that routes writes and filters recalls, (c) consolidation/
-  observation layers (Hindsight Observations/Mental Models, ChatGPT Dreaming, Supermemory
-  dreaming, TencentDB L0→L3), (d) temporal validity as *system-maintained fact rewriting or
-  invalidation* (Zep invalidation, ChatGPT self-updating memories) — never as writer-declared
-  valid-time.
+- What actually correlates with benchmark wins in 2026: (a) multi-signal retrieval with rerank, (b)
+  coarse epistemic typing that routes writes and filters recalls, (c) consolidation/ observation
+  layers (Hindsight Observations/Mental Models, ChatGPT Dreaming, Supermemory dreaming, TencentDB
+  L0→L3), (d) temporal validity as _system-maintained fact rewriting or invalidation_ (Zep
+  invalidation, ChatGPT self-updating memories) — never as writer-declared valid-time.
 - **Implication for Sibyl's representation question**: typed relations and ontologies are NOT the
   gap behind our 30% vs 42.8% — the frontier baseline we're chasing is flat RAG over slices+notes.
   The evidence supports investing in (b)+(c)+(d) — type-aware retrieval filters over the enum we
@@ -272,28 +280,30 @@ Is richer writer-side expressiveness paying off? **Mostly no — with one precis
 
 ## 6. Differentiation map
 
-**Crowded** (do not build a pitch here): "your agent forgets" (dead), LongMemEval-v1/LoCoMo
-numbers (saturated + discredited), personal-assistant fact memory (Mem0/Supermemory/platform
-silos), memory-OS framing (MemOS, MemMachine, EverOS all claim it), markdown-files memory
-(EverOS + every platform native).
+**Crowded** (do not build a pitch here): "your agent forgets" (dead), LongMemEval-v1/LoCoMo numbers
+(saturated + discredited), personal-assistant fact memory (Mem0/Supermemory/platform silos),
+memory-OS framing (MemOS, MemMachine, EverOS all claim it), markdown-files memory (EverOS + every
+platform native).
 
 **Newly contested** (was open in July, now has entrants — move fast or reframe):
-- *Team memory for coding agents*: TencentDB v2.0 + Hindsight coding-agents. Tencent has
-  governance visibility levels but no graph, no provenance semantics, no LLM-free write path;
-  Hindsight has no team/scope privacy ladder. Sibyl's combination is still unique but the phrase
-  "team-level memory hub for AI coding agents" is now Tencent's headline.
-- *Consolidation with receipts*: Dreaming (OpenAI), Mental Models (Hindsight), dreaming param
+
+- _Team memory for coding agents_: TencentDB v2.0 + Hindsight coding-agents. Tencent has governance
+  visibility levels but no graph, no provenance semantics, no LLM-free write path; Hindsight has no
+  team/scope privacy ladder. Sibyl's combination is still unique but the phrase "team-level memory
+  hub for AI coding agents" is now Tencent's headline.
+- _Consolidation with receipts_: Dreaming (OpenAI), Mental Models (Hindsight), dreaming param
   (Supermemory). The v1.3 dream-cycle lane has three brand-name competitors for the narrative.
 
 **Still open** (verified by absence across every system surveyed):
+
 - LME-V2 leaderboard first entry (empty today).
-- Schema-level memory-scope privacy ladder with grant semantics (Tencent's visibility levels are
-  the closest anyone has come; still no private→team→org gradation with grants).
+- Schema-level memory-scope privacy ladder with grant semantics (Tencent's visibility levels are the
+  closest anyone has come; still no private→team→org gradation with grants).
 - Deterministic/LLM-free write path (still 100% of surveyed systems put an LLM in the write path).
 - Cross-user coalescence under privacy constraints (still shipped by nobody).
 - Honest multi-operating-point accuracy+latency reporting (Mem0's report gestures at tokens/query;
   nobody publishes frontiers).
-- Cross-harness memory as a *graph-backed* file convention (EverOS is files-first without a graph;
+- Cross-harness memory as a _graph-backed_ file convention (EverOS is files-first without a graph;
   we're still the only graph-projected entrant).
 
 ## 7. Watch list (revised)
@@ -313,8 +323,8 @@ silos), memory-OS framing (MemOS, MemMachine, EverOS all claim it), markdown-fil
 
 ## Sources (primary, fetched 2026-08-13)
 
-- GitHub API: star counts/pushed dates/licenses for all 14 repos listed; release feeds for
-  graphiti (v0.29.3), mem0 (v2.0.18), cognee (v1.4.2), hindsight (v0.9.0 full release notes),
+- GitHub API: star counts/pushed dates/licenses for all 14 repos listed; release feeds for graphiti
+  (v0.29.3), mem0 (v2.0.18), cognee (v1.4.2), hindsight (v0.9.0 full release notes),
   TencentDB-Agent-Memory (v2.0.0); READMEs for MemOS, EverOS, OpenMemory, letta-ai/ai-memory-sdk.
 - help.getzep.com/graphiti/core-concepts/custom-entity-and-edge-types (typed edges mechanics).
 - mem0.ai/blog/state-of-ai-agent-memory-2026 (pub 2026-08-13); docs.mem0.ai custom-categories.

--- a/docs/architecture/AUDIT_2026-08-13/sota-systems.md
+++ b/docs/architecture/AUDIT_2026-08-13/sota-systems.md
@@ -1,0 +1,330 @@
+# SOTA: Agent Memory Systems & Products — 2026-08-13
+
+Scope: products and open-source systems (papers are a sibling lane). Delta-focused against
+`docs/architecture/SOTA_LANDSCAPE_2026-07-25.md`. Star counts and release dates below were pulled
+live from the GitHub API on 2026-08-13 (verified); vendor benchmark numbers are labeled as claims.
+
+## Executive verdict
+
+The field's center of gravity in August 2026 is **typed epistemic categories + flat text payloads +
+heavy multi-signal retrieval** — not ontologies and not writer-declared relation vocabularies. The
+two systems that doubled down on rich typed graphs (cognee ontology grounding, Graphiti Pydantic
+edge types) are the exception; the volume leader (Mem0) just **retreated** from graph memory
+entirely, removing its queryable `relations` interface in favor of entity-linking that only
+influences ranking. Meanwhile a new lane opened that is exactly Sibyl's lane: **team-level memory
+hubs for coding agents** (TencentDB Agent Memory v2.0, Aug 3; Hindsight's `hindsight-coding-agents`
+harness plugin, v0.9.0, Aug 7). The LongMemEval-V2 leaderboard is **still empty** ("Leaderboard
+entries coming soon" on both tiers, verified on the project page today) — the first-mover slot
+remains open, 3 weeks after our July read said the same.
+
+---
+
+## 1. Landscape delta since 2026-07-25 (3 weeks)
+
+- **TencentDB Agent Memory v2.0** (2026-08-03, verified release tag): the biggest new entrant, and
+  the closest thing to a direct Sibyl competitor to appear all year. Team-level memory hub for AI
+  coding agents; 21,170 stars 90 days after open-sourcing (verified; GitHub license field reads
+  NOASSERTION while press says MIT — unverified licensing). Four memory asset types: Chat Memory
+  (L0→L3 layered distillation to Core/Persona), Skill (versioned reusable procedures), LLM-Wiki
+  (docs → structured pages with link graphs), Code-Graph (symbols/calls/impact paths). Retrieval:
+  BM25 + vector + RRF under strict token/character budgets. Governance: private/team/restricted/
+  agent-targeted visibility, "private is owner-only, not readable even by team admins," explicit
+  sharing. Self-reported PersonaMem 48%→76%; no independent reproduction.
+  Repo: github.com/TencentCloud/TencentDB-Agent-Memory.
+  **This is our scope ladder, our budgeted packs, and our team story, shipped by Tencent with a
+  20k-star megaphone.** What it does NOT have: a knowledge graph, provenance-per-write semantics,
+  or (apparently) an LLM-free write path.
+- **Hindsight went after coding agents.** v0.9.0 (2026-08-07, verified release notes): a
+  `hindsight-coding-agents` package — "harness-pluggable long-term memory for coding agents" — plus
+  transcript readers for Copilot CLI and Devin, OpenClaw plugins, Obsidian vault ingestion,
+  client-managed Knowledge Pages, and "Mental Models" (consolidated per-scope syntheses with
+  dry-run refresh). 19,898 stars (verified). Release cadence is ~weekly.
+- **Mem0 published its "State of AI Agent Memory 2026" report today (2026-08-13)** and it contains
+  a load-bearing architecture confession: Mem0 moved from external graph stores (Neo4j) to
+  "built-in entity linking" — the `relations` field is **removed**, there is "no longer a queryable
+  graph interface," entities influence retrieval ranking but cannot be traversed. Their own words:
+  for teams needing traversable graphs this is "a regression." (Fetched from
+  mem0.ai/blog/state-of-ai-agent-memory-2026.)
+- **Elastic entered** (missed by the July sweep): Atlas agent memory, open-sourced 2026-06-30
+  (InfoQ). Cognitive-science triad — episodic / semantic / procedural memories in separate
+  Elasticsearch indices with distinct lifecycles; episodic decays, LLM consolidation promotes
+  episodes into semantic facts. Hybrid BM25 + Jina v5 embeddings + RRF + cross-encoder rerank.
+  Reported 0.89 Recall@10 on their own QA eval (self-reported). Repo not at elastic/atlas (404);
+  exact location unverified.
+- **Cursor killed its Memories feature.** Auto-extracted per-project memories (introduced mid-2025)
+  were removed around v2.1.x in late 2025; users told to export memories and convert to Rules
+  (static, human-maintained text). A big-IDE data point AGAINST auto-extracted memory and FOR
+  curated flat files. (Multiple secondary sources; not verified against Cursor's own changelog.)
+- **LME-V2 leaderboard: still zero entries** (verified today on xiaowu0162.github.io/longmemeval-v2
+  — "Leaderboard entries coming soon," both tiers). Reference frontier unchanged (Small: RAG 51.0%
+  @0.2s → AgentRunbook-C 74.9% @108.3s).
+- Star deltas since 2026-07-25 (verified): Mem0 61.7k→63.2k, cognee 29.3k→30.0k, Graphiti
+  29.2k→29.9k, Supermemory →28.9k, Hindsight 18.8k→19.9k, MemOS →10.7k, EverOS 11.5k→12.0k,
+  MemMachine →3.3k, OpenMemory →4.4k (repo banner: "currently being rewritten"). Letta core 24.2k
+  but last push Aug 1 (legacy-mode confirmed); Letta Code 2,996 and active daily.
+
+---
+
+## 2. System profiles
+
+### Zep / Graphiti — the typed-relations flagship
+- **Representation** (verified from help.getzep.com custom-entity-and-edge-types doc): temporal
+  knowledge graph. Facts are edges with `valid_at`/`invalid_at` bitemporal handling (invalidation
+  preserves history + provenance). Custom entity AND edge types are **Pydantic models with typed
+  attributes** (e.g. an `Employment` edge carrying `position`, `start_date`, `salary`,
+  `is_current`). An `edge_type_map` constrains which edge types may form between entity-type pairs,
+  e.g. `("Person","Company"): ["Employment"]`. Untyped pairs fall back to **generic RELATES_TO** —
+  the default graph is exactly Sibyl's shape; typing is opt-in schema work by the *developer*, not
+  the writing agent. Extraction pipeline: LLM detects → classifies against the map → populates
+  attributes → Pydantic validates.
+- **Tagging**: no user-facing tag system; typing IS the categorization. Group graphs for scoping.
+- **Retrieval**: hybrid vector + BM25 + graph traversal, single ranked answer, no LLM rerank; Zep
+  claims P95 300ms. `SearchFilters` accept `node_labels=[...]` and `edge_types=[...]` — typed
+  filters are a real retrieval feature, the strongest structure-pays-off mechanism in the field.
+- **Positioning**: Zep is now fully enterprise "Context Lake" (SOC 2 Type II, ABAC, retention/legal
+  hold, BYOC; customers AWS, Samsung, Writer). Graphiti stays Apache-2.0 engine-only (29.9k stars,
+  v0.29.3 2026-07-27, FalkorDB backend work; releases verified). Self-host product door remains
+  closed.
+- **Benchmarks**: old LongMemEval-v1 claims (71.2–90.2 across eras); nothing new since July.
+
+### Mem0 — volume leader, retreating from structure
+- **Representation** (their Aug 13 report, fetched): extracted **facts** as flat text, single-pass
+  ADD-only extraction at `add()` time; agent-generated facts now first-class alongside user facts.
+  Graph memory: **removed as a queryable surface** (see delta above). Temporal: admits "temporal
+  abstraction at scale" is a weakness (25% drop from BEAM-1M to BEAM-10M).
+- **Tagging** (verified from docs.mem0.ai custom-categories): 15 default categories
+  (`personal_details`, `food`, `travel`, ... `misc`), replaceable with custom lists;
+  auto-classified asynchronously post-ingestion. Docs show no filter-by-category retrieval —
+  categories are for reporting/organization. **Vestigial for retrieval.**
+- **Retrieval**: multi-signal — semantic + BM25 + entity matching; entity links boost ranking only.
+- **Numbers** (self-published, Aug 13 report): LoCoMo 92.5 @~6,956 tok/query, LongMemEval-v1 94.4
+  @~6,787, BEAM-1M 64.1, BEAM-10M 48.6. Admitted open problems: identity resolution, staleness,
+  privacy/consent architecture "still undefined," no app-level eval framework.
+- **Releases**: v2.0.18 (2026-08-11, verified). 63.2k stars.
+
+### cognee — the ontology camp
+- **Representation** (verified via docs + search): semantic graph of **Pydantic DataPoint** typed
+  nodes; optional **OWL ontology grounding** (RDF/XML): entity types fuzzy-matched to OWL classes
+  (80% cutoff), individuals matched, names canonicalized to URI-derived forms (killing
+  cross-document duplicates), then BFS injects `rdfs:subClassOf` hierarchies and
+  `owl:ObjectProperty` edges into the graph; every node tagged `ontology_valid` true/false.
+  This is the deepest writer/developer-declared structure in the field.
+- **Retrieval**: graph-completion retrievers (GRAPH_COMPLETION_COT), tunable graph construction.
+- **Numbers** (self-published): BEAM-100k 79% vs prior SOTA 73.4%; BEAM-10M 67% vs Hindsight's
+  64.1%, flat token usage. Jan 2026 head-to-head (24 HotPotQA q, 45 runs): cognee 0.85 DeepEval
+  correctness vs Graphiti 0.74, LightRAG 0.67, Mem0 0.54 — their claim: "structured recall beats
+  chunk retrieval" on multi-hop. Tiny n, self-run.
+- **Cadence**: v1.4.2 (2026-08-08, verified), near-weekly. 30.0k stars, passed Graphiti this month.
+
+### Hindsight (Vectorize) — typed epistemic categories, benchmark-marketing crown
+- **Representation** (verified via docs/search + arXiv 2512.12818): memory **banks** organized into
+  four networks by epistemic role — **World** (objective facts), **Experience** (first-person agent
+  biography), **Opinion** (subjective judgments with confidence scores + formation timestamps),
+  **Observation** (preference-neutral entity summaries consolidated from the other networks).
+  Facts are structured text with entity resolution (pg_trgm fuzzy matching, configurable threshold)
+  and temporal extraction — NOT triples, NOT a relation vocabulary. Notably v0.9.0 **removed** the
+  "deprecated entity schema from memory_links" — they simplified link structure. Banks carry
+  mission/directives/disposition traits that steer Reflect.
+- **Tagging**: a tags column exists (referenced in v0.9.0 changelog) but consolidation was just
+  fixed to key on resolved scope "not the tags column" — tags look secondary; scope is
+  load-bearing.
+- **Retrieval**: Recall = parallel semantic + BM25 + **graph traversal** + temporal strategies,
+  cross-encoder rerank (now with reranker failover chains); fact-type filters on recall (invalid
+  types 422). Reflect = agentic reasoning over recalled memories.
+- **Numbers**: LongMemEval-v1 94.6% "independently reproduced by Virginia Tech's Sanghani Center
+  and The Washington Post" (their claim; reproduction reports not fetched); BEAM-10M 64.1% #1 claim
+  from April. New blog "How to Actually Evaluate an Agent-Memory System" — they're playing the
+  integrity discourse too.
+- **Direction**: hard pivot into coding-agent memory (see delta). Postgres-native, MIT, 19.9k stars.
+
+### Letta / Letta Code — memory blocks + git-backed files
+- **Representation**: memory **blocks** — labeled, always-in-context, agent-editable sections
+  (structured prompt real estate, not a datastore); Letta Code adds git-tracked context rewriting,
+  markdown **skill files**, and `/init`, `/remember` learning commands. New `ai-memory-sdk`
+  (verified repo, 45 stars, Apache-2.0): Subjects → Blocks → Messages, a "subconscious agent"
+  updates blocks asynchronously; archival memory (vector) optional behind it.
+- **Tagging**: block labels are the taxonomy; agent-defined, load-bearing (the agent routes writes
+  by label).
+- **Retrieval**: mostly no retrieval — blocks are pinned; archival search (vector/full-text/hybrid)
+  for overflow.
+- **Positioning**: flagship repo confirmed legacy (last push Aug 1); Letta Code claims #1
+  model-agnostic OSS coding harness on Terminal-Bench (their claim). They sell the harness now, not
+  the memory layer.
+
+### MemOS (MemTensor) — "memory OS," Chinese ecosystem
+- **Representation** (verified README): MemOS 2.0 "Stardust"; graph-structured unified memory API
+  ("inspectable and editable by design, not a black-box embedding store"), multi-modal (text,
+  images, tool traces, personas), **MemCube** composable knowledge bases, layered self-evolving
+  memory (L1 traces → L2 policies → L3 world models → crystallized Skills). Neo4j + Qdrant
+  self-host stack.
+- **Numbers** (self-published via their own OmniMemEval harness, 14 commercial products, 10
+  datasets): LoCoMo 88.83, LongMemEval-v1 89.20, BEAM-10M 56.75, PersonaMem-v2 40.58; OpenClaw task
+  completion 36.63%→50.87%. 10.7k stars, Apache-2.0, active daily.
+
+### Elastic Atlas — cognitive triad, new entrant
+Covered in delta. The notable part is WHO: Elastic productizing episodic/semantic/procedural
+memory over Elasticsearch legitimizes the typed-category (not typed-relation) representation for
+enterprise buyers.
+
+### EverMind EverOS — Markdown as source of truth
+- **Representation** (verified README): canonical `.md` files (readable, diffable, git-versioned)
+  + synced SQLite + LanceDB indexes; separate user tracks (episodes/profile) and agent tracks
+  (cases/skills); an editable "Knowledge Wiki" with taxonomy. Orthogonal retrieval keyed by
+  user/agent/app/project/session ids. 12.0k stars, Apache-2.0. Claims LoCoMo 93.05% / LongMemEval-S
+  83.00% (self-published; their blog also runs a rankings content mill — treat as marketing).
+- The star/commit anomaly flagged in July persists as a credibility question, but the repo is
+  active daily.
+
+### Supermemory — consumer/API memory with an internal graph
+- **Representation** (their docs/blog): documents → Chunks + derived Memories + Profile; "Memory
+  Graph" on a custom vector-graph engine with "ontology-aware edges," contradiction resolution,
+  temporal reasoning — all system-extracted, zero writer declaration. "Dreaming" ingestion param
+  (May 2026) batches related docs so memories form from coherent units. Sub-300ms recall claim.
+  28.9k stars, MIT. Marketing-heavy; internals unverified.
+
+### Smaller/other OSS
+- **MemMachine** (3.3k stars): arXiv 2604.04853, "ground-truth-preserving" memory; episodic +
+  profile; modest traction.
+- **CaviraOSS OpenMemory** (4.4k stars, verified README): "cognitive memory engine," flat
+  add/search API, explainable recall traces; **entire project mid-rewrite** on a branch — unstable.
+- **LangMem** (1.6k stars, v0.0.30 still latest from Oct 2025): alive but frozen; it's a thin
+  extraction layer over LangGraph's BaseStore (flat namespaced JSON docs + semantic search).
+  LangChain's answer to memory is the store primitive, not a memory product.
+
+### Platform-native (the silos)
+- **Anthropic**: Managed Agents memory public beta (2026-04-23; `agent-memory-2026-07-22` header
+  for memory-store endpoints — a July revision): memories are **files** in a managed store,
+  export/edit/delete via API + Console, full audit trails. Claude Code auto-memory (on by default
+  since v2.1.59): `~/.claude/projects/<proj>/memory/` with MEMORY.md index (first 200 lines/25KB
+  auto-loaded) + topic files on demand. Flat markdown, agent-written, greppable. Not synced across
+  machines.
+- **OpenAI**: ChatGPT "Dreaming" GA'd broadly (announced 2026-06-04): background consolidation,
+  automatic capture, **self-updating temporal rewrites** ("you are going to Singapore" → "you went
+  to Singapore in July 2026") — the most user-visible temporal-validity feature anywhere. Agents
+  SDK evolution continues (sandboxed long-horizon agents); memory primitives remain per-platform
+  files/summaries.
+- **Cursor**: Memories feature REMOVED (~v2.1.x); Rules (static curated text) are the only native
+  persistence. **Windsurf**: Cascade Memories persist snippets across sessions but contextual
+  understanding still resets; third-party MCP memory add-ons (agentmemory, MemNexus, Hindsight's
+  coding-agents package) are filling the gap — an aftermarket that proves native IDE memory is
+  underdelivering.
+- **Copilot Memory**: default-on since Mar 2026 (no notable August change found).
+
+---
+
+## 3. Benchmark state (products lens)
+
+- **LME-V2: zero entries, both tiers, verified today.** Every vendor still markets LongMemEval-v1
+  and LoCoMo numbers despite v1 saturation (94.x claims from Mem0 AND Hindsight simultaneously) and
+  the Penfield LoCoMo audit. Nobody has touched the agentic-tier benchmark publicly. Sibyl's
+  ~30.4% (new 3-pass anchor) against RAG-51.0/AgentRunbook-74.9 frontier remains unflattering in
+  absolute terms but would still be the FIRST leaderboard number in existence.
+- **BEAM is the new marketing battleground** (10M-token tier): Hindsight 64.1 → cognee claims 67 →
+  MemOS 56.75 → Mem0 admits 48.6. All self-run.
+- **OmniMemEval** (MemTensor) is a new cross-product harness (14 products, 10 datasets) — worth
+  watching as a GLUE-style shared harness candidate, though vendor-owned.
+- **PersonaMem** shows up twice (Tencent 76%, MemOS 40.58 on v2) — becoming the personalization
+  yardstick.
+
+## 4. Tagging/categorization across the field
+
+- **Load-bearing**: Letta block labels (routing), Hindsight banks + four networks (epistemic
+  routing at write AND recall filter), Elastic Atlas memory types (separate indices + lifecycles),
+  TencentDB asset types (four products essentially), Graphiti node_labels/edge_types (retrieval
+  filters).
+- **Vestigial**: Mem0 categories (auto-assigned, reporting-only, no retrieval filter documented),
+  Hindsight's literal tags column (consolidation just moved OFF it onto scope).
+- Pattern: **coarse enumerated type systems (4–15 values) with retrieval consequences win; freeform
+  tags without retrieval consequences rot.** Sibyl's entity-type enum + scope is the winning shape;
+  our freeform tags match the field's vestigial tier unless they gate retrieval.
+
+## 5. Expressiveness verdict
+
+Is richer writer-side expressiveness paying off? **Mostly no — with one precise exception.**
+
+- The **retreats**: Mem0 removed its queryable graph (the single loudest data point — the largest
+  system by adoption measured graph maintenance cost against ranking benefit and kept only entity
+  links). Hindsight removed entity schema from memory_links. Cursor removed auto-memories in favor
+  of flat rules. Letta left the memory-layer market for pinned flat blocks + markdown skills.
+- The **holds**: Graphiti's typed edges survive because they're *developer-declared schema*
+  (Pydantic, per-deployment) validated at extraction — not agent-declared at write time — and
+  because they cash out as retrieval filters. cognee's OWL grounding survives for the same reason:
+  the ontology is an input artifact that canonicalizes entities (dedup) and injects hierarchy;
+  agents never author triples.
+- **Nobody ships agent-authored typed relations.** In every surveyed system the writer (agent)
+  emits text; structure is either extracted by LLM pipeline (Graphiti, cognee, Mem0, Hindsight,
+  Supermemory) or declared by the developer as schema/config (Graphiti Pydantic, cognee OWL, Letta
+  block labels, TencentDB asset types). Sibyl's writer-declared retrieval keys are already more
+  writer-side structure than anyone else's product asks for.
+- What actually correlates with benchmark wins in 2026: (a) multi-signal retrieval with rerank,
+  (b) coarse epistemic typing that routes writes and filters recalls, (c) consolidation/
+  observation layers (Hindsight Observations/Mental Models, ChatGPT Dreaming, Supermemory
+  dreaming, TencentDB L0→L3), (d) temporal validity as *system-maintained fact rewriting or
+  invalidation* (Zep invalidation, ChatGPT self-updating memories) — never as writer-declared
+  valid-time.
+- **Implication for Sibyl's representation question**: typed relations and ontologies are NOT the
+  gap behind our 30% vs 42.8% — the frontier baseline we're chasing is flat RAG over slices+notes.
+  The evidence supports investing in (b)+(c)+(d) — type-aware retrieval filters over the enum we
+  already have, a consolidation/observation layer, and system-side fact invalidation — before any
+  relation-vocabulary expansion. If we ever type edges, the Graphiti pattern (developer schema +
+  extraction-time validation + retrieval filters) is the only one with production proof, and its
+  default fallback is literally RELATES_TO.
+
+## 6. Differentiation map
+
+**Crowded** (do not build a pitch here): "your agent forgets" (dead), LongMemEval-v1/LoCoMo
+numbers (saturated + discredited), personal-assistant fact memory (Mem0/Supermemory/platform
+silos), memory-OS framing (MemOS, MemMachine, EverOS all claim it), markdown-files memory
+(EverOS + every platform native).
+
+**Newly contested** (was open in July, now has entrants — move fast or reframe):
+- *Team memory for coding agents*: TencentDB v2.0 + Hindsight coding-agents. Tencent has
+  governance visibility levels but no graph, no provenance semantics, no LLM-free write path;
+  Hindsight has no team/scope privacy ladder. Sibyl's combination is still unique but the phrase
+  "team-level memory hub for AI coding agents" is now Tencent's headline.
+- *Consolidation with receipts*: Dreaming (OpenAI), Mental Models (Hindsight), dreaming param
+  (Supermemory). The v1.3 dream-cycle lane has three brand-name competitors for the narrative.
+
+**Still open** (verified by absence across every system surveyed):
+- LME-V2 leaderboard first entry (empty today).
+- Schema-level memory-scope privacy ladder with grant semantics (Tencent's visibility levels are
+  the closest anyone has come; still no private→team→org gradation with grants).
+- Deterministic/LLM-free write path (still 100% of surveyed systems put an LLM in the write path).
+- Cross-user coalescence under privacy constraints (still shipped by nobody).
+- Honest multi-operating-point accuracy+latency reporting (Mem0's report gestures at tokens/query;
+  nobody publishes frontiers).
+- Cross-harness memory as a *graph-backed* file convention (EverOS is files-first without a graph;
+  we're still the only graph-projected entrant).
+
+## 7. Watch list (revised)
+
+1. **TencentDB Agent Memory** — release cadence and whether Code-Graph/Skill assets grow real
+   retrieval semantics; it owns the coding-team-memory narrative megaphone right now.
+2. **Hindsight coding-agents package** — harness-pluggable memory for Claude Code/Copilot/Devin is
+   an adoption wedge aimed at exactly our users.
+3. **LME-V2 leaderboard** — still empty; every week it stays empty, the first-entry payoff holds.
+4. **cognee BEAM claims** — if independently reproduced, the ontology camp gets its first
+   third-party win and the "structure wins multi-hop" story gets teeth.
+5. **Mem0's entity-linking architecture** — if their numbers hold without a graph, that's the
+   strongest public evidence for retrieval-over-representation; if temporal/multi-hop regresses in
+   the wild, the pendulum swings back.
+6. **OmniMemEval** — vendor-owned but the only live cross-product harness; check whether neutral
+   parties adopt it.
+
+## Sources (primary, fetched 2026-08-13)
+
+- GitHub API: star counts/pushed dates/licenses for all 14 repos listed; release feeds for
+  graphiti (v0.29.3), mem0 (v2.0.18), cognee (v1.4.2), hindsight (v0.9.0 full release notes),
+  TencentDB-Agent-Memory (v2.0.0); READMEs for MemOS, EverOS, OpenMemory, letta-ai/ai-memory-sdk.
+- help.getzep.com/graphiti/core-concepts/custom-entity-and-edge-types (typed edges mechanics).
+- mem0.ai/blog/state-of-ai-agent-memory-2026 (pub 2026-08-13); docs.mem0.ai custom-categories.
+- xiaowu0162.github.io/longmemeval-v2 + leaderboard/README.md (empty leaderboard + frontier).
+- cognee.ai/blog/deep-dives/knowledge-graph-memory-benchmarks; docs.cognee.ai ontology guides.
+- hindsight.vectorize.io comparison guide + developer docs (via search excerpts); arXiv 2512.12818.
+- marktechpost.com 2026-08-07 TencentDB v2.0; Manila Times/AAP newswire 2026-08-13 (20k stars).
+- infoq.com/news/2026/06/elastic-atlas-agent-memory.
+- letta.com/blog/letta-code (2025-12-16); letta.com/blog/our-next-phase.
+- openai.com/index/chatgpt-memory-dreaming (2026-06-04); platform.claude.com managed-agents/memory
+  (+ agent-memory-2026-07-22 header); Claude Code auto-memory coverage (secondary).
+- Cursor Memories removal: dredyson.com + skillwright/memnexus coverage (secondary — not verified
+  against Cursor changelog).

--- a/docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md
+++ b/docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md
@@ -1,0 +1,185 @@
+# Sibyl 1.3 Rethink — expressiveness, structure, and the debt ledger
+
+- Status: synthesis of the 2026-08-13 seven-lane audit (four Opus tech-debt deep dives, one
+  expressiveness map, two SOTA sweeps). Direction proposal, not yet a locked plan.
+- Inputs: full reports with file:line receipts in
+  [`docs/architecture/AUDIT_2026-08-13/`](AUDIT_2026-08-13/). Nothing in this doc is asserted
+  without a receipt in one of them.
+- Relationship to [`SIBYL_1_3_STRATEGY_SKELETON.md`](SIBYL_1_3_STRATEGY_SKELETON.md): the
+  skeleton's ingest-side levers survive intact; this doc adds a Phase 0 (benchmark
+  decontamination) ahead of them and a representation workstream alongside them.
+
+## 1. Verdicts on the framing questions
+
+**Is Sibyl expressive enough?** The write surface is already among the richest in the field — the
+systems sweep found no shipping product that asks agents for more structure than we do (scopes,
+projects, types, tags, importance, confidence, epistemic basis, spans, retrieval keys, probes,
+relationships). The defect is not vocabulary, it is consequence: roughly half the expressive axes
+are stored and never read by retrieval, and the highest-value consumer (typed edge traversal
+weights) exists with no writer able to feed it. Expressiveness is not the gap. Wiring is.
+
+**Can an agent accurately express relationships and concepts?** No — and not because the schema
+can't hold them. Every relationship an agent declares collapses to untyped `RELATED_TO` at write
+(`tools/add.py:720`), while the expansion scorer already weights `DECIDES` 1.0, `REQUIRES` 0.98,
+`SUPERSEDES` 0.95, `SUPPORTS` 0.94 (`retrieval/search.py:85-107`). The consumer is built; the
+producer was never wired. That weight table is currently a wish list.
+
+**Does it matter?** Only where structure changes retrieval behavior — and the research is
+unusually crisp here. Typed *stores* have the one clean ablation win in the field (ENGRAM: 77.6%
+vs 46.6% with types collapsed). Typed *edges* have zero controlled evidence anywhere, and the
+market is actively retreating from them (Mem0 removed its queryable graph interface this week;
+Cursor killed auto-Memories; Letta left the memory-layer market). The winning shape everywhere is
+coarse typed categories + verbatim flat payloads + heavy multi-signal retrieval + write-time
+gating. Conclusion: we do NOT need an ontology or an edge-schema migration. We need the small set
+of predicates retrieval already scores, wired end to end, plus type-aware retrieval semantics over
+the enum we already have.
+
+**Should we reconsider tagging and categorization?** Yes, in both directions. Tags are inert today
+(unindexed, zero WHERE clauses — pure write-only theater) and no research shows flat tags earning
+accuracy as a scoring signal, so they should become a cheap filter/facet surface or be demoted
+honestly. Entity types, by contrast, are under-used: eight of them (including `person` and `place`,
+added deliberately for personal memory) are unreachable by recall because `FACET_TYPES` omits them.
+Categories earn their keep exactly when they change retrieval behavior; ours mostly don't yet.
+
+**What are we missing?** Ranked by evidence strength:
+
+1. **Supersession and correction enforcement** — the field's loudest open gap and our worst
+   instance of it. Proactive interference degrades retrieval log-linearly as stale associations
+   accumulate (arXiv:2603.14517), and we don't just fail to filter superseded memories — we boost
+   them: traversal carries no temporal predicate and `SUPERSEDES` weighs 0.95, so following the
+   edge *promotes* the superseded row. `sibyl correct` mutates only `raw_captures`; the graph row
+   keeps ranking. `excluded_from_recall` is a declaration, not an enforcement.
+2. **Reader conversion** — formally recognized loss bucket ("Sufficient Context", ICLR 2025) with
+   cheap validated levers: CoT-before-answer, extract-then-answer, span-level citation forcing,
+   and pack length itself as a reader tax even at perfect retrieval. We convert 50-54% when the
+   gold literal is exposed.
+3. **Failure-strategy distillation** (ReasoningBank lane) — distilling strategies from failures as
+   well as successes is the closest research lane to coding-agent procedural memory, and we don't
+   systematically exploit it.
+4. **Entity aliasing/merging** — extraction dedupes only within a single batch; nothing merges
+   across sessions.
+
+## 2. The stored-vs-used matrix (compressed)
+
+Full table with receipts in `expressiveness-map.md`.
+
+| Axis | Status |
+| --- | --- |
+| scopes, project, status, retrieval keys, entity type, freshness, usage signals | **Load-bearing** (keys are their own fused lane; usage loop stretches half-life 4× on citation, collapses 10× at misled_count ≥ 5) |
+| spans, atomic | Used indirectly via minted passage rows |
+| importance, pinned, retention | Retention job only — never retrieval |
+| tags, priority, updated_at, probes, basis, confidence, edge weight, edge temporal validity, node_labels filter | **Stored, never read** |
+| typed predicates (DECIDES/REQUIRES/SUPPORTS/SUPERSEDES...) | **Read, never writable** |
+
+Two failure modes at once: expressed-but-ignored, and consumed-but-unwritable.
+
+## 3. Benchmark integrity: the contamination finding
+
+`retrieval/query_ranking.py:337-705` hardcodes LongMemEval corpus vocabulary in the production
+ranker: `_CONCEPT_GROUPS` contains `seattle`, `basil`, `airfryer`, and the dataset misspelling
+`buisiness`; twenty regex pairs match `dermatologist`, `triathlon`, `screen protectors`. These
+feed `_CONCEPT_OVERLAP_WEIGHT` and `_QUERY_FRAME_WEIGHT` (0.52 — second-largest weight in the
+model). `query_anchors.py:42-43` re-fixes the same typo.
+
+Consequences, stated precisely:
+
+- Every real user's search is scored against benchmark-tuned tables. Product defect regardless of
+  benchmarks.
+- The 30.38% anchor partly measures the tables, not the architecture. The **paired lever verdicts
+  mostly survive** (both arms of every gate shared the contaminated ranker, same-commit), but the
+  anchor *level* and anything interacting with concept overlap is suspect until re-measured clean.
+- Related and compounding: the ranking pipeline is ordinal end to end (`fusion.py:126` binds score
+  magnitudes to a variable never read), so most weight/boost constants cannot change outcomes.
+  Weeks of knob-tuning were structurally noise — which is consistent with how many lever classes
+  died at the gates.
+
+**Phase 0 of 1.3 is therefore: strip the contamination, decide the ordinal-vs-scored fusion
+question deliberately, unify or explicitly pair the two retrieval pipelines, and cut a clean
+anchor.** Protocol law from the 1.2 plan carries unchanged.
+
+## 4. The debt ledger — kill order
+
+~120 findings across the four lanes. Full detail in the four `debt-*.md` reports. Tiered:
+
+**Tier 0 — security (fix first, small):** MCP never enforces `api:read`/`api:write` (check exists,
+wired to `None` — an `["mcp"]`-scoped key is refused by REST and accepted by MCP writes);
+`GET /backups/jobs/{job_id}` cross-org readable; stock `helm install` ships production-labelled
+with MCP auth disabled; no test walks routes asserting auth (a ~30-line test catches the class).
+
+**Tier 1 — serving wrong data:** corrections never reach retrieval; superseded edges boosted (§1);
+deleted memories' passage spans survive the retire sweep and keep serving deleted text
+(`projection/passages.py:606`); the #354 self-feeding-synthesis guard landed one stage upstream of
+where packs are actually rebuilt; three-way metadata storage where deleted keys resurrect on read;
+blind full-replace entity writes (three real data-loss incidents already, each hand-patched).
+
+**Tier 2 — benchmark + retrieval integrity:** ranker decontamination (§3); two mutually-unaware
+retrieval pipelines with divergent weight scales; ordinal fusion decision; exact-name rescue lane
+gated on a condition true whenever search succeeds (never fires); passages don't inherit
+`retrieval_keys` (the 1.2 headline feature contributes nothing to its highest-precision query
+class).
+
+**Tier 3 — reliability:** startup failures invisible to health probes; `coordination_backend=auto`
+never selects Redis (default queue is in-process, loses everything on restart); CI change
+classifier blind to `uv.lock`/`pyproject.toml`/`charts/`/`VERSION`/Dockerfiles; `moon run :check`
+never runs in PR CI (~32 suites first run at RC cut); the browser e2e suite cannot fail (all five
+tests assert the login redirect); `sibyl auth login` env-var precedence inverted vs the client
+(login succeeds, everything after 401s and buffers silently); 19 CLI failure paths exit 0; buffered
+writes surface nowhere a user looks; web realtime gives up permanently after 10 attempts with no
+polling fallback.
+
+**Tier 4 — cleanliness:** 6,559 lines of domain logic in the API route package (the root cause of
+MCP/REST divergence); dead `EntityStore`/`GraphStore` Protocol seam (zero production consumers);
+`episode`/`mentions` tables defined everywhere, written only by archive-restore; three divergent
+result normalizers; production code monkeypatching module globals as a test shim.
+
+Corrections to prior beliefs, verified: `entity.updated_at` string hazard retired by migration v5;
+the five dead Graphiti tables dropped by migration v4; the graph starfield fix has landed
+client-side (500-node cap + live overview mode).
+
+## 5. SOTA and differentiation
+
+**Landscape (receipts in `sota-systems.md` / `sota-research.md`):** write-time structuring that
+*replaces* raw text is empirically refuted — extracted artifacts lose 15.9-22 points vs verbatim
+chunks, and union storage (chunks + artifacts) fully recovers chunk accuracy. Retrieval method
+spans 20 points on LoCoMo while write strategy spans 3-8. Passage projection is on the right side
+of this iff spans keep verbatim text and distilled forms coexist rather than replace — that is the
+binding design rule for the skeleton's sub-1K rebuild. LongMemEval-V2 remains the only public
+benchmark in our workload shape and **its leaderboard is still empty on both tiers** — our number
+would be the first in existence.
+
+**Contested since July:** team memory for coding agents (TencentDB Agent Memory v2.0, 21.2k stars
+in 90 days; Hindsight v0.9.0 shipping harness-pluggable memory for Claude Code) and
+consolidation-with-a-brand-name (Dreaming / Mental Models).
+
+**Verified open lanes:** first LME-V2 entry; schema-level private→team→org privacy ladder with
+grants; deterministic LLM-free write paths (100% of surveyed systems put an LLM in the write
+path — Sibyl's writer-declared path is already LLM-free-capable); cross-user coalescence under
+privacy; and the one this audit makes ours to claim: **writer-declared structure that provably
+pays**. Everyone else either extracts structure with an LLM or dropped structure entirely; nobody
+lets the agent declare it and then *demonstrably* routes retrieval through it. We have the
+declaration surface shipped and the consumers half-built. Closing that loop is a story no
+competitor currently occupies: "what your agent says when it saves is what changes what it
+recalls."
+
+## 6. Proposed 1.3 shape
+
+- **Phase 0 — clean room.** Ranker decontamination, fusion decision, pipeline unification (or
+  explicit pairing), fresh anchor via the standard unpaid screen ladder. No lever work lands on a
+  contaminated baseline.
+- **Phase 1 — structure with consequences.** Writable typed predicates (small closed vocabulary:
+  supersedes, contradicts, requires, supports, decides/caused-by) feeding the existing traversal
+  weights; supersession + correction enforcement at traversal and pack admission (write-time
+  gating per MemGuard, recency-override rewriting per Infini Memory); passages inherit
+  `retrieval_keys`; facet completion for the eight unreachable entity types; tags become an
+  indexed filter surface or are honestly demoted; confidence/basis either enter scoring or stop
+  being collected.
+- **Phase 2 — the skeleton's ingest levers**, unchanged in intent, sharpened by research: sub-1K
+  spans keep verbatim text with distilled notes as union storage; retrieval-key declaration;
+  premise/gotcha notes; candidate acquisition over the overfetch path.
+- **Phase 3 — reader conversion + latency.** Extract-then-answer, citation forcing, pack-length
+  tax, tighter packs at fixed recall.
+- **Parallel lane — Tier 0/1/3 debt** as fix-mode work, sized S/M and largely independent of the
+  benchmark ladder.
+
+Measurement law carries forward whole: replay-before-paid, 3-pass paired gates, pre-registered
+numbers, same-commit pairing, jitter floors, receipt-checked arm activity.

--- a/docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md
+++ b/docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md
@@ -5,9 +5,9 @@
 - Inputs: full reports with file:line receipts in
   [`docs/architecture/AUDIT_2026-08-13/`](AUDIT_2026-08-13/). Nothing in this doc is asserted
   without a receipt in one of them.
-- Relationship to [`SIBYL_1_3_STRATEGY_SKELETON.md`](SIBYL_1_3_STRATEGY_SKELETON.md): the
-  skeleton's ingest-side levers survive intact; this doc adds a Phase 0 (benchmark
-  decontamination) ahead of them and a representation workstream alongside them.
+- Relationship to [`SIBYL_1_3_STRATEGY_SKELETON.md`](SIBYL_1_3_STRATEGY_SKELETON.md): the skeleton's
+  ingest-side levers survive intact; this doc adds a Phase 0 (benchmark decontamination) ahead of
+  them and a representation workstream alongside them.
 
 ## 1. Verdicts on the framing questions
 
@@ -24,15 +24,15 @@ can't hold them. Every relationship an agent declares collapses to untyped `RELA
 `SUPERSEDES` 0.95, `SUPPORTS` 0.94 (`retrieval/search.py:85-107`). The consumer is built; the
 producer was never wired. That weight table is currently a wish list.
 
-**Does it matter?** Only where structure changes retrieval behavior — and the research is
-unusually crisp here. Typed *stores* have the one clean ablation win in the field (ENGRAM: 77.6%
-vs 46.6% with types collapsed). Typed *edges* have zero controlled evidence anywhere, and the
-market is actively retreating from them (Mem0 removed its queryable graph interface this week;
-Cursor killed auto-Memories; Letta left the memory-layer market). The winning shape everywhere is
-coarse typed categories + verbatim flat payloads + heavy multi-signal retrieval + write-time
-gating. Conclusion: we do NOT need an ontology or an edge-schema migration. We need the small set
-of predicates retrieval already scores, wired end to end, plus type-aware retrieval semantics over
-the enum we already have.
+**Does it matter?** Only where structure changes retrieval behavior — and the research is unusually
+crisp here. Typed _stores_ have the one clean ablation win in the field (ENGRAM: 77.6% vs 46.6% with
+types collapsed). Typed _edges_ have zero controlled evidence anywhere, and the market is actively
+retreating from them (Mem0 removed its queryable graph interface this week; Cursor killed
+auto-Memories; Letta left the memory-layer market). The winning shape everywhere is coarse typed
+categories + verbatim flat payloads + heavy multi-signal retrieval + write-time gating. Conclusion:
+we do NOT need an ontology or an edge-schema migration. We need the small set of predicates
+retrieval already scores, wired end to end, plus type-aware retrieval semantics over the enum we
+already have.
 
 **Should we reconsider tagging and categorization?** Yes, in both directions. Tags are inert today
 (unindexed, zero WHERE clauses — pure write-only theater) and no research shows flat tags earning
@@ -43,16 +43,16 @@ Categories earn their keep exactly when they change retrieval behavior; ours mos
 
 **What are we missing?** Ranked by evidence strength:
 
-1. **Supersession and correction enforcement** — the field's loudest open gap and our worst
-   instance of it. Proactive interference degrades retrieval log-linearly as stale associations
-   accumulate (arXiv:2603.14517), and we don't just fail to filter superseded memories — we boost
-   them: traversal carries no temporal predicate and `SUPERSEDES` weighs 0.95, so following the
-   edge *promotes* the superseded row. `sibyl correct` mutates only `raw_captures`; the graph row
-   keeps ranking. `excluded_from_recall` is a declaration, not an enforcement.
+1. **Supersession and correction enforcement** — the field's loudest open gap and our worst instance
+   of it. Proactive interference degrades retrieval log-linearly as stale associations accumulate
+   (arXiv:2603.14517), and we don't just fail to filter superseded memories — we boost them:
+   traversal carries no temporal predicate and `SUPERSEDES` weighs 0.95, so following the edge
+   _promotes_ the superseded row. `sibyl correct` mutates only `raw_captures`; the graph row keeps
+   ranking. `excluded_from_recall` is a declaration, not an enforcement.
 2. **Reader conversion** — formally recognized loss bucket ("Sufficient Context", ICLR 2025) with
-   cheap validated levers: CoT-before-answer, extract-then-answer, span-level citation forcing,
-   and pack length itself as a reader tax even at perfect retrieval. We convert 50-54% when the
-   gold literal is exposed.
+   cheap validated levers: CoT-before-answer, extract-then-answer, span-level citation forcing, and
+   pack length itself as a reader tax even at perfect retrieval. We convert 50-54% when the gold
+   literal is exposed.
 3. **Failure-strategy distillation** (ReasoningBank lane) — distilling strategies from failures as
    well as successes is the closest research lane to coding-agent procedural memory, and we don't
    systematically exploit it.
@@ -63,13 +63,13 @@ Categories earn their keep exactly when they change retrieval behavior; ours mos
 
 Full table with receipts in `expressiveness-map.md`.
 
-| Axis | Status |
-| --- | --- |
-| scopes, project, status, retrieval keys, entity type, freshness, usage signals | **Load-bearing** (keys are their own fused lane; usage loop stretches half-life 4× on citation, collapses 10× at misled_count ≥ 5) |
-| spans, atomic | Used indirectly via minted passage rows |
-| importance, pinned, retention | Retention job only — never retrieval |
-| tags, priority, updated_at, probes, basis, confidence, edge weight, edge temporal validity, node_labels filter | **Stored, never read** |
-| typed predicates (DECIDES/REQUIRES/SUPPORTS/SUPERSEDES...) | **Read, never writable** |
+| Axis                                                                                                           | Status                                                                                                                             |
+| -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| scopes, project, status, retrieval keys, entity type, freshness, usage signals                                 | **Load-bearing** (keys are their own fused lane; usage loop stretches half-life 4× on citation, collapses 10× at misled_count ≥ 5) |
+| spans, atomic                                                                                                  | Used indirectly via minted passage rows                                                                                            |
+| importance, pinned, retention                                                                                  | Retention job only — never retrieval                                                                                               |
+| tags, priority, updated_at, probes, basis, confidence, edge weight, edge temporal validity, node_labels filter | **Stored, never read**                                                                                                             |
+| typed predicates (DECIDES/REQUIRES/SUPPORTS/SUPERSEDES...)                                                     | **Read, never writable**                                                                                                           |
 
 Two failure modes at once: expressed-but-ignored, and consumed-but-unwritable.
 
@@ -77,9 +77,9 @@ Two failure modes at once: expressed-but-ignored, and consumed-but-unwritable.
 
 `retrieval/query_ranking.py:337-705` hardcodes LongMemEval corpus vocabulary in the production
 ranker: `_CONCEPT_GROUPS` contains `seattle`, `basil`, `airfryer`, and the dataset misspelling
-`buisiness`; twenty regex pairs match `dermatologist`, `triathlon`, `screen protectors`. These
-feed `_CONCEPT_OVERLAP_WEIGHT` and `_QUERY_FRAME_WEIGHT` (0.52 — second-largest weight in the
-model). `query_anchors.py:42-43` re-fixes the same typo.
+`buisiness`; twenty regex pairs match `dermatologist`, `triathlon`, `screen protectors`. These feed
+`_CONCEPT_OVERLAP_WEIGHT` and `_QUERY_FRAME_WEIGHT` (0.52 — second-largest weight in the model).
+`query_anchors.py:42-43` re-fixes the same typo.
 
 Consequences, stated precisely:
 
@@ -87,15 +87,15 @@ Consequences, stated precisely:
   benchmarks.
 - The 30.38% anchor partly measures the tables, not the architecture. The **paired lever verdicts
   mostly survive** (both arms of every gate shared the contaminated ranker, same-commit), but the
-  anchor *level* and anything interacting with concept overlap is suspect until re-measured clean.
+  anchor _level_ and anything interacting with concept overlap is suspect until re-measured clean.
 - Related and compounding: the ranking pipeline is ordinal end to end (`fusion.py:126` binds score
-  magnitudes to a variable never read), so most weight/boost constants cannot change outcomes.
-  Weeks of knob-tuning were structurally noise — which is consistent with how many lever classes
-  died at the gates.
+  magnitudes to a variable never read), so most weight/boost constants cannot change outcomes. Weeks
+  of knob-tuning were structurally noise — which is consistent with how many lever classes died at
+  the gates.
 
-**Phase 0 of 1.3 is therefore: strip the contamination, decide the ordinal-vs-scored fusion
-question deliberately, unify or explicitly pair the two retrieval pipelines, and cut a clean
-anchor.** Protocol law from the 1.2 plan carries unchanged.
+**Phase 0 of 1.3 is therefore: strip the contamination, decide the ordinal-vs-scored fusion question
+deliberately, unify or explicitly pair the two retrieval pipelines, and cut a clean anchor.**
+Protocol law from the 1.2 plan carries unchanged.
 
 ## 4. The debt ledger — kill order
 
@@ -103,8 +103,8 @@ anchor.** Protocol law from the 1.2 plan carries unchanged.
 
 **Tier 0 — security (fix first, small):** MCP never enforces `api:read`/`api:write` (check exists,
 wired to `None` — an `["mcp"]`-scoped key is refused by REST and accepted by MCP writes);
-`GET /backups/jobs/{job_id}` cross-org readable; stock `helm install` ships production-labelled
-with MCP auth disabled; no test walks routes asserting auth (a ~30-line test catches the class).
+`GET /backups/jobs/{job_id}` cross-org readable; stock `helm install` ships production-labelled with
+MCP auth disabled; no test walks routes asserting auth (a ~30-line test catches the class).
 
 **Tier 1 — serving wrong data:** corrections never reach retrieval; superseded edges boosted (§1);
 deleted memories' passage spans survive the retire sweep and keep serving deleted text
@@ -119,13 +119,12 @@ gated on a condition true whenever search succeeds (never fires); passages don't
 class).
 
 **Tier 3 — reliability:** startup failures invisible to health probes; `coordination_backend=auto`
-never selects Redis (default queue is in-process, loses everything on restart); CI change
-classifier blind to `uv.lock`/`pyproject.toml`/`charts/`/`VERSION`/Dockerfiles; `moon run :check`
-never runs in PR CI (~32 suites first run at RC cut); the browser e2e suite cannot fail (all five
-tests assert the login redirect); `sibyl auth login` env-var precedence inverted vs the client
-(login succeeds, everything after 401s and buffers silently); 19 CLI failure paths exit 0; buffered
-writes surface nowhere a user looks; web realtime gives up permanently after 10 attempts with no
-polling fallback.
+never selects Redis (default queue is in-process, loses everything on restart); CI change classifier
+blind to `uv.lock`/`pyproject.toml`/`charts/`/`VERSION`/Dockerfiles; `moon run :check` never runs in
+PR CI (~32 suites first run at RC cut); the browser e2e suite cannot fail (all five tests assert the
+login redirect); `sibyl auth login` env-var precedence inverted vs the client (login succeeds,
+everything after 401s and buffers silently); 19 CLI failure paths exit 0; buffered writes surface
+nowhere a user looks; web realtime gives up permanently after 10 attempts with no polling fallback.
 
 **Tier 4 — cleanliness:** 6,559 lines of domain logic in the API route package (the root cause of
 MCP/REST divergence); dead `EntityStore`/`GraphStore` Protocol seam (zero production consumers);
@@ -139,27 +138,26 @@ client-side (500-node cap + live overview mode).
 ## 5. SOTA and differentiation
 
 **Landscape (receipts in `sota-systems.md` / `sota-research.md`):** write-time structuring that
-*replaces* raw text is empirically refuted — extracted artifacts lose 15.9-22 points vs verbatim
-chunks, and union storage (chunks + artifacts) fully recovers chunk accuracy. Retrieval method
-spans 20 points on LoCoMo while write strategy spans 3-8. Passage projection is on the right side
-of this iff spans keep verbatim text and distilled forms coexist rather than replace — that is the
-binding design rule for the skeleton's sub-1K rebuild. LongMemEval-V2 remains the only public
-benchmark in our workload shape and **its leaderboard is still empty on both tiers** — our number
-would be the first in existence.
+_replaces_ raw text is empirically refuted — extracted artifacts lose 15.9-22 points vs verbatim
+chunks, and union storage (chunks + artifacts) fully recovers chunk accuracy. Retrieval method spans
+20 points on LoCoMo while write strategy spans 3-8. Passage projection is on the right side of this
+iff spans keep verbatim text and distilled forms coexist rather than replace — that is the binding
+design rule for the skeleton's sub-1K rebuild. LongMemEval-V2 remains the only public benchmark in
+our workload shape and **its leaderboard is still empty on both tiers** — our number would be the
+first in existence.
 
-**Contested since July:** team memory for coding agents (TencentDB Agent Memory v2.0, 21.2k stars
-in 90 days; Hindsight v0.9.0 shipping harness-pluggable memory for Claude Code) and
+**Contested since July:** team memory for coding agents (TencentDB Agent Memory v2.0, 21.2k stars in
+90 days; Hindsight v0.9.0 shipping harness-pluggable memory for Claude Code) and
 consolidation-with-a-brand-name (Dreaming / Mental Models).
 
 **Verified open lanes:** first LME-V2 entry; schema-level private→team→org privacy ladder with
-grants; deterministic LLM-free write paths (100% of surveyed systems put an LLM in the write
-path — Sibyl's writer-declared path is already LLM-free-capable); cross-user coalescence under
-privacy; and the one this audit makes ours to claim: **writer-declared structure that provably
-pays**. Everyone else either extracts structure with an LLM or dropped structure entirely; nobody
-lets the agent declare it and then *demonstrably* routes retrieval through it. We have the
-declaration surface shipped and the consumers half-built. Closing that loop is a story no
-competitor currently occupies: "what your agent says when it saves is what changes what it
-recalls."
+grants; deterministic LLM-free write paths (100% of surveyed systems put an LLM in the write path —
+Sibyl's writer-declared path is already LLM-free-capable); cross-user coalescence under privacy; and
+the one this audit makes ours to claim: **writer-declared structure that provably pays**. Everyone
+else either extracts structure with an LLM or dropped structure entirely; nobody lets the agent
+declare it and then _demonstrably_ routes retrieval through it. We have the declaration surface
+shipped and the consumers half-built. Closing that loop is a story no competitor currently occupies:
+"what your agent says when it saves is what changes what it recalls."
 
 ## 6. Proposed 1.3 shape
 
@@ -168,16 +166,15 @@ recalls."
   contaminated baseline.
 - **Phase 1 — structure with consequences.** Writable typed predicates (small closed vocabulary:
   supersedes, contradicts, requires, supports, decides/caused-by) feeding the existing traversal
-  weights; supersession + correction enforcement at traversal and pack admission (write-time
-  gating per MemGuard, recency-override rewriting per Infini Memory); passages inherit
-  `retrieval_keys`; facet completion for the eight unreachable entity types; tags become an
-  indexed filter surface or are honestly demoted; confidence/basis either enter scoring or stop
-  being collected.
+  weights; supersession + correction enforcement at traversal and pack admission (write-time gating
+  per MemGuard, recency-override rewriting per Infini Memory); passages inherit `retrieval_keys`;
+  facet completion for the eight unreachable entity types; tags become an indexed filter surface or
+  are honestly demoted; confidence/basis either enter scoring or stop being collected.
 - **Phase 2 — the skeleton's ingest levers**, unchanged in intent, sharpened by research: sub-1K
   spans keep verbatim text with distilled notes as union storage; retrieval-key declaration;
   premise/gotcha notes; candidate acquisition over the overfetch path.
-- **Phase 3 — reader conversion + latency.** Extract-then-answer, citation forcing, pack-length
-  tax, tighter packs at fixed recall.
+- **Phase 3 — reader conversion + latency.** Extract-then-answer, citation forcing, pack-length tax,
+  tighter packs at fixed recall.
 - **Parallel lane — Tier 0/1/3 debt** as fix-mode work, sized S/M and largely independent of the
   benchmark ladder.
 


### PR DESCRIPTION
## 🔮 What this is

The synthesis of today's seven-lane 1.3 kickoff audit, plus the raw reports it draws from. Four Opus tech-debt deep dives (core graph/persistence, retrieval/ai, apps/api, web/cli/infra), an expressiveness map of the memory write surface, and two SOTA sweeps (systems and research). Everything lands as internal architecture docs; a one-line `srcExclude` addition keeps the `AUDIT_*` bundle off the published docsite alongside the existing uppercase-doc exclusion.

## 💎 What the synthesis concludes

- **Expressiveness is not the gap; wiring is.** The write surface is richer than anything shipping in the field, but half its axes are stored and never read by retrieval (tags, confidence, basis, probes, edge temporal validity), while the typed traversal weight table is read and never writable — every agent-declared relationship collapses to untyped `RELATED_TO`.
- **The production ranker is benchmark-contaminated.** `query_ranking.py` hardcodes LongMemEval corpus vocabulary (concept groups and twenty regex pairs) feeding the second-largest weight in the model. Phase 0 of 1.3 is decontamination and a fresh anchor; paired lever verdicts mostly survive because both arms shared the contamination.
- **Supersession is unenforced and inverted.** Traversal carries no temporal predicate and `SUPERSEDES` weighs 0.95, so superseded memories get boosted, and `sibyl correct` never reaches what retrieval serves. The research sweep says stale associations degrade retrieval log-linearly, making this the loudest gap in both the field and this codebase.
- **The debt ledger is tiered into a kill order** — security first (MCP scope enforcement is dead code, one cross-org read, helm's production default ships with MCP auth off), then serving-wrong-data, benchmark integrity, reliability, cleanliness.
- **Differentiation lanes verified open as of today:** first LongMemEval-V2 leaderboard entry, privacy ladder with grants, LLM-free write paths, and writer-declared structure that provably pays — the loop this audit shows is half-built on both ends.

## 🧪 Verification

Docs-only change. `srcExclude` verified by pattern against the existing `architecture/[A-Z]*.md` rule; every claim in the synthesis carries a file:line receipt in the bundled reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture audits covering API, core graph, retrieval and AI, web, CLI, infrastructure, and technical debt.
  * Documented the platform’s expressiveness, storage and retrieval capabilities, limitations, and identified gaps.
  * Added research surveys of agent-memory systems, benchmarks, and current industry approaches.
  * Added a strategic direction document outlining proposed improvements and phased planning.
  * Audit documents are excluded from published documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->