### PR TITLE
fix(charts): fail the render when a production install has no JWT secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,7 +512,7 @@ jobs:
     timeout-minutes: 20
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-ci
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_COORDINATION_BACKEND: local
@@ -577,7 +577,7 @@ jobs:
     timeout-minutes: 30
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-ci
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_LOCAL_AUTH_ENABLED: "true"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -156,7 +156,7 @@ jobs:
     timeout-minutes: 30
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-eval
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_PUBLIC_SIGNUPS_ENABLED: "true"
@@ -325,7 +325,7 @@ jobs:
     timeout-minutes: 45
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-eval
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_PUBLIC_SIGNUPS_ENABLED: "true"
@@ -521,7 +521,7 @@ jobs:
     timeout-minutes: 60
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-eval
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_PUBLIC_SIGNUPS_ENABLED: "true"
@@ -809,7 +809,7 @@ jobs:
     timeout-minutes: 180
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-eval
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_PUBLIC_SIGNUPS_ENABLED: "true"

--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -353,7 +353,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-longmemeval-v2
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_PUBLIC_SIGNUPS_ENABLED: "true"

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 30
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-nightly
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_LOCAL_AUTH_ENABLED: "true"
@@ -238,7 +238,7 @@ jobs:
     timeout-minutes: 45
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-nightly
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_COORDINATION_BACKEND: local
@@ -325,7 +325,7 @@ jobs:
     timeout-minutes: 45
     env:
       SIBYL_ENVIRONMENT: production
-      SIBYL_JWT_SECRET: test-secret-for-nightly
+      SIBYL_JWT_SECRET: not-a-real-secret-not-a-real-secret
       SIBYL_STORE: surreal
       SIBYL_AUTH_STORE: surreal
       SIBYL_COORDINATION_BACKEND: local

--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -21,6 +21,8 @@ _EXTRA_OIDC_ISSUER_HOSTS = {"github.com", "accounts.google.com"}
 _EMBEDDED_SURREAL_SCHEMES = ("memory://", "surrealkv://", "rocksdb://", "file://")
 DEFAULT_LOCAL_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 DEFAULT_LOCAL_EMBEDDING_DIMENSIONS = 384
+# Matches the HS256 output width, and what `openssl rand -hex 32` produces.
+MINIMUM_PRODUCTION_JWT_SECRET_BYTES = 32
 _OPENAI_GRAPH_EMBEDDING_MODEL = "text-embedding-3-small"
 _OPENAI_GRAPH_EMBEDDING_DIMENSIONS = 1024
 _LOCAL_EMBEDDING_MODEL_DIMENSIONS = {
@@ -586,23 +588,43 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def validate_production_jwt_secret(self) -> "Settings":
-        """Refuse to boot production without a signing key.
+    def validate_production_auth_posture(self) -> "Settings":
+        """Refuse to boot production with a weak signing key or MCP auth off.
 
         Runs after check_api_key_fallbacks so the non-prefixed JWT_SECRET
         fallback has already been applied.
         """
         if self.environment != "production":
             return self
-        if self.jwt_secret.get_secret_value():
-            return self
-        raise ValueError(
-            "CRITICAL: A JWT secret is required in production. Without it sessions "
-            "are signed with an empty key and MCP auth disables itself under the "
-            "default mcp_auth_mode=auto. Set SIBYL_JWT_SECRET to a high-entropy "
-            "value, or set SIBYL_ENVIRONMENT=development to use the generated "
-            "development secret."
-        )
+
+        # A key arriving from a file or a k8s Secret often carries a trailing
+        # newline, which would make the API and worker disagree on the signature.
+        secret = self.jwt_secret.get_secret_value().strip()
+        if secret != self.jwt_secret.get_secret_value():
+            object.__setattr__(self, "jwt_secret", SecretStr(secret))
+
+        if not secret:
+            raise ValueError(
+                "CRITICAL: A JWT secret is required in production. Without it sessions "
+                "are signed with an empty key and MCP auth disables itself under the "
+                "default mcp_auth_mode=auto. Generate one with `openssl rand -hex 32` "
+                "and set SIBYL_JWT_SECRET, or set SIBYL_ENVIRONMENT=development to use "
+                "the generated development secret."
+            )
+        if len(secret.encode()) < MINIMUM_PRODUCTION_JWT_SECRET_BYTES:
+            raise ValueError(
+                f"CRITICAL: The production JWT secret is {len(secret.encode())} bytes; "
+                f"at least {MINIMUM_PRODUCTION_JWT_SECRET_BYTES} are required. HS256 "
+                "signatures are only as strong as the key, so a short one is forgeable. "
+                "Generate a replacement with `openssl rand -hex 32`."
+            )
+        if self.mcp_auth_mode == "off":
+            raise ValueError(
+                "CRITICAL: mcp_auth_mode=off is forbidden in production. It serves every "
+                'MCP tool unauthenticated. Use "auto" or "on", or set '
+                "SIBYL_ENVIRONMENT=development for a local unauthenticated endpoint."
+            )
+        return self
 
     embedding_provider: Literal["openai", "gemini"] = Field(
         default="openai",

--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -585,6 +585,25 @@ class Settings(BaseSettings):
 
         return self
 
+    @model_validator(mode="after")
+    def validate_production_jwt_secret(self) -> "Settings":
+        """Refuse to boot production without a signing key.
+
+        Runs after check_api_key_fallbacks so the non-prefixed JWT_SECRET
+        fallback has already been applied.
+        """
+        if self.environment != "production":
+            return self
+        if self.jwt_secret.get_secret_value():
+            return self
+        raise ValueError(
+            "CRITICAL: A JWT secret is required in production. Without it sessions "
+            "are signed with an empty key and MCP auth disables itself under the "
+            "default mcp_auth_mode=auto. Set SIBYL_JWT_SECRET to a high-entropy "
+            "value, or set SIBYL_ENVIRONMENT=development to use the generated "
+            "development secret."
+        )
+
     embedding_provider: Literal["openai", "gemini"] = Field(
         default="openai",
         description="Provider for document chunk embeddings",

--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -597,11 +597,8 @@ class Settings(BaseSettings):
         if self.environment != "production":
             return self
 
-        # A key arriving from a file or a k8s Secret often carries a trailing
-        # newline, which would make the API and worker disagree on the signature.
-        secret = self.jwt_secret.get_secret_value().strip()
-        if secret != self.jwt_secret.get_secret_value():
-            object.__setattr__(self, "jwt_secret", SecretStr(secret))
+        raw = self.jwt_secret.get_secret_value()
+        secret = raw.strip()
 
         if not secret:
             raise ValueError(
@@ -610,6 +607,16 @@ class Settings(BaseSettings):
                 "default mcp_auth_mode=auto. Generate one with `openssl rand -hex 32` "
                 "and set SIBYL_JWT_SECRET, or set SIBYL_ENVIRONMENT=development to use "
                 "the generated development secret."
+            )
+        # Rejected rather than trimmed: silently trimming would change the signing
+        # key, so a rolling upgrade would leave old and new revisions unable to
+        # verify each other's tokens.
+        if secret != raw:
+            raise ValueError(
+                "CRITICAL: The production JWT secret has leading or trailing whitespace, "
+                "which usually means a trailing newline from `$(cat secret.txt)` or a "
+                "file-projected Kubernetes Secret. Remove it and restart. The value is "
+                "used exactly as given, so trimming it here would change every signature."
             )
         if len(secret.encode()) < MINIMUM_PRODUCTION_JWT_SECRET_BYTES:
             raise ValueError(

--- a/apps/api/tests/test_auth_cookie_config.py
+++ b/apps/api/tests/test_auth_cookie_config.py
@@ -33,7 +33,7 @@ def test_cookie_secure_defaults_true_in_production_http(monkeypatch) -> None:
     monkeypatch.setenv("SIBYL_SURREAL_URL", "ws://surrealdb:8000/rpc")
     monkeypatch.setenv("SIBYL_SURREAL_USERNAME", "sibyl_admin")
     monkeypatch.setenv("SIBYL_SURREAL_PASSWORD", "really_secure_password")
-    monkeypatch.setenv("SIBYL_JWT_SECRET", "test-jwt-secret")
+    monkeypatch.setenv("SIBYL_JWT_SECRET", "test-jwt-secret-0123456789abcdef0123456789abcdef")
     monkeypatch.delenv("SIBYL_COOKIE_SECURE", raising=False)
 
     from sibyl import config as config_module

--- a/apps/api/tests/test_auth_cookie_config.py
+++ b/apps/api/tests/test_auth_cookie_config.py
@@ -33,6 +33,7 @@ def test_cookie_secure_defaults_true_in_production_http(monkeypatch) -> None:
     monkeypatch.setenv("SIBYL_SURREAL_URL", "ws://surrealdb:8000/rpc")
     monkeypatch.setenv("SIBYL_SURREAL_USERNAME", "sibyl_admin")
     monkeypatch.setenv("SIBYL_SURREAL_PASSWORD", "really_secure_password")
+    monkeypatch.setenv("SIBYL_JWT_SECRET", "test-jwt-secret")
     monkeypatch.delenv("SIBYL_COOKIE_SECURE", raising=False)
 
     from sibyl import config as config_module

--- a/apps/api/tests/test_auth_settings.py
+++ b/apps/api/tests/test_auth_settings.py
@@ -256,7 +256,7 @@ def test_settings_auth_defaults_disable_production_local_login() -> None:
         surreal_url="ws://surrealdb:8000/rpc",
         surreal_username="sibyl_admin",
         surreal_password="really_secure_password",
-        jwt_secret="test-jwt-secret",
+        jwt_secret="test-jwt-secret-0123456789abcdef0123456789abcdef",
     )
 
     assert s.local_auth_enabled is False
@@ -280,7 +280,7 @@ def test_settings_explicit_production_local_auth_override_is_respected() -> None
         surreal_url="ws://surrealdb:8000/rpc",
         surreal_username="sibyl_admin",
         surreal_password="really_secure_password",
-        jwt_secret="test-jwt-secret",
+        jwt_secret="test-jwt-secret-0123456789abcdef0123456789abcdef",
         local_auth_enabled=True,
     )
 
@@ -296,7 +296,7 @@ def test_settings_enterprise_auth_features_are_opt_in() -> None:
         surreal_url="ws://surrealdb:8000/rpc",
         surreal_username="sibyl_admin",
         surreal_password="really_secure_password",
-        jwt_secret="test-jwt-secret",
+        jwt_secret="test-jwt-secret-0123456789abcdef0123456789abcdef",
     )
 
     assert s.local_auth_enabled is False

--- a/apps/api/tests/test_auth_settings.py
+++ b/apps/api/tests/test_auth_settings.py
@@ -256,6 +256,7 @@ def test_settings_auth_defaults_disable_production_local_login() -> None:
         surreal_url="ws://surrealdb:8000/rpc",
         surreal_username="sibyl_admin",
         surreal_password="really_secure_password",
+        jwt_secret="test-jwt-secret",
     )
 
     assert s.local_auth_enabled is False
@@ -279,6 +280,7 @@ def test_settings_explicit_production_local_auth_override_is_respected() -> None
         surreal_url="ws://surrealdb:8000/rpc",
         surreal_username="sibyl_admin",
         surreal_password="really_secure_password",
+        jwt_secret="test-jwt-secret",
         local_auth_enabled=True,
     )
 
@@ -294,6 +296,7 @@ def test_settings_enterprise_auth_features_are_opt_in() -> None:
         surreal_url="ws://surrealdb:8000/rpc",
         surreal_username="sibyl_admin",
         surreal_password="really_secure_password",
+        jwt_secret="test-jwt-secret",
     )
 
     assert s.local_auth_enabled is False

--- a/apps/api/tests/test_config_security.py
+++ b/apps/api/tests/test_config_security.py
@@ -44,7 +44,7 @@ class TestDisableAuthSecurity:
             }
             if env == "production":
                 kwargs["surreal_url"] = "ws://surrealdb:8000/rpc"
-                kwargs["jwt_secret"] = "test-jwt-secret"
+                kwargs["jwt_secret"] = "test-jwt-secret-0123456789abcdef0123456789abcdef"
             settings = Settings(**kwargs)  # type: ignore[arg-type]
             assert settings.disable_auth is False
 
@@ -76,7 +76,7 @@ class TestEnvironmentValidation:
             }
             if env == "production":
                 kwargs["surreal_url"] = "ws://surrealdb:8000/rpc"
-                kwargs["jwt_secret"] = "test-jwt-secret"
+                kwargs["jwt_secret"] = "test-jwt-secret-0123456789abcdef0123456789abcdef"
             settings = Settings(**kwargs)  # type: ignore[arg-type]
             assert settings.environment == env
 
@@ -111,7 +111,7 @@ class TestProductionPasswordSecurity:
             store="surreal",
             auth_store="surreal",
             surreal_url="ws://surrealdb:8000/rpc",
-            jwt_secret="test-jwt-secret",
+            jwt_secret="test-jwt-secret-0123456789abcdef0123456789abcdef",
         )
 
         assert settings.fully_surreal is True
@@ -152,7 +152,7 @@ class TestProductionPasswordSecurity:
             surreal_username="sibyl_admin",
             surreal_password="really_secure_password",
             allow_embedded_single_writer=True,
-            jwt_secret="test-jwt-secret",
+            jwt_secret="test-jwt-secret-0123456789abcdef0123456789abcdef",
         )
 
         assert settings.resolved_surreal_url == "surrealkv:///var/lib/sibyl/surreal"
@@ -188,7 +188,7 @@ class TestProductionPasswordSecurity:
             surreal_url="ws://surrealdb:8000/rpc",
             surreal_username="sibyl_admin",
             surreal_password="really_secure_password",
-            jwt_secret="test-jwt-secret",
+            jwt_secret="test-jwt-secret-0123456789abcdef0123456789abcdef",
         )
 
         assert settings.environment == "production"
@@ -200,7 +200,7 @@ class TestProductionPasswordSecurity:
             store="surreal",
             auth_store="surreal",
             surreal_url="ws://surrealdb:8000/rpc",
-            jwt_secret="test-jwt-secret",
+            jwt_secret="test-jwt-secret-0123456789abcdef0123456789abcdef",
         )
         assert settings.environment == "production"
 
@@ -226,7 +226,7 @@ class TestProductionJwtSecret:
     def test_non_prefixed_jwt_secret_satisfies_production(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("JWT_SECRET", "fallback-jwt-secret")
+        monkeypatch.setenv("JWT_SECRET", "fallback-jwt-secret-0123456789abcdef0123456789ab")
         settings = Settings(
             _env_file=None,
             environment="production",
@@ -237,7 +237,10 @@ class TestProductionJwtSecret:
             surreal_password="really_secure_password",
         )
 
-        assert settings.jwt_secret.get_secret_value() == "fallback-jwt-secret"
+        assert (
+            settings.jwt_secret.get_secret_value()
+            == "fallback-jwt-secret-0123456789abcdef0123456789ab"
+        )
 
     def test_missing_jwt_secret_allowed_outside_production(
         self, monkeypatch: pytest.MonkeyPatch
@@ -246,3 +249,85 @@ class TestProductionJwtSecret:
         settings = Settings(_env_file=None, environment="staging")
 
         assert settings.jwt_secret.get_secret_value()
+
+    def test_short_jwt_secret_forbidden_in_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        with pytest.raises(ValueError, match="at least 32 are required"):
+            Settings(
+                _env_file=None,
+                environment="production",
+                store="surreal",
+                auth_store="surreal",
+                surreal_url="ws://surrealdb:8000/rpc",
+                surreal_username="sibyl_admin",
+                surreal_password="really_secure_password",
+                jwt_secret="x",
+            )
+
+    def test_whitespace_padding_is_stripped_before_the_length_check(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A key read from a file or a k8s Secret often carries a trailing newline."""
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        padded = "  " + "a" * 40 + "\n"
+        settings = Settings(
+            _env_file=None,
+            environment="production",
+            store="surreal",
+            auth_store="surreal",
+            surreal_url="ws://surrealdb:8000/rpc",
+            surreal_username="sibyl_admin",
+            surreal_password="really_secure_password",
+            jwt_secret=padded,
+        )
+
+        assert settings.jwt_secret.get_secret_value() == "a" * 40
+
+    def test_whitespace_only_jwt_secret_forbidden_in_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        with pytest.raises(ValueError, match="A JWT secret is required in production"):
+            Settings(
+                _env_file=None,
+                environment="production",
+                store="surreal",
+                auth_store="surreal",
+                surreal_url="ws://surrealdb:8000/rpc",
+                surreal_username="sibyl_admin",
+                surreal_password="really_secure_password",
+                jwt_secret="   ",
+            )
+
+
+class TestProductionMcpAuthMode:
+    """MCP auth must not be switched off in production."""
+
+    def _production(self, **overrides: object) -> Settings:
+        kwargs: dict[str, object] = {
+            "_env_file": None,
+            "environment": "production",
+            "store": "surreal",
+            "auth_store": "surreal",
+            "surreal_url": "ws://surrealdb:8000/rpc",
+            "surreal_username": "sibyl_admin",
+            "surreal_password": "really_secure_password",
+            "jwt_secret": "a" * 40,
+        }
+        kwargs.update(overrides)
+        return Settings(**kwargs)  # type: ignore[arg-type]
+
+    def test_auth_mode_off_forbidden_in_production(self) -> None:
+        with pytest.raises(ValueError, match="mcp_auth_mode=off is forbidden in production"):
+            self._production(mcp_auth_mode="off")
+
+    def test_auth_mode_auto_and_on_allowed_in_production(self) -> None:
+        for mode in ("auto", "on"):
+            assert self._production(mcp_auth_mode=mode).mcp_auth_mode == mode
+
+    def test_auth_mode_off_allowed_outside_production(self) -> None:
+        settings = Settings(_env_file=None, environment="development", mcp_auth_mode="off")
+
+        assert settings.mcp_auth_mode == "off"

--- a/apps/api/tests/test_config_security.py
+++ b/apps/api/tests/test_config_security.py
@@ -266,12 +266,29 @@ class TestProductionJwtSecret:
                 jwt_secret="x",
             )
 
-    def test_whitespace_padding_is_stripped_before_the_length_check(
+    def test_padded_jwt_secret_is_rejected_not_trimmed(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A key read from a file or a k8s Secret often carries a trailing newline."""
+        """Trimming would change the signing key and split a rolling upgrade."""
         monkeypatch.delenv("JWT_SECRET", raising=False)
-        padded = "  " + "a" * 40 + "\n"
+        for padded in ("a" * 40 + "\n", "  " + "a" * 40, " " + "a" * 40 + " "):
+            with pytest.raises(ValueError, match="leading or trailing whitespace"):
+                Settings(
+                    _env_file=None,
+                    environment="production",
+                    store="surreal",
+                    auth_store="surreal",
+                    surreal_url="ws://surrealdb:8000/rpc",
+                    surreal_username="sibyl_admin",
+                    surreal_password="really_secure_password",
+                    jwt_secret=padded,
+                )
+
+    def test_clean_jwt_secret_is_preserved_byte_for_byte(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        key = "a" * 40
         settings = Settings(
             _env_file=None,
             environment="production",
@@ -280,10 +297,10 @@ class TestProductionJwtSecret:
             surreal_url="ws://surrealdb:8000/rpc",
             surreal_username="sibyl_admin",
             surreal_password="really_secure_password",
-            jwt_secret=padded,
+            jwt_secret=key,
         )
 
-        assert settings.jwt_secret.get_secret_value() == "a" * 40
+        assert settings.jwt_secret.get_secret_value() == key
 
     def test_whitespace_only_jwt_secret_forbidden_in_production(
         self, monkeypatch: pytest.MonkeyPatch

--- a/apps/api/tests/test_config_security.py
+++ b/apps/api/tests/test_config_security.py
@@ -44,6 +44,7 @@ class TestDisableAuthSecurity:
             }
             if env == "production":
                 kwargs["surreal_url"] = "ws://surrealdb:8000/rpc"
+                kwargs["jwt_secret"] = "test-jwt-secret"
             settings = Settings(**kwargs)  # type: ignore[arg-type]
             assert settings.disable_auth is False
 
@@ -75,6 +76,7 @@ class TestEnvironmentValidation:
             }
             if env == "production":
                 kwargs["surreal_url"] = "ws://surrealdb:8000/rpc"
+                kwargs["jwt_secret"] = "test-jwt-secret"
             settings = Settings(**kwargs)  # type: ignore[arg-type]
             assert settings.environment == env
 
@@ -109,6 +111,7 @@ class TestProductionPasswordSecurity:
             store="surreal",
             auth_store="surreal",
             surreal_url="ws://surrealdb:8000/rpc",
+            jwt_secret="test-jwt-secret",
         )
 
         assert settings.fully_surreal is True
@@ -149,6 +152,7 @@ class TestProductionPasswordSecurity:
             surreal_username="sibyl_admin",
             surreal_password="really_secure_password",
             allow_embedded_single_writer=True,
+            jwt_secret="test-jwt-secret",
         )
 
         assert settings.resolved_surreal_url == "surrealkv:///var/lib/sibyl/surreal"
@@ -184,6 +188,7 @@ class TestProductionPasswordSecurity:
             surreal_url="ws://surrealdb:8000/rpc",
             surreal_username="sibyl_admin",
             surreal_password="really_secure_password",
+            jwt_secret="test-jwt-secret",
         )
 
         assert settings.environment == "production"
@@ -195,5 +200,49 @@ class TestProductionPasswordSecurity:
             store="surreal",
             auth_store="surreal",
             surreal_url="ws://surrealdb:8000/rpc",
+            jwt_secret="test-jwt-secret",
         )
         assert settings.environment == "production"
+
+
+class TestProductionJwtSecret:
+    """Tests for the production JWT signing key requirement."""
+
+    def test_missing_jwt_secret_forbidden_in_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        with pytest.raises(ValueError, match="A JWT secret is required in production"):
+            Settings(
+                _env_file=None,
+                environment="production",
+                store="surreal",
+                auth_store="surreal",
+                surreal_url="ws://surrealdb:8000/rpc",
+                surreal_username="sibyl_admin",
+                surreal_password="really_secure_password",
+            )
+
+    def test_non_prefixed_jwt_secret_satisfies_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("JWT_SECRET", "fallback-jwt-secret")
+        settings = Settings(
+            _env_file=None,
+            environment="production",
+            store="surreal",
+            auth_store="surreal",
+            surreal_url="ws://surrealdb:8000/rpc",
+            surreal_username="sibyl_admin",
+            surreal_password="really_secure_password",
+        )
+
+        assert settings.jwt_secret.get_secret_value() == "fallback-jwt-secret"
+
+    def test_missing_jwt_secret_allowed_outside_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        settings = Settings(_env_file=None, environment="staging")
+
+        assert settings.jwt_secret.get_secret_value()

--- a/charts/sibyl/templates/_helpers.tpl
+++ b/charts/sibyl/templates/_helpers.tpl
@@ -142,3 +142,21 @@ Fail fast when a non-corporate extra provider is configured without the explicit
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Fail fast when a production-labelled release configures no JWT secret source.
+Without SIBYL_JWT_SECRET the API starts with an empty signing key, the server
+disables MCP auth under the default mcp_auth_mode=auto, and session cookies are
+signed with an empty key. The chart must not auto-generate that secret in
+production: a per-render value would rotate every upgrade and diverge between
+the backend, worker, and bootstrap pods.
+*/}}
+{{- define "sibyl.validateProductionAuthSecret" -}}
+{{- $env := default dict .Values.backend.env -}}
+{{- $environment := lower (trim (default "" (get $env "SIBYL_ENVIRONMENT"))) -}}
+{{- $inlineJwt := trim (default "" (get $env "SIBYL_JWT_SECRET")) -}}
+{{- $existing := trim (default "" .Values.backend.existingSecret) -}}
+{{- if and (eq $environment "production") (empty $existing) (empty $inlineJwt) -}}
+{{- fail "backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is \"production\".\nWithout it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to \"auto\", which enforces Bearer auth only when a JWT secret is present).\nCreate the secret, then point the chart at it:\n  kubectl create secret generic sibyl-secrets \\\n    --from-literal=SIBYL_JWT_SECRET=\"$(openssl rand -hex 32)\" \\\n    --from-literal=SIBYL_SETTINGS_KEY=\"$(openssl rand -hex 32)\"\n  helm install sibyl charts/sibyl --set backend.existingSecret=sibyl-secrets\nFor a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead, which lets the server generate a development JWT secret on its own." -}}
+{{- end -}}
+{{- end }}

--- a/charts/sibyl/templates/_helpers.tpl
+++ b/charts/sibyl/templates/_helpers.tpl
@@ -149,14 +149,18 @@ Without SIBYL_JWT_SECRET the API starts with an empty signing key, the server
 disables MCP auth under the default mcp_auth_mode=auto, and session cookies are
 signed with an empty key. The chart must not auto-generate that secret in
 production: a per-render value would rotate every upgrade and diverge between
-the backend, worker, and bootstrap pods.
+the backend, worker, and bootstrap pods. An inline backend.env.SIBYL_JWT_SECRET
+is rejected too, because backend.env is rendered into a plaintext ConfigMap.
 */}}
 {{- define "sibyl.validateProductionAuthSecret" -}}
 {{- $env := default dict .Values.backend.env -}}
 {{- $environment := lower (trim (default "" (get $env "SIBYL_ENVIRONMENT"))) -}}
 {{- $inlineJwt := trim (default "" (get $env "SIBYL_JWT_SECRET")) -}}
 {{- $existing := trim (default "" .Values.backend.existingSecret) -}}
-{{- if and (eq $environment "production") (empty $existing) (empty $inlineJwt) -}}
-{{- fail "backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is \"production\".\nWithout it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to \"auto\", which enforces Bearer auth only when a JWT secret is present).\nCreate the secret, then point the chart at it:\n  kubectl create secret generic sibyl-secrets \\\n    --from-literal=SIBYL_JWT_SECRET=\"$(openssl rand -hex 32)\" \\\n    --from-literal=SIBYL_SETTINGS_KEY=\"$(openssl rand -hex 32)\"\n  helm install sibyl charts/sibyl --set backend.existingSecret=sibyl-secrets\nFor a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead, which lets the server generate a development JWT secret on its own." -}}
+{{- if and (eq $environment "production") (empty $existing) -}}
+{{- fail "backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is \"production\".\nWithout it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to \"auto\", which enforces Bearer auth only when a JWT secret is present).\nCreate the secret, then point the chart at it:\n  kubectl create secret generic sibyl-secrets \\\n    --from-literal=SIBYL_JWT_SECRET=\"$(openssl rand -hex 32)\" \\\n    --from-literal=SIBYL_SETTINGS_KEY=\"$(openssl rand -hex 32)\"\n  helm install sibyl charts/sibyl --set backend.existingSecret=sibyl-secrets\nSetting backend.env.SIBYL_JWT_SECRET does not satisfy this: every backend.env key is rendered into the plaintext sibyl-config ConfigMap, which is readable under broader RBAC than a Secret.\nFor a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead. The server then derives its own JWT secret per process, so sessions break on restart and across replicas, which is why that path is unfit for production." -}}
+{{- end -}}
+{{- if and (eq $environment "production") (not (empty $inlineJwt)) -}}
+{{- fail "backend.env.SIBYL_JWT_SECRET must not be used in production. Every backend.env key is rendered into the plaintext sibyl-config ConfigMap, so the signing key would be stored unencrypted and readable under broader RBAC than a Secret. Put SIBYL_JWT_SECRET in the Secret referenced by backend.existingSecret instead." -}}
 {{- end -}}
 {{- end }}

--- a/charts/sibyl/templates/_helpers.tpl
+++ b/charts/sibyl/templates/_helpers.tpl
@@ -151,16 +151,28 @@ signed with an empty key. The chart must not auto-generate that secret in
 production: a per-render value would rotate every upgrade and diverge between
 the backend, worker, and bootstrap pods. An inline backend.env.SIBYL_JWT_SECRET
 is rejected too, because backend.env is rendered into a plaintext ConfigMap.
+Keys are matched case-insensitively: pydantic-settings resolves environment
+variables that way, so sibyl_jwt_secret reaches the process exactly as
+SIBYL_JWT_SECRET does.
 */}}
 {{- define "sibyl.validateProductionAuthSecret" -}}
 {{- $env := default dict .Values.backend.env -}}
-{{- $environment := lower (trim (default "" (get $env "SIBYL_ENVIRONMENT"))) -}}
-{{- $inlineJwt := trim (default "" (get $env "SIBYL_JWT_SECRET")) -}}
+{{- $isProduction := false -}}
+{{- $inlineJwt := "" -}}
+{{- range $key, $value := $env -}}
+{{- $normalized := trim (toString $value) -}}
+{{- if and (eq (upper $key) "SIBYL_ENVIRONMENT") (eq (lower $normalized) "production") -}}
+{{- $isProduction = true -}}
+{{- end -}}
+{{- if and (eq (upper $key) "SIBYL_JWT_SECRET") (not (empty $normalized)) -}}
+{{- $inlineJwt = $normalized -}}
+{{- end -}}
+{{- end -}}
 {{- $existing := trim (default "" .Values.backend.existingSecret) -}}
-{{- if and (eq $environment "production") (empty $existing) -}}
+{{- if and $isProduction (empty $existing) -}}
 {{- fail "backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is \"production\".\nWithout it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to \"auto\", which enforces Bearer auth only when a JWT secret is present).\nCreate the secret, then point the chart at it:\n  kubectl create secret generic sibyl-secrets \\\n    --from-literal=SIBYL_JWT_SECRET=\"$(openssl rand -hex 32)\" \\\n    --from-literal=SIBYL_SETTINGS_KEY=\"$(openssl rand -hex 32)\"\n  helm install sibyl charts/sibyl --set backend.existingSecret=sibyl-secrets\nSetting backend.env.SIBYL_JWT_SECRET does not satisfy this: every backend.env key is rendered into the plaintext sibyl-config ConfigMap, which is readable under broader RBAC than a Secret.\nFor a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead. The server then derives its own JWT secret per process, so sessions break on restart and across replicas, which is why that path is unfit for production." -}}
 {{- end -}}
-{{- if and (eq $environment "production") (not (empty $inlineJwt)) -}}
+{{- if and $isProduction (not (empty $inlineJwt)) -}}
 {{- fail "backend.env.SIBYL_JWT_SECRET must not be used in production. Every backend.env key is rendered into the plaintext sibyl-config ConfigMap, so the signing key would be stored unencrypted and readable under broader RBAC than a Secret. Put SIBYL_JWT_SECRET in the Secret referenced by backend.existingSecret instead." -}}
 {{- end -}}
 {{- end }}

--- a/charts/sibyl/templates/_helpers.tpl
+++ b/charts/sibyl/templates/_helpers.tpl
@@ -177,8 +177,31 @@ sitting in the plaintext ConfigMap.
 {{- end -}}
 {{- end -}}
 {{- $existing := trim (default "" .Values.backend.existingSecret) -}}
-{{- $secretName := default "sibyl-secrets" $existing -}}
-{{- $remediation := printf "Create the Secret in the release namespace, then point the chart at it:\n  kubectl create secret generic %s --namespace %s \\\n    --from-literal=SIBYL_JWT_SECRET=\"$(openssl rand -hex 32)\" \\\n    --from-literal=SIBYL_SETTINGS_KEY=\"$(openssl rand -hex 32)\"\n  helm upgrade --install %s charts/sibyl --namespace %s --set backend.existingSecret=%s" $secretName .Release.Namespace .Release.Name .Release.Namespace $secretName -}}
+{{/*
+Only interpolate operator-supplied names into the remediation commands when they
+are RFC 1123 DNS subdomains. An unvalidated value lands inside a shell snippet a
+reader is invited to paste, so `$(id)` would execute on their machine.
+*/}}
+{{- $dnsPattern := "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" -}}
+{{- $secretName := "<your-secret-name>" -}}
+{{- if empty $existing -}}
+{{- $secretName = "sibyl-secrets" -}}
+{{- else if and (le (len $existing) 253) (regexMatch $dnsPattern $existing) -}}
+{{- $secretName = $existing -}}
+{{- end -}}
+{{- $namespace := "<your-namespace>" -}}
+{{- if and (le (len .Release.Namespace) 253) (regexMatch $dnsPattern .Release.Namespace) -}}
+{{- $namespace = .Release.Namespace -}}
+{{- end -}}
+{{- $release := "<your-release>" -}}
+{{- if and (le (len .Release.Name) 253) (regexMatch $dnsPattern .Release.Name) -}}
+{{- $release = .Release.Name -}}
+{{- end -}}
+{{/*
+Split by install shape. `helm upgrade --set` without --reuse-values resets an
+existing release to chart defaults, silently discarding every other override.
+*/}}
+{{- $remediation := printf "Create the Secret in the release namespace:\n  kubectl create secret generic %s --namespace %s \\\n    --from-literal=SIBYL_JWT_SECRET=\"$(openssl rand -hex 32)\" \\\n    --from-literal=SIBYL_SETTINGS_KEY=\"$(openssl rand -hex 32)\"\nThen, for a first install:\n  helm install %s charts/sibyl --namespace %s --set backend.existingSecret=%s\nFor a release that already exists, keep its current values or you will reset it to chart defaults:\n  helm upgrade %s charts/sibyl --namespace %s --reuse-values --set backend.existingSecret=%s\n  (or re-apply your values files with -f and add the same --set)" $secretName $namespace $release $namespace $secretName $release $namespace $secretName -}}
 {{- if and $isProduction (empty $existing) -}}
 {{- fail (printf "backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is \"production\".\nWithout it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to \"auto\", which enforces Bearer auth only when a JWT secret is present).\n%s\nSetting backend.env.SIBYL_JWT_SECRET or backend.env.JWT_SECRET does not satisfy this: every backend.env key is rendered into the plaintext %s-config ConfigMap, which is readable under broader RBAC than a Secret.\nFor a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead. The server then derives its own JWT secret per process, so sessions break on restart and across replicas, which is why that path is unfit for production." $remediation (include "sibyl.fullname" .)) -}}
 {{- end -}}

--- a/charts/sibyl/templates/_helpers.tpl
+++ b/charts/sibyl/templates/_helpers.tpl
@@ -144,35 +144,48 @@ Fail fast when a non-corporate extra provider is configured without the explicit
 {{- end }}
 
 {{/*
-Fail fast when a production-labelled release configures no JWT secret source.
+Fail fast when a production-labelled release configures no JWT secret source,
+puts the signing key in a plaintext ConfigMap, or switches MCP auth off.
 Without SIBYL_JWT_SECRET the API starts with an empty signing key, the server
 disables MCP auth under the default mcp_auth_mode=auto, and session cookies are
 signed with an empty key. The chart must not auto-generate that secret in
 production: a per-render value would rotate every upgrade and diverge between
-the backend, worker, and bootstrap pods. An inline backend.env.SIBYL_JWT_SECRET
-is rejected too, because backend.env is rendered into a plaintext ConfigMap.
-Keys are matched case-insensitively: pydantic-settings resolves environment
-variables that way, so sibyl_jwt_secret reaches the process exactly as
-SIBYL_JWT_SECRET does.
+the backend, worker, and bootstrap pods.
+
+Keys are matched case-insensitively, and both SIBYL_JWT_SECRET and the
+unprefixed JWT_SECRET alias count, because pydantic-settings resolves
+environment variables case-insensitively and config.py falls back to the
+unprefixed name. Either spelling in backend.env reaches the process while
+sitting in the plaintext ConfigMap.
 */}}
 {{- define "sibyl.validateProductionAuthSecret" -}}
 {{- $env := default dict .Values.backend.env -}}
 {{- $isProduction := false -}}
-{{- $inlineJwt := "" -}}
+{{- $inlineJwtKeys := list -}}
+{{- $authOff := false -}}
 {{- range $key, $value := $env -}}
+{{- $upperKey := upper $key -}}
 {{- $normalized := trim (toString $value) -}}
-{{- if and (eq (upper $key) "SIBYL_ENVIRONMENT") (eq (lower $normalized) "production") -}}
+{{- if and (eq $upperKey "SIBYL_ENVIRONMENT") (eq (lower $normalized) "production") -}}
 {{- $isProduction = true -}}
 {{- end -}}
-{{- if and (eq (upper $key) "SIBYL_JWT_SECRET") (not (empty $normalized)) -}}
-{{- $inlineJwt = $normalized -}}
+{{- if and (has $upperKey (list "SIBYL_JWT_SECRET" "JWT_SECRET")) (not (empty $normalized)) -}}
+{{- $inlineJwtKeys = append $inlineJwtKeys $key -}}
+{{- end -}}
+{{- if and (eq $upperKey "SIBYL_MCP_AUTH_MODE") (eq (lower $normalized) "off") -}}
+{{- $authOff = true -}}
 {{- end -}}
 {{- end -}}
 {{- $existing := trim (default "" .Values.backend.existingSecret) -}}
+{{- $secretName := default "sibyl-secrets" $existing -}}
+{{- $remediation := printf "Create the Secret in the release namespace, then point the chart at it:\n  kubectl create secret generic %s --namespace %s \\\n    --from-literal=SIBYL_JWT_SECRET=\"$(openssl rand -hex 32)\" \\\n    --from-literal=SIBYL_SETTINGS_KEY=\"$(openssl rand -hex 32)\"\n  helm upgrade --install %s charts/sibyl --namespace %s --set backend.existingSecret=%s" $secretName .Release.Namespace .Release.Name .Release.Namespace $secretName -}}
 {{- if and $isProduction (empty $existing) -}}
-{{- fail "backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is \"production\".\nWithout it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to \"auto\", which enforces Bearer auth only when a JWT secret is present).\nCreate the secret, then point the chart at it:\n  kubectl create secret generic sibyl-secrets \\\n    --from-literal=SIBYL_JWT_SECRET=\"$(openssl rand -hex 32)\" \\\n    --from-literal=SIBYL_SETTINGS_KEY=\"$(openssl rand -hex 32)\"\n  helm install sibyl charts/sibyl --set backend.existingSecret=sibyl-secrets\nSetting backend.env.SIBYL_JWT_SECRET does not satisfy this: every backend.env key is rendered into the plaintext sibyl-config ConfigMap, which is readable under broader RBAC than a Secret.\nFor a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead. The server then derives its own JWT secret per process, so sessions break on restart and across replicas, which is why that path is unfit for production." -}}
+{{- fail (printf "backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is \"production\".\nWithout it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to \"auto\", which enforces Bearer auth only when a JWT secret is present).\n%s\nSetting backend.env.SIBYL_JWT_SECRET or backend.env.JWT_SECRET does not satisfy this: every backend.env key is rendered into the plaintext %s-config ConfigMap, which is readable under broader RBAC than a Secret.\nFor a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead. The server then derives its own JWT secret per process, so sessions break on restart and across replicas, which is why that path is unfit for production." $remediation (include "sibyl.fullname" .)) -}}
 {{- end -}}
-{{- if and $isProduction (not (empty $inlineJwt)) -}}
-{{- fail "backend.env.SIBYL_JWT_SECRET must not be used in production. Every backend.env key is rendered into the plaintext sibyl-config ConfigMap, so the signing key would be stored unencrypted and readable under broader RBAC than a Secret. Put SIBYL_JWT_SECRET in the Secret referenced by backend.existingSecret instead." -}}
+{{- if and $isProduction (not (empty $inlineJwtKeys)) -}}
+{{- fail (printf "backend.env.%s must not be used in production. Every backend.env key is rendered into the plaintext %s-config ConfigMap, so the signing key would be stored unencrypted and readable under broader RBAC than a Secret. The unprefixed JWT_SECRET alias is rejected for the same reason, because config.py falls back to it. Put SIBYL_JWT_SECRET in the Secret referenced by backend.existingSecret instead.\n%s" (join ", backend.env." $inlineJwtKeys) (include "sibyl.fullname" .) $remediation) -}}
+{{- end -}}
+{{- if and $isProduction $authOff -}}
+{{- fail "backend.env.SIBYL_MCP_AUTH_MODE=off is forbidden in production. It serves every MCP tool unauthenticated regardless of the JWT secret. Use \"auto\" (enforce once a secret is set) or \"on\" (always enforce), or set backend.env.SIBYL_ENVIRONMENT=development for a local unauthenticated endpoint." -}}
 {{- end -}}
 {{- end }}

--- a/charts/sibyl/templates/configmap.yaml
+++ b/charts/sibyl/templates/configmap.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 {{- include "sibyl.validateOidcProviders" . }}
+{{- include "sibyl.validateProductionAuthSecret" . }}
 {{- if hasKey .Values "store" }}
 {{- fail "Deprecated value 'store' is no longer supported. Remove it and complete legacy-to-Surreal migration before upgrading." }}
 {{- end }}

--- a/charts/sibyl/values.yaml
+++ b/charts/sibyl/values.yaml
@@ -166,7 +166,9 @@ backend:
   # Must contain: SIBYL_JWT_SECRET and SIBYL_SETTINGS_KEY.
   # Add provider and LLM API keys as needed. Production and read-only containers require this.
   # Leaving this empty while env.SIBYL_ENVIRONMENT is "production" fails the render, because the
-  # backend would otherwise start with an empty JWT secret and turn MCP auth off.
+  # backend would otherwise start with an empty JWT secret and turn MCP auth off. Supplying
+  # env.SIBYL_JWT_SECRET instead also fails the render: every env key lands in a plaintext
+  # ConfigMap, so the signing key has to come from a Secret.
   existingSecret: ""
 
   # -- SurrealDB connection settings

--- a/charts/sibyl/values.yaml
+++ b/charts/sibyl/values.yaml
@@ -165,6 +165,8 @@ backend:
   # -- Reference to existing secret for sensitive env vars
   # Must contain: SIBYL_JWT_SECRET and SIBYL_SETTINGS_KEY.
   # Add provider and LLM API keys as needed. Production and read-only containers require this.
+  # Leaving this empty while env.SIBYL_ENVIRONMENT is "production" fails the render, because the
+  # backend would otherwise start with an empty JWT secret and turn MCP auth off.
   existingSecret: ""
 
   # -- SurrealDB connection settings

--- a/charts/sibyl/values.yaml
+++ b/charts/sibyl/values.yaml
@@ -167,8 +167,9 @@ backend:
   # Add provider and LLM API keys as needed. Production and read-only containers require this.
   # Leaving this empty while env.SIBYL_ENVIRONMENT is "production" fails the render, because the
   # backend would otherwise start with an empty JWT secret and turn MCP auth off. Supplying
-  # env.SIBYL_JWT_SECRET instead also fails the render: every env key lands in a plaintext
-  # ConfigMap, so the signing key has to come from a Secret.
+  # env.SIBYL_JWT_SECRET or env.JWT_SECRET instead also fails the render: every env key lands in a
+  # plaintext ConfigMap, so the signing key has to come from a Secret. Production also rejects
+  # env.SIBYL_MCP_AUTH_MODE=off, which would serve every MCP tool unauthenticated.
   existingSecret: ""
 
   # -- SurrealDB connection settings

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -127,6 +127,9 @@ services:
         ${SIBYL_SURREAL_USERNAME:?Set SIBYL_SURREAL_USERNAME in the environment}
       SIBYL_SURREAL_PASSWORD:
         ${SIBYL_SURREAL_PASSWORD:?Set SIBYL_SURREAL_PASSWORD in the environment}
+      # Auth (REQUIRED): the worker shares the API's signing key so both agree on
+      # a signature, and production refuses to start without one.
+      SIBYL_JWT_SECRET: ${SIBYL_JWT_SECRET:?Set SIBYL_JWT_SECRET in the environment}
       SIBYL_OPENAI_API_KEY: ${SIBYL_OPENAI_API_KEY:?Set SIBYL_OPENAI_API_KEY in the environment}
       SIBYL_ANTHROPIC_API_KEY:
         ${SIBYL_ANTHROPIC_API_KEY:?Set SIBYL_ANTHROPIC_API_KEY in the environment}

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -255,13 +255,21 @@ makes MCP auth disable itself under the default `mcp_auth_mode: auto`. The chart
 not auto-generate the secret in production, since a per-render value would rotate on every upgrade
 and diverge across the backend, worker, and bootstrap pods.
 
-Passing the signing key as `backend.env.SIBYL_JWT_SECRET` fails the render as well. Every key under
+Passing the signing key as `backend.env.SIBYL_JWT_SECRET` fails the render as well, and so does the
+unprefixed `backend.env.JWT_SECRET` alias that the server falls back to. Every key under
 `backend.env` is written into the plaintext `<release>-config` ConfigMap, which is readable under
-broader RBAC than a Secret and routinely committed to GitOps repositories. The escape hatch for a
-trial install is `backend.env.SIBYL_ENVIRONMENT: development`, which is unsuitable for real traffic:
-the server then derives a JWT secret per process, and the chart's default
-`readOnlyRootFilesystem: true` blocks the write that would persist it, so sessions break on every
-restart and across replicas.
+broader RBAC than a Secret and routinely committed to GitOps repositories. Key names are matched
+case-insensitively, because pydantic-settings resolves environment variables that way.
+
+Production also rejects `backend.env.SIBYL_MCP_AUTH_MODE: off`, which would serve every MCP tool
+unauthenticated no matter how well the JWT secret is provisioned. Use `auto` to enforce Bearer auth
+once a secret is set, or `on` to enforce it unconditionally. The server refuses to boot on the same
+condition, so the mode cannot be switched off in production by editing the ConfigMap after install.
+
+The escape hatch for a trial install is `backend.env.SIBYL_ENVIRONMENT: development`, which is
+unsuitable for real traffic: the server then derives a JWT secret per process, and the chart's
+default `readOnlyRootFilesystem: true` blocks the write that would persist it, so sessions break on
+every restart and across replicas.
 
 Both required keys are non-optional pod references, so a missing key fails before Sibyl starts
 instead of silently generating an ephemeral replacement. Keep `SIBYL_SETTINGS_KEY` stable across

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -247,10 +247,17 @@ backend:
   existingSecret: ""
 ```
 
-Production and read-only containers must set `existingSecret`. Both required keys are non-optional
-pod references, so a missing key fails before Sibyl starts instead of silently generating an
-ephemeral replacement. Keep `SIBYL_SETTINGS_KEY` stable across upgrades and pod replacements;
-changing it makes encrypted settings unreadable.
+Production and read-only containers must set `existingSecret`. The chart enforces this at render
+time: with `backend.env.SIBYL_ENVIRONMENT` set to `production` and no `backend.existingSecret`,
+`helm template` and `helm install` both abort with an error naming the value to set. That guard
+exists because an unset `SIBYL_JWT_SECRET` makes the backend sign sessions with an empty key and
+makes MCP auth disable itself under the default `mcp_auth_mode: auto`. The chart deliberately does
+not auto-generate the secret in production, since a per-render value would rotate on every upgrade
+and diverge across the backend, worker, and bootstrap pods.
+
+Both required keys are non-optional pod references, so a missing key fails before Sibyl starts
+instead of silently generating an ephemeral replacement. Keep `SIBYL_SETTINGS_KEY` stable across
+upgrades and pod replacements; changing it makes encrypted settings unreadable.
 
 ### Storage Mode
 

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -255,6 +255,14 @@ makes MCP auth disable itself under the default `mcp_auth_mode: auto`. The chart
 not auto-generate the secret in production, since a per-render value would rotate on every upgrade
 and diverge across the backend, worker, and bootstrap pods.
 
+Passing the signing key as `backend.env.SIBYL_JWT_SECRET` fails the render as well. Every key under
+`backend.env` is written into the plaintext `<release>-config` ConfigMap, which is readable under
+broader RBAC than a Secret and routinely committed to GitOps repositories. The escape hatch for a
+trial install is `backend.env.SIBYL_ENVIRONMENT: development`, which is unsuitable for real traffic:
+the server then derives a JWT secret per process, and the chart's default
+`readOnlyRootFilesystem: true` blocks the write that would persist it, so sessions break on every
+restart and across replicas.
+
 Both required keys are non-optional pod references, so a missing key fails before Sibyl starts
 instead of silently generating an ephemeral replacement. Keep `SIBYL_SETTINGS_KEY` stable across
 upgrades and pod replacements; changing it makes encrypted settings unreadable.

--- a/moon.yml
+++ b/moon.yml
@@ -484,7 +484,6 @@ tasks:
       tools/tests/test_usage_rerank_harness.py -v
     inputs:
       - tools/**/*.py
-      - charts/sibyl/**/*
       - benchmarks/git_provenance.py
       - benchmarks/longmemeval_v2_official.py
       - benchmarks/longmemeval_v2_reader_replay.py

--- a/moon.yml
+++ b/moon.yml
@@ -484,6 +484,7 @@ tasks:
       tools/tests/test_usage_rerank_harness.py -v
     inputs:
       - tools/**/*.py
+      - charts/sibyl/**/*
       - benchmarks/git_provenance.py
       - benchmarks/longmemeval_v2_official.py
       - benchmarks/longmemeval_v2_reader_replay.py

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -171,7 +171,7 @@ def test_helm_production_render_rejects_a_configmap_resident_jwt_secret() -> Non
 @requires_helm
 def test_helm_production_guard_matches_env_keys_case_insensitively() -> None:
     """pydantic-settings resolves env vars case-insensitively, so the guard must too."""
-    for key in ("sibyl_jwt_secret", "Sibyl_Jwt_Secret"):
+    for key in ("sibyl_jwt_secret", "Sibyl_Jwt_Secret", "JWT_SECRET", "jwt_secret"):
         result = _helm_template(
             "--set",
             "backend.existingSecret=sibyl-secrets",
@@ -180,7 +180,7 @@ def test_helm_production_guard_matches_env_keys_case_insensitively() -> None:
         )
 
         assert result.returncode != 0, f"{key} rendered instead of failing"
-        assert "backend.env.SIBYL_JWT_SECRET must not be used in production" in result.stderr
+        assert f"backend.env.{key} must not be used in production" in result.stderr
 
     lowercase_production = _helm_template(
         "--set",
@@ -627,3 +627,56 @@ def test_no_graphiti_smoke_covers_default_entrypoints() -> None:
 
     for expected in ("apps/cli/src/sibyl_cli/data/hooks/session-start.py",):
         assert expected in entrypoint_script
+
+
+@requires_helm
+def test_helm_production_render_rejects_mcp_auth_mode_off() -> None:
+    """auth_mode off serves every MCP tool unauthenticated regardless of the secret."""
+    for key, value in (
+        ("SIBYL_MCP_AUTH_MODE", "off"),
+        ("sibyl_mcp_auth_mode", "OFF"),
+    ):
+        result = _helm_template(
+            "--set",
+            "backend.existingSecret=sibyl-secrets",
+            "--set",
+            f"backend.env.{key}={value}",
+        )
+
+        assert result.returncode != 0, f"{key}={value} rendered instead of failing"
+        assert "SIBYL_MCP_AUTH_MODE=off is forbidden in production" in result.stderr
+
+    enforcing = _helm_template(
+        "--set",
+        "backend.existingSecret=sibyl-secrets",
+        "--set",
+        "backend.env.SIBYL_MCP_AUTH_MODE=on",
+    )
+
+    assert enforcing.returncode == 0, enforcing.stderr
+
+    development = _helm_template(
+        "--set",
+        "backend.env.SIBYL_ENVIRONMENT=development",
+        "--set",
+        "backend.env.SIBYL_MCP_AUTH_MODE=off",
+    )
+
+    assert development.returncode == 0, development.stderr
+
+
+@requires_helm
+def test_helm_guard_remediation_names_the_release_namespace() -> None:
+    """A namespace-free kubectl line would create the Secret in `default` instead."""
+    assert _HELM_BINARY is not None
+    result = subprocess.run(  # noqa: S603
+        [_HELM_BINARY, "template", "sibyl", "charts/sibyl", "--namespace", "sibyl-prod"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "--namespace sibyl-prod" in result.stderr
+    assert "helm upgrade --install sibyl charts/sibyl --namespace sibyl-prod" in result.stderr

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -24,6 +24,7 @@ from tools.inventory.runtime_surface import (
     parse_dependency_name,
     unclassified_graphiti_imports,
 )
+from tools.trust.enterprise_readiness_evidence import SIBYL_HELM_RENDER_ARGS
 
 EXPECTED_ROUTER_COUNT = 31
 EXPECTED_HTTP_ROUTE_COUNT = 3
@@ -145,6 +146,42 @@ def test_helm_non_production_render_keeps_development_jwt_autogeneration() -> No
     assert result.returncode == 0, result.stderr
     assert 'SIBYL_ENVIRONMENT: "development"' in result.stdout
     assert "key: SIBYL_JWT_SECRET" not in result.stdout
+
+
+@requires_helm
+def test_helm_production_render_rejects_a_configmap_resident_jwt_secret() -> None:
+    """An inline env secret satisfies neither guard, with or without a Secret alongside it."""
+    inline_only = _helm_template("--set", "backend.env.SIBYL_JWT_SECRET=hunter2")
+
+    assert inline_only.returncode != 0
+    assert "backend.existingSecret is required" in inline_only.stderr
+    assert "does not satisfy this" in inline_only.stderr
+
+    alongside_secret = _helm_template(
+        "--set",
+        "backend.existingSecret=sibyl-secrets",
+        "--set",
+        "backend.env.SIBYL_JWT_SECRET=hunter2",
+    )
+
+    assert alongside_secret.returncode != 0
+    assert "backend.env.SIBYL_JWT_SECRET must not be used in production" in alongside_secret.stderr
+
+
+@requires_helm
+def test_helm_enterprise_evidence_render_args_still_render() -> None:
+    """The readiness evidence tool renders charts/sibyl with these exact overrides."""
+    assert _HELM_BINARY is not None
+    result = subprocess.run(  # noqa: S603
+        [_HELM_BINARY, *SIBYL_HELM_RENDER_ARGS],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "key: SIBYL_JWT_SECRET" in result.stdout
 
 
 CORE_LEGACY_GRAPH_CONTRACT_MARKED_TESTS = (

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import ast
+import shutil
+import subprocess
 
 import pytest
 from tools.inventory.runtime_surface import (
@@ -93,6 +95,56 @@ def test_helm_runtime_secret_requires_stable_settings_key() -> None:
 
     assert "key: SIBYL_SETTINGS_KEY" in backend
     assert "key: SIBYL_SETTINGS_KEY" in worker
+
+
+_HELM_BINARY = shutil.which("helm")
+requires_helm = pytest.mark.skipif(_HELM_BINARY is None, reason="helm CLI is not installed")
+
+
+def _helm_template(*overrides: str) -> subprocess.CompletedProcess[str]:
+    assert _HELM_BINARY is not None
+    return subprocess.run(  # noqa: S603
+        [_HELM_BINARY, "template", "sibyl", "charts/sibyl", *overrides],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_helm_production_auth_secret_guard_is_wired() -> None:
+    helpers = (REPO_ROOT / "charts/sibyl/templates/_helpers.tpl").read_text(encoding="utf-8")
+    configmap = (REPO_ROOT / "charts/sibyl/templates/configmap.yaml").read_text(encoding="utf-8")
+
+    assert 'define "sibyl.validateProductionAuthSecret"' in helpers
+    assert 'include "sibyl.validateProductionAuthSecret" .' in configmap
+
+
+@requires_helm
+def test_helm_production_render_fails_without_a_jwt_secret_source() -> None:
+    result = _helm_template()
+
+    assert result.returncode != 0
+    assert "backend.existingSecret is required" in result.stderr
+    assert "SIBYL_JWT_SECRET" in result.stderr
+
+
+@requires_helm
+def test_helm_production_render_succeeds_with_an_existing_secret() -> None:
+    result = _helm_template("--set", "backend.existingSecret=sibyl-secrets")
+
+    assert result.returncode == 0, result.stderr
+    assert "key: SIBYL_JWT_SECRET" in result.stdout
+    assert "key: SIBYL_SETTINGS_KEY" in result.stdout
+
+
+@requires_helm
+def test_helm_non_production_render_keeps_development_jwt_autogeneration() -> None:
+    result = _helm_template("--set", "backend.env.SIBYL_ENVIRONMENT=development")
+
+    assert result.returncode == 0, result.stderr
+    assert 'SIBYL_ENVIRONMENT: "development"' in result.stdout
+    assert "key: SIBYL_JWT_SECRET" not in result.stdout
 
 
 CORE_LEGACY_GRAPH_CONTRACT_MARKED_TESTS = (

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -169,6 +169,31 @@ def test_helm_production_render_rejects_a_configmap_resident_jwt_secret() -> Non
 
 
 @requires_helm
+def test_helm_production_guard_matches_env_keys_case_insensitively() -> None:
+    """pydantic-settings resolves env vars case-insensitively, so the guard must too."""
+    for key in ("sibyl_jwt_secret", "Sibyl_Jwt_Secret"):
+        result = _helm_template(
+            "--set",
+            "backend.existingSecret=sibyl-secrets",
+            "--set",
+            f"backend.env.{key}=hunter2",
+        )
+
+        assert result.returncode != 0, f"{key} rendered instead of failing"
+        assert "backend.env.SIBYL_JWT_SECRET must not be used in production" in result.stderr
+
+    lowercase_production = _helm_template(
+        "--set",
+        "backend.env.SIBYL_ENVIRONMENT=null",
+        "--set",
+        "backend.env.sibyl_environment=production",
+    )
+
+    assert lowercase_production.returncode != 0
+    assert "backend.existingSecret is required" in lowercase_production.stderr
+
+
+@requires_helm
 def test_helm_enterprise_evidence_render_args_still_render() -> None:
     """The readiness evidence tool renders charts/sibyl with these exact overrides."""
     assert _HELM_BINARY is not None

--- a/tools/tests/test_runtime_surface.py
+++ b/tools/tests/test_runtime_surface.py
@@ -679,4 +679,40 @@ def test_helm_guard_remediation_names_the_release_namespace() -> None:
 
     assert result.returncode != 0
     assert "--namespace sibyl-prod" in result.stderr
-    assert "helm upgrade --install sibyl charts/sibyl --namespace sibyl-prod" in result.stderr
+    assert "helm install sibyl charts/sibyl --namespace sibyl-prod" in result.stderr
+
+
+@requires_helm
+def test_helm_guard_remediation_separates_install_from_upgrade() -> None:
+    """`helm upgrade --set` without --reuse-values resets a release to chart defaults."""
+    result = _helm_template()
+
+    assert result.returncode != 0
+    assert "for a first install:" in result.stderr
+    assert "--reuse-values --set backend.existingSecret=" in result.stderr
+
+
+@requires_helm
+def test_helm_guard_remediation_refuses_to_interpolate_shell_metacharacters() -> None:
+    """The remediation is a snippet operators paste, so an unvalidated name executes."""
+    for hostile in ("$(id)", "`id`", "a;rm -rf /", "UPPERCASE"):
+        result = _helm_template(
+            "--set-string",
+            f"backend.existingSecret={hostile}",
+            "--set",
+            "backend.env.SIBYL_JWT_SECRET=x",
+        )
+
+        assert result.returncode != 0
+        assert "<your-secret-name>" in result.stderr
+        assert hostile not in result.stderr
+
+    valid = _helm_template(
+        "--set-string",
+        "backend.existingSecret=ok-name-123",
+        "--set",
+        "backend.env.SIBYL_JWT_SECRET=x",
+    )
+
+    assert valid.returncode != 0
+    assert "kubectl create secret generic ok-name-123" in valid.stderr

--- a/tools/trust/enterprise_readiness_evidence.py
+++ b/tools/trust/enterprise_readiness_evidence.py
@@ -96,6 +96,8 @@ SIBYL_HELM_RENDER_ARGS = (
     "--set",
     "breakGlass.allowedIPs[0]=203.0.113.0/24",
     "--set",
+    "backend.existingSecret=sibyl-secrets",
+    "--set",
     "backend.surreal.existingSecret=sibyl-surrealdb-root",
     "--set",
     "oidc.providers[0].name=entra",


### PR DESCRIPTION
# 🛡️ Production installs stop silently disabling MCP auth

> Fixes finding I3 from `docs/architecture/AUDIT_2026-08-13/debt-web-cli-infra.md`, rated blocker.
> Eleven commits: the chart guard, a matching server-side validator for deployments the chart cannot reach, then the fixes three review rounds turned up.

## 💡 What this is

A stock `helm install charts/sibyl` produced a deployment labelled `SIBYL_ENVIRONMENT: production` with MCP authentication turned off, and nothing anywhere said so. This makes that configuration fail at template time with a message naming the value to set.

The obvious fix is to have the chart generate a JWT secret when none is supplied, the way `surreal-secret.yaml` generates a SurrealDB root password. That fix is wrong here, and the SurrealDB secret is the proof: `randAlphaNum` has no `lookup` guard, so it writes a new password on every `helm upgrade`, and the audit filed that as its own blocker (I5). A generated JWT secret would inherit the same defect and add a second one, since the backend, worker, and bootstrap pods each read the value at their own render. Rotating the signing key invalidates every live session; diverging it across pods means tokens minted by one are rejected by another. Production secrets have to come from outside the chart, so the chart's job is to refuse to render without one.

## 🤔 The mechanism it closes

Four defaults line up so that no single one looks wrong:

```mermaid
flowchart LR
    A["values.yaml<br/>SIBYL_ENVIRONMENT: production"] --> D
    B["values.yaml<br/>existingSecret: ''"] --> C["backend-deployment.yaml<br/>if .Values.backend.existingSecret<br/>skips the SIBYL_JWT_SECRET block"]
    C --> D["config.py<br/>dev auto-generation is gated on<br/>environment != production, so it<br/>never fires"]
    D --> E["jwt_secret == ''"]
    E --> F["server.py<br/>auth_mode 'auto' enforces Bearer auth<br/>only when a JWT secret is set"]
    F --> G["MCP auth off.<br/>SessionMiddleware built with secret_key=''"]
```

Startup logged the outcome at INFO and carried on (`main.py:133-137`). The production validator at `config.py:229-276` checked `disable_auth`, in-memory and embedded Surreal URLs, `cookie_secure`, and default Surreal credentials, and never checked for a signing key. The values comment above `existingSecret` stated the requirement in prose, which is documentation rather than enforcement.

## 🎯 The invariant

No render labelled production completes without a usable JWT secret held in a Kubernetes Secret and MCP auth left enabled, and no process labelled production starts without the same. Anchor the review on that pair: the chart guard covers Helm, the config validator covers everything else, and the two enforce the same three conditions so neither is the only thing standing between an operator and an unauthenticated deploy.

## 🛠️ How it works

**The chart guard.** `sibyl.validateProductionAuthSecret` in `charts/sibyl/templates/_helpers.tpl` follows the shape of the existing `sibyl.validateOidcProviders` helper: a `define` block that calls Helm's `fail`, included from `configmap.yaml`. The ConfigMap is the right host because it renders unconditionally, unlike the deployments, which sit behind enable toggles. It reads `backend.env.SIBYL_ENVIRONMENT`, and when that is `production` it requires `backend.existingSecret`.

A second clause rejects `backend.env.SIBYL_JWT_SECRET` and the unprefixed `backend.env.JWT_SECRET` in production. Supplying the key either way looks like it should work, but the `range .Values.backend.env` loop in `configmap.yaml` writes every key verbatim into the plaintext `<release>-config` ConfigMap. A signing key stored there is readable under broader RBAC than a Secret and lands in GitOps repositories in the clear. The unprefixed alias is not inert, either: the JWT fallback in `config.py` reads it whenever the prefixed variable is empty, so a Secret that exists but carries an empty value hands the process the plaintext copy.

A third clause rejects `backend.env.SIBYL_MCP_AUTH_MODE: off` in production, which would serve every MCP tool unauthenticated no matter how carefully the Secret was provisioned. Development still allows it, since `docs/guide/self-hosting.md` documents it as the local unauthenticated endpoint.

All three clauses range over `backend.env` and compare `upper $key` rather than looking up an exact key, because `SettingsConfigDict` in `config.py` leaves `case_sensitive` at its default of `False`. A lowercase `sibyl_jwt_secret` reaches `Settings.jwt_secret` exactly as the uppercase spelling does, so an exact-key guard would wave it through while the ConfigMap still received the signing key. The environment check treats any casing that spells `production` as production, which is the fail-safe direction when a values file carries the key twice in different cases.

The failure text is a shell snippet an operator is invited to paste, so it is built defensively. The secret name, release name, and namespace reach the message only when they match an RFC 1123 DNS subdomain and fit in 253 characters; anything else renders a placeholder, because an unvalidated `backend.existingSecret` of `$(id)` would otherwise put executable text in front of a reader who is being told to run it. The commands are also split by install shape. A single `helm upgrade --set` drops every other override on an existing release, since `--set` without `--reuse-values` or a values file resets it to chart defaults, so the text gives `helm install` for a first install and `helm upgrade --reuse-values` for a release that already exists.

**The server-side validator.** `validate_production_auth_posture` in `apps/api/src/sibyl/config.py` refuses to construct `Settings` in production on three conditions: an empty signing key, a key under 32 bytes, and `mcp_auth_mode == "off"`. The length floor exists because HS256 is only as strong as its key, and a one-byte secret produced verifiable tokens before it. A key carrying leading or trailing whitespace is refused rather than trimmed. Trimming looks helpful and is not: it changes the signing key, so a rolling upgrade leaves old and new revisions unable to verify each other's tokens. The message names the usual cause instead, a trailing newline from `$(cat secret.txt)` or a file-projected Kubernetes Secret, and a whitespace-only value still lands in the empty case. Placement matters as much as the checks: it is defined after `check_api_key_fallbacks` rather than inside `validate_security_settings`, because the non-prefixed `JWT_SECRET` environment fallback is applied in `check_api_key_fallbacks`, and pydantic runs `mode="after"` validators in class-body order. Putting the check in `validate_security_settings`, where the other production rules live, would see the pre-fallback value and reject a configuration that sets bare `JWT_SECRET`. A test pins that ordering.

**Why both.** The chart guard cannot see a raw `docker run`, a systemd unit, or a hand-written manifest. The config validator catches those, and it is the reason this change closes the finding rather than moving it.

**The enterprise readiness evidence tool.** `SIBYL_HELM_RENDER_ARGS` in `tools/trust/enterprise_readiness_evidence.py` renders `charts/sibyl` with a long override list that turns on Gateway API, network policy, restricted pod security, bootstrap, and break-glass. It never set `backend.existingSecret`, so it inherited the production default and the new guard stopped it, which took down the `rendered_helm_manifests` evidence item and the `moon run enterprise-readiness-evidence` workflow documented in `docs/admin/backup-restore.md`. The guard was right to fire: that render was certifying a production manifest with no JWT secret, which is the vulnerability this branch exists to close. The override list now sets the Secret, so the evidence reflects a correctly secured deployment.

## 🧪 Validation

The chart scenarios, run against helm 4.2.3 and re-run against helm 3.20.2 to match the version pinned in `publish.yml`:

| Configuration | Command suffix | Exit |
| --- | --- | --- |
| Production, no secret | (defaults) | 1 |
| Production, Secret supplied | `--set backend.existingSecret=sibyl-secrets` | 0 |
| Non-production | `--set backend.env.SIBYL_ENVIRONMENT=development` | 0 |
| Production, key in the ConfigMap | `--set backend.existingSecret=sibyl-secrets --set backend.env.SIBYL_JWT_SECRET=hunter2` | 1 |
| Same, unprefixed alias | `... --set backend.env.JWT_SECRET=hunter2` | 1 |
| Same, lowercase and mixed case | `... --set backend.env.sibyl_jwt_secret=hunter2` | 1 |
| Production labelled in lowercase | `--set backend.env.SIBYL_ENVIRONMENT=null --set backend.env.sibyl_environment=production` | 1 |
| Production, MCP auth switched off | `... --set backend.env.SIBYL_MCP_AUTH_MODE=off` | 1 |
| Production, MCP auth enforcing | `... --set backend.env.SIBYL_MCP_AUTH_MODE=on` | 0 |
| Development, MCP auth off | `--set backend.env.SIBYL_ENVIRONMENT=development --set backend.env.SIBYL_MCP_AUTH_MODE=off` | 0 |
| Enterprise evidence render | the tool's own `SIBYL_HELM_RENDER_ARGS` | 0 |

The default case now prints:

```
Error: execution error at (sibyl/templates/worker-deployment.yaml:18:28): backend.existingSecret is required when backend.env.SIBYL_ENVIRONMENT is "production".
Without it SIBYL_JWT_SECRET is never set, so the API signs sessions with an empty key and MCP auth disables itself (mcp_auth_mode defaults to "auto", which enforces Bearer auth only when a JWT secret is present).
Create the secret, then point the chart at it:
  kubectl create secret generic sibyl-secrets \
    --from-literal=SIBYL_JWT_SECRET="$(openssl rand -hex 32)" \
    --from-literal=SIBYL_SETTINGS_KEY="$(openssl rand -hex 32)"
  helm install sibyl charts/sibyl --set backend.existingSecret=sibyl-secrets
Setting backend.env.SIBYL_JWT_SECRET does not satisfy this: every backend.env key is rendered into the plaintext sibyl-config ConfigMap, which is readable under broader RBAC than a Secret.
For a non-production trial set backend.env.SIBYL_ENVIRONMENT=development instead. The server then derives its own JWT secret per process, so sessions break on restart and across replicas, which is why that path is unfit for production.
```

`helm install sibyl charts/sibyl --dry-run=client` fails identically, so the guard holds on the install path and not only in `helm template`. The Secret-supplied case renders 413 lines carrying `key: SIBYL_JWT_SECRET` and `key: SIBYL_SETTINGS_KEY` for both the backend and the worker. The development case renders `SIBYL_ENVIRONMENT: "development"` and zero `SIBYL_JWT_SECRET` references, which is what leaves the server's development auto-generation path intact, and it still renders when a lowercase inline key is present, since the rejection is production-only.

`helm lint charts/sibyl` exits 0 on both helm versions, with `1 chart(s) linted, 0 chart(s) failed`. The linter reports a template `fail` at INFO level rather than as an error, so the bare `helm lint` in the `helm-package` job of `publish.yml` stays green while `helm template` and `helm install` abort. That asymmetry is why the new tests assert on `helm template` rather than on lint.

Test suites:

- `moon run api:test` → 2122 passed, 5 skipped, on the interpreter `.prototools` pins (Python 3.13.12). The skips are the four live SurrealDB runtime smokes and the archive drift test that needs a real 3.x server.
- `uv run pytest tools/tests/test_runtime_surface.py tools/tests/test_enterprise_readiness_evidence.py -q` → 118 passed.
- `moon run :lint` → 12 tasks clean, including `api:lint`.
- `moon run sync-versions-check` → `All deployment pins match VERSION (1.2.0).`
- `moon run api:typecheck` → `All checks passed!`

Twenty-one tests are new. Eleven live in `tools/tests/test_runtime_surface.py`, covering the helper being defined and included, every row of the table above, the evidence tool's own `SIBYL_HELM_RENDER_ARGS` so the pairing cannot break silently again, the remediation naming the release namespace, its split between install and upgrade, and its refusal to interpolate four hostile secret names while still passing a valid one through. The ten that shell out skip cleanly when the helm binary is absent. The other ten cover the config validator: the empty-secret rejection, the bare `JWT_SECRET` fallback satisfying it, staging staying exempt, the 32-byte floor, three padded key shapes rejected, a clean key preserved byte for byte, a whitespace-only value failing as empty, `mcp_auth_mode=off` rejected in production, `auto` and `on` staying allowed, and `off` staying allowed outside production.

One existing test earns a note. `test_cookie_secure_defaults_true_in_production_http` in `apps/api/tests/test_auth_cookie_config.py` sets `SIBYL_ENVIRONMENT=production` through `monkeypatch`, so it now sets a `SIBYL_JWT_SECRET` alongside it. Deleting that one line fails the test with a `ValidationError` from the new validator, which is what makes the addition a check on the validator rather than a way around it.

## 🔍 What reviewers should focus on

- **The validator ordering in `config.py`.** If `validate_production_jwt_secret` ever moves above `check_api_key_fallbacks` in the class body, deployments that set bare `JWT_SECRET` break. `test_non_prefixed_jwt_secret_satisfies_production` is the guard against that.
- **Whether the guard has a bypass.** It keys on a `backend.env` entry named `SIBYL_ENVIRONMENT` in any casing. An operator who labels production some other way renders without the check. One known inert edge remains: a whitespace-only inline value passes the ConfigMap clause, and it cannot carry a real key, and the backend and worker both declare an explicit `env` entry sourcing `SIBYL_JWT_SECRET` from the Secret, which kubelet resolves ahead of `envFrom`.
- **The `backend.existingSecret` addition to `SIBYL_HELM_RENDER_ARGS`.** The evidence manifest is a compliance artifact, and this changes what it renders. Worth confirming the new manifest is the one that should be certified.
- **Blast radius on existing installs.** Anyone already running the chart in production has `existingSecret` set, since without it their auth was off. An upgrade for them is a no-op unless their key is under 32 bytes or they had switched MCP auth off, both of which now fail loudly. The people this breaks are the ones whose deploy was silently unauthenticated, plus anyone who put the signing key in `backend.env`, which is the intent in every case.
- **The 32-byte floor is a hard gate on an existing value.** An operator running a short key today gets a refused boot rather than a warning. That is the correct trade for a forgeable HS256 signature, and it is the one change here that can stop a currently-running deployment from restarting. The same applies to a key with a stray newline, which is refused rather than quietly repaired.
- **The ten workflow secrets.** Ten production-labelled CI jobs carried 18 to 30 byte fake keys that the floor rejects, so they all move to one obviously-fake 35-byte marker. Worth confirming none of those jobs asserts on the old literal.
- **The twelve fixture updates in `apps/api/tests`.** Each adds `jwt_secret="test-jwt-secret"` to a `Settings` construction that was asserting something unrelated (cookie behavior, Surreal credentials, local auth defaults). Worth a scan for any case where the added kwarg changes what the test proves.

## 📌 Deliberately not in scope

The new chart tests live in `tools/tests/test_runtime_surface.py`, which the `inventory-test` moon task runs. That task is a dependency of root `check` and `test`, so it runs at RC cut through `release.yml`, and it does not run in PR CI: `ci.yml` never invokes `inventory-test`, and helm is installed only in `publish.yml`. Closing that gap means fixing the CI change classifier first, since finding I1 documents that `charts/` is absent from the `runtime_changed` case list entirely, so a chart-only pull request currently trips no classifier flag and reaches no test job. This PR adds `charts/sibyl/**/*` to the `inventory-test` inputs so chart edits invalidate its cache once a job does run it.

The audit's other infrastructure blockers stay open and untouched: the worker crash-loop under the chart's own `coordinationBackend: "auto"` default (I4), the SurrealDB root password regenerating on every upgrade (I5), and the SurrealDB PVC mounted without `fsGroup` (I6). Fixing the CI change classifier so chart edits reach a test job is audit item I1 and stays out of this PR; the boundary is named above rather than patched here.

The audit also lists one unverified question this change does not answer: whether tokens signed with an empty HMAC key also verify, which would make sessions forgeable rather than merely unauthenticated. Both guards make the empty-key state unreachable in production, so the question stops being reachable in practice, but it is not settled on its own terms.

One cosmetic edge survives. Passing a non-map `backend.env` (`--set backend.env=oops`) produces a raw Go template type error from `_helpers.tpl` rather than a written message. It fails closed, so it is a legibility issue rather than a security one.
