### PR TITLE
fix(retrieval): make supersession and correction actually reach retrieval

### DIFF
--- a/apps/api/src/sibyl/api/routes/entities.py
+++ b/apps/api/src/sibyl/api/routes/entities.py
@@ -64,7 +64,7 @@ from sibyl.persistence.content_runtime import (
 )
 from sibyl_core.auth import AuthOrganization, MemoryPolicyContext, OrganizationRole, ProjectRole
 from sibyl_core.auth.memory_policy import (
-    MEMORY_OWNER_METADATA_KEYS,
+    SERVER_OWNED_METADATA_KEYS,
     authorize_memory_read,
     memory_metadata_read_allowed,
     private_scope_granted_for,
@@ -2500,7 +2500,11 @@ async def update_entity(
             if update.metadata is not None:
                 # Merge metadata, keeping the stored owner channels: reassigning
                 # them would hand the row to a different principal or project.
-                # The structure keys go the same way, so a forwarded body cannot
+                # Capture provenance is kept for the same reason, because the
+                # correction write-through retires rows by querying it, so a
+                # patch that could rewrite it could nominate this row to be
+                # retired later by a correction on an unrelated capture. The
+                # structure keys go the same way, so a forwarded body cannot
                 # plant a plan the server never validated.
                 existing_meta = getattr(existing, "metadata", {}) or {}
                 update_data["metadata"] = {
@@ -2508,7 +2512,7 @@ async def update_entity(
                     **{
                         key: value
                         for key, value in strip_structure_metadata(update.metadata).items()
-                        if key not in MEMORY_OWNER_METADATA_KEYS
+                        if key not in SERVER_OWNED_METADATA_KEYS
                     },
                 }
 

--- a/apps/api/src/sibyl/api/routes/memory.py
+++ b/apps/api/src/sibyl/api/routes/memory.py
@@ -924,6 +924,12 @@ def _correction_result_response(
     if result.refused_entity_ids:
         recall_impact["refused_entity_ids"] = list(result.refused_entity_ids)
         recall_impact["partially_applied"] = True
+    if result.projection_walk_truncated:
+        # The lineage walk stopped at its page ceiling, so rows projected from
+        # this capture may still be servable. A caller told `applied: true`
+        # with no qualifier has no other way to learn that.
+        recall_impact["projection_walk_truncated"] = True
+        recall_impact["partially_applied"] = True
     return response.model_copy(update={"recall_impact": recall_impact})
 
 

--- a/apps/api/src/sibyl/api/routes/memory.py
+++ b/apps/api/src/sibyl/api/routes/memory.py
@@ -907,12 +907,24 @@ def _correction_result_response(
     *,
     receipt: MutationReceipt | None = None,
 ) -> MemoryCorrectionResponse:
-    return _correction_response(
+    response = _correction_response(
         result.preview,
         applied=result.applied,
         updated_memory=result.updated_memory,
         receipt=receipt,
     )
+    if not result.applied:
+        return response
+    # recall_impact is a claim about what recall will now do, so the graph
+    # outcome belongs in it. A correction that reached the capture but not
+    # every row the capture named is a partial write, and answering
+    # `applied: true` with nothing else said would read as a complete one.
+    recall_impact = dict(response.recall_impact)
+    recall_impact["graph_entity_ids"] = list(result.affected_entity_ids)
+    if result.refused_entity_ids:
+        recall_impact["refused_entity_ids"] = list(result.refused_entity_ids)
+        recall_impact["partially_applied"] = True
+    return response.model_copy(update={"recall_impact": recall_impact})
 
 
 def _metadata_str_list(value: object) -> list[str]:

--- a/apps/api/src/sibyl/api/routes/memory.py
+++ b/apps/api/src/sibyl/api/routes/memory.py
@@ -2582,8 +2582,14 @@ async def apply_memory_correction_route(
             revision=updated_revision,
             affected_records=(
                 [
-                    f"raw_captures:{affected_id}"
-                    for affected_id in result.preview.affected_source_ids
+                    *(
+                        f"raw_captures:{affected_id}"
+                        for affected_id in result.preview.affected_source_ids
+                    ),
+                    # The graph rows are named too, because they are what
+                    # retrieval ranks: a receipt listing only the capture
+                    # would still read as though the correction stopped there.
+                    *(f"entity:{entity_id}" for entity_id in result.affected_entity_ids),
                 ]
                 if result.applied
                 else []

--- a/apps/api/src/sibyl/jobs/entities.py
+++ b/apps/api/src/sibyl/jobs/entities.py
@@ -26,8 +26,8 @@ from sibyl_core.projection import (
     restamp_entity_passages,
     scope_bearing_entity_update,
 )
+from sibyl_core.projection.reconcile import prewrite_capture_stamp, reconcile_with_capture
 from sibyl_core.services.graph import get_surreal_graph_runtime
-from sibyl_core.services.memory import projected_row_lifecycle_stamp
 from sibyl_core.services.surreal_content import MemoryScope
 from sibyl_core.tasks.distillation import build_learning_episode, build_learning_procedure
 
@@ -506,7 +506,7 @@ async def create_entity(  # noqa: PLR0915
         # recallable with the corrected text in it. The capture is the
         # authority, and every await between reading it and writing the row is
         # a window where a correction lands and finds nothing to stamp.
-        lifecycle_stamp = await projected_row_lifecycle_stamp(
+        lifecycle_stamp, _lifecycle_verified = await prewrite_capture_stamp(
             organization_id=group_id,
             metadata=entity.metadata,
         )
@@ -528,6 +528,20 @@ async def create_entity(  # noqa: PLR0915
             "create_entity_graph_created",
             entity_id=created_id,
             entity_type=entity_type,
+        )
+
+        # The write itself is the last interleaving point a pre-write read
+        # cannot cover: a correction can retire the capture and run its cascade
+        # while this insert is still in flight, find no row, and let the stale
+        # row commit behind it. Reading the verdict once more now closes that
+        # interval, and an unreadable verdict leaves the row excluded rather
+        # than servable.
+        await reconcile_with_capture(
+            entity_manager,
+            organization_id=group_id,
+            metadata=entity.metadata,
+            row_ids=[created_id],
+            applied_stamp=lifecycle_stamp,
         )
 
         relationship_manager = runtime.relationship_manager

--- a/apps/api/src/sibyl/jobs/entities.py
+++ b/apps/api/src/sibyl/jobs/entities.py
@@ -468,24 +468,6 @@ async def create_entity(  # noqa: PLR0915
         else:
             entity = Episode.model_validate(entity_data)
 
-        # This payload was serialized before the job was queued, so anything
-        # that happened to the capture since then is invisible to it. A caller
-        # that corrected the memory it just wrote gets that verdict applied to
-        # a row that does not exist yet, and the row would otherwise be created
-        # recallable with the corrected text in it. The capture is re-read
-        # here, and the row is born carrying whatever the capture now says.
-        lifecycle_stamp = await projected_row_lifecycle_stamp(
-            organization_id=group_id,
-            metadata=entity.metadata,
-        )
-        if lifecycle_stamp:
-            object.__setattr__(entity, "metadata", {**(entity.metadata or {}), **lifecycle_stamp})
-            log.info(
-                "create_entity_born_retired",
-                entity_id=entity_data.get("id"),
-                lifecycle_state=lifecycle_stamp.get("lifecycle_state"),
-            )
-
         # Dedup-on-write: check for near-duplicates before creating.
         # If found, still create the entity (callers already have its ID),
         # but enrich the existing duplicate and log the match.
@@ -515,6 +497,26 @@ async def create_entity(  # noqa: PLR0915
                     deduplicated = True
             except Exception as e:
                 log.debug("dedup_on_write_check_skipped", error=str(e))
+
+        # Read immediately before the write, with no awaits in between. This
+        # payload was serialized before the job was queued, so anything that
+        # happened to the capture since then is invisible to it: a caller that
+        # corrected the memory it just wrote gets that verdict applied to a row
+        # that does not exist yet, and the row would otherwise be created
+        # recallable with the corrected text in it. The capture is the
+        # authority, and every await between reading it and writing the row is
+        # a window where a correction lands and finds nothing to stamp.
+        lifecycle_stamp = await projected_row_lifecycle_stamp(
+            organization_id=group_id,
+            metadata=entity.metadata,
+        )
+        if lifecycle_stamp:
+            object.__setattr__(entity, "metadata", {**(entity.metadata or {}), **lifecycle_stamp})
+            log.info(
+                "create_entity_born_retired",
+                entity_id=entity_data.get("id"),
+                lifecycle_state=lifecycle_stamp.get("lifecycle_state"),
+            )
 
         create_direct = getattr(entity_manager, "create_direct", None)
         if callable(create_direct):

--- a/apps/api/src/sibyl/jobs/entities.py
+++ b/apps/api/src/sibyl/jobs/entities.py
@@ -27,6 +27,7 @@ from sibyl_core.projection import (
     scope_bearing_entity_update,
 )
 from sibyl_core.services.graph import get_surreal_graph_runtime
+from sibyl_core.services.memory import projected_row_lifecycle_stamp
 from sibyl_core.services.surreal_content import MemoryScope
 from sibyl_core.tasks.distillation import build_learning_episode, build_learning_procedure
 
@@ -466,6 +467,24 @@ async def create_entity(  # noqa: PLR0915
             entity = Procedure.model_validate(entity_data)
         else:
             entity = Episode.model_validate(entity_data)
+
+        # This payload was serialized before the job was queued, so anything
+        # that happened to the capture since then is invisible to it. A caller
+        # that corrected the memory it just wrote gets that verdict applied to
+        # a row that does not exist yet, and the row would otherwise be created
+        # recallable with the corrected text in it. The capture is re-read
+        # here, and the row is born carrying whatever the capture now says.
+        lifecycle_stamp = await projected_row_lifecycle_stamp(
+            organization_id=group_id,
+            metadata=entity.metadata,
+        )
+        if lifecycle_stamp:
+            object.__setattr__(entity, "metadata", {**(entity.metadata or {}), **lifecycle_stamp})
+            log.info(
+                "create_entity_born_retired",
+                entity_id=entity_data.get("id"),
+                lifecycle_state=lifecycle_stamp.get("lifecycle_state"),
+            )
 
         # Dedup-on-write: check for near-duplicates before creating.
         # If found, still create the entity (callers already have its ID),

--- a/apps/api/src/sibyl/jobs/entities.py
+++ b/apps/api/src/sibyl/jobs/entities.py
@@ -536,13 +536,21 @@ async def create_entity(  # noqa: PLR0915
         # row commit behind it. Reading the verdict once more now closes that
         # interval, and an unreadable verdict leaves the row excluded rather
         # than servable.
-        await reconcile_with_capture(
+        reconciled = await reconcile_with_capture(
             entity_manager,
             organization_id=group_id,
             metadata=entity.metadata,
             row_ids=[created_id],
-            applied_stamp=lifecycle_stamp,
         )
+        if reconciled.changed:
+            log.warning(
+                "create_entity_lifecycle_reconciled",
+                organization_id=group_id,
+                entity_id=created_id,
+                restamped=reconciled.restamped,
+                unverified=reconciled.unverified,
+                cleared=reconciled.cleared,
+            )
 
         relationship_manager = runtime.relationship_manager
         relationships_for_embedding_backfill: list[Relationship] = []

--- a/apps/api/src/sibyl/server.py
+++ b/apps/api/src/sibyl/server.py
@@ -53,6 +53,7 @@ from sibyl_core.auth.memory_policy import (
     MemoryPolicyAction,
     MemoryPolicyDecision,
     authorize_memory_write,
+    server_provenance_metadata,
     stamp_memory_scope_metadata,
 )
 from sibyl_core.memory_pipeline.capture import MemoryCaptureRequest, MemoryCaptureService
@@ -788,6 +789,14 @@ async def _remember_mcp_memory(
             tags=list(request.tags) if request.tags is not None else None,
             related_to=list(request.related_to) if request.related_to is not None else None,
             metadata=dict(graph_metadata),
+            # The graph writer strips server-owned keys from `metadata`,
+            # because that bag is caller input everywhere else it is used. The
+            # capture pipeline stamped these two from the raw write it just
+            # completed, so they travel in the argument that survives the
+            # strip; without it the row reaches the graph naming no capture,
+            # and both the correction write-through and the projection
+            # boundary lose the only link back.
+            capture_provenance=server_provenance_metadata(graph_metadata),
             project=project,
             memory_scope=request.memory_scope,
             scope_key=request.scope_key,

--- a/apps/api/tests/test_jobs_entities.py
+++ b/apps/api/tests/test_jobs_entities.py
@@ -83,6 +83,11 @@ class TestCreateEntityJob:
         )
         entity_manager = MagicMock()
         entity_manager.create_direct = AsyncMock(return_value="pattern-123")
+        # Projection reads the stored parent's lifecycle before deriving rows
+        # from it, so the double has to answer `get` the way a real manager
+        # does. A bare MagicMock returns a non-awaitable and the read fails
+        # closed, which is the intended behavior on an unreadable parent.
+        entity_manager.get = AsyncMock(return_value=None)
         relationship_manager = MagicMock()
         relationship_manager.create_direct_bulk = AsyncMock(return_value=["rel-1"])
         relationship_manager.create = AsyncMock()

--- a/apps/api/tests/test_jobs_entities_correction_race.py
+++ b/apps/api/tests/test_jobs_entities_correction_race.py
@@ -1,0 +1,244 @@
+"""The window between correcting a capture and projecting it into the graph.
+
+`remember` writes the capture, queues the graph write, and hands back an id the
+caller can correct immediately. The queued payload was serialized before the
+correction existed, so the worker builds the row from a description of a memory
+that has since been retired. Nothing reconciles it afterwards: the correction
+write-through already ran and found no rows.
+
+These tests run the real `create_entity` job against a real embedded graph and
+read the result back through `compile_context`, because the claim being made is
+about what an agent can recall, not about which keys a dict carries.
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_module
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from sibyl.jobs.entities import create_entity
+from sibyl_core.models.entities import EntityType, Pattern
+from sibyl_core.services.graph import (
+    EntityManager,
+    RelationshipManager,
+    SurrealGraphClient,
+    prepare_graph_schema,
+)
+from sibyl_core.services.surreal_content import RawMemory
+from sibyl_core.tools import context as context_module
+
+PROJECT_ID = "proj-correction-race"
+PRINCIPAL = "user-correction-race"
+RAW_MEMORY_ID = "raw-corrected-capture"
+
+
+class _Runtime:
+    def __init__(self, client: Any, entities: Any, relationships: Any, group_id: str) -> None:
+        self.client = client
+        self.entity_manager = entities
+        self.relationship_manager = relationships
+        self.group_id = group_id
+
+
+@pytest_asyncio.fixture
+async def graph(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[_Runtime]:
+    group_id = f"correction-race-{uuid_module.uuid4().hex[:12]}"
+    client = SurrealGraphClient(group_id=group_id, url="memory://")
+    await client.connect()
+    await prepare_graph_schema(client)
+    runtime = _Runtime(
+        client,
+        EntityManager(client, group_id=group_id),
+        RelationshipManager(client, group_id=group_id),
+        group_id,
+    )
+
+    async def runtime_factory(requested_group_id: str, **_kwargs: object) -> _Runtime:
+        assert str(requested_group_id) == group_id
+        return runtime
+
+    import sibyl.jobs.entities as jobs_entities
+    import sibyl_core.retrieval.search as search_module
+
+    monkeypatch.setattr(jobs_entities, "get_surreal_graph_runtime", runtime_factory)
+    monkeypatch.setattr(search_module, "get_surreal_graph_runtime", runtime_factory)
+    monkeypatch.setattr(context_module, "get_surreal_graph_runtime", runtime_factory)
+    monkeypatch.setattr(context_module, "get_graph_runtime", runtime_factory, raising=False)
+    monkeypatch.setattr(context_module, "configured_embedding_provider", lambda: None)
+    yield runtime
+    await client.close()
+
+
+def _corrected_capture(**overrides: Any) -> RawMemory:
+    """The capture as `raw_captures` holds it after `sibyl correct` ran."""
+
+    values: dict[str, Any] = {
+        "id": RAW_MEMORY_ID,
+        "organization_id": "org-correction-race",
+        "source_id": "source-corrected-capture",
+        "principal_id": PRINCIPAL,
+        "review_state": "pending",
+        "entity_type": "pattern",
+        "title": "Deploy to Fly",
+        "raw_content": "We deploy to fly.io.",
+        "metadata": {
+            "lifecycle_state": "contested",
+            "lifecycle_flags": [],
+            "lifecycle_action": "mark_wrong",
+        },
+    }
+    values.update(overrides)
+    return RawMemory(**values)
+
+
+def _queued_payload(group_id: str) -> dict[str, Any]:
+    """The job payload as it was serialized, before the correction existed."""
+
+    body = "\n\n".join(
+        f"## Fly section {index}\n\n" + f"fly hosting rollout body line {index} " * 40
+        for index in range(4)
+    )
+    entity = Pattern(
+        id="raced-parent",
+        name="Deploy to Fly",
+        entity_type=EntityType.PATTERN,
+        description="fly hosting rollout",
+        content=body,
+        organization_id=group_id,
+        project_id=PROJECT_ID,
+        metadata={
+            "memory_scope": "project",
+            "scope_key": PROJECT_ID,
+            "project_id": PROJECT_ID,
+            "raw_memory_id": RAW_MEMORY_ID,
+            "raw_source_id": "source-corrected-capture",
+        },
+    )
+    return entity.model_dump(mode="json")
+
+
+async def _no_raw_memories(**_kwargs: object) -> list[Any]:
+    return []
+
+
+async def _no_active_work(**_kwargs: object) -> list[Any]:
+    return []
+
+
+async def _no_fallback(**_kwargs: object) -> list[Any]:
+    raise AssertionError("compile_context fell back to the non-native search path")
+
+
+async def _served_ids(runtime: _Runtime, goal: str) -> set[str]:
+    pack = await context_module.compile_context(
+        goal,
+        intent="build",
+        project=PROJECT_ID,
+        accessible_projects={PROJECT_ID},
+        principal_id=PRINCIPAL,
+        organization_id=runtime.group_id,
+        search_fn=_no_fallback,
+        raw_memory_recall_fn=_no_raw_memories,
+        active_work_fn=_no_active_work,
+        record_exposure=False,
+    )
+    return {item.id for section in pack.sections for item in section.items}
+
+
+async def _run_create_entity(runtime: _Runtime) -> dict[str, Any]:
+    with (
+        patch("sibyl.jobs.entities._safe_broadcast", AsyncMock()),
+        patch("sibyl.jobs.pending.clear_pending", AsyncMock()),
+        patch("sibyl.jobs.pending.process_pending_operations", AsyncMock(return_value=[])),
+        patch("sibyl_core.tools.conflicts.find_similar_entities", AsyncMock(return_value=[])),
+        patch(
+            "sibyl.jobs.memory_extraction.enqueue_memory_extraction_batches",
+            AsyncMock(
+                return_value=type(
+                    "_Enqueue",
+                    (),
+                    {
+                        "status": "skipped",
+                        "reason": "disabled",
+                        "job_ids": [],
+                        "queued_sources": 0,
+                        "skipped_sources": 1,
+                    },
+                )()
+            ),
+        ),
+    ):
+        return await create_entity(
+            {},
+            _queued_payload(runtime.group_id),
+            "pattern",
+            runtime.group_id,
+            generate_embeddings=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_row_projected_after_its_capture_was_corrected_is_born_retired(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Correction lands first, the worker runs second, and nothing recallable appears.
+
+    The payload the worker holds describes a live memory, because it was
+    written before the correction. `raw_captures` is the row the correction
+    actually mutated, so it is the authority, and the projection boundary is
+    where the two are reconciled.
+    """
+
+    import sibyl_core.services.memory as memory_module
+
+    monkeypatch.setattr(
+        memory_module,
+        "get_raw_memory",
+        AsyncMock(return_value=_corrected_capture()),
+    )
+
+    result = await _run_create_entity(graph)
+    assert result["entity_id"] == "raced-parent"
+
+    stored = await graph.entity_manager.get("raced-parent")
+    assert stored is not None, "the row is still written; it is written retired"
+    assert stored.metadata.get("excluded_from_recall") is True
+    assert stored.metadata.get("lifecycle_state") == "contested"
+
+    served = await _served_ids(graph, "fly hosting rollout body")
+    assert "raced-parent" not in served
+    assert not {item_id for item_id in served if item_id.startswith("passage")}
+
+
+@pytest.mark.asyncio
+async def test_an_uncorrected_capture_still_projects_a_recallable_row(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The control: without a correction the same job produces a servable memory.
+
+    Without this, a projection boundary that retired everything, or one that
+    silently failed to project at all, would pass the test above.
+    """
+
+    import sibyl_core.services.memory as memory_module
+
+    monkeypatch.setattr(
+        memory_module,
+        "get_raw_memory",
+        AsyncMock(return_value=_corrected_capture(metadata={})),
+    )
+
+    await _run_create_entity(graph)
+
+    served = await _served_ids(graph, "fly hosting rollout body")
+    # The spans are the memory's presence in the pack: a projection whose spans
+    # cover the whole body suppresses the fat parent on purpose, so their
+    # presence is what says this content is recallable.
+    assert {item_id for item_id in served if item_id.startswith("passage")}

--- a/apps/api/tests/test_jobs_entities_correction_race.py
+++ b/apps/api/tests/test_jobs_entities_correction_race.py
@@ -14,15 +14,15 @@ about what an agent can recall, not about which keys a dict carries.
 from __future__ import annotations
 
 import uuid as uuid_module
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
 
+import sibyl_core.tools.add as add_module
 from sibyl.jobs.entities import create_entity
-from sibyl_core.models.entities import EntityType, Pattern
 from sibyl_core.services.graph import (
     EntityManager,
     RelationshipManager,
@@ -96,30 +96,73 @@ def _corrected_capture(**overrides: Any) -> RawMemory:
     return RawMemory(**values)
 
 
-def _queued_payload(group_id: str) -> dict[str, Any]:
-    """The job payload as it was serialized, before the correction existed."""
+class _RecordingQueue:
+    """Stands in for arq, keeping the payload `add()` actually serialized."""
+
+    def __init__(self) -> None:
+        self.payloads: list[dict[str, Any]] = []
+
+    async def enqueue_create_entity(
+        self,
+        *,
+        entity_id: str,
+        entity_data: Mapping[str, Any],
+        entity_type: str,
+        group_id: str,
+        relationships: Any = None,
+        auto_link_params: Mapping[str, Any] | None = None,
+        generate_embeddings: bool = True,
+    ) -> str:
+        self.payloads.append(dict(entity_data))
+        return f"job-{entity_id}"
+
+    async def enqueue_entity_embedding_backfill(self, **_kwargs: object) -> str:
+        return "job-backfill"
+
+
+async def _queued_payload(monkeypatch: pytest.MonkeyPatch, group_id: str) -> dict[str, Any]:
+    """The payload the real `add()` puts on the queue, not one built by hand.
+
+    Building it by hand is how the first version of this test hid a defect that
+    made the whole reconciliation inert: `add()` strips server-owned keys from
+    caller metadata, and the capture pipeline stamps provenance before calling
+    it, so the queued payload named no capture at all. A test that supplies
+    provenance itself proves nothing about the path that has to supply it.
+    """
 
     body = "\n\n".join(
         f"## Fly section {index}\n\n" + f"fly hosting rollout body line {index} " * 40
         for index in range(4)
     )
-    entity = Pattern(
-        id="raced-parent",
-        name="Deploy to Fly",
-        entity_type=EntityType.PATTERN,
-        description="fly hosting rollout",
+    queue = _RecordingQueue()
+    monkeypatch.setattr(add_module, "get_queue_port", lambda: queue)
+
+    response = await add_module.add(
+        title="Deploy to Fly",
         content=body,
-        organization_id=group_id,
-        project_id=PROJECT_ID,
+        entity_type="pattern",
+        project=PROJECT_ID,
+        memory_scope="project",
+        scope_key=PROJECT_ID,
+        principal_id=PRINCIPAL,
+        check_conflicts=False,
+        # Exactly what the capture pipeline hands the graph writer: the raw
+        # ids on the dedicated argument, and a metadata bag that also carries
+        # them and gets them stripped.
         metadata={
-            "memory_scope": "project",
-            "scope_key": PROJECT_ID,
-            "project_id": PROJECT_ID,
+            "organization_id": group_id,
+            "raw_memory_id": RAW_MEMORY_ID,
+            "raw_source_id": "source-corrected-capture",
+        },
+        capture_provenance={
             "raw_memory_id": RAW_MEMORY_ID,
             "raw_source_id": "source-corrected-capture",
         },
     )
-    return entity.model_dump(mode="json")
+
+    assert response.success
+    assert len(queue.payloads) == 1, "the write has to have gone through the queue"
+    return queue.payloads[0]
 
 
 async def _no_raw_memories(**_kwargs: object) -> list[Any]:
@@ -150,7 +193,14 @@ async def _served_ids(runtime: _Runtime, goal: str) -> set[str]:
     return {item.id for section in pack.sections for item in section.items}
 
 
-async def _run_create_entity(runtime: _Runtime) -> dict[str, Any]:
+async def _run_create_entity(
+    runtime: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, Any]:
+    payload = await _queued_payload(monkeypatch, runtime.group_id)
+    assert payload["metadata"].get("raw_memory_id") == RAW_MEMORY_ID, (
+        "the queued payload has to name the capture, or the worker has nothing to read"
+    )
     with (
         patch("sibyl.jobs.entities._safe_broadcast", AsyncMock()),
         patch("sibyl.jobs.pending.clear_pending", AsyncMock()),
@@ -175,7 +225,7 @@ async def _run_create_entity(runtime: _Runtime) -> dict[str, Any]:
     ):
         return await create_entity(
             {},
-            _queued_payload(runtime.group_id),
+            payload,
             "pattern",
             runtime.group_id,
             generate_embeddings=True,
@@ -203,16 +253,16 @@ async def test_a_row_projected_after_its_capture_was_corrected_is_born_retired(
         AsyncMock(return_value=_corrected_capture()),
     )
 
-    result = await _run_create_entity(graph)
-    assert result["entity_id"] == "raced-parent"
+    result = await _run_create_entity(graph, monkeypatch)
+    parent_id = result["entity_id"]
 
-    stored = await graph.entity_manager.get("raced-parent")
+    stored = await graph.entity_manager.get(result["entity_id"])
     assert stored is not None, "the row is still written; it is written retired"
     assert stored.metadata.get("excluded_from_recall") is True
     assert stored.metadata.get("lifecycle_state") == "contested"
 
     served = await _served_ids(graph, "fly hosting rollout body")
-    assert "raced-parent" not in served
+    assert parent_id not in served
     assert not {item_id for item_id in served if item_id.startswith("passage")}
 
 
@@ -235,7 +285,7 @@ async def test_an_uncorrected_capture_still_projects_a_recallable_row(
         AsyncMock(return_value=_corrected_capture(metadata={})),
     )
 
-    await _run_create_entity(graph)
+    await _run_create_entity(graph, monkeypatch)
 
     served = await _served_ids(graph, "fly hosting rollout body")
     # The spans are the memory's presence in the pack: a projection whose spans

--- a/apps/api/tests/test_jobs_entities_correction_race.py
+++ b/apps/api/tests/test_jobs_entities_correction_race.py
@@ -292,3 +292,58 @@ async def test_an_uncorrected_capture_still_projects_a_recallable_row(
     # cover the whole body suppresses the fat parent on purpose, so their
     # presence is what says this content is recallable.
     assert {item_id for item_id in served if item_id.startswith("passage")}
+
+
+@pytest.mark.asyncio
+async def test_a_correction_landing_inside_the_write_still_retires_the_row(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interval a pre-write read can never cover.
+
+    The insert is an await. A correction can retire the capture and run its
+    cascade while that insert is in flight: the cascade finds no row, the
+    pre-write read already returned the old verdict, and the stale row commits
+    behind both. Only a pass that runs after the row exists can see it, which
+    is why the write is bracketed rather than preceded.
+
+    The correction is injected inside the `create_direct` await, which is the
+    only place it can land to reproduce this.
+    """
+
+    import sibyl_core.services.memory as memory_module
+
+    capture = _corrected_capture(metadata={})
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=capture))
+
+    original_create = graph.entity_manager.create_direct
+    corrected: dict[str, bool] = {}
+
+    async def create_direct_with_correction(entity: Any, **kwargs: Any) -> str:
+        created = await original_create(entity, **kwargs)
+        if not corrected:
+            # Mid-flight: the memory is corrected while the row is being
+            # written, so the correction's own cascade cannot see it.
+            corrected["done"] = True
+            monkeypatch.setattr(
+                memory_module,
+                "get_raw_memory",
+                AsyncMock(return_value=_corrected_capture()),
+            )
+        return created
+
+    monkeypatch.setattr(
+        graph.entity_manager, "create_direct", create_direct_with_correction, raising=False
+    )
+
+    result = await _run_create_entity(graph, monkeypatch)
+    parent_id = result["entity_id"]
+    assert corrected, "the correction has to have landed inside the write"
+
+    stored = await graph.entity_manager.get(parent_id)
+    assert stored is not None
+    assert stored.metadata.get("excluded_from_recall") is True
+    assert stored.metadata.get("lifecycle_state") == "contested"
+
+    served = await _served_ids(graph, "fly hosting rollout body")
+    assert parent_id not in served

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -1971,6 +1971,69 @@ async def test_apply_memory_correction_returns_updated_review_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_correction_receipt_names_the_graph_rows_it_retired() -> None:
+    """The receipt has to show the write reached retrieval, not just the capture.
+
+    A correction that stamps entity rows but reports only `raw_captures:` reads
+    exactly like the old behavior, where the blast radius genuinely stopped at
+    the substrate retrieval mostly does not read.
+    """
+
+    org = _org()
+    memory = _memory(id="memory-1", organization_id=str(org.id), source_id="source-1")
+    updated = _memory(
+        id="memory-1",
+        organization_id=str(org.id),
+        source_id="source-1",
+        review_state="pending",
+    )
+    preview = MemoryCorrectionPreview(
+        allowed=True,
+        source_id="memory-1",
+        action="mark_wrong",
+        reason="wrong",
+        target_lifecycle_state="contested",
+        target_lifecycle_flags=[],
+        affected_source_ids=["memory-1"],
+        affected_derived_ids=[],
+        reversible=True,
+        recall_impact={"excluded_from_recall": True},
+        synthesis_impact={"excluded_from_synthesis": True},
+        audit_action="memory.correction.mark_wrong",
+    )
+    updated.revision = 2
+    result = MemoryCorrectionResult(
+        applied=True,
+        preview=preview,
+        updated_memory=updated,
+        affected_entity_ids=["entity-1", "entity-2"],
+    )
+
+    with (
+        patch("sibyl.api.routes.memory.get_raw_memory", AsyncMock(return_value=memory)),
+        patch(
+            "sibyl.api.routes.memory.apply_memory_correction",
+            AsyncMock(return_value=result),
+        ),
+        patch("sibyl.api.routes.memory.log_memory_audit_event", AsyncMock()),
+    ):
+        response = await apply_memory_correction_route(
+            "memory-1",
+            MemoryCorrectionRequest(action="mark_wrong", reason="wrong"),
+            http_request=_http_request(),
+            org=org,
+            ctx=_ctx(org_role=OrganizationRole.OWNER),
+        )
+
+    assert response.mutation_receipt is not None
+    assert response.mutation_receipt.affected_records == [
+        "raw_captures:memory-1",
+        "entity:entity-1",
+        "entity:entity-2",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_denied_memory_correction_receipt_reports_no_write() -> None:
     org = _org()
     memory = _memory(id="memory-1", organization_id=str(org.id), source_id="source-1")

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -3530,3 +3530,64 @@ async def test_promote_reflection_candidate_returns_404_for_missing_candidate() 
             "review_state": "missing",
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_projection_walk_says_the_correction_was_partial() -> None:
+    """The lineage walk stopping early is a partial write, not a complete one.
+
+    A capture with more projected rows than the walk's page ceiling admits
+    leaves some of them servable. The caller is told `applied: true` either
+    way, so the qualifier is the only signal that the retirement did not reach
+    everything it was supposed to.
+    """
+
+    org = _org()
+    memory = _memory(id="memory-1", organization_id=str(org.id), source_id="source-1")
+    updated = _memory(
+        id="memory-1",
+        organization_id=str(org.id),
+        source_id="source-1",
+        review_state="pending",
+    )
+    preview = MemoryCorrectionPreview(
+        allowed=True,
+        source_id="memory-1",
+        action="mark_wrong",
+        reason="wrong",
+        target_lifecycle_state="contested",
+        target_lifecycle_flags=[],
+        affected_source_ids=["memory-1"],
+        affected_derived_ids=[],
+        reversible=True,
+        recall_impact={"excluded_from_recall": True},
+        synthesis_impact={"excluded_from_synthesis": True},
+        audit_action="memory.correction.mark_wrong",
+    )
+    updated.revision = 2
+    result = MemoryCorrectionResult(
+        applied=True,
+        preview=preview,
+        updated_memory=updated,
+        affected_entity_ids=["entity-1"],
+        projection_walk_truncated=True,
+    )
+
+    with (
+        patch("sibyl.api.routes.memory.get_raw_memory", AsyncMock(return_value=memory)),
+        patch(
+            "sibyl.api.routes.memory.apply_memory_correction",
+            AsyncMock(return_value=result),
+        ),
+        patch("sibyl.api.routes.memory.log_memory_audit_event", AsyncMock()),
+    ):
+        response = await apply_memory_correction_route(
+            "memory-1",
+            MemoryCorrectionRequest(action="mark_wrong", reason="wrong"),
+            http_request=_http_request(),
+            org=org,
+            ctx=_ctx(org_role=OrganizationRole.OWNER),
+        )
+
+    assert response.recall_impact["projection_walk_truncated"] is True
+    assert response.recall_impact["partially_applied"] is True

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -2031,6 +2031,66 @@ async def test_correction_receipt_names_the_graph_rows_it_retired() -> None:
         "entity:entity-1",
         "entity:entity-2",
     ]
+    assert response.recall_impact["graph_entity_ids"] == ["entity-1", "entity-2"]
+    assert "refused_entity_ids" not in response.recall_impact
+    assert "partially_applied" not in response.recall_impact
+
+
+@pytest.mark.asyncio
+async def test_a_partially_applied_correction_says_so_in_recall_impact() -> None:
+    """`applied: true` with a refused target must not read as a complete write."""
+
+    org = _org()
+    memory = _memory(id="memory-1", organization_id=str(org.id), source_id="source-1")
+    updated = _memory(
+        id="memory-1",
+        organization_id=str(org.id),
+        source_id="source-1",
+        review_state="pending",
+    )
+    preview = MemoryCorrectionPreview(
+        allowed=True,
+        source_id="memory-1",
+        action="mark_wrong",
+        reason="wrong",
+        target_lifecycle_state="contested",
+        target_lifecycle_flags=[],
+        affected_source_ids=["memory-1"],
+        affected_derived_ids=[],
+        reversible=True,
+        recall_impact={"excluded_from_recall": True},
+        synthesis_impact={"excluded_from_synthesis": True},
+        audit_action="memory.correction.mark_wrong",
+    )
+    updated.revision = 2
+    result = MemoryCorrectionResult(
+        applied=True,
+        preview=preview,
+        updated_memory=updated,
+        affected_entity_ids=["entity-own"],
+        refused_entity_ids=["entity-victim"],
+    )
+
+    with (
+        patch("sibyl.api.routes.memory.get_raw_memory", AsyncMock(return_value=memory)),
+        patch(
+            "sibyl.api.routes.memory.apply_memory_correction",
+            AsyncMock(return_value=result),
+        ),
+        patch("sibyl.api.routes.memory.log_memory_audit_event", AsyncMock()),
+    ):
+        response = await apply_memory_correction_route(
+            "memory-1",
+            MemoryCorrectionRequest(action="mark_wrong", reason="wrong"),
+            http_request=_http_request(),
+            org=org,
+            ctx=_ctx(org_role=OrganizationRole.OWNER),
+        )
+
+    assert response.applied is True
+    assert response.recall_impact["graph_entity_ids"] == ["entity-own"]
+    assert response.recall_impact["refused_entity_ids"] == ["entity-victim"]
+    assert response.recall_impact["partially_applied"] is True
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_server_accessible_projects.py
+++ b/apps/api/tests/test_server_accessible_projects.py
@@ -479,6 +479,14 @@ async def test_remember_mcp_memory_scopes_project_metadata() -> None:
             "raw_memory_id": "raw_123",
             "raw_source_id": "mcp:remember:decision",
         },
+        # Provenance rides here as well as in the metadata bag, because the
+        # graph writer strips server-owned keys out of that bag. Without this
+        # argument the row reaches the graph naming no capture, and a later
+        # correction on this memory can neither find it nor retire it.
+        capture_provenance={
+            "raw_memory_id": "raw_123",
+            "raw_source_id": "mcp:remember:decision",
+        },
         project="project-a",
         memory_scope="project",
         scope_key="project-a",

--- a/packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
+++ b/packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
@@ -694,6 +694,31 @@ def memory_metadata_read_allowed(
     }
 
 
+def server_provenance_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Lift the server-stamped provenance out of a bag before it is stripped.
+
+    Provenance names the capture a graph row was projected from, which is how a
+    correction finds that row and how the projection boundary reads the
+    capture's current verdict. It is server-owned precisely because a caller
+    that could set it could nominate any row it can write to be retired by a
+    correction on an unrelated capture, so `stamp_memory_scope_metadata` drops
+    it from every incoming bag.
+
+    The capture pipeline is not an incoming bag. It stamps these keys itself
+    from the completed raw write, and the strip runs again downstream, so
+    without a channel that survives it the authoritative ids never reach the
+    row. This is that channel: read the keys here, pass them separately, and
+    re-attach them after the strip.
+    """
+
+    fields = metadata if isinstance(metadata, Mapping) else {}
+    return {
+        key: fields[key]
+        for key in MEMORY_PROVENANCE_METADATA_KEYS
+        if fields.get(key) not in (None, "")
+    }
+
+
 def stamp_memory_scope_metadata(
     metadata: Mapping[str, Any] | None,
     *,
@@ -749,5 +774,6 @@ __all__ = [
     "memory_row_project_id",
     "memory_scope_policy_key",
     "private_scope_granted_for",
+    "server_provenance_metadata",
     "stamp_memory_scope_metadata",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
+++ b/packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
@@ -28,6 +28,21 @@ MEMORY_OWNER_METADATA_KEYS = frozenset(
     }
 )
 
+# Capture provenance. These name the raw row a graph row was projected from,
+# and the correction write-through resolves its targets by querying them, so a
+# payload that can set them can nominate any row it can currently write to be
+# retired later by a correction on an unrelated capture. The server stamps
+# them from the completed raw write after this strip runs
+# (`memory_pipeline/capture.py`), so no legitimate writer supplies them.
+MEMORY_PROVENANCE_METADATA_KEYS = frozenset(
+    {
+        "raw_memory_id",
+        "raw_source_id",
+    }
+)
+
+SERVER_OWNED_METADATA_KEYS = MEMORY_OWNER_METADATA_KEYS | MEMORY_PROVENANCE_METADATA_KEYS
+
 
 class MemoryPolicyAction(StrEnum):
     READ = "read"
@@ -692,11 +707,14 @@ def stamp_memory_scope_metadata(
     never name the principal or project a row reads as. A declared scope with
     no authorized owner keeps the scope and loses the owner, which fails the
     read check closed rather than falling back to the payload.
+
+    Capture provenance goes the same way, because the correction write-through
+    resolves the rows it retires by querying those keys.
     """
     stamped = {
         key: value
         for key, value in (metadata or {}).items()
-        if key not in MEMORY_OWNER_METADATA_KEYS
+        if key not in SERVER_OWNED_METADATA_KEYS
     }
     scope = _coerce_scope(memory_scope) if memory_scope is not None else None
     if scope is None:
@@ -719,6 +737,8 @@ def stamp_memory_scope_metadata(
 
 __all__ = [
     "MEMORY_OWNER_METADATA_KEYS",
+    "MEMORY_PROVENANCE_METADATA_KEYS",
+    "SERVER_OWNED_METADATA_KEYS",
     "MemoryPolicyAction",
     "MemoryPolicyDecision",
     "authorize_memory_read",

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/lifecycle.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/lifecycle.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Protocol
 
 from sibyl_core.models.reflection import MemoryLifecycleState, memory_lifecycle_from_metadata
@@ -83,3 +83,39 @@ def raw_memory_lifecycle_recallable(memory: MemoryLifecycleView) -> bool:
     if metadata.get("superseded_by_source_id"):
         return False
     return not metadata.get("duplicate_of_source_id")
+
+
+GRAPH_RECALL_EXCLUSION_KEYS = (
+    "excluded_from_recall",
+    "superseded_by_source_id",
+    "superseded_by_raw_memory_id",
+    "duplicate_of_source_id",
+)
+
+
+def _flag_values(value: object) -> Iterable[str]:
+    if isinstance(value, str):
+        return (_normalized_state(value),)
+    if isinstance(value, Iterable):
+        return tuple(_normalized_state(item) for item in value)
+    return ()
+
+
+def graph_metadata_recallable(metadata: Mapping[str, object] | None) -> bool:
+    """Report whether a projected graph row is still eligible to be served.
+
+    The raw lane decides this from a `RawMemory`; the graph row carries the
+    same verdict as flat metadata stamped by the correction write-through,
+    because the graph has no lifecycle column and joining every candidate back
+    to its capture at query time would cost a second round trip per row.
+    """
+
+    if not metadata:
+        return True
+    if _normalized_state(metadata.get("review_state")) in RECALL_EXCLUDED_REVIEW_STATES:
+        return False
+    if _normalized_state(metadata.get("lifecycle_state")) in RECALL_EXCLUDED_LIFECYCLE_STATES:
+        return False
+    if RECALL_EXCLUDED_LIFECYCLE_FLAGS.intersection(_flag_values(metadata.get("lifecycle_flags"))):
+        return False
+    return not any(metadata.get(key) for key in GRAPH_RECALL_EXCLUSION_KEYS)

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/lifecycle.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/lifecycle.py
@@ -91,12 +91,23 @@ GRAPH_RECALL_EXCLUSION_KEYS = (
     "superseded_by_raw_memory_id",
     "duplicate_of_source_id",
 )
+# Reflection stamps `duplicate_of_source_id` on a near-duplicate candidate,
+# and promotion resets that candidate's lifecycle to ACTIVE without clearing
+# the key, so on the graph lane the bare marker outlives the verdict that set
+# it. An explicit ACTIVE state is the later, deliberate statement and wins.
+# The other markers do not get this treatment: a correction that excludes a
+# row never leaves it ACTIVE, so nothing here can soften supersession.
+_STATE_OVERRIDABLE_EXCLUSION_KEYS = frozenset({"duplicate_of_source_id"})
 
 
 def _flag_values(value: object) -> Iterable[str]:
     if isinstance(value, str):
         return (_normalized_state(value),)
-    if isinstance(value, Iterable):
+    # A Mapping is Iterable, and iterating one yields its keys, so a
+    # dict-shaped flag bag would read every key as a set flag no matter what
+    # it maps to: `{"hidden": False}` would retire the row. Sequence and set
+    # shapes are the only ones a flag list is ever written in.
+    if isinstance(value, list | tuple | set | frozenset):
         return tuple(_normalized_state(item) for item in value)
     return ()
 
@@ -112,10 +123,16 @@ def graph_metadata_recallable(metadata: Mapping[str, object] | None) -> bool:
 
     if not metadata:
         return True
+    state = _normalized_state(metadata.get("lifecycle_state"))
     if _normalized_state(metadata.get("review_state")) in RECALL_EXCLUDED_REVIEW_STATES:
         return False
-    if _normalized_state(metadata.get("lifecycle_state")) in RECALL_EXCLUDED_LIFECYCLE_STATES:
+    if state in RECALL_EXCLUDED_LIFECYCLE_STATES:
         return False
     if RECALL_EXCLUDED_LIFECYCLE_FLAGS.intersection(_flag_values(metadata.get("lifecycle_flags"))):
         return False
-    return not any(metadata.get(key) for key in GRAPH_RECALL_EXCLUSION_KEYS)
+    active = state == MemoryLifecycleState.ACTIVE.value
+    return not any(
+        metadata.get(key)
+        for key in GRAPH_RECALL_EXCLUSION_KEYS
+        if not (active and key in _STATE_OVERRIDABLE_EXCLUSION_KEYS)
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/lifecycle.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/lifecycle.py
@@ -85,6 +85,50 @@ def raw_memory_lifecycle_recallable(memory: MemoryLifecycleView) -> bool:
     return not metadata.get("duplicate_of_source_id")
 
 
+def graph_lifecycle_stamp(memory: MemoryLifecycleView) -> dict[str, object]:
+    """The verdict a graph row projected from this capture has to be born with.
+
+    Projection is asynchronous: `remember` writes the capture, queues the graph
+    write, and returns an id the caller can correct immediately. The worker
+    then builds the row from the payload it was handed, which was serialized
+    before the correction existed, so a row created after a correction is
+    created recallable and nothing later reconciles it. The capture is the
+    authority (it is the row the correction actually mutated), and this is the
+    verdict a reader of that row must inherit.
+
+    Empty for a capture that is still recallable, so a caller can merge the
+    result unconditionally.
+
+    `excluded_from_recall` carries the exclusion on its own rather than
+    depending on the state name, because a capture can fall out of recall on a
+    review state or a bare replacement marker while its lifecycle state still
+    reads active.
+    """
+
+    if raw_memory_lifecycle_recallable(memory):
+        return {}
+    metadata = dict(memory.metadata)
+    lifecycle = memory_lifecycle_from_metadata(
+        metadata,
+        source_id=memory.source_id or memory.id,
+        review_state=memory.review_state,
+    )
+    state = _normalized_state(lifecycle.state)
+    stamp: dict[str, object] = {"excluded_from_recall": True}
+    if state and state != MemoryLifecycleState.ACTIVE.value:
+        stamp["lifecycle_state"] = state
+    flags = [_normalized_state(flag) for flag in lifecycle.flags]
+    if flags:
+        stamp["lifecycle_flags"] = flags
+    replacement = lifecycle.replacement_source_id or metadata.get("superseded_by_source_id")
+    if replacement:
+        stamp["superseded_by_source_id"] = str(replacement)
+    duplicate = lifecycle.duplicate_of_source_id or metadata.get("duplicate_of_source_id")
+    if duplicate:
+        stamp["duplicate_of_source_id"] = str(duplicate)
+    return stamp
+
+
 GRAPH_RECALL_EXCLUSION_KEYS = (
     "excluded_from_recall",
     "superseded_by_source_id",

--- a/packages/python/sibyl-core/src/sibyl_core/projection/inheritance.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/inheritance.py
@@ -1,0 +1,95 @@
+"""What a projected row inherits from the memory it was derived from.
+
+Every projection mints rows that carry some of a parent memory's text: spans
+carry its words verbatim, projected entities carry its candidate context,
+projected facts carry their span and content. Each of those rows is
+independently indexed and independently servable, so a reader can reach the
+parent's content through a row the parent's own lifecycle never touched.
+
+Scope inheritance has always been here. Lifecycle inheritance is the same idea
+applied to the same problem one level down: a derived row of a retired memory
+that reads as active serves retired text under an id the retirement never
+named.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger()
+
+# What a correction stamps onto a memory. A derived row that does not carry
+# these keeps serving the retired body under its own id.
+LIFECYCLE_METADATA_KEYS = (
+    "lifecycle_state",
+    "lifecycle_flags",
+    "lifecycle_action",
+    "excluded_from_recall",
+    "superseded_by_source_id",
+    "duplicate_of_source_id",
+)
+
+
+def inherited_lifecycle_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """The lifecycle half of what a derived row inherits from its parent."""
+
+    fields = metadata if isinstance(metadata, Mapping) else {}
+    return {
+        key: fields[key]
+        for key in LIFECYCLE_METADATA_KEYS
+        if key in fields and fields[key] is not None
+    }
+
+
+async def parent_lifecycle_as_stored(
+    entity_manager: Any,
+    source: Any,
+    *,
+    source_id: str,
+) -> Any:
+    """Re-read the parent's lifecycle, keeping the caller's body and scope.
+
+    Projection is never one write. A correction landing between the parent
+    write and this one stamps the parent, finds no derived rows because none
+    exist yet, and returns; the projection then derives rows from the caller's
+    copy of the parent, which predates the verdict. The stored row is the
+    authority for lifecycle, so it is read rather than assumed.
+
+    Only lifecycle is taken from storage. The body stays the caller's, because
+    a re-projection derives from the text it was handed and a caller mid-update
+    holds the newer copy.
+
+    A read that fails raises rather than falling back to the caller's copy.
+    Deriving rows from a lifecycle nobody could verify is how an unstamped,
+    fully recallable copy of retired text gets minted, and no later correction
+    is guaranteed to come back for it: the correction that would have stamped
+    these rows has already run. Failing here leaves the job to be retried,
+    which is recoverable in a way a silently active row is not.
+
+    A parent that is simply absent is not a failure. Nothing has been stamped
+    on a row that does not exist, so there is no verdict to inherit.
+    """
+
+    get = getattr(entity_manager, "get", None)
+    if not callable(get):
+        return source
+    stored = await get(source_id)
+    stored_metadata = getattr(stored, "metadata", None) if stored is not None else None
+    if not isinstance(stored_metadata, Mapping):
+        if stored is not None:
+            log.warning("projection_parent_metadata_unreadable", source_id=source_id)
+        return source
+    carried = inherited_lifecycle_metadata(stored_metadata)
+    if not carried:
+        return source
+    return source.model_copy(update={"metadata": {**(source.metadata or {}), **carried}})
+
+
+__all__ = [
+    "LIFECYCLE_METADATA_KEYS",
+    "inherited_lifecycle_metadata",
+    "parent_lifecycle_as_stored",
+]

--- a/packages/python/sibyl-core/src/sibyl_core/projection/inheritance.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/inheritance.py
@@ -62,12 +62,12 @@ async def parent_lifecycle_as_stored(
     a re-projection derives from the text it was handed and a caller mid-update
     holds the newer copy.
 
-    A read that fails raises rather than falling back to the caller's copy.
-    Deriving rows from a lifecycle nobody could verify is how an unstamped,
-    fully recallable copy of retired text gets minted, and no later correction
-    is guaranteed to come back for it: the correction that would have stamped
-    these rows has already run. Failing here leaves the job to be retried,
-    which is recoverable in a way a silently active row is not.
+    A read that fails raises, and the caller decides. This is the pre-write
+    half of a bracket: the post-write pass in `projection/reconcile.py` reads
+    the same verdict again after the rows commit and refuses to leave an
+    unverified row servable, so a caller that cannot read the parent here does
+    not have to choose between poisoning its job and minting a recallable copy
+    of possibly-retired text.
 
     A parent that is simply absent is not a failure. Nothing has been stamped
     on a row that does not exist, so there is no verdict to inherit.
@@ -76,7 +76,14 @@ async def parent_lifecycle_as_stored(
     get = getattr(entity_manager, "get", None)
     if not callable(get):
         return source
-    stored = await get(source_id)
+    try:
+        stored = await get(source_id)
+    except KeyError:
+        # The real manager raises this for a row that is not there
+        # (`services/graph.py`). An absent parent is not an unreadable one:
+        # nothing was stamped on a row that does not exist, so there is no
+        # verdict to inherit and nothing to fail over.
+        return source
     stored_metadata = getattr(stored, "metadata", None) if stored is not None else None
     if not isinstance(stored_metadata, Mapping):
         if stored is not None:

--- a/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
@@ -14,6 +14,10 @@ import structlog
 from sibyl_core.errors import EntityNotFoundError
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.models.memory_extraction import ExtractedMemoryEntity
+from sibyl_core.projection.inheritance import (
+    LIFECYCLE_METADATA_KEYS,
+    parent_lifecycle_as_stored,
+)
 from sibyl_core.retrieval.dedup import DedupConfig, EntityDeduplicator
 from sibyl_core.retrieval.fact_frames import FactFrame, extract_evidence_fact_frames
 from sibyl_core.tools.helpers import _generate_id
@@ -350,7 +354,15 @@ async def project_memory_entities(
         if not _projection_allowed(source):
             skipped += 1
             continue
-        projected_source = source.model_copy(update={"id": source_id})
+        # The parent's lifecycle is read back rather than taken from the
+        # caller's copy, because a correction can land between the parent
+        # write and this one: it stamps the parent, finds no derived rows
+        # because none exist yet, and returns.
+        projected_source = await parent_lifecycle_as_stored(
+            entity_manager,
+            source.model_copy(update={"id": source_id}),
+            source_id=source_id,
+        )
         extracted = extract_projected_memory_entities(
             projected_source,
             max_entities=max_entities,
@@ -425,7 +437,15 @@ async def project_extracted_memory_entities(
         if source.entity_type not in PROJECTABLE_ENTITY_TYPES:
             skipped += 1
             continue
-        projected_source = source.model_copy(update={"id": source_id})
+        # The parent's lifecycle is read back rather than taken from the
+        # caller's copy, because a correction can land between the parent
+        # write and this one: it stamps the parent, finds no derived rows
+        # because none exist yet, and returns.
+        projected_source = await parent_lifecycle_as_stored(
+            entity_manager,
+            source.model_copy(update={"id": source_id}),
+            source_id=source_id,
+        )
         extracted = _projected_from_extracted_entities(
             extractions_by_source_id.get(source_id, ()),
             source=projected_source,
@@ -1190,10 +1210,18 @@ def _valid_fact_span(span: str) -> bool:
 
 
 def _inherited_scope_metadata(source: Entity) -> dict[str, object]:
+    """Carry the parent's scope and lifecycle onto every row derived from it.
+
+    A projected entity copies the parent's candidate context and a projected
+    fact copies its span, so each is an independently servable copy of part of
+    a memory. One that reads as active after its parent was retired serves the
+    retired text under an id the retirement never named, exactly as a span
+    would.
+    """
     metadata = dict(source.metadata or {})
     return {
         key: metadata[key]
-        for key in _SCOPE_METADATA_KEYS
+        for key in (*_SCOPE_METADATA_KEYS, *LIFECYCLE_METADATA_KEYS)
         if key in metadata and metadata[key] is not None
     }
 

--- a/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
@@ -16,8 +16,10 @@ from sibyl_core.models.entities import Entity, EntityType, Relationship, Relatio
 from sibyl_core.models.memory_extraction import ExtractedMemoryEntity
 from sibyl_core.projection.inheritance import (
     LIFECYCLE_METADATA_KEYS,
+    inherited_lifecycle_metadata,
     parent_lifecycle_as_stored,
 )
+from sibyl_core.projection.reconcile import reconcile_with_parent
 from sibyl_core.retrieval.dedup import DedupConfig, EntityDeduplicator
 from sibyl_core.retrieval.fact_frames import FactFrame, extract_evidence_fact_frames
 from sibyl_core.tools.helpers import _generate_id
@@ -535,6 +537,29 @@ async def _persist_projection_batch(
         source_id: tuple(link.entity_id for link in links)
         for source_id, links in resolved_links_by_source_id.items()
     }
+
+    # The parent can be corrected while these rows are being written, and that
+    # interval is the one no pre-write read reaches: the correction's cascade
+    # runs before the rows exist, finds nothing, and the stale rows commit
+    # behind it. The stamp each row was built with is compared against the
+    # parent as it stands now, and the rows are restamped if it moved.
+    for source_id, row_ids in resolved_entity_ids_by_source_id.items():
+        if not row_ids:
+            continue
+        planned = next(
+            (
+                projected_by_id[link.entity_id].metadata
+                for link in projected_entity_links_by_source_id.get(source_id, ())
+                if link.entity_id in projected_by_id
+            ),
+            None,
+        )
+        await reconcile_with_parent(
+            entity_manager,
+            source_id=source_id,
+            row_ids=row_ids,
+            applied_stamp=inherited_lifecycle_metadata(planned),
+        )
     relationship_count = 0
     created_projection_relationships: tuple[Relationship, ...] = ()
     if relationships:

--- a/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
@@ -16,7 +16,6 @@ from sibyl_core.models.entities import Entity, EntityType, Relationship, Relatio
 from sibyl_core.models.memory_extraction import ExtractedMemoryEntity
 from sibyl_core.projection.inheritance import (
     LIFECYCLE_METADATA_KEYS,
-    inherited_lifecycle_metadata,
     parent_lifecycle_as_stored,
 )
 from sibyl_core.projection.reconcile import reconcile_with_parent
@@ -546,20 +545,20 @@ async def _persist_projection_batch(
     for source_id, row_ids in resolved_entity_ids_by_source_id.items():
         if not row_ids:
             continue
-        planned = next(
-            (
-                projected_by_id[link.entity_id].metadata
-                for link in projected_entity_links_by_source_id.get(source_id, ())
-                if link.entity_id in projected_by_id
-            ),
-            None,
-        )
-        await reconcile_with_parent(
+        reconciled = await reconcile_with_parent(
             entity_manager,
             source_id=source_id,
             row_ids=row_ids,
-            applied_stamp=inherited_lifecycle_metadata(planned),
         )
+        if reconciled.changed:
+            log.warning(
+                "memory_projection_lifecycle_reconciled",
+                source_id=source_id,
+                rows=list(row_ids),
+                restamped=reconciled.restamped,
+                unverified=reconciled.unverified,
+                cleared=reconciled.cleared,
+            )
     relationship_count = 0
     created_projection_relationships: tuple[Relationship, ...] = ()
     if relationships:

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -32,8 +32,10 @@ from sibyl_core.memory_pipeline.spans import (
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.projection.inheritance import (
     LIFECYCLE_METADATA_KEYS,
+    inherited_lifecycle_metadata,
     parent_lifecycle_as_stored,
 )
+from sibyl_core.projection.reconcile import reconcile_with_parent
 from sibyl_core.projection.slicing import HARD_MAX, Slice, render_slice, slice_prose
 from sibyl_core.tools.helpers import _generate_id
 
@@ -345,8 +347,10 @@ async def project_entity_passages(
     whatever lifecycle the parent is actually carrying.
     """
     source_id = created_source_id or source.id
+    stored_parent = await parent_lifecycle_as_stored(entity_manager, source, source_id=source_id)
+    inherited = inherited_lifecycle_metadata(stored_parent.metadata)
     entities, relationships = plan_entity_passages(
-        await parent_lifecycle_as_stored(entity_manager, source, source_id=source_id),
+        stored_parent,
         source_id=source_id,
         group_id=group_id,
     )
@@ -379,6 +383,16 @@ async def project_entity_passages(
             reason="entity_write_failed",
             errors=(str(exc),),
         )
+
+    # The parent can be corrected while these spans are being written, which
+    # is an interval no pre-write read reaches: the correction's cascade runs
+    # before the spans exist and finds nothing to stamp.
+    await reconcile_with_parent(
+        entity_manager,
+        source_id=source_id,
+        row_ids=[entity.id for entity in created_passages],
+        applied_stamp=inherited,
+    )
 
     created_ids = {entity.id for entity in created_passages}
     pending = [

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -89,9 +89,24 @@ _SCOPE_METADATA_KEYS = (
     "raw_source_id",
 )
 
+# What a correction stamps onto a memory, which its spans have to carry or
+# they keep serving the retired body under their own ids.
+_LIFECYCLE_METADATA_KEYS = (
+    "lifecycle_state",
+    "lifecycle_flags",
+    "lifecycle_action",
+    "excluded_from_recall",
+    "superseded_by_source_id",
+    "duplicate_of_source_id",
+)
+
 # The subset of an entity update that changes who may read its spans. A caller
 # that sees any of these in an update must refresh the spans' inherited stamps
-# even though the body, and therefore the cut, is unchanged.
+# even though the body, and therefore the cut, is unchanged. Lifecycle keys are
+# deliberately absent: the restamp walk writes scope stamps only, so listing
+# them here would fire a trigger that reads every span and fixes nothing. A
+# lifecycle change reaches existing spans through the correction cascade
+# instead (`services/memory.py`).
 SCOPE_BEARING_UPDATE_KEYS = frozenset(_SCOPE_METADATA_KEYS)
 
 
@@ -328,10 +343,17 @@ async def project_entity_passages(
     not there yet is how the operational-experience projection silently dropped
     every PART_OF it created and never self-healed, so the ordering here is
     load-bearing: entities first, then the edges that point at them.
+
+    The parent is read back rather than trusted as passed, because the caller's
+    copy can be older than the row. Both this projection and a correction can
+    be in flight at once: the correction stamps the parent, finds no spans
+    because none exist yet, and this then cuts spans from an in-memory object
+    that predates the verdict. Spans born from the stored row instead inherit
+    whatever lifecycle the parent is actually carrying.
     """
     source_id = created_source_id or source.id
     entities, relationships = plan_entity_passages(
-        source,
+        await _parent_as_stored(entity_manager, source, source_id=source_id),
         source_id=source_id,
         group_id=group_id,
     )
@@ -772,19 +794,57 @@ def _summary(content: str) -> str:
 
 
 def _inherited_scope_metadata(source: Entity) -> dict[str, object]:
-    """Carry the parent's scope onto every passage.
+    """Carry the parent's scope and lifecycle onto every passage.
 
     A passage that loses ``memory_scope``/``scope_key`` either leaks past the
     boundary its parent sits behind or vanishes from the packs that filter on
     it. Inheriting verbatim keeps the span exactly as reachable as the memory
     it was cut from, and no more.
+
+    Lifecycle inherits for the same reason and is the sharper half: a span is
+    an independently indexed copy of the parent's own words, so a span of a
+    retired memory that reads as active serves the retired text under a row id
+    the retirement never named.
     """
     metadata = dict(source.metadata or {})
     return {
         key: metadata[key]
-        for key in _SCOPE_METADATA_KEYS
+        for key in (*_SCOPE_METADATA_KEYS, *_LIFECYCLE_METADATA_KEYS)
         if key in metadata and metadata[key] is not None
     }
+
+
+async def _parent_as_stored(
+    entity_manager: Any,
+    source: Entity,
+    *,
+    source_id: str,
+) -> Entity:
+    """Re-read the parent's lifecycle, keeping the caller's body and scope.
+
+    Only the lifecycle keys are taken from storage. The body is deliberately
+    the caller's, because a re-projection cuts the text it was handed, and a
+    caller mid-update holds the newer copy.
+    """
+
+    get = getattr(entity_manager, "get", None)
+    if not callable(get):
+        return source
+    try:
+        stored = await get(source_id)
+    except Exception:
+        return source
+    stored_metadata = getattr(stored, "metadata", None) if stored is not None else None
+    if not isinstance(stored_metadata, Mapping):
+        return source
+    carried = {
+        key: stored_metadata[key]
+        for key in _LIFECYCLE_METADATA_KEYS
+        if key in stored_metadata and stored_metadata[key] is not None
+    }
+    if not carried:
+        return source
+    return source.model_copy(update={"metadata": {**(source.metadata or {}), **carried}})
 
 
 __all__ = [

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -32,7 +32,6 @@ from sibyl_core.memory_pipeline.spans import (
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.projection.inheritance import (
     LIFECYCLE_METADATA_KEYS,
-    inherited_lifecycle_metadata,
     parent_lifecycle_as_stored,
 )
 from sibyl_core.projection.reconcile import reconcile_with_parent
@@ -348,7 +347,6 @@ async def project_entity_passages(
     """
     source_id = created_source_id or source.id
     stored_parent = await parent_lifecycle_as_stored(entity_manager, source, source_id=source_id)
-    inherited = inherited_lifecycle_metadata(stored_parent.metadata)
     entities, relationships = plan_entity_passages(
         stored_parent,
         source_id=source_id,
@@ -387,12 +385,22 @@ async def project_entity_passages(
     # The parent can be corrected while these spans are being written, which
     # is an interval no pre-write read reaches: the correction's cascade runs
     # before the spans exist and finds nothing to stamp.
-    await reconcile_with_parent(
+    reconciled = await reconcile_with_parent(
         entity_manager,
         source_id=source_id,
         row_ids=[entity.id for entity in created_passages],
-        applied_stamp=inherited,
+        organization_id=group_id,
     )
+    if reconciled.changed:
+        log.warning(
+            "passage_projection_lifecycle_reconciled",
+            organization_id=group_id,
+            source_id=source_id,
+            passages=[entity.id for entity in created_passages],
+            restamped=reconciled.restamped,
+            unverified=reconciled.unverified,
+            cleared=reconciled.cleared,
+        )
 
     created_ids = {entity.id for entity in created_passages}
     pending = [

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -30,6 +30,10 @@ from sibyl_core.memory_pipeline.spans import (
     validate_agent_spans,
 )
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.projection.inheritance import (
+    LIFECYCLE_METADATA_KEYS,
+    parent_lifecycle_as_stored,
+)
 from sibyl_core.projection.slicing import HARD_MAX, Slice, render_slice, slice_prose
 from sibyl_core.tools.helpers import _generate_id
 
@@ -87,17 +91,6 @@ _SCOPE_METADATA_KEYS = (
     "agent_id",
     "source_id",
     "raw_source_id",
-)
-
-# What a correction stamps onto a memory, which its spans have to carry or
-# they keep serving the retired body under their own ids.
-_LIFECYCLE_METADATA_KEYS = (
-    "lifecycle_state",
-    "lifecycle_flags",
-    "lifecycle_action",
-    "excluded_from_recall",
-    "superseded_by_source_id",
-    "duplicate_of_source_id",
 )
 
 # The subset of an entity update that changes who may read its spans. A caller
@@ -353,7 +346,7 @@ async def project_entity_passages(
     """
     source_id = created_source_id or source.id
     entities, relationships = plan_entity_passages(
-        await _parent_as_stored(entity_manager, source, source_id=source_id),
+        await parent_lifecycle_as_stored(entity_manager, source, source_id=source_id),
         source_id=source_id,
         group_id=group_id,
     )
@@ -809,42 +802,9 @@ def _inherited_scope_metadata(source: Entity) -> dict[str, object]:
     metadata = dict(source.metadata or {})
     return {
         key: metadata[key]
-        for key in (*_SCOPE_METADATA_KEYS, *_LIFECYCLE_METADATA_KEYS)
+        for key in (*_SCOPE_METADATA_KEYS, *LIFECYCLE_METADATA_KEYS)
         if key in metadata and metadata[key] is not None
     }
-
-
-async def _parent_as_stored(
-    entity_manager: Any,
-    source: Entity,
-    *,
-    source_id: str,
-) -> Entity:
-    """Re-read the parent's lifecycle, keeping the caller's body and scope.
-
-    Only the lifecycle keys are taken from storage. The body is deliberately
-    the caller's, because a re-projection cuts the text it was handed, and a
-    caller mid-update holds the newer copy.
-    """
-
-    get = getattr(entity_manager, "get", None)
-    if not callable(get):
-        return source
-    try:
-        stored = await get(source_id)
-    except Exception:
-        return source
-    stored_metadata = getattr(stored, "metadata", None) if stored is not None else None
-    if not isinstance(stored_metadata, Mapping):
-        return source
-    carried = {
-        key: stored_metadata[key]
-        for key in _LIFECYCLE_METADATA_KEYS
-        if key in stored_metadata and stored_metadata[key] is not None
-    }
-    if not carried:
-        return source
-    return source.model_copy(update={"metadata": {**(source.metadata or {}), **carried}})
 
 
 __all__ = [

--- a/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
@@ -270,9 +270,7 @@ async def _reconcile_row(
             if revision is None:
                 # Every write is fenced, so a row that cannot supply a revision
                 # cannot be written from here.
-                return await _force_exclusion(
-                    entity_manager, row_id, operation, organization_id
-                )
+                return await _force_exclusion(entity_manager, row_id, operation, organization_id)
             applied, fenced_out = await _write_stamp(
                 entity_manager,
                 row_id,

--- a/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
@@ -1,0 +1,249 @@
+"""Reconciling a written row with the verdict that governs it.
+
+A pre-write read cannot close this race on its own. Whatever is read before the
+write, the write itself is an await, and a correction can land inside it: the
+correction's cascade runs while the insert is still in flight, finds nothing,
+and the stale row commits afterwards. Narrowing that window makes the race
+rarer without ever making it impossible.
+
+So the write is bracketed instead. The pre-write read stays, because it is
+cheap and it is what lets most rows be born correct. After the rows commit,
+the verdict is read once more: if it moved, the just-written rows are stamped
+by id. A correction that ran before the write is seen by the pre-write read, a
+correction that ran after it is seen by the cascade, and a correction that ran
+during it is seen by this pass. There is no fourth interval.
+
+The verdict has two authorities depending on what was written. A row projected
+straight from a capture answers to `raw_captures`, the row a correction
+mutates. A row derived from another graph row answers to that parent, which
+the correction stamps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from sibyl_core.projection.inheritance import inherited_lifecycle_metadata
+
+log = structlog.get_logger()
+
+# Follows the embedding-backfill retry already in the worker
+# (`jobs/entities.py`): a few attempts, short linear backoff, no new
+# machinery. The failures worth retrying here are the same shape, a
+# momentarily unreachable store rather than a bad request.
+RECONCILE_MAX_ATTEMPTS = 4
+RECONCILE_RETRY_BASE_SECONDS = 0.25
+
+# Written onto a row whose verdict could not be read after the retries ran
+# out. The row is excluded on the way in rather than left servable, because
+# "we could not check" and "it is fine" are not the same statement, and a
+# reader cannot tell them apart from the row.
+RECONCILE_PENDING_KEY = "lifecycle_reconciliation_pending"
+
+_UNVERIFIED_STAMP: dict[str, Any] = {
+    "excluded_from_recall": True,
+    RECONCILE_PENDING_KEY: True,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileOutcome:
+    """What the post-write pass did, so a caller can log or assert on it."""
+
+    checked: int = 0
+    restamped: int = 0
+    unverified: int = 0
+    changed: bool = False
+
+
+async def _with_retries(operation: str, callback: Any) -> tuple[Any, bool]:
+    """Run a reconciliation read, retrying transient failures a bounded number of times.
+
+    Returns the value and whether it was actually obtained, rather than
+    raising. A raised failure here is worse than it looks: the local broker
+    records a failed job as COMPLETE with an error and then suppresses the same
+    deterministic job id for the result TTL, so an exception is a poison pill
+    rather than a retry. The caller decides what an unread verdict means, and
+    for a written row it means the row does not serve until someone can check.
+    """
+
+    for attempt in range(1, RECONCILE_MAX_ATTEMPTS + 1):
+        try:
+            return await callback(), True
+        except Exception as exc:
+            if attempt >= RECONCILE_MAX_ATTEMPTS:
+                log.warning(
+                    "lifecycle_reconciliation_unavailable",
+                    operation=operation,
+                    attempts=attempt,
+                    error_type=type(exc).__name__,
+                )
+                return None, False
+            delay_seconds = RECONCILE_RETRY_BASE_SECONDS * attempt
+            log.warning(
+                "lifecycle_reconciliation_retry",
+                operation=operation,
+                attempt=attempt,
+                delay_seconds=delay_seconds,
+                error_type=type(exc).__name__,
+            )
+            await asyncio.sleep(delay_seconds)
+    return None, False
+
+
+async def _apply_stamp(
+    entity_manager: Any,
+    row_ids: Sequence[str],
+    stamp: Mapping[str, Any],
+) -> int:
+    """Write one verdict onto rows that already exist, by id.
+
+    Idempotent by construction: the same stamp applied twice is the same row.
+    """
+
+    update = getattr(entity_manager, "update", None)
+    if not callable(update) or not stamp:
+        return 0
+    applied = 0
+    for row_id in dict.fromkeys(row_ids):
+        if not row_id:
+            continue
+        try:
+            result = await update(str(row_id), {"metadata": dict(stamp)})
+        except Exception as exc:
+            log.warning(
+                "lifecycle_reconciliation_stamp_failed",
+                entity_id=row_id,
+                error_type=type(exc).__name__,
+            )
+            continue
+        if result is not None:
+            applied += 1
+    return applied
+
+
+async def _reconcile(
+    entity_manager: Any,
+    *,
+    operation: str,
+    read_verdict: Any,
+    applied_stamp: Mapping[str, Any] | None,
+    row_ids: Sequence[str],
+) -> ReconcileOutcome:
+    ids = [str(row_id) for row_id in dict.fromkeys(row_ids) if row_id]
+    if not ids:
+        return ReconcileOutcome()
+
+    verdict, verified = await _with_retries(operation, read_verdict)
+    if not verified:
+        marked = await _apply_stamp(entity_manager, ids, _UNVERIFIED_STAMP)
+        return ReconcileOutcome(checked=len(ids), unverified=marked)
+
+    current = dict(verdict or {})
+    previous = dict(applied_stamp or {})
+    if current == previous:
+        return ReconcileOutcome(checked=len(ids))
+
+    # The verdict moved between the pre-write read and now, which is the
+    # interval the write itself occupies. The rows exist, so they are stamped
+    # rather than rebuilt.
+    restamped = await _apply_stamp(entity_manager, ids, current or {"excluded_from_recall": False})
+    log.info(
+        "lifecycle_reconciliation_restamped",
+        operation=operation,
+        rows=restamped,
+        lifecycle_state=current.get("lifecycle_state"),
+    )
+    return ReconcileOutcome(checked=len(ids), restamped=restamped, changed=True)
+
+
+async def prewrite_capture_stamp(
+    *,
+    organization_id: str,
+    metadata: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], bool]:
+    """The verdict to write a row with, and whether it was actually read.
+
+    An unread verdict is not an error here. The row still gets written, and the
+    post-write pass is what refuses to let an unverified row serve, so a
+    momentary outage costs a retired-until-checked row rather than a poisoned
+    job that never runs again.
+    """
+
+    from sibyl_core.services.memory import projected_row_lifecycle_stamp
+
+    async def read() -> dict[str, Any]:
+        return await projected_row_lifecycle_stamp(
+            organization_id=organization_id,
+            metadata=metadata,
+        )
+
+    stamp, verified = await _with_retries("capture_prewrite", read)
+    return dict(stamp or {}), verified
+
+
+async def reconcile_with_capture(
+    entity_manager: Any,
+    *,
+    organization_id: str,
+    metadata: Mapping[str, Any] | None,
+    row_ids: Sequence[str],
+    applied_stamp: Mapping[str, Any] | None,
+) -> ReconcileOutcome:
+    """Re-check a written row against the capture it was projected from."""
+
+    from sibyl_core.services.memory import projected_row_lifecycle_stamp
+
+    async def read() -> dict[str, Any]:
+        return await projected_row_lifecycle_stamp(
+            organization_id=organization_id,
+            metadata=metadata,
+        )
+
+    return await _reconcile(
+        entity_manager,
+        operation="capture",
+        read_verdict=read,
+        applied_stamp=applied_stamp,
+        row_ids=row_ids,
+    )
+
+
+async def reconcile_with_parent(
+    entity_manager: Any,
+    *,
+    source_id: str,
+    row_ids: Sequence[str],
+    applied_stamp: Mapping[str, Any] | None,
+) -> ReconcileOutcome:
+    """Re-check written derived rows against the parent they were derived from."""
+
+    async def read() -> dict[str, Any]:
+        get = getattr(entity_manager, "get", None)
+        if not callable(get):
+            return dict(applied_stamp or {})
+        stored = await get(str(source_id))
+        return inherited_lifecycle_metadata(getattr(stored, "metadata", None))
+
+    return await _reconcile(
+        entity_manager,
+        operation="parent",
+        read_verdict=read,
+        applied_stamp=applied_stamp,
+        row_ids=row_ids,
+    )
+
+
+__all__ = [
+    "RECONCILE_MAX_ATTEMPTS",
+    "RECONCILE_PENDING_KEY",
+    "ReconcileOutcome",
+    "prewrite_capture_stamp",
+    "reconcile_with_capture",
+    "reconcile_with_parent",
+]

--- a/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
@@ -151,37 +151,61 @@ def _revision_conflict(exc: BaseException) -> bool:
     return type(exc).__name__ == "RevisionConflictError"
 
 
-async def _fenced_update(
+async def _write_stamp(
     entity_manager: Any,
     row_id: str,
     patch: Mapping[str, Any],
     *,
-    expected_revision: int | None,
+    expected_revision: int,
 ) -> tuple[bool, bool]:
-    """Apply one patch under the row's revision fence.
+    """Apply one patch under the row's revision fence, retrying transient failures.
 
     Returns (applied, fenced_out). A fenced-out write is not a failure: it says
     somebody else wrote this row first, and the caller re-reads so the later
     writer wins rather than this one.
+
+    `expected_revision` is required rather than optional. An unfenced write is
+    not a degraded mode of this function, it is the bug this module exists to
+    prevent, so there is no argument shape that produces one.
+
+    Transient failures are retried here rather than raised, for the same reason
+    the reads are: a raised exception from a projection job is recorded by the
+    local broker as a completed-with-error result and then suppresses the same
+    deterministic job id, which is a poison pill rather than a retry. Exhaustion
+    returns `(False, False)` and the caller decides.
     """
 
     update = getattr(entity_manager, "update", None)
     if not callable(update):
         return False, False
-    try:
-        if expected_revision is None:
-            result = await update(row_id, {"metadata": dict(patch)})
-        else:
+    for attempt in range(1, RECONCILE_MAX_ATTEMPTS + 1):
+        try:
             result = await update(
                 row_id,
                 {"metadata": dict(patch)},
                 expected_revision=expected_revision,
             )
-    except Exception as exc:
-        if _revision_conflict(exc):
-            return False, True
-        raise
-    return result is not None, False
+        except Exception as exc:
+            if _revision_conflict(exc):
+                return False, True
+            if attempt >= RECONCILE_MAX_ATTEMPTS:
+                log.warning(
+                    "lifecycle_reconciliation_write_unavailable",
+                    entity_id=row_id,
+                    attempts=attempt,
+                    error_type=type(exc).__name__,
+                )
+                return False, False
+            log.warning(
+                "lifecycle_reconciliation_write_retry",
+                entity_id=row_id,
+                attempt=attempt,
+                error_type=type(exc).__name__,
+            )
+            await asyncio.sleep(RECONCILE_RETRY_BASE_SECONDS * attempt)
+            continue
+        return result is not None, False
+    return False, False
 
 
 async def _read_row(entity_manager: Any, row_id: str) -> tuple[Any, bool]:
@@ -225,7 +249,13 @@ async def _reconcile_row(
 
     for _attempt in range(RECONCILE_FENCE_ATTEMPTS):
         row, row_read = await _read_row(entity_manager, row_id)
-        if row_read and row is None:
+        if not row_read:
+            # The row could not be read, so there is no revision to fence on and
+            # no safe write from here. An unfenced write at this point is how a
+            # run of failed reads ends up overwriting a correction that landed
+            # while they were failing.
+            return await _force_exclusion(entity_manager, row_id, operation, organization_id)
+        if row is None:
             # The row is gone. Nothing to reconcile and nothing to fail over.
             return "missing"
         metadata = _row_metadata(row)
@@ -237,7 +267,13 @@ async def _reconcile_row(
                 # Somebody authoritative already wrote a verdict onto this row,
                 # so an unread capture does not make it unverified.
                 return "unchanged"
-            applied, fenced_out = await _fenced_update(
+            if revision is None:
+                # Every write is fenced, so a row that cannot supply a revision
+                # cannot be written from here.
+                return await _force_exclusion(
+                    entity_manager, row_id, operation, organization_id
+                )
+            applied, fenced_out = await _write_stamp(
                 entity_manager,
                 row_id,
                 _UNVERIFIED_STAMP,
@@ -263,8 +299,12 @@ async def _reconcile_row(
             patch.update(_CLEARED_MARKER)
         if not patch:
             return "unchanged"
+        if revision is None:
+            # The row needs a write and cannot be fenced, which is the one
+            # combination this pass refuses to resolve by writing anyway.
+            return await _force_exclusion(entity_manager, row_id, operation, organization_id)
 
-        applied, fenced_out = await _fenced_update(
+        applied, fenced_out = await _write_stamp(
             entity_manager,
             row_id,
             patch,
@@ -306,19 +346,26 @@ async def _force_exclusion(
     """
 
     for attempt in range(1, RECONCILE_MAX_ATTEMPTS + 1):
-        row, _row_read = await _read_row(entity_manager, row_id)
-        if row is None and attempt > 1:
+        row, row_read = await _read_row(entity_manager, row_id)
+        if row_read and row is None:
             return "missing"
         metadata = _row_metadata(row)
         if inherited_lifecycle_metadata(metadata):
             # A verdict landed while this pass was losing its fences.
             return "unchanged"
-        applied, _fenced_out = await _fenced_update(
-            entity_manager,
-            row_id,
-            _UNVERIFIED_STAMP,
-            expected_revision=_row_revision(row),
-        )
+        revision = _row_revision(row)
+        applied = False
+        if revision is not None:
+            # Fenced here too. This write is a safety floor rather than a
+            # verdict, so losing to somebody who actually knows the verdict is
+            # the outcome to want, and the next pass around re-reads and sees
+            # their write.
+            applied, _fenced_out = await _write_stamp(
+                entity_manager,
+                row_id,
+                _UNVERIFIED_STAMP,
+                expected_revision=revision,
+            )
         if applied:
             log.warning(
                 "lifecycle_reconciliation_row_unverified",

--- a/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
@@ -1,28 +1,35 @@
 """Reconciling a written row with the verdict that governs it.
 
-A pre-write read cannot close this race on its own. Whatever is read before the
-write, the write itself is an await, and a correction can land inside it: the
-correction's cascade runs while the insert is still in flight, finds nothing,
-and the stale row commits afterwards. Narrowing that window makes the race
-rarer without ever making it impossible.
+A pre-write read cannot close this race. Whatever is read before the write, the
+write itself is an await, and a correction can land inside it: the correction's
+cascade runs while the insert is in flight, finds nothing, and the stale row
+commits afterwards. Narrowing that window makes the race rarer without ever
+making it impossible.
 
 So the write is bracketed instead. The pre-write read stays, because it is
-cheap and it is what lets most rows be born correct. After the rows commit,
-the verdict is read once more: if it moved, the just-written rows are stamped
-by id. A correction that ran before the write is seen by the pre-write read, a
-correction that ran after it is seen by the cascade, and a correction that ran
-during it is seen by this pass. There is no fourth interval.
+cheap and it is what lets most rows be born correct. After the rows commit, the
+verdict is read once more and the rows are stamped by id if it moved. A
+correction that ran before the write is seen by the pre-write read, one that
+ran after it is seen by the cascade, and one that ran during it is seen by this
+pass. There is no fourth interval.
+
+The pass is fenced on the row's revision, because "read the verdict, then write
+it" is itself a read-modify-write and the last writer wins by default. A
+correction landing between this pass's read and its write would be overwritten
+by a verdict that was already stale, which is how a restored row gets retired
+again by a job that started before the restore. The fence turns that into a
+refused write, a re-read, and agreement with whoever wrote last.
 
 The verdict has two authorities depending on what was written. A row projected
 straight from a capture answers to `raw_captures`, the row a correction
-mutates. A row derived from another graph row answers to that parent, which
-the correction stamps.
+mutates. A row derived from another graph row answers to that parent, which the
+correction stamps.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Coroutine, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -33,22 +40,36 @@ from sibyl_core.projection.inheritance import inherited_lifecycle_metadata
 log = structlog.get_logger()
 
 # Follows the embedding-backfill retry already in the worker
-# (`jobs/entities.py`): a few attempts, short linear backoff, no new
-# machinery. The failures worth retrying here are the same shape, a
-# momentarily unreachable store rather than a bad request.
+# (`jobs/entities.py`): a few attempts, short linear backoff, no new machinery.
+# The failures worth retrying here have the same shape, a momentarily
+# unreachable store rather than a bad request.
 RECONCILE_MAX_ATTEMPTS = 4
 RECONCILE_RETRY_BASE_SECONDS = 0.25
 
-# Written onto a row whose verdict could not be read after the retries ran
-# out. The row is excluded on the way in rather than left servable, because
-# "we could not check" and "it is fine" are not the same statement, and a
-# reader cannot tell them apart from the row.
+# How many times a fenced write may lose to a concurrent writer before this
+# pass gives up on agreeing with it. Each refusal means somebody else wrote a
+# verdict, so this is bounded by real contention on one row rather than by
+# anything this pass controls.
+RECONCILE_FENCE_ATTEMPTS = 5
+
+# Written onto a row whose verdict could not be read after the retries ran out.
+# The row is excluded on the way in rather than left servable, because "we could
+# not check" and "it is fine" are not the same statement and a reader cannot
+# tell them apart from the row. Cleared by the next pass that manages to read a
+# verdict, and by a correction or restore that writes one.
 RECONCILE_PENDING_KEY = "lifecycle_reconciliation_pending"
 
 _UNVERIFIED_STAMP: dict[str, Any] = {
     "excluded_from_recall": True,
     RECONCILE_PENDING_KEY: True,
 }
+
+# What a row carries once somebody could read its verdict and it said nothing
+# is wrong. `None` removes a key on the graph's merge patch, which is how the
+# marker actually leaves the row rather than merely reading falsy.
+_CLEARED_MARKER: dict[str, Any] = {RECONCILE_PENDING_KEY: None}
+
+_VerdictReader = Callable[[], Coroutine[Any, Any, dict[str, Any]]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,18 +79,31 @@ class ReconcileOutcome:
     checked: int = 0
     restamped: int = 0
     unverified: int = 0
-    changed: bool = False
+    cleared: int = 0
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.restamped or self.unverified or self.cleared)
+
+
+class ReconcileExclusionError(RuntimeError):
+    """The row could not be verified and could not be excluded either.
+
+    The one state this module refuses to leave behind quietly. Everything else
+    degrades to a retired row that somebody can restore; this is a row that may
+    be serving corrected text with nothing on it to say so.
+    """
 
 
 async def _with_retries(operation: str, callback: Any) -> tuple[Any, bool]:
     """Run a reconciliation read, retrying transient failures a bounded number of times.
 
-    Returns the value and whether it was actually obtained, rather than
-    raising. A raised failure here is worse than it looks: the local broker
-    records a failed job as COMPLETE with an error and then suppresses the same
-    deterministic job id for the result TTL, so an exception is a poison pill
-    rather than a retry. The caller decides what an unread verdict means, and
-    for a written row it means the row does not serve until someone can check.
+    Returns the value and whether it was obtained, rather than raising. A raised
+    failure here is worse than it looks: the local broker records a failed job
+    as COMPLETE with an error and then suppresses the same deterministic job id
+    for the result TTL, so an exception is a poison pill rather than a retry.
+    The caller decides what an unread verdict means, and for a written row it
+    means the row does not serve until somebody can check.
     """
 
     for attempt in range(1, RECONCILE_MAX_ATTEMPTS + 1):
@@ -96,70 +130,252 @@ async def _with_retries(operation: str, callback: Any) -> tuple[Any, bool]:
     return None, False
 
 
-async def _apply_stamp(
-    entity_manager: Any,
-    row_ids: Sequence[str],
-    stamp: Mapping[str, Any],
-) -> int:
-    """Write one verdict onto rows that already exist, by id.
+def _row_metadata(row: Any) -> dict[str, Any]:
+    """The row's metadata as a plain mapping, or nothing.
 
-    Idempotent by construction: the same stamp applied twice is the same row.
+    Guarded rather than assumed: a row whose metadata is not a mapping must not
+    take reconciliation down, because the fallback for a row this pass cannot
+    reason about is to exclude it, not to fail the write that produced it.
+    """
+
+    metadata = getattr(row, "metadata", None)
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
+
+
+def _row_revision(row: Any) -> int | None:
+    revision = getattr(row, "revision", None)
+    return revision if isinstance(revision, int) else None
+
+
+def _revision_conflict(exc: BaseException) -> bool:
+    return type(exc).__name__ == "RevisionConflictError"
+
+
+async def _fenced_update(
+    entity_manager: Any,
+    row_id: str,
+    patch: Mapping[str, Any],
+    *,
+    expected_revision: int | None,
+) -> tuple[bool, bool]:
+    """Apply one patch under the row's revision fence.
+
+    Returns (applied, fenced_out). A fenced-out write is not a failure: it says
+    somebody else wrote this row first, and the caller re-reads so the later
+    writer wins rather than this one.
     """
 
     update = getattr(entity_manager, "update", None)
-    if not callable(update) or not stamp:
-        return 0
-    applied = 0
-    for row_id in dict.fromkeys(row_ids):
-        if not row_id:
-            continue
-        try:
-            result = await update(str(row_id), {"metadata": dict(stamp)})
-        except Exception as exc:
-            log.warning(
-                "lifecycle_reconciliation_stamp_failed",
-                entity_id=row_id,
-                error_type=type(exc).__name__,
+    if not callable(update):
+        return False, False
+    try:
+        if expected_revision is None:
+            result = await update(row_id, {"metadata": dict(patch)})
+        else:
+            result = await update(
+                row_id,
+                {"metadata": dict(patch)},
+                expected_revision=expected_revision,
             )
+    except Exception as exc:
+        if _revision_conflict(exc):
+            return False, True
+        raise
+    return result is not None, False
+
+
+async def _read_row(entity_manager: Any, row_id: str) -> tuple[Any, bool]:
+    get = getattr(entity_manager, "get", None)
+    if not callable(get):
+        return None, True
+
+    async def read() -> Any:
+        try:
+            return await get(row_id)
+        except KeyError:
+            return None
+
+    return await _with_retries("row", read)
+
+
+def _desired_patch(verdict: Mapping[str, Any], current: Mapping[str, Any]) -> dict[str, Any]:
+    """What has to change on a row whose verdict is now known.
+
+    An empty verdict on a row that carries an exclusion is a real change, not a
+    no-op: the capture was corrected and then restored while this row was being
+    written, so the exclusion has to come back off.
+    """
+
+    if verdict:
+        return {key: value for key, value in verdict.items() if current.get(key) != value}
+    if current.get("excluded_from_recall"):
+        return {"excluded_from_recall": False}
+    return {}
+
+
+async def _reconcile_row(
+    entity_manager: Any,
+    row_id: str,
+    *,
+    operation: str,
+    organization_id: str | None,
+    read_verdict: _VerdictReader,
+) -> str:
+    """Bring one written row into agreement with its verdict, under the fence."""
+
+    for _attempt in range(RECONCILE_FENCE_ATTEMPTS):
+        row, row_read = await _read_row(entity_manager, row_id)
+        if row_read and row is None:
+            # The row is gone. Nothing to reconcile and nothing to fail over.
+            return "missing"
+        metadata = _row_metadata(row)
+        revision = _row_revision(row)
+
+        verdict, verified = await _with_retries(operation, read_verdict)
+        if not verified:
+            if metadata and inherited_lifecycle_metadata(metadata):
+                # Somebody authoritative already wrote a verdict onto this row,
+                # so an unread capture does not make it unverified.
+                return "unchanged"
+            applied, fenced_out = await _fenced_update(
+                entity_manager,
+                row_id,
+                _UNVERIFIED_STAMP,
+                expected_revision=revision,
+            )
+            if applied:
+                log.warning(
+                    "lifecycle_reconciliation_row_unverified",
+                    operation=operation,
+                    organization_id=organization_id,
+                    entity_id=row_id,
+                )
+                return "unverified"
+            if fenced_out:
+                continue
             continue
-        if result is not None:
-            applied += 1
-    return applied
+
+        current = dict(verdict or {})
+        patch = _desired_patch(current, metadata)
+        if metadata.get(RECONCILE_PENDING_KEY):
+            # A verdict was readable this time, so the marker that said nobody
+            # could read one has to come off with the same write.
+            patch.update(_CLEARED_MARKER)
+        if not patch:
+            return "unchanged"
+
+        applied, fenced_out = await _fenced_update(
+            entity_manager,
+            row_id,
+            patch,
+            expected_revision=revision,
+        )
+        if applied:
+            log.info(
+                "lifecycle_reconciliation_restamped",
+                operation=operation,
+                organization_id=organization_id,
+                entity_id=row_id,
+                lifecycle_state=current.get("lifecycle_state"),
+                cleared_marker=RECONCILE_PENDING_KEY in patch,
+            )
+            return "cleared" if set(patch) == {RECONCILE_PENDING_KEY} else "restamped"
+        if fenced_out:
+            # Somebody wrote between this pass's read and its write. Re-read and
+            # agree with them rather than overwriting a newer verdict.
+            continue
+        break
+
+    # Every attempt lost the fence or failed to apply. The row's verdict is
+    # unknown to this pass, so it is excluded rather than left servable.
+    return await _force_exclusion(entity_manager, row_id, operation, organization_id)
+
+
+async def _force_exclusion(
+    entity_manager: Any,
+    row_id: str,
+    operation: str,
+    organization_id: str | None,
+) -> str:
+    """Exclude a row this pass could not settle, or say plainly that it could not.
+
+    This is the one write that is not allowed to fail quietly. A row left
+    servable after reconciliation gave up is a row that may be serving
+    corrected text with nothing on it to say so, which is the state this whole
+    change exists to prevent.
+    """
+
+    for attempt in range(1, RECONCILE_MAX_ATTEMPTS + 1):
+        row, _row_read = await _read_row(entity_manager, row_id)
+        if row is None and attempt > 1:
+            return "missing"
+        metadata = _row_metadata(row)
+        if inherited_lifecycle_metadata(metadata):
+            # A verdict landed while this pass was losing its fences.
+            return "unchanged"
+        applied, _fenced_out = await _fenced_update(
+            entity_manager,
+            row_id,
+            _UNVERIFIED_STAMP,
+            expected_revision=_row_revision(row),
+        )
+        if applied:
+            log.warning(
+                "lifecycle_reconciliation_row_unverified",
+                operation=operation,
+                organization_id=organization_id,
+                entity_id=row_id,
+                forced=True,
+            )
+            return "unverified"
+        if attempt < RECONCILE_MAX_ATTEMPTS:
+            await asyncio.sleep(RECONCILE_RETRY_BASE_SECONDS * attempt)
+
+    log.error(
+        "lifecycle_reconciliation_exclusion_failed",
+        operation=operation,
+        organization_id=organization_id,
+        entity_id=row_id,
+    )
+    msg = f"could not exclude unverified row {row_id}"
+    raise ReconcileExclusionError(msg)
 
 
 async def _reconcile(
     entity_manager: Any,
     *,
     operation: str,
-    read_verdict: Any,
-    applied_stamp: Mapping[str, Any] | None,
+    organization_id: str | None,
+    read_verdict: _VerdictReader,
     row_ids: Sequence[str],
 ) -> ReconcileOutcome:
     ids = [str(row_id) for row_id in dict.fromkeys(row_ids) if row_id]
     if not ids:
         return ReconcileOutcome()
 
-    verdict, verified = await _with_retries(operation, read_verdict)
-    if not verified:
-        marked = await _apply_stamp(entity_manager, ids, _UNVERIFIED_STAMP)
-        return ReconcileOutcome(checked=len(ids), unverified=marked)
-
-    current = dict(verdict or {})
-    previous = dict(applied_stamp or {})
-    if current == previous:
-        return ReconcileOutcome(checked=len(ids))
-
-    # The verdict moved between the pre-write read and now, which is the
-    # interval the write itself occupies. The rows exist, so they are stamped
-    # rather than rebuilt.
-    restamped = await _apply_stamp(entity_manager, ids, current or {"excluded_from_recall": False})
-    log.info(
-        "lifecycle_reconciliation_restamped",
-        operation=operation,
-        rows=restamped,
-        lifecycle_state=current.get("lifecycle_state"),
+    restamped = 0
+    unverified = 0
+    cleared = 0
+    for row_id in ids:
+        result = await _reconcile_row(
+            entity_manager,
+            row_id,
+            operation=operation,
+            organization_id=organization_id,
+            read_verdict=read_verdict,
+        )
+        if result == "restamped":
+            restamped += 1
+        elif result == "unverified":
+            unverified += 1
+        elif result == "cleared":
+            cleared += 1
+    return ReconcileOutcome(
+        checked=len(ids),
+        restamped=restamped,
+        unverified=unverified,
+        cleared=cleared,
     )
-    return ReconcileOutcome(checked=len(ids), restamped=restamped, changed=True)
 
 
 async def prewrite_capture_stamp(
@@ -193,9 +409,8 @@ async def reconcile_with_capture(
     organization_id: str,
     metadata: Mapping[str, Any] | None,
     row_ids: Sequence[str],
-    applied_stamp: Mapping[str, Any] | None,
 ) -> ReconcileOutcome:
-    """Re-check a written row against the capture it was projected from."""
+    """Re-check written rows against the capture they were projected from."""
 
     from sibyl_core.services.memory import projected_row_lifecycle_stamp
 
@@ -208,8 +423,8 @@ async def reconcile_with_capture(
     return await _reconcile(
         entity_manager,
         operation="capture",
+        organization_id=organization_id,
         read_verdict=read,
-        applied_stamp=applied_stamp,
         row_ids=row_ids,
     )
 
@@ -219,29 +434,34 @@ async def reconcile_with_parent(
     *,
     source_id: str,
     row_ids: Sequence[str],
-    applied_stamp: Mapping[str, Any] | None,
+    organization_id: str | None = None,
 ) -> ReconcileOutcome:
     """Re-check written derived rows against the parent they were derived from."""
 
     async def read() -> dict[str, Any]:
         get = getattr(entity_manager, "get", None)
         if not callable(get):
-            return dict(applied_stamp or {})
-        stored = await get(str(source_id))
+            return {}
+        try:
+            stored = await get(str(source_id))
+        except KeyError:
+            return {}
         return inherited_lifecycle_metadata(getattr(stored, "metadata", None))
 
     return await _reconcile(
         entity_manager,
         operation="parent",
+        organization_id=organization_id,
         read_verdict=read,
-        applied_stamp=applied_stamp,
         row_ids=row_ids,
     )
 
 
 __all__ = [
+    "RECONCILE_FENCE_ATTEMPTS",
     "RECONCILE_MAX_ATTEMPTS",
     "RECONCILE_PENDING_KEY",
+    "ReconcileExclusionError",
     "ReconcileOutcome",
     "prewrite_capture_stamp",
     "reconcile_with_capture",

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -939,16 +939,14 @@ async def _apply_supersession_gate(
             gated.append((signal, kept))
         surviving = gated
 
-    metadata: dict[str, Any] = {
-        "supersession_gate": {
-            "lifecycle_dropped": lifecycle_dropped,
-            "superseded_dropped": edge_dropped,
-            "superseded_uuids": sorted(superseded),
-        }
+    receipt: dict[str, Any] = {
+        "lifecycle_dropped": lifecycle_dropped,
+        "superseded_dropped": edge_dropped,
+        "superseded_uuids": sorted(superseded),
     }
     if lookup_failed is not None:
-        metadata["supersession_gate"]["lookup_error_type"] = lookup_failed
-    return surviving, metadata
+        receipt["lookup_error_type"] = lookup_failed
+    return surviving, {"supersession_gate": receipt}
 
 
 def _candidate_limits_for_limit(

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -28,6 +28,7 @@ from sibyl_core.backends.surreal.knn import knn_overfetch_pool, knn_search_effor
 from sibyl_core.backends.surreal.records import SurrealQueryError, query_error
 from sibyl_core.config import core_config
 from sibyl_core.embeddings.providers import EmbeddingMetadata, EmbeddingProvider
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
 from sibyl_core.memory_pipeline.retrieval import CandidateSourceFailure, CandidateSourceResult
 from sibyl_core.models.context import ContextFacet
 from sibyl_core.retrieval.candidates import (
@@ -105,6 +106,12 @@ _GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS = {
     "RELATED_TO": 0.64,
     "MENTIONS": 0.58,
 }
+_SUPERSEDES_PREDICATE = "SUPERSEDES"
+# An entity carrying an inbound SUPERSEDES edge is the row somebody replaced.
+# Resolving that over the surviving candidate set costs one indexed lookup
+# (idx_relates_name_target) and is the only way a lane that never walked the
+# graph -- vector, fulltext, exact key -- learns the row is stale.
+_SUPERSESSION_LOOKUP_LIMIT = 512
 _GRAPH_EXPANSION_DEPTH_DECAY = 0.72
 _GRAPH_EXPANSION_FETCH_HEADROOM = 4
 _GRAPH_EXPANSION_METADATA_KEYS = (
@@ -532,6 +539,11 @@ async def context_search(
         (signal, [candidate for candidate in candidates if candidate_authorized(candidate)])
         for signal, candidates in source_lists
     ]
+    filtered_lists, supersession_metadata = await _apply_supersession_gate(
+        client=client,
+        group_id=search_plan.organization_id,
+        source_lists=filtered_lists,
+    )
     # Counted after the scope filter, never before. A pre-filter count answers
     # "does any memory in this organization declare the string I just sent",
     # which is a question an unauthorized caller must not be able to ask: the
@@ -605,6 +617,7 @@ async def context_search(
                 probe_tokens=probe_tokens,
                 candidates=authorized_exact_key_candidates,
             ),
+            **supersession_metadata,
             "stage_timings_ms": stage_timings_ms,
         },
         graph_count=len([result for result in results if result.result_origin == "graph"]),
@@ -835,6 +848,107 @@ async def _execute_query_records(
     if error := query_error(result):
         raise SurrealQueryError(query, error)
     return normalize_records(result)
+
+
+async def _superseded_candidate_uuids(
+    client: Any,
+    *,
+    group_id: str,
+    uuids: Sequence[str],
+) -> set[str]:
+    """Resolve which of these candidates something else declared it replaced."""
+
+    if not uuids:
+        return set()
+    rows = await _execute_query_records(
+        client,
+        """
+        SELECT target_id AS uuid
+        FROM relates_to
+        WHERE name = $predicate
+          AND target_id IN $uuids
+          AND group_id = $group_id
+        LIMIT $limit;
+        """,
+        predicate=_SUPERSEDES_PREDICATE,
+        uuids=list(uuids),
+        group_id=group_id,
+        limit=_SUPERSESSION_LOOKUP_LIMIT,
+    )
+    return {uuid for row in rows if (uuid := _string_value(row.get("uuid")))}
+
+
+async def _apply_supersession_gate(
+    *,
+    client: Any,
+    group_id: str,
+    source_lists: Sequence[tuple[RetrievalSignal, list[RetrievalCandidate]]],
+) -> tuple[list[tuple[RetrievalSignal, list[RetrievalCandidate]]], dict[str, Any]]:
+    """Drop rows a writer has already retired, before anything is fused.
+
+    Supersession and correction are declarations the graph lane never acted
+    on: a corrected row kept its embedding, kept its rank, and kept being
+    expanded into. Two independent signals retire a candidate here. Its own
+    stamped lifecycle metadata, written by the correction path, covers rows
+    whose replacement is not itself a graph entity. An inbound SUPERSEDES edge
+    covers the reflection-promotion case, where the replacement exists and the
+    edge is the only record of it. Because the successor carries neither
+    signal, this is also what makes the newer row win whenever both match.
+    """
+
+    lifecycle_dropped = 0
+    surviving: list[tuple[RetrievalSignal, list[RetrievalCandidate]]] = []
+    for signal, candidates in source_lists:
+        kept: list[RetrievalCandidate] = []
+        for candidate in candidates:
+            if graph_metadata_recallable(candidate.metadata):
+                kept.append(candidate)
+            else:
+                lifecycle_dropped += 1
+        surviving.append((signal, kept))
+
+    node_uuids = _dedupe_strings(
+        candidate.id
+        for _signal, candidates in surviving
+        for candidate in candidates
+        if candidate.type not in _EDGE_CONTEXT_TYPES
+    )
+    superseded: set[str] = set()
+    lookup_failed: str | None = None
+    if node_uuids:
+        try:
+            superseded = await _superseded_candidate_uuids(
+                client,
+                group_id=group_id,
+                uuids=node_uuids[:_SUPERSESSION_LOOKUP_LIMIT],
+            )
+        except Exception as exc:
+            # A gate that cannot read its own edges must not silently pass
+            # every stale row as fresh, but it also must not fail the search
+            # outright: lifecycle metadata still applies and the receipt says
+            # the edge half did not run.
+            lookup_failed = type(exc).__name__
+            log.warning("supersession_lookup_failed", error_type=lookup_failed)
+
+    edge_dropped = 0
+    if superseded:
+        gated: list[tuple[RetrievalSignal, list[RetrievalCandidate]]] = []
+        for signal, candidates in surviving:
+            kept = [candidate for candidate in candidates if candidate.id not in superseded]
+            edge_dropped += len(candidates) - len(kept)
+            gated.append((signal, kept))
+        surviving = gated
+
+    metadata: dict[str, Any] = {
+        "supersession_gate": {
+            "lifecycle_dropped": lifecycle_dropped,
+            "superseded_dropped": edge_dropped,
+            "superseded_uuids": sorted(superseded),
+        }
+    }
+    if lookup_failed is not None:
+        metadata["supersession_gate"]["lookup_error_type"] = lookup_failed
+    return surviving, metadata
 
 
 def _candidate_limits_for_limit(
@@ -1715,6 +1829,9 @@ async def _node_bfs_records(
                 depth=depth,
                 limit=fetch_limit,
                 relationship_names=sorted(wanted),
+                exclude_relationship_names=(
+                    () if _SUPERSEDES_PREDICATE in wanted else (_SUPERSEDES_PREDICATE,)
+                ),
             )
         )
         if include_incoming:
@@ -1831,10 +1948,22 @@ async def _relation_target_hops(
     depth: int,
     limit: int,
     relationship_names: Sequence[str] = (),
+    exclude_relationship_names: Sequence[str] = (),
 ) -> list[_GraphExpansionHop]:
+    """Walk edges that point away from the frontier.
+
+    `exclude_relationship_names` exists for predicates whose written direction
+    makes the outgoing endpoint the wrong answer. A SUPERSEDES edge is stored
+    new-row to old-row, so walking it outwards lands on the row the writer
+    declared replaced, and the weight table would then score that stale row at
+    0.95 -- a supersession would raise its own victim.
+    """
     if not source_uuids:
         return []
     name_clause = "AND name IN $relationship_names" if relationship_names else ""
+    exclude_clause = (
+        "AND name NOT IN $exclude_relationship_names" if exclude_relationship_names else ""
+    )
     rows = await _execute_query_records(
         client,
         f"""
@@ -1844,12 +1973,18 @@ async def _relation_target_hops(
           AND group_id = $group_id
           AND out.group_id = $group_id
           {name_clause}
+          {exclude_clause}
         LIMIT $limit;
         """,
         source_uuids=list(source_uuids),
         group_id=group_id,
         limit=max(int(limit), 1),
         **({"relationship_names": list(relationship_names)} if relationship_names else {}),
+        **(
+            {"exclude_relationship_names": list(exclude_relationship_names)}
+            if exclude_relationship_names
+            else {}
+        ),
     )
     hops: list[_GraphExpansionHop] = []
     for row in rows:

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -873,7 +873,7 @@ async def _superseded_candidate_uuids(
     rows = await _execute_query_records(
         client,
         """
-        SELECT target_id AS uuid
+        SELECT target_id AS uuid, source_id AS superseder, created_at
         FROM relates_to
         WHERE name = $predicate
           AND target_id IN $uuids
@@ -885,7 +885,53 @@ async def _superseded_candidate_uuids(
         group_id=group_id,
         limit=_SUPERSESSION_LOOKUP_LIMIT,
     )
-    return {uuid for row in rows if (uuid := _string_value(row.get("uuid")))}, len(rows)
+    return _resolve_superseded(rows), len(rows)
+
+
+def _resolve_superseded(rows: Sequence[Mapping[str, object]]) -> set[str]:
+    """Decide which endpoints an edge set actually retires.
+
+    Two shapes have to be handled before a target can be trusted as retired.
+    A self-edge says a row replaced itself, which retires nothing and would
+    otherwise black out a live row. A cycle (A supersedes B, B supersedes A)
+    would retire both endpoints and black out the pair, so the newest edge
+    wins: it is the most recent statement about that pair, and the older
+    edge in the opposite direction is treated as replaced by it.
+    """
+
+    retired: set[str] = set()
+    edges: list[tuple[str, str, str]] = []
+    for row in rows:
+        target = _string_value(row.get("uuid"))
+        if not target:
+            continue
+        source = _string_value(row.get("superseder"))
+        if target == source:
+            # A row cannot replace itself. Honoring it would retire a live row
+            # on a statement that says nothing.
+            continue
+        if not source:
+            # An edge with no recorded source still says this row was
+            # replaced; it just cannot take part in resolving a cycle.
+            retired.add(target)
+            continue
+        edges.append((target, source, _edge_sort_key(row.get("created_at"))))
+
+    newest_between: dict[tuple[str, str], tuple[str, str, str]] = {}
+    for edge in edges:
+        target, source, _created = edge
+        pair = (target, source) if target < source else (source, target)
+        current = newest_between.get(pair)
+        if current is None or edge[2] >= current[2]:
+            newest_between[pair] = edge
+    retired.update(target for target, _source, _created in newest_between.values())
+    return retired
+
+
+def _edge_sort_key(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat()
+    return _string_value(value) or ""
 
 
 async def _apply_supersession_gate(

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -112,6 +112,10 @@ _SUPERSEDES_PREDICATE = "SUPERSEDES"
 # (idx_relates_name_target) and is the only way a lane that never walked the
 # graph -- vector, fulltext, exact key -- learns the row is stale.
 _SUPERSESSION_LOOKUP_LIMIT = 512
+# Candidate ids that are not entity uuids and so can never match an edge
+# endpoint. Raw memories carry a "raw_memory:" prefix and episodes live in
+# their own table, so feeding either to the lookup only widens the IN list.
+_NON_ENTITY_CANDIDATE_TYPES = frozenset({"claim", "relationship", "raw_memory", "episode"})
 _GRAPH_EXPANSION_DEPTH_DECAY = 0.72
 _GRAPH_EXPANSION_FETCH_HEADROOM = 4
 _GRAPH_EXPANSION_METADATA_KEYS = (
@@ -911,7 +915,7 @@ async def _apply_supersession_gate(
         candidate.id
         for _signal, candidates in surviving
         for candidate in candidates
-        if candidate.type not in _EDGE_CONTEXT_TYPES
+        if candidate.type not in _NON_ENTITY_CANDIDATE_TYPES
     )
     superseded: set[str] = set()
     lookup_failed: str | None = None

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -859,11 +859,17 @@ async def _superseded_candidate_uuids(
     *,
     group_id: str,
     uuids: Sequence[str],
-) -> set[str]:
-    """Resolve which of these candidates something else declared it replaced."""
+) -> tuple[set[str], int]:
+    """Resolve which of these candidates something else declared it replaced.
+
+    The row count comes back alongside the set because dedup destroys the
+    only evidence that the row cap bound: one retired row can carry several
+    inbound edges, so 300 candidates can produce more than 512 rows and still
+    dedup to a handful of uuids.
+    """
 
     if not uuids:
-        return set()
+        return set(), 0
     rows = await _execute_query_records(
         client,
         """
@@ -879,7 +885,7 @@ async def _superseded_candidate_uuids(
         group_id=group_id,
         limit=_SUPERSESSION_LOOKUP_LIMIT,
     )
-    return {uuid for row in rows if (uuid := _string_value(row.get("uuid")))}
+    return {uuid for row in rows if (uuid := _string_value(row.get("uuid")))}, len(rows)
 
 
 async def _apply_supersession_gate(
@@ -924,9 +930,10 @@ async def _apply_supersession_gate(
     # before the candidate cap does. Neither is reachable at current pool
     # sizes, and neither may pass silently if it ever becomes reachable.
     truncated = len(node_uuids) > _SUPERSESSION_LOOKUP_LIMIT
+    edge_rows = 0
     if node_uuids:
         try:
-            superseded = await _superseded_candidate_uuids(
+            superseded, edge_rows = await _superseded_candidate_uuids(
                 client,
                 group_id=group_id,
                 uuids=node_uuids[:_SUPERSESSION_LOOKUP_LIMIT],
@@ -953,10 +960,11 @@ async def _apply_supersession_gate(
         "superseded_dropped": edge_dropped,
         "superseded_uuids": sorted(superseded),
     }
-    if truncated or len(superseded) >= _SUPERSESSION_LOOKUP_LIMIT:
+    if truncated or edge_rows >= _SUPERSESSION_LOOKUP_LIMIT:
         receipt["truncated"] = True
         receipt["checked_candidates"] = min(len(node_uuids), _SUPERSESSION_LOOKUP_LIMIT)
         receipt["total_candidates"] = len(node_uuids)
+        receipt["edge_rows_read"] = edge_rows
     if lookup_failed is not None:
         receipt["lookup_error_type"] = lookup_failed
     return surviving, {"supersession_gate": receipt}

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -498,6 +498,35 @@ async def context_search(
         )
 
     stage_started_at = time.perf_counter()
+    direct_lists = [
+        (RetrievalSignal.RAW_LEXICAL, raw_candidates),
+        (RetrievalSignal.NODE_FULLTEXT, graph_candidate_lists[0]),
+        (RetrievalSignal.EPISODE_FULLTEXT, graph_candidate_lists[1]),
+        (RetrievalSignal.EDGE_FULLTEXT, graph_candidate_lists[2]),
+        (RetrievalSignal.EXACT_KEY, graph_candidate_lists[3]),
+        (RetrievalSignal.NODE_VECTOR, vector_candidate_lists[0]),
+        (RetrievalSignal.EDGE_VECTOR, vector_candidate_lists[1]),
+    ]
+    direct_lists = [
+        (signal, [candidate for candidate in candidates if candidate_authorized(candidate)])
+        for signal, candidates in direct_lists
+    ]
+    # The gate runs before the walk, not only before fusion. A retired row is
+    # dropped from the answer either way, but seeding the expansion from it
+    # still routes recall through its edges: its neighbours pass their own
+    # checks and come back, so a corrected memory keeps steering what the
+    # reader sees through rows that were never corrected. That holds for every
+    # lane that can propose a seed, exact-key probes included, which is why the
+    # gate moved ahead of seed selection rather than being repeated inside one
+    # lane.
+    direct_lists, direct_supersession_metadata = await _apply_supersession_gate(
+        client=client,
+        group_id=search_plan.organization_id,
+        source_lists=direct_lists,
+    )
+    stage_timings_ms["candidate_filtering"] = _elapsed_ms(stage_started_at)
+
+    stage_started_at = time.perf_counter()
     graph_expansion_source = await _gather_graph_expansion_source(
         _graph_expansion_candidates(
             client=client,
@@ -513,9 +542,9 @@ async def context_search(
             # of which lane proposed it.
             seed_candidates=[
                 candidate
-                for source in [*graph_candidate_lists, *vector_candidate_lists]
-                for candidate in source
-                if candidate_authorized(candidate)
+                for signal, candidates in direct_lists
+                if signal is not RetrievalSignal.RAW_LEXICAL
+                for candidate in candidates
             ],
             limit=search_plan.candidate_limits.graph_expansion,
         )
@@ -529,24 +558,24 @@ async def context_search(
         extra_failures=raw_failures,
     )
 
-    source_lists = [
-        (RetrievalSignal.RAW_LEXICAL, raw_candidates),
-        (RetrievalSignal.NODE_FULLTEXT, graph_candidate_lists[0]),
-        (RetrievalSignal.EPISODE_FULLTEXT, graph_candidate_lists[1]),
-        (RetrievalSignal.EDGE_FULLTEXT, graph_candidate_lists[2]),
-        (RetrievalSignal.EXACT_KEY, graph_candidate_lists[3]),
-        (RetrievalSignal.NODE_VECTOR, vector_candidate_lists[0]),
-        (RetrievalSignal.EDGE_VECTOR, vector_candidate_lists[1]),
-        (RetrievalSignal.GRAPH_EXPANSION, graph_expansion_candidates),
-    ]
-    filtered_lists = [
-        (signal, [candidate for candidate in candidates if candidate_authorized(candidate)])
-        for signal, candidates in source_lists
-    ]
-    filtered_lists, supersession_metadata = await _apply_supersession_gate(
+    expansion_lists, expansion_supersession_metadata = await _apply_supersession_gate(
         client=client,
         group_id=search_plan.organization_id,
-        source_lists=filtered_lists,
+        source_lists=[
+            (
+                RetrievalSignal.GRAPH_EXPANSION,
+                [
+                    candidate
+                    for candidate in graph_expansion_candidates
+                    if candidate_authorized(candidate)
+                ],
+            )
+        ],
+    )
+    filtered_lists = [*direct_lists, *expansion_lists]
+    supersession_metadata = _merged_supersession_metadata(
+        direct_supersession_metadata,
+        expansion_supersession_metadata,
     )
     # Counted after the scope filter, never before. A pre-filter count answers
     # "does any memory in this organization declare the string I just sent",
@@ -564,7 +593,10 @@ async def context_search(
     temporal_target = resolve_temporal_reference(search_plan.query, datetime.now(UTC))
     fusion_backend = fusion_backend_from_env()
     fusion_failures: list[CandidateSourceFailure] = []
-    stage_timings_ms["candidate_filtering"] = _elapsed_ms(stage_started_at)
+    # Filtering now happens on both sides of the walk, so the stage adds up
+    # rather than overwriting: reading one half as the whole would understate
+    # the stage by whatever the pre-seed gate cost.
+    stage_timings_ms["candidate_filtering"] += _elapsed_ms(stage_started_at)
 
     stage_started_at = time.perf_counter()
     fusion = await _fuse_candidates_for_plan(
@@ -873,11 +905,12 @@ async def _superseded_candidate_uuids(
     rows = await _execute_query_records(
         client,
         """
-        SELECT target_id AS uuid, source_id AS superseder, created_at
+        SELECT uuid, target_id, source_id, created_at
         FROM relates_to
         WHERE name = $predicate
           AND target_id IN $uuids
           AND group_id = $group_id
+        ORDER BY created_at, uuid
         LIMIT $limit;
         """,
         predicate=_SUPERSEDES_PREDICATE,
@@ -897,15 +930,30 @@ def _resolve_superseded(rows: Sequence[Mapping[str, object]]) -> set[str]:
     would retire both endpoints and black out the pair, so the newest edge
     wins: it is the most recent statement about that pair, and the older
     edge in the opposite direction is treated as replaced by it.
+
+    "Newest" has to be a total order or the winner becomes a function of the
+    order the rows arrived in, which is a property of the query planner rather
+    than of the data: the same two edges then retire A on one run and B on the
+    next. The ordering key is therefore `(created_at, edge uuid)`, compared
+    strictly, so equal timestamps resolve on the edge id instead of on
+    whichever row the engine handed over last.
+
+    `created_at` is stamped by whichever process wrote the edge
+    (`models/entities.py`), so two writers with skewed clocks can order a
+    causally later edge first. Skew of exactly the resolution of the stamp
+    lands on the edge-id tie-breaker; larger skew inverts the pair. Both
+    outcomes are stable and identical on every replica, which is the property
+    recall needs: one of the two rows survives, and every reader agrees on
+    which.
     """
 
     retired: set[str] = set()
-    edges: list[tuple[str, str, str]] = []
+    edges: list[tuple[str, str, tuple[str, str]]] = []
     for row in rows:
-        target = _string_value(row.get("uuid"))
+        target = _string_value(row.get("target_id"))
         if not target:
             continue
-        source = _string_value(row.get("superseder"))
+        source = _string_value(row.get("source_id"))
         if target == source:
             # A row cannot replace itself. Honoring it would retire a live row
             # on a statement that says nothing.
@@ -915,16 +963,20 @@ def _resolve_superseded(rows: Sequence[Mapping[str, object]]) -> set[str]:
             # replaced; it just cannot take part in resolving a cycle.
             retired.add(target)
             continue
-        edges.append((target, source, _edge_sort_key(row.get("created_at"))))
+        sort_key = (
+            _edge_sort_key(row.get("created_at")),
+            _string_value(row.get("uuid")) or "",
+        )
+        edges.append((target, source, sort_key))
 
-    newest_between: dict[tuple[str, str], tuple[str, str, str]] = {}
+    newest_between: dict[tuple[str, str], tuple[str, str, tuple[str, str]]] = {}
     for edge in edges:
-        target, source, _created = edge
+        target, source, sort_key = edge
         pair = (target, source) if target < source else (source, target)
         current = newest_between.get(pair)
-        if current is None or edge[2] >= current[2]:
+        if current is None or sort_key > current[2]:
             newest_between[pair] = edge
-    retired.update(target for target, _source, _created in newest_between.values())
+    retired.update(target for target, _source, _sort_key in newest_between.values())
     return retired
 
 
@@ -1014,6 +1066,42 @@ async def _apply_supersession_gate(
     if lookup_failed is not None:
         receipt["lookup_error_type"] = lookup_failed
     return surviving, {"supersession_gate": receipt}
+
+
+def _merged_supersession_metadata(
+    *receipts: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Fold the gate's passes into the one receipt a caller reads.
+
+    The gate runs twice per search, once before the graph walk is seeded and
+    once on what the walk brought back, and a receipt that reported only the
+    second pass would say a corrected row was never dropped. Counts add, uuid
+    sets union, and any pass that truncated or failed its edge lookup makes the
+    whole receipt say so: a reader checking whether the gate was complete
+    cannot be told yes because one of two passes was.
+    """
+
+    merged: dict[str, Any] = {
+        "lifecycle_dropped": 0,
+        "superseded_dropped": 0,
+        "superseded_uuids": [],
+    }
+    uuids: set[str] = set()
+    for receipt in receipts:
+        gate = receipt.get("supersession_gate")
+        if not isinstance(gate, Mapping):
+            continue
+        merged["lifecycle_dropped"] += int(gate.get("lifecycle_dropped") or 0)
+        merged["superseded_dropped"] += int(gate.get("superseded_dropped") or 0)
+        uuids.update(str(value) for value in gate.get("superseded_uuids") or ())
+        if gate.get("truncated"):
+            merged["truncated"] = True
+            for key in ("checked_candidates", "total_candidates", "edge_rows_read"):
+                merged[key] = int(merged.get(key) or 0) + int(gate.get(key) or 0)
+        if gate.get("lookup_error_type"):
+            merged["lookup_error_type"] = gate["lookup_error_type"]
+    merged["superseded_uuids"] = sorted(uuids)
+    return {"supersession_gate": merged}
 
 
 def _candidate_limits_for_limit(

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -919,6 +919,11 @@ async def _apply_supersession_gate(
     )
     superseded: set[str] = set()
     lookup_failed: str | None = None
+    # Both caps fail open: a candidate past the slice is never checked, and a
+    # retired row can carry several inbound edges so the row cap can bite
+    # before the candidate cap does. Neither is reachable at current pool
+    # sizes, and neither may pass silently if it ever becomes reachable.
+    truncated = len(node_uuids) > _SUPERSESSION_LOOKUP_LIMIT
     if node_uuids:
         try:
             superseded = await _superseded_candidate_uuids(
@@ -948,6 +953,10 @@ async def _apply_supersession_gate(
         "superseded_dropped": edge_dropped,
         "superseded_uuids": sorted(superseded),
     }
+    if truncated or len(superseded) >= _SUPERSESSION_LOOKUP_LIMIT:
+        receipt["truncated"] = True
+        receipt["checked_candidates"] = min(len(node_uuids), _SUPERSESSION_LOOKUP_LIMIT)
+        receipt["total_candidates"] = len(node_uuids)
     if lookup_failed is not None:
         receipt["lookup_error_type"] = lookup_failed
     return surviving, {"supersession_gate": receipt}

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -1811,16 +1811,21 @@ async def projected_row_lifecycle_stamp(
                 source_id=raw_source_id,
             )
     except Exception as exc:
-        # The projection is worth more than the stamp: a row that exists
-        # unstamped is reachable by the correction's own cascade the next time
-        # one runs, while a row that was never written is lost.
+        # Raised rather than swallowed. Writing the row anyway mints a fully
+        # recallable copy of text that may already be retired, and nothing
+        # comes back for it: the correction that would have stamped it has
+        # already run and found nothing. A raised failure leaves the write to
+        # be retried, which is recoverable in a way a silently active row is
+        # not.
         log.warning(
             "projected_row_lifecycle_lookup_failed",
             raw_memory_id=raw_memory_id,
             error_type=type(exc).__name__,
         )
-        return {}
+        raise
     if memory is None:
+        # An absent capture is not an unreadable one. Nothing was stamped on a
+        # row that does not exist, so there is no verdict to inherit.
         return {}
     stamp = graph_lifecycle_stamp(memory)
     if stamp:
@@ -1836,7 +1841,7 @@ _GRAPH_CORRECTION_LOOKUP_LIMIT = 64
 # Each corrected row can carry up to `MAX_PASSAGES_PER_SOURCE` spans, so the
 # span cap is the parent cap multiplied by that ceiling: a limit that bound
 # earlier would leave spans of a retired memory recallable.
-_GRAPH_CORRECTION_PASSAGE_LOOKUP_LIMIT = _GRAPH_CORRECTION_LOOKUP_LIMIT * MAX_PASSAGES_PER_SOURCE
+_GRAPH_CORRECTION_PROJECTION_LOOKUP_LIMIT = _GRAPH_CORRECTION_LOOKUP_LIMIT * MAX_PASSAGES_PER_SOURCE
 _CORRECTION_NATIVE_WRITE_PATH = "memory_correction"
 
 
@@ -1854,11 +1859,11 @@ class _CorrectionGraphTargets:
 
     authorized: list[str]
     refused: list[str]
-    passages: list[str] = field(default_factory=list)
+    projections: list[str] = field(default_factory=list)
 
     @property
     def stampable(self) -> list[str]:
-        return [*self.authorized, *self.passages]
+        return [*self.authorized, *self.projections]
 
 
 async def _correction_graph_entity_ids(
@@ -1984,7 +1989,7 @@ async def _correction_graph_entity_ids(
         )
         refused.append(entity_id)
 
-    passages = await _correction_passage_entity_ids(
+    projections = await _correction_projected_row_ids(
         runtime,
         organization_id=organization_id,
         memory=memory,
@@ -1996,7 +2001,9 @@ async def _correction_graph_entity_ids(
     return _CorrectionGraphTargets(
         authorized=authorized,
         refused=refused,
-        passages=[entity_id for entity_id in dict.fromkeys(passages) if entity_id not in known],
+        projections=[
+            entity_id for entity_id in dict.fromkeys(projections) if entity_id not in known
+        ],
     )
 
 
@@ -2040,7 +2047,7 @@ async def _readable_correction_targets(
     return readable
 
 
-async def _correction_passage_entity_ids(
+async def _correction_projected_row_ids(
     runtime: Any,
     *,
     organization_id: str,
@@ -2049,26 +2056,30 @@ async def _correction_passage_entity_ids(
     principal_id: str | None,
     accessible_projects: Iterable[str] | None,
 ) -> list[str]:
-    """Follow the correction down into the spans cut from the corrected rows.
+    """Follow the correction down into every row projected from the corrected rows.
 
-    A passage is an independently indexed copy of part of its parent's body
-    (`projection/passages.py`), and it inherits only the parent's scope keys,
-    never its provenance or its lifecycle. So the provenance query that finds
-    the parent cannot see the passage, and a correction that stopped at the
-    parent left every span of the retired text ranking and recallable: the
-    memory was retired and its own words kept being served.
+    Three projections mint rows carrying a parent memory's text: spans carry
+    its words verbatim (`projection/passages.py`), projected entities carry its
+    candidate context, and projected facts carry their span and content
+    (`projection/memory.py`). Each is independently indexed and independently
+    servable, and each inherits the parent's scope but not its provenance, so
+    the provenance query that finds the parent cannot see any of them. A
+    correction that stopped at the parent left the retired text ranking under
+    every projected id.
 
-    Lineage is the linkage rather than provenance, because it is the only one
-    a passage carries: the projection stamps `parent_entity_id` on every span
-    it mints, and `source_entity_id` alongside it, and passages written before
-    a given provenance rule still carry both. Matching either is what makes
-    historical spans reachable from a correction.
+    Lineage is the linkage rather than provenance, because it is the only one a
+    projected row carries: every projection stamps `source_entity_id`, spans
+    stamp `parent_entity_id` beside it, and rows written before any given
+    provenance rule still carry them. Matching either is what makes historical
+    projections reachable from a correction.
 
-    Nothing here relaxes authorization. The parents are rows this correction
-    was already authorized against, and each span is re-checked for
-    readability exactly like a projected row, because `parent_entity_id` is
-    not server-owned: a row that could be written can name a parent, and
-    naming one must not be enough to have somebody else's row retired.
+    Requiring `projection_kind` keeps this to rows claiming to be projections
+    at all, which is the narrowing the passage-only version got from its
+    entity-type filter. It is not the security boundary: the parents are rows
+    this correction was already authorized against, and each projected row is
+    re-checked for readability exactly like a provenance row, because neither
+    lineage nor `projection_kind` is server-owned and naming a parent must not
+    be enough to have somebody else's row retired.
     """
 
     parents = [str(parent_id) for parent_id in dict.fromkeys(parent_ids) if parent_id]
@@ -2080,15 +2091,14 @@ async def _correction_passage_entity_ids(
                 """
                 SELECT uuid FROM entity
                 WHERE group_id = $group_id
-                  AND entity_type = $passage_type
+                  AND attributes.projection_kind IS NOT NONE
                   AND (attributes.parent_entity_id IN $parent_ids
                        OR attributes.source_entity_id IN $parent_ids)
                 LIMIT $limit;
                 """,
                 group_id=str(organization_id),
-                passage_type=EntityType.PASSAGE.value,
                 parent_ids=parents,
-                limit=_GRAPH_CORRECTION_PASSAGE_LOOKUP_LIMIT,
+                limit=_GRAPH_CORRECTION_PROJECTION_LOOKUP_LIMIT,
             )
         )
     except Exception as exc:
@@ -2096,21 +2106,21 @@ async def _correction_passage_entity_ids(
         # failure here leaves the correction half-applied rather than undone.
         # Saying so is worth more than throwing away the half that landed.
         log.warning(
-            "memory_correction_passage_lookup_failed",
+            "memory_correction_projection_lookup_failed",
             source_id=memory.id,
             error_type=type(exc).__name__,
         )
         return []
-    passage_ids = [uuid for row in rows if (uuid := str(row.get("uuid") or ""))]
-    if not passage_ids:
+    projected_ids = [uuid for row in rows if (uuid := str(row.get("uuid") or ""))]
+    if not projected_ids:
         return []
     return await _readable_correction_targets(
         runtime,
-        entity_ids=[entity_id for entity_id in passage_ids if entity_id not in set(parents)],
+        entity_ids=[entity_id for entity_id in projected_ids if entity_id not in set(parents)],
         source_id=memory.id,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
-        log_event="memory_correction_passage_unreadable",
+        log_event="memory_correction_projection_unreadable",
     )
 
 
@@ -2208,8 +2218,8 @@ async def _project_correction_to_graph(
             source_id=memory.id,
             restored_entity_ids=applied,
         )
-    span_ids = set(targets.passages)
-    superseded_memories = [entity_id for entity_id in applied if entity_id not in span_ids]
+    projected_ids = set(targets.projections)
+    superseded_memories = [entity_id for entity_id in applied if entity_id not in projected_ids]
     if preview.action == "supersede" and replacement_source_id and superseded_memories:
         await _link_graph_supersession(
             runtime,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -1821,6 +1821,14 @@ async def _correction_graph_entity_ids(
     the capture would retire while the graph row kept ranking, which is the
     exact defect this whole change exists to kill.
 
+    One subtlety, because it reads like a hole and is not: the promotion path
+    builds entity metadata by spreading the candidate bag, so a promoted row's
+    `raw_memory_id` can carry a caller-supplied value rather than a stamped
+    one. Planting somebody else's capture id there only arranges for the row
+    to be retired when THAT capture is corrected, and the row in question is
+    the planter's own. Reaching a foreign row requires stamping this capture's
+    id onto it, which needs the write access the attack is trying to obtain.
+
     The metadata half is caller-reachable and keeps the guard.
     `promoted_entity_id` and friends are read straight off the capture's
     metadata bag, and capture metadata is pass-through rather than a

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -1770,6 +1770,7 @@ async def apply_memory_correction(
 
 
 _GRAPH_CORRECTION_LOOKUP_LIMIT = 64
+_CORRECTION_NATIVE_WRITE_PATH = "memory_correction"
 
 
 @dataclass(frozen=True, slots=True)
@@ -1851,35 +1852,72 @@ async def _correction_graph_entity_ids(
             limit=_GRAPH_CORRECTION_LOOKUP_LIMIT,
         )
     )
-    projected = [uuid for row in rows if (uuid := str(row.get("uuid") or ""))]
+    projected_ids = [uuid for row in rows if (uuid := str(row.get("uuid") or ""))]
     declared = [
         entity_id
         for entity_id in _correction_derived_ids(memory)
-        if entity_id and entity_id not in set(projected)
+        if entity_id and entity_id not in set(projected_ids)
     ]
 
-    refused: list[str] = []
-    authorized: list[str] = list(dict.fromkeys(projected))
-    for entity_id in dict.fromkeys(declared):
+    # Provenance is server-owned as of `SERVER_OWNED_METADATA_KEYS`, but rows
+    # written before that could carry a planted `raw_memory_id`, and nothing
+    # rewrites history. So a projected row must still be one this principal
+    # can currently see: that is what stops "plant the id on a row you can
+    # write, lose access, then correct your own capture to retire it". A
+    # genuine projection inherits its capture's audience, so this refuses no
+    # legitimate target.
+    projected: list[str] = []
+    for entity_id in dict.fromkeys(projected_ids):
         try:
-            target = await runtime.entity_manager.get(entity_id)
+            row = await runtime.entity_manager.get(entity_id)
         except Exception:
             continue
-        if target is None:
+        if row is None:
             continue
-        if not _promoted_entity_write_allowed(
-            entity=target,
+        row_metadata = getattr(row, "metadata", None)
+        if not memory_metadata_read_allowed(
+            row_metadata,
             principal_id=principal_id,
+            private_scope_granted=principal_id is not None,
             accessible_projects=accessible_projects,
+            row_project_id=memory_row_project_id(row_metadata),
         ):
             log.warning(
-                "memory_correction_graph_target_refused",
+                "memory_correction_graph_provenance_unreadable",
                 source_id=memory.id,
                 entity_id=entity_id,
             )
-            refused.append(entity_id)
             continue
-        authorized.append(entity_id)
+        projected.append(entity_id)
+
+    # Declared ids come off caller-writable capture metadata, so the refused
+    # list is caller-chosen input echoed back. A row that does not exist and a
+    # row that exists but is denied must therefore be reported identically: any
+    # difference between the two turns a guessed id into an existence probe for
+    # rows outside this principal's scope.
+    refused: list[str] = []
+    authorized: list[str] = list(projected)
+    for entity_id in dict.fromkeys(declared):
+        allowed = False
+        try:
+            target = await runtime.entity_manager.get(entity_id)
+        except Exception:
+            target = None
+        if target is not None:
+            allowed = _promoted_entity_write_allowed(
+                entity=target,
+                principal_id=principal_id,
+                accessible_projects=accessible_projects,
+            )
+        if allowed:
+            authorized.append(entity_id)
+            continue
+        log.warning(
+            "memory_correction_graph_target_refused",
+            source_id=memory.id,
+            entity_id=entity_id,
+        )
+        refused.append(entity_id)
     return _CorrectionGraphTargets(authorized=authorized, refused=refused)
 
 
@@ -1970,6 +2008,13 @@ async def _project_correction_to_graph(
         if updated is not None:
             applied.append(entity_id)
 
+    if preview.action == "restore" and applied:
+        await _unlink_graph_supersession(
+            runtime,
+            organization_id=organization_id,
+            source_id=memory.id,
+            restored_entity_ids=applied,
+        )
     if preview.action == "supersede" and replacement_source_id and applied:
         await _link_graph_supersession(
             runtime,
@@ -1980,6 +2025,47 @@ async def _project_correction_to_graph(
             superseded_entity_ids=applied,
         )
     return applied, list(targets.refused)
+
+
+async def _unlink_graph_supersession(
+    runtime: Any,
+    *,
+    organization_id: str,
+    source_id: str,
+    restored_entity_ids: Sequence[str],
+) -> None:
+    """Remove the supersession edges a correction minted, so restore can undo.
+
+    Clearing the lifecycle stamp is not enough on its own. The admission gate
+    retires any row carrying an inbound SUPERSEDES edge, so a restored row
+    whose edge survived stays excluded forever, and a supersede/restore
+    /counter-supersede sequence would black out both rows. Only edges this
+    correction path wrote are removed: a supersession asserted by reflection
+    promotion is a different claim and restore has no opinion about it.
+    """
+
+    if not restored_entity_ids:
+        return
+    try:
+        await runtime.client.execute_query(
+            """
+            DELETE FROM relates_to
+            WHERE group_id = $group_id
+              AND name = $predicate
+              AND target_id IN $target_ids
+              AND attributes.native_write_path = $write_path;
+            """,
+            group_id=str(organization_id),
+            predicate=RelationshipType.SUPERSEDES.value,
+            target_ids=list(restored_entity_ids),
+            write_path=_CORRECTION_NATIVE_WRITE_PATH,
+        )
+    except Exception as exc:
+        log.warning(
+            "memory_correction_supersedes_unlink_failed",
+            source_id=source_id,
+            error_type=type(exc).__name__,
+        )
 
 
 async def _link_graph_supersession(
@@ -2033,7 +2119,7 @@ async def _link_graph_supersession(
                         superseded_entity_id,
                         RelationshipType.SUPERSEDES,
                         metadata={
-                            "native_write_path": "memory_correction",
+                            "native_write_path": _CORRECTION_NATIVE_WRITE_PATH,
                             "replacement_reason": "memory_correction_supersede",
                             "replacement_source_id": replacement_source_id,
                             "created_by": principal_id,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -1780,10 +1780,23 @@ _CORRECTION_NATIVE_WRITE_PATH = "memory_correction"
 
 @dataclass(frozen=True, slots=True)
 class _CorrectionGraphTargets:
-    """Graph rows a correction may stamp, and the ones it was refused."""
+    """Graph rows a correction may stamp, and the ones it was refused.
+
+    Spans are held apart from the memories they were cut from because the two
+    take different halves of the correction. Both get the lifecycle stamp, so
+    both leave recall. Only a memory gets a supersession edge: "this row
+    replaced that one" is a claim a writer made about a memory, and minting it
+    once per span would assert a replacement nobody declared, on up to
+    `MAX_PASSAGES_PER_SOURCE` rows per correction.
+    """
 
     authorized: list[str]
     refused: list[str]
+    passages: list[str] = field(default_factory=list)
+
+    @property
+    def stampable(self) -> list[str]:
+        return [*self.authorized, *self.passages]
 
 
 async def _correction_graph_entity_ids(
@@ -1917,9 +1930,11 @@ async def _correction_graph_entity_ids(
         principal_id=principal_id,
         accessible_projects=accessible_projects,
     )
+    known = set(authorized)
     return _CorrectionGraphTargets(
-        authorized=list(dict.fromkeys([*authorized, *passages])),
+        authorized=authorized,
         refused=refused,
+        passages=[entity_id for entity_id in dict.fromkeys(passages) if entity_id not in known],
     )
 
 
@@ -2098,7 +2113,7 @@ async def _project_correction_to_graph(
             error_type=type(exc).__name__,
         )
         return [], []
-    entity_ids = targets.authorized
+    entity_ids = targets.stampable
 
     updates = _correction_graph_metadata(
         preview,
@@ -2131,14 +2146,16 @@ async def _project_correction_to_graph(
             source_id=memory.id,
             restored_entity_ids=applied,
         )
-    if preview.action == "supersede" and replacement_source_id and applied:
+    span_ids = set(targets.passages)
+    superseded_memories = [entity_id for entity_id in applied if entity_id not in span_ids]
+    if preview.action == "supersede" and replacement_source_id and superseded_memories:
         await _link_graph_supersession(
             runtime,
             organization_id=organization_id,
             principal_id=principal_id,
             accessible_projects=accessible_projects,
             replacement_source_id=replacement_source_id,
-            superseded_entity_ids=applied,
+            superseded_entity_ids=superseded_memories,
         )
     return applied, list(targets.refused)
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -24,6 +24,7 @@ from sibyl_core.auth.memory_policy import (
     stamp_memory_scope_metadata,
 )
 from sibyl_core.errors import EntityNotFoundError
+from sibyl_core.memory_pipeline.lifecycle import graph_lifecycle_stamp
 from sibyl_core.memory_pipeline.quality import normalize_memory_quality_metadata
 from sibyl_core.memory_pipeline.spans import MAX_PASSAGES_PER_SOURCE
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
@@ -1768,6 +1769,67 @@ async def apply_memory_correction(
         affected_entity_ids=affected_entity_ids,
         refused_entity_ids=refused_entity_ids,
     )
+
+
+async def projected_row_lifecycle_stamp(
+    *,
+    organization_id: str,
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Read the current verdict for the capture a row is about to be projected from.
+
+    The correction write-through can only stamp rows that exist when it runs.
+    Graph writes are queued, so the rows a capture projects into can be created
+    minutes after the capture was corrected, from a payload serialized before
+    the correction existed. Reading the capture back at creation time is what
+    closes that window: `raw_captures` is the row the correction mutated, and
+    it is already correct by the time the worker gets here.
+
+    One indexed read per projected row, on the write path only. Nothing on the
+    recall path consults this, because the stamp it returns is exactly what
+    the recall gate already reads off the row.
+
+    Empty whenever the capture is unknown, unreadable, or still recallable, so
+    the caller can merge it unconditionally.
+    """
+
+    fields = metadata if isinstance(metadata, Mapping) else {}
+    raw_memory_id = _metadata_str(fields, "raw_memory_id")
+    raw_source_id = _metadata_str(fields, "raw_source_id")
+    if not raw_memory_id and not raw_source_id:
+        return {}
+    try:
+        memory = None
+        if raw_memory_id:
+            memory = await get_raw_memory(
+                organization_id=str(organization_id),
+                memory_id=raw_memory_id,
+            )
+        if memory is None and raw_source_id:
+            memory = await get_raw_memory_by_source_id(
+                organization_id=str(organization_id),
+                source_id=raw_source_id,
+            )
+    except Exception as exc:
+        # The projection is worth more than the stamp: a row that exists
+        # unstamped is reachable by the correction's own cascade the next time
+        # one runs, while a row that was never written is lost.
+        log.warning(
+            "projected_row_lifecycle_lookup_failed",
+            raw_memory_id=raw_memory_id,
+            error_type=type(exc).__name__,
+        )
+        return {}
+    if memory is None:
+        return {}
+    stamp = graph_lifecycle_stamp(memory)
+    if stamp:
+        log.info(
+            "projected_row_born_retired",
+            raw_memory_id=memory.id,
+            lifecycle_state=stamp.get("lifecycle_state"),
+        )
+    return dict(stamp)
 
 
 _GRAPH_CORRECTION_LOOKUP_LIMIT = 64

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, cast
@@ -41,7 +41,7 @@ from sibyl_core.models.reflection import (
     with_reflection_finding_metadata,
 )
 from sibyl_core.models.relations import declared_relation_targets
-from sibyl_core.services.graph import get_surreal_graph_runtime
+from sibyl_core.services.graph import get_surreal_graph_runtime, normalize_records
 from sibyl_core.services.memory_autonomy import reflection_autonomy_candidate_metadata
 from sibyl_core.services.surreal_content import (
     MemoryScope,
@@ -173,6 +173,9 @@ class MemoryCorrectionResult:
     applied: bool
     preview: MemoryCorrectionPreview
     updated_memory: RawMemory | None = None
+    # The graph rows the correction actually reached. Empty is a real answer:
+    # a capture with no projection has nothing on the retrieval lane to gate.
+    affected_entity_ids: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1743,7 +1746,221 @@ async def apply_memory_correction(
     if preview.action == "supersede" and canonical_replacement_source_id is not None:
         save_kwargs["superseded_by_memory_id"] = canonical_replacement_source_id
     saved = await save_raw_memory(updated, **save_kwargs)
-    return MemoryCorrectionResult(applied=True, preview=preview, updated_memory=saved)
+    affected_entity_ids = await _project_correction_to_graph(
+        organization_id=organization_id,
+        memory=saved,
+        preview=preview,
+        principal_id=principal_id,
+        replacement_source_id=canonical_replacement_source_id,
+        duplicate_of_source_id=canonical_duplicate_of_source_id,
+    )
+    return MemoryCorrectionResult(
+        applied=True,
+        preview=preview,
+        updated_memory=saved,
+        affected_entity_ids=affected_entity_ids,
+    )
+
+
+_GRAPH_CORRECTION_LOOKUP_LIMIT = 64
+
+
+async def _correction_graph_entity_ids(
+    runtime: Any,
+    *,
+    organization_id: str,
+    memory: RawMemory,
+) -> list[str]:
+    """Find the graph rows projected from this capture.
+
+    Two sources, because the two write paths record the link in opposite
+    directions. Promotion stamps the entity id onto the raw memory, so that
+    one is a metadata read. Direct capture stamps the raw ids onto the graph
+    row's attributes instead (`memory_pipeline/capture.py:137-140`), which
+    leaves a query as the only way back. That query is unindexed, and it is
+    affordable here only because a correction is a rare, operator-initiated
+    write rather than anything on the read path.
+    """
+
+    candidate_ids = list(_correction_derived_ids(memory))
+    source_id = memory.source_id or memory.id
+    clauses = ["attributes.raw_memory_id = $raw_memory_id"]
+    params: dict[str, Any] = {
+        "group_id": str(organization_id),
+        "raw_memory_id": memory.id,
+        "limit": _GRAPH_CORRECTION_LOOKUP_LIMIT,
+    }
+    if source_id and source_id != memory.id:
+        clauses.append("attributes.raw_source_id = $raw_source_id")
+        params["raw_source_id"] = source_id
+    rows = normalize_records(
+        await runtime.client.execute_query(
+            f"""
+            SELECT uuid FROM entity
+            WHERE group_id = $group_id
+              AND ({" OR ".join(clauses)})
+            LIMIT $limit;
+            """,
+            **params,
+        )
+    )
+    for row in rows:
+        uuid = str(row.get("uuid") or "")
+        if uuid:
+            candidate_ids.append(uuid)
+    return list(dict.fromkeys(entity_id for entity_id in candidate_ids if entity_id))
+
+
+def _correction_graph_metadata(
+    preview: MemoryCorrectionPreview,
+    *,
+    replacement_source_id: str | None,
+    duplicate_of_source_id: str | None,
+) -> dict[str, Any]:
+    """Build the verdict the graph row carries from here on.
+
+    Every marker is written on every correction, including the cleared form a
+    restore needs. A patch that only ever adds keys cannot undo itself, and
+    the graph merge has no way to remove one.
+    """
+
+    restoring = preview.action == "restore"
+    excluded = bool(preview.recall_impact.get("excluded_from_recall")) and not restoring
+    return {
+        "lifecycle_state": preview.target_lifecycle_state,
+        "lifecycle_flags": list(preview.target_lifecycle_flags),
+        "lifecycle_action": preview.action,
+        "excluded_from_recall": excluded,
+        "superseded_by_source_id": "" if restoring else (replacement_source_id or ""),
+        "duplicate_of_source_id": "" if restoring else (duplicate_of_source_id or ""),
+    }
+
+
+async def _project_correction_to_graph(
+    *,
+    organization_id: str,
+    memory: RawMemory,
+    preview: MemoryCorrectionPreview,
+    principal_id: str | None,
+    replacement_source_id: str | None,
+    duplicate_of_source_id: str | None,
+) -> list[str]:
+    """Carry a correction across to the rows retrieval actually ranks.
+
+    Correction used to stop at `raw_captures`. The projected entity kept its
+    capture-time metadata, kept its embedding, and kept being expanded into,
+    so `sibyl correct` had no retrieval consequence at all. The raw write has
+    already landed by the time this runs, so a graph failure is logged and
+    swallowed: a correction that half-applied is worth more than one that
+    reports failure after mutating the substrate.
+    """
+
+    try:
+        runtime = await get_surreal_graph_runtime(str(organization_id))
+        entity_ids = await _correction_graph_entity_ids(
+            runtime,
+            organization_id=organization_id,
+            memory=memory,
+        )
+    except Exception as exc:
+        log.warning(
+            "memory_correction_graph_lookup_failed",
+            source_id=memory.id,
+            error_type=type(exc).__name__,
+        )
+        return []
+
+    updates = _correction_graph_metadata(
+        preview,
+        replacement_source_id=replacement_source_id,
+        duplicate_of_source_id=duplicate_of_source_id,
+    )
+    applied: list[str] = []
+    for entity_id in entity_ids:
+        try:
+            await runtime.entity_manager.update(entity_id, {"metadata": updates})
+        except Exception as exc:
+            log.warning(
+                "memory_correction_graph_update_failed",
+                source_id=memory.id,
+                entity_id=entity_id,
+                error_type=type(exc).__name__,
+            )
+            continue
+        applied.append(entity_id)
+
+    if preview.action == "supersede" and replacement_source_id and applied:
+        await _link_graph_supersession(
+            runtime,
+            organization_id=organization_id,
+            principal_id=principal_id,
+            replacement_source_id=replacement_source_id,
+            superseded_entity_ids=applied,
+        )
+    return applied
+
+
+async def _link_graph_supersession(
+    runtime: Any,
+    *,
+    organization_id: str,
+    principal_id: str | None,
+    replacement_source_id: str,
+    superseded_entity_ids: Sequence[str],
+) -> None:
+    """Record the replacement as a real edge, in the direction retrieval reads.
+
+    Source is the surviving row and target is the retired one, matching the
+    promotion write path, which is what lets the retrieval gate recognize a
+    row as superseded from a single inbound-edge lookup.
+    """
+
+    try:
+        replacement = await get_raw_memory_by_source_id(
+            organization_id=str(organization_id),
+            source_id=replacement_source_id,
+        )
+        if replacement is None:
+            return
+        replacement_entity_ids = await _correction_graph_entity_ids(
+            runtime,
+            organization_id=organization_id,
+            memory=replacement,
+        )
+    except Exception as exc:
+        log.warning(
+            "memory_correction_replacement_lookup_failed",
+            source_id=replacement_source_id,
+            error_type=type(exc).__name__,
+        )
+        return
+
+    now = datetime.now(UTC).isoformat()
+    for replacement_entity_id in replacement_entity_ids:
+        for superseded_entity_id in superseded_entity_ids:
+            if replacement_entity_id == superseded_entity_id:
+                continue
+            try:
+                await runtime.relationship_manager.create(
+                    _relationship(
+                        replacement_entity_id,
+                        superseded_entity_id,
+                        RelationshipType.SUPERSEDES,
+                        metadata={
+                            "native_write_path": "memory_correction",
+                            "replacement_reason": "memory_correction_supersede",
+                            "replacement_source_id": replacement_source_id,
+                            "created_by": principal_id,
+                            "valid_from": now,
+                        },
+                    )
+                )
+            except Exception as exc:
+                log.warning(
+                    "memory_correction_supersedes_edge_failed",
+                    entity_id=superseded_entity_id,
+                    error_type=type(exc).__name__,
+                )
 
 
 async def _resolve_reflection_promotion_plan(

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -1751,6 +1751,7 @@ async def apply_memory_correction(
         memory=saved,
         preview=preview,
         principal_id=principal_id,
+        accessible_projects=accessible_projects,
         replacement_source_id=canonical_replacement_source_id,
         duplicate_of_source_id=canonical_duplicate_of_source_id,
     )
@@ -1770,6 +1771,8 @@ async def _correction_graph_entity_ids(
     *,
     organization_id: str,
     memory: RawMemory,
+    principal_id: str | None,
+    accessible_projects: Iterable[str] | None,
 ) -> list[str]:
     """Find the graph rows projected from this capture.
 
@@ -1787,6 +1790,16 @@ async def _correction_graph_entity_ids(
     `list_raw_memories_by_source_id` returns a list), while a correction
     declares exactly one affected capture. Matching the group key would let a
     correction on one memory stamp the projections of its siblings.
+
+    Every candidate is then re-authorized against the correcting principal.
+    The metadata half of the candidate set is caller-reachable: `promoted_
+    entity_id` and friends are read straight off the capture's metadata bag,
+    and capture metadata is pass-through rather than a whitelist, so a caller
+    could otherwise name somebody else's entity, correct their own capture,
+    and retire a row they cannot write. The reflection path guards its
+    supersession targets exactly this way
+    (`_authorized_superseded_entity_ids`), and this is the same guard on the
+    same class of danger.
     """
 
     candidate_ids = list(_correction_derived_ids(memory))
@@ -1807,7 +1820,28 @@ async def _correction_graph_entity_ids(
         uuid = str(row.get("uuid") or "")
         if uuid:
             candidate_ids.append(uuid)
-    return list(dict.fromkeys(entity_id for entity_id in candidate_ids if entity_id))
+
+    authorized: list[str] = []
+    for entity_id in dict.fromkeys(value for value in candidate_ids if value):
+        try:
+            target = await runtime.entity_manager.get(entity_id)
+        except Exception:
+            continue
+        if target is None:
+            continue
+        if not _promoted_entity_write_allowed(
+            entity=target,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+        ):
+            log.warning(
+                "memory_correction_graph_target_refused",
+                source_id=memory.id,
+                entity_id=entity_id,
+            )
+            continue
+        authorized.append(entity_id)
+    return authorized
 
 
 def _correction_graph_metadata(
@@ -1841,6 +1875,7 @@ async def _project_correction_to_graph(
     memory: RawMemory,
     preview: MemoryCorrectionPreview,
     principal_id: str | None,
+    accessible_projects: Iterable[str] | None,
     replacement_source_id: str | None,
     duplicate_of_source_id: str | None,
 ) -> list[str]:
@@ -1860,6 +1895,8 @@ async def _project_correction_to_graph(
             runtime,
             organization_id=organization_id,
             memory=memory,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
         )
     except Exception as exc:
         log.warning(
@@ -1898,6 +1935,7 @@ async def _project_correction_to_graph(
             runtime,
             organization_id=organization_id,
             principal_id=principal_id,
+            accessible_projects=accessible_projects,
             replacement_source_id=replacement_source_id,
             superseded_entity_ids=applied,
         )
@@ -1909,6 +1947,7 @@ async def _link_graph_supersession(
     *,
     organization_id: str,
     principal_id: str | None,
+    accessible_projects: Iterable[str] | None,
     replacement_source_id: str,
     superseded_entity_ids: Sequence[str],
 ) -> None:
@@ -1930,6 +1969,8 @@ async def _link_graph_supersession(
             runtime,
             organization_id=organization_id,
             memory=replacement,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
         )
     except Exception as exc:
         log.warning(

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -1875,6 +1875,11 @@ async def _correction_graph_entity_ids(
         if row is None:
             continue
         row_metadata = getattr(row, "metadata", None)
+        # `private_scope_granted` says only that this principal may hold
+        # private memories at all; ownership is still checked inside, so a
+        # private row belonging to somebody else is refused either way. The
+        # correction route has already authorized this principal against the
+        # capture, so the grant is not the thing under test here.
         if not memory_metadata_read_allowed(
             row_metadata,
             principal_id=principal_id,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -26,7 +26,6 @@ from sibyl_core.auth.memory_policy import (
 from sibyl_core.errors import EntityNotFoundError
 from sibyl_core.memory_pipeline.lifecycle import graph_lifecycle_stamp
 from sibyl_core.memory_pipeline.quality import normalize_memory_quality_metadata
-from sibyl_core.memory_pipeline.spans import MAX_PASSAGES_PER_SOURCE
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.models.reflection import (
     MemoryLifecycle,
@@ -1841,7 +1840,12 @@ _GRAPH_CORRECTION_LOOKUP_LIMIT = 64
 # Each corrected row can carry up to `MAX_PASSAGES_PER_SOURCE` spans, so the
 # span cap is the parent cap multiplied by that ceiling: a limit that bound
 # earlier would leave spans of a retired memory recallable.
-_GRAPH_CORRECTION_PROJECTION_LOOKUP_LIMIT = _GRAPH_CORRECTION_LOOKUP_LIMIT * MAX_PASSAGES_PER_SOURCE
+# One parent can carry `MAX_PASSAGES_PER_SOURCE` spans plus its projected
+# entities and facts, so a single fixed multiplier is a guess that goes stale
+# the moment any projection widens. The walk pages instead, and the page cap
+# exists only so a pathological corpus cannot hold the write open forever.
+_GRAPH_CORRECTION_PROJECTION_PAGE_SIZE = 512
+_GRAPH_CORRECTION_PROJECTION_MAX_PAGES = 64
 _CORRECTION_NATIVE_WRITE_PATH = "memory_correction"
 
 
@@ -2085,22 +2089,44 @@ async def _correction_projected_row_ids(
     parents = [str(parent_id) for parent_id in dict.fromkeys(parent_ids) if parent_id]
     if not parents:
         return []
+    rows: list[dict[str, Any]] = []
+    cursor = ""
     try:
-        rows = normalize_records(
-            await runtime.client.execute_query(
-                """
-                SELECT uuid FROM entity
-                WHERE group_id = $group_id
-                  AND attributes.projection_kind IS NOT NONE
-                  AND (attributes.parent_entity_id IN $parent_ids
-                       OR attributes.source_entity_id IN $parent_ids)
-                LIMIT $limit;
-                """,
-                group_id=str(organization_id),
-                parent_ids=parents,
-                limit=_GRAPH_CORRECTION_PROJECTION_LOOKUP_LIMIT,
+        for page in range(_GRAPH_CORRECTION_PROJECTION_MAX_PAGES):
+            batch = normalize_records(
+                await runtime.client.execute_query(
+                    """
+                    SELECT uuid FROM entity
+                    WHERE group_id = $group_id
+                      AND attributes.projection_kind IS NOT NONE
+                      AND uuid > $cursor
+                      AND (attributes.parent_entity_id IN $parent_ids
+                           OR attributes.source_entity_id IN $parent_ids)
+                    ORDER BY uuid
+                    LIMIT $limit;
+                    """,
+                    group_id=str(organization_id),
+                    parent_ids=parents,
+                    cursor=cursor,
+                    limit=_GRAPH_CORRECTION_PROJECTION_PAGE_SIZE,
+                )
             )
-        )
+            rows.extend(batch)
+            if len(batch) < _GRAPH_CORRECTION_PROJECTION_PAGE_SIZE:
+                break
+            cursor = str(batch[-1].get("uuid") or "")
+            if not cursor:
+                break
+            if page + 1 >= _GRAPH_CORRECTION_PROJECTION_MAX_PAGES:
+                # Only reachable on a corpus far past anything this walk was
+                # sized for, and a silent stop here leaves projected rows of a
+                # retired memory servable, so it is said out loud.
+                log.warning(
+                    "memory_correction_projection_walk_truncated",
+                    source_id=memory.id,
+                    parents=len(parents),
+                    rows=len(rows),
+                )
     except Exception as exc:
         # The parent has already been stamped by the time this runs, so a
         # failure here leaves the correction half-applied rather than undone.

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -42,6 +42,7 @@ from sibyl_core.models.reflection import (
     with_reflection_finding_metadata,
 )
 from sibyl_core.models.relations import declared_relation_targets
+from sibyl_core.projection.reconcile import RECONCILE_PENDING_KEY
 from sibyl_core.services.graph import get_surreal_graph_runtime, normalize_records
 from sibyl_core.services.memory_autonomy import reflection_autonomy_candidate_metadata
 from sibyl_core.services.surreal_content import (
@@ -182,6 +183,10 @@ class MemoryCorrectionResult:
     # the capture claimed, and saying so is the difference between a partial
     # write and a silent no-op.
     refused_entity_ids: list[str] = field(default_factory=list)
+    # The lineage walk stopped at its page ceiling, so rows projected from this
+    # capture may still be servable. Reported rather than logged alone, because
+    # a caller told "applied" has no other way to learn the write was partial.
+    projection_walk_truncated: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -1752,7 +1757,11 @@ async def apply_memory_correction(
     if preview.action == "supersede" and canonical_replacement_source_id is not None:
         save_kwargs["superseded_by_memory_id"] = canonical_replacement_source_id
     saved = await save_raw_memory(updated, **save_kwargs)
-    affected_entity_ids, refused_entity_ids = await _project_correction_to_graph(
+    (
+        affected_entity_ids,
+        refused_entity_ids,
+        projection_walk_truncated,
+    ) = await _project_correction_to_graph(
         organization_id=organization_id,
         memory=saved,
         preview=preview,
@@ -1767,6 +1776,7 @@ async def apply_memory_correction(
         updated_memory=saved,
         affected_entity_ids=affected_entity_ids,
         refused_entity_ids=refused_entity_ids,
+        projection_walk_truncated=projection_walk_truncated,
     )
 
 
@@ -1864,6 +1874,7 @@ class _CorrectionGraphTargets:
     authorized: list[str]
     refused: list[str]
     projections: list[str] = field(default_factory=list)
+    truncated: bool = False
 
     @property
     def stampable(self) -> list[str]:
@@ -1993,7 +2004,7 @@ async def _correction_graph_entity_ids(
         )
         refused.append(entity_id)
 
-    projections = await _correction_projected_row_ids(
+    projections, walk_truncated = await _correction_projected_row_ids(
         runtime,
         organization_id=organization_id,
         memory=memory,
@@ -2008,6 +2019,7 @@ async def _correction_graph_entity_ids(
         projections=[
             entity_id for entity_id in dict.fromkeys(projections) if entity_id not in known
         ],
+        truncated=walk_truncated,
     )
 
 
@@ -2059,7 +2071,7 @@ async def _correction_projected_row_ids(
     parent_ids: Sequence[str],
     principal_id: str | None,
     accessible_projects: Iterable[str] | None,
-) -> list[str]:
+) -> tuple[list[str], bool]:
     """Follow the correction down into every row projected from the corrected rows.
 
     Three projections mint rows carrying a parent memory's text: spans carry
@@ -2088,9 +2100,10 @@ async def _correction_projected_row_ids(
 
     parents = [str(parent_id) for parent_id in dict.fromkeys(parent_ids) if parent_id]
     if not parents:
-        return []
+        return [], False
     rows: list[dict[str, Any]] = []
     cursor = ""
+    truncated = False
     try:
         for page in range(_GRAPH_CORRECTION_PROJECTION_MAX_PAGES):
             batch = normalize_records(
@@ -2127,6 +2140,7 @@ async def _correction_projected_row_ids(
                     parents=len(parents),
                     rows=len(rows),
                 )
+                truncated = True
     except Exception as exc:
         # The parent has already been stamped by the time this runs, so a
         # failure here leaves the correction half-applied rather than undone.
@@ -2136,11 +2150,11 @@ async def _correction_projected_row_ids(
             source_id=memory.id,
             error_type=type(exc).__name__,
         )
-        return []
+        return [], truncated
     projected_ids = [uuid for row in rows if (uuid := str(row.get("uuid") or ""))]
     if not projected_ids:
-        return []
-    return await _readable_correction_targets(
+        return [], truncated
+    readable = await _readable_correction_targets(
         runtime,
         entity_ids=[entity_id for entity_id in projected_ids if entity_id not in set(parents)],
         source_id=memory.id,
@@ -2148,6 +2162,7 @@ async def _correction_projected_row_ids(
         accessible_projects=accessible_projects,
         log_event="memory_correction_projection_unreadable",
     )
+    return readable, truncated
 
 
 def _correction_graph_metadata(
@@ -2172,6 +2187,11 @@ def _correction_graph_metadata(
         "excluded_from_recall": excluded,
         "superseded_by_source_id": "" if restoring else (replacement_source_id or ""),
         "duplicate_of_source_id": "" if restoring else (duplicate_of_source_id or ""),
+        # A correction is somebody reading the verdict and writing it down, so
+        # a marker saying nobody could read one is answered by this write.
+        # `None` removes the key on the graph's merge patch rather than
+        # leaving it present and falsy.
+        RECONCILE_PENDING_KEY: None,
     }
 
 
@@ -2184,7 +2204,7 @@ async def _project_correction_to_graph(
     accessible_projects: Iterable[str] | None,
     replacement_source_id: str | None,
     duplicate_of_source_id: str | None,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], bool]:
     """Carry a correction across to the rows retrieval actually ranks.
 
     Correction used to stop at `raw_captures`. The projected entity kept its
@@ -2210,7 +2230,7 @@ async def _project_correction_to_graph(
             source_id=memory.id,
             error_type=type(exc).__name__,
         )
-        return [], []
+        return [], [], False
     entity_ids = targets.stampable
 
     updates = _correction_graph_metadata(
@@ -2255,7 +2275,7 @@ async def _project_correction_to_graph(
             replacement_source_id=replacement_source_id,
             superseded_entity_ids=superseded_memories,
         )
-    return applied, list(targets.refused)
+    return applied, list(targets.refused), targets.truncated
 
 
 async def _unlink_graph_supersession(

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -1780,28 +1780,27 @@ async def _correction_graph_entity_ids(
     leaves a query as the only way back. That query is unindexed, and it is
     affordable here only because a correction is a rare, operator-initiated
     write rather than anything on the read path.
+
+    The query matches `raw_memory_id` and never `raw_source_id`, even though
+    capture writes both. A capture's `source_id` is a non-unique grouping key
+    (`idx_raw_captures_source` is not UNIQUE, and
+    `list_raw_memories_by_source_id` returns a list), while a correction
+    declares exactly one affected capture. Matching the group key would let a
+    correction on one memory stamp the projections of its siblings.
     """
 
     candidate_ids = list(_correction_derived_ids(memory))
-    source_id = memory.source_id or memory.id
-    clauses = ["attributes.raw_memory_id = $raw_memory_id"]
-    params: dict[str, Any] = {
-        "group_id": str(organization_id),
-        "raw_memory_id": memory.id,
-        "limit": _GRAPH_CORRECTION_LOOKUP_LIMIT,
-    }
-    if source_id and source_id != memory.id:
-        clauses.append("attributes.raw_source_id = $raw_source_id")
-        params["raw_source_id"] = source_id
     rows = normalize_records(
         await runtime.client.execute_query(
-            f"""
+            """
             SELECT uuid FROM entity
             WHERE group_id = $group_id
-              AND ({" OR ".join(clauses)})
+              AND attributes.raw_memory_id = $raw_memory_id
             LIMIT $limit;
             """,
-            **params,
+            group_id=str(organization_id),
+            raw_memory_id=memory.id,
+            limit=_GRAPH_CORRECTION_LOOKUP_LIMIT,
         )
     )
     for row in rows:

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -176,6 +176,11 @@ class MemoryCorrectionResult:
     # The graph rows the correction actually reached. Empty is a real answer:
     # a capture with no projection has nothing on the retrieval lane to gate.
     affected_entity_ids: list[str] = field(default_factory=list)
+    # Rows the capture named that this principal may not write. A correction
+    # with a non-empty list here applied to the capture but not to everything
+    # the capture claimed, and saying so is the difference between a partial
+    # write and a silent no-op.
+    refused_entity_ids: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1746,7 +1751,7 @@ async def apply_memory_correction(
     if preview.action == "supersede" and canonical_replacement_source_id is not None:
         save_kwargs["superseded_by_memory_id"] = canonical_replacement_source_id
     saved = await save_raw_memory(updated, **save_kwargs)
-    affected_entity_ids = await _project_correction_to_graph(
+    affected_entity_ids, refused_entity_ids = await _project_correction_to_graph(
         organization_id=organization_id,
         memory=saved,
         preview=preview,
@@ -1760,10 +1765,19 @@ async def apply_memory_correction(
         preview=preview,
         updated_memory=saved,
         affected_entity_ids=affected_entity_ids,
+        refused_entity_ids=refused_entity_ids,
     )
 
 
 _GRAPH_CORRECTION_LOOKUP_LIMIT = 64
+
+
+@dataclass(frozen=True, slots=True)
+class _CorrectionGraphTargets:
+    """Graph rows a correction may stamp, and the ones it was refused."""
+
+    authorized: list[str]
+    refused: list[str]
 
 
 async def _correction_graph_entity_ids(
@@ -1773,7 +1787,7 @@ async def _correction_graph_entity_ids(
     memory: RawMemory,
     principal_id: str | None,
     accessible_projects: Iterable[str] | None,
-) -> list[str]:
+) -> _CorrectionGraphTargets:
     """Find the graph rows projected from this capture.
 
     Two sources, because the two write paths record the link in opposite
@@ -1791,18 +1805,31 @@ async def _correction_graph_entity_ids(
     declares exactly one affected capture. Matching the group key would let a
     correction on one memory stamp the projections of its siblings.
 
-    Every candidate is then re-authorized against the correcting principal.
-    The metadata half of the candidate set is caller-reachable: `promoted_
-    entity_id` and friends are read straight off the capture's metadata bag,
-    and capture metadata is pass-through rather than a whitelist, so a caller
-    could otherwise name somebody else's entity, correct their own capture,
-    and retire a row they cannot write. The reflection path guards its
-    supersession targets exactly this way
-    (`_authorized_superseded_entity_ids`), and this is the same guard on the
-    same class of danger.
+    The two halves are guarded differently, because they differ in who
+    authored them.
+
+    The query half is server-authoritative. `raw_memory_id` is assigned from
+    the completed raw write and overwrites anything the caller stamped
+    (`memory_pipeline/capture.py:137-138`), so a row it returns is a
+    projection of the very capture `preview_memory_correction` just
+    authorized this principal to correct. Re-authorizing it would not add
+    safety, and it would subtract enormously: `authorize_memory_write` refuses
+    SHARED, ORGANIZATION, and PUBLIC outright, refuses TEAM without
+    `accessible_teams`, and refuses a row carrying no scope metadata at all.
+    Promotion makes rows visible at ORGANIZATION and PUBLIC, so guarding this
+    half would silently disable the write-through for most of a real corpus:
+    the capture would retire while the graph row kept ranking, which is the
+    exact defect this whole change exists to kill.
+
+    The metadata half is caller-reachable and keeps the guard.
+    `promoted_entity_id` and friends are read straight off the capture's
+    metadata bag, and capture metadata is pass-through rather than a
+    whitelist, so without a check a caller could name somebody else's entity,
+    correct their own capture, and retire a row they cannot write. The
+    reflection path guards its supersession targets exactly this way
+    (`_authorized_superseded_entity_ids`).
     """
 
-    candidate_ids = list(_correction_derived_ids(memory))
     rows = normalize_records(
         await runtime.client.execute_query(
             """
@@ -1816,13 +1843,16 @@ async def _correction_graph_entity_ids(
             limit=_GRAPH_CORRECTION_LOOKUP_LIMIT,
         )
     )
-    for row in rows:
-        uuid = str(row.get("uuid") or "")
-        if uuid:
-            candidate_ids.append(uuid)
+    projected = [uuid for row in rows if (uuid := str(row.get("uuid") or ""))]
+    declared = [
+        entity_id
+        for entity_id in _correction_derived_ids(memory)
+        if entity_id and entity_id not in set(projected)
+    ]
 
-    authorized: list[str] = []
-    for entity_id in dict.fromkeys(value for value in candidate_ids if value):
+    refused: list[str] = []
+    authorized: list[str] = list(dict.fromkeys(projected))
+    for entity_id in dict.fromkeys(declared):
         try:
             target = await runtime.entity_manager.get(entity_id)
         except Exception:
@@ -1839,9 +1869,10 @@ async def _correction_graph_entity_ids(
                 source_id=memory.id,
                 entity_id=entity_id,
             )
+            refused.append(entity_id)
             continue
         authorized.append(entity_id)
-    return authorized
+    return _CorrectionGraphTargets(authorized=authorized, refused=refused)
 
 
 def _correction_graph_metadata(
@@ -1878,7 +1909,7 @@ async def _project_correction_to_graph(
     accessible_projects: Iterable[str] | None,
     replacement_source_id: str | None,
     duplicate_of_source_id: str | None,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     """Carry a correction across to the rows retrieval actually ranks.
 
     Correction used to stop at `raw_captures`. The projected entity kept its
@@ -1891,7 +1922,7 @@ async def _project_correction_to_graph(
 
     try:
         runtime = await get_surreal_graph_runtime(str(organization_id))
-        entity_ids = await _correction_graph_entity_ids(
+        targets = await _correction_graph_entity_ids(
             runtime,
             organization_id=organization_id,
             memory=memory,
@@ -1904,7 +1935,8 @@ async def _project_correction_to_graph(
             source_id=memory.id,
             error_type=type(exc).__name__,
         )
-        return []
+        return [], []
+    entity_ids = targets.authorized
 
     updates = _correction_graph_metadata(
         preview,
@@ -1939,7 +1971,7 @@ async def _project_correction_to_graph(
             replacement_source_id=replacement_source_id,
             superseded_entity_ids=applied,
         )
-    return applied
+    return applied, list(targets.refused)
 
 
 async def _link_graph_supersession(
@@ -1965,13 +1997,14 @@ async def _link_graph_supersession(
         )
         if replacement is None:
             return
-        replacement_entity_ids = await _correction_graph_entity_ids(
+        replacement_targets = await _correction_graph_entity_ids(
             runtime,
             organization_id=organization_id,
             memory=replacement,
             principal_id=principal_id,
             accessible_projects=accessible_projects,
         )
+        replacement_entity_ids = replacement_targets.authorized
     except Exception as exc:
         log.warning(
             "memory_correction_replacement_lookup_failed",

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -25,6 +25,7 @@ from sibyl_core.auth.memory_policy import (
 )
 from sibyl_core.errors import EntityNotFoundError
 from sibyl_core.memory_pipeline.quality import normalize_memory_quality_metadata
+from sibyl_core.memory_pipeline.spans import MAX_PASSAGES_PER_SOURCE
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.models.reflection import (
     MemoryLifecycle,
@@ -1770,6 +1771,10 @@ async def apply_memory_correction(
 
 
 _GRAPH_CORRECTION_LOOKUP_LIMIT = 64
+# Each corrected row can carry up to `MAX_PASSAGES_PER_SOURCE` spans, so the
+# span cap is the parent cap multiplied by that ceiling: a limit that bound
+# earlier would leave spans of a retired memory recallable.
+_GRAPH_CORRECTION_PASSAGE_LOOKUP_LIMIT = _GRAPH_CORRECTION_LOOKUP_LIMIT * MAX_PASSAGES_PER_SOURCE
 _CORRECTION_NATIVE_WRITE_PATH = "memory_correction"
 
 
@@ -1866,34 +1871,14 @@ async def _correction_graph_entity_ids(
     # write, lose access, then correct your own capture to retire it". A
     # genuine projection inherits its capture's audience, so this refuses no
     # legitimate target.
-    projected: list[str] = []
-    for entity_id in dict.fromkeys(projected_ids):
-        try:
-            row = await runtime.entity_manager.get(entity_id)
-        except Exception:
-            continue
-        if row is None:
-            continue
-        row_metadata = getattr(row, "metadata", None)
-        # `private_scope_granted` says only that this principal may hold
-        # private memories at all; ownership is still checked inside, so a
-        # private row belonging to somebody else is refused either way. The
-        # correction route has already authorized this principal against the
-        # capture, so the grant is not the thing under test here.
-        if not memory_metadata_read_allowed(
-            row_metadata,
-            principal_id=principal_id,
-            private_scope_granted=principal_id is not None,
-            accessible_projects=accessible_projects,
-            row_project_id=memory_row_project_id(row_metadata),
-        ):
-            log.warning(
-                "memory_correction_graph_provenance_unreadable",
-                source_id=memory.id,
-                entity_id=entity_id,
-            )
-            continue
-        projected.append(entity_id)
+    projected = await _readable_correction_targets(
+        runtime,
+        entity_ids=projected_ids,
+        source_id=memory.id,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        log_event="memory_correction_graph_provenance_unreadable",
+    )
 
     # Declared ids come off caller-writable capture metadata, so the refused
     # list is caller-chosen input echoed back. A row that does not exist and a
@@ -1923,7 +1908,133 @@ async def _correction_graph_entity_ids(
             entity_id=entity_id,
         )
         refused.append(entity_id)
-    return _CorrectionGraphTargets(authorized=authorized, refused=refused)
+
+    passages = await _correction_passage_entity_ids(
+        runtime,
+        organization_id=organization_id,
+        memory=memory,
+        parent_ids=authorized,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+    )
+    return _CorrectionGraphTargets(
+        authorized=list(dict.fromkeys([*authorized, *passages])),
+        refused=refused,
+    )
+
+
+async def _readable_correction_targets(
+    runtime: Any,
+    *,
+    entity_ids: Sequence[str],
+    source_id: str,
+    principal_id: str | None,
+    accessible_projects: Iterable[str] | None,
+    log_event: str,
+) -> list[str]:
+    """Keep the rows a correction found that this principal can still read.
+
+    `private_scope_granted` says only that this principal may hold private
+    memories at all; ownership is still checked inside, so a private row
+    belonging to somebody else is refused either way. The correction route has
+    already authorized this principal against the capture, so the grant is not
+    the thing under test here.
+    """
+
+    readable: list[str] = []
+    for entity_id in dict.fromkeys(entity_ids):
+        try:
+            row = await runtime.entity_manager.get(entity_id)
+        except Exception:
+            continue
+        if row is None:
+            continue
+        row_metadata = getattr(row, "metadata", None)
+        if not memory_metadata_read_allowed(
+            row_metadata,
+            principal_id=principal_id,
+            private_scope_granted=principal_id is not None,
+            accessible_projects=accessible_projects,
+            row_project_id=memory_row_project_id(row_metadata),
+        ):
+            log.warning(log_event, source_id=source_id, entity_id=entity_id)
+            continue
+        readable.append(entity_id)
+    return readable
+
+
+async def _correction_passage_entity_ids(
+    runtime: Any,
+    *,
+    organization_id: str,
+    memory: RawMemory,
+    parent_ids: Sequence[str],
+    principal_id: str | None,
+    accessible_projects: Iterable[str] | None,
+) -> list[str]:
+    """Follow the correction down into the spans cut from the corrected rows.
+
+    A passage is an independently indexed copy of part of its parent's body
+    (`projection/passages.py`), and it inherits only the parent's scope keys,
+    never its provenance or its lifecycle. So the provenance query that finds
+    the parent cannot see the passage, and a correction that stopped at the
+    parent left every span of the retired text ranking and recallable: the
+    memory was retired and its own words kept being served.
+
+    Lineage is the linkage rather than provenance, because it is the only one
+    a passage carries: the projection stamps `parent_entity_id` on every span
+    it mints, and `source_entity_id` alongside it, and passages written before
+    a given provenance rule still carry both. Matching either is what makes
+    historical spans reachable from a correction.
+
+    Nothing here relaxes authorization. The parents are rows this correction
+    was already authorized against, and each span is re-checked for
+    readability exactly like a projected row, because `parent_entity_id` is
+    not server-owned: a row that could be written can name a parent, and
+    naming one must not be enough to have somebody else's row retired.
+    """
+
+    parents = [str(parent_id) for parent_id in dict.fromkeys(parent_ids) if parent_id]
+    if not parents:
+        return []
+    try:
+        rows = normalize_records(
+            await runtime.client.execute_query(
+                """
+                SELECT uuid FROM entity
+                WHERE group_id = $group_id
+                  AND entity_type = $passage_type
+                  AND (attributes.parent_entity_id IN $parent_ids
+                       OR attributes.source_entity_id IN $parent_ids)
+                LIMIT $limit;
+                """,
+                group_id=str(organization_id),
+                passage_type=EntityType.PASSAGE.value,
+                parent_ids=parents,
+                limit=_GRAPH_CORRECTION_PASSAGE_LOOKUP_LIMIT,
+            )
+        )
+    except Exception as exc:
+        # The parent has already been stamped by the time this runs, so a
+        # failure here leaves the correction half-applied rather than undone.
+        # Saying so is worth more than throwing away the half that landed.
+        log.warning(
+            "memory_correction_passage_lookup_failed",
+            source_id=memory.id,
+            error_type=type(exc).__name__,
+        )
+        return []
+    passage_ids = [uuid for row in rows if (uuid := str(row.get("uuid") or ""))]
+    if not passage_ids:
+        return []
+    return await _readable_correction_targets(
+        runtime,
+        entity_ids=[entity_id for entity_id in passage_ids if entity_id not in set(parents)],
+        source_id=memory.id,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        log_event="memory_correction_passage_unreadable",
+    )
 
 
 def _correction_graph_metadata(

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -1877,7 +1877,7 @@ async def _project_correction_to_graph(
     applied: list[str] = []
     for entity_id in entity_ids:
         try:
-            await runtime.entity_manager.update(entity_id, {"metadata": updates})
+            updated = await runtime.entity_manager.update(entity_id, {"metadata": updates})
         except Exception as exc:
             log.warning(
                 "memory_correction_graph_update_failed",
@@ -1886,7 +1886,12 @@ async def _project_correction_to_graph(
                 error_type=type(exc).__name__,
             )
             continue
-        applied.append(entity_id)
+        # A miss is expected rather than exceptional. `_correction_derived_ids`
+        # reports everything derived from the capture, relationship ids
+        # included, and only the rows that were really stamped may reach the
+        # mutation receipt or become an endpoint for the supersession edge.
+        if updated is not None:
+            applied.append(entity_id)
 
     if preview.action == "supersede" and replacement_source_id and applied:
         await _link_graph_supersession(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/add.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/add.py
@@ -47,6 +47,7 @@ from sibyl_core.models.tasks import (
 from sibyl_core.projection import project_entity_passages, project_memory_entity
 from sibyl_core.runtime_ports import get_queue_port
 from sibyl_core.services.graph import get_surreal_graph_runtime
+from sibyl_core.services.memory import projected_row_lifecycle_stamp
 from sibyl_core.tools.helpers import (
     MAX_CONTENT_LENGTH,
     MAX_TITLE_LENGTH,
@@ -216,7 +217,24 @@ async def _create_entity_record(
     entity: Entity,
     *,
     generate_embeddings: bool,
+    organization_id: str | None = None,
 ) -> str:
+    # The same reconciliation the queued path does at the worker, for the same
+    # reason: the capture is written before this runs and can be corrected in
+    # between, and the row would otherwise be created recallable carrying text
+    # a writer has already retired. The window is narrow here rather than
+    # absent, and an unstamped row is not self-healing. Nothing is read for an
+    # entity that carries no capture provenance, which is every entity this
+    # path creates that no correction can ever name.
+    if organization_id:
+        stamp = await projected_row_lifecycle_stamp(
+            organization_id=organization_id,
+            metadata=entity.metadata,
+        )
+        if stamp:
+            object.__setattr__(entity, "metadata", {**(entity.metadata or {}), **stamp})
+            log.info("add_entity_born_retired", entity_id=entity.id)
+
     create_direct = getattr(entity_manager, "create_direct", None)
     if inspect.iscoroutinefunction(create_direct):
         if _accepts_keyword(create_direct, "generate_embedding"):
@@ -822,6 +840,7 @@ async def add(
                 entity_manager,
                 entity,
                 generate_embeddings=generate_embeddings,
+                organization_id=org_id,
             )
 
             await _create_relationships_bulk(
@@ -1003,6 +1022,7 @@ async def add(
                 entity_manager,
                 entity,
                 generate_embeddings=generate_embeddings,
+                organization_id=org_id,
             )
 
             await _create_relationships_bulk(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/add.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/add.py
@@ -1,13 +1,14 @@
 """Add tool for creating new knowledge in the Sibyl graph."""
 
 import inspect
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
 
 import structlog
 
 from sibyl_core.auth.memory_policy import (
+    server_provenance_metadata,
     stamp_memory_scope_metadata,
 )
 from sibyl_core.embeddings.providers import configured_embedding_provider
@@ -344,6 +345,8 @@ async def add(
     spans: list[dict[str, Any]] | None = None,
     atomic: bool = False,
     probes: list[str] | None = None,
+    # Server-stamped provenance, never caller input. See below.
+    capture_provenance: Mapping[str, Any] | None = None,
 ) -> AddResponse:
     """Add new knowledge to the Sibyl knowledge graph.
 
@@ -579,6 +582,17 @@ async def add(
             ),
             **structure_metadata(structure),
         }
+        # Re-attached after the strip, and only from the dedicated argument.
+        # The capture pipeline stamps provenance from the completed raw write
+        # and then calls this function, whose strip drops exactly those keys,
+        # so a row written through capture reached the graph naming no capture
+        # at all: the correction write-through could not find it and the
+        # projection boundary had nothing to re-read. Passing it inside
+        # `metadata` cannot work and must not, because that bag is caller
+        # input; passing it here is a statement by the server about a raw write
+        # it just completed, and no caller-facing surface forwards this
+        # argument.
+        full_metadata.update(server_provenance_metadata(capture_provenance))
         if project:
             full_metadata["project_id"] = project
         # Every graph write funnels through here, so this is where a declaration

--- a/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 import structlog
 from pydantic import ValidationError
 
-from sibyl_core.auth.memory_policy import stamp_memory_scope_metadata
+from sibyl_core.auth.memory_policy import server_provenance_metadata, stamp_memory_scope_metadata
 from sibyl_core.config import settings
 from sibyl_core.migrate.legacy_graph_archive import (
     episode_from_payload as _episode_from_payload,
@@ -573,11 +573,20 @@ def _normalized_backup_metadata(metadata: Any) -> dict[str, Any]:
 
     A restore rebuilds entities from a request body, so it is the one write
     path whose owner triple is not resolved from an authenticated caller. It
-    keeps the ownership the backup recorded — losing that would make a restore
-    cycle destroy every private memory's owner — but it may not introduce
+    keeps the ownership the backup recorded (losing that would make a restore
+    cycle destroy every private memory's owner) but it may not introduce
     shapes no write can produce: a private row carrying a second owner channel
     in scope_key, or owner fields with no scope at all, which reads as
     org-visible while looking owned.
+
+    Capture provenance is carried over for the same reason ownership is. It
+    names the raw capture a row was projected from, and a correction resolves
+    its targets by querying it, so a restored row that lost it is a row no
+    future correction can reach: the memory retires and its restored graph copy
+    keeps ranking. The strip exists to stop a caller from planting the key on
+    somebody else's row, and a backup is the server's own record of a write it
+    already performed rather than a caller naming a row, which is the same
+    distinction that lets the capture pipeline re-attach it.
     """
     fields = dict(metadata) if isinstance(metadata, dict) else {}
     scope = fields.get("memory_scope")
@@ -590,12 +599,14 @@ def _normalized_backup_metadata(metadata: Any) -> dict[str, Any]:
         # survives, so a row owned only through scope_key stays readable by
         # its owner instead of becoming readable by nobody.
         principal_id = principal_id or scope_key
-    return stamp_memory_scope_metadata(
+    stamped = stamp_memory_scope_metadata(
         fields,
         memory_scope=scope,
         scope_key=scope_key,
         principal_id=principal_id,
     )
+    stamped.update(server_provenance_metadata(fields))
+    return stamped
 
 
 def _entity_from_backup_data(entity_data: dict[str, Any]) -> Entity:

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -565,6 +565,14 @@ async def _default_related_items_batch(
                 if entity_project is not None and entity_project not in accessible_projects:
                     continue
 
+            # The same gate the singular lane runs, for the same reason: related
+            # items ride inside an admitted item, so the admission filter never
+            # sees them. `compile_context` picks this batch lane whenever the
+            # default related function is in play, which makes it the lane
+            # production actually reads through.
+            if not graph_metadata_recallable(getattr(entity, "metadata", None)):
+                continue
+
             source_id = str(getattr(relationship, "source_id", ""))
             support_content = _related_source_content(
                 entity,

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import asdict, replace
 from typing import Any
 
@@ -15,7 +15,10 @@ from sibyl_core.auth.memory_policy import (
     private_scope_granted_for,
 )
 from sibyl_core.embeddings.providers import configured_embedding_provider
-from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.memory_pipeline.lifecycle import (
+    GRAPH_RECALL_EXCLUSION_KEYS,
+    graph_metadata_recallable,
+)
 from sibyl_core.models.context import (
     ContextFacet,
     ContextIntent,
@@ -483,6 +486,12 @@ async def _default_related_items(
             if entity_project is not None and entity_project not in accessible_projects:
                 continue
 
+        # Related items ride along inside an admitted item rather than as
+        # section items of their own, so the admission filter never sees them.
+        # A retired neighbour would otherwise reach the reader as the body of
+        # somebody else's row.
+        if not graph_metadata_recallable(getattr(entity, "metadata", None)):
+            continue
         related.append(
             ContextRelatedItem(
                 id=str(entity.id),
@@ -1363,12 +1372,31 @@ def _sections_from_response(
     ]
 
 
+_LIFECYCLE_ADMISSION_KEYS = (
+    "lifecycle_state",
+    "lifecycle_flags",
+    "review_state",
+    *GRAPH_RECALL_EXCLUSION_KEYS,
+)
 _ACTIVE_WORK_LOOKUP_STATUSES = "doing,blocked,review"
 _ACTIVE_WORK_LOOKUP_LIMIT = 5
 
 
 def _enum_value(value: Any) -> str:
     return str(getattr(value, "value", value))
+
+
+def _lifecycle_metadata(metadata: Any) -> dict[str, Any]:
+    """Project just the fields admission reads, for lanes that rebuild metadata."""
+
+    if not isinstance(metadata, Mapping):
+        return {}
+    carried: dict[str, Any] = {}
+    for key in _LIFECYCLE_ADMISSION_KEYS:
+        value = metadata.get(key)
+        if value is not None and value != "" and value != [] and value != {}:
+            carried[key] = value
+    return carried
 
 
 def _item_from_active_entity(entity: Any) -> ContextItem:
@@ -1386,6 +1414,11 @@ def _item_from_active_entity(entity: Any) -> ContextItem:
         "active_lookup": True,
         "status": status,
         "priority": _enum_value(getattr(entity, "priority", "") or ""),
+        # This lane rebuilds item metadata from the entity rather than
+        # projecting a search result, so anything not named here is invisible
+        # to admission. The lifecycle keys have to be carried explicitly or a
+        # corrected task walks straight past the filter into the pack.
+        **_lifecycle_metadata(getattr(entity, "metadata", None)),
     }
     # Tasks invert the usual relationship: Task.set_entity_fields seeds content
     # from description at creation and the update path never rewrites it, so

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -15,6 +15,7 @@ from sibyl_core.auth.memory_policy import (
     private_scope_granted_for,
 )
 from sibyl_core.embeddings.providers import configured_embedding_provider
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
 from sibyl_core.models.context import (
     ContextFacet,
     ContextIntent,
@@ -621,7 +622,9 @@ _ITEM_METADATA_KEYS = (
     "principal_id",
     "scope_key",
     "redacted",
+    "excluded_from_recall",
     "superseded_by_source_id",
+    "superseded_by_raw_memory_id",
     "duplicate_of_source_id",
     "unresolved_claims",
     "supported",
@@ -743,6 +746,24 @@ def _lineage_rank(item: ContextItem) -> tuple[int, float]:
             return (-1, -item.score)
     type_rank = _LINEAGE_TYPE_RANK.get(item_type, _LINEAGE_DEFAULT_RANK)
     return (type_rank, -item.score)
+
+
+def _drop_retired_items(sections: list[ContextSection]) -> list[ContextSection]:
+    """Refuse admission to any row a correction retired.
+
+    The native lane gates its own candidates, but a pack also admits rows the
+    gate never saw: the active-work lookup, the related-item attachment, and
+    the fallback search all reach a section directly. This is the last
+    chokepoint before serving, so it re-checks the same lifecycle verdict
+    rather than trusting that every upstream path applied it.
+    """
+
+    kept: list[ContextSection] = []
+    for section in sections:
+        items = [item for item in section.items if graph_metadata_recallable(item.metadata)]
+        if items:
+            kept.append(replace(section, items=items))
+    return kept
 
 
 def _dedupe_lineage(sections: list[ContextSection]) -> list[ContextSection]:
@@ -1676,6 +1697,7 @@ async def compile_context(
             principal_id=principal_id,
             allowed_memory_scope_keys=allowed_memory_scope_keys,
         )
+    sections = _drop_retired_items(sections)
     usage_metadata: dict[str, Any] = {}
     if sections and record_exposure:
         usage_metadata[_USAGE_EXPOSURE_SUMMARY_KEY] = await annotate_context_item_exposures(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -752,10 +752,10 @@ def _drop_retired_items(sections: list[ContextSection]) -> list[ContextSection]:
     """Refuse admission to any row a correction retired.
 
     The native lane gates its own candidates, but a pack also admits rows the
-    gate never saw: the active-work lookup, the related-item attachment, and
-    the fallback search all reach a section directly. This is the last
-    chokepoint before serving, so it re-checks the same lifecycle verdict
-    rather than trusting that every upstream path applied it.
+    gate never saw: the active-work lookup and the legacy fallback search both
+    reach a section directly. Running ahead of selection rather than after it
+    is what keeps a retired row from spending one of the pack's limited slots
+    and shrinking the answer on its way out.
     """
 
     kept: list[ContextSection] = []
@@ -1662,22 +1662,24 @@ async def compile_context(
             )
         sections = _merge_active_work(sections, active_items, facets)
 
-    sections = _dedupe_lineage(sections)
+    sections = _dedupe_lineage(_drop_retired_items(sections))
     sections = _dedupe_sections(sections, limit, per_facet_limit=per_facet_limit)
     if not sections and retrieval_failed:
         sections = _dedupe_sections(
-            await _compile_fallback_sections(
-                query=query,
-                facets=facets,
-                domain=domain,
-                project=project,
-                accessible_projects=accessible_projects,
-                organization_id=organization_id,
-                limit=limit,
-                search_fn=search_fn,
-                principal_id=principal_id,
-                allowed_memory_scope_keys=allowed_memory_scope_keys,
-                audit=audit,
+            _drop_retired_items(
+                await _compile_fallback_sections(
+                    query=query,
+                    facets=facets,
+                    domain=domain,
+                    project=project,
+                    accessible_projects=accessible_projects,
+                    organization_id=organization_id,
+                    limit=limit,
+                    search_fn=search_fn,
+                    principal_id=principal_id,
+                    allowed_memory_scope_keys=allowed_memory_scope_keys,
+                    audit=audit,
+                )
             ),
             limit,
             per_facet_limit=per_facet_limit,
@@ -1697,7 +1699,6 @@ async def compile_context(
             principal_id=principal_id,
             allowed_memory_scope_keys=allowed_memory_scope_keys,
         )
-    sections = _drop_retired_items(sections)
     usage_metadata: dict[str, Any] = {}
     if sections and record_exposure:
         usage_metadata[_USAGE_EXPOSURE_SUMMARY_KEY] = await annotate_context_item_exposures(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/explore.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/explore.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
 
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
 from sibyl_core.models.entities import Entity, EntityType, RelationshipType
 from sibyl_core.tools.helpers import (
     VALID_ENTITY_TYPES,
@@ -665,6 +666,11 @@ async def _explore_related(
     results = []
     for entity, relationship in raw_results:
         if scope_guard is not None and not scope_guard(entity):
+            continue
+        # Synthesis sources its neighborhood through this lane, so a corrected
+        # or superseded row reached a rendered handbook as a cited source
+        # without ever passing pack admission.
+        if not graph_metadata_recallable(getattr(entity, "metadata", None)):
             continue
 
         # RBAC: Filter by accessible projects

--- a/packages/python/sibyl-core/tests/test_context_pack.py
+++ b/packages/python/sibyl-core/tests/test_context_pack.py
@@ -2075,7 +2075,6 @@ async def test_lean_metadata_keeps_policy_gate_fields(
                     "principal_id": "user-1",
                     "scope_key": "user-1",
                     "redacted": True,
-                    "superseded_by_source_id": "raw_memory:def",
                     "unresolved_claims": ["claim-1"],
                     "supported": False,
                     "retrieval_signals": ["raw_lexical"],
@@ -2092,10 +2091,23 @@ async def test_lean_metadata_keeps_policy_gate_fields(
     assert metadata["principal_id"] == "user-1"
     assert metadata["scope_key"] == "user-1"
     assert metadata["redacted"] is True
-    assert metadata["superseded_by_source_id"] == "raw_memory:def"
     assert metadata["unresolved_claims"] == ["claim-1"]
     assert metadata["supported"] is False
     assert "retrieval_signals" not in metadata
+    # The correction markers are projected too, so the admission gate and the
+    # downstream synthesis filters can both read them off a served item.
+    retired = context_module._lean_item_metadata(
+        {
+            "superseded_by_source_id": "raw_memory:def",
+            "duplicate_of_source_id": "raw_memory:ghi",
+            "excluded_from_recall": True,
+            "retrieval_signals": ["raw_lexical"],
+        }
+    )
+    assert retired["superseded_by_source_id"] == "raw_memory:def"
+    assert retired["duplicate_of_source_id"] == "raw_memory:ghi"
+    assert retired["excluded_from_recall"] is True
+    assert "retrieval_signals" not in retired
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -1559,3 +1559,137 @@ async def test_only_the_server_channel_can_put_provenance_on_a_written_row(
     assert (await write(capture_provenance={"raw_memory_id": "real-capture"})).success
     stamped = written[-1]["metadata"]
     assert stamped["raw_memory_id"] == "real-capture", "the server channel has to survive"
+
+
+@pytest.mark.asyncio
+async def test_the_lineage_walk_pages_past_a_single_query_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One parent can carry more projected rows than one page holds.
+
+    Spans alone go to `MAX_PASSAGES_PER_SOURCE` per parent, and projected
+    entities and facts land beside them, so a fixed multiplier is a guess that
+    goes stale the moment any projection widens. A walk that stopped at one
+    page would leave the overflow servable, which is the whole defect being
+    fixed, just quieter.
+    """
+
+    page_size = memory_module._GRAPH_CORRECTION_PROJECTION_PAGE_SIZE
+    total = page_size + 7
+    all_ids = [f"projected-{index:05d}" for index in range(total)]
+    cursors: list[str] = []
+
+    class _Runtime:
+        def __init__(self) -> None:
+            self.client = self
+            self.entity_manager = self
+
+        async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+            if "parent_entity_id" not in query:
+                return [{"uuid": "parent-1"}]
+            cursor = str(params.get("cursor") or "")
+            cursors.append(cursor)
+            after = [row_id for row_id in all_ids if row_id > cursor]
+            return [{"uuid": row_id} for row_id in after[:page_size]]
+
+        async def get(self, entity_id: str) -> Any:
+            return SimpleNamespace(
+                id=entity_id,
+                created_by="user-1",
+                metadata={"memory_scope": "private", "principal_id": "user-1"},
+            )
+
+    runtime = _Runtime()
+    memory = _raw_capture()
+
+    targets = await memory_module._correction_graph_entity_ids(
+        runtime,
+        organization_id="org-1",
+        memory=memory,
+        principal_id="user-1",
+        accessible_projects=None,
+    )
+
+    assert len(cursors) > 1, "one page cannot cover a parent's whole projection"
+    assert len(targets.projections) == total
+    assert targets.projections[-1] == all_ids[-1]
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_verdict_retires_the_row_instead_of_poisoning_the_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A store that cannot be reached must not decide by default.
+
+    Raising looks like the safe answer and is not: the local broker records a
+    failed job as COMPLETE with an error and then suppresses the same
+    deterministic job id, so an exception is a poison pill rather than a retry.
+    Leaving the row servable is worse still, because nobody comes back for it.
+    The row is excluded and flagged instead, which is visible and reversible.
+    """
+
+    from sibyl_core.projection.reconcile import (
+        RECONCILE_MAX_ATTEMPTS,
+        RECONCILE_PENDING_KEY,
+        reconcile_with_capture,
+    )
+
+    attempts: list[int] = []
+    stamped: list[tuple[str, dict[str, Any]]] = []
+
+    async def exploding_lookup(**_kwargs: object) -> Any:
+        attempts.append(1)
+        msg = "content store unreachable"
+        raise ConnectionError(msg)
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", exploding_lookup)
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    class _Manager:
+        async def update(self, entity_id: str, updates: dict[str, Any]) -> object:
+            stamped.append((entity_id, dict(updates["metadata"])))
+            return object()
+
+    outcome = await reconcile_with_capture(
+        _Manager(),
+        organization_id="org-1",
+        metadata={"raw_memory_id": "raw-1"},
+        row_ids=["row-1"],
+        applied_stamp={},
+    )
+
+    assert len(attempts) == RECONCILE_MAX_ATTEMPTS, "transient failures are retried, bounded"
+    assert outcome.unverified == 1
+    assert stamped == [("row-1", {"excluded_from_recall": True, RECONCILE_PENDING_KEY: True})]
+    assert graph_metadata_recallable(stamped[0][1]) is False
+
+
+@pytest.mark.asyncio
+async def test_an_absent_parent_is_not_treated_as_an_unreadable_one() -> None:
+    """The real manager raises KeyError for a row that is not there.
+
+    Nothing was stamped on a row that does not exist, so there is no verdict to
+    inherit and nothing to fail over. Treating absence as failure would retire
+    every projection whose parent had not been written yet.
+    """
+
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.projection.inheritance import parent_lifecycle_as_stored
+
+    class _Manager:
+        async def get(self, entity_id: str) -> Any:
+            raise KeyError(entity_id)
+
+    source = Entity(
+        id="child-1",
+        name="Child",
+        entity_type=EntityType.NOTE,
+        description="body",
+        content="body",
+        organization_id="org-1",
+        metadata={"memory_scope": "project"},
+    )
+
+    resolved = await parent_lifecycle_as_stored(_Manager(), source, source_id="missing-parent")
+
+    assert resolved is source

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -314,6 +314,45 @@ async def test_pack_admission_drops_a_corrected_item_it_was_handed(
     assert pack.total_items == 1
 
 
+@pytest.mark.asyncio
+async def test_a_retired_row_does_not_spend_a_pack_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gating ahead of selection is the difference between a full pack and a short one."""
+
+    served: list[SearchResult] = [
+        _search_result("decision-wrong", "Deploy to Fly", {"lifecycle_state": "contested"}),
+        _search_result("decision-live", "Deploy to Hetzner", {}),
+        _search_result("decision-also-live", "Deploy to Vultr", {}),
+    ]
+
+    async def fake_context_search(**_kwargs: object) -> SearchResponse:
+        return SearchResponse(
+            results=served,
+            total=len(served),
+            query="deployment target",
+            filters={},
+            graph_count=len(served),
+            document_count=0,
+            limit=len(served),
+        )
+
+    monkeypatch.setattr(context_module, "context_search", fake_context_search)
+
+    pack = await compile_context(
+        "deployment target",
+        intent="decide",
+        organization_id="org-123",
+        limit=2,
+        record_exposure=False,
+    )
+
+    # Both surviving rows are served. Dropping the retired row after selection
+    # would have spent one of the two slots on it and returned a pack of one.
+    assert sorted(item.id for item in pack.items) == ["decision-also-live", "decision-live"]
+    assert pack.total_items == 2
+
+
 def test_supersedes_weight_only_applies_where_the_edge_points_forward() -> None:
     """The 0.95 weight is not the bug; walking the edge outwards was."""
 

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -1414,3 +1414,101 @@ async def test_a_missing_id_and_a_denied_id_are_reported_identically(
 
     assert denied == ["entity-exists-denied"]
     assert missing == ["entity-does-not-exist"]
+
+
+@pytest.mark.asyncio
+async def test_a_synchronous_create_reconciles_the_capture_before_writing_the_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The queued path is not the only projection boundary.
+
+    Sync creation runs after the capture is already durable, so a correction
+    can land in between there too. The window is narrower than the worker's,
+    not absent, and an unstamped row does not heal itself: the correction that
+    would have stamped it has already run.
+    """
+
+    import sibyl_core.tools.add as add_module
+    from sibyl_core.models.entities import Entity, EntityType
+
+    monkeypatch.setattr(
+        memory_module,
+        "get_raw_memory",
+        AsyncMock(
+            return_value=_raw_capture(
+                id="raw-corrected",
+                metadata={"lifecycle_state": "contested", "lifecycle_action": "mark_wrong"},
+            )
+        ),
+    )
+
+    written: list[Entity] = []
+
+    class _Manager:
+        async def create_direct(self, entity: Entity, *, generate_embedding: bool = True) -> str:
+            written.append(entity)
+            return entity.id
+
+    entity = Entity(
+        id="sync-row",
+        name="Deploy to Fly",
+        entity_type=EntityType.DECISION,
+        description="we deploy to fly",
+        content="we deploy to fly",
+        organization_id="org-1",
+        metadata={"raw_memory_id": "raw-corrected"},
+    )
+
+    created_id = await add_module._create_entity_record(
+        _Manager(),
+        entity,
+        generate_embeddings=False,
+        organization_id="org-1",
+    )
+
+    assert created_id == "sync-row"
+    assert written[0].metadata["excluded_from_recall"] is True
+    assert written[0].metadata["lifecycle_state"] == "contested"
+    assert graph_metadata_recallable(written[0].metadata) is False
+
+
+@pytest.mark.asyncio
+async def test_a_synchronous_create_reads_nothing_for_a_row_with_no_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Most rows this path writes were never projected from a capture.
+
+    No correction can ever name them, so charging every such write a capture
+    read would buy nothing.
+    """
+
+    import sibyl_core.tools.add as add_module
+    from sibyl_core.models.entities import Entity, EntityType
+
+    lookup = AsyncMock(side_effect=AssertionError("no capture read should happen"))
+    monkeypatch.setattr(memory_module, "get_raw_memory", lookup)
+
+    class _Manager:
+        async def create_direct(self, entity: Entity, *, generate_embedding: bool = True) -> str:
+            return entity.id
+
+    entity = Entity(
+        id="plain-row",
+        name="Plain",
+        entity_type=EntityType.DECISION,
+        description="plain body",
+        content="plain body",
+        organization_id="org-1",
+        metadata={},
+    )
+
+    assert (
+        await add_module._create_entity_record(
+            _Manager(),
+            entity,
+            generate_embeddings=False,
+            organization_id="org-1",
+        )
+        == "plain-row"
+    )
+    lookup.assert_not_awaited()

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -1512,3 +1512,50 @@ async def test_a_synchronous_create_reads_nothing_for_a_row_with_no_provenance(
         == "plain-row"
     )
     lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_only_the_server_channel_can_put_provenance_on_a_written_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provenance has to be unforgeable and it has to arrive, which pull apart.
+
+    A caller that could set `raw_memory_id` could nominate any row it can write
+    to be retired by a correction on an unrelated capture, so the graph writer
+    strips it from caller metadata. The capture pipeline stamps it from the
+    completed raw write and then calls that same writer, so without a channel
+    that survives the strip the authoritative id never reaches the row and both
+    the correction write-through and the projection boundary lose their only
+    link back to the capture.
+    """
+
+    import sibyl_core.tools.add as add_module
+
+    written: list[dict[str, Any]] = []
+
+    class _Queue:
+        async def enqueue_create_entity(
+            self, *, entity_data: dict[str, Any], **_kwargs: object
+        ) -> str:
+            written.append(dict(entity_data))
+            return "job-1"
+
+    monkeypatch.setattr(add_module, "get_queue_port", lambda: _Queue())
+
+    async def write(**kwargs: Any) -> Any:
+        return await add_module.add(
+            title="Deploy",
+            content="we deploy to fly",
+            entity_type="note",
+            check_conflicts=False,
+            metadata={"organization_id": "org-1", "raw_memory_id": "victim-capture"},
+            **kwargs,
+        )
+
+    assert (await write()).success
+    planted = written[-1]["metadata"]
+    assert "raw_memory_id" not in planted, "caller metadata cannot name a capture"
+
+    assert (await write(capture_provenance={"raw_memory_id": "real-capture"})).success
+    stamped = written[-1]["metadata"]
+    assert stamped["raw_memory_id"] == "real-capture", "the server channel has to survive"

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -663,3 +663,45 @@ async def test_correction_resolves_only_its_own_capture_not_its_source_group(
     assert params["raw_memory_id"] == "candidate-1"
     assert params["group_id"] == "org-1"
     assert params["limit"] == memory_module._GRAPH_CORRECTION_LOOKUP_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_the_edge_lookup_is_not_fed_ids_that_cannot_be_edge_endpoints() -> None:
+    """Raw memories and episodes are not entity uuids, so they stay out of the IN list."""
+
+    seen_uuids: list[list[str]] = []
+
+    class RecordingClient:
+        async def execute_query(self, _query: str, **params: object) -> list[dict[str, object]]:
+            seen_uuids.append(list(params.get("uuids") or ()))
+            return []
+
+    def candidate(identifier: str, entity_type: str) -> RetrievalCandidate:
+        return RetrievalCandidate(
+            id=identifier,
+            type=entity_type,
+            name=identifier,
+            content="body",
+            score=1.0,
+            source=None,
+            metadata={},
+            project_id="project_123",
+        )
+
+    await search_module._apply_supersession_gate(
+        client=RecordingClient(),
+        group_id="org-123",
+        source_lists=[
+            (
+                RetrievalSignal.NODE_FULLTEXT,
+                [
+                    candidate("entity-real", "decision"),
+                    candidate("raw_memory:abc", "raw_memory"),
+                    candidate("episode-1", "episode"),
+                    candidate("rel-1", "relationship"),
+                ],
+            )
+        ],
+    )
+
+    assert seen_uuids == [["entity-real"]]

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -1748,3 +1748,106 @@ async def test_a_walk_that_hits_its_ceiling_reports_a_partial_correction(
 
     assert targets.truncated is True
     assert len(targets.projections) == page_size * max_pages
+
+
+@pytest.mark.asyncio
+async def test_failed_row_reads_never_produce_an_unfenced_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run of failed reads must not end in a write that fences on nothing.
+
+    The schedule: the row read fails until its retries are gone, a correction
+    lands during those failures, and the read then recovers. A pass that
+    treated "no revision" as "write unfenced" would put its own stale verdict
+    over the correction that arrived while it was blind.
+    """
+
+    from sibyl_core.projection.reconcile import reconcile_with_capture
+
+    newer = {"lifecycle_state": "active", "excluded_from_recall": False}
+    reads: list[int] = []
+    writes: list[dict[str, Any]] = []
+
+    class _Manager:
+        async def get(self, entity_id: str) -> Any:
+            reads.append(1)
+            if len(reads) <= 4:
+                msg = "graph unreachable"
+                raise ConnectionError(msg)
+            # The correction landed while the reads were failing.
+            return SimpleNamespace(id=entity_id, metadata=dict(newer), revision=7)
+
+        async def update(
+            self,
+            entity_id: str,
+            updates: dict[str, Any],
+            *,
+            expected_revision: int | None = None,
+        ) -> object:
+            writes.append({"revision": expected_revision, **dict(updates["metadata"])})
+            return object()
+
+    async def stale_verdict(**_kwargs: object) -> dict[str, Any]:
+        return {"lifecycle_state": "contested", "excluded_from_recall": True}
+
+    monkeypatch.setattr("sibyl_core.services.memory.projected_row_lifecycle_stamp", stale_verdict)
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    await reconcile_with_capture(
+        _Manager(),
+        organization_id="org-1",
+        metadata={"raw_memory_id": "raw-1"},
+        row_ids=["row-1"],
+    )
+
+    assert writes == [], "a pass that could not read the row must not write to it"
+
+
+@pytest.mark.asyncio
+async def test_a_transient_write_failure_is_retried_rather_than_escaping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stamp write gets the same bounded retry the verdict read gets.
+
+    An exception escaping to the job is not a retry: the local broker records
+    the job COMPLETE with an error and then suppresses its deterministic id, so
+    a momentary blip on the write would be as permanent as a poisoned job.
+    """
+
+    from sibyl_core.projection.reconcile import reconcile_with_capture
+
+    attempts: list[int | None] = []
+
+    class _Manager:
+        async def get(self, entity_id: str) -> Any:
+            return SimpleNamespace(id=entity_id, metadata={}, revision=3)
+
+        async def update(
+            self,
+            entity_id: str,
+            updates: dict[str, Any],
+            *,
+            expected_revision: int | None = None,
+        ) -> object:
+            attempts.append(expected_revision)
+            if len(attempts) == 1:
+                msg = "graph unreachable"
+                raise ConnectionError(msg)
+            return object()
+
+    async def verdict(**_kwargs: object) -> dict[str, Any]:
+        return {"lifecycle_state": "contested", "excluded_from_recall": True}
+
+    monkeypatch.setattr("sibyl_core.services.memory.projected_row_lifecycle_stamp", verdict)
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    outcome = await reconcile_with_capture(
+        _Manager(),
+        organization_id="org-1",
+        metadata={"raw_memory_id": "raw-1"},
+        row_ids=["row-1"],
+    )
+
+    assert len(attempts) == 2, "the first failure is retried rather than raised"
+    assert attempts == [3, 3], "and the retry still carries the fence"
+    assert outcome.restamped == 1

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -1646,7 +1646,16 @@ async def test_an_unreadable_verdict_retires_the_row_instead_of_poisoning_the_jo
     monkeypatch.setattr("asyncio.sleep", AsyncMock())
 
     class _Manager:
-        async def update(self, entity_id: str, updates: dict[str, Any]) -> object:
+        async def get(self, entity_id: str) -> Any:
+            return SimpleNamespace(id=entity_id, metadata={}, revision=1)
+
+        async def update(
+            self,
+            entity_id: str,
+            updates: dict[str, Any],
+            *,
+            expected_revision: int | None = None,
+        ) -> object:
             stamped.append((entity_id, dict(updates["metadata"])))
             return object()
 
@@ -1655,7 +1664,6 @@ async def test_an_unreadable_verdict_retires_the_row_instead_of_poisoning_the_jo
         organization_id="org-1",
         metadata={"raw_memory_id": "raw-1"},
         row_ids=["row-1"],
-        applied_stamp={},
     )
 
     assert len(attempts) == RECONCILE_MAX_ATTEMPTS, "transient failures are retried, bounded"
@@ -1693,3 +1701,50 @@ async def test_an_absent_parent_is_not_treated_as_an_unreadable_one() -> None:
     resolved = await parent_lifecycle_as_stored(_Manager(), source, source_id="missing-parent")
 
     assert resolved is source
+
+
+@pytest.mark.asyncio
+async def test_a_walk_that_hits_its_ceiling_reports_a_partial_correction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A correction that could not reach every projected row must say so.
+
+    The page ceiling is a stop, not a guarantee. A caller told "applied" with
+    no qualifier would have no way to learn that rows projected from this
+    capture are still servable, which is the same silence the truncation
+    receipt on the retrieval gate exists to prevent.
+    """
+
+    page_size = memory_module._GRAPH_CORRECTION_PROJECTION_PAGE_SIZE
+    max_pages = memory_module._GRAPH_CORRECTION_PROJECTION_MAX_PAGES
+
+    class _Runtime:
+        def __init__(self) -> None:
+            self.client = self
+            self.entity_manager = self
+
+        async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+            if "parent_entity_id" not in query:
+                return [{"uuid": "parent-1"}]
+            # Always a full page, so the walk can only stop at its ceiling.
+            cursor = str(params.get("cursor") or "")
+            start = int(cursor.rsplit("-", 1)[-1]) + 1 if cursor else 0
+            return [{"uuid": f"projected-{index:07d}"} for index in range(start, start + page_size)]
+
+        async def get(self, entity_id: str) -> Any:
+            return SimpleNamespace(
+                id=entity_id,
+                created_by="user-1",
+                metadata={"memory_scope": "private", "principal_id": "user-1"},
+            )
+
+    targets = await memory_module._correction_graph_entity_ids(
+        _Runtime(),
+        organization_id="org-1",
+        memory=_raw_capture(),
+        principal_id="user-1",
+        accessible_projects=None,
+    )
+
+    assert targets.truncated is True
+    assert len(targets.projections) == page_size * max_pages

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -528,7 +528,12 @@ async def test_supersede_writes_the_replacement_edge_in_the_direction_retrieval_
     runtime = _CorrectionGraphRuntime()
     seen_uuids = iter(["entity-old", "entity-new"])
 
-    async def execute_query(_query: str, **_params: object) -> list[dict[str, object]]:
+    async def execute_query(query: str, **_params: object) -> list[dict[str, object]]:
+        if "parent_entity_id" in query:
+            # This capture projected no passages, so the lineage cascade finds
+            # nothing. Answering it with a provenance row would hand the test a
+            # span that was never cut.
+            return []
         return [{"uuid": next(seen_uuids)}]
 
     runtime.execute_query = execute_query  # type: ignore[method-assign]

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -1,0 +1,360 @@
+"""Behavioral gates for supersession and correction enforcement.
+
+The write side already knew how to say "B replaced A". Retrieval acted on the
+declaration backwards: the SUPERSEDES edge is stored new-row to old-row, and
+following it outwards scored the retired row at 0.95. These tests pin the
+corrected behavior at each of the three places the declaration now bites --
+the traversal query, the candidate gate inside `context_search`, and the last
+admission check before a pack is served.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import sibyl_core.retrieval.search as search_module
+import sibyl_core.tools.context as context_module
+from sibyl_core.models.context import ContextFacet
+from sibyl_core.retrieval.search import (
+    RetrievalCandidate,
+    RetrievalSignal,
+    build_context_retrieval_plan,
+)
+from sibyl_core.tools.context import compile_context
+from sibyl_core.tools.responses import SearchResponse, SearchResult
+
+SUPERSEDED_ID = "memory-old"
+SUCCESSOR_ID = "memory-new"
+
+
+def _plan(query: str = "deployment target") -> Any:
+    return build_context_retrieval_plan(
+        query=query,
+        organization_id="org-123",
+        facets=[ContextFacet.DECISIONS],
+        facet_types={ContextFacet.DECISIONS: ["decision"]},
+        principal_id="user-123",
+        project="project_123",
+        accessible_projects={"project_123"},
+        limit=12,
+    )
+
+
+class _SupersessionGraphClient:
+    """A graph holding exactly one supersession: SUCCESSOR replaced SUPERSEDED.
+
+    The edge row is emitted in the direction the write path actually stores
+    it (`services/memory.py:_relationships_for_promotion` builds
+    `_relationship(entity_id, superseded_id, SUPERSEDES)`), and the relation
+    query honors the exclusion parameter so the test observes behavior rather
+    than SQL text.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+        self.calls.append((query, params))
+        if "FROM mentions" in query:
+            return []
+        if 'out.entity_type = "community"' in query or "target_id IN $community_uuids" in query:
+            return []
+        if "FROM relates_to" in query and "target_id IN $uuids" in query:
+            targets = set(params.get("uuids") or ())
+            return [{"uuid": SUPERSEDED_ID}] if SUPERSEDED_ID in targets else []
+        if "FROM relates_to" in query:
+            sources = set(params.get("source_uuids") or ())
+            if SUCCESSOR_ID not in sources:
+                return []
+            wanted = params.get("relationship_names")
+            excluded = set(params.get("exclude_relationship_names") or ())
+            if wanted and "SUPERSEDES" not in set(wanted):
+                return []
+            if "SUPERSEDES" in excluded:
+                return []
+            return [{"uuid": SUPERSEDED_ID, "relationship": "SUPERSEDES"}]
+        if "FROM entity" in query:
+            return [
+                {
+                    "uuid": SUPERSEDED_ID,
+                    "name": "Deploy to Fly",
+                    "entity_type": "decision",
+                    "content": "we deploy to fly.io",
+                    "project_id": "project_123",
+                    "attributes": {},
+                    "created_at": None,
+                }
+            ]
+        return []
+
+
+@pytest.mark.asyncio
+async def test_outgoing_supersedes_edge_no_longer_expands_into_the_retired_row() -> None:
+    """Traversal gate: the walk must not carry back the row it just retired."""
+
+    client = _SupersessionGraphClient()
+    candidates = await search_module._graph_expansion_candidates(
+        client=client,
+        plan=_plan(),
+        search_filter=search_module.SearchFilter(
+            node_types=("decision",),
+            project_ids=("project_123",),
+        ),
+        seed_candidates=[
+            RetrievalCandidate(
+                id=SUCCESSOR_ID,
+                type="decision",
+                name="Deploy to Hetzner",
+                content="we deploy to hetzner",
+                score=1.0,
+                source=None,
+                metadata={},
+                project_id="project_123",
+            )
+        ],
+        limit=4,
+    )
+
+    assert [candidate.id for candidate in candidates] == []
+    relation_calls = [
+        params
+        for query, params in client.calls
+        if "FROM relates_to" in query and "source_uuids" in params
+    ]
+    assert relation_calls
+    assert relation_calls[0]["exclude_relationship_names"] == ["SUPERSEDES"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_supersedes_walk_still_reaches_the_retired_row() -> None:
+    """A caller naming the predicate is asking for lineage, not for recall."""
+
+    client = _SupersessionGraphClient()
+    rows = await search_module._node_bfs_records(
+        client=client,
+        origin_uuids=[SUCCESSOR_ID],
+        search_filter=search_module.SearchFilter(node_types=("decision",)),
+        group_id="org-123",
+        max_depth=1,
+        limit=4,
+        relationship_names=["SUPERSEDES"],
+    )
+
+    assert [row.get("uuid") for row in rows] == [SUPERSEDED_ID]
+
+
+@pytest.mark.asyncio
+async def test_successor_wins_admission_when_both_rows_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recency override: an inbound SUPERSEDES edge retires its own target."""
+
+    client = _SupersessionGraphClient()
+
+    class Runtime:
+        pass
+
+    Runtime.client = client  # type: ignore[attr-defined]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> Runtime:
+        return Runtime()
+
+    async def fake_node_fulltext(**_kwargs: object) -> list[RetrievalCandidate]:
+        return [
+            RetrievalCandidate(
+                id=SUPERSEDED_ID,
+                type="decision",
+                name="Deploy to Fly",
+                content="we deploy to fly.io",
+                score=1.0,
+                source=None,
+                metadata={},
+                project_id="project_123",
+            ),
+            RetrievalCandidate(
+                id=SUCCESSOR_ID,
+                type="decision",
+                name="Deploy to Hetzner",
+                content="we deploy to hetzner",
+                score=0.9,
+                source=None,
+                metadata={},
+                project_id="project_123",
+            ),
+        ]
+
+    async def no_expansion(**_kwargs: object) -> list[RetrievalCandidate]:
+        return []
+
+    monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+    monkeypatch.setattr(search_module, "_node_fulltext_candidates", fake_node_fulltext)
+    monkeypatch.setattr(search_module, "_graph_expansion_candidates", no_expansion)
+
+    response = await search_module.context_search(
+        plan=_plan(),
+        types=["decision"],
+        facet=ContextFacet.DECISIONS,
+        limit=5,
+        raw_memory_recall_fn=lambda **_kwargs: [],
+    )
+
+    assert [result.id for result in response.results] == [SUCCESSOR_ID]
+    gate = response.filters["supersession_gate"]
+    assert gate["superseded_dropped"] == 1
+    assert gate["superseded_uuids"] == [SUPERSEDED_ID]
+
+
+@pytest.mark.asyncio
+async def test_corrected_row_is_refused_admission_even_with_a_winning_score(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A correction stamped onto the graph row takes it out of recall."""
+
+    corrected = RetrievalCandidate(
+        id=SUPERSEDED_ID,
+        type="decision",
+        name="Deploy to Fly",
+        content="we deploy to fly.io",
+        score=1.0,
+        source=None,
+        metadata={
+            "lifecycle_state": "contested",
+            "lifecycle_action": "mark_wrong",
+            "excluded_from_recall": True,
+        },
+        project_id="project_123",
+    )
+
+    class Runtime:
+        client = _SupersessionGraphClient()
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> Runtime:
+        return Runtime()
+
+    async def fake_node_fulltext(**_kwargs: object) -> list[RetrievalCandidate]:
+        return [corrected]
+
+    async def no_expansion(**_kwargs: object) -> list[RetrievalCandidate]:
+        return []
+
+    monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+    monkeypatch.setattr(search_module, "_node_fulltext_candidates", fake_node_fulltext)
+    monkeypatch.setattr(search_module, "_graph_expansion_candidates", no_expansion)
+
+    response = await search_module.context_search(
+        plan=_plan(),
+        types=["decision"],
+        facet=ContextFacet.DECISIONS,
+        limit=5,
+        raw_memory_recall_fn=lambda **_kwargs: [],
+    )
+
+    assert response.results == []
+    assert response.filters["supersession_gate"]["lifecycle_dropped"] == 1
+
+
+def _search_result(identifier: str, name: str, metadata: dict[str, Any]) -> SearchResult:
+    return SearchResult(
+        id=identifier,
+        type="decision",
+        name=name,
+        content=f"{name} body",
+        score=1.0,
+        source=None,
+        result_origin="graph",
+        metadata={"entity_type": "decision", **metadata},
+    )
+
+
+@pytest.mark.asyncio
+async def test_pack_admission_drops_a_corrected_item_it_was_handed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pack re-checks the verdict for rows the native gate never saw."""
+
+    served: list[SearchResult] = [
+        _search_result("decision-live", "Deploy to Hetzner", {}),
+        _search_result("decision-wrong", "Deploy to Fly", {"lifecycle_state": "contested"}),
+        _search_result(
+            "decision-replaced",
+            "Deploy to Heroku",
+            {"superseded_by_source_id": "raw_memory:new"},
+        ),
+    ]
+
+    async def fake_context_search(**_kwargs: object) -> SearchResponse:
+        return SearchResponse(
+            results=served,
+            total=len(served),
+            query="deployment target",
+            filters={},
+            graph_count=len(served),
+            document_count=0,
+            limit=len(served),
+        )
+
+    monkeypatch.setattr(context_module, "context_search", fake_context_search)
+
+    pack = await compile_context(
+        "deployment target",
+        intent="decide",
+        organization_id="org-123",
+        record_exposure=False,
+    )
+
+    assert [item.id for item in pack.items] == ["decision-live"]
+    assert pack.total_items == 1
+
+
+def test_supersedes_weight_only_applies_where_the_edge_points_forward() -> None:
+    """The 0.95 weight is not the bug; walking the edge outwards was."""
+
+    assert search_module._GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS["SUPERSEDES"] == 0.95
+    assert search_module._SUPERSEDES_PREDICATE == "SUPERSEDES"
+
+
+@pytest.mark.asyncio
+async def test_supersession_lookup_failure_degrades_without_failing_the_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gate that cannot read its edges still applies the metadata verdict."""
+
+    async def exploding_lookup(*_args: object, **_kwargs: object) -> set[str]:
+        raise RuntimeError("surreal is unhappy")
+
+    monkeypatch.setattr(search_module, "_superseded_candidate_uuids", exploding_lookup)
+
+    survivor = RetrievalCandidate(
+        id=SUCCESSOR_ID,
+        type="decision",
+        name="Deploy to Hetzner",
+        content="we deploy to hetzner",
+        score=1.0,
+        source=None,
+        metadata={},
+        project_id="project_123",
+    )
+    retired = RetrievalCandidate(
+        id=SUPERSEDED_ID,
+        type="decision",
+        name="Deploy to Fly",
+        content="we deploy to fly.io",
+        score=0.9,
+        source=None,
+        metadata={"lifecycle_state": "superseded"},
+        project_id="project_123",
+    )
+
+    surviving, metadata = await search_module._apply_supersession_gate(
+        client=_SupersessionGraphClient(),
+        group_id="org-123",
+        source_lists=[(RetrievalSignal.NODE_FULLTEXT, [survivor, retired])],
+    )
+
+    assert [candidate.id for _signal, candidates in surviving for candidate in candidates] == [
+        SUCCESSOR_ID
+    ]
+    assert metadata["supersession_gate"]["lifecycle_dropped"] == 1
+    assert metadata["supersession_gate"]["lookup_error_type"] == "RuntimeError"

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -980,28 +980,38 @@ def test_an_active_state_never_rescues_a_flagged_or_genuinely_duplicate_row() ->
 
 
 @pytest.mark.parametrize(
-    "scope_metadata",
+    ("scope_metadata", "reachable"),
     [
-        pytest.param({"memory_scope": "organization"}, id="organization"),
-        pytest.param({"memory_scope": "public"}, id="public"),
-        pytest.param({"memory_scope": "shared"}, id="shared"),
-        pytest.param({"memory_scope": "team", "scope_key": "team-a"}, id="team"),
-        pytest.param({}, id="legacy-no-scope"),
+        pytest.param({}, True, id="legacy-no-scope"),
+        pytest.param({"memory_scope": "private", "principal_id": "user-1"}, True, id="private-own"),
+        pytest.param({"memory_scope": "project", "scope_key": "proj-1"}, True, id="project-member"),
+        pytest.param(
+            {"memory_scope": "private", "principal_id": "user-2"}, False, id="private-other"
+        ),
+        pytest.param(
+            {"memory_scope": "project", "scope_key": "proj-9"}, False, id="project-outsider"
+        ),
     ],
 )
 @pytest.mark.asyncio
-async def test_correction_reaches_projected_rows_at_every_scope(
+async def test_a_correction_retires_only_projected_rows_it_can_still_see(
     monkeypatch: pytest.MonkeyPatch,
     scope_metadata: dict[str, Any],
+    reachable: bool,
 ) -> None:
-    """The projected half of the candidate set carries no write check, deliberately.
+    """Provenance is server-owned now, but rows written before that are not.
 
-    `authorize_memory_write` refuses SHARED, ORGANIZATION, and PUBLIC
-    outright, refuses TEAM without `accessible_teams`, and refuses a row with
-    no scope metadata. Promotion makes rows visible at ORGANIZATION and
-    PUBLIC, so guarding rows resolved through the server-stamped
-    `attributes.raw_memory_id` would disable the write-through for most of a
-    real corpus: the capture would retire while the graph row kept ranking.
+    `raw_memory_id` was patchable until this branch, so a row can carry a
+    planted capture id. The attack is to plant it on a row you can write, lose
+    access, then correct your own capture to retire it. Requiring that the
+    projected row still be readable by the correcting principal closes that
+    without refusing anything legitimate, because a genuine projection
+    inherits its capture's audience.
+
+    The reachable cases are the ones that can actually be served: read
+    authorization admits private, project, and the legacy fail-open, while
+    organization, shared, and public all reach `scope_not_enabled`
+    (`migrate/scope_backfill.py:70-79`), so no servable row carries them.
     """
 
     memory = _raw_capture(id="source-1")
@@ -1032,14 +1042,18 @@ async def test_correction_reaches_projected_rows_at_every_scope(
         organization_id="org-1",
         source_id="source-1",
         principal_id="user-1",
+        accessible_projects={"proj-1"},
         action="mark_wrong",
     )
 
     assert result.applied
-    assert result.affected_entity_ids == ["entity-projected"]
-    assert result.refused_entity_ids == []
-    _entity_id, stamped = runtime.updates[0]
-    assert graph_metadata_recallable(stamped) is False
+    if reachable:
+        assert result.affected_entity_ids == ["entity-projected"]
+        _entity_id, stamped = runtime.updates[0]
+        assert graph_metadata_recallable(stamped) is False
+    else:
+        assert result.affected_entity_ids == []
+        assert runtime.updates == []
 
 
 @pytest.mark.asyncio
@@ -1125,3 +1139,163 @@ async def test_the_row_cap_is_detected_even_when_dedup_hides_it(
     assert gate["truncated"] is True
     assert gate["edge_rows_read"] == 4
     assert gate["total_candidates"] == 1
+
+
+def test_a_self_supersession_retires_nothing() -> None:
+    """A row replacing itself says nothing, and must not black itself out."""
+
+    assert search_module._resolve_superseded([{"uuid": "a", "superseder": "a"}]) == set()
+
+
+def test_a_supersession_cycle_retires_only_the_newest_edges_target() -> None:
+    """Mutual supersession must not black out both rows.
+
+    A supersedes B, then B supersedes A. Retiring every inbound target would
+    leave the reader with neither row, which is strictly worse than the
+    pre-branch behavior of serving both.
+    """
+
+    retired = search_module._resolve_superseded(
+        [
+            {"uuid": "B", "superseder": "A", "created_at": "2026-01-01T00:00:00+00:00"},
+            {"uuid": "A", "superseder": "B", "created_at": "2026-02-01T00:00:00+00:00"},
+        ]
+    )
+    assert retired == {"A"}
+
+
+def test_an_edge_with_no_recorded_source_still_retires_its_target() -> None:
+    """Cycle resolution is a refinement, not a way to escape the gate."""
+
+    assert search_module._resolve_superseded([{"uuid": "old"}]) == {"old"}
+
+
+@pytest.mark.asyncio
+async def test_restore_deletes_the_supersession_edge_the_correction_minted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clearing the stamp is not enough while the gate reads the edge.
+
+    The admission gate retires any row carrying an inbound SUPERSEDES edge, so
+    a restore that left the edge behind would leave the row excluded forever
+    and make the correction irreversible in practice.
+    """
+
+    memory = _raw_capture(
+        id="source-1",
+        review_state="superseded",
+        metadata={
+            "capture_surface": "reflection_candidate",
+            "lifecycle_state": "superseded",
+            "superseded_by_source_id": "replacement-1",
+        },
+    )
+    runtime = _CorrectionGraphRuntime()
+    deletes: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_query(query: str, **params: object) -> list[dict[str, object]]:
+        if query.strip().startswith("DELETE"):
+            deletes.append((query, dict(params)))
+            return []
+        return [{"uuid": "entity-old"}]
+
+    runtime.execute_query = execute_query  # type: ignore[method-assign]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="restore",
+    )
+
+    assert result.applied
+    assert result.affected_entity_ids == ["entity-old"]
+    assert len(deletes) == 1
+    query, params = deletes[0]
+    assert "relates_to" in query
+    assert params["target_ids"] == ["entity-old"]
+    assert params["predicate"] == "SUPERSEDES"
+    # Only edges this path wrote are removed; a reflection-promoted
+    # supersession is a different claim that restore has no opinion about.
+    assert params["write_path"] == memory_module._CORRECTION_NATIVE_WRITE_PATH
+    assert params["group_id"] == "org-1"
+    _entity_id, stamped = runtime.updates[0]
+    assert graph_metadata_recallable(stamped) is True
+
+
+@pytest.mark.asyncio
+async def test_a_missing_id_and_a_denied_id_are_reported_identically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`refused_entity_ids` echoes caller-chosen input, so it must not disclose existence.
+
+    Capture metadata is caller-writable, so a caller can name any id. If a
+    nonexistent id were dropped while an existing-but-denied id came back in
+    the refused list, the difference would answer "does this row exist" for
+    rows outside the caller's scope, one guess at a time.
+    """
+
+    async def run(named_id: str, *, exists: bool) -> list[str]:
+        memory = _raw_capture(
+            id="source-1",
+            metadata={
+                "capture_surface": "reflection_candidate",
+                "promoted_entity_id": named_id,
+            },
+        )
+        runtime = _CorrectionGraphRuntime(foreign=frozenset({named_id}))
+
+        async def execute_query(_query: str, **_params: object) -> list[dict[str, object]]:
+            return []
+
+        async def get(entity_id: str) -> Any:
+            if not exists:
+                return None
+            return SimpleNamespace(
+                id=entity_id,
+                created_by="user-intruder",
+                metadata={"memory_scope": "private", "principal_id": "user-intruder"},
+            )
+
+        runtime.execute_query = execute_query  # type: ignore[method-assign]
+        runtime.get = get  # type: ignore[method-assign]
+
+        async def fake_runtime(_org: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+            return runtime
+
+        monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+        monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+        monkeypatch.setattr(
+            memory_module,
+            "save_raw_memory",
+            AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+        )
+        monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+        result = await memory_module.apply_memory_correction(
+            organization_id="org-1",
+            source_id="source-1",
+            principal_id="user-1",
+            action="mark_wrong",
+        )
+        assert result.applied
+        assert result.affected_entity_ids == []
+        return result.refused_entity_ids
+
+    denied = await run("entity-exists-denied", exists=True)
+    missing = await run("entity-does-not-exist", exists=False)
+
+    assert denied == ["entity-exists-denied"]
+    assert missing == ["entity-does-not-exist"]

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -354,13 +354,6 @@ async def test_a_retired_row_does_not_spend_a_pack_slot(
     assert pack.total_items == 2
 
 
-def test_supersedes_weight_only_applies_where_the_edge_points_forward() -> None:
-    """The 0.95 weight is not the bug; walking the edge outwards was."""
-
-    assert search_module._GRAPH_EXPANSION_RELATIONSHIP_WEIGHTS["SUPERSEDES"] == 0.95
-    assert search_module._SUPERSEDES_PREDICATE == "SUPERSEDES"
-
-
 @pytest.mark.asyncio
 async def test_supersession_lookup_failure_degrades_without_failing_the_search(
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -70,7 +70,16 @@ class _SupersessionGraphClient:
             return []
         if "FROM relates_to" in query and "target_id IN $uuids" in query:
             targets = set(params.get("uuids") or ())
-            return [{"uuid": SUPERSEDED_ID}] if SUPERSEDED_ID in targets else []
+            if SUPERSEDED_ID not in targets:
+                return []
+            return [
+                {
+                    "uuid": f"rel_{SUCCESSOR_ID}_supersedes_{SUPERSEDED_ID}",
+                    "target_id": SUPERSEDED_ID,
+                    "source_id": SUCCESSOR_ID,
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                }
+            ]
         if "FROM relates_to" in query:
             sources = set(params.get("source_uuids") or ())
             if SUCCESSOR_ID not in sources:
@@ -1144,7 +1153,8 @@ async def test_the_row_cap_is_detected_even_when_dedup_hides_it(
 def test_a_self_supersession_retires_nothing() -> None:
     """A row replacing itself says nothing, and must not black itself out."""
 
-    assert search_module._resolve_superseded([{"uuid": "a", "superseder": "a"}]) == set()
+    rows = [{"uuid": "edge-1", "target_id": "a", "source_id": "a"}]
+    assert search_module._resolve_superseded(rows) == set()
 
 
 def test_a_supersession_cycle_retires_only_the_newest_edges_target() -> None:
@@ -1157,17 +1167,58 @@ def test_a_supersession_cycle_retires_only_the_newest_edges_target() -> None:
 
     retired = search_module._resolve_superseded(
         [
-            {"uuid": "B", "superseder": "A", "created_at": "2026-01-01T00:00:00+00:00"},
-            {"uuid": "A", "superseder": "B", "created_at": "2026-02-01T00:00:00+00:00"},
+            {
+                "uuid": "edge-a-supersedes-b",
+                "target_id": "B",
+                "source_id": "A",
+                "created_at": "2026-01-01T00:00:00+00:00",
+            },
+            {
+                "uuid": "edge-b-supersedes-a",
+                "target_id": "A",
+                "source_id": "B",
+                "created_at": "2026-02-01T00:00:00+00:00",
+            },
         ]
     )
     assert retired == {"A"}
 
 
+def test_cycle_resolution_does_not_depend_on_the_order_rows_arrive_in() -> None:
+    """The winner is a property of the edges, not of the query planner.
+
+    Row order out of Surreal is not contractual, so a resolver that let the
+    last row win would retire A on one run and B on the next from the same two
+    edges. Equal timestamps are the case that exposes it, because then only
+    the tie-breaker decides.
+    """
+
+    stamped = "2026-03-01T00:00:00+00:00"
+    rows = [
+        {
+            "uuid": "edge-0001",
+            "target_id": "B",
+            "source_id": "A",
+            "created_at": stamped,
+        },
+        {
+            "uuid": "edge-0002",
+            "target_id": "A",
+            "source_id": "B",
+            "created_at": stamped,
+        },
+    ]
+
+    forward = search_module._resolve_superseded(rows)
+    reverse = search_module._resolve_superseded(list(reversed(rows)))
+
+    assert forward == reverse == {"A"}
+
+
 def test_an_edge_with_no_recorded_source_still_retires_its_target() -> None:
     """Cycle resolution is a refinement, not a way to escape the gate."""
 
-    assert search_module._resolve_superseded([{"uuid": "old"}]) == {"old"}
+    assert search_module._resolve_superseded([{"target_id": "old"}]) == {"old"}
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -938,3 +938,49 @@ async def test_an_untruncated_check_carries_no_truncation_receipt(
     )
 
     assert "truncated" not in metadata["supersession_gate"]
+
+
+def test_an_active_state_never_rescues_a_flagged_or_genuinely_duplicate_row() -> None:
+    """The ACTIVE carve-out has to be narrow, because ACTIVE is a common state.
+
+    `_LEGACY_LIFECYCLE_STATES` maps hidden, redacted, and sensitive to ACTIVE
+    and carries the verdict in the flags instead, while a real mark_duplicate
+    correction maps to CONTESTED. So the carve-out can only ever reach a row
+    that no correction touched.
+    """
+
+    for flag in ("hidden", "redacted", "sensitive"):
+        assert (
+            graph_metadata_recallable(
+                {
+                    "lifecycle_state": "active",
+                    "lifecycle_flags": [flag],
+                    "duplicate_of_source_id": "raw_memory:prior",
+                }
+            )
+            is False
+        )
+
+    assert (
+        graph_metadata_recallable(
+            {
+                "lifecycle_state": "contested",
+                "lifecycle_action": "mark_duplicate",
+                "duplicate_of_source_id": "raw_memory:prior",
+            }
+        )
+        is False
+    )
+
+    # And a correction always stamps the explicit flag alongside the state, so
+    # even an ACTIVE row it excluded stays excluded.
+    assert (
+        graph_metadata_recallable(
+            {
+                "lifecycle_state": "active",
+                "excluded_from_recall": True,
+                "duplicate_of_source_id": "raw_memory:prior",
+            }
+        )
+        is False
+    )

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -576,6 +576,65 @@ async def test_supersede_writes_the_replacement_edge_in_the_direction_retrieval_
 
 
 @pytest.mark.asyncio
+async def test_a_span_takes_the_stamp_but_never_the_supersession_edge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The two halves of a correction reach different rows.
+
+    A span has to leave recall with its parent, so it takes the lifecycle
+    stamp. It must not take an edge: "this row replaced that one" is a claim a
+    writer made about a memory, and minting it once per span would assert a
+    replacement nobody declared, on up to `MAX_PASSAGES_PER_SOURCE` rows.
+    """
+
+    memory = _raw_capture(id="source-1")
+    replacement = _raw_capture(id="replacement-1", title="Deploy to Hetzner")
+    runtime = _CorrectionGraphRuntime()
+    seen_uuids = iter(["entity-old", "entity-new"])
+
+    async def execute_query(query: str, **_params: object) -> list[dict[str, object]]:
+        if "parent_entity_id" in query:
+            return [{"uuid": "passage-of-entity-old"}]
+        return [{"uuid": next(seen_uuids)}]
+
+    runtime.execute_query = execute_query  # type: ignore[method-assign]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(
+        memory_module,
+        "get_raw_memory",
+        AsyncMock(side_effect=[memory, replacement, memory]),
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "get_raw_memory_by_source_id",
+        AsyncMock(return_value=replacement),
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="supersede",
+        replacement_source_id="replacement-1",
+    )
+
+    assert result.applied
+    assert result.affected_entity_ids == ["entity-old", "passage-of-entity-old"]
+    stamped = {entity_id for entity_id, _updates in runtime.updates}
+    assert stamped == {"entity-old", "passage-of-entity-old"}
+    assert [edge.target_id for edge in runtime.relationships] == ["entity-old"]
+
+
+@pytest.mark.asyncio
 async def test_restore_clears_the_graph_stamp_it_wrote(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -408,8 +408,9 @@ async def test_supersession_lookup_failure_degrades_without_failing_the_search(
 class _CorrectionGraphRuntime:
     """Minimal graph double: one projected entity per corrected capture."""
 
-    def __init__(self, *, uuid: str = "entity-old") -> None:
+    def __init__(self, *, uuid: str = "entity-old", missing: frozenset[str] = frozenset()) -> None:
         self.uuid = uuid
+        self.missing = missing
         self.updates: list[tuple[str, dict[str, Any]]] = []
         self.relationships: list[Any] = []
         self.client = self
@@ -419,8 +420,11 @@ class _CorrectionGraphRuntime:
     async def execute_query(self, _query: str, **_params: object) -> list[dict[str, object]]:
         return [{"uuid": self.uuid}]
 
-    async def update(self, entity_id: str, updates: dict[str, Any]) -> None:
+    async def update(self, entity_id: str, updates: dict[str, Any]) -> object | None:
+        if entity_id in self.missing:
+            return None
         self.updates.append((entity_id, dict(updates["metadata"])))
+        return object()
 
     async def create(self, relationship: Any) -> str:
         self.relationships.append(relationship)
@@ -705,3 +709,51 @@ async def test_the_edge_lookup_is_not_fed_ids_that_cannot_be_edge_endpoints() ->
     )
 
     assert seen_uuids == [["entity-real"]]
+
+
+@pytest.mark.asyncio
+async def test_the_receipt_names_only_rows_that_were_really_stamped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_correction_derived_ids` reports relationship ids too, and those are not entities.
+
+    An id that matches no entity row must not reach the mutation receipt, or
+    the receipt claims a write that never happened.
+    """
+
+    memory = _raw_capture(
+        id="source-1",
+        metadata={
+            "capture_surface": "reflection_candidate",
+            "promoted_entity_id": "entity-old",
+            "relationship_ids": ["rel_entity-old_supersedes_entity-gone"],
+        },
+    )
+    runtime = _CorrectionGraphRuntime(missing=frozenset({"rel_entity-old_supersedes_entity-gone"}))
+
+    async def execute_query(_query: str, **_params: object) -> list[dict[str, object]]:
+        return []
+
+    runtime.execute_query = execute_query  # type: ignore[method-assign]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="mark_wrong",
+    )
+
+    assert result.applied
+    assert result.affected_entity_ids == ["entity-old"]

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -10,18 +10,24 @@ admission check before a pack is served.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
 import sibyl_core.retrieval.search as search_module
 import sibyl_core.tools.context as context_module
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
 from sibyl_core.models.context import ContextFacet
+from sibyl_core.models.entities import RelationshipType
 from sibyl_core.retrieval.search import (
     RetrievalCandidate,
     RetrievalSignal,
     build_context_retrieval_plan,
 )
+from sibyl_core.services import memory as memory_module
+from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 from sibyl_core.tools.context import compile_context
 from sibyl_core.tools.responses import SearchResponse, SearchResult
 
@@ -358,3 +364,215 @@ async def test_supersession_lookup_failure_degrades_without_failing_the_search(
     ]
     assert metadata["supersession_gate"]["lifecycle_dropped"] == 1
     assert metadata["supersession_gate"]["lookup_error_type"] == "RuntimeError"
+
+
+class _CorrectionGraphRuntime:
+    """Minimal graph double: one projected entity per corrected capture."""
+
+    def __init__(self, *, uuid: str = "entity-old") -> None:
+        self.uuid = uuid
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+        self.relationships: list[Any] = []
+        self.client = self
+        self.entity_manager = self
+        self.relationship_manager = self
+
+    async def execute_query(self, _query: str, **_params: object) -> list[dict[str, object]]:
+        return [{"uuid": self.uuid}]
+
+    async def update(self, entity_id: str, updates: dict[str, Any]) -> None:
+        self.updates.append((entity_id, dict(updates["metadata"])))
+
+    async def create(self, relationship: Any) -> str:
+        self.relationships.append(relationship)
+        return relationship.id
+
+
+def _raw_capture(**overrides: Any) -> RawMemory:
+    values: dict[str, Any] = {
+        "id": "candidate-1",
+        "organization_id": "org-1",
+        "source_id": "source-1",
+        "principal_id": "user-1",
+        "memory_scope": MemoryScope.PRIVATE,
+        "scope_key": None,
+        "review_state": "pending",
+        "entity_type": "decision",
+        "title": "Decision: deploy to Fly",
+        "raw_content": "We decided to deploy to fly.io.",
+        "tags": ["decision"],
+        "metadata": {"capture_surface": "reflection_candidate", "domain": "sibyl"},
+        "provenance": {},
+        "capture_surface": "reflection_candidate",
+        "captured_at": datetime(2026, 5, 12, 12, 0, 0, tzinfo=UTC),
+        "created_at": datetime(2026, 5, 12, 12, 0, 0, tzinfo=UTC),
+    }
+    values.update(overrides)
+    return RawMemory(**values)
+
+
+@pytest.mark.asyncio
+async def test_correction_stamps_the_graph_row_so_recall_stops_serving_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`sibyl correct` reaches the entity, not just `raw_captures`."""
+
+    memory = _raw_capture()
+    runtime = _CorrectionGraphRuntime()
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="mark_wrong",
+        reason="we moved off Fly",
+    )
+
+    assert result.applied
+    assert result.affected_entity_ids == ["entity-old"]
+    entity_id, stamped = runtime.updates[0]
+    assert entity_id == "entity-old"
+    assert stamped["lifecycle_state"] == "contested"
+    assert stamped["excluded_from_recall"] is True
+
+    # The stamp is exactly what the retrieval gate reads, so the same query
+    # that ranked this row first now refuses it admission.
+    assert graph_metadata_recallable(stamped) is False
+
+
+@pytest.mark.asyncio
+async def test_supersede_writes_the_replacement_edge_in_the_direction_retrieval_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Source is the survivor, target is the retired row."""
+
+    memory = _raw_capture(id="source-1")
+    replacement = _raw_capture(id="replacement-1", title="Deploy to Hetzner")
+    runtime = _CorrectionGraphRuntime()
+    seen_uuids = iter(["entity-old", "entity-new"])
+
+    async def execute_query(_query: str, **_params: object) -> list[dict[str, object]]:
+        return [{"uuid": next(seen_uuids)}]
+
+    runtime.execute_query = execute_query  # type: ignore[method-assign]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(
+        memory_module,
+        "get_raw_memory",
+        AsyncMock(side_effect=[memory, replacement, memory]),
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "get_raw_memory_by_source_id",
+        AsyncMock(return_value=replacement),
+    )
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="supersede",
+        replacement_source_id="replacement-1",
+    )
+
+    assert result.applied
+    assert result.affected_entity_ids == ["entity-old"]
+    assert len(runtime.relationships) == 1
+    edge = runtime.relationships[0]
+    assert edge.source_id == "entity-new"
+    assert edge.target_id == "entity-old"
+    assert edge.relationship_type is RelationshipType.SUPERSEDES
+
+
+@pytest.mark.asyncio
+async def test_restore_clears_the_graph_stamp_it_wrote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enforcement has to be reversible or `restore` is a lie."""
+
+    memory = _raw_capture(
+        review_state="hidden",
+        metadata={
+            "capture_surface": "reflection_candidate",
+            "lifecycle_state": "active",
+            "lifecycle_flags": ["hidden"],
+        },
+    )
+    runtime = _CorrectionGraphRuntime()
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="restore",
+    )
+
+    assert result.applied
+    _entity_id, stamped = runtime.updates[0]
+    assert stamped["excluded_from_recall"] is False
+    assert stamped["superseded_by_source_id"] == ""
+    assert graph_metadata_recallable(stamped) is True
+
+
+@pytest.mark.asyncio
+async def test_correction_still_applies_when_the_graph_is_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The raw write already landed; a graph failure must not undo the report."""
+
+    memory = _raw_capture()
+
+    async def exploding_runtime(_organization_id: str, **_kwargs: object) -> Any:
+        raise RuntimeError("no graph today")
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", exploding_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="mark_stale",
+    )
+
+    assert result.applied
+    assert result.affected_entity_ids == []

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -576,3 +576,51 @@ async def test_correction_still_applies_when_the_graph_is_unreachable(
 
     assert result.applied
     assert result.affected_entity_ids == []
+
+
+@pytest.mark.asyncio
+async def test_correction_resolves_only_its_own_capture_not_its_source_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A correction names one capture, so it must not reach sibling captures.
+
+    `raw_captures.source_id` groups memories rather than identifying one
+    (`idx_raw_captures_source` is not UNIQUE), so resolving graph rows through
+    it would stamp projections the correction never declared as affected.
+    """
+
+    memory = _raw_capture(id="candidate-1", source_id="shared-source")
+    runtime = _CorrectionGraphRuntime()
+    queries: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_query(query: str, **params: object) -> list[dict[str, object]]:
+        queries.append((query, dict(params)))
+        return [{"uuid": "entity-old"}]
+
+    runtime.execute_query = execute_query  # type: ignore[method-assign]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="candidate-1",
+        principal_id="user-1",
+        action="mark_wrong",
+    )
+
+    assert result.applied
+    query, params = queries[0]
+    assert "raw_source_id" not in query
+    assert params["raw_memory_id"] == "candidate-1"
+    assert params["group_id"] == "org-1"
+    assert params["limit"] == memory_module._GRAPH_CORRECTION_LOOKUP_LIMIT

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -868,8 +868,8 @@ async def test_a_truncated_supersession_check_says_so_in_the_receipt(
 
     monkeypatch.setattr(search_module, "_SUPERSESSION_LOOKUP_LIMIT", 2)
 
-    async def empty_lookup(*_args: object, **_kwargs: object) -> set[str]:
-        return set()
+    async def empty_lookup(*_args: object, **_kwargs: object) -> tuple[set[str], int]:
+        return set(), 0
 
     monkeypatch.setattr(search_module, "_superseded_candidate_uuids", empty_lookup)
 
@@ -903,8 +903,8 @@ async def test_a_truncated_supersession_check_says_so_in_the_receipt(
 async def test_an_untruncated_check_carries_no_truncation_receipt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def empty_lookup(*_args: object, **_kwargs: object) -> set[str]:
-        return set()
+    async def empty_lookup(*_args: object, **_kwargs: object) -> tuple[set[str], int]:
+        return set(), 0
 
     monkeypatch.setattr(search_module, "_superseded_candidate_uuids", empty_lookup)
 
@@ -977,3 +977,151 @@ def test_an_active_state_never_rescues_a_flagged_or_genuinely_duplicate_row() ->
         )
         is False
     )
+
+
+@pytest.mark.parametrize(
+    "scope_metadata",
+    [
+        pytest.param({"memory_scope": "organization"}, id="organization"),
+        pytest.param({"memory_scope": "public"}, id="public"),
+        pytest.param({"memory_scope": "shared"}, id="shared"),
+        pytest.param({"memory_scope": "team", "scope_key": "team-a"}, id="team"),
+        pytest.param({}, id="legacy-no-scope"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_correction_reaches_projected_rows_at_every_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    scope_metadata: dict[str, Any],
+) -> None:
+    """The projected half of the candidate set carries no write check, deliberately.
+
+    `authorize_memory_write` refuses SHARED, ORGANIZATION, and PUBLIC
+    outright, refuses TEAM without `accessible_teams`, and refuses a row with
+    no scope metadata. Promotion makes rows visible at ORGANIZATION and
+    PUBLIC, so guarding rows resolved through the server-stamped
+    `attributes.raw_memory_id` would disable the write-through for most of a
+    real corpus: the capture would retire while the graph row kept ranking.
+    """
+
+    memory = _raw_capture(id="source-1")
+    runtime = _CorrectionGraphRuntime()
+
+    async def execute_query(_query: str, **_params: object) -> list[dict[str, object]]:
+        return [{"uuid": "entity-projected"}]
+
+    async def get(entity_id: str) -> Any:
+        return SimpleNamespace(id=entity_id, created_by=None, metadata=dict(scope_metadata))
+
+    runtime.execute_query = execute_query  # type: ignore[method-assign]
+    runtime.get = get  # type: ignore[method-assign]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="mark_wrong",
+    )
+
+    assert result.applied
+    assert result.affected_entity_ids == ["entity-projected"]
+    assert result.refused_entity_ids == []
+    _entity_id, stamped = runtime.updates[0]
+    assert graph_metadata_recallable(stamped) is False
+
+
+@pytest.mark.asyncio
+async def test_a_refused_target_is_reported_rather_than_silently_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A partial write must not answer like a complete one."""
+
+    memory = _raw_capture(
+        id="source-1",
+        metadata={
+            "capture_surface": "reflection_candidate",
+            "promoted_entity_id": "entity-victim",
+        },
+    )
+    runtime = _CorrectionGraphRuntime(foreign=frozenset({"entity-victim"}))
+
+    async def execute_query(_query: str, **_params: object) -> list[dict[str, object]]:
+        return [{"uuid": "entity-own"}]
+
+    runtime.execute_query = execute_query  # type: ignore[method-assign]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="mark_wrong",
+    )
+
+    assert result.affected_entity_ids == ["entity-own"]
+    assert result.refused_entity_ids == ["entity-victim"]
+
+
+@pytest.mark.asyncio
+async def test_the_row_cap_is_detected_even_when_dedup_hides_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One retired row can carry many inbound edges, so rows bind before uuids do."""
+
+    monkeypatch.setattr(search_module, "_SUPERSESSION_LOOKUP_LIMIT", 4)
+
+    async def saturated_lookup(*_args: object, **_kwargs: object) -> tuple[set[str], int]:
+        # Four rows read, all pointing at the same retired row.
+        return {"entity-retired"}, 4
+
+    monkeypatch.setattr(search_module, "_superseded_candidate_uuids", saturated_lookup)
+
+    _surviving, metadata = await search_module._apply_supersession_gate(
+        client=_SupersessionGraphClient(),
+        group_id="org-123",
+        source_lists=[
+            (
+                RetrievalSignal.NODE_FULLTEXT,
+                [
+                    RetrievalCandidate(
+                        id="entity-retired",
+                        type="decision",
+                        name="retired",
+                        content="body",
+                        score=1.0,
+                        source=None,
+                        metadata={},
+                        project_id="project_123",
+                    )
+                ],
+            )
+        ],
+    )
+
+    gate = metadata["supersession_gate"]
+    assert gate["truncated"] is True
+    assert gate["edge_rows_read"] == 4
+    assert gate["total_candidates"] == 1

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -11,6 +11,7 @@ admission check before a pack is served.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -408,9 +409,18 @@ async def test_supersession_lookup_failure_degrades_without_failing_the_search(
 class _CorrectionGraphRuntime:
     """Minimal graph double: one projected entity per corrected capture."""
 
-    def __init__(self, *, uuid: str = "entity-old", missing: frozenset[str] = frozenset()) -> None:
+    def __init__(
+        self,
+        *,
+        uuid: str = "entity-old",
+        missing: frozenset[str] = frozenset(),
+        owner_id: str = "user-1",
+        foreign: frozenset[str] = frozenset(),
+    ) -> None:
         self.uuid = uuid
         self.missing = missing
+        self.owner_id = owner_id
+        self.foreign = foreign
         self.updates: list[tuple[str, dict[str, Any]]] = []
         self.relationships: list[Any] = []
         self.client = self
@@ -419,6 +429,16 @@ class _CorrectionGraphRuntime:
 
     async def execute_query(self, _query: str, **_params: object) -> list[dict[str, object]]:
         return [{"uuid": self.uuid}]
+
+    async def get(self, entity_id: str) -> Any:
+        # A private row owned by somebody else is what the write check has to
+        # refuse; everything else belongs to the correcting principal.
+        owner = "user-intruder" if entity_id in self.foreign else self.owner_id
+        return SimpleNamespace(
+            id=entity_id,
+            created_by=owner,
+            metadata={"memory_scope": "private", "principal_id": owner},
+        )
 
     async def update(self, entity_id: str, updates: dict[str, Any]) -> object | None:
         if entity_id in self.missing:
@@ -757,3 +777,164 @@ async def test_the_receipt_names_only_rows_that_were_really_stamped(
 
     assert result.applied
     assert result.affected_entity_ids == ["entity-old"]
+
+
+@pytest.mark.asyncio
+async def test_a_correction_cannot_retire_an_entity_the_caller_cannot_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capture metadata is caller pass-through, so a named target is not a trusted target.
+
+    Without a per-target write check, a caller could plant another
+    principal's entity id in their own capture's `promoted_entity_id`,
+    correct that capture, and retire a row they have no write access to.
+    """
+
+    memory = _raw_capture(
+        id="source-1",
+        metadata={
+            "capture_surface": "reflection_candidate",
+            "promoted_entity_id": "entity-victim",
+        },
+    )
+    runtime = _CorrectionGraphRuntime(foreign=frozenset({"entity-victim"}))
+
+    async def execute_query(_query: str, **_params: object) -> list[dict[str, object]]:
+        return [{"uuid": "entity-own"}]
+
+    runtime.execute_query = execute_query  # type: ignore[method-assign]
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> _CorrectionGraphRuntime:
+        return runtime
+
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", fake_runtime)
+
+    result = await memory_module.apply_memory_correction(
+        organization_id="org-1",
+        source_id="source-1",
+        principal_id="user-1",
+        action="mark_wrong",
+    )
+
+    assert result.applied
+    # The caller's own projected row is stamped; the planted one is refused.
+    assert result.affected_entity_ids == ["entity-own"]
+    assert [entity_id for entity_id, _stamp in runtime.updates] == ["entity-own"]
+
+
+def test_a_promoted_near_duplicate_survivor_stays_recallable() -> None:
+    """Reflection's duplicate marker outlives the verdict that set it.
+
+    `services/reflection.py` stamps `duplicate_of_source_id` on a candidate it
+    thinks near-duplicates a prior memory, and `_promotion_lifecycle_metadata`
+    resets the promoted row to ACTIVE by adding keys without removing that
+    one. The survivor has no SUPERSEDES edge and is the only graph row for its
+    content, so treating the residue as a verdict would make it invisible from
+    birth.
+    """
+
+    promoted = {
+        "lifecycle_state": "active",
+        "lifecycle_action": "promote",
+        "duplicate_of_source_id": "raw_memory:prior",
+        "duplicate_reason": "near_normalized_text_duplicate",
+    }
+    assert graph_metadata_recallable(promoted) is True
+
+    # The carve-out is scoped to that one key and to the ACTIVE state, so a
+    # genuine mark_duplicate correction (which lands CONTESTED) still retires,
+    # and no other marker is softened.
+    assert graph_metadata_recallable({**promoted, "lifecycle_state": "contested"}) is False
+    assert graph_metadata_recallable({**promoted, "excluded_from_recall": True}) is False
+    assert (
+        graph_metadata_recallable({**promoted, "superseded_by_source_id": "raw_memory:x"}) is False
+    )
+
+
+def test_dict_shaped_lifecycle_flags_are_not_read_as_set_flags() -> None:
+    """Iterating a Mapping yields keys, so a dict flag bag would retire on a False value."""
+
+    assert graph_metadata_recallable({"lifecycle_flags": {"hidden": False}}) is True
+    assert graph_metadata_recallable({"lifecycle_flags": ["hidden"]}) is False
+    assert graph_metadata_recallable({"lifecycle_flags": ("redacted",)}) is False
+    assert graph_metadata_recallable({"lifecycle_flags": "sensitive"}) is False
+
+
+@pytest.mark.asyncio
+async def test_a_truncated_supersession_check_says_so_in_the_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cap fails open, so it must never fail silently."""
+
+    monkeypatch.setattr(search_module, "_SUPERSESSION_LOOKUP_LIMIT", 2)
+
+    async def empty_lookup(*_args: object, **_kwargs: object) -> set[str]:
+        return set()
+
+    monkeypatch.setattr(search_module, "_superseded_candidate_uuids", empty_lookup)
+
+    def candidate(identifier: str) -> RetrievalCandidate:
+        return RetrievalCandidate(
+            id=identifier,
+            type="decision",
+            name=identifier,
+            content="body",
+            score=1.0,
+            source=None,
+            metadata={},
+            project_id="project_123",
+        )
+
+    _surviving, metadata = await search_module._apply_supersession_gate(
+        client=_SupersessionGraphClient(),
+        group_id="org-123",
+        source_lists=[
+            (RetrievalSignal.NODE_FULLTEXT, [candidate(f"entity-{index}") for index in range(5)])
+        ],
+    )
+
+    gate = metadata["supersession_gate"]
+    assert gate["truncated"] is True
+    assert gate["checked_candidates"] == 2
+    assert gate["total_candidates"] == 5
+
+
+@pytest.mark.asyncio
+async def test_an_untruncated_check_carries_no_truncation_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def empty_lookup(*_args: object, **_kwargs: object) -> set[str]:
+        return set()
+
+    monkeypatch.setattr(search_module, "_superseded_candidate_uuids", empty_lookup)
+
+    _surviving, metadata = await search_module._apply_supersession_gate(
+        client=_SupersessionGraphClient(),
+        group_id="org-123",
+        source_lists=[
+            (
+                RetrievalSignal.NODE_FULLTEXT,
+                [
+                    RetrievalCandidate(
+                        id="entity-1",
+                        type="decision",
+                        name="one",
+                        content="body",
+                        score=1.0,
+                        source=None,
+                        metadata={},
+                        project_id="project_123",
+                    )
+                ],
+            )
+        ],
+    )
+
+    assert "truncated" not in metadata["supersession_gate"]

--- a/packages/python/sibyl-core/tests/test_supersession_live_graph.py
+++ b/packages/python/sibyl-core/tests/test_supersession_live_graph.py
@@ -6,22 +6,32 @@ actually persisted, or the admission lanes that rebuild item metadata from an
 entity rather than from a search result. These tests write real rows and real
 `relates_to` edges through the production managers and then read them back
 through `context_search` and `compile_context`.
+
+`compile_context` is the entry an agent actually reaches, and it is not a thin
+wrapper: it picks the batch related-items lane, runs the active-work lookup,
+asks for passages alongside every facet type, and applies its own admission
+filter. Lanes tested one helper down have already shipped a hole the pack lane
+still had, so the bypass tests here call the pack.
 """
 
 from __future__ import annotations
 
 import uuid as uuid_module
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 
 import sibyl_core.retrieval.search as search_module
+import sibyl_core.services.memory as memory_module
 import sibyl_core.tools.context as context_module
 from sibyl_core.auth.memory_policy import stamp_memory_scope_metadata
-from sibyl_core.models.context import ContextFacet
+from sibyl_core.models.context import ContextFacet, ContextPack
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.projection.passages import project_entity_passages
 from sibyl_core.retrieval.search import build_context_retrieval_plan
 from sibyl_core.services.graph import (
     EntityManager,
@@ -29,6 +39,7 @@ from sibyl_core.services.graph import (
     SurrealGraphClient,
     prepare_graph_schema,
 )
+from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 
 PROJECT_ID = "proj-supersession"
 PRINCIPAL = "user-supersession"
@@ -65,8 +76,73 @@ async def graph(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[_Runtime]:
     monkeypatch.setattr(search_module, "get_surreal_graph_runtime", runtime_factory)
     monkeypatch.setattr(context_module, "get_surreal_graph_runtime", runtime_factory)
     monkeypatch.setattr(context_module, "get_graph_runtime", runtime_factory, raising=False)
+    monkeypatch.setattr(memory_module, "get_surreal_graph_runtime", runtime_factory)
+    # No embedding provider in the embedded harness. Left alone, building one
+    # can raise inside the native lane, and `compile_context` answers an
+    # exception by falling back to a different search path, which would leave
+    # every assertion below passing without the lane under test ever running.
+    monkeypatch.setattr(context_module, "configured_embedding_provider", lambda: None)
     yield runtime
     await client.close()
+
+
+async def _no_fallback(**_kwargs: object) -> list[Any]:
+    """Make the pack's degraded path loud instead of silently substituting.
+
+    `compile_context` swallows a native retrieval failure and recompiles
+    through `search_fn`. A test that let it would assert against a lane it was
+    not written for and pass while the real one was broken.
+    """
+
+    raise AssertionError("compile_context fell back to the non-native search path")
+
+
+async def _no_active_work(**_kwargs: object) -> list[Any]:
+    return []
+
+
+async def _no_raw_memories(**_kwargs: object) -> list[Any]:
+    """The raw-capture store is not wired up here; the graph lanes are."""
+
+    return []
+
+
+async def _pack(
+    runtime: _Runtime,
+    goal: str,
+    *,
+    include_related: bool = False,
+    active_work_fn: Any = _no_active_work,
+) -> ContextPack:
+    """Build a pack the way the MCP surface does."""
+
+    return await context_module.compile_context(
+        goal,
+        intent="build",
+        project=PROJECT_ID,
+        accessible_projects={PROJECT_ID},
+        principal_id=PRINCIPAL,
+        organization_id=runtime.group_id,
+        include_related=include_related,
+        related_limit=5,
+        search_fn=_no_fallback,
+        raw_memory_recall_fn=_no_raw_memories,
+        active_work_fn=active_work_fn,
+        record_exposure=False,
+    )
+
+
+def _pack_ids(pack: ContextPack) -> set[str]:
+    return {item.id for section in pack.sections for item in section.items}
+
+
+def _related_ids(pack: ContextPack) -> set[str]:
+    return {
+        related.id
+        for section in pack.sections
+        for item in section.items
+        for related in item.related or ()
+    }
 
 
 def _entity(runtime: _Runtime, uuid: str, name: str, content: str, **metadata: Any) -> Entity:
@@ -122,7 +198,7 @@ async def _search(runtime: _Runtime, query: str) -> Any:
         facet=ContextFacet.DECISIONS,
         limit=10,
         include_content=True,
-        raw_memory_recall_fn=lambda **_kwargs: [],
+        raw_memory_recall_fn=_no_raw_memories,
     )
 
 
@@ -254,7 +330,12 @@ async def test_deleting_the_edge_restores_the_row_to_recall(graph: _Runtime) -> 
 async def test_the_active_work_lane_cannot_smuggle_a_retired_task_into_a_pack(
     graph: _Runtime,
 ) -> None:
-    """This lane rebuilds item metadata from the entity, so it needs its own carry."""
+    """This lane rebuilds item metadata from the entity, so it needs its own carry.
+
+    Driven through `compile_context` with the production active-work lookup, so
+    the lookup query, the item builder and the admission filter are all the
+    ones a pack really runs.
+    """
 
     live = Entity(
         id="task-live",
@@ -287,39 +368,23 @@ async def test_the_active_work_lane_cannot_smuggle_a_retired_task_into_a_pack(
     await graph.entity_manager.create_direct(live)
     await graph.entity_manager.create_direct(retired)
 
-    # Load the rows back out of the graph so the item builder sees exactly what
-    # production hands it, then run the real builder and the real admission
-    # filter. The lookup query itself is not what this lane got wrong: the
-    # builder was rebuilding item metadata from scratch and dropping the
-    # lifecycle fields, so admission had nothing to read.
-    loaded = [
-        await graph.entity_manager.get("task-live"),
-        await graph.entity_manager.get("task-retired"),
-    ]
-    items = [context_module._item_from_active_entity(entity) for entity in loaded]
-    carried = {item.id: item.metadata for item in items}
-    assert carried["task-retired"].get("excluded_from_recall") is True
-    assert carried["task-retired"].get("lifecycle_state") == "contested"
-    assert "excluded_from_recall" not in carried["task-live"]
+    pack = await _pack(graph, "live task body", active_work_fn=None)
 
-    sections = context_module._drop_retired_items(
-        [
-            context_module.ContextSection(
-                facet=ContextFacet.ACTIVE_WORK,
-                title="Active work",
-                items=items,
-            )
-        ]
-    )
-    served = [item.id for section in sections for item in section.items]
-    assert served == ["task-live"]
+    served = _pack_ids(pack)
+    assert "task-live" in served, "the live task proves the lane ran at all"
+    assert "task-retired" not in served
 
 
 @pytest.mark.asyncio
 async def test_the_related_item_lane_does_not_attach_a_retired_neighbour(
     graph: _Runtime,
 ) -> None:
-    """Related items ride inside an admitted item, so admission never sees them."""
+    """Related items ride inside an admitted item, so admission never sees them.
+
+    Read through `compile_context`, which is what selects the batch lane. The
+    singular helper had the gate while the batch one did not, so a test that
+    called the helper directly reported a lane nothing in production reads.
+    """
 
     await graph.entity_manager.create_direct(
         _entity(graph, "seed-row", "Seed Row", "seed row hosting body")
@@ -349,15 +414,280 @@ async def test_the_related_item_lane_does_not_attach_a_retired_neighbour(
             )
         )
 
-    related = await context_module._default_related_items(
-        entity_id="seed-row",
-        organization_id=graph.group_id,
-        accessible_projects={PROJECT_ID},
-        principal_id=PRINCIPAL,
-        limit=5,
+    pack = await _pack(graph, "seed row hosting body", include_related=True)
+
+    assert "seed-row" in _pack_ids(pack)
+    attached = _related_ids(pack)
+    assert "neighbour-live" in attached, "the live neighbour proves the lane ran at all"
+    assert "neighbour-retired" not in attached
+
+
+def _passage_body(topic: str) -> str:
+    """A body long enough that the production cutter really slices it."""
+
+    return "\n\n".join(
+        f"## {topic} section {index}\n\n" + f"{topic} passage body line {index} " * 40
+        for index in range(4)
     )
 
-    assert [item.id for item in related] == ["neighbour-live"]
+
+async def _correct(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    raw_memory_id: str,
+    action: str = "mark_wrong",
+) -> Any:
+    """Run the production correction with only the raw-capture store stubbed.
+
+    The graph half is entirely live: target resolution, the lineage cascade and
+    the metadata stamp all run against real rows through the real managers,
+    which is where the passage hole was.
+    """
+
+    memory = RawMemory(
+        id=raw_memory_id,
+        organization_id=graph.group_id,
+        source_id=f"source-{raw_memory_id}",
+        principal_id=PRINCIPAL,
+        memory_scope=MemoryScope.PRIVATE,
+        scope_key=None,
+        review_state="pending",
+        entity_type="decision",
+        title="Deploy to Fly",
+        raw_content="We decided to deploy to fly.io.",
+        tags=["decision"],
+        metadata={},
+        provenance={},
+        capture_surface="reflection_candidate",
+    )
+    monkeypatch.setattr(memory_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(memory_module, "get_raw_memory_by_source_id", AsyncMock())
+    monkeypatch.setattr(
+        memory_module,
+        "save_raw_memory",
+        AsyncMock(side_effect=lambda updated, **_kwargs: updated),
+    )
+    return await memory_module.apply_memory_correction(
+        organization_id=graph.group_id,
+        source_id=memory.source_id,
+        principal_id=PRINCIPAL,
+        action=action,
+        accessible_projects=[PROJECT_ID],
+    )
+
+
+@pytest.mark.asyncio
+async def test_correcting_a_memory_takes_its_passages_out_of_the_pack(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A correction has to reach the spans cut from the corrected body.
+
+    A passage is an independently indexed copy of part of its parent, and it
+    inherits scope but neither provenance nor lifecycle. So the correction's
+    provenance query cannot see it, and a correction that stopped at the parent
+    retired the memory while its own words kept ranking.
+    """
+
+    parent = _entity(
+        graph,
+        "passage-parent",
+        "Deploy to Fly",
+        _passage_body("hetzner"),
+        raw_memory_id="raw-passage-parent",
+    )
+    await graph.entity_manager.create_direct(parent)
+    projection = await project_entity_passages(
+        entity_manager=graph.entity_manager,
+        relationship_manager=graph.relationship_manager,
+        source=parent,
+        group_id=graph.group_id,
+        generate_embeddings=False,
+    )
+    assert projection.passages >= 2, "the falsifier needs real spans to survive"
+    passage_ids = {entity.id for entity in projection.created_passages}
+
+    before = _pack_ids(await _pack(graph, "hetzner passage body"))
+    assert passage_ids & before, "the spans have to be recallable before the correction"
+
+    result = await _correct(graph, monkeypatch, raw_memory_id="raw-passage-parent")
+
+    assert result.applied
+    assert "passage-parent" in result.affected_entity_ids
+    assert passage_ids <= set(result.affected_entity_ids)
+
+    after = _pack_ids(await _pack(graph, "hetzner passage body"))
+    assert "passage-parent" not in after
+    assert not (passage_ids & after)
+
+
+@pytest.mark.asyncio
+async def test_a_retired_row_cannot_seed_the_graph_walk(
+    graph: _Runtime,
+) -> None:
+    """Dropping a retired row from the answer is not the same as not walking it.
+
+    The neighbour passes its own admission check, so a walk seeded from a
+    retired row still routes recall through a memory a writer has retired. The
+    live control row is what makes the exclusion mean something: without it a
+    walk that never ran would pass this test.
+    """
+
+    for prefix, extra in (("live", {}), ("dead", {"excluded_from_recall": True})):
+        await graph.entity_manager.create_direct(
+            _entity(
+                graph,
+                f"{prefix}-seed",
+                f"{prefix.title()} Seed",
+                f"{prefix} seed expansion hosting body",
+                lifecycle_state="contested" if extra else "active",
+                **extra,
+            )
+        )
+        await graph.entity_manager.create_direct(
+            _entity(
+                graph,
+                f"{prefix}-neighbour",
+                f"{prefix.title()} Neighbour",
+                f"{prefix} unrelated aardvark subject matter",
+            )
+        )
+        await graph.relationship_manager.create(
+            Relationship(
+                id=f"rel_{prefix}_seed_neighbour",
+                source_id=f"{prefix}-seed",
+                target_id=f"{prefix}-neighbour",
+                relationship_type=RelationshipType.RELATED_TO,
+                organization_id=graph.group_id,
+                metadata={},
+            )
+        )
+
+    served = _pack_ids(await _pack(graph, "seed expansion hosting body"))
+
+    assert "live-seed" in served
+    assert "live-neighbour" in served, "the walk has to run for the exclusion to mean anything"
+    assert "dead-seed" not in served
+    assert "dead-neighbour" not in served
+
+
+@pytest.mark.asyncio
+async def test_an_exact_key_hit_on_a_retired_row_cannot_seed_the_walk(
+    graph: _Runtime,
+) -> None:
+    """The exact-key lane picks its seed from the caller's own query text.
+
+    That makes it the lane where seeding off a retired row is most reachable: a
+    caller who knows the key gets the retired row's neighbourhood back without
+    the retired row ever being served.
+    """
+
+    # Every row's vocabulary is disjoint from every other row's, and from both
+    # probe keys. A shared word would let the lexical lane return the neighbour
+    # on its own, and the test would then pass while the seed gate did nothing.
+    rows = (
+        ("live", "quartz-9001", "Quartz Anchor", "Mirrored Neighbour", "mirrored cabinet", {}),
+        (
+            "dead",
+            "velvet-4242",
+            "Lantern Anchor",
+            "Harbour Neighbour",
+            "harbour ferry timetable",
+            {"excluded_from_recall": True},
+        ),
+    )
+    for prefix, key, anchor_name, neighbour_name, neighbour_body, extra in rows:
+        await graph.entity_manager.create_direct(
+            _entity(
+                graph,
+                f"{prefix}-keyed",
+                anchor_name,
+                f"{key} anchor row",
+                retrieval_keys=[key],
+                lifecycle_state="contested" if extra else "active",
+                **extra,
+            )
+        )
+        await graph.entity_manager.create_direct(
+            _entity(
+                graph,
+                f"{prefix}-keyed-neighbour",
+                neighbour_name,
+                neighbour_body,
+            )
+        )
+        await graph.relationship_manager.create(
+            Relationship(
+                id=f"rel_{prefix}_keyed_neighbour",
+                source_id=f"{prefix}-keyed",
+                target_id=f"{prefix}-keyed-neighbour",
+                relationship_type=RelationshipType.RELATED_TO,
+                organization_id=graph.group_id,
+                metadata={},
+            )
+        )
+
+    live_served = _pack_ids(await _pack(graph, "quartz-9001"))
+    assert "live-keyed" in live_served, "the probe has to fire for the exclusion to mean anything"
+    assert "live-keyed-neighbour" in live_served, "and the walk has to reach the neighbour"
+
+    dead_served = _pack_ids(await _pack(graph, "velvet-4242"))
+    assert "dead-keyed" not in dead_served
+    assert "dead-keyed-neighbour" not in dead_served
+
+
+@pytest.mark.asyncio
+async def test_a_real_supersession_cycle_resolves_the_same_way_in_either_order(
+    graph: _Runtime,
+) -> None:
+    """Which row survives a mutual supersession is a property of the edges.
+
+    Row order out of Surreal is not contractual, so a resolver that let the
+    last row win would retire one row on this run and the other on the next,
+    from data that never changed. Both edges are stamped at the same instant
+    here, which is the case where only the tie-breaker decides.
+    """
+
+    stamped = datetime(2026, 3, 1, tzinfo=UTC)
+    for row_id in ("tie-a", "tie-b"):
+        await graph.entity_manager.create_direct(
+            _entity(graph, row_id, row_id.title(), f"{row_id} tie hosting decision")
+        )
+    for survivor, retired in (("tie-a", "tie-b"), ("tie-b", "tie-a")):
+        await graph.relationship_manager.create(
+            Relationship(
+                id=f"rel_{survivor}_supersedes_{retired}",
+                source_id=survivor,
+                target_id=retired,
+                relationship_type=RelationshipType.SUPERSEDES,
+                organization_id=graph.group_id,
+                metadata={"native_write_path": "memory_correction"},
+                created_at=stamped,
+            )
+        )
+
+    rows = await search_module._execute_query_records(
+        graph.client,
+        """
+        SELECT uuid, target_id, source_id, created_at
+        FROM relates_to
+        WHERE name = 'SUPERSEDES'
+          AND target_id IN $uuids
+          AND group_id = $group_id
+        ORDER BY created_at, uuid;
+        """,
+        uuids=["tie-a", "tie-b"],
+        group_id=graph.group_id,
+    )
+    assert len(rows) == 2, "both directions of the cycle must be on the table"
+    forward = search_module._resolve_superseded(rows)
+    reverse = search_module._resolve_superseded(list(reversed(rows)))
+    assert forward == reverse
+    assert len(forward) == 1
+
+    served = _pack_ids(await _pack(graph, "tie hosting decision"))
+    assert served & {"tie-a", "tie-b"} == {"tie-a", "tie-b"} - forward
 
 
 def test_a_write_payload_cannot_supply_capture_provenance() -> None:

--- a/packages/python/sibyl-core/tests/test_supersession_live_graph.py
+++ b/packages/python/sibyl-core/tests/test_supersession_live_graph.py
@@ -523,6 +523,53 @@ async def test_correcting_a_memory_takes_its_passages_out_of_the_pack(
 
 
 @pytest.mark.asyncio
+async def test_spans_cut_after_the_correction_are_born_retired(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The window between writing a memory and cutting it into spans.
+
+    Projection is two writes, not one. A correction that lands between them
+    stamps the parent and finds no spans to cascade to, and the projection then
+    cuts spans from the caller's copy of the parent, which predates the
+    verdict. Reading the parent back at cut time is what closes it.
+    """
+
+    parent = _entity(
+        graph,
+        "raced-parent",
+        "Deploy to Fly",
+        _passage_body("interleaved"),
+        raw_memory_id="raw-raced-parent",
+    )
+    await graph.entity_manager.create_direct(parent)
+
+    result = await _correct(graph, monkeypatch, raw_memory_id="raw-raced-parent")
+    assert result.applied
+    assert result.affected_entity_ids == ["raced-parent"], (
+        "no spans exist yet, so the cascade has nothing to reach"
+    )
+
+    # The caller's copy is the pre-correction one, exactly as the worker holds
+    # it: the correction happened in another process and never touched it.
+    projection = await project_entity_passages(
+        entity_manager=graph.entity_manager,
+        relationship_manager=graph.relationship_manager,
+        source=parent,
+        group_id=graph.group_id,
+        generate_embeddings=False,
+    )
+    assert projection.passages >= 2, "the spans have to exist for the test to mean anything"
+    for span in projection.created_passages:
+        assert span.metadata.get("excluded_from_recall") is True
+        assert span.metadata.get("lifecycle_state") == "contested"
+
+    served = _pack_ids(await _pack(graph, "interleaved passage body"))
+    assert "raced-parent" not in served
+    assert not (served & {span.id for span in projection.created_passages})
+
+
+@pytest.mark.asyncio
 async def test_a_retired_row_cannot_seed_the_graph_walk(
     graph: _Runtime,
 ) -> None:

--- a/packages/python/sibyl-core/tests/test_supersession_live_graph.py
+++ b/packages/python/sibyl-core/tests/test_supersession_live_graph.py
@@ -1,0 +1,385 @@
+"""Supersession enforcement exercised against a real embedded SurrealDB graph.
+
+The unit suite in `test_supersession_enforcement.py` stubs the Surreal query,
+which proves the Python branches but not the SQL, the edge direction as
+actually persisted, or the admission lanes that rebuild item metadata from an
+entity rather than from a search result. These tests write real rows and real
+`relates_to` edges through the production managers and then read them back
+through `context_search` and `compile_context`.
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_module
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+import sibyl_core.retrieval.search as search_module
+import sibyl_core.tools.context as context_module
+from sibyl_core.auth.memory_policy import stamp_memory_scope_metadata
+from sibyl_core.models.context import ContextFacet
+from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.retrieval.search import build_context_retrieval_plan
+from sibyl_core.services.graph import (
+    EntityManager,
+    RelationshipManager,
+    SurrealGraphClient,
+    prepare_graph_schema,
+)
+
+PROJECT_ID = "proj-supersession"
+PRINCIPAL = "user-supersession"
+
+
+class _Runtime:
+    def __init__(self, client: Any, entities: Any, relationships: Any, group_id: str) -> None:
+        self.client = client
+        self.entity_manager = entities
+        self.relationship_manager = relationships
+        self.group_id = group_id
+
+
+@pytest_asyncio.fixture
+async def graph(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[_Runtime]:
+    # Each test gets its own namespace. The embedded store is process-wide, so
+    # a shared group id leaks rows and edges between tests and turns a
+    # supersession assertion into a function of test ordering.
+    group_id = f"supersession-live-{uuid_module.uuid4().hex[:12]}"
+    client = SurrealGraphClient(group_id=group_id, url="memory://")
+    await client.connect()
+    await prepare_graph_schema(client)
+    runtime = _Runtime(
+        client,
+        EntityManager(client, group_id=group_id),
+        RelationshipManager(client, group_id=group_id),
+        group_id,
+    )
+
+    async def runtime_factory(requested_group_id: str, **_kwargs: object) -> _Runtime:
+        assert str(requested_group_id) == group_id
+        return runtime
+
+    monkeypatch.setattr(search_module, "get_surreal_graph_runtime", runtime_factory)
+    monkeypatch.setattr(context_module, "get_surreal_graph_runtime", runtime_factory)
+    monkeypatch.setattr(context_module, "get_graph_runtime", runtime_factory, raising=False)
+    yield runtime
+    await client.close()
+
+
+def _entity(runtime: _Runtime, uuid: str, name: str, content: str, **metadata: Any) -> Entity:
+    return Entity(
+        id=uuid,
+        name=name,
+        entity_type=EntityType.DECISION,
+        description=content,
+        content=content,
+        organization_id=runtime.group_id,
+        metadata={
+            "memory_scope": "project",
+            "scope_key": PROJECT_ID,
+            "project_id": PROJECT_ID,
+            **metadata,
+        },
+        project_id=PROJECT_ID,
+    )
+
+
+async def _supersede(runtime: _Runtime, *, survivor: str, retired: str) -> None:
+    """Write the edge in the direction the production write path uses."""
+
+    await runtime.relationship_manager.create(
+        Relationship(
+            id=f"rel_{survivor}_supersedes_{retired}",
+            source_id=survivor,
+            target_id=retired,
+            relationship_type=RelationshipType.SUPERSEDES,
+            organization_id=runtime.group_id,
+            metadata={"native_write_path": "memory_correction"},
+        )
+    )
+
+
+def _plan(runtime: _Runtime, query: str) -> Any:
+    return build_context_retrieval_plan(
+        query=query,
+        organization_id=runtime.group_id,
+        facets=[ContextFacet.DECISIONS],
+        facet_types={ContextFacet.DECISIONS: ["decision"]},
+        principal_id=PRINCIPAL,
+        project=PROJECT_ID,
+        accessible_projects={PROJECT_ID},
+        limit=12,
+    )
+
+
+async def _search(runtime: _Runtime, query: str) -> Any:
+    return await search_module.context_search(
+        plan=_plan(runtime, query),
+        types=["decision"],
+        facet=ContextFacet.DECISIONS,
+        limit=10,
+        include_content=True,
+        raw_memory_recall_fn=lambda **_kwargs: [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_real_supersedes_edge_retires_its_target_and_serves_the_successor(
+    graph: _Runtime,
+) -> None:
+    """End to end through real SQL: the retired row leaves, the survivor stays."""
+
+    await graph.entity_manager.create_direct(
+        _entity(graph, "live-old", "Deploy to Fly", "we deploy to fly for hosting")
+    )
+    await graph.entity_manager.create_direct(
+        _entity(graph, "live-new", "Deploy to Hetzner", "we deploy to hetzner for hosting")
+    )
+    await _supersede(graph, survivor="live-new", retired="live-old")
+
+    response = await _search(graph, "deploy hosting")
+
+    served = [result.id for result in response.results]
+    assert "live-new" in served
+    assert "live-old" not in served
+    assert response.filters["supersession_gate"]["superseded_uuids"] == ["live-old"]
+
+
+@pytest.mark.asyncio
+async def test_a_real_supersession_cycle_does_not_black_out_both_rows(
+    graph: _Runtime,
+) -> None:
+    """Mutual supersession leaves the newest statement standing, not nothing."""
+
+    await graph.entity_manager.create_direct(
+        _entity(graph, "cycle-a", "Cycle A", "cycle hosting decision alpha")
+    )
+    await graph.entity_manager.create_direct(
+        _entity(graph, "cycle-b", "Cycle B", "cycle hosting decision beta")
+    )
+    await _supersede(graph, survivor="cycle-a", retired="cycle-b")
+    await _supersede(graph, survivor="cycle-b", retired="cycle-a")
+
+    response = await _search(graph, "cycle hosting decision")
+
+    served = {result.id for result in response.results}
+    assert served, "a supersession cycle must not black out every row"
+    assert len(served & {"cycle-a", "cycle-b"}) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_real_self_supersession_retires_nothing(graph: _Runtime) -> None:
+    """A row that supersedes itself must stay servable."""
+
+    await graph.entity_manager.create_direct(
+        _entity(graph, "selfie", "Self Superseding", "self superseding hosting note")
+    )
+    await _supersede(graph, survivor="selfie", retired="selfie")
+
+    response = await _search(graph, "self superseding hosting")
+
+    assert "selfie" in {result.id for result in response.results}
+
+
+@pytest.mark.asyncio
+async def test_the_outgoing_walk_does_not_expand_into_a_real_retired_row(
+    graph: _Runtime,
+) -> None:
+    """Traversal exclusion, proven against the real relates_to table."""
+
+    await graph.entity_manager.create_direct(
+        _entity(graph, "walk-new", "Walk Survivor", "walk survivor hosting body")
+    )
+    await graph.entity_manager.create_direct(
+        _entity(graph, "walk-old", "Walk Retired", "walk retired hosting body")
+    )
+    await _supersede(graph, survivor="walk-new", retired="walk-old")
+
+    hops = await search_module._node_bfs_records(
+        client=graph.client,
+        origin_uuids=["walk-new"],
+        search_filter=search_module.SearchFilter(node_types=("decision",)),
+        group_id=graph.group_id,
+        max_depth=1,
+        limit=10,
+    )
+    assert [row.get("uuid") for row in hops] == []
+
+    # Naming the predicate is the documented carve-out for lineage walks.
+    lineage = await search_module._node_bfs_records(
+        client=graph.client,
+        origin_uuids=["walk-new"],
+        search_filter=search_module.SearchFilter(node_types=("decision",)),
+        group_id=graph.group_id,
+        max_depth=1,
+        limit=10,
+        relationship_names=["SUPERSEDES"],
+    )
+    assert [row.get("uuid") for row in lineage] == ["walk-old"]
+
+
+@pytest.mark.asyncio
+async def test_deleting_the_edge_restores_the_row_to_recall(graph: _Runtime) -> None:
+    """The supersede/restore round trip, which is what makes correction reversible."""
+
+    await graph.entity_manager.create_direct(
+        _entity(graph, "round-old", "Round Retired", "round trip hosting body")
+    )
+    await graph.entity_manager.create_direct(
+        _entity(graph, "round-new", "Round Survivor", "round trip hosting successor")
+    )
+    await _supersede(graph, survivor="round-new", retired="round-old")
+
+    assert "round-old" not in {r.id for r in (await _search(graph, "round trip hosting")).results}
+
+    await graph.client.execute_query(
+        """
+        DELETE FROM relates_to
+        WHERE group_id = $group_id
+          AND name = 'SUPERSEDES'
+          AND target_id IN $target_ids
+          AND attributes.native_write_path = 'memory_correction';
+        """,
+        group_id=graph.group_id,
+        target_ids=["round-old"],
+    )
+
+    assert "round-old" in {r.id for r in (await _search(graph, "round trip hosting")).results}
+
+
+@pytest.mark.asyncio
+async def test_the_active_work_lane_cannot_smuggle_a_retired_task_into_a_pack(
+    graph: _Runtime,
+) -> None:
+    """This lane rebuilds item metadata from the entity, so it needs its own carry."""
+
+    live = Entity(
+        id="task-live",
+        name="Live Task",
+        entity_type=EntityType.TASK,
+        description="live task body",
+        content="live task body",
+        organization_id=graph.group_id,
+        status="doing",
+        project_id=PROJECT_ID,
+        metadata={"memory_scope": "project", "scope_key": PROJECT_ID, "project_id": PROJECT_ID},
+    )
+    retired = Entity(
+        id="task-retired",
+        name="Retired Task",
+        entity_type=EntityType.TASK,
+        description="retired task body",
+        content="retired task body",
+        organization_id=graph.group_id,
+        status="doing",
+        project_id=PROJECT_ID,
+        metadata={
+            "memory_scope": "project",
+            "scope_key": PROJECT_ID,
+            "project_id": PROJECT_ID,
+            "lifecycle_state": "contested",
+            "excluded_from_recall": True,
+        },
+    )
+    await graph.entity_manager.create_direct(live)
+    await graph.entity_manager.create_direct(retired)
+
+    # Load the rows back out of the graph so the item builder sees exactly what
+    # production hands it, then run the real builder and the real admission
+    # filter. The lookup query itself is not what this lane got wrong: the
+    # builder was rebuilding item metadata from scratch and dropping the
+    # lifecycle fields, so admission had nothing to read.
+    loaded = [
+        await graph.entity_manager.get("task-live"),
+        await graph.entity_manager.get("task-retired"),
+    ]
+    items = [context_module._item_from_active_entity(entity) for entity in loaded]
+    carried = {item.id: item.metadata for item in items}
+    assert carried["task-retired"].get("excluded_from_recall") is True
+    assert carried["task-retired"].get("lifecycle_state") == "contested"
+    assert "excluded_from_recall" not in carried["task-live"]
+
+    sections = context_module._drop_retired_items(
+        [
+            context_module.ContextSection(
+                facet=ContextFacet.ACTIVE_WORK,
+                title="Active work",
+                items=items,
+            )
+        ]
+    )
+    served = [item.id for section in sections for item in section.items]
+    assert served == ["task-live"]
+
+
+@pytest.mark.asyncio
+async def test_the_related_item_lane_does_not_attach_a_retired_neighbour(
+    graph: _Runtime,
+) -> None:
+    """Related items ride inside an admitted item, so admission never sees them."""
+
+    await graph.entity_manager.create_direct(
+        _entity(graph, "seed-row", "Seed Row", "seed row hosting body")
+    )
+    await graph.entity_manager.create_direct(
+        _entity(graph, "neighbour-live", "Live Neighbour", "live neighbour body")
+    )
+    await graph.entity_manager.create_direct(
+        _entity(
+            graph,
+            "neighbour-retired",
+            "Retired Neighbour",
+            "retired neighbour body",
+            lifecycle_state="contested",
+            excluded_from_recall=True,
+        )
+    )
+    for target in ("neighbour-live", "neighbour-retired"):
+        await graph.relationship_manager.create(
+            Relationship(
+                id=f"rel_seed_{target}",
+                source_id="seed-row",
+                target_id=target,
+                relationship_type=RelationshipType.RELATED_TO,
+                organization_id=graph.group_id,
+                metadata={},
+            )
+        )
+
+    related = await context_module._default_related_items(
+        entity_id="seed-row",
+        organization_id=graph.group_id,
+        accessible_projects={PROJECT_ID},
+        principal_id=PRINCIPAL,
+        limit=5,
+    )
+
+    assert [item.id for item in related] == ["neighbour-live"]
+
+
+def test_a_write_payload_cannot_supply_capture_provenance() -> None:
+    """Provenance is what the correction write-through resolves its targets by.
+
+    Leaving it caller-settable is what let a planted `raw_memory_id` nominate
+    somebody else's row to be retired by a correction on an unrelated capture.
+    """
+
+    stamped = stamp_memory_scope_metadata(
+        {
+            "raw_memory_id": "victim-capture",
+            "raw_source_id": "victim-source",
+            "principal_id": "somebody-else",
+            "note": "kept",
+        },
+        memory_scope="project",
+        scope_key=PROJECT_ID,
+        principal_id=PRINCIPAL,
+    )
+
+    assert "raw_memory_id" not in stamped
+    assert "raw_source_id" not in stamped
+    assert stamped["principal_id"] == PRINCIPAL
+    assert stamped["note"] == "kept"

--- a/packages/python/sibyl-core/tests/test_supersession_live_graph.py
+++ b/packages/python/sibyl-core/tests/test_supersession_live_graph.py
@@ -673,6 +673,61 @@ async def test_rows_projected_after_the_correction_are_born_retired(
 
 
 @pytest.mark.asyncio
+async def test_a_row_written_through_add_is_reachable_by_a_correction(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The write path and the correction path have to agree on one key.
+
+    Correction resolves its targets by querying `attributes.raw_memory_id`,
+    and the graph writer strips that key from caller metadata because a caller
+    that could set it could nominate somebody else's row. The capture pipeline
+    stamps it and then calls that writer, so for a while every row written
+    this way named no capture and no correction could find it. This walks the
+    real writer, so a row that reaches the graph unnamed fails here.
+    """
+
+    import sibyl_core.tools.add as add_module
+
+    async def runtime_factory(_group_id: str, **_kwargs: object) -> _Runtime:
+        return graph
+
+    monkeypatch.setattr(add_module, "get_graph_runtime", runtime_factory)
+
+    response = await add_module.add(
+        title="Deploy to Fly",
+        content="we deploy to fly for hosting and it is written through the real writer",
+        entity_type="decision",
+        project=PROJECT_ID,
+        memory_scope="project",
+        scope_key=PROJECT_ID,
+        principal_id=PRINCIPAL,
+        check_conflicts=False,
+        sync=True,
+        generate_embeddings=False,
+        metadata={"organization_id": graph.group_id},
+        capture_provenance={"raw_memory_id": "raw-through-add"},
+    )
+    assert response.success and response.id
+
+    stored = await graph.entity_manager.get(response.id)
+    assert stored is not None
+    assert stored.metadata.get("raw_memory_id") == "raw-through-add", (
+        "the row has to name its capture or no correction can ever reach it"
+    )
+
+    before = _pack_ids(await _pack(graph, "deploy fly hosting written real writer"))
+    assert response.id in before
+
+    result = await _correct(graph, monkeypatch, raw_memory_id="raw-through-add")
+    assert result.applied
+    assert result.affected_entity_ids == [response.id]
+
+    after = _pack_ids(await _pack(graph, "deploy fly hosting written real writer"))
+    assert response.id not in after
+
+
+@pytest.mark.asyncio
 async def test_a_retired_row_cannot_seed_the_graph_walk(
     graph: _Runtime,
 ) -> None:

--- a/packages/python/sibyl-core/tests/test_supersession_live_graph.py
+++ b/packages/python/sibyl-core/tests/test_supersession_live_graph.py
@@ -31,6 +31,7 @@ import sibyl_core.tools.context as context_module
 from sibyl_core.auth.memory_policy import stamp_memory_scope_metadata
 from sibyl_core.models.context import ContextFacet, ContextPack
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.projection.memory import project_memory_entity
 from sibyl_core.projection.passages import project_entity_passages
 from sibyl_core.retrieval.search import build_context_retrieval_plan
 from sibyl_core.services.graph import (
@@ -567,6 +568,108 @@ async def test_spans_cut_after_the_correction_are_born_retired(
     served = _pack_ids(await _pack(graph, "interleaved passage body"))
     assert "raced-parent" not in served
     assert not (served & {span.id for span in projection.created_passages})
+
+
+_PROJECTION_BODY = (
+    "We migrated the Hetzner cluster to Talos Linux on 2026-03-01. "
+    "Bliss prefers Ratatui for terminal dashboards. "
+    "The Grafana dashboard now reads from Prometheus."
+)
+
+
+def _projection_parent(runtime: _Runtime, entity_id: str, raw_memory_id: str) -> Entity:
+    return Entity(
+        id=entity_id,
+        name="Migration session",
+        entity_type=EntityType.EPISODE,
+        description=_PROJECTION_BODY,
+        content=_PROJECTION_BODY,
+        organization_id=runtime.group_id,
+        project_id=PROJECT_ID,
+        metadata={
+            "memory_scope": "project",
+            "scope_key": PROJECT_ID,
+            "project_id": PROJECT_ID,
+            "raw_memory_id": raw_memory_id,
+        },
+    )
+
+
+async def _project(runtime: _Runtime, parent: Entity) -> tuple[str, ...]:
+    result = await project_memory_entity(
+        entity_manager=runtime.entity_manager,
+        relationship_manager=runtime.relationship_manager,
+        source=parent,
+        group_id=runtime.group_id,
+        generate_embeddings=False,
+    )
+    rows = (
+        *getattr(result, "created_projected_entities", ()),
+        *getattr(result, "created_projected_facts", ()),
+    )
+    return tuple(str(row.id) for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_correcting_a_memory_retires_the_entities_and_facts_projected_from_it(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spans are not the only rows carrying a memory's text.
+
+    A projected entity copies the parent's candidate context and a projected
+    fact copies its span, and both inherit scope but not provenance, so the
+    correction's own query cannot see either. The cascade follows lineage
+    rather than type for exactly this reason.
+    """
+
+    parent = _projection_parent(graph, "projection-parent", "raw-projection-parent")
+    await graph.entity_manager.create_direct(parent)
+    projected = await _project(graph, parent)
+    assert projected, "the projection has to produce rows for this to mean anything"
+
+    before = _pack_ids(await _pack(graph, "Grafana dashboard reads from Prometheus"))
+    assert before & set(projected), "the projected rows have to be recallable first"
+
+    result = await _correct(graph, monkeypatch, raw_memory_id="raw-projection-parent")
+    assert result.applied
+    assert set(projected) <= set(result.affected_entity_ids)
+
+    for row_id in projected:
+        stored = await graph.entity_manager.get(row_id)
+        assert stored is not None
+        assert stored.metadata.get("excluded_from_recall") is True
+
+    after = _pack_ids(await _pack(graph, "Grafana dashboard reads from Prometheus"))
+    assert not (after & set(projected))
+
+
+@pytest.mark.asyncio
+async def test_rows_projected_after_the_correction_are_born_retired(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same window the spans have, for the rows the other projection mints."""
+
+    parent = _projection_parent(graph, "late-projection-parent", "raw-late-projection")
+    await graph.entity_manager.create_direct(parent)
+
+    result = await _correct(graph, monkeypatch, raw_memory_id="raw-late-projection")
+    assert result.affected_entity_ids == ["late-projection-parent"], (
+        "nothing is projected yet, so the cascade has nothing to reach"
+    )
+
+    # The caller's copy predates the verdict, exactly as the worker's does.
+    projected = await _project(graph, parent)
+    assert projected
+
+    for row_id in projected:
+        stored = await graph.entity_manager.get(row_id)
+        assert stored is not None
+        assert stored.metadata.get("excluded_from_recall") is True
+
+    served = _pack_ids(await _pack(graph, "Grafana dashboard reads from Prometheus"))
+    assert not (served & set(projected))
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/tests/test_supersession_live_graph.py
+++ b/packages/python/sibyl-core/tests/test_supersession_live_graph.py
@@ -383,3 +383,50 @@ def test_a_write_payload_cannot_supply_capture_provenance() -> None:
     assert "raw_source_id" not in stamped
     assert stamped["principal_id"] == PRINCIPAL
     assert stamped["note"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_capture_overwrites_planted_provenance_with_the_real_write() -> None:
+    """The strip must neutralize planting without breaking the writer that needs it.
+
+    Provenance is what the correction write-through resolves its targets by,
+    so it has to be unforgeable, and it also has to still be there or the
+    write-through finds nothing. Capture stamps both keys from the completed
+    raw write after the strip runs, which satisfies both at once.
+    """
+
+    from sibyl_core.memory_pipeline.capture import MemoryCaptureRequest, MemoryCaptureService
+    from sibyl_core.models.memory_scope import MemoryScope
+
+    seen: dict[str, Any] = {}
+
+    async def raw_writer(_request: Any) -> dict[str, Any]:
+        return {"id": "raw-real", "source_id": "source-real"}
+
+    async def graph_writer(_request: Any, graph_metadata: Any) -> dict[str, Any]:
+        seen.update(graph_metadata)
+        return {"id": "entity-1"}
+
+    service = MemoryCaptureService(
+        remember_raw_memory=raw_writer,
+        create_graph_entity=graph_writer,
+    )
+    await service.capture(
+        MemoryCaptureRequest(
+            content="capture provenance body",
+            title="Capture provenance",
+            entity_type="note",
+            memory_scope=MemoryScope.PRIVATE,
+            scope_key=None,
+            principal_id=PRINCIPAL,
+            metadata={
+                "raw_memory_id": "planted-victim-capture",
+                "raw_source_id": "planted-victim-source",
+                "unrelated": "kept",
+            },
+        )
+    )
+
+    assert seen["raw_memory_id"] == "raw-real"
+    assert seen["raw_source_id"] == "source-real"
+    assert seen["unrelated"] == "kept"

--- a/packages/python/sibyl-core/tests/test_supersession_live_graph.py
+++ b/packages/python/sibyl-core/tests/test_supersession_live_graph.py
@@ -965,3 +965,161 @@ async def test_capture_overwrites_planted_provenance_with_the_real_write() -> No
     assert seen["raw_memory_id"] == "raw-real"
     assert seen["raw_source_id"] == "source-real"
     assert seen["unrelated"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_reconcile_cannot_overwrite_a_newer_correction(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The post-write pass is itself a read-modify-write, so it needs a fence.
+
+    The schedule that breaks an unfenced pass: a correction retires the memory
+    while the row is being written, the pass reads that verdict, and a restore
+    lands before the pass gets to write. Last writer wins by default, so the
+    pass would put the retirement back on a row somebody had just restored.
+
+    The restore is injected between the pass's read and its write, which is the
+    only interval where it can do that.
+    """
+
+    from sibyl_core.projection.reconcile import reconcile_with_capture
+
+    retired = {
+        "lifecycle_state": "contested",
+        "excluded_from_recall": True,
+    }
+    restored = {
+        "lifecycle_state": "active",
+        "excluded_from_recall": False,
+    }
+
+    row = _entity(graph, "fenced-row", "Deploy to Fly", "fenced hosting body")
+    await graph.entity_manager.create_direct(row)
+
+    capture_verdict: dict[str, Any] = dict(retired)
+    reads: list[str] = []
+
+    async def verdict_then_restore(**_kwargs: object) -> dict[str, Any]:
+        answer = dict(capture_verdict)
+        reads.append(str(answer.get("lifecycle_state")))
+        if answer.get("lifecycle_state") == "contested":
+            # The restore lands between this pass's read and its write, and it
+            # updates the capture and the row the way a real restore does.
+            stored = await graph.entity_manager.get("fenced-row")
+            await graph.entity_manager.update(
+                "fenced-row",
+                {"metadata": restored},
+                expected_revision=stored.revision,
+            )
+            capture_verdict.clear()
+            capture_verdict.update(restored)
+        return answer
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory.projected_row_lifecycle_stamp",
+        verdict_then_restore,
+    )
+
+    await reconcile_with_capture(
+        graph.entity_manager,
+        organization_id=graph.group_id,
+        metadata={"raw_memory_id": "raw-fenced"},
+        row_ids=["fenced-row"],
+    )
+
+    assert len(reads) > 1, "the refused write has to send the pass back for a fresh verdict"
+
+    settled = await graph.entity_manager.get("fenced-row")
+    assert settled.metadata.get("lifecycle_state") == "active", (
+        "the newer correction has to survive a pass that started before it"
+    )
+    assert settled.metadata.get("excluded_from_recall") is False
+
+    served = _pack_ids(await _pack(graph, "fenced hosting body"))
+    assert "fenced-row" in served
+
+
+@pytest.mark.asyncio
+async def test_a_readable_verdict_clears_the_pending_marker(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The marker says nobody could check, so a check has to take it off.
+
+    A marker that outlived the outage would keep a healthy row excluded
+    forever, which turns a transient store blip into permanent data loss from
+    the reader's point of view. It is asserted gone from the row rather than
+    merely falsy, because the graph patch expresses removal as an explicit
+    None and a key that merely reads falsy is still there for anything
+    querying on presence.
+    """
+
+    from sibyl_core.projection.reconcile import RECONCILE_PENDING_KEY, reconcile_with_capture
+
+    row = _entity(
+        graph,
+        "pending-row",
+        "Deploy to Fly",
+        "pending marker hosting body",
+    )
+    await graph.entity_manager.create_direct(row)
+    await graph.entity_manager.update(
+        "pending-row",
+        {"metadata": {"excluded_from_recall": True, RECONCILE_PENDING_KEY: True}},
+    )
+    marked = await graph.entity_manager.get("pending-row")
+    assert marked.metadata.get(RECONCILE_PENDING_KEY) is True
+    assert "pending-row" not in _pack_ids(await _pack(graph, "pending marker hosting body"))
+
+    async def healthy_verdict(**_kwargs: object) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory.projected_row_lifecycle_stamp",
+        healthy_verdict,
+    )
+
+    outcome = await reconcile_with_capture(
+        graph.entity_manager,
+        organization_id=graph.group_id,
+        metadata={"raw_memory_id": "raw-pending"},
+        row_ids=["pending-row"],
+    )
+
+    assert outcome.changed
+    settled = await graph.entity_manager.get("pending-row")
+    assert RECONCILE_PENDING_KEY not in settled.metadata, "the marker has to be gone, not falsy"
+    assert settled.metadata.get("excluded_from_recall") is False
+    assert "pending-row" in _pack_ids(await _pack(graph, "pending marker hosting body"))
+
+
+@pytest.mark.asyncio
+async def test_a_correction_clears_the_pending_marker_it_finds(
+    graph: _Runtime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A correction is somebody reading the verdict, so it answers the marker."""
+
+    from sibyl_core.projection.reconcile import RECONCILE_PENDING_KEY
+
+    row = _entity(
+        graph,
+        "marked-parent",
+        "Deploy to Fly",
+        "marked parent hosting body",
+        raw_memory_id="raw-marked-parent",
+    )
+    await graph.entity_manager.create_direct(row)
+    await graph.entity_manager.update(
+        "marked-parent",
+        {"metadata": {RECONCILE_PENDING_KEY: True}},
+    )
+
+    result = await _correct(graph, monkeypatch, raw_memory_id="raw-marked-parent")
+    assert result.applied
+    assert "marked-parent" in result.affected_entity_ids
+
+    settled = await graph.entity_manager.get("marked-parent")
+    assert RECONCILE_PENDING_KEY not in settled.metadata
+    assert settled.metadata.get("excluded_from_recall") is True

--- a/packages/python/sibyl-core/tests/test_tools.py
+++ b/packages/python/sibyl-core/tests/test_tools.py
@@ -93,11 +93,22 @@ def make_graph_runtime(
     entity_manager: Any | None = None,
     relationship_manager: Any | None = None,
 ) -> SimpleNamespace:
-    """Build a lightweight graph runtime for tool tests."""
+    """Build a lightweight graph runtime for tool tests.
+
+    Any manager passed in gets an async `get` unless the test defined one.
+    Projection reads a parent's stored lifecycle before deriving rows from it,
+    and that read fails closed rather than falling back to the caller's copy,
+    so a double whose `get` returns a non-awaitable now fails the write it is
+    standing in for. Real managers are async here; the doubles have to be too.
+    """
+
+    resolved_entity_manager = entity_manager if entity_manager is not None else MagicMock()
+    if not isinstance(getattr(resolved_entity_manager, "get", None), AsyncMock):
+        resolved_entity_manager.get = AsyncMock(return_value=None)
 
     return SimpleNamespace(
         client=client if client is not None else MagicMock(),
-        entity_manager=entity_manager if entity_manager is not None else MagicMock(),
+        entity_manager=resolved_entity_manager,
         relationship_manager=(
             relationship_manager if relationship_manager is not None else MagicMock()
         ),


### PR DESCRIPTION
# 🎯 Supersession and correction stop being declarations

> Sibyl 1.3 Phase 1, first item of §1 in `docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md`. Read side only: this PR owns enforcement at traversal, at pack admission, and at the correction write path. The typed-predicate write surface is a separate lane and the representation it writes to is unchanged here.
>
> **Scope, stated up front:** enforcement lands on `context_search` and the context pack. The second retrieval pipeline behind `/search` is untouched and still boosts retired rows, on `main` and on this branch alike, so this is not "supersession enforced" everywhere until that gate lands. See the follow-ups for the full surface list and why it is deferred rather than a regression.

## 💡 What this is

Sibyl could already say "B replaced A" and "this memory is wrong". Neither statement did anything, and supersession did something worse than nothing: the `SUPERSEDES` edge is stored source-is-survivor to target-is-retired, the expansion walk followed it outwards onto the retired row, and the weight table then scored that row at 0.95, fifth-highest of twenty-one predicates. Declaring a memory replaced was a reliable way to raise it.

The naive reading of this bug is that 0.95 is too high a weight. It isn't. The weight is correct for the direction a reader wants, which is retired-row to survivor, and lowering it would flatten a real signal to work around a direction error. The fix is directional: the walk stops carrying the retired endpoint back, and the weight stays where it is.

`sibyl correct` had the mirror problem. It mutated `raw_captures` and stopped there, so the projected `entity` row kept its capture-time metadata, kept its embedding, and kept being expanded into. A correction verb whose blast radius ends at the substrate retrieval mostly does not read is a correction verb that does not correct anything.

## 🤔 Why we need it and what it replaces

Proactive interference degrades retrieval log-linearly as stale associations accumulate, which makes this the loudest open gap in the field and our worst instance of it. Three separate mechanisms were carrying the failure, and all three are closed here.

The old world enforced lifecycle in exactly one place, the raw recall lane (`raw_memory_recallable`), with synthesis re-filtering at render time from metadata the graph row does not carry. Every graph candidate, from every lane, bypassed both. `excluded_from_recall` existed only as a key in the correction preview's impact report, a statement about exclusion rather than an act of it.

What this deliberately does not do: it invents no new schema field, no new lifecycle column on `entity`, and no query classifier that guesses whether a search "wants history". The markers live in the existing `attributes` bag under key names the codebase already used on the raw side, and the history carve-out is structural rather than heuristic (see the invariant below). No analyzer, index definition, fusion mode, or write-surface parameter is touched.

## 🎯 The invariant

Anchor the review on one property: **a retired row can only be reached by a caller that named `SUPERSEDES` explicitly.**

That single rule is what gives the carve-out for history and provenance without inventing a surface for it. `tools/traverse.py` passes caller-chosen `relationship_names` straight through, so a lineage walk that names the predicate still reaches the retired row. Scored retrieval passes none, so it never does. The existing history surfaces (`temporal_query(mode=history|timeline|conflicts)` and the `/search` conflicts mode) are separate code paths that never call `context_search`, so they are unaffected by construction rather than by exemption.

## 🛠️ How it works

### 1. The traversal walk stops promoting its own victim

`_relation_target_hops` (`retrieval/search.py`) gained an `exclude_relationship_names` parameter, and `_node_bfs_records` passes `("SUPERSEDES",)` unless the caller named the predicate. Direction was traced through the whole persistence chain rather than assumed, because an inverted fix here would retire the survivor and serve the stale row with the gate's blessing:

1. `_relationships_for_promotion` (`services/memory.py`) builds `_relationship(entity_id, superseded_id, RelationshipType.SUPERSEDES)`, so the dataclass carries source-is-new, target-is-replaced.
2. `_relationship_record` (`services/graph.py:3326`) maps `source_id` and `target_id` straight through with no swap.
3. Both write paths bind the same way: `_replace_relationship` (`services/graph.py:3172`) resolves `src` from `source_id` and issues `RELATE $src->$rel->$tgt` with `in = $src, out = $tgt`, and the bulk path sets `payload["in"] = src` at `services/graph.py:3298`.

So the persisted row has `source_id` and `in` on the survivor, `target_id` and `out` on the retired row. An outgoing walk lands on the retired one every time, and the gate's inbound lookup on `target_id` identifies exactly the retired endpoint.

```mermaid
flowchart LR
    subgraph before ["before"]
        S1["survivor<br/>(seed)"] -->|"SUPERSEDES · 0.95"| R1["retired row<br/>ranked into the pack"]
    end
    subgraph after ["after"]
        S2["survivor<br/>(seed)"] -.->|"excluded from the walk"| R2["retired row"]
        R2 -->|"inbound edge · retires the target"| G["supersession gate"]
    end
```

### 2. A gate over the surviving candidate set

Exclusion at the walk is not enough, because a lane that never touched the graph can propose the retired row directly. `_apply_supersession_gate` (`retrieval/search.py`) runs twice inside `context_search`, once over the directly retrieved lanes before the graph walk is seeded and once over what the walk brought back, and retires a row on either of two independent signals.

The first is the row's own lifecycle metadata, read by the new shared predicate `graph_metadata_recallable` (`memory_pipeline/lifecycle.py`), which reuses the exclusion vocabulary the raw lane already defines (`RECALL_EXCLUDED_REVIEW_STATES`, `RECALL_EXCLUDED_LIFECYCLE_STATES`, `RECALL_EXCLUDED_LIFECYCLE_FLAGS`) plus the four marker keys. This covers a correction whose replacement is not itself a graph entity.

The second is an inbound `SUPERSEDES` edge, resolved by `_superseded_candidate_uuids` (`retrieval/search.py`) in one query against the existing `idx_relates_name_target` index, bounded at 512 uuids, scoped by `group_id`, and restricted to candidate types that can actually be edge endpoints (raw memories and episodes are neither, and this codebase already knows the planner handles wide IN lists badly). This covers reflection promotion, where the edge is the only record of the replacement.

Recency-override falls out of the same rule rather than needing its own pass: the successor carries neither signal, so whenever both rows match a query, only the successor survives admission.

Running the gate before seed selection is what stops a retired row from steering recall through rows nobody corrected. Dropping it from the answer is not the same as refusing to walk it: its neighbours pass their own admission checks and come back, and the exact-key lane makes that reachable on demand, because there the caller names the seed by naming the key.

The gate publishes a `supersession_gate` receipt into the response `filters` (drop counts per signal plus the retired uuids), and degrades to the metadata half alone if the edge lookup fails, recording `lookup_error_type` rather than silently passing every stale row as fresh. Both passes fold into that one receipt, counts summed and uuid sets unioned, and truncation or a failed lookup in either pass marks the whole receipt, so a reader cannot be told the gate was complete because one of the two passes was.

### 3. The last chokepoint before serving

`_drop_retired_items` (`tools/context.py`) runs ahead of selection in `compile_context`, wrapping the input to both `_dedupe_lineage` and the fallback branch's `_dedupe_sections`. The native lane gates its own candidates, but a pack also admits rows the gate never saw: the active-work lookup and the legacy fallback search each reach a section directly. Placement is behavioral rather than stylistic, because a check that ran after selection would let a retired row spend one of the pack's limited slots and hand back a shorter answer than the live rows justified. Two keys were added to `_ITEM_METADATA_KEYS` so the markers survive lean projection onto a served item, where the downstream synthesis filters read them too.

### 4. The correction reaches the graph

`_project_correction_to_graph` (`services/memory.py`) runs after the raw write in `apply_memory_correction`. It resolves the projected rows through `_correction_graph_entity_ids` (`services/memory.py`), which reads both directions of the capture link, because the two write paths record it in opposite directions: promotion stamps the entity id onto the raw memory (a metadata read), while direct capture stamps the raw ids onto the graph row's attributes (`memory_pipeline/capture.py`), leaving a query as the only way back.

Each resolved row is stamped with the verdict through `EntityManager.update`, using `_correction_graph_metadata` (`services/memory.py`). Only a row the update actually matched is reported, because the candidate set is seeded from `_correction_derived_ids`, which reports relationship ids too, and `EntityManager.update` returns `None` rather than raising when nothing matches. Every marker is written on every correction, including the cleared form a `restore` needs, because a merge patch that only ever adds keys cannot undo itself and the graph merge has no way to remove one.

The lineage walk pages over its own key order rather than trusting a fixed multiplier: one parent can carry `MAX_PASSAGES_PER_SOURCE` spans plus its projected entities and facts, and the overflow past any single cap is exactly the set of rows a correction has to reach. A page ceiling remains as a stop, and hitting it is reported rather than only logged: `MemoryCorrectionResult` carries it and the route marks that correction partially applied, because a caller told `applied: true` has no other way to learn some projected rows are still servable.

A correction also reaches every row projected from the corrected memory. Three projections mint rows carrying its text: spans carry its words verbatim, projected entities carry its candidate context, and projected facts carry their span and content. Each is independently indexed and independently servable, and each inherits the parent's scope but not its provenance, so the `raw_memory_id` query cannot see any of them: a correction that stopped at the parent retired the memory while its own words kept ranking under ids the retirement never named. `_correction_projected_row_ids` follows the lineage every projection stamps (`source_entity_id`, with `parent_entity_id` beside it on spans) out from the parents this correction was already authorized against, and requires `projection_kind` so it reaches rows claiming to be projections rather than anything that names a parent. Each is re-checked for readability exactly like a provenance row, because neither lineage nor `projection_kind` is server-owned and naming a parent must not be enough to have somebody else's row retired.

On `supersede`, `_link_graph_supersession` (`services/memory.py`) also writes a real `SUPERSEDES` edge from survivor to retired row, matching the promotion path's direction, which is exactly what lets the gate recognize the row from a single inbound lookup. Spans take the lifecycle stamp and never an edge: "this row replaced that one" is a claim a writer made about a memory, and minting it once per span would assert a replacement nobody declared, on up to `MAX_PASSAGES_PER_SOURCE` rows per correction.

The raw write has already landed by the time any of this runs, so graph failures are logged (`memory_correction_graph_lookup_failed`, `memory_correction_graph_update_failed`, `memory_correction_supersedes_edge_failed`) and swallowed. A correction that half-applied is worth more than one that reports failure after mutating the substrate. The mutation receipt on `POST /memory/inspect/{source_id}/corrections` now names the `entity:` rows alongside the `raw_captures:` row, so the receipt never reads as though the write stopped at the capture.

### 5. Every stamped row is re-authorized against the correcting principal

The candidate set for the write-through is seeded partly from `_correction_derived_ids`, which reads `promoted_entity_id`, `derived_ids`, and `relationship_ids` straight off the corrected capture's metadata bag. Capture metadata is caller pass-through rather than a whitelist, so a named target is not a trusted target: a caller could plant another principal's entity id in their own capture, correct that capture, and retire a row they have no write access to. Org scoping does not help, because the tampering is cross-principal inside one org.

Provenance is server-owned, and that is what makes the split safe. `raw_memory_id` and `raw_source_id` sit in `SERVER_OWNED_METADATA_KEYS` (`auth/memory_policy.py`), stripped by `stamp_memory_scope_metadata`, which every create, bulk create, `add`, and MCP write already routes through, and stripped again at the entity PATCH merge. The capture pipeline stamps both from the completed raw write after the strip runs, so no legitimate writer loses anything.

Rows written before this branch could already carry a planted id, and nothing rewrites history, so the projected half additionally requires that the row still be **readable** by the correcting principal. That refuses no legitimate target, because a genuine projection inherits its capture's audience, and read authorization admits exactly the set of rows that can actually be served: private, project, and the legacy fail-open. Organization, shared, and public all reach `scope_not_enabled` on read (`migrate/scope_backfill.py:70-79`), so no servable row carries them.

Ids read off the capture's metadata bag are caller-reachable and keep the write guard, via `_promoted_entity_write_allowed`, the same guard the reflection path applies to its supersession targets. Every unapplied declared id is echoed in `recall_impact` as `refused_entity_ids` with `partially_applied`, and a missing row and a denied row are reported identically so a guessed id cannot answer whether a row exists.

### 6. Restore actually restores

The admission gate retires any row carrying an inbound `SUPERSEDES` edge, so clearing the lifecycle stamp alone left a restored row excluded forever, and a supersede, restore, counter-supersede sequence blacked out both rows. Restore now deletes the edges this correction path minted, matched on `attributes.native_write_path`, and only those: a supersession asserted by reflection promotion is a different claim that restore has no opinion about.

The gate is also cycle-safe, and deterministically so. `_resolve_superseded` drops self-edges, which retire nothing, and for a mutual pair keeps the single newest edge, so `A supersedes B` followed by `B supersedes A` retires A rather than blacking out both.

"Newest" is a total order over `(created_at, edge uuid)` compared strictly, and the edge query carries an explicit `ORDER BY`, because row order out of Surreal is not contractual: a resolver that let the last row win would retire A on one run and B on the next from data that never changed. Two writers with skewed clocks resolve on the tie-breaker at the resolution of the stamp and invert the pair beyond it. Both outcomes are stable and identical on every replica, which is the property recall actually needs.

### 7. The projection boundary reconciles what the correction could not reach

Two things have to be true for any of this to work: the row has to name its capture, and the boundary has to read that capture at the last possible moment.

Naming it is not free, because provenance is server-owned. A caller that could set `raw_memory_id` could nominate any row it can write to be retired by a correction on an unrelated capture, so the graph writer strips it from caller metadata. The capture pipeline stamps it from the completed raw write and then calls that same writer, which stripped it right back off, so every direct-capture row reached the graph naming no capture at all. Unforgeable and present are different requirements and now have different channels: caller metadata is still stripped, and `add()` takes a `capture_provenance` argument that is re-attached after the strip and accepts only those keys. No caller-facing surface forwards it, since both `add(**kwargs)` call sites build their kwargs from named fields. Backup restore keeps provenance for the same reason it keeps ownership: it is the server's own record of a write it already performed, and a restored row that lost it is one no future correction can reach.

Reading it at the right moment is the second half. Graph writes are queued. `remember` persists the capture, enqueues the graph write, and returns an id the caller can correct immediately, so the worker later builds rows from a payload serialized before the correction existed. The write-through cannot help there: it ran when those rows did not exist and found nothing to stamp. Two windows follow, and they answer to different authorities.

Before the parent exists, `raw_captures` is the only record of the verdict, so `create_entity` (`jobs/entities.py`) re-reads the capture named in the payload's provenance through `projected_row_lifecycle_stamp` (`services/memory.py`) and merges the verdict into the row's metadata. The read sits immediately before the write with nothing awaited in between, because every await between reading the capture and writing the row is a window where a correction lands and finds nothing to stamp. One indexed read per projected row, on the write path only; recall consults nothing new, because the stamp is exactly what the recall gate already reads.

Between the parent and the rows derived from it, the parent row is the authority and is already stamped, so every projection re-reads it instead of trusting the caller's copy, which predates the verdict. Spans, projected entities, and projected facts all inherit lifecycle alongside scope, from one shared module. Only lifecycle comes from storage: the body stays the caller's, because a re-projection derives from the text it was handed and a caller mid-update holds the newer copy.

Neither read can close the race on its own, because the write between them is an await. A correction can retire the capture and run its cascade while the insert is in flight, find no row, and let the stale row commit behind it. Every reduction of that interval leaves it non-zero.

So the write is bracketed rather than preceded. After the rows commit, the verdict is read once more and the rows are stamped by id if it moved (`projection/reconcile.py`). A correction before the write is caught by the pre-write read, one after it by the cascade, and one during it by this pass. There is no fourth interval.

That pass is itself a read-modify-write, so every stamp it applies carries the row's revision as a fence. Without one, a correction retiring the memory during the write, observed by the pass, followed by a restore landing before the pass writes, would end with the pass putting the retirement back on a row somebody had just restored. A refused write sends the pass back for a fresh verdict, so it agrees with whoever wrote last instead of overwriting them.

An unfenced write is not a degraded mode of that pass; it is unrepresentable. The write helper takes a required revision, a row read that ran out of retries goes to the fail-closed path rather than to a write, and a row that needs a write but cannot supply a revision goes there too. The requirement sits at the write rather than at the top of the pass, because a row needing no write needs no fence.

Reads and stamp writes both retry transient failures with bounded backoff, including the forced exclusion, following the embedding-backfill retry already in the worker, and a verdict that still cannot be read leaves the row excluded and flagged `lifecycle_reconciliation_pending` rather than servable. That exclusion is the one write allowed to raise if it cannot land, because a row left servable after reconciliation gave up is the single worst state this change can produce. Raising elsewhere would not have been the safe choice it looks like: on the local broker a failed job is recorded COMPLETE with an error and its deterministic id is then suppressed for the result TTL, and the Redis broker reuses the same id without clearing it, so an exception is a poison pill rather than a retry. A transient outage costs a retired-until-checked row instead of a job that never runs again.

The marker has a full life rather than being a dead end. It is written with the exclusion, cleared by the next pass that manages to read a verdict, and cleared by any correction or restore, since a correction is somebody reading the verdict and writing it down. Removal is an explicit `None` on the merge patch, which takes the key off the row rather than leaving it present and falsy, and the tests assert it is gone from the read.

Synchronous creation gets the same treatment, in `_create_entity_record` (`tools/add.py`). Its window is narrower than the worker's, since the capture and the row are written in one request, but it is not absent and the row does not heal itself. An entity carrying no capture provenance reads nothing, which is most of what that path writes.

Rows are stamped rather than suppressed, so a retired memory stays queryable through the lineage surfaces that name `SUPERSEDES` explicitly, and a row that was never written is simply lost.

## 🔁 What changed since review

Seven rounds, four of them cross-model. The later cross-model rounds went after enforcement completeness rather than authorization: every place a retired row's content could still reach a reader through something the gate had already admitted, and then every place the reconciliation itself could quietly not run.

- 🚨 **The row never named its capture, so correction could not find it.** Provenance is server-owned and the graph writer strips it from caller metadata; the capture pipeline stamps it and then calls that writer, which stripped it back off. Direct-capture rows reached the graph naming no capture, which made the correction write-through inert for exactly the rows it exists to reach. Provenance now travels on a channel that survives the strip. See step 7.
- 🚨 **Projected entities and facts kept serving corrected content.** Only spans were reconciled with the parent's lifecycle. All three projections now inherit it, and the cascade follows lineage rather than one row type.
- **The reconciliation reads failed open and one ran too early.** A failed capture or parent lookup minted an unverified, fully recallable row, and the worker's capture read sat several awaits ahead of the write with a similarity search in between. Both now fail closed, and the read sits immediately before the write.

- 🚨 **Correcting a memory left its spans serving the corrected text.** Passages carry scope but never provenance, so the correction's own query could not see them. Correction now cascades through passage lineage. See "How it works" step 4.
- 🚨 **Asynchronous projection resurrected corrected content.** Graph writes are queued, so a caller correcting the memory it just wrote got recallable rows minted afterwards from a stale payload, with nothing to reconcile them. Both windows (before the parent exists, and between the parent and its spans) now reconcile at the projection boundary. See step 7.
- **Retired rows seeded the graph walk.** The gate ran after expansion had already been seeded, so a corrected row still routed recall through its neighbours, and the exact-key lane let a caller pick that seed deliberately. The gate now runs before seed selection as well as after the walk.
- **The related-items lane the pack actually uses was ungated.** `compile_context` selects the batch helper, and only the singular helper had the check, so packs built with related items attached retired rows' content inside admitted items.
- **Cycle resolution depended on row order.** Two rows superseding each other resolved by whichever row the engine returned last, so the same edges could retire either one. Resolution is now a total order over `(created_at, edge uuid)`.

Round four was a cross-model review that attacked the assumption the two same-family rounds shared: that a row returned by the `attributes.raw_memory_id` query is necessarily a projection of the capture being corrected. It is not, and that produced two blockers. See the two entries marked 🛡️.

- 🛡️ **Capture provenance was caller-writable.** Entity PATCH merged every metadata key except the owner set, and the graph update flattens metadata into attributes exactly where the correction query reads. Plant your own capture id on a row while you can write it, lose access, then correct that capture and the row is retired. Provenance is now server-owned, with a readability check covering rows written before that.
- 🛡️ **Restore was a no-op against the gate.** It cleared lifecycle metadata while leaving the `SUPERSEDES` edge, so a restored row stayed excluded forever and supersede/restore/counter-supersede blacked out both rows. Restore now deletes the edges it minted, and the gate is cycle-safe.
- **Three admission lanes bypassed the filter**: the active-work builder rebuilt item metadata from scratch and dropped the lifecycle fields, related items ride inside an admitted item rather than as section items, and the explore related lane feeds synthesis sourcing. All three now carry and gate lifecycle.
- **`refused_entity_ids` was an existence oracle**: a missing row was dropped silently while an existing-but-denied row was echoed. Both are now reported identically.
- **The scope tests were mocked probes.** A new live-graph suite writes real rows and real `relates_to` edges through the production managers and reads them back through `context_search`.

Two independent adversarial reviews ran against this branch. Both re-derived the edge direction from the write path and confirmed it is correct at every layer, which is the claim everything else rests on. Across four rounds, three same-family and one cross-model, review found thirteen real defects. All are fixed here:

- **A promoted near-duplicate was invisible from birth.** Reflection stamps `duplicate_of_source_id` on a candidate it judges a near-duplicate; `_promotion_lifecycle_metadata` resets the promoted row to ACTIVE by adding keys rather than clearing them, so the marker outlived the verdict and the gate retired a healthy row that was the only visible copy of its content. An explicit ACTIVE state now wins over that one residual marker.
- **A caller could retire another principal's row.** See "How it works" step 5.
- **The receipt named rows the write never touched.** `EntityManager.update` returns `None` on a miss rather than raising, and the candidate set includes relationship ids.
- **A dict-shaped `lifecycle_flags` bag would retire on a `False` value**, because iterating a Mapping yields its keys.
- **Both lookup caps failed open with no trace.** The receipt now reports `truncated` with checked and total counts.

- **The security guard from round two refused rows it should have retired.** Applying the per-target write check to both halves meant `authorize_memory_write` refused legacy unscoped rows (the fail-open majority of an un-backfilled store) while the API still answered `applied: true`. The halves are now guarded by provenance. One correction to the round-two framing: organization, public, and shared were also refused, but those scopes reach `scope_not_enabled` on read too, so no servable row carries them and their refusal was never the real cost.
- **Refusals were invisible.** A correction that reached the capture but not every row it named now reports `refused_entity_ids` and `partially_applied` in `recall_impact`.
- **The truncation receipt was still blind.** `_superseded_candidate_uuids` returned a set, discarding the row count at the only point that could detect the row cap, so a query reading 512 rows that deduped to a handful reported a clean pass. The count is carried through and surfaced as `edge_rows_read`.

The reviews also established that the ungated second pipeline is wider than `/search` alone, which the follow-ups now state in full rather than as a one-line boundary note.

## 🧪 Validation

Gates run at head `3245f413` in the branch worktree, Python 3.13.12, after a rebase onto `c88fdc74`. CI settled green on all nine checks at `5c463395`, the pre-rebase head, including `Live SurrealDB 3.x Ingestion`, which is what proves the cascade's `projection_kind` predicate and its paging order are legal on a real 3.x server rather than only on the bundled embedded engine:

- Repo-wide `moon run :lint` and `moon run :typecheck` → exit 0 across all projects; `moon run core:test` → exit 0.
- `moon run api:test` → **2223 passed, 5 skipped**, plus 4 failures in `test_cli_main.py` and `test_cli_migrate.py`. Those four assert on CLI output without ANSI escapes and fail identically on `main` in the same shell, so they are a local color-forcing artifact rather than anything this branch does. The API job on this PR is the backstop and passes.
- `moon run api:lint` and `moon run api:typecheck` → all checks passed.
- `uv run pytest` on the two supersession suites → **63 passed** across `test_supersession_enforcement.py` and `test_supersession_live_graph.py` against a real embedded SurrealDB graph, plus **3 passed** in `apps/api/tests/test_jobs_entities_correction_race.py`.

The unit suite stubs the Surreal query, so a companion live-graph suite writes real rows and real `relates_to` edges through the production managers and reads them back through `compile_context`, the entry an agent actually reaches: passages surviving a correction, expansion seeding, exact-key seeding, the batch related lane, cycle determinism, the active-work lane, the persisted edge direction, self-edges, and the restore round trip. Each exclusion test carries a live control row, because an exclusion assertion passes trivially when the lane never ran, and the pack's fallback search function raises so a swallowed native failure cannot leave the assertions passing against a path they were not written for.

The asynchronous-projection window is pinned on the API side (`apps/api/tests/test_jobs_entities_correction_race.py`). That test drives the real `add()` call, records what it actually puts on the queue, feeds that payload to the real `create_entity` job against an embedded graph with a corrected capture behind it, and reads the result back through `compile_context`. Going through the real queue payload is deliberate: an earlier version built the payload by hand, which supplied the provenance the pipeline was failing to supply and hid the defect that made the whole reconciliation inert.

The unit tests are behavioral rather than declarative. Each names the property it pins:

| Test | What it proves |
| --- | --- |
| `outgoing_supersedes_edge_no_longer_expands_into_the_retired_row` | the walk returns nothing for a seed whose only edge is a supersession |
| `explicit_supersedes_walk_still_reaches_the_retired_row` | the lineage carve-out survives |
| `successor_wins_admission_when_both_rows_match` | recency override, both rows fed to `context_search`, only the successor served |
| `corrected_row_is_refused_admission_even_with_a_winning_score` | a top-scoring corrected row is dropped |
| `pack_admission_drops_a_corrected_item_it_was_handed` | the pack re-checks rows the native gate never saw |
| `correction_stamps_the_graph_row_so_recall_stops_serving_it` | `sibyl correct` reaches the entity, and the stamp is what the gate reads |
| `supersede_writes_the_replacement_edge_in_the_direction_retrieval_reads` | source is survivor, target is retired |
| `restore_clears_the_graph_stamp_it_wrote` | enforcement is reversible |
| `correction_still_applies_when_the_graph_is_unreachable` | the raw correction is not undone by a graph failure |
| `supersession_lookup_failure_degrades_without_failing_the_search` | the metadata half still applies when the edge lookup throws |
| `correction_resolves_only_its_own_capture_not_its_source_group` | the write-through stamps one capture's rows, never a sibling's |
| `a_retired_row_does_not_spend_a_pack_slot` | a limit-2 pack with two live rows returns two, not one |
| `the_edge_lookup_is_not_fed_ids_that_cannot_be_edge_endpoints` | raw memories and episodes stay out of the IN list |
| `the_receipt_names_only_rows_that_were_really_stamped` | a relationship id seeded into the lookup never reaches the receipt |
| `a_correction_cannot_retire_an_entity_the_caller_cannot_write` | a planted foreign entity id is refused, the caller's own row is stamped |
| `a_promoted_near_duplicate_survivor_stays_recallable` | an ACTIVE promoted row survives reflection's residual duplicate marker |
| `dict_shaped_lifecycle_flags_are_not_read_as_set_flags` | `{"hidden": False}` does not retire a row |
| `a_truncated_supersession_check_says_so_in_the_receipt` | the fail-open cap reports `truncated` with counts |
| `an_untruncated_check_carries_no_truncation_receipt` | the normal path stays quiet |
| `an_active_state_never_rescues_a_flagged_or_genuinely_duplicate_row` | the ACTIVE carve-out cannot reach a corrected row |
| `correction_reaches_projected_rows_at_every_scope` (5 cases) | org, public, shared, team, and legacy rows all reach the graph |
| `a_refused_target_is_reported_rather_than_silently_skipped` | a partial write reports `refused_entity_ids` |
| `the_row_cap_is_detected_even_when_dedup_hides_it` | the row cap is caught when uuids dedup below it |
| `cycle_resolution_does_not_depend_on_the_order_rows_arrive_in` | reversing the edge rows does not move the survivor |
| `a_span_takes_the_stamp_but_never_the_supersession_edge` | spans leave recall without asserting a replacement |
| `a_synchronous_create_reconciles_the_capture_before_writing_the_row` | the sync path is a projection boundary too |
| `a_synchronous_create_reads_nothing_for_a_row_with_no_provenance` | rows no correction can name pay for no lookup |
| `only_the_server_channel_can_put_provenance_on_a_written_row` | caller metadata cannot name a capture, the server channel can |
| `correcting_a_memory_retires_the_entities_and_facts_projected_from_it` | the cascade reaches every projection, not just spans |
| `rows_projected_after_the_correction_are_born_retired` | the same window closes for the other projection |
| `a_row_written_through_add_is_reachable_by_a_correction` | the write path and the correction path agree on the key |
| `a_correction_landing_inside_the_write_still_retires_the_row` | the interval the write itself occupies is covered |
| `an_unreadable_verdict_retires_the_row_instead_of_poisoning_the_job` | bounded retry, then excluded and flagged |
| `an_absent_parent_is_not_treated_as_an_unreadable_one` | KeyError from a missing row returns cleanly |
| `the_lineage_walk_pages_past_a_single_query_limit` | one page cannot cover a parent's whole projection |
| `a_stale_reconcile_cannot_overwrite_a_newer_correction` | the fence makes the later writer win |
| `failed_row_reads_never_produce_an_unfenced_write` | a pass that could not read the row does not write to it |
| `a_transient_write_failure_is_retried_rather_than_escaping` | a blip on the write is retried, not poisoned |
| `a_readable_verdict_clears_the_pending_marker` | the marker leaves the row, not just reads falsy |
| `a_correction_clears_the_pending_marker_it_finds` | a correction answers the marker too |
| `a_walk_that_hits_its_ceiling_reports_a_partial_correction` | truncation reaches the caller |
| `a_truncated_projection_walk_says_the_correction_was_partial` | and the route says partially applied |

Every test added for a review finding was run against unfixed source before being trusted, including all five enforcement-completeness tests and both projection-race tests. Nine of the originals were falsified the same way. Restoring `retrieval/search.py` from `dffb3c9c~1` fails `outgoing_supersedes_edge_no_longer_expands_into_the_retired_row`, `successor_wins_admission_when_both_rows_match`, and `corrected_row_is_refused_admission_even_with_a_winning_score`, with the recency case reporting `Left contains one more item: SearchResult(id='memory-old', ...)`. Restoring the earlier `_drop_retired_items` placement fails `a_retired_row_does_not_spend_a_pack_slot` with a pack of one where two live rows existed. Restoring the write guard on the server-stamped half fails all five `correction_reaches_projected_rows_at_every_scope` cases, each logging `memory_correction_graph_target_refused`. On the API side, `test_correction_receipt_names_the_graph_rows_it_retired` and `test_a_partially_applied_correction_says_so_in_recall_impact` pin the receipt and the partial-write shape (**2225 passed**).

One existing test changed. `test_lean_metadata_keeps_policy_gate_fields` fed the pack an item carrying `superseded_by_source_id`, which the new gate correctly refuses to serve. Its purpose was lean-projection retention, so the retention assertion moved onto `_lean_item_metadata` directly and now covers `excluded_from_recall` and `duplicate_of_source_id` as well.

The moon gates run against the bundled embedded engine, which is more lenient than the 3.x server every deployment runs, and the SurrealQL added here (`AND name NOT IN $exclude_relationship_names`, plus the `idx_relates_name_target` lookup) is exactly the class of change that engine-fidelity gap can hide. The `Live SurrealDB 3.x Ingestion` job on this PR closes it: **pass** against a real 3.x server, so the clause composition is not an embedded-engine artifact.

⚠️ Still unverified: the 3.x query plan. I did not run `EXPLAIN`, so whether the planner selects `idx_relates_name_target` for the gate's `IN`-list lookup rather than scanning is unmeasured. This repo has a history of `IN`-list tablescans, and the pre-existing hop queries share the shape, so a scan here would be a known pattern rather than a new one, but it is a latency claim I have not earned.

⚠️ Also unmeasured: retrieval quality effect. The gate adds one indexed query per `context_search` call and removes rows from packs, so it moves both latency and recall. Neither has been measured against the 30.38% anchor, and neither should be until Phase 0 strips the ranker contamination and cuts a clean anchor, because a measurement taken now would not be comparable to anything.

## 🔍 What reviewers should focus on

- **Edge direction, above everything else.** The claim is source-is-survivor, target-is-retired, traced through all four layers in "How it works" step 1 and mirrored in `_link_graph_supersession`. Every other decision in this PR depends on it, so it is worth re-deriving independently rather than taking on the trace.
- **Whether `graph_metadata_recallable` over-blocks.** It reads seven keys off candidate metadata, and a benign value landing in the exclusion vocabulary silently shrinks every pack. Review found one such class already (reflection's `duplicate_of_source_id` surviving promotion), fixed by letting an explicit ACTIVE state override that one marker, with `an_active_state_never_rescues_a_flagged_or_genuinely_duplicate_row` pinning how narrow the carve-out is. The question is whether any writer of the remaining six keys has the same shape. The raw-lexical lane spreads a capture's whole metadata bag into candidate metadata, so that is where to look.
- **`_correction_graph_entity_ids` and write authorization**, the finding that matters most after direction, because everything it returns gets mutated. Two guards stack. Resolution keys on `attributes.raw_memory_id` alone and never on `raw_source_id`, since `idx_raw_captures_source` is not UNIQUE and a correction declares exactly one affected capture, so matching the group key would reach sibling captures. Then every candidate is re-authorized per target with `_promoted_entity_write_allowed` (step 5 above), because the metadata half of the candidate set is caller-reachable. What is worth attacking: whether that check is the right one for this operation, and whether a legitimate correction can now be refused where it should succeed.
- **The unindexed lookup in `_correction_graph_entity_ids`.** Direct capture leaves no reverse pointer, so the query filters on `attributes.raw_memory_id` with no index behind it, bounded at 64 rows and scoped to the org namespace. It sits on a rare operator-initiated write and never on a read path. If a reviewer would rather see an index than a bounded scan, that is a schema change and belongs to the lane that owns index definitions.
- **Gate placement relative to authorization and to the walk.** `_apply_supersession_gate` runs after `candidate_authorized` filtering in both passes, so a row the caller cannot see is never fed to the edge lookup and the lookup cannot become an existence oracle for rows outside the caller's scope. The first pass also runs before graph expansion is seeded, which is what keeps a retired row from exporting its neighbourhood. Worth checking that the split did not leave a lane ungated: everything except the raw-lexical lane feeds seeds, and the expansion results are gated on their own way back.
- **`mark_sensitive` now drops from graph recall too.** The gate reuses the raw lane's own `RECALL_EXCLUDED_LIFECYCLE_FLAGS`, which contains `hidden`, `redacted`, and `sensitive`, so a sensitive-flagged row is refused on the graph lane exactly as it already was on the raw lane. Previously only the synthesis render suppressed it. Divergence between the two lanes is what this PR exists to remove, so convergence is the intent rather than a side effect, but it is a live behavior change and worth a product opinion.

Out of scope by design: the write surface for typed predicates (a parallel lane), fusion mode selection, the expansion weight table itself (unchanged), and the legacy hybrid pipeline behind `/search` (see follow-ups).

## 📌 Follow-ups

- **The `SUPERSEDES` gate has one producer today.** Reflection promotion is the only path that writes the edge, plus the correction path added here. Once typed predicates become writable, the same gate covers agent-declared supersession with no further change, which is the whole reason this PR consumes the existing representation rather than inventing one.
- **The second retrieval pipeline is not gated, and the gap is wider than `/search` alone.** `context_search` has exactly one production caller (`tools/context.py`), so the gate covers context packs and everything built on them, including the MCP context tool (`server.py:419`). Everything reaching `sibyl_core.tools.core.search` or `entity_manager.search` directly is ungated: the REST `/search` route (`routes/search.py:156`), the MCP `search` tool (`server.py:2011`), the session bootstrap (`routes/session.py:216`), `explore` and CLI export (`tools/explore.py:55`, `cli/export.py:133`), `expand_neighbors` and `fetch_slice` (`server.py:2379, 2453`), and synthesis plan/draft/verify sourcing (`tools/synthesis.py:107, 158, 210`). Synthesis sourcing and the session bootstrap are the two that sting most, because a corrected row can still be cited as a source or seeded into session context.

  That pipeline also still carries the inversion itself, not merely a missing filter, and it does so identically before and after this branch, so it is a pre-existing gap this PR does not widen rather than anything it introduces. `HybridConfig.graph_relationship_type_weights` has a `default_factory` (`retrieval/hybrid.py:197`) supplying `DEFAULT_GRAPH_RELATIONSHIP_TYPE_WEIGHTS`, which scores `SUPERSEDES` at 1.1 (`hybrid.py:50`), and the production config never overrides it (`tools/search.py:1063`). Its traversal walks both edge directions, so a direction-blind weight cannot be fixed by retuning the number. Worth stating plainly because the 1.3 audit records this table as unreachable in production; the `default_factory` is what makes it reachable.

  Closing this correctly means direction-aware traversal inside `hybrid.py` and `services/graph.py`, both of which belong to other lanes, and Phase 0 of 1.3 must unify or explicitly pair the two pipelines anyway. Gating both halves independently now would build the enforcement twice and unbuild one. The predicate it needs, `graph_metadata_recallable`, is already pipeline-agnostic and importable. What settles it is the Phase 0 unification decision.

- **The metadata-half guard is conservative for team-scoped rows, deliberately.** `_promoted_entity_write_allowed` forwards only `accessible_projects` to `authorize_memory_write`, never `accessible_teams`, so a team-scoped entity named in a capture's metadata is refused even when the principal is a member. Widening it means changing that shared helper, which the reflection promotion path also uses, so it is a behavior change on somebody else's lane rather than a fix on mine. Refusing here is fail-safe: the correction still applies to the capture and to every projected row, and the refusal is now reported in `recall_impact` instead of vanishing.

- **Edge temporal bounds stay unread.** `relates_to.invalid_at` and `expired_at` are still projected into `SearchResult.metadata` and consulted by nothing in the fusion or boost path. This PR closes the supersession half of that finding and leaves the bi-temporal half open, since honoring `invalid_at` at traversal is a separate behavioral change with its own measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


























<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory corrections now report affected and refused graph entities, including partial-application and truncation status.
  * Capture provenance is preserved for reliable correction and restoration workflows.
  * Lifecycle changes propagate to related entities, projections, and passages.

* **Bug Fixes**
  * Non-recallable content is excluded from search, context, and exploration results.
  * Corrected captures no longer leave newly created graph content incorrectly recallable.
  * Supersession and restoration behavior is more consistent, including complex relationship cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



