### PR TITLE
fix(api): scope the backup job status route to the caller's org

### DIFF
--- a/apps/api/src/sibyl/api/routes/backups.py
+++ b/apps/api/src/sibyl/api/routes/backups.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
+from sibyl.api.routes.jobs import job_visible_to_org
 from sibyl.auth.dependencies import get_current_organization, get_current_user, require_org_admin
 from sibyl.backup_ids import generate_backup_id
 from sibyl.config import settings
@@ -426,14 +427,23 @@ async def delete_backup(
 
 
 @router.get("/jobs/{job_id}")
-async def get_backup_job_status(job_id: str) -> dict[str, Any]:
+async def get_backup_job_status(
+    job_id: str,
+    org: AuthOrganization = Depends(get_current_organization),
+) -> dict[str, Any]:
     """Get status of a backup job.
 
     Returns job status, result (if complete), or error (if failed).
     """
+    from sibyl.coordination.broker import JobStatus
     from sibyl.jobs.queue import get_job_status
 
     info = await get_job_status(job_id)
+
+    # A missing job carries no payload, so it stays reportable to any caller and
+    # keeps the poll loops in the CLI and web client on their terminal state.
+    if info.status != JobStatus.NOT_FOUND and not await job_visible_to_org(info, org=org):
+        raise HTTPException(status_code=404, detail=f"Job not found: {job_id}")
 
     return {
         "job_id": info.job_id,

--- a/apps/api/src/sibyl/api/routes/backups.py
+++ b/apps/api/src/sibyl/api/routes/backups.py
@@ -440,9 +440,9 @@ async def get_backup_job_status(
 
     info = await get_job_status(job_id)
 
-    # A missing job carries no payload, so it stays reportable to any caller and
-    # keeps the poll loops in the CLI and web client on their terminal state.
-    if info.status != JobStatus.NOT_FOUND and not await job_visible_to_org(info, org=org):
+    # An id the queue never held and an id belonging to another org answer
+    # identically, so the route cannot be used to probe for foreign job ids.
+    if info.status == JobStatus.NOT_FOUND or not await job_visible_to_org(info, org=org):
         raise HTTPException(status_code=404, detail=f"Job not found: {job_id}")
 
     return {

--- a/apps/api/src/sibyl/api/routes/jobs.py
+++ b/apps/api/src/sibyl/api/routes/jobs.py
@@ -39,7 +39,7 @@ async def _source_visible_to_org(
     return source is not None and source.organization_id == org_id
 
 
-async def _job_visible_to_org(
+async def job_visible_to_org(
     job: Any,
     *,
     org: AuthOrganization,
@@ -167,7 +167,7 @@ async def list_jobs(
         visible = [
             j
             for j in jobs
-            if await _job_visible_to_org(
+            if await job_visible_to_org(
                 j,
                 org=org,
                 visible_source_ids=visible_source_ids,
@@ -233,7 +233,7 @@ async def get_jobs_status(
         visible_source_ids = await _resolve_visible_source_ids(infos, org=org)
         jobs: dict[str, dict[str, Any]] = {}
         for job_id, info in zip(job_ids, infos, strict=True):
-            if info.status == JobStatus.NOT_FOUND or not await _job_visible_to_org(
+            if info.status == JobStatus.NOT_FOUND or not await job_visible_to_org(
                 info,
                 org=org,
                 visible_source_ids=visible_source_ids,
@@ -345,7 +345,7 @@ async def get_job(
 
         if info.status == JobStatus.NOT_FOUND:
             raise HTTPException(status_code=404, detail=f"Job not found: {job_id}")
-        if not await _job_visible_to_org(info, org=org):
+        if not await job_visible_to_org(info, org=org):
             raise HTTPException(status_code=404, detail=f"Job not found: {job_id}")
 
         return _job_status_payload(info)
@@ -369,7 +369,7 @@ async def cancel_job(
 
     try:
         info = await get_job_status(job_id)
-        if not await _job_visible_to_org(info, org=org):
+        if not await job_visible_to_org(info, org=org):
             raise HTTPException(status_code=404, detail=f"Job not found: {job_id}")
 
         cancelled = await _cancel_job(job_id)

--- a/apps/api/src/sibyl/cli/db.py
+++ b/apps/api/src/sibyl/cli/db.py
@@ -1844,6 +1844,10 @@ def backup_create(
                 error("Job not found (may have been cleaned up)")
                 break
 
+            if status == "cancelled":
+                error("Backup job was cancelled")
+                break
+
             console.print(".", end="", style="dim")
             time.sleep(2)
 

--- a/apps/api/src/sibyl/cli/db.py
+++ b/apps/api/src/sibyl/cli/db.py
@@ -1682,13 +1682,35 @@ def _get_api_url() -> str:
     return f"http://{host}:{settings.server_port}"
 
 
+def _is_api_not_found(response: Any, message: str) -> bool:
+    """Recognize the API's own not-found envelope rather than any 404.
+
+    A reverse proxy, a stale route table and a server too old to serve the
+    path all answer 404 too. Reading those as "the record is gone" would turn
+    an unreachable API into a clean answer.
+    """
+    if response.status_code != 404:
+        return False
+
+    try:
+        body = response.json()
+    except ValueError:
+        return False
+
+    return (
+        isinstance(body, dict)
+        and body.get("error") == "not_found"
+        and body.get("message") == message
+    )
+
+
 def _api_request(
     method: str,
     path: str,
     *,
     json_data: dict | None = None,
     stream: bool = False,
-    missing_ok: bool = False,
+    missing_message: str | None = None,
 ) -> dict | bytes | None:
     """Make an API request to the backup endpoints.
 
@@ -1721,7 +1743,7 @@ def _api_request(
         error("Cannot connect to Sibyl API. Is 'sibyld serve' running?")
         raise typer.Exit(code=1) from None
     except httpx.HTTPStatusError as e:
-        if missing_ok and e.response.status_code == 404:
+        if missing_message is not None and _is_api_not_found(e.response, missing_message):
             return None
         error(f"API error: {e.response.status_code} - {e.response.text}")
         raise typer.Exit(code=1) from None
@@ -1780,14 +1802,20 @@ def backup_create(
 
     if wait:
         info("Waiting for backup to complete...")
+        confirmed = False
 
         # Poll for completion
         while True:
-            status_result = _api_request("GET", f"/backups/jobs/{job_id}", missing_ok=True)
+            status_result = _api_request(
+                "GET",
+                f"/backups/jobs/{job_id}",
+                missing_message=f"Job not found: {job_id}",
+            )
             if status_result is None:
                 error("Job not found (may have been cleaned up)")
                 break
             if not isinstance(status_result, dict):
+                error("Unexpected response from API")
                 break
 
             status = status_result.get("status", "unknown")
@@ -1795,6 +1823,7 @@ def backup_create(
             if status == "complete":
                 job_result = status_result.get("result", {})
                 if job_result.get("success"):
+                    confirmed = True
                     archive_path = job_result.get("archive_path", "unknown")
                     size_kb = job_result.get("archive_size_bytes", 0) / 1024
                     duration = job_result.get("duration_seconds", 0)
@@ -1819,6 +1848,11 @@ def backup_create(
             time.sleep(2)
 
         console.print()  # Newline after dots
+
+        # --wait promises the archive exists by the time it returns, so every
+        # way out of the loop except a confirmed success is a failed run.
+        if not confirmed:
+            raise typer.Exit(code=1)
 
 
 @app.command("backup-list")

--- a/apps/api/src/sibyl/cli/db.py
+++ b/apps/api/src/sibyl/cli/db.py
@@ -1688,7 +1688,8 @@ def _api_request(
     *,
     json_data: dict | None = None,
     stream: bool = False,
-) -> dict | bytes:
+    missing_ok: bool = False,
+) -> dict | bytes | None:
     """Make an API request to the backup endpoints.
 
     Note: This requires the API server to be running and assumes local access.
@@ -1720,6 +1721,8 @@ def _api_request(
         error("Cannot connect to Sibyl API. Is 'sibyld serve' running?")
         raise typer.Exit(code=1) from None
     except httpx.HTTPStatusError as e:
+        if missing_ok and e.response.status_code == 404:
+            return None
         error(f"API error: {e.response.status_code} - {e.response.text}")
         raise typer.Exit(code=1) from None
 
@@ -1780,7 +1783,10 @@ def backup_create(
 
         # Poll for completion
         while True:
-            status_result = _api_request("GET", f"/backups/jobs/{job_id}")
+            status_result = _api_request("GET", f"/backups/jobs/{job_id}", missing_ok=True)
+            if status_result is None:
+                error("Job not found (may have been cleaned up)")
+                break
             if not isinstance(status_result, dict):
                 break
 

--- a/apps/api/src/sibyl/coordination/broker.py
+++ b/apps/api/src/sibyl/coordination/broker.py
@@ -28,6 +28,7 @@ _JOB_ORG_ARGUMENT_INDEX = {
     "consolidate_org": 0,
     "priority_decay": 0,
     "run_reflection_dream_cycle": 0,
+    "run_backup": 0,
 }
 
 

--- a/apps/api/tests/test_backups_routes.py
+++ b/apps/api/tests/test_backups_routes.py
@@ -4,8 +4,10 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 
 from sibyl.api.routes import backups as backup_routes
+from sibyl.coordination.broker import JobInfo, JobStatus
 from sibyl.persistence.backups_common import BackupListResult
 
 
@@ -268,3 +270,62 @@ async def test_delete_backup_uses_runtime_delete_helper(monkeypatch: pytest.Monk
     response = await backup_routes.delete_backup("backup_a", org=_org())
 
     assert response == {"deleted": True, "backup_id": "backup_a"}
+
+
+def _backup_job(organization_id: str) -> JobInfo:
+    return JobInfo(
+        job_id="backup:backup_secret",
+        function="run_backup",
+        status=JobStatus.COMPLETE,
+        args=(organization_id,),
+        kwargs={"backup_id": "backup_secret"},
+        result={
+            "success": True,
+            "backup_id": "backup_secret",
+            "organization_id": organization_id,
+            "archive_path": "/var/lib/sibyl/backups/backup_secret.tar.gz",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_backup_job_status_hides_another_orgs_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    reader = _org()
+    owner_org_id = str(uuid4())
+    monkeypatch.setattr(
+        "sibyl.jobs.queue.get_job_status",
+        AsyncMock(return_value=_backup_job(owner_org_id)),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await backup_routes.get_backup_job_status("backup:backup_secret", org=reader)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Job not found: backup:backup_secret"
+
+
+@pytest.mark.asyncio
+async def test_backup_job_status_returns_own_orgs_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    org = _org()
+    monkeypatch.setattr(
+        "sibyl.jobs.queue.get_job_status",
+        AsyncMock(return_value=_backup_job(str(org.id))),
+    )
+
+    response = await backup_routes.get_backup_job_status("backup:backup_secret", org=org)
+
+    assert response["status"] == "complete"
+    assert response["result"]["organization_id"] == str(org.id)
+
+
+@pytest.mark.asyncio
+async def test_backup_job_status_reports_missing_job_to_any_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing = JobInfo(job_id="backup:gone", function="unknown", status=JobStatus.NOT_FOUND)
+    monkeypatch.setattr("sibyl.jobs.queue.get_job_status", AsyncMock(return_value=missing))
+
+    response = await backup_routes.get_backup_job_status("backup:gone", org=_org())
+
+    assert response["status"] == "not_found"
+    assert response["result"] is None

--- a/apps/api/tests/test_backups_routes.py
+++ b/apps/api/tests/test_backups_routes.py
@@ -319,13 +319,27 @@ async def test_backup_job_status_returns_own_orgs_job(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
-async def test_backup_job_status_reports_missing_job_to_any_org(
+async def test_backup_job_status_answers_unknown_and_foreign_jobs_alike(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    missing = JobInfo(job_id="backup:gone", function="unknown", status=JobStatus.NOT_FOUND)
-    monkeypatch.setattr("sibyl.jobs.queue.get_job_status", AsyncMock(return_value=missing))
+    """A 200 for one and a 404 for the other would confirm a foreign job exists."""
+    reader = _org()
 
-    response = await backup_routes.get_backup_job_status("backup:gone", org=_org())
+    monkeypatch.setattr(
+        "sibyl.jobs.queue.get_job_status",
+        AsyncMock(return_value=_backup_job(str(uuid4()))),
+    )
+    with pytest.raises(HTTPException) as foreign:
+        await backup_routes.get_backup_job_status("backup:backup_secret", org=reader)
 
-    assert response["status"] == "not_found"
-    assert response["result"] is None
+    unknown_job = JobInfo(
+        job_id="backup:backup_secret",
+        function="unknown",
+        status=JobStatus.NOT_FOUND,
+    )
+    monkeypatch.setattr("sibyl.jobs.queue.get_job_status", AsyncMock(return_value=unknown_job))
+    with pytest.raises(HTTPException) as unknown:
+        await backup_routes.get_backup_job_status("backup:backup_secret", org=reader)
+
+    assert foreign.value.status_code == unknown.value.status_code == 404
+    assert foreign.value.detail == unknown.value.detail

--- a/apps/api/tests/test_cli_db.py
+++ b/apps/api/tests/test_cli_db.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 from typer.testing import CliRunner
 
 from sibyl.cli import db as db_cli
@@ -359,6 +360,31 @@ def test_backup_create_uses_database_dump_request_field() -> None:
         "include_database_dump": False,
         "include_graph": True,
     }
+
+
+def test_backup_create_wait_stops_when_the_server_forgot_the_job() -> None:
+    with patch(
+        "sibyl.cli.db._api_request",
+        side_effect=[{"job_id": "job-123"}, None],
+    ) as api_request:
+        result = runner.invoke(db_cli.app, ["backup-create", "--wait"])
+
+    assert result.exit_code == 0
+    assert api_request.call_args.args == ("GET", "/backups/jobs/job-123")
+    assert api_request.call_args.kwargs["missing_ok"] is True
+    assert "Job not found" in result.output
+
+
+def test_api_request_reports_a_missing_job_instead_of_exiting() -> None:
+    response = SimpleNamespace(status_code=404, text="Job not found: job-123")
+    request_error = httpx.HTTPStatusError("404", request=None, response=response)
+    client = MagicMock()
+    client.get.return_value.raise_for_status.side_effect = request_error
+
+    with patch("httpx.Client") as client_factory:
+        client_factory.return_value.__enter__.return_value = client
+
+        assert db_cli._api_request("GET", "/backups/jobs/job-123", missing_ok=True) is None
 
 
 class _StubSchemaClient:

--- a/apps/api/tests/test_cli_db.py
+++ b/apps/api/tests/test_cli_db.py
@@ -388,6 +388,20 @@ def test_backup_create_wait_succeeds_on_a_confirmed_archive() -> None:
     assert "Backup complete!" in result.output
 
 
+def test_backup_create_wait_stops_on_a_cancelled_job() -> None:
+    """cancelled is terminal, so polling it forever would hang the command."""
+    cancelled = {"status": "cancelled", "result": None}
+    with patch(
+        "sibyl.cli.db._api_request",
+        side_effect=[{"job_id": "job-123"}, cancelled],
+    ) as api_request:
+        result = runner.invoke(db_cli.app, ["backup-create", "--wait"])
+
+    assert result.exit_code == 1
+    assert api_request.call_count == 2
+    assert "cancelled" in result.output
+
+
 def _client_raising(status_code: int, body: object, text: str = "") -> MagicMock:
     response = MagicMock(status_code=status_code, text=text)
     if isinstance(body, Exception):

--- a/apps/api/tests/test_cli_db.py
+++ b/apps/api/tests/test_cli_db.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
+import typer
 from typer.testing import CliRunner
 
 from sibyl.cli import db as db_cli
@@ -362,29 +364,69 @@ def test_backup_create_uses_database_dump_request_field() -> None:
     }
 
 
-def test_backup_create_wait_stops_when_the_server_forgot_the_job() -> None:
+def test_backup_create_wait_fails_when_the_server_forgot_the_job() -> None:
+    """--wait never saw the archive, so it must not exit green."""
     with patch(
         "sibyl.cli.db._api_request",
         side_effect=[{"job_id": "job-123"}, None],
     ) as api_request:
         result = runner.invoke(db_cli.app, ["backup-create", "--wait"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert api_request.call_args.args == ("GET", "/backups/jobs/job-123")
-    assert api_request.call_args.kwargs["missing_ok"] is True
+    assert api_request.call_args.kwargs["missing_message"] == "Job not found: job-123"
     assert "Job not found" in result.output
 
 
-def test_api_request_reports_a_missing_job_instead_of_exiting() -> None:
-    response = SimpleNamespace(status_code=404, text="Job not found: job-123")
-    request_error = httpx.HTTPStatusError("404", request=None, response=response)
-    client = MagicMock()
-    client.get.return_value.raise_for_status.side_effect = request_error
+def test_backup_create_wait_succeeds_on_a_confirmed_archive() -> None:
+    archive = {"success": True, "archive_path": "backups/a.tar.gz"}
+    complete = {"status": "complete", "result": archive}
+    with patch("sibyl.cli.db._api_request", side_effect=[{"job_id": "job-123"}, complete]):
+        result = runner.invoke(db_cli.app, ["backup-create", "--wait"])
 
+    assert result.exit_code == 0
+    assert "Backup complete!" in result.output
+
+
+def _client_raising(status_code: int, body: object, text: str = "") -> MagicMock:
+    response = MagicMock(status_code=status_code, text=text)
+    if isinstance(body, Exception):
+        response.json.side_effect = body
+    else:
+        response.json.return_value = body
+    client = MagicMock()
+    client.get.return_value.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "error", request=None, response=response
+    )
+    return client
+
+
+def _get_with(client: MagicMock, **kwargs: object) -> object:
     with patch("httpx.Client") as client_factory:
         client_factory.return_value.__enter__.return_value = client
+        return db_cli._api_request("GET", "/backups/jobs/job-123", **kwargs)
 
-        assert db_cli._api_request("GET", "/backups/jobs/job-123", missing_ok=True) is None
+
+def test_api_request_reports_the_apis_own_missing_job() -> None:
+    client = _client_raising(404, {"error": "not_found", "message": "Job not found: job-123"})
+
+    assert _get_with(client, missing_message="Job not found: job-123") is None
+
+
+def test_api_request_does_not_read_an_unrelated_404_as_a_missing_job() -> None:
+    """A proxy or a route the server does not serve must not look like success."""
+    unrelated = [
+        _client_raising(404, {"error": "not_found", "message": "Not Found"}),
+        _client_raising(404, {"detail": "Not Found"}),
+        _client_raising(404, ValueError("not json"), text="<html>404</html>"),
+        _client_raising(404, {"error": "not_found", "message": "Job not found: other-job"}),
+    ]
+
+    for client in unrelated:
+        with pytest.raises(typer.Exit) as exit_info:
+            _get_with(client, missing_message="Job not found: job-123")
+
+        assert exit_info.value.exit_code == 1
 
 
 class _StubSchemaClient:

--- a/apps/api/tests/test_route_auth_coverage.py
+++ b/apps/api/tests/test_route_auth_coverage.py
@@ -1,0 +1,187 @@
+"""Every mounted route must bind a caller identity of its own.
+
+Scope tests elsewhere in this suite override the auth dependencies, so a route
+that never declared them looks exactly like a route that did. This test reads
+the mounted application instead of calling it, which is the only way a missing
+dependency becomes visible.
+
+The rule is deliberately stricter than "the route is authenticated". A
+router-level gate such as require_org_admin() proves the caller administers
+some organization, and every user owns a personal organization with the OWNER
+role, so inheriting that gate proves nothing about whose data the handler is
+about to serve. Only a dependency the route declares for itself tells the
+handler which caller, and which organization, it is answering for.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import params
+from fastapi.dependencies.utils import get_dependant
+from fastapi.routing import APIRoute, APIWebSocketRoute
+
+from sibyl.api.app import create_api_app
+from sibyl.auth.dependencies import (
+    get_auth_context,
+    get_current_org_role,
+    get_current_organization,
+    get_current_user,
+)
+from sibyl.persistence.operations_runtime import (
+    require_global_admin,
+    require_setup_mode_or_admin,
+    require_setup_mode_or_auth,
+)
+
+# Dependencies that resolve who is calling. Role gates such as require_org_admin
+# and require_org_role are deliberately absent: they authorize a caller against
+# an organization someone else already resolved.
+CALLER_IDENTITY_DEPENDENCIES = frozenset(
+    {
+        get_auth_context,
+        get_current_org_role,
+        get_current_organization,
+        get_current_user,
+        require_global_admin,
+        require_setup_mode_or_admin,
+        require_setup_mode_or_auth,
+    }
+)
+
+# Routes that answer without knowing the caller, keyed by "<methods> <path>".
+# Adding an entry here is a decision to serve a route to anyone who reaches it,
+# so each one records why that is safe.
+ROUTES_WITHOUT_CALLER_IDENTITY: dict[str, str] = {
+    # Service surface, no stored data.
+    "GET /": "version banner",
+    "GET /health": "liveness probe",
+    "GET /health/ready": "readiness probe",
+    "GET,HEAD /openapi.json": "generated API schema",
+    "GET,HEAD /docs": "Swagger UI shell",
+    "GET,HEAD /docs/oauth2-redirect": "Swagger UI OAuth redirect shim",
+    "GET,HEAD /redoc": "ReDoc UI shell",
+    # Establishing a session: the caller has no identity yet.
+    "GET /auth/providers": "lists configured login providers",
+    "GET /auth/github": "starts the GitHub OAuth redirect",
+    "GET /auth/github/callback": "GitHub OAuth callback, state-verified",
+    "GET /auth/oidc/{provider_name}/login": "starts the OIDC redirect",
+    "GET /auth/oidc/{provider_name}/callback": "OIDC callback, state-verified",
+    "GET /auth/oidc/{provider_name}/refresh": "OIDC silent refresh, cookie-verified",
+    "POST /auth/local/signup": "creates the first account for an email",
+    "POST /auth/local/login": "exchanges credentials for a session",
+    "POST /auth/device": "starts the device authorization grant",
+    "POST /auth/device/token": "polls the device grant for a token",
+    "GET /auth/device/verify": "renders the device code confirmation page",
+    "POST /auth/device/verify": "confirms a device code, session-verified",
+    "POST /auth/refresh": "rotates a session from the refresh cookie",
+    "POST /auth/logout": "clears session cookies",
+    "POST /users/password/reset": "sends a reset mail for an email address",
+    "POST /users/password/reset/confirm": "redeems a reset token",
+    "GET /setup/status": "reports whether the instance is unconfigured",
+    # Instance-wide settings, gated in the handler body by require_settings_owner
+    # rather than by a dependency (see AUDIT_2026-08-13 debt-api finding 6).
+    "GET /settings": "require_settings_owner called in the handler",
+    "PATCH /settings": "require_settings_owner called in the handler",
+    "DELETE /settings/{key}": "require_settings_owner called in the handler",
+    "GET /settings/ai/llm": "require_settings_owner called in the handler",
+    "PUT /settings/ai/llm/{surface}": "require_settings_owner called in the handler",
+    "PUT /settings/ai/llm-budget": "require_settings_owner called in the handler",
+    "POST /settings/ai/llm/{surface}/test": "require_settings_owner called in the handler",
+    "POST /settings/ai/keys/{provider}/test": "require_settings_owner called in the handler",
+    "POST /settings/ai/models/{model_alias}/test": "require_settings_owner called in the handler",
+    "GET /settings/ai/registry": "require_settings_owner called in the handler",
+    # WebSockets cannot use HTTP dependencies and authenticate in the handler.
+    "WS /ws": "token checked in websocket_handler",
+    "WS /logs/stream": "token checked in the stream handler",
+    # Org-independent answers: no row, document or job of any org is reachable.
+    "GET /jobs/health": "broker and queue health counters",
+    "GET /sources/health": "crawler subsystem health",
+    "GET /sources/preview": "fetches a caller-supplied URL, reads nothing stored",
+    "GET /ingestion/import-adapters": "static list of compiled-in import adapters",
+}
+
+# A walk that silently returns nothing would pass every assertion below.
+MINIMUM_MOUNTED_ROUTES = 150
+
+
+def _resolved_calls(dependant: Any, found: set[Any]) -> set[Any]:
+    for sub in dependant.dependencies:
+        if sub.call is not None:
+            found.add(sub.call)
+        _resolved_calls(sub, found)
+    return found
+
+
+def _calls_of(dependencies: list[params.Depends]) -> set[Any]:
+    found: set[Any] = set()
+    for dependency in dependencies:
+        call = dependency.dependency
+        if call is None:
+            continue
+        found.add(call)
+        _resolved_calls(get_dependant(path="/", call=call), found)
+    return found
+
+
+def _route_key(route: Any, path: str) -> str:
+    methods = getattr(route, "methods", None)
+    label = ",".join(sorted(methods)) if methods else "WS"
+    return f"{label} {path}"
+
+
+def _mounted_routes(
+    routes: list[Any],
+    prefix: str = "",
+    inherited: frozenset[Any] = frozenset(),
+) -> list[tuple[str, Any, frozenset[Any]]]:
+    """Flatten the app into leaf routes, tracking what each router applies."""
+    flattened: list[tuple[str, Any, frozenset[Any]]] = []
+    for route in routes:
+        # FastAPI mounts an included router as a single node rather than copying
+        # its routes, so the router's own dependencies live on the node.
+        include = getattr(route, "include_context", None)
+        if include is not None:
+            router = include.included_router
+            below = (
+                set(inherited) | _calls_of(include.dependencies) | _calls_of(router.dependencies)
+            )
+            flattened += _mounted_routes(router.routes, prefix + include.prefix, frozenset(below))
+            continue
+
+        path = prefix + getattr(route, "path", "")
+        flattened.append((path, route, inherited))
+    return flattened
+
+
+def _self_declared_identity(route: Any, inherited: frozenset[Any]) -> set[Any]:
+    if not isinstance(route, APIRoute | APIWebSocketRoute):
+        return set()
+    declared = _resolved_calls(route.dependant, set()) - inherited
+    return declared & CALLER_IDENTITY_DEPENDENCIES
+
+
+class TestRouteAuthCoverage:
+    def test_walk_reaches_the_whole_application(self) -> None:
+        mounted = _mounted_routes(create_api_app().routes)
+
+        assert len(mounted) >= MINIMUM_MOUNTED_ROUTES
+
+    def test_every_route_declares_a_caller_identity(self) -> None:
+        unscoped = [
+            _route_key(route, path)
+            for path, route, inherited in _mounted_routes(create_api_app().routes)
+            if not _self_declared_identity(route, inherited)
+        ]
+
+        assert sorted(unscoped) == sorted(ROUTES_WITHOUT_CALLER_IDENTITY), (
+            "A route resolves no caller identity of its own. Give it "
+            "get_current_organization (or another identity dependency), or add "
+            "it to ROUTES_WITHOUT_CALLER_IDENTITY with the reason it is safe."
+        )
+
+    def test_allowlist_carries_no_retired_routes(self) -> None:
+        routes = _mounted_routes(create_api_app().routes)
+        mounted = {_route_key(route, path) for path, route, _ in routes}
+
+        assert set(ROUTES_WITHOUT_CALLER_IDENTITY) <= mounted

--- a/apps/api/tests/test_route_auth_coverage.py
+++ b/apps/api/tests/test_route_auth_coverage.py
@@ -23,8 +23,11 @@ route's own parameters rather than the whole resolved dependency tree.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
+from uuid import UUID
 
+import pytest
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.dependencies.utils import get_dependant
 from fastapi.routing import APIRoute, APIWebSocketRoute
@@ -40,15 +43,17 @@ from sibyl.auth.dependencies import (
     require_org_admin,
     require_org_role,
 )
+from sibyl.persistence import graph_runtime
 from sibyl.persistence.operations_runtime import (
     require_global_admin,
     require_setup_mode_or_admin,
     require_setup_mode_or_auth,
 )
+from sibyl_core.auth import AuthOrganization
 
 # Dependencies that resolve an organization and hand back something already
 # scoped to it, so a handler receiving one cannot read across tenants.
-# test_org_scoped_providers_resolve_an_organization holds them to that claim.
+# test_org_scoped_providers_bind_the_organization_they_resolve holds them to it.
 ORG_SCOPED_PROVIDERS = frozenset({get_graph_store, get_knowledge_read_service})
 
 # Values that tell a handler which organization it is answering for.
@@ -236,6 +241,34 @@ async def _wrapped_org_gate(_gate: Any = _ORG_ADMIN_GATE) -> None:
     """A real role gate buried one dependency deep."""
 
 
+async def _stub_graph_runtime(group_id: str) -> Any:
+    """Stand in for the live graph runtime so the probe needs no database."""
+    del group_id
+    return SimpleNamespace(
+        client=SimpleNamespace(),
+        entity_manager=SimpleNamespace(),
+        relationship_manager=SimpleNamespace(),
+    )
+
+
+async def _resolve_provider(provider: Any, org: AuthOrganization) -> Any:
+    """Resolve a provider the way FastAPI would, one signature at a time."""
+    if provider is get_graph_store:
+        return await get_graph_store(org=org)
+    if provider is get_knowledge_read_service:
+        return await get_knowledge_read_service(graph_store=await get_graph_store(org=org))
+    raise AssertionError(f"add a behavioural probe for {provider}")
+
+
+def _bound_organization(capability: Any) -> str:
+    """Read the organization a resolved capability is actually scoped to."""
+    store = getattr(capability, "_store", capability)
+    group_id = getattr(getattr(store, "entities", None), "_group_id", None)
+
+    assert isinstance(group_id, str), f"no organization is observable on {capability!r}"
+    return group_id
+
+
 class TestRouteAuthCoverage:
     def test_walk_reaches_the_whole_application(self) -> None:
         assert len(_mounted_routes(create_api_app().routes)) >= MINIMUM_MOUNTED_ROUTES
@@ -253,6 +286,31 @@ class TestRouteAuthCoverage:
             "parameter, or add the route to ROUTES_WITHOUT_CALLER_IDENTITY with "
             "the reason it is safe to answer without one."
         )
+
+    @pytest.mark.asyncio
+    async def test_org_scoped_providers_bind_the_organization_they_resolve(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reaching an org proves nothing; a provider could accept and ignore it.
+
+        Treating these as org-bearing is only sound if what they hand back is
+        scoped to the caller's organization, so resolve each one under two
+        organizations and watch the capability change with them.
+        """
+        monkeypatch.setattr(graph_runtime, "_get_graph_runtime", _stub_graph_runtime)
+        first = AuthOrganization(
+            id=UUID("00000000-0000-0000-0000-0000000000a1"), name="First", slug="first"
+        )
+        second = AuthOrganization(
+            id=UUID("00000000-0000-0000-0000-0000000000b2"), name="Second", slug="second"
+        )
+
+        for provider in ORG_SCOPED_PROVIDERS:
+            for org in (first, second):
+                bound = _bound_organization(await _resolve_provider(provider, org))
+
+                assert bound == str(org.id), provider
 
     def test_a_discarded_identity_does_not_scope_a_route(self) -> None:
         """Depends() in the decorator resolves into nowhere, so it proves nothing."""

--- a/apps/api/tests/test_route_auth_coverage.py
+++ b/apps/api/tests/test_route_auth_coverage.py
@@ -1,28 +1,37 @@
-"""Every mounted route must bind a caller identity of its own.
+"""Every mounted route must receive the caller identity it needs.
 
 Scope tests elsewhere in this suite override the auth dependencies, so a route
 that never declared them looks exactly like a route that did. This test reads
 the mounted application instead of calling it, which is the only way a missing
 dependency becomes visible.
 
-The rule is deliberately stricter than "the route is authenticated". A
-router-level gate such as require_org_admin() proves the caller administers
+Two things make the rule stricter than "the route is authenticated", and both
+are load-bearing.
+
+A router-level gate such as require_org_admin() proves the caller administers
 some organization, and every user owns a personal organization with the OWNER
-role, so inheriting that gate proves nothing about whose data the handler is
-about to serve. Only a dependency the route declares for itself tells the
-handler which caller, and which organization, it is answering for.
+role, so inheriting that gate says nothing about whose data the handler is
+about to serve. A route sitting under one of those gates therefore has to
+receive an organization, not merely sit behind a check.
+
+And a dependency only counts when its value reaches something that uses it. A
+Depends() listed in a route or router decorator has nowhere to put its result,
+so it can prove a check ran but can never hand the handler an organization.
+Only parameter-bound dependencies are credited, which is why this reads the
+route's own parameters rather than the whole resolved dependency tree.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, FastAPI, params
+from fastapi import APIRouter, Depends, FastAPI
 from fastapi.dependencies.utils import get_dependant
 from fastapi.routing import APIRoute, APIWebSocketRoute
 from starlette.routing import Host, Mount
 
 from sibyl.api.app import create_api_app
+from sibyl.api.dependencies import get_graph_store, get_knowledge_read_service
 from sibyl.auth.dependencies import (
     get_auth_context,
     get_current_org_role,
@@ -37,25 +46,29 @@ from sibyl.persistence.operations_runtime import (
     require_setup_mode_or_auth,
 )
 
-# Dependencies that resolve who is calling. Role gates such as require_org_admin
-# and require_org_role are deliberately absent: they authorize a caller against
-# an organization someone else already resolved.
-CALLER_IDENTITY_DEPENDENCIES = frozenset(
-    {
-        get_auth_context,
-        get_current_org_role,
-        get_current_organization,
-        get_current_user,
-        require_global_admin,
-        require_setup_mode_or_admin,
-        require_setup_mode_or_auth,
-    }
+# Dependencies that resolve an organization and hand back something already
+# scoped to it, so a handler receiving one cannot read across tenants.
+# test_org_scoped_providers_resolve_an_organization holds them to that claim.
+ORG_SCOPED_PROVIDERS = frozenset({get_graph_store, get_knowledge_read_service})
+
+# Values that tell a handler which organization it is answering for.
+ORG_BEARING_DEPENDENCIES = (
+    frozenset({get_auth_context, get_current_organization}) | ORG_SCOPED_PROVIDERS
 )
 
-# Factories whose closures authorize a caller against an organization someone
-# else resolved. They reach an identity dependency internally, so crediting
-# anything under them would let a route pass on the strength of the very gate
-# this test exists to discount.
+# Values that name the caller, whether or not they carry an organization.
+CALLER_IDENTITY_DEPENDENCIES = ORG_BEARING_DEPENDENCIES | frozenset(
+    {get_current_org_role, get_current_user}
+)
+
+# Gates that raise by themselves, so a route may discard what they return.
+# Org role gates are deliberately absent: they authorize a caller against an
+# organization someone else resolved, which is the vacuity this test exists to
+# catch, so they are listed as gate factories instead.
+ENFORCING_GATES = frozenset(
+    {require_global_admin, require_setup_mode_or_admin, require_setup_mode_or_auth}
+)
+
 ORG_ROLE_GATE_FACTORIES = (require_org_admin, require_org_role)
 
 # Routes that answer without knowing the caller, keyed by "<methods> <path>".
@@ -122,105 +135,128 @@ def _is_org_role_gate(call: Any) -> bool:
     )
 
 
-def _resolved_calls(dependant: Any, found: set[Any]) -> set[Any]:
-    for sub in dependant.dependencies:
-        if sub.call is not None:
-            if _is_org_role_gate(sub.call):
-                continue
-            found.add(sub.call)
-        _resolved_calls(sub, found)
-    return found
-
-
-def _calls_of(dependencies: list[params.Depends]) -> set[Any]:
-    found: set[Any] = set()
-    for dependency in dependencies:
-        call = dependency.dependency
-        if call is None:
-            continue
-        found.add(call)
-        _resolved_calls(get_dependant(path="/", call=call), found)
-    return found
-
-
 def _route_key(route: Any, path: str) -> str:
     methods = getattr(route, "methods", None)
     label = ",".join(sorted(methods)) if methods else "WS"
     return f"{label} {path}"
 
 
-def _mounted_routes(
-    routes: list[Any],
-    prefix: str = "",
-    inherited: frozenset[Any] = frozenset(),
-) -> list[tuple[str, Any, frozenset[Any]]]:
-    """Flatten the app into leaf routes, tracking what each router applies."""
-    flattened: list[tuple[str, Any, frozenset[Any]]] = []
+def _mounted_routes(routes: list[Any], prefix: str = "") -> list[tuple[str, Any]]:
+    """Flatten the app into its leaf routes."""
+    flattened: list[tuple[str, Any]] = []
     for route in routes:
         # FastAPI mounts an included router as a single node rather than copying
-        # its routes, so the router's own dependencies live on the node.
+        # its routes, so the tree has to be walked through that node.
         include = getattr(route, "include_context", None)
         if include is not None:
-            router = include.included_router
-            below = (
-                set(inherited) | _calls_of(include.dependencies) | _calls_of(router.dependencies)
-            )
-            flattened += _mounted_routes(router.routes, prefix + include.prefix, frozenset(below))
+            flattened += _mounted_routes(include.included_router.routes, prefix + include.prefix)
             continue
 
-        path = prefix + getattr(route, "path", "")
-        flattened.append((path, route, inherited))
+        flattened.append((prefix + getattr(route, "path", ""), route))
     return flattened
 
 
-def _self_declared_identity(route: Any, inherited: frozenset[Any]) -> set[Any]:
+def _received(route: Any) -> set[Any]:
+    """Dependencies whose resolved value the route is actually handed.
+
+    A Depends() in a route or router decorator resolves into nowhere, so it
+    never appears here however deeply it reaches an identity internally.
+    """
     if not isinstance(route, APIRoute | APIWebSocketRoute):
         return set()
-    declared = _resolved_calls(route.dependant, set()) - inherited
-    return declared & CALLER_IDENTITY_DEPENDENCIES
+    return {sub.call for sub in route.dependant.dependencies if sub.name is not None and sub.call}
+
+
+def _declared(route: Any) -> set[Any]:
+    if not isinstance(route, APIRoute | APIWebSocketRoute):
+        return set()
+    return {sub.call for sub in route.dependant.dependencies if sub.call}
+
+
+def _has_caller_identity(route: Any) -> bool:
+    declared = _declared(route)
+    received = _received(route)
+
+    if any(_is_org_role_gate(call) for call in declared):
+        return bool(received & ORG_BEARING_DEPENDENCIES)
+    return bool(received & CALLER_IDENTITY_DEPENDENCIES) or bool(declared & ENFORCING_GATES)
+
+
+def _unrecognized_gate() -> Any:
+    """A role gate this test has never heard of, shaped like the real ones."""
+
+    async def _check(ctx: Any = Depends(get_auth_context)) -> None:
+        return None
+
+    return _check
 
 
 class TestRouteAuthCoverage:
     def test_walk_reaches_the_whole_application(self) -> None:
-        mounted = _mounted_routes(create_api_app().routes)
+        assert len(_mounted_routes(create_api_app().routes)) >= MINIMUM_MOUNTED_ROUTES
 
-        assert len(mounted) >= MINIMUM_MOUNTED_ROUTES
-
-    def test_every_route_declares_a_caller_identity(self) -> None:
+    def test_every_route_receives_a_caller_identity(self) -> None:
         unscoped = [
             _route_key(route, path)
-            for path, route, inherited in _mounted_routes(create_api_app().routes)
-            if not _self_declared_identity(route, inherited)
+            for path, route in _mounted_routes(create_api_app().routes)
+            if not _has_caller_identity(route)
         ]
 
         assert sorted(unscoped) == sorted(ROUTES_WITHOUT_CALLER_IDENTITY), (
-            "A route resolves no caller identity of its own. Give it "
-            "get_current_organization (or another identity dependency), or add "
-            "it to ROUTES_WITHOUT_CALLER_IDENTITY with the reason it is safe."
+            "A route is not handed the caller identity it needs. Bind "
+            "get_current_organization (or another org-bearing dependency) to a "
+            "parameter, or add the route to ROUTES_WITHOUT_CALLER_IDENTITY with "
+            "the reason it is safe to answer without one."
         )
 
-    def test_a_route_level_role_gate_is_not_a_caller_identity(self) -> None:
-        """The gate reaches get_auth_context internally; that must not count."""
-        router = APIRouter()
+    def test_org_scoped_providers_resolve_an_organization(self) -> None:
+        """The providers are trusted to carry an org, so prove that they do."""
+        for provider in ORG_SCOPED_PROVIDERS:
+            dependant = get_dependant(path="/", call=provider)
+            reached: set[Any] = set()
+            queue = list(dependant.dependencies)
+            while queue:
+                sub = queue.pop()
+                if sub.name is None or sub.call is None:
+                    continue
+                reached.add(sub.call)
+                queue += sub.dependencies
 
-        @router.get("/gated", dependencies=[Depends(require_org_admin())])
-        async def gated() -> dict[str, str]:
+            assert get_current_organization in reached, provider
+
+    def test_a_discarded_identity_does_not_scope_a_route(self) -> None:
+        """Depends() in the decorator resolves into nowhere, so it proves nothing."""
+        router = APIRouter(dependencies=[Depends(require_org_admin())])
+
+        @router.get("/discarded", dependencies=[Depends(get_current_user)])
+        async def discarded() -> dict[str, str]:
             return {}
 
-        app = FastAPI()
-        app.include_router(router)
-        gated_routes = [
-            (route, inherited)
-            for path, route, inherited in _mounted_routes(app.routes)
-            if path == "/gated"
-        ]
+        assert not _has_caller_identity(self._only_route(router, "/discarded"))
 
-        assert len(gated_routes) == 1
-        assert not _self_declared_identity(*gated_routes[0])
+    def test_an_unrecognized_role_gate_does_not_scope_a_route(self) -> None:
+        """A gate reaching get_auth_context internally still hands over nothing."""
+        router = APIRouter()
+
+        @router.get("/unknown-gate", dependencies=[Depends(_unrecognized_gate())])
+        async def unknown_gate() -> dict[str, str]:
+            return {}
+
+        assert not _has_caller_identity(self._only_route(router, "/unknown-gate"))
+
+    def test_a_bound_organization_scopes_a_route(self) -> None:
+        """The negative cases would be vacuous if nothing satisfied the rule."""
+        router = APIRouter(dependencies=[Depends(require_org_admin())])
+
+        @router.get("/bound")
+        async def bound(org: Any = Depends(get_current_organization)) -> dict[str, str]:
+            return {}
+
+        assert _has_caller_identity(self._only_route(router, "/bound"))
 
     def test_no_sub_application_hides_routes_from_the_walk(self) -> None:
         mounted = _mounted_routes(create_api_app().routes)
-        opaque = [_route_key(r, p) for p, r, _ in mounted if isinstance(r, Mount | Host)]
+        opaque = [_route_key(r, p) for p, r in mounted if isinstance(r, Mount | Host)]
 
         assert opaque == [], (
             "A mounted sub-application is a single opaque leaf to this walk, so "
@@ -229,7 +265,17 @@ class TestRouteAuthCoverage:
         )
 
     def test_allowlist_carries_no_retired_routes(self) -> None:
-        routes = _mounted_routes(create_api_app().routes)
-        mounted = {_route_key(route, path) for path, route, _ in routes}
+        mounted = {
+            _route_key(route, path) for path, route in _mounted_routes(create_api_app().routes)
+        }
 
         assert set(ROUTES_WITHOUT_CALLER_IDENTITY) <= mounted
+
+    @staticmethod
+    def _only_route(router: APIRouter, path: str) -> Any:
+        app = FastAPI()
+        app.include_router(router)
+        matches = [route for route_path, route in _mounted_routes(app.routes) if route_path == path]
+
+        assert len(matches) == 1
+        return matches[0]

--- a/apps/api/tests/test_route_auth_coverage.py
+++ b/apps/api/tests/test_route_auth_coverage.py
@@ -135,24 +135,59 @@ def _is_org_role_gate(call: Any) -> bool:
     )
 
 
+def _tree_has_org_role_gate(dependant: Any) -> bool:
+    """Find a role gate anywhere beneath a dependency, not only at its surface.
+
+    A gate reached through a wrapper still gates the route, so discovery
+    descends even though identity credit never does.
+    """
+    queue = list(dependant.dependencies)
+    while queue:
+        sub = queue.pop()
+        if sub.call is not None and _is_org_role_gate(sub.call):
+            return True
+        queue += sub.dependencies
+    return False
+
+
+def _reaches_org_role_gate(call: Any) -> bool:
+    return _is_org_role_gate(call) or _tree_has_org_role_gate(get_dependant(path="/", call=call))
+
+
 def _route_key(route: Any, path: str) -> str:
     methods = getattr(route, "methods", None)
     label = ",".join(sorted(methods)) if methods else "WS"
     return f"{label} {path}"
 
 
-def _mounted_routes(routes: list[Any], prefix: str = "") -> list[tuple[str, Any]]:
-    """Flatten the app into its leaf routes."""
-    flattened: list[tuple[str, Any]] = []
+def _mounted_routes(
+    routes: list[Any],
+    prefix: str = "",
+    gated_above: bool = False,
+) -> list[tuple[str, Any, bool]]:
+    """Flatten the app into its leaf routes, carrying include-time role gates.
+
+    A gate passed to include_router is applied by the mount node rather than
+    baked into the leaf, so it is invisible from the route alone and has to be
+    handed down.
+    """
+    flattened: list[tuple[str, Any, bool]] = []
     for route in routes:
         # FastAPI mounts an included router as a single node rather than copying
         # its routes, so the tree has to be walked through that node.
         include = getattr(route, "include_context", None)
         if include is not None:
-            flattened += _mounted_routes(include.included_router.routes, prefix + include.prefix)
+            gated = gated_above or any(
+                _reaches_org_role_gate(dependency.dependency)
+                for dependency in include.dependencies
+                if dependency.dependency is not None
+            )
+            flattened += _mounted_routes(
+                include.included_router.routes, prefix + include.prefix, gated
+            )
             continue
 
-        flattened.append((prefix + getattr(route, "path", ""), route))
+        flattened.append((prefix + getattr(route, "path", ""), route, gated_above))
     return flattened
 
 
@@ -173,13 +208,16 @@ def _declared(route: Any) -> set[Any]:
     return {sub.call for sub in route.dependant.dependencies if sub.call}
 
 
-def _has_caller_identity(route: Any) -> bool:
-    declared = _declared(route)
-    received = _received(route)
+def _has_caller_identity(route: Any, gated_above: bool = False) -> bool:
+    if not isinstance(route, APIRoute | APIWebSocketRoute):
+        return False
 
-    if any(_is_org_role_gate(call) for call in declared):
+    received = _received(route)
+    if gated_above or _tree_has_org_role_gate(route.dependant):
         return bool(received & ORG_BEARING_DEPENDENCIES)
-    return bool(received & CALLER_IDENTITY_DEPENDENCIES) or bool(declared & ENFORCING_GATES)
+    if received & CALLER_IDENTITY_DEPENDENCIES:
+        return True
+    return bool(_declared(route) & ENFORCING_GATES)
 
 
 def _unrecognized_gate() -> Any:
@@ -191,6 +229,13 @@ def _unrecognized_gate() -> Any:
     return _check
 
 
+_ORG_ADMIN_GATE = Depends(require_org_admin())
+
+
+async def _wrapped_org_gate(_gate: Any = _ORG_ADMIN_GATE) -> None:
+    """A real role gate buried one dependency deep."""
+
+
 class TestRouteAuthCoverage:
     def test_walk_reaches_the_whole_application(self) -> None:
         assert len(_mounted_routes(create_api_app().routes)) >= MINIMUM_MOUNTED_ROUTES
@@ -198,8 +243,8 @@ class TestRouteAuthCoverage:
     def test_every_route_receives_a_caller_identity(self) -> None:
         unscoped = [
             _route_key(route, path)
-            for path, route in _mounted_routes(create_api_app().routes)
-            if not _has_caller_identity(route)
+            for path, route, gated_above in _mounted_routes(create_api_app().routes)
+            if not _has_caller_identity(route, gated_above)
         ]
 
         assert sorted(unscoped) == sorted(ROUTES_WITHOUT_CALLER_IDENTITY), (
@@ -208,21 +253,6 @@ class TestRouteAuthCoverage:
             "parameter, or add the route to ROUTES_WITHOUT_CALLER_IDENTITY with "
             "the reason it is safe to answer without one."
         )
-
-    def test_org_scoped_providers_resolve_an_organization(self) -> None:
-        """The providers are trusted to carry an org, so prove that they do."""
-        for provider in ORG_SCOPED_PROVIDERS:
-            dependant = get_dependant(path="/", call=provider)
-            reached: set[Any] = set()
-            queue = list(dependant.dependencies)
-            while queue:
-                sub = queue.pop()
-                if sub.name is None or sub.call is None:
-                    continue
-                reached.add(sub.call)
-                queue += sub.dependencies
-
-            assert get_current_organization in reached, provider
 
     def test_a_discarded_identity_does_not_scope_a_route(self) -> None:
         """Depends() in the decorator resolves into nowhere, so it proves nothing."""
@@ -244,6 +274,35 @@ class TestRouteAuthCoverage:
 
         assert not _has_caller_identity(self._only_route(router, "/unknown-gate"))
 
+    def test_a_wrapped_role_gate_still_demands_an_organization(self) -> None:
+        """The gate is a dependency deep, so surface-only discovery misses it."""
+        router = APIRouter()
+
+        @router.get("/wrapped", dependencies=[Depends(_wrapped_org_gate)])
+        async def wrapped(user: Any = Depends(get_current_user)) -> dict[str, str]:
+            return {}
+
+        assert not _has_caller_identity(self._only_route(router, "/wrapped"))
+
+    def test_an_include_time_role_gate_still_demands_an_organization(self) -> None:
+        """A gate passed to include_router never reaches the leaf's dependant."""
+        router = APIRouter()
+
+        @router.get("/included")
+        async def included(user: Any = Depends(get_current_user)) -> dict[str, str]:
+            return {}
+
+        app = FastAPI()
+        app.include_router(router, dependencies=[Depends(require_org_admin())])
+        matches = [
+            (route, gated_above)
+            for path, route, gated_above in _mounted_routes(app.routes)
+            if path == "/included"
+        ]
+
+        assert len(matches) == 1
+        assert not _has_caller_identity(*matches[0])
+
     def test_a_bound_organization_scopes_a_route(self) -> None:
         """The negative cases would be vacuous if nothing satisfied the rule."""
         router = APIRouter(dependencies=[Depends(require_org_admin())])
@@ -256,7 +315,7 @@ class TestRouteAuthCoverage:
 
     def test_no_sub_application_hides_routes_from_the_walk(self) -> None:
         mounted = _mounted_routes(create_api_app().routes)
-        opaque = [_route_key(r, p) for p, r in mounted if isinstance(r, Mount | Host)]
+        opaque = [_route_key(r, p) for p, r, _ in mounted if isinstance(r, Mount | Host)]
 
         assert opaque == [], (
             "A mounted sub-application is a single opaque leaf to this walk, so "
@@ -265,9 +324,8 @@ class TestRouteAuthCoverage:
         )
 
     def test_allowlist_carries_no_retired_routes(self) -> None:
-        mounted = {
-            _route_key(route, path) for path, route in _mounted_routes(create_api_app().routes)
-        }
+        routes = _mounted_routes(create_api_app().routes)
+        mounted = {_route_key(route, path) for path, route, _ in routes}
 
         assert set(ROUTES_WITHOUT_CALLER_IDENTITY) <= mounted
 
@@ -275,7 +333,9 @@ class TestRouteAuthCoverage:
     def _only_route(router: APIRouter, path: str) -> Any:
         app = FastAPI()
         app.include_router(router)
-        matches = [route for route_path, route in _mounted_routes(app.routes) if route_path == path]
+        matches = [
+            route for route_path, route, _ in _mounted_routes(app.routes) if route_path == path
+        ]
 
         assert len(matches) == 1
         return matches[0]

--- a/apps/api/tests/test_route_auth_coverage.py
+++ b/apps/api/tests/test_route_auth_coverage.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import params
+from fastapi import APIRouter, Depends, FastAPI, params
 from fastapi.dependencies.utils import get_dependant
 from fastapi.routing import APIRoute, APIWebSocketRoute
+from starlette.routing import Host, Mount
 
 from sibyl.api.app import create_api_app
 from sibyl.auth.dependencies import (
@@ -27,6 +28,8 @@ from sibyl.auth.dependencies import (
     get_current_org_role,
     get_current_organization,
     get_current_user,
+    require_org_admin,
+    require_org_role,
 )
 from sibyl.persistence.operations_runtime import (
     require_global_admin,
@@ -48,6 +51,12 @@ CALLER_IDENTITY_DEPENDENCIES = frozenset(
         require_setup_mode_or_auth,
     }
 )
+
+# Factories whose closures authorize a caller against an organization someone
+# else resolved. They reach an identity dependency internally, so crediting
+# anything under them would let a route pass on the strength of the very gate
+# this test exists to discount.
+ORG_ROLE_GATE_FACTORIES = (require_org_admin, require_org_role)
 
 # Routes that answer without knowing the caller, keyed by "<methods> <path>".
 # Adding an entry here is a decision to serve a route to anyone who reaches it,
@@ -105,9 +114,19 @@ ROUTES_WITHOUT_CALLER_IDENTITY: dict[str, str] = {
 MINIMUM_MOUNTED_ROUTES = 150
 
 
+def _is_org_role_gate(call: Any) -> bool:
+    qualname = getattr(call, "__qualname__", "")
+    return any(
+        qualname.startswith(f"{factory.__qualname__}.<locals>.")
+        for factory in ORG_ROLE_GATE_FACTORIES
+    )
+
+
 def _resolved_calls(dependant: Any, found: set[Any]) -> set[Any]:
     for sub in dependant.dependencies:
         if sub.call is not None:
+            if _is_org_role_gate(sub.call):
+                continue
             found.add(sub.call)
         _resolved_calls(sub, found)
     return found
@@ -178,6 +197,35 @@ class TestRouteAuthCoverage:
             "A route resolves no caller identity of its own. Give it "
             "get_current_organization (or another identity dependency), or add "
             "it to ROUTES_WITHOUT_CALLER_IDENTITY with the reason it is safe."
+        )
+
+    def test_a_route_level_role_gate_is_not_a_caller_identity(self) -> None:
+        """The gate reaches get_auth_context internally; that must not count."""
+        router = APIRouter()
+
+        @router.get("/gated", dependencies=[Depends(require_org_admin())])
+        async def gated() -> dict[str, str]:
+            return {}
+
+        app = FastAPI()
+        app.include_router(router)
+        gated_routes = [
+            (route, inherited)
+            for path, route, inherited in _mounted_routes(app.routes)
+            if path == "/gated"
+        ]
+
+        assert len(gated_routes) == 1
+        assert not _self_declared_identity(*gated_routes[0])
+
+    def test_no_sub_application_hides_routes_from_the_walk(self) -> None:
+        mounted = _mounted_routes(create_api_app().routes)
+        opaque = [_route_key(r, p) for p, r, _ in mounted if isinstance(r, Mount | Host)]
+
+        assert opaque == [], (
+            "A mounted sub-application is a single opaque leaf to this walk, so "
+            "allowlisting it would exempt every route inside it. Teach "
+            "_mounted_routes to descend the sub-application instead."
         )
 
     def test_allowlist_carries_no_retired_routes(self) -> None:

--- a/apps/api/tests/test_routes_jobs.py
+++ b/apps/api/tests/test_routes_jobs.py
@@ -11,7 +11,7 @@ from fastapi import HTTPException
 
 from sibyl.api.routes.jobs import (
     JobStatusBatchRequest,
-    _job_visible_to_org,
+    job_visible_to_org,
     cancel_job,
     get_jobs_status,
     jobs_health,
@@ -36,8 +36,8 @@ class TestJobVisibility:
             function="project_memory_batch",
         )
 
-        assert await _job_visible_to_org(visible, org=org) is True
-        assert await _job_visible_to_org(hidden, org=org) is False
+        assert await job_visible_to_org(visible, org=org) is True
+        assert await job_visible_to_org(hidden, org=org) is False
 
     @pytest.mark.asyncio
     async def test_source_jobs_use_embedded_org_metadata_without_db_lookup(self) -> None:
@@ -49,7 +49,7 @@ class TestJobVisibility:
             kwargs={"organization_id": str(org.id)},
         )
 
-        assert await _job_visible_to_org(job, org=org, session=session) is True
+        assert await job_visible_to_org(job, org=org, session=session) is True
         session.execute.assert_not_called()
 
     @pytest.mark.asyncio
@@ -62,7 +62,7 @@ class TestJobVisibility:
             kwargs={"organization_id": "00000000-0000-0000-0000-000000000999"},
         )
 
-        assert await _job_visible_to_org(job, org=org, session=session) is False
+        assert await job_visible_to_org(job, org=org, session=session) is False
         session.execute.assert_not_called()
 
     @pytest.mark.asyncio
@@ -79,7 +79,7 @@ class TestJobVisibility:
             "sibyl.api.routes.jobs.get_crawl_source_by_id",
             AsyncMock(return_value=SimpleNamespace(organization_id=org.id)),
         ) as get_source:
-            assert await _job_visible_to_org(job, org=org, session=session) is True
+            assert await job_visible_to_org(job, org=org, session=session) is True
 
         get_source.assert_awaited_once_with(
             session,
@@ -106,9 +106,9 @@ class TestJobVisibility:
             kwargs=None,
         )
 
-        assert await _job_visible_to_org(visible_consolidation, org=org, session=session) is True
-        assert await _job_visible_to_org(visible_reflection, org=org, session=session) is True
-        assert await _job_visible_to_org(hidden, org=org, session=session) is False
+        assert await job_visible_to_org(visible_consolidation, org=org, session=session) is True
+        assert await job_visible_to_org(visible_reflection, org=org, session=session) is True
+        assert await job_visible_to_org(hidden, org=org, session=session) is False
         session.get.assert_not_called()
 
     @pytest.mark.asyncio
@@ -129,8 +129,8 @@ class TestJobVisibility:
             kwargs=None,
         )
 
-        assert await _job_visible_to_org(visible, org=org, session=session) is True
-        assert await _job_visible_to_org(hidden, org=org, session=session) is False
+        assert await job_visible_to_org(visible, org=org, session=session) is True
+        assert await job_visible_to_org(hidden, org=org, session=session) is False
         session.get.assert_not_called()
 
 
@@ -286,7 +286,7 @@ class TestCancelJobRoute:
 
         with (
             patch("sibyl.jobs.queue.get_job_status", AsyncMock(return_value=job)),
-            patch("sibyl.api.routes.jobs._job_visible_to_org", AsyncMock(return_value=False)),
+            patch("sibyl.api.routes.jobs.job_visible_to_org", AsyncMock(return_value=False)),
             pytest.raises(HTTPException) as exc_info,
         ):
             await cancel_job("crawl:source-123", org=org)

--- a/apps/api/tests/test_routes_jobs.py
+++ b/apps/api/tests/test_routes_jobs.py
@@ -11,9 +11,9 @@ from fastapi import HTTPException
 
 from sibyl.api.routes.jobs import (
     JobStatusBatchRequest,
-    job_visible_to_org,
     cancel_job,
     get_jobs_status,
+    job_visible_to_org,
     jobs_health,
     list_jobs,
     trigger_consolidation,


### PR DESCRIPTION
# 🛡️ Production installs stop silently disabling MCP auth

> Fixes finding I3 from `docs/architecture/AUDIT_2026-08-13/debt-web-cli-infra.md`, rated blocker.
> Eight commits: the chart guard, a matching server-side validator for deployments the chart cannot reach, then the fixes three review rounds turned up.

## 💡 What this is

A stock `helm install charts/sibyl` produced a deployment labelled `SIBYL_ENVIRONMENT: production` with MCP authentication turned off, and nothing anywhere said so. This makes that configuration fail at template time with a message naming the value to set.

The obvious fix is to have the chart generate a JWT secret when none is supplied, the way `surreal-secret.yaml` generates a SurrealDB root password. That fix is wrong here, and the SurrealDB secret is the proof: `randAlphaNum` has no `lookup` guard, so it writes a new password on every `helm upgrade`, and the audit filed that as its own blocker (I5). A generated JWT secret would inherit the same defect and add a second one, since the backend, worker, and bootstrap pods each read the value at their own render. Rotating the signing key invalidates every live session; diverging it across pods means tokens minted by one are rejected by another. Production secrets have to come from outside the chart, so the chart's job is to refuse to render without one.

## 🤔 The mechanism it closes

Four defaults line up so that no single one looks wrong:

```mermaid
flowchart LR
    A["values.yaml<br/>SIBYL_ENVIRONMENT: production"] --> D
    B["values.yaml<br/>existingSecret: ''"] --> C["backend-deployment.yaml<br/>if .Values.backend.existingSecret<br/>skips the SIBYL_JWT_SECRET block"]
    C --> D["config.py<br/>dev auto-generation is gated on<br/>environment != production, so it<br/>never fires"]
    D --> E["jwt_secret == ''"]
    E --> F["server.py<br/>auth_mode 'auto' enforces Bearer auth<br/>only when a JWT secret is set"]
    F --> G["MCP auth off.<br/>SessionMiddleware built with secret_key=''"]
```

Startup logged the outcome at INFO and carried on (`main.py:133-137`). The production validator at `config.py:229-276` checked `disable_auth`, in-memory and embedded Surreal URLs, `cookie_secure`, and default Surreal credentials, and never checked for a signing key. The values comment above `existingSecret` stated the requirement in prose, which is documentation rather than enforcement.

## 🎯 The invariant

No render labelled production completes without a usable JWT secret held in a Kubernetes Secret and MCP auth left enabled, and no process labelled production starts without the same. Anchor the review on that pair: the chart guard covers Helm, the config validator covers everything else, and the two enforce the same three conditions so neither is the only thing standing between an operator and an unauthenticated deploy.

## 🛠️ How it works

**The chart guard.** `sibyl.validateProductionAuthSecret` in `charts/sibyl/templates/_helpers.tpl` follows the shape of the existing `sibyl.validateOidcProviders` helper: a `define` block that calls Helm's `fail`, included from `configmap.yaml`. The ConfigMap is the right host because it renders unconditionally, unlike the deployments, which sit behind enable toggles. It reads `backend.env.SIBYL_ENVIRONMENT`, and when that is `production` it requires `backend.existingSecret`.

A second clause rejects `backend.env.SIBYL_JWT_SECRET` and the unprefixed `backend.env.JWT_SECRET` in production. Supplying the key either way looks like it should work, but the `range .Values.backend.env` loop in `configmap.yaml` writes every key verbatim into the plaintext `<release>-config` ConfigMap. A signing key stored there is readable under broader RBAC than a Secret and lands in GitOps repositories in the clear. The unprefixed alias is not inert, either: the JWT fallback in `config.py` reads it whenever the prefixed variable is empty, so a Secret that exists but carries an empty value hands the process the plaintext copy.

A third clause rejects `backend.env.SIBYL_MCP_AUTH_MODE: off` in production, which would serve every MCP tool unauthenticated no matter how carefully the Secret was provisioned. Development still allows it, since `docs/guide/self-hosting.md` documents it as the local unauthenticated endpoint.

All three clauses range over `backend.env` and compare `upper $key` rather than looking up an exact key, because `SettingsConfigDict` in `config.py` leaves `case_sensitive` at its default of `False`. A lowercase `sibyl_jwt_secret` reaches `Settings.jwt_secret` exactly as the uppercase spelling does, so an exact-key guard would wave it through while the ConfigMap still received the signing key. The environment check treats any casing that spells `production` as production, which is the fail-safe direction when a values file carries the key twice in different cases.

The failure text threads `.Release.Namespace` and `.Release.Name` through `printf`. A namespace-free `kubectl create secret` would land the Secret in `default` while the release lives elsewhere, and recommending `helm install` for what is usually an existing release invites orphaning it, so the remediation names the namespace in both lines and recommends `helm upgrade --install`.

**The server-side validator.** `validate_production_auth_posture` in `apps/api/src/sibyl/config.py` refuses to construct `Settings` in production on three conditions: an empty signing key, a key under 32 bytes, and `mcp_auth_mode == "off"`. The length floor exists because HS256 is only as strong as its key, and a one-byte secret produced verifiable tokens before it. The key is stripped first, since a value read from a file or projected from a Kubernetes Secret commonly carries a trailing newline that would make the API and the worker disagree on a signature; stripping also turns a whitespace-only value into the empty case rather than a valid key. Placement matters as much as the checks: it is defined after `check_api_key_fallbacks` rather than inside `validate_security_settings`, because the non-prefixed `JWT_SECRET` environment fallback is applied in `check_api_key_fallbacks`, and pydantic runs `mode="after"` validators in class-body order. Putting the check in `validate_security_settings`, where the other production rules live, would see the pre-fallback value and reject a configuration that sets bare `JWT_SECRET`. A test pins that ordering.

**Why both.** The chart guard cannot see a raw `docker run`, a systemd unit, or a hand-written manifest. The config validator catches those, and it is the reason this change closes the finding rather than moving it.

**The enterprise readiness evidence tool.** `SIBYL_HELM_RENDER_ARGS` in `tools/trust/enterprise_readiness_evidence.py` renders `charts/sibyl` with a long override list that turns on Gateway API, network policy, restricted pod security, bootstrap, and break-glass. It never set `backend.existingSecret`, so it inherited the production default and the new guard stopped it, which took down the `rendered_helm_manifests` evidence item and the `moon run enterprise-readiness-evidence` workflow documented in `docs/admin/backup-restore.md`. The guard was right to fire: that render was certifying a production manifest with no JWT secret, which is the vulnerability this branch exists to close. The override list now sets the Secret, so the evidence reflects a correctly secured deployment.

## 🧪 Validation

The chart scenarios, run against helm 4.2.3 and re-run against helm 3.20.2 to match the version pinned in `publish.yml`:

| Configuration | Command suffix | Exit |
| --- | --- | --- |
| Production, no secret | (defaults) | 1 |
| Production, Secret supplied | `--set backend.existingSecret=sibyl-secrets` | 0 |
| Non-production | `--set backend.env.SIBYL_ENVIRONMENT=development` | 0 |
| Production, key in the ConfigMap | `--set backend.existingSecret=sibyl-secrets --set backend.env.SIBYL_JWT_SECRET=hunter2` | 1 |
| Same, unprefixed alias | `... --set backend.env.JWT_SECRET=hunter2` | 1 |
| Same, lowercase and mixed case | `... --set backend.env.sibyl_jwt_secret=hunter2` | 1 |
| Production labelled in lowercase | `--set backend.env.SIBYL_ENVIRONMENT=null --set backend.env.sibyl_environment=production` | 1 |
| Production, MCP auth switched off | `... --set backend.env.SIBYL_MCP_AUTH_MODE=off` | 1 |
| Production, MCP auth enforcing | `... --set backend.env.SIBYL_MCP_AUTH_MODE=on` | 0 |
| Development, MCP auth off | `--set backend.env.SIBYL_ENVIRONMENT=development --set backend.env.SIBYL_MCP_AUTH_MODE=off` | 0 |
| Enterprise evidence render | the tool's own `SIBYL_HELM_RENDER_ARGS` | 0 |

The default case now prints:

```
Error: execution error at (sibyl/templates/worker-deployment.yaml:18:28): backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is "production".
Without it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to "auto", which enforces Bearer auth only when a JWT secret is present).
Create the secret, then point the chart at it:
  kubectl create secret generic sibyl-secrets \
    --from-literal=SIBYL_JWT_SECRET="$(openssl rand -hex 32)" \
    --from-literal=SIBYL_SETTINGS_KEY="$(openssl rand -hex 32)"
  helm install sibyl charts/sibyl --set backend.existingSecret=sibyl-secrets
Setting backend.env.SIBYL_JWT_SECRET does not satisfy this: every backend.env key is rendered into the plaintext sibyl-config ConfigMap, which is readable under broader RBAC than a Secret.
For a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead. The server then derives its own JWT secret per process, so sessions break on restart and across replicas, which is why that path is unfit for production.
```

`helm install sibyl charts/sibyl --dry-run=client` fails identically, so the guard holds on the install path and not only in `helm template`. The Secret-supplied case renders 413 lines carrying `key: SIBYL_JWT_SECRET` and `key: SIBYL_SETTINGS_KEY` for both the backend and the worker. The development case renders `SIBYL_ENVIRONMENT: "development"` and zero `SIBYL_JWT_SECRET` references, which is what leaves the server's development auto-generation path intact, and it still renders when a lowercase inline key is present, since the rejection is production-only.

`helm lint charts/sibyl` exits 0 on both helm versions, with `1 chart(s) linted, 0 chart(s) failed`. The linter reports a template `fail` at INFO level rather than as an error, so the bare `helm lint` in the `helm-package` job of `publish.yml` stays green while `helm template` and `helm install` abort. That asymmetry is why the new tests assert on `helm template` rather than on lint.

Test suites:

- `moon run api:test` → 2121 passed, 5 skipped, on the interpreter `.prototools` pins (Python 3.13.12). The skips are the four live SurrealDB runtime smokes and the archive drift test that needs a real 3.x server.
- `uv run pytest tools/tests/test_runtime_surface.py tools/tests/test_enterprise_readiness_evidence.py -q` → 116 passed.
- `moon run :lint` → 12 tasks clean, including `api:lint`.
- `moon run sync-versions-check` → `All deployment pins match VERSION (1.2.0).`
- `moon run api:typecheck` → `All checks passed!`

Eighteen tests are new. Nine live in `tools/tests/test_runtime_surface.py`, covering the helper being defined and included, every row of the table above, the evidence tool's own `SIBYL_HELM_RENDER_ARGS` so the pairing cannot break silently again, and the remediation naming the release namespace under `helm template --namespace sibyl-prod`. The eight that shell out skip cleanly when the helm binary is absent. The other nine cover the config validator: the empty-secret rejection, the bare `JWT_SECRET` fallback satisfying it, staging staying exempt, the 32-byte floor, whitespace stripping, a whitespace-only value failing as empty, `mcp_auth_mode=off` rejected in production, `auto` and `on` staying allowed, and `off` staying allowed outside production.

One existing test earns a note. `test_cookie_secure_defaults_true_in_production_http` in `apps/api/tests/test_auth_cookie_config.py` sets `SIBYL_ENVIRONMENT=production` through `monkeypatch`, so it now sets a `SIBYL_JWT_SECRET` alongside it. Deleting that one line fails the test with a `ValidationError` from the new validator, which is what makes the addition a check on the validator rather than a way around it.

## 🔍 What reviewers should focus on

- **The validator ordering in `config.py`.** If `validate_production_jwt_secret` ever moves above `check_api_key_fallbacks` in the class body, deployments that set bare `JWT_SECRET` break. `test_non_prefixed_jwt_secret_satisfies_production` is the guard against that.
- **Whether the guard has a bypass.** It keys on a `backend.env` entry named `SIBYL_ENVIRONMENT` in any casing. An operator who labels production some other way renders without the check. One known inert edge remains: a whitespace-only inline value passes the ConfigMap clause, and it cannot carry a real key, and the backend and worker both declare an explicit `env` entry sourcing `SIBYL_JWT_SECRET` from the Secret, which kubelet resolves ahead of `envFrom`.
- **The `backend.existingSecret` addition to `SIBYL_HELM_RENDER_ARGS`.** The evidence manifest is a compliance artifact, and this changes what it renders. Worth confirming the new manifest is the one that should be certified.
- **Blast radius on existing installs.** Anyone already running the chart in production has `existingSecret` set, since without it their auth was off. An upgrade for them is a no-op unless their key is under 32 bytes or they had switched MCP auth off, both of which now fail loudly. The people this breaks are the ones whose deploy was silently unauthenticated, plus anyone who put the signing key in `backend.env`, which is the intent in every case.
- **The 32-byte floor is a hard gate on an existing value.** An operator running a short key today gets a refused boot rather than a warning. That is the correct trade for a forgeable HS256 signature, and it is the one change here that can stop a currently-running deployment from restarting.
- **The twelve fixture updates in `apps/api/tests`.** Each adds `jwt_secret="test-jwt-secret"` to a `Settings` construction that was asserting something unrelated (cookie behavior, Surreal credentials, local auth defaults). Worth a scan for any case where the added kwarg changes what the test proves.

## 📌 Deliberately not in scope

The new chart tests live in `tools/tests/test_runtime_surface.py`, which the `inventory-test` moon task runs. That task is a dependency of root `check` and `test`, so it runs at RC cut through `release.yml`, and it does not run in PR CI: `ci.yml` never invokes `inventory-test`, and helm is installed only in `publish.yml`. Closing that gap means fixing the CI change classifier first, since finding I1 documents that `charts/` is absent from the `runtime_changed` case list entirely, so a chart-only pull request currently trips no classifier flag and reaches no test job. This PR adds `charts/sibyl/**/*` to the `inventory-test` inputs so chart edits invalidate its cache once a job does run it.

The audit's other infrastructure blockers stay open and untouched: the worker crash-loop under the chart's own `coordinationBackend: "auto"` default (I4), the SurrealDB root password regenerating on every upgrade (I5), and the SurrealDB PVC mounted without `fsGroup` (I6). Fixing the CI change classifier so chart edits reach a test job is audit item I1 and stays out of this PR; the boundary is named above rather than patched here.

The audit also lists one unverified question this change does not answer: whether tokens signed with an empty HMAC key also verify, which would make sessions forgeable rather than merely unauthenticated. Both guards make the empty-key state unreachable in production, so the question stops being reachable in practice, but it is not settled on its own terms.

One cosmetic edge survives. Passing a non-map `backend.env` (`--set backend.env=oops`) produces a raw Go template type error from `_helpers.tpl` rather than a written message. It fails closed, so it is a legibility issue rather than a security one.
