### PR TITLE
docs(architecture): lexicon contamination gets a structural kill

### DIFF
--- a/docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md
+++ b/docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md
@@ -164,6 +164,20 @@ shipped and the consumers half-built. Closing that loop is a story no competitor
 - **Phase 0 — clean room.** Ranker decontamination, fusion decision, pipeline unification (or
   explicit pairing), fresh anchor via the standard unpaid screen ladder. No lever work lands on a
   contaminated baseline.
+- **Phase 0/1 standing direction — make hand-lexicon contamination unwriteable.** The
+  decontamination PR (#386) removed the corpus vocabulary, but the architecture that grew it is
+  intact: the lexical lane is a hand-maintained English micro-NLP pipeline (stopword lists,
+  graded-adjective tables, action-verb groups, fact frames, scaffolding terms), and hand lexicons
+  rot toward whatever eval is being run because entries get added the day a query misses. The
+  durable fix is structural, in order of rightness: (1) move morphological normalization into the
+  search engine — SurrealDB analyzers support `snowball(english)` stemming, which normalizes
+  index-side and query-side uniformly and deletes the comparative table, the plural fallback, and
+  the drifted duplicate tokenizer in one move; (2) where Python-side normalization must survive, a
+  real lemmatizer (`simplemma`-class: pure-Python, no model) replaces every morphology table we
+  would otherwise hand-write; (3) shrink the bespoke coverage ranker's role in favor of the lanes
+  that never had this problem — embeddings are morphology-blind, and the audit already proved most
+  of the ranker's hand weights are ordinal no-ops. New hand-lexicon entries are treated as a design
+  smell requiring adjudication, not a routine fix.
 - **Phase 1 — structure with consequences.** Writable typed predicates (small closed vocabulary:
   supersedes, contradicts, requires, supports, decides/caused-by) feeding the existing traversal
   weights; supersession + correction enforcement at traversal and pack admission (write-time gating

--- a/docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md
+++ b/docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md
@@ -161,9 +161,28 @@ shipped and the consumers half-built. Closing that loop is a story no competitor
 
 ## 6. Proposed 1.3 shape
 
-- **Phase 0 — clean room.** Ranker decontamination, fusion decision, pipeline unification (or
-  explicit pairing), fresh anchor via the standard unpaid screen ladder. No lever work lands on a
-  contaminated baseline.
+- **Phase 0 — clean room.** Ranker decontamination (landed, #386), fresh anchor via the standard
+  unpaid screen ladder, and the headline experiment below. No lever work lands on a contaminated
+  baseline.
+- **Phase 0 headline experiment — race the machine against a naive-strong arm.** The evidence says
+  simplicity is already winning: the 42.8% frontier baseline is naive slice-RAG; Emergence AI's 86%
+  on LongMemEval-V1 is turn-match → session-scope retrieval → cross-encoder rerank → CoT with no
+  memory architecture at all ("advanced memory architecture appears to be overkill"); the bottleneck
+  study measures retrieval method at a 20-point spread on LoCoMo vs 3-8 for write strategy. Against
+  that, Sibyl runs two mutually-unaware pipelines (8-lane `context_search`, 2-lane `hybrid_search`),
+  ordinal fusion that discards score magnitudes (so most hand weights cannot change outcomes), and
+  sequential phases that put enterprise at ~32s against a 10s budget. The experiment: build a
+  naive-strong arm — verbatim spans + BM25 with analyzer-level stemming + dense KNN +
+  reciprocal-rank fusion + tight pack + extract-then-answer reader (mostly existing pieces;
+  `hybrid_search` is ~80% of it) — and screen it against the full machine on the same corpus under
+  standard protocol. Every outcome wins: parity or better deletes the machine (and most of the
+  latency); a loss is the first clean measurement of which lanes actually carry the 30.4%. The
+  fusion decision and pipeline unification questions resolve as consequences of the race rather than
+  as abstract design calls. Note: re-ranking's refutation (decision `715454c60c9b`) was conditional
+  on pool-absence under the current acquisition — the simplified pipeline changes the mechanism, so
+  the cross-encoder re-enters through the killed-lever ledger's own revival clause. The graph then
+  stops competing with flat retrieval and does the two jobs flat pipelines can't:
+  supersession/correction enforcement and typed multi-hop traversal.
 - **Phase 0/1 standing direction — make hand-lexicon contamination unwriteable.** The
   decontamination PR (#386) removed the corpus vocabulary, but the architecture that grew it is
   intact: the lexical lane is a hand-maintained English micro-NLP pipeline (stopword lists,


### PR DESCRIPTION
## 🔮 What this is

Two additions to the 1.3 rethink doc, both structural directions that came out of interrogating the decontamination work:

1. **A standing direction that kills the hand-lexicon contamination class structurally.** The decontamination PR (#386) removed the LongMemEval vocabulary, but the architecture that grew it is intact — a hand-maintained English micro-NLP pipeline whose entries accrete whenever an eval query misses. The direction: morphology moves into the SurrealDB analyzer (`snowball(english)`, uniform index-side and query-side), a lemmatizer covers any surviving Python-side normalization, and the bespoke coverage ranker shrinks in favor of the morphology-blind lanes. New hand-lexicon entries become adjudicated exceptions rather than routine fixes.

2. **Phase 0's headline experiment: race the machine against a naive-strong arm.** The field evidence says simplicity is winning (the 42.8% frontier baseline is naive slice-RAG; the strongest LongMemEval-V1 result is a four-step pipeline with no memory architecture), while our audit shows most of the 8-lane machine's weights are ordinal no-ops. The naive-strong arm is verbatim spans + stemmed BM25 + dense KNN + RRF + tight pack + extract-then-answer, screened against the full machine under standard protocol. Parity deletes the machine; a loss is the first clean measurement of which lanes actually carry the score. The fusion and pipeline-unification questions resolve as consequences of the race.