### PR TITLE
fix(cli): auth URL precedence, exit codes, and pending-write visibility

### DIFF
--- a/apps/cli/src/sibyl_cli/auth.py
+++ b/apps/cli/src/sibyl_cli/auth.py
@@ -21,7 +21,12 @@ from sibyl_cli.auth_store import (
     read_server_credentials,
     set_tokens,
 )
-from sibyl_cli.client import SibylClient, SibylClientError, get_client
+from sibyl_cli.client import (
+    SibylClient,
+    SibylClientError,
+    get_client,
+    resolve_api_base_url,
+)
 from sibyl_cli.common import error, info, print_json, run_async, success, warn
 
 app = typer.Typer(help="Authentication and credentials")
@@ -40,28 +45,33 @@ def _pkce_s256(code_verifier: str) -> str:
     return base64.urlsafe_b64encode(sha256).decode("utf-8").rstrip("=")
 
 
-def _compute_api_url(server: str | None) -> str:
+def _effective_context_name(context_name: str | None = None) -> str | None:
+    """Resolve the context every other command would use for this invocation."""
+    from sibyl_cli import config_store
+
+    return context_name or config_store.resolve_context_name()
+
+
+def _compute_api_url(server: str | None, *, context_name: str | None = None) -> str:
+    """Resolve the server an auth command should act on.
+
+    An explicit --server/URL wins; everything else defers to the client's
+    resolver, so the token lands under the key later commands read back.
+    """
     if server and server.strip():
         raw = server.strip().rstrip("/")
         if raw.endswith("/api"):
             return normalize_api_url(raw)
         return normalize_api_url(raw + "/api")
 
-    env_api_url = os.environ.get("SIBYL_API_URL", "").strip()
-    if env_api_url:
-        return normalize_api_url(env_api_url)
-
-    return normalize_api_url(SibylClient().base_url)
+    return normalize_api_url(resolve_api_base_url(_effective_context_name(context_name)))
 
 
 def _current_credential_scope(context_name: str | None = None) -> str | None:
     from sibyl_cli import config_store
 
-    ctx = (
-        config_store.get_context(context_name)
-        if context_name
-        else config_store.get_active_context()
-    )
+    resolved = _effective_context_name(context_name)
+    ctx = config_store.get_context(resolved) if resolved else None
     if ctx is None:
         return None
     return credential_scope(ctx.name, ctx.org_slug)
@@ -655,7 +665,7 @@ def status_cmd() -> None:
     """Show auth status for the current context."""
     from sibyl_cli import config_store
 
-    ctx = config_store.get_active_context()
+    ctx = config_store.resolve_effective_context()
     api_url = _compute_api_url(None)
     scope = _current_credential_scope()
     creds = read_server_credentials(api_url, credential_scope=scope)
@@ -790,7 +800,7 @@ def login_cmd(
     """
     # Positional URL takes precedence over --server option
     effective_server = url.strip() if url.strip() else server
-    api_url = _compute_api_url(effective_server)
+    api_url = _compute_api_url(effective_server, context_name=context)
     scope = _login_credential_scope(context)
 
     # Perform login

--- a/apps/cli/src/sibyl_cli/auth.py
+++ b/apps/cli/src/sibyl_cli/auth.py
@@ -83,6 +83,43 @@ def _login_credential_scope(context_name: str | None = None) -> str | None:
     return _current_credential_scope(context_name) or credential_scope(context_name, None)
 
 
+def _context_for_server(api_url: str) -> str | None:
+    """Find the configured context that points at this API URL, if any."""
+    from sibyl_cli import config_store
+
+    for ctx in config_store.list_contexts():
+        if normalize_api_url(f"{ctx.server_url}/api") == normalize_api_url(api_url):
+            return ctx.name
+    return None
+
+
+def _scope_for_login_target(
+    api_url: str,
+    *,
+    context_name: str | None,
+    explicit_target: bool,
+) -> str | None:
+    """Derive the credential scope from the server the login actually targets.
+
+    Credentials are keyed by server URL *and* scope, so a scope taken from the
+    ambient selection while the URL comes from an explicit argument produces a
+    key nothing reads back. An explicit target therefore defines its own scope.
+    """
+    if context_name:
+        return _login_credential_scope(context_name)
+    if not explicit_target:
+        return _current_credential_scope()
+
+    matched = _context_for_server(api_url)
+    ambient = _effective_context_name()
+    if ambient and ambient != matched:
+        warn(
+            f"Logging in to {api_url}, which is not the selected context "
+            f"'{ambient}'. Storing the credential for {matched or 'this server'}."
+        )
+    return _current_credential_scope(matched) if matched else None
+
+
 def _load_oauth_metadata(*, issuer_url: str, insecure: bool = False) -> dict:
     import httpx
 
@@ -801,7 +838,11 @@ def login_cmd(
     # Positional URL takes precedence over --server option
     effective_server = url.strip() if url.strip() else server
     api_url = _compute_api_url(effective_server, context_name=context)
-    scope = _login_credential_scope(context)
+    scope = _scope_for_login_target(
+        api_url,
+        context_name=context,
+        explicit_target=bool(effective_server),
+    )
 
     # Perform login
     _login_auto(

--- a/apps/cli/src/sibyl_cli/auth.py
+++ b/apps/cli/src/sibyl_cli/auth.py
@@ -83,14 +83,37 @@ def _login_credential_scope(context_name: str | None = None) -> str | None:
     return _current_credential_scope(context_name) or credential_scope(context_name, None)
 
 
-def _context_for_server(api_url: str) -> str | None:
-    """Find the configured context that points at this API URL, if any."""
+def _contexts_for_server(api_url: str) -> list[str]:
     from sibyl_cli import config_store
 
-    for ctx in config_store.list_contexts():
-        if normalize_api_url(f"{ctx.server_url}/api") == normalize_api_url(api_url):
-            return ctx.name
-    return None
+    target = normalize_api_url(api_url)
+    return [
+        ctx.name
+        for ctx in config_store.list_contexts()
+        if normalize_api_url(f"{ctx.server_url}/api") == target
+    ]
+
+
+def _context_for_server(api_url: str) -> str | None:
+    """Find the configured context that points at this API URL, if any.
+
+    Several contexts can share one server and differ only by org, so config
+    order must not decide which credential a login overwrites. The selected
+    context wins whenever it points at the target; otherwise an ambiguous
+    server is a question for the user, not a guess.
+    """
+    matches = _contexts_for_server(api_url)
+    if not matches:
+        return None
+
+    selected = _effective_context_name()
+    if selected and selected in matches:
+        return selected
+    if len(matches) > 1:
+        error(f"{api_url} is configured by more than one context: {', '.join(sorted(matches))}.")
+        info("Name the one to log in to: sibyl -C <name> auth login")
+        raise typer.Exit(1)
+    return matches[0]
 
 
 def _scope_for_login_target(

--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -51,7 +51,7 @@ class ErrorPayload:
     details: dict[str, object] | None = None
 
 
-def _get_default_api_url(context_name: str | None = None) -> str:
+def resolve_api_base_url(context_name: str | None = None) -> str:
     """Get API URL from context, config file, env var, or default.
 
     Priority:
@@ -60,6 +60,10 @@ def _get_default_api_url(context_name: str | None = None) -> str:
     3. Environment variable (SIBYL_API_URL)
     4. Legacy config file (server.url)
     5. Default (http://localhost:3334/api)
+
+    This is the single source of truth for CLI server selection. `sibyl auth`
+    resolves through it too, so a login stores its token under the same server
+    key every later command reads.
 
     Args:
         context_name: Optional context name to use instead of active context.
@@ -347,7 +351,7 @@ class SibylClient:
         """
         self.context_name = context_name
         self._explicit_base_url = base_url is not None
-        self.base_url = normalize_api_url(base_url or _get_default_api_url(context_name))
+        self.base_url = normalize_api_url(base_url or resolve_api_base_url(context_name))
         self.credential_scope = (
             _auth_credential_scope(context_name)
             if context_name or not self._explicit_base_url

--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -71,12 +71,14 @@ def resolve_api_base_url(context_name: str | None = None) -> str:
     # Lazy import to avoid circular dependency
     from sibyl_cli import config_store
 
-    # 1. If explicit context provided, use that
+    # 1. If explicit context provided, use that. A named context that does not
+    #    exist stops the command rather than falling through, because falling
+    #    through retargets the request at whatever server is active.
     if context_name:
+        config_store.require_known_context(context_name)
         ctx = config_store.get_context(context_name)
         if ctx:
             return f"{ctx.server_url}/api"
-        # Context not found - fall through to other options
 
     # 2. Try active context
     ctx = config_store.get_active_context()
@@ -375,6 +377,7 @@ class SibylClient:
         from sibyl_cli import config_store
 
         if context_name:
+            config_store.require_known_context(context_name)
             ctx = config_store.get_context(context_name)
             if ctx:
                 return ctx.insecure

--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
 
 # Shared console instance (for styled output only, NOT for JSON)
 console = Console(width=160) if not sys.stdout.isatty() else Console()
+# Second console for notices that must never land in a --json pipe.
+err_console = Console(stderr=True, width=160) if not sys.stderr.isatty() else Console(stderr=True)
 DEFAULT_CONTENT_FILE_MAX_SIZE = 1_048_576
 CONTENT_FILE_BINARY_CHECK_BYTES = 8192
 
@@ -198,6 +200,28 @@ def info(message: str) -> None:
 def hint(message: str) -> None:
     """Print a hint message."""
     console.print(f"[{ELECTRIC_YELLOW}]Hint:[/{ELECTRIC_YELLOW}] {message}")
+
+
+def pending_writes_summary(count: int) -> str:
+    plural = "s" if count != 1 else ""
+    return (
+        f"{count} write{plural} buffered locally and not saved on the server. "
+        "Run 'sibyl pending-writes flush' to replay them."
+    )
+
+
+def notify_pending_writes() -> None:
+    """Warn on stderr when writes are sitting in the local buffer.
+
+    Runs at the end of every command, including the ones that just filled
+    the buffer, so a queued write is never silent.
+    """
+    from sibyl_cli.pending_writes import pending_write_count
+
+    count = pending_write_count()
+    if count <= 0:
+        return
+    err_console.print(f"[{ELECTRIC_YELLOW}]![/{ELECTRIC_YELLOW}] {pending_writes_summary(count)}")
 
 
 def print_db_hint() -> None:

--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -244,13 +244,13 @@ def notify_pending_writes() -> None:
 
     if _pending_writes_reported:
         return
-    # Claim the report before printing, so a caller reachable from more than
-    # one entry point cannot emit the same line twice.
-    mark_pending_writes_reported()
     count = pending_write_count()
     if count <= 0:
         return
     err_console.print(f"[{ELECTRIC_YELLOW}]![/{ELECTRIC_YELLOW}] {pending_writes_summary(count)}")
+    # Claimed only once the line is out, so a queue we failed to read stays
+    # unclaimed and a later caller can still report it.
+    mark_pending_writes_reported()
 
 
 def print_db_hint() -> None:

--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -227,8 +227,10 @@ _pending_writes_reported = False
 def mark_pending_writes_reported() -> None:
     """Claim the queue report for a command that already made it.
 
-    `sibyl health`, `sibyl doctor`, and the pending-writes group all render the
-    queue themselves, so the end-of-command notice would repeat them verbatim.
+    `sibyl health`, `sibyl doctor`, `pending-writes list` and `flush` all render
+    the queue themselves, so the end-of-command notice would repeat them
+    verbatim. `discard` deliberately does not claim it, because it can leave the
+    queue untouched and the notice is then the only thing that says so.
     """
     global _pending_writes_reported
     _pending_writes_reported = True
@@ -239,21 +241,26 @@ def notify_pending_writes() -> None:
 
     Runs at the end of every command, including the ones that just filled
     the buffer, so a queued write is never silent.
+
+    Nothing in here may change the outcome. It runs from a finally block, so
+    any exception that escapes replaces the status the command already earned,
+    and a decorative notice turning a success into a failure is worse than no
+    notice at all. Rich reports a closed stream as ValueError and converts a
+    broken pipe into SystemExit, so neither an OSError guard nor a plain
+    `except Exception` is enough on its own.
     """
     from sibyl_cli.pending_writes import pending_write_count
 
     if _pending_writes_reported:
         return
-    count = pending_write_count()
-    if count <= 0:
-        return
     try:
+        count = pending_write_count()
+        if count <= 0:
+            return
         err_console.print(
             f"[{ELECTRIC_YELLOW}]![/{ELECTRIC_YELLOW}] {pending_writes_summary(count)}"
         )
-    except OSError:
-        # The notice runs from a finally block, so a closed or broken stderr
-        # must not replace the exit status the command already earned.
+    except (Exception, SystemExit):
         return
     # Claimed only once the line is out, so a queue we failed to read stays
     # unclaimed and a later caller can still report it.

--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -67,6 +67,17 @@ def print_json(data: object) -> None:
     print(json.dumps(clean_data, indent=2, default=str, ensure_ascii=False))
 
 
+def print_json_result(data: object, *, succeeded: bool) -> None:
+    """Emit a machine-readable result and let a refusal reach the exit status.
+
+    Agents and CI call --json, so a refused write has to move $? on this path
+    too and not only in the table renderer.
+    """
+    print_json(data)
+    if not succeeded:
+        raise typer.Exit(1)
+
+
 def print_mutation_receipt(response: Mapping[str, object]) -> None:
     receipt = response.get("mutation_receipt")
     if not isinstance(receipt, Mapping):
@@ -210,6 +221,19 @@ def pending_writes_summary(count: int) -> str:
     )
 
 
+_pending_writes_reported = False
+
+
+def mark_pending_writes_reported() -> None:
+    """Claim the queue report for a command that already made it.
+
+    `sibyl health`, `sibyl doctor`, and the pending-writes group all render the
+    queue themselves, so the end-of-command notice would repeat them verbatim.
+    """
+    global _pending_writes_reported
+    _pending_writes_reported = True
+
+
 def notify_pending_writes() -> None:
     """Warn on stderr when writes are sitting in the local buffer.
 
@@ -218,6 +242,8 @@ def notify_pending_writes() -> None:
     """
     from sibyl_cli.pending_writes import pending_write_count
 
+    if _pending_writes_reported:
+        return
     count = pending_write_count()
     if count <= 0:
         return

--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -244,6 +244,9 @@ def notify_pending_writes() -> None:
 
     if _pending_writes_reported:
         return
+    # Claim the report before printing, so a caller reachable from more than
+    # one entry point cannot emit the same line twice.
+    mark_pending_writes_reported()
     count = pending_write_count()
     if count <= 0:
         return

--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -247,7 +247,14 @@ def notify_pending_writes() -> None:
     count = pending_write_count()
     if count <= 0:
         return
-    err_console.print(f"[{ELECTRIC_YELLOW}]![/{ELECTRIC_YELLOW}] {pending_writes_summary(count)}")
+    try:
+        err_console.print(
+            f"[{ELECTRIC_YELLOW}]![/{ELECTRIC_YELLOW}] {pending_writes_summary(count)}"
+        )
+    except OSError:
+        # The notice runs from a finally block, so a closed or broken stderr
+        # must not replace the exit status the command already earned.
+        return
     # Claimed only once the line is out, so a queue we failed to read stays
     # unclaimed and a later caller can still report it.
     mark_pending_writes_reported()

--- a/apps/cli/src/sibyl_cli/config_store.py
+++ b/apps/cli/src/sibyl_cli/config_store.py
@@ -709,6 +709,57 @@ def delete_context(name: str) -> bool:
     return True
 
 
+class UnknownContextError(Exception):
+    """An explicitly selected context does not exist.
+
+    Selecting a context by name is a statement about which server to touch, so
+    a name that resolves to nothing must stop the command. Falling back to the
+    active context would silently retarget the write at whatever server happens
+    to be active, which is how a typo in `-C staging` reaches production.
+    """
+
+    def __init__(self, name: str, source: str = "--context") -> None:
+        self.name = name
+        self.source = source
+        self.known = [ctx.name for ctx in list_contexts()]
+        known = ", ".join(self.known) if self.known else "none configured"
+        super().__init__(f"Unknown context '{name}' (from {source}). Known contexts: {known}.")
+
+
+def require_known_context(name: str | None, source: str = "--context") -> None:
+    """Reject an explicitly named context that does not exist."""
+    if name and get_context(name) is None:
+        raise UnknownContextError(name, source)
+
+
+def explicit_context_selection() -> tuple[str, str] | None:
+    """Return the explicitly selected context and where the selection came from."""
+    from sibyl_cli.state import get_context_override
+
+    if override := get_context_override():
+        return override, _override_source()
+    if pinned := resolve_context_from_cwd():
+        return pinned, "directory pin"
+    return None
+
+
+def _override_source() -> str:
+    """Name the surface the override came from.
+
+    Typer fills the --context parameter from SIBYL_CONTEXT, so the stored
+    override cannot tell them apart; argv can.
+    """
+    import os
+    import sys
+
+    for arg in sys.argv[1:]:
+        if arg in {"-C", "--context"} or arg.startswith("--context="):
+            return "--context"
+    if os.environ.get("SIBYL_CONTEXT", "").strip():
+        return "SIBYL_CONTEXT"
+    return "--context"
+
+
 def resolve_context_name() -> str | None:
     """Resolve the effective context name across all selection inputs.
 
@@ -719,7 +770,10 @@ def resolve_context_name() -> str | None:
 
     Returns None in legacy mode (no context configured or selected).
     """
-    from sibyl_cli.state import get_context_override
+    from sibyl_cli.state import context_selection_ignored, get_context_override
+
+    if context_selection_ignored():
+        return get_active_context_name()
 
     override = get_context_override()
     if override:

--- a/apps/cli/src/sibyl_cli/config_store.py
+++ b/apps/cli/src/sibyl_cli/config_store.py
@@ -797,18 +797,18 @@ def resolve_effective_context() -> Context | None:
 def get_effective_server_url() -> str:
     """Get the effective server URL.
 
-    Priority:
-    1. Effective context's server_url (override > directory pin > active)
-    2. Legacy server.url config
-    3. Default localhost
+    Delegates to the single resolver in ``client`` and strips the ``/api``
+    suffix, so callers that want a display URL cannot drift from the URL
+    requests are actually sent to. Resolving here independently is what left
+    this function blind to SIBYL_API_URL.
 
     Returns:
         Server URL to use.
     """
-    context = resolve_effective_context()
-    if context:
-        return context.server_url
-    return get_server_url()
+    from sibyl_cli.client import resolve_api_base_url
+
+    api_url = resolve_api_base_url(resolve_context_name())
+    return api_url.rstrip("/").removesuffix("/api") or api_url
 
 
 def get_effective_project() -> str | None:

--- a/apps/cli/src/sibyl_cli/context_quick.py
+++ b/apps/cli/src/sibyl_cli/context_quick.py
@@ -7,8 +7,8 @@ from time import time
 
 from sibyl_cli.auth_store import credential_scope, read_server_credentials
 from sibyl_cli.config_store import (
-    get_active_context,
     get_effective_server_url,
+    resolve_effective_context,
     resolve_project_from_cwd,
 )
 
@@ -38,7 +38,7 @@ def _auth_status(
 
 
 def quick_context_payload() -> dict[str, object]:
-    active = get_active_context()
+    active = resolve_effective_context()
     linked_project = resolve_project_from_cwd()
     server_url = active.server_url if active else get_effective_server_url()
     effective_project = linked_project or (active.default_project if active else None)

--- a/apps/cli/src/sibyl_cli/crawl.py
+++ b/apps/cli/src/sibyl_cli/crawl.py
@@ -389,11 +389,11 @@ def link_graph(
             _handle_client_error(e)
             return
 
-        if json_out:
-            print_json(response)
-            return
-
         status = response.get("status", "unknown")
+
+        if json_out:
+            print_json_result(response, succeeded=status != "error")
+            return
 
         if status == "dry_run":
             sources_processed = response.get("sources_processed", [])

--- a/apps/cli/src/sibyl_cli/crawl.py
+++ b/apps/cli/src/sibyl_cli/crawl.py
@@ -22,6 +22,7 @@ from sibyl_cli.common import (
     handle_client_error,
     info,
     print_json,
+    print_json_result,
     run_async,
     success,
     truncate,
@@ -251,19 +252,22 @@ def health(
         try:
             response = await client.crawler_health()
 
+            available = bool(response.get("crawl4ai_available"))
+
             # JSON output (default)
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=available)
                 return
 
             # Table output
             console.print(f"\n[{ELECTRIC_PURPLE}]Crawl System Health[/{ELECTRIC_PURPLE}]\n")
 
             # Check Crawl4AI
-            if response.get("crawl4ai_available"):
+            if available:
                 success("Crawl4AI: Ready")
             else:
                 error("Crawl4AI: Not available")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -289,7 +293,7 @@ def delete_source(
 
             # JSON output (default)
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("deleted")))
                 return
 
             # Table output

--- a/apps/cli/src/sibyl_cli/crawl.py
+++ b/apps/cli/src/sibyl_cli/crawl.py
@@ -297,6 +297,7 @@ def delete_source(
                 success(f"Source deleted: {source_id}")
             else:
                 error("Failed to delete source")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)

--- a/apps/cli/src/sibyl_cli/crawl.py
+++ b/apps/cli/src/sibyl_cli/crawl.py
@@ -409,7 +409,7 @@ def link_graph(
 
         if status == "error":
             error(response.get("error", "Unknown error"))
-            return
+            raise typer.Exit(1)
 
         console.print(f"\n[{SUCCESS_GREEN}]✓[/{SUCCESS_GREEN}] Graph integration complete\n")
         console.print(

--- a/apps/cli/src/sibyl_cli/crawl_shared.py
+++ b/apps/cli/src/sibyl_cli/crawl_shared.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
 
+import typer
+
 from sibyl_cli.client import SibylClientError, get_client
 from sibyl_cli.common import (
     ELECTRIC_PURPLE,
@@ -48,6 +50,7 @@ def add_crawl_source(
                 info(f"Run '{next_step_command} {response['id']}' to start crawling")
             else:
                 error("Failed to add source")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             handle_client_error(e)

--- a/apps/cli/src/sibyl_cli/crawl_shared.py
+++ b/apps/cli/src/sibyl_cli/crawl_shared.py
@@ -10,6 +10,7 @@ from sibyl_cli.common import (
     error,
     info,
     print_json,
+    print_json_result,
     run_async,
     success,
 )
@@ -42,7 +43,7 @@ def add_crawl_source(
             )
 
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("id")))
                 return
 
             if response.get("id"):
@@ -118,7 +119,10 @@ def start_crawl_source(
             status = response.get("status", "unknown")
 
             if json_out:
-                print_json(response)
+                print_json_result(
+                    response,
+                    succeeded=status in {"queued", "started", "already_running"},
+                )
                 return
 
             if status in {"queued", "started"}:
@@ -128,6 +132,7 @@ def start_crawl_source(
                 info(response.get("message", "Crawl already in progress"))
             else:
                 error(f"Crawl failed: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             handle_client_error(e)

--- a/apps/cli/src/sibyl_cli/doctor.py
+++ b/apps/cli/src/sibyl_cli/doctor.py
@@ -500,8 +500,10 @@ def _check_agent_prompt_content() -> DoctorCheck:
 
 def _check_pending_writes() -> DoctorCheck:
     """Surface the local write buffer, where refused writes accumulate unseen."""
+    from sibyl_cli.common import mark_pending_writes_reported
     from sibyl_cli.pending_writes import pending_write_count, pending_writes_dir
 
+    mark_pending_writes_reported()
     count = pending_write_count()
     if not count:
         return DoctorCheck("pending-writes", "pass", "No writes are buffered locally.")

--- a/apps/cli/src/sibyl_cli/doctor.py
+++ b/apps/cli/src/sibyl_cli/doctor.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 import httpx
 import typer
 
-from sibyl_cli import config_store
+from sibyl_cli import config_store, state
 from sibyl_cli.client import SibylClientError, get_client
 from sibyl_cli.common import (
     ELECTRIC_YELLOW,
@@ -530,6 +530,19 @@ async def collect_doctor_checks(
     *, timeout: float, write_test: bool, skip_agent: bool = False
 ) -> list[DoctorCheck]:
     checks, context = _load_config_context()
+    if state.context_selection_ignored():
+        # The selection the user asked for does not exist. Every probe below
+        # would be aimed at the active context instead, which is a different
+        # server than the one being diagnosed, so this stays on the filesystem.
+        checks.append(
+            DoctorCheck(
+                "context-selection",
+                "fail",
+                "The selected context does not exist, so server probes were skipped.",
+                "Run 'sibyl config context list', then re-run doctor with a known context.",
+            )
+        )
+        context = None
     if context is not None:
         health = await _check_public_health(context, timeout)
         checks.append(health)

--- a/apps/cli/src/sibyl_cli/doctor.py
+++ b/apps/cli/src/sibyl_cli/doctor.py
@@ -498,6 +498,22 @@ def _check_agent_prompt_content() -> DoctorCheck:
     )
 
 
+def _check_pending_writes() -> DoctorCheck:
+    """Surface the local write buffer, where refused writes accumulate unseen."""
+    from sibyl_cli.pending_writes import pending_write_count, pending_writes_dir
+
+    count = pending_write_count()
+    if not count:
+        return DoctorCheck("pending-writes", "pass", "No writes are buffered locally.")
+    plural = "s" if count != 1 else ""
+    return DoctorCheck(
+        "pending-writes",
+        "warn",
+        f"{count} write{plural} buffered locally and not saved on the server.",
+        f"Replay with 'sibyl pending-writes flush'; queued at {pending_writes_dir()}.",
+    )
+
+
 def collect_agent_checks() -> list[DoctorCheck]:
     """Filesystem-only checks: skill stub, hooks, and CLAUDE.md content."""
     return [
@@ -526,6 +542,7 @@ async def collect_doctor_checks(
                 )
             )
         checks.append(await _check_write_probe(write_test))
+    checks.append(_check_pending_writes())
     if not skip_agent:
         checks.extend(collect_agent_checks())
     return checks

--- a/apps/cli/src/sibyl_cli/entity.py
+++ b/apps/cli/src/sibyl_cli/entity.py
@@ -20,6 +20,7 @@ from sibyl_cli.common import (
     handle_client_error,
     info,
     print_json,
+    print_json_result,
     run_async,
     success,
     truncate,
@@ -251,7 +252,7 @@ def create_entity(
 
             # JSON output (default)
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("id")))
                 return
 
             # Table output

--- a/apps/cli/src/sibyl_cli/entity.py
+++ b/apps/cli/src/sibyl_cli/entity.py
@@ -115,7 +115,7 @@ def list_entities(
     if entity_type not in ENTITY_TYPES:
         error(f"Invalid entity type: {entity_type}")
         info(f"Valid types: {', '.join(ENTITY_TYPES)}")
-        return
+        raise typer.Exit(1)
 
     @run_async
     async def _list() -> None:
@@ -229,7 +229,7 @@ def create_entity(
     if entity_type not in ENTITY_TYPES:
         error(f"Invalid entity type: {entity_type}")
         info(f"Valid types: {', '.join(ENTITY_TYPES)}")
-        return
+        raise typer.Exit(1)
 
     @run_async
     async def _create() -> None:

--- a/apps/cli/src/sibyl_cli/entity.py
+++ b/apps/cli/src/sibyl_cli/entity.py
@@ -259,6 +259,7 @@ def create_entity(
                 success(f"Entity created: {response['id']}")
             else:
                 error("Failed to create entity")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)

--- a/apps/cli/src/sibyl_cli/entrypoint.py
+++ b/apps/cli/src/sibyl_cli/entrypoint.py
@@ -18,13 +18,20 @@ def _is_quick_context_invocation(argv: list[str]) -> bool:
 
 
 def main() -> None:
-    if _is_quick_context_invocation(sys.argv):
-        from sibyl_cli.context_quick import quick_context_payload, render_quick_context
+    # The notice lives at the console-script boundary because the fast path
+    # below never reaches sibyl_cli.main, and agent hooks take that path.
+    from sibyl_cli.common import notify_pending_writes
 
-        json_out = "--json" in sys.argv or "-j" in sys.argv
-        render_quick_context(quick_context_payload(), json_out=json_out)
-        return
+    try:
+        if _is_quick_context_invocation(sys.argv):
+            from sibyl_cli.context_quick import quick_context_payload, render_quick_context
 
-    from sibyl_cli.main import main as cli_main
+            json_out = "--json" in sys.argv or "-j" in sys.argv
+            render_quick_context(quick_context_payload(), json_out=json_out)
+            return
 
-    cli_main()
+        from sibyl_cli.main import main as cli_main
+
+        cli_main()
+    finally:
+        notify_pending_writes()

--- a/apps/cli/src/sibyl_cli/epic.py
+++ b/apps/cli/src/sibyl_cli/epic.py
@@ -663,7 +663,7 @@ def update_epic(
                 error(
                     "No fields to update. Use --status, --priority, --title, --assignee, or --tags"
                 )
-                return
+                raise typer.Exit(1)
 
             resolved_id = await _resolve_epic_id(client, epic_id)
 

--- a/apps/cli/src/sibyl_cli/epic.py
+++ b/apps/cli/src/sibyl_cli/epic.py
@@ -490,6 +490,7 @@ def create_epic(
                     info(f"Lead: {assignee}")
             else:
                 error("Failed to create epic")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -529,6 +530,7 @@ def start_epic(
                 success(f"Epic started: {epic_id}")
             else:
                 error(f"Failed to start epic: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -572,6 +574,7 @@ def complete_epic(
                     info("Learnings captured")
             else:
                 error(f"Failed to complete epic: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -612,6 +615,7 @@ def archive_epic(
                 success(f"Epic archived: {resolved_id}")
             else:
                 error(f"Failed to archive epic: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -683,6 +687,7 @@ def update_epic(
                 info(f"Fields: {', '.join(updates.keys())}")
             else:
                 error(f"Failed to update epic: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)

--- a/apps/cli/src/sibyl_cli/epic.py
+++ b/apps/cli/src/sibyl_cli/epic.py
@@ -22,6 +22,7 @@ from sibyl_cli.common import (
     handle_client_error,
     info,
     print_json,
+    print_json_result,
     run_async,
     success,
 )
@@ -481,7 +482,7 @@ def create_epic(
             )
 
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("id")))
                 return
 
             if response.get("id"):
@@ -523,7 +524,10 @@ def start_epic(
             response = await client.update_entity(resolved_id, metadata=metadata)
 
             if json_out:
-                print_json(response)
+                print_json_result(
+                    response,
+                    succeeded=bool(response.get("success") or response.get("id")),
+                )
                 return
 
             if response.get("success") or response.get("id"):
@@ -565,7 +569,10 @@ def complete_epic(
             response = await client.update_entity(resolved_id, metadata=metadata)
 
             if json_out:
-                print_json(response)
+                print_json_result(
+                    response,
+                    succeeded=bool(response.get("success") or response.get("id")),
+                )
                 return
 
             if response.get("success") or response.get("id"):
@@ -608,7 +615,10 @@ def archive_epic(
             response = await client.update_entity(resolved_id, metadata=metadata)
 
             if json_out:
-                print_json(response)
+                print_json_result(
+                    response,
+                    succeeded=bool(response.get("success") or response.get("id")),
+                )
                 return
 
             if response.get("success") or response.get("id"):
@@ -679,7 +689,10 @@ def update_epic(
             response = await client.update_entity(resolved_id, **updates)
 
             if json_out:
-                print_json(response)
+                print_json_result(
+                    response,
+                    succeeded=bool(response.get("success") or response.get("id")),
+                )
                 return
 
             if response.get("success") or response.get("id"):

--- a/apps/cli/src/sibyl_cli/explore.py
+++ b/apps/cli/src/sibyl_cli/explore.py
@@ -105,7 +105,7 @@ def explore_traverse(
     """Multi-hop graph traversal from an entity. Default: table output."""
     if depth < 1 or depth > 3:
         error("Depth must be between 1 and 3")
-        return
+        raise typer.Exit(1)
 
     @run_async
     async def _traverse() -> None:
@@ -175,7 +175,7 @@ def explore_dependencies(
     """Show task dependency graph with topological ordering. Default: table output."""
     if not entity_id and not project:
         error("Must specify either entity_id or --project")
-        return
+        raise typer.Exit(1)
 
     @run_async
     async def _deps() -> None:

--- a/apps/cli/src/sibyl_cli/host.py
+++ b/apps/cli/src/sibyl_cli/host.py
@@ -53,7 +53,7 @@ def resolve_host_context() -> HostContext | None:
     ctx = (
         config_store.get_context(context_name)
         if context_name
-        else config_store.get_active_context()
+        else config_store.resolve_effective_context()
     )
     if ctx is None:
         return None

--- a/apps/cli/src/sibyl_cli/local.py
+++ b/apps/cli/src/sibyl_cli/local.py
@@ -429,6 +429,7 @@ def stop(
         success("Sibyl stopped")
     else:
         error("Failed to stop Sibyl")
+        raise typer.Exit(1)
 
 
 @app.command()

--- a/apps/cli/src/sibyl_cli/local.py
+++ b/apps/cli/src/sibyl_cli/local.py
@@ -573,5 +573,6 @@ def setup(
         print_prompt_snippet()
         return
 
-    if setup_agent_integration():
-        print_prompt_snippet()
+    if not setup_agent_integration():
+        raise typer.Exit(1)
+    print_prompt_snippet()

--- a/apps/cli/src/sibyl_cli/logs.py
+++ b/apps/cli/src/sibyl_cli/logs.py
@@ -200,8 +200,15 @@ async def _stream_logs(
 
                     _print_entry(entry)
                 except websockets.ConnectionClosed:
+                    # A supervisor cannot tell a finished follow from a dropped
+                    # one unless the exit status says so, and this stream only
+                    # ends when the server or the network ends it.
                     error("Connection closed")
-                    break
+                    raise typer.Exit(1) from None
+    except typer.Exit:
+        # typer.Exit is a RuntimeError subclass, so the handler below would
+        # swallow it and relabel a clean exit as a WebSocket error.
+        raise
     except asyncio.CancelledError:
         console.print("\n[dim]Stream stopped[/dim]")
     except Exception as e:

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 import typer
 from rich.markup import escape
+from typer.core import TyperGroup
 
 from sibyl_cli import config_store, state
 from sibyl_cli.archive import app as archive_app
@@ -108,9 +109,44 @@ def version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+def _resolve_command_path(group: Any, ctx: Any, args: list[str]) -> tuple[str, ...]:
+    """Walk the command tree as far as the arguments unambiguously reach.
+
+    Resolution stops at the first token that is not a subcommand of the group
+    reached so far, which leaves an option-interleaved invocation with a short
+    path. Callers treat a short path as unrecognized, so the ambiguity fails
+    closed rather than granting a leaf's privileges to its group.
+    """
+    path: list[str] = []
+    command = group
+    for arg in args:
+        lookup = getattr(command, "get_command", None)
+        if lookup is None:
+            break
+        sub = lookup(ctx, arg)
+        if sub is None:
+            break
+        path.append(getattr(sub, "name", None) or arg)
+        command = sub
+    return tuple(path)
+
+
+class SibylRootGroup(TyperGroup):
+    """Records the resolved subcommand path before any callback runs."""
+
+    def parse_args(self, ctx: Any, args: list[str]) -> list[str]:
+        rest = super().parse_args(ctx, args)
+        protected = getattr(ctx, "_protected_args", None)
+        if protected is None:
+            protected = getattr(ctx, "protected_args", [])
+        state.set_command_path(_resolve_command_path(self, ctx, [*protected, *ctx.args]))
+        return rest
+
+
 # Main app
 app = typer.Typer(
     name="sibyl",
+    cls=SibylRootGroup,
     help="Sibyl - Oracle of Development Wisdom (CLI Client)",
     add_completion=False,
     no_args_is_help=False,
@@ -1371,12 +1407,38 @@ def _handle_client_error(e: SibylClientError) -> None:
 # ============================================================================
 
 
-# These repair or inspect the context configuration, so they have to keep
-# working while the selection is broken. Everything else stops.
-_CONTEXT_REPAIR_COMMANDS = frozenset({"context", "init", "config", "doctor"})
+# Leaves whose whole subject is the local config file. None of them opens a
+# connection, so dropping a broken selection cannot retarget anything. Groups
+# never appear here: `sibyl context` is the network recall command and
+# `sibyl config context pack` fetches a pack, while `sibyl config context list`
+# reads a TOML file, so the privilege belongs to the leaf and not to the name
+# it shares with a group.
+_LOCAL_CONTEXT_LEAVES = (
+    "list",
+    "show",
+    "create",
+    "use",
+    "update",
+    "delete",
+    "link",
+    "unlink",
+    "clear",
+)
+_LOCAL_CONFIG_LEAVES = ("init", "show", "get", "set", "path", "reset", "edit")
+_CONTEXT_REPAIR_COMMANDS = frozenset(
+    [
+        ("init",),
+        # doctor stays reachable because it is what you run when the selection
+        # is broken, and it drops to filesystem checks once that happens.
+        ("doctor",),
+        *[("config", leaf) for leaf in _LOCAL_CONFIG_LEAVES],
+        *[("config", "context", leaf) for leaf in _LOCAL_CONTEXT_LEAVES],
+        *[("contexts", leaf) for leaf in _LOCAL_CONTEXT_LEAVES],
+    ]
+)
 
 
-def _reject_unknown_context(ctx: typer.Context) -> None:
+def _reject_unknown_context() -> None:
     """Stop before any command logic when the selected context does not exist."""
     try:
         selection = config_store.explicit_context_selection()
@@ -1389,7 +1451,7 @@ def _reject_unknown_context(ctx: typer.Context) -> None:
         # Config is unreadable, so there is nothing to validate against. The
         # resolver still refuses to fall through if a name is used later.
         return
-    if ctx.invoked_subcommand in _CONTEXT_REPAIR_COMMANDS:
+    if state.command_path() in _CONTEXT_REPAIR_COMMANDS:
         warn(f"Selected context '{name}' ({source}) does not exist; ignoring it.")
         state.ignore_context_selection()
         return
@@ -1431,7 +1493,7 @@ def main_callback(
     if context:
         set_context_override(context)
 
-    _reject_unknown_context(ctx)
+    _reject_unknown_context()
     _emit_command_marker(ctx)
 
     # Show help if no command

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -34,9 +34,11 @@ from sibyl_cli.common import (
     error,
     handle_client_error,
     info,
+    mark_pending_writes_reported,
     notify_pending_writes,
     pending_writes_summary,
     print_json,
+    print_json_result,
     print_mutation_receipt,
     resolve_content_input,
     run_async,
@@ -1486,6 +1488,7 @@ def _print_version_lines(data: dict[str, object]) -> None:
 
 def _print_pending_write_health() -> None:
     """Report the local write buffer, the queue a failed write lands in."""
+    mark_pending_writes_reported()
     count = pending_write_count()
     if count:
         warn(pending_writes_summary(count))
@@ -1506,6 +1509,7 @@ def health(
                 data = await client.get("/health")
 
                 if json_output:
+                    mark_pending_writes_reported()
                     print_json({**data, "pending_writes": pending_write_status()})
                     return
                 status = data.get("status", "unknown")
@@ -2091,7 +2095,10 @@ def note_alias(
                         author or "",
                     )
                     if json_output:
-                        print_json(response)
+                        print_json_result(
+                            response,
+                            succeeded=bool(response.get("id") or response.get("success")),
+                        )
                         return
                     note_id = response.get("id")
                     if note_id:
@@ -3959,9 +3966,7 @@ def main() -> None:
     try:
         app()
     finally:
-        # The pending-writes commands report the queue themselves.
-        if "pending-writes" not in sys.argv[1:]:
-            notify_pending_writes()
+        notify_pending_writes()
 
 
 if __name__ == "__main__":

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -1349,7 +1349,7 @@ def _handle_client_error(e: SibylClientError) -> None:
             f"    [{NEON_CYAN}]›[/{NEON_CYAN}] [bold {NEON_CYAN}]sibyl auth login[/bold {NEON_CYAN}]   [dim]Log in[/dim]"
         )
         console.print(
-            f"    [{NEON_CYAN}]›[/{NEON_CYAN}] [bold {NEON_CYAN}]sibyl auth signup[/bold {NEON_CYAN}]  [dim]Create account[/dim]"
+            f"    [{NEON_CYAN}]›[/{NEON_CYAN}] [bold {NEON_CYAN}]sibyl auth local-signup[/bold {NEON_CYAN}]  [dim]Create a local account[/dim]"
         )
         console.print()
     elif e.status_code == 403:

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -2083,6 +2083,7 @@ def note_alias(
                         success(f"Note added to task: {resolved_id}")
                     else:
                         error("Failed to add note")
+                        raise typer.Exit(1)
                     return
 
                 parsed_tags = [t.strip() for t in tags.split(",") if t.strip()] if tags else None

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -1508,13 +1508,17 @@ def health(
             async with get_client() as client:
                 data = await client.get("/health")
 
-                if json_output:
-                    mark_pending_writes_reported()
-                    print_json({**data, "pending_writes": pending_write_status()})
-                    return
                 status = data.get("status", "unknown")
                 server = data.get("server_name", "sibyl")
                 healthy = status == "healthy"
+
+                if json_output:
+                    mark_pending_writes_reported()
+                    print_json_result(
+                        {**data, "pending_writes": pending_write_status()},
+                        succeeded=healthy,
+                    )
+                    return
 
                 if healthy:
                     success(f"{server} is healthy")

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -2437,10 +2437,15 @@ def synthesis_remember_command(
                     scope_key=scope_key,
                     tags=_parse_csv_ids(tags),
                 )
+            artifact = cast("dict[str, object]", data.get("artifact") or {})
+            remembered = bool(artifact.get("remembered_memory_id"))
+
             if json_output:
-                print_json(data)
+                print_json_result(data, succeeded=remembered)
                 return
             _print_synthesis_remember(cast("dict[str, object]", data))
+            if not remembered:
+                raise typer.Exit(1)
         except SibylClientError as e:
             _handle_client_error(e)
 

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -19,7 +19,7 @@ from uuid import UUID
 import typer
 from rich.markup import escape
 
-from sibyl_cli import config_store
+from sibyl_cli import config_store, state
 from sibyl_cli.archive import app as archive_app
 from sibyl_cli.auth import app as auth_app
 from sibyl_cli.auth import clear_token_cmd as logout_cmd
@@ -1371,6 +1371,39 @@ def _handle_client_error(e: SibylClientError) -> None:
 # ============================================================================
 
 
+# These repair or inspect the context configuration, so they have to keep
+# working while the selection is broken. Everything else stops.
+_CONTEXT_REPAIR_COMMANDS = frozenset({"context", "init", "config", "doctor"})
+
+
+def _reject_unknown_context(ctx: typer.Context) -> None:
+    """Stop before any command logic when the selected context does not exist."""
+    try:
+        selection = config_store.explicit_context_selection()
+        if selection is None:
+            return
+        name, source = selection
+        if config_store.get_context(name) is not None:
+            return
+    except (OSError, RuntimeError):
+        # Config is unreadable, so there is nothing to validate against. The
+        # resolver still refuses to fall through if a name is used later.
+        return
+    if ctx.invoked_subcommand in _CONTEXT_REPAIR_COMMANDS:
+        warn(f"Selected context '{name}' ({source}) does not exist; ignoring it.")
+        state.ignore_context_selection()
+        return
+
+    known = [c.name for c in config_store.list_contexts()]
+    error(f"Unknown context '{name}' selected by {source}.")
+    if known:
+        info(f"Known contexts: {', '.join(known)}")
+        info("Switch with: sibyl context use <name>")
+    else:
+        info("No contexts are configured. Create one with: sibyl init")
+    raise typer.Exit(1)
+
+
 @app.callback(invoke_without_command=True)
 def main_callback(
     ctx: typer.Context,
@@ -1398,6 +1431,7 @@ def main_callback(
     if context:
         set_context_override(context)
 
+    _reject_unknown_context(ctx)
     _emit_command_marker(ctx)
 
     # Show help if no command
@@ -3974,6 +4008,10 @@ def main() -> None:
     """CLI entry point."""
     try:
         app()
+    except config_store.UnknownContextError as exc:
+        # Backstop for any resolver reached without passing the root callback.
+        error(str(exc))
+        raise typer.Exit(1) from exc
     finally:
         notify_pending_writes()
 

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -2391,10 +2391,15 @@ def synthesis_verify_command(
         try:
             async with get_client() as client:
                 data = await client.synthesis_draft(**options, output_format="json")
+            verification = cast("dict[str, object]", data.get("verification") or {})
+            passed = str(verification.get("status") or "unknown") == "pass"
+
             if json_output:
-                print_json(data)
+                print_json_result(data, succeeded=passed)
                 return
             _print_synthesis_verification(cast("dict[str, object]", data))
+            if not passed:
+                raise typer.Exit(1)
         except SibylClientError as e:
             _handle_client_error(e)
 

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -34,6 +34,8 @@ from sibyl_cli.common import (
     error,
     handle_client_error,
     info,
+    notify_pending_writes,
+    pending_writes_summary,
     print_json,
     print_mutation_receipt,
     resolve_content_input,
@@ -74,6 +76,7 @@ from sibyl_cli.memory_display import (
 )
 from sibyl_cli.org import app as org_app
 from sibyl_cli.pending import app as pending_writes_app
+from sibyl_cli.pending_writes import pending_write_count, pending_write_status
 from sibyl_cli.project import app as project_app
 from sibyl_cli.project_refs import resolve_project_reference
 from sibyl_cli.session import app as session_app
@@ -1481,6 +1484,15 @@ def _print_version_lines(data: dict[str, object]) -> None:
         warn(f"Server is newer than this CLI ({server_text} > {current}) — run `sibyl update`.")
 
 
+def _print_pending_write_health() -> None:
+    """Report the local write buffer, the queue a failed write lands in."""
+    count = pending_write_count()
+    if count:
+        warn(pending_writes_summary(count))
+    else:
+        console.print("  [dim]Pending writes: 0[/dim]")
+
+
 @app.command()
 def health(
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
@@ -1494,12 +1506,13 @@ def health(
                 data = await client.get("/health")
 
                 if json_output:
-                    print_json(data)
+                    print_json({**data, "pending_writes": pending_write_status()})
                     return
                 status = data.get("status", "unknown")
                 server = data.get("server_name", "sibyl")
+                healthy = status == "healthy"
 
-                if status == "healthy":
+                if healthy:
                     success(f"{server} is healthy")
                     _print_version_lines(data)
                     if counts := data.get("counts"):
@@ -1509,6 +1522,10 @@ def health(
                         )
                 else:
                     error(f"{server} is unhealthy: {status}")
+
+                _print_pending_write_health()
+
+                if not healthy:
                     raise typer.Exit(1)
         except SibylClientError as e:
             _handle_client_error(e)
@@ -3939,7 +3956,12 @@ def version() -> None:
 
 def main() -> None:
     """CLI entry point."""
-    app()
+    try:
+        app()
+    finally:
+        # The pending-writes commands report the queue themselves.
+        if "pending-writes" not in sys.argv[1:]:
+            notify_pending_writes()
 
 
 if __name__ == "__main__":

--- a/apps/cli/src/sibyl_cli/onboarding.py
+++ b/apps/cli/src/sibyl_cli/onboarding.py
@@ -193,5 +193,5 @@ def needs_onboarding() -> bool:
     if not config_store.config_exists():
         return True
 
-    url = config_store.get_server_url()
+    url = config_store.get_effective_server_url()
     return not url or url == config_store.DEFAULT_CONFIG["server"]["url"]

--- a/apps/cli/src/sibyl_cli/org.py
+++ b/apps/cli/src/sibyl_cli/org.py
@@ -22,7 +22,7 @@ console = Console()
 
 
 def _org_credential_scope(org_slug: str | None) -> str | None:
-    ctx = config_store.get_active_context()
+    ctx = config_store.resolve_effective_context()
     if ctx is None:
         return None
     return credential_scope(ctx.name, org_slug or ctx.org_slug)

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -31,12 +31,6 @@ from sibyl_cli.pending_writes import (
 app = typer.Typer(help="Inspect and replay locally buffered writes")
 
 
-@app.callback()
-def _claim_queue_report() -> None:
-    """Every command in this group reports the queue itself."""
-    mark_pending_writes_reported()
-
-
 def _summary(item: dict[str, Any]) -> dict[str, Any]:
     title, kind = pending_write_label(item)
     return {
@@ -96,6 +90,7 @@ def list_writes(
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output JSON")] = False,
 ) -> None:
     """List buffered writes without printing sensitive payload bodies."""
+    mark_pending_writes_reported()
     summaries = [_summary(item) for item in list_pending_writes()]
     if json_output:
         print_json({"pending_writes": summaries})
@@ -166,6 +161,7 @@ def flush_writes(
     ] = None,
 ) -> None:
     """Replay buffered writes."""
+    mark_pending_writes_reported()
     try:
         selected = _selected_writes(write_ids or [])
     except (FileNotFoundError, ValueError) as exc:

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -141,22 +141,28 @@ def discard_writes(
     if not selected:
         success("No pending writes matched")
         return
+    # Deduplicated, since the same id named twice discards once and the second
+    # pass would otherwise count as a miss.
+    selected = list(dict.fromkeys(selected))
     removed = 0
+    missed = 0
     for write_id in selected:
         try:
             if delete_pending_write(write_id):
                 removed += 1
                 record_pending_metric("discarded")
+            else:
+                missed += 1
         except ValueError as exc:
             error(str(exc))
             raise typer.Exit(code=1) from exc
 
+    success(f"Discarded {removed} pending write{'s' if removed != 1 else ''}")
     # A named id that matched nothing is a refusal, not an empty result: the
     # caller asked for a specific write and the queue still holds it.
-    if not read_like and removed < len(selected):
-        error(f"No pending write matched {len(selected) - removed} of the given IDs")
+    if not read_like and missed:
+        error(f"No pending write matched {missed} of the given IDs")
         raise typer.Exit(code=1)
-    success(f"Discarded {removed} pending write{'s' if removed != 1 else ''}")
 
 
 @app.command("flush")

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -150,6 +150,12 @@ def discard_writes(
         except ValueError as exc:
             error(str(exc))
             raise typer.Exit(code=1) from exc
+
+    # A named id that matched nothing is a refusal, not an empty result: the
+    # caller asked for a specific write and the queue still holds it.
+    if not read_like and removed < len(selected):
+        error(f"No pending write matched {len(selected) - removed} of the given IDs")
+        raise typer.Exit(code=1)
     success(f"Discarded {removed} pending write{'s' if removed != 1 else ''}")
 
 

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -9,7 +9,16 @@ import typer
 
 from sibyl_cli.auth_store import normalize_api_url
 from sibyl_cli.client import SibylClient, SibylClientError, _is_read_like_post
-from sibyl_cli.common import console, create_table, error, print_json, run_async, success, warn
+from sibyl_cli.common import (
+    console,
+    create_table,
+    error,
+    mark_pending_writes_reported,
+    print_json,
+    run_async,
+    success,
+    warn,
+)
 from sibyl_cli.pending_writes import (
     delete_pending_write,
     increment_attempts,
@@ -20,6 +29,12 @@ from sibyl_cli.pending_writes import (
 )
 
 app = typer.Typer(help="Inspect and replay locally buffered writes")
+
+
+@app.callback()
+def _claim_queue_report() -> None:
+    """Every command in this group reports the queue itself."""
+    mark_pending_writes_reported()
 
 
 def _summary(item: dict[str, Any]) -> dict[str, Any]:

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -120,14 +120,16 @@ def list_pending_writes() -> list[dict[str, Any]]:
 def pending_write_count() -> int:
     """Count queued writes without parsing them.
 
-    Runs after every command, so it stays a directory listing.
+    Runs after every command, so it stays a directory listing, and an
+    unreadable or undeterminable home never turns a successful command into
+    a failing one. Path.home() raises RuntimeError when it cannot resolve.
     """
-    root = pending_writes_dir()
-    if not root.exists():
-        return 0
     try:
+        root = pending_writes_dir()
+        if not root.exists():
+            return 0
         return sum(1 for _ in root.glob("*.json"))
-    except OSError:
+    except (OSError, RuntimeError):
         return 0
 
 

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -117,6 +117,20 @@ def list_pending_writes() -> list[dict[str, Any]]:
     return writes
 
 
+def pending_write_count() -> int:
+    """Count queued writes without parsing them.
+
+    Runs after every command, so it stays a directory listing.
+    """
+    root = pending_writes_dir()
+    if not root.exists():
+        return 0
+    try:
+        return sum(1 for _ in root.glob("*.json"))
+    except OSError:
+        return 0
+
+
 def delete_pending_write(write_id: str) -> bool:
     try:
         path = resolve_pending_write_path(write_id)

--- a/apps/cli/src/sibyl_cli/project.py
+++ b/apps/cli/src/sibyl_cli/project.py
@@ -273,6 +273,7 @@ def create_project(
                 success(f"Project created: {response['id']}")
             else:
                 error("Failed to create project")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)

--- a/apps/cli/src/sibyl_cli/project.py
+++ b/apps/cli/src/sibyl_cli/project.py
@@ -23,6 +23,7 @@ from sibyl_cli.common import (
     handle_client_error,
     info,
     print_json,
+    print_json_result,
     run_async,
     success,
     truncate,
@@ -265,7 +266,7 @@ def create_project(
 
             # JSON output (default)
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("id")))
                 return
 
             # Table output

--- a/apps/cli/src/sibyl_cli/project.py
+++ b/apps/cli/src/sibyl_cli/project.py
@@ -444,7 +444,7 @@ def relink_project(
                         for project in projects[:10]:
                             console.print(f"  - {project.get('id')}  {project.get('name', '')}")
                     info("Run: sibyl project relink --id <project>")
-                    return
+                    raise typer.Exit(1)
 
             set_path_mapping(target_path, selected_id, context=context_name)
             success(f"Relinked [{NEON_CYAN}]{target_path}[/{NEON_CYAN}]")

--- a/apps/cli/src/sibyl_cli/session.py
+++ b/apps/cli/src/sibyl_cli/session.py
@@ -21,10 +21,10 @@ from sibyl_cli.common import (
     run_async,
 )
 from sibyl_cli.config_store import (
-    get_active_context,
     get_current_context,
     get_effective_project,
     get_effective_server_url,
+    resolve_effective_context,
 )
 from sibyl_core.session_bundle import (
     derive_query,
@@ -96,7 +96,7 @@ async def _build_session_bundle(
     memory_limit: int,
     all_projects: bool,
 ) -> dict[str, Any]:
-    active_context = get_active_context()
+    active_context = resolve_effective_context()
     linked_project, matched_path = get_current_context()
     effective_project = None if all_projects else get_effective_project()
     server_url = get_effective_server_url()

--- a/apps/cli/src/sibyl_cli/setup.py
+++ b/apps/cli/src/sibyl_cli/setup.py
@@ -326,6 +326,8 @@ def setup_agent_integration(verbose: bool = True) -> bool:
         )
         console.print()
 
+    hooks_installed = True
+
     # Determine source - prefer dev symlinks, fall back to package data
     repo_dir = find_sibyl_repo()
     data_dir = get_package_data_dir()
@@ -349,6 +351,7 @@ def setup_agent_integration(verbose: bool = True) -> bool:
             if configure_claude_hooks() and verbose:
                 success("Installed Claude Code hooks")
         else:
+            hooks_installed = False
             if verbose:
                 warn("Could not find hooks in repo")
 
@@ -366,6 +369,7 @@ def setup_agent_integration(verbose: bool = True) -> bool:
             if configure_claude_hooks() and verbose:
                 success("Installed Claude Code hooks")
         else:
+            hooks_installed = False
             if verbose:
                 warn("No embedded hooks found in package")
 
@@ -379,7 +383,12 @@ def setup_agent_integration(verbose: bool = True) -> bool:
 
     if verbose:
         console.print()
-        success("Sibyl integration setup complete!")
+        if hooks_installed:
+            success("Sibyl integration setup complete!")
+        else:
+            # Claiming completion under a warning that hooks are missing is the
+            # same untruth as exiting 0 on a refusal, one layer up.
+            warn("Sibyl skills installed; hooks were not.")
         console.print()
         console.print(f"  [{NEON_CYAN}]Claude Code:[/{NEON_CYAN}]  Skills and hooks installed")
         console.print(f"  [{NEON_CYAN}]Codex CLI:[/{NEON_CYAN}]    Skills installed (no hooks)")

--- a/apps/cli/src/sibyl_cli/setup.py
+++ b/apps/cli/src/sibyl_cli/setup.py
@@ -348,8 +348,13 @@ def setup_agent_integration(verbose: bool = True) -> bool:
 
         # Install hooks
         if install_hooks_symlink(repo_dir):
-            if configure_claude_hooks() and verbose:
-                success("Installed Claude Code hooks")
+            if configure_claude_hooks():
+                if verbose:
+                    success("Installed Claude Code hooks")
+            else:
+                hooks_installed = False
+                if verbose:
+                    warn("Could not configure Claude Code hooks")
         else:
             hooks_installed = False
             if verbose:
@@ -366,8 +371,13 @@ def setup_agent_integration(verbose: bool = True) -> bool:
 
         # Install hooks
         if install_hooks_copy(data_dir):
-            if configure_claude_hooks() and verbose:
-                success("Installed Claude Code hooks")
+            if configure_claude_hooks():
+                if verbose:
+                    success("Installed Claude Code hooks")
+            else:
+                hooks_installed = False
+                if verbose:
+                    warn("Could not configure Claude Code hooks")
         else:
             hooks_installed = False
             if verbose:
@@ -390,12 +400,16 @@ def setup_agent_integration(verbose: bool = True) -> bool:
             # same untruth as exiting 0 on a refusal, one layer up.
             warn("Sibyl skills installed; hooks were not.")
         console.print()
-        console.print(f"  [{NEON_CYAN}]Claude Code:[/{NEON_CYAN}]  Skills and hooks installed")
+        claude_line = "Skills and hooks installed" if hooks_installed else "Skills installed only"
+        console.print(f"  [{NEON_CYAN}]Claude Code:[/{NEON_CYAN}]  {claude_line}")
         console.print(f"  [{NEON_CYAN}]Codex CLI:[/{NEON_CYAN}]    Skills installed (no hooks)")
         console.print()
-        console.print(f"[{CORAL}]Restart Claude Code to activate hooks.[/{CORAL}]")
+        if hooks_installed:
+            console.print(f"[{CORAL}]Restart Claude Code to activate hooks.[/{CORAL}]")
 
-    return True
+    # Hooks are half of what this command installs, so a run that skipped them
+    # is not a success its caller can report as one.
+    return hooks_installed
 
 
 def print_prompt_snippet() -> None:

--- a/apps/cli/src/sibyl_cli/state.py
+++ b/apps/cli/src/sibyl_cli/state.py
@@ -18,6 +18,23 @@ def set_context_override(context_name: str | None) -> None:
     _context_override = context_name
 
 
+_ignore_selection = False
+
+
+def ignore_context_selection() -> None:
+    """Drop a broken context selection for the rest of this invocation.
+
+    The commands that repair a context have to keep working while the selection
+    is broken, and they cannot do that if every resolver raises on the name.
+    """
+    global _ignore_selection
+    _ignore_selection = True
+
+
+def context_selection_ignored() -> bool:
+    return _ignore_selection
+
+
 def get_context_override() -> str | None:
     """Get the current context override.
 
@@ -26,6 +43,8 @@ def get_context_override() -> str | None:
     2. SIBYL_CONTEXT environment variable
     3. None (use active context from config)
     """
+    if _ignore_selection:
+        return None
     if _context_override:
         return _context_override
 

--- a/apps/cli/src/sibyl_cli/state.py
+++ b/apps/cli/src/sibyl_cli/state.py
@@ -18,6 +18,24 @@ def set_context_override(context_name: str | None) -> None:
     _context_override = context_name
 
 
+_command_path: tuple[str, ...] = ()
+
+
+def set_command_path(path: tuple[str, ...]) -> None:
+    """Record the exact subcommand path click resolved for this invocation.
+
+    Click hands the root callback only the first name, so `context` cannot be
+    told apart from `config context list` there, and the two have opposite
+    blast radii: one talks to the server, the other edits a local file.
+    """
+    global _command_path
+    _command_path = path
+
+
+def command_path() -> tuple[str, ...]:
+    return _command_path
+
+
 _ignore_selection = False
 
 

--- a/apps/cli/src/sibyl_cli/task.py
+++ b/apps/cli/src/sibyl_cli/task.py
@@ -1121,7 +1121,7 @@ def update_task(
                     "--description, --assignee, --epic, --feature, --tags, --tech, "
                     "--add-dep, or --remove-dep"
                 )
-                return
+                raise typer.Exit(1)
 
             resolved_id = await _resolve_task_id(client, task_id)
             assignees = [assignee] if assignee else None

--- a/apps/cli/src/sibyl_cli/task.py
+++ b/apps/cli/src/sibyl_cli/task.py
@@ -587,6 +587,7 @@ def start_task(
                 _display_task_panel(entity)
             else:
                 error(f"Failed to start task: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -629,6 +630,7 @@ def block_task(
                 print_mutation_receipt(response)
             else:
                 error(f"Failed to block task: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -670,6 +672,7 @@ def unblock_task(
                 print_mutation_receipt(response)
             else:
                 error(f"Failed to unblock task: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -724,6 +727,7 @@ def submit_review(
                 print_mutation_receipt(response)
             else:
                 error(f"Failed to submit for review: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -813,6 +817,7 @@ def complete_task(
                     )
             else:
                 error(f"Failed to complete task: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -1042,6 +1047,7 @@ def create_task(
                     info(f"Dependencies: {', '.join(dep_list)}")
             else:
                 error(f"Failed to create task: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -1160,6 +1166,7 @@ def update_task(
                 info(f"Fields: {', '.join(response.get('data', {}).keys())}")
             else:
                 error(f"Failed to update task: {response.get('message', 'Unknown error')}")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)
@@ -1242,8 +1249,11 @@ def add_note(
             if response.get("id"):
                 success(f"Note added: {response['id']}")
                 print_mutation_receipt(response)
+            elif response.get("success"):
+                success(f"Note added to task: {resolved_id}")
             else:
                 error("Failed to add note")
+                raise typer.Exit(1)
 
         except SibylClientError as e:
             _handle_client_error(e)

--- a/apps/cli/src/sibyl_cli/task.py
+++ b/apps/cli/src/sibyl_cli/task.py
@@ -29,6 +29,7 @@ from sibyl_cli.common import (
     info,
     pagination_hint,
     print_json,
+    print_json_result,
     print_mutation_receipt,
     resolve_content_input,
     run_async,
@@ -46,16 +47,6 @@ app = typer.Typer(
 
 # Use centralized handler from common.py
 _handle_client_error = handle_client_error
-
-
-def _output_response(response: dict, json_out: bool, success_msg: str | None = None) -> None:
-    """Output response as JSON or table message."""
-    if json_out:
-        print_json(response)
-    elif success_msg and response.get("success"):
-        success(success_msg)
-    elif not response.get("success"):
-        error(f"Failed: {response.get('message', 'Unknown error')}")
 
 
 def _normalize_created_task_response(
@@ -572,7 +563,7 @@ def start_task(
             response = await client.start_task(resolved_id, assignee, **revision_kwargs)
 
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("success")))
                 return
 
             if response.get("success"):
@@ -622,7 +613,7 @@ def block_task(
             response = await client.block_task(resolved_id, reason, **revision_kwargs)
 
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("success")))
                 return
 
             if response.get("success"):
@@ -664,7 +655,7 @@ def unblock_task(
             response = await client.unblock_task(resolved_id, **revision_kwargs)
 
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("success")))
                 return
 
             if response.get("success"):
@@ -719,7 +710,7 @@ def submit_review(
             )
 
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("success")))
                 return
 
             if response.get("success"):
@@ -800,7 +791,7 @@ def complete_task(
             )
 
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("success")))
                 return
 
             if response.get("success"):
@@ -1034,7 +1025,10 @@ def create_task(
             )
 
             if json_out:
-                print_json(normalized_response)
+                print_json_result(
+                    normalized_response,
+                    succeeded=bool(response.get("success") or normalized_response.get("id")),
+                )
                 return
 
             task_id = normalized_response.get("id")
@@ -1157,7 +1151,7 @@ def update_task(
             )
 
             if json_out:
-                print_json(response)
+                print_json_result(response, succeeded=bool(response.get("success")))
                 return
 
             if response.get("success"):
@@ -1243,7 +1237,10 @@ def add_note(
             )
 
             if json_out:
-                print_json(response)
+                print_json_result(
+                    response,
+                    succeeded=bool(response.get("id") or response.get("success")),
+                )
                 return
 
             if response.get("id"):

--- a/apps/cli/src/sibyl_cli/update.py
+++ b/apps/cli/src/sibyl_cli/update.py
@@ -513,3 +513,4 @@ def update(
         success("Update complete!")
     else:
         warn("Update completed with some issues")
+        raise typer.Exit(1)

--- a/apps/cli/src/sibyl_cli/update.py
+++ b/apps/cli/src/sibyl_cli/update.py
@@ -250,8 +250,9 @@ def update_cli() -> bool:
         # Get new version
         new_version = get_current_cli_version()
         success(f"CLI updated to {new_version}")
-        sync_skills_after_cli_update()
-        return True
+        # The binary landed but its skills did not, so the command as a whole
+        # did not do what it said it would.
+        return sync_skills_after_cli_update()
     else:
         error("Failed to update CLI")
         if result.stderr:
@@ -507,6 +508,7 @@ def update(
             success("Skills refreshed")
         else:
             warn("Skills refresh had issues")
+            all_success = False
 
     console.print()
     if all_success:

--- a/apps/cli/src/sibyl_cli/update.py
+++ b/apps/cli/src/sibyl_cli/update.py
@@ -140,7 +140,7 @@ def get_server_version() -> str | None:
     try:
         from sibyl_cli import config_store
 
-        base_url = config_store.get_server_url()
+        base_url = config_store.get_effective_server_url()
     except Exception:
         return None
     if not base_url:

--- a/apps/cli/tests/test_auth_login.py
+++ b/apps/cli/tests/test_auth_login.py
@@ -8,7 +8,7 @@ import typer
 from typer.testing import CliRunner
 
 from sibyl_cli import auth, auth_store, config_store
-from sibyl_cli.client import SibylClientError
+from sibyl_cli.client import SibylClient, SibylClientError
 from sibyl_cli.main import app
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -364,3 +364,37 @@ def test_auth_status_exits_non_zero_without_a_stored_token(
 
     assert result.exit_code == 1
     assert "No auth token found" in _plain(result.stdout)
+
+
+def test_login_resolves_the_same_server_as_every_other_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An active context outranks SIBYL_API_URL for auth exactly as it does for the client."""
+    calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    config_store.create_context("prod", "https://sibyl.example.com", set_active=True)
+    monkeypatch.setenv("SIBYL_API_URL", "http://localhost:3334/api")
+    monkeypatch.setattr(auth, "_login_auto", lambda **kwargs: calls.append(kwargs))
+
+    result = CliRunner().invoke(app, ["auth", "login"])
+
+    assert result.exit_code == 0
+    assert calls[0]["api_url"] == "https://sibyl.example.com/api"
+    assert calls[0]["api_url"] == SibylClient().base_url
+
+
+def test_auth_commands_follow_the_context_override_like_the_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    config_store.create_context("local", "http://localhost:3334", set_active=True)
+    config_store.create_context("prod", "https://sibyl.example.com", org_slug="acme")
+
+    monkeypatch.setenv("SIBYL_CONTEXT", "prod")
+
+    assert auth._compute_api_url(None) == "https://sibyl.example.com/api"
+    assert auth._current_credential_scope() == "context:prod:org:acme"
+    assert auth._compute_api_url(None) == SibylClient(context_name="prod").base_url

--- a/apps/cli/tests/test_auth_login.py
+++ b/apps/cli/tests/test_auth_login.py
@@ -463,3 +463,55 @@ def test_a_login_with_no_explicit_url_still_uses_the_selected_context(
     assert result.exit_code == 0
     assert calls[0]["api_url"] == "https://prod.example.com/api"
     assert calls[0]["credential_scope_name"] == "context:prod:org:acme"
+
+
+def test_a_shared_server_scopes_the_login_to_the_selected_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two contexts, one server: config order must not decide whose token this is."""
+    from sibyl_cli import state
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(state, "_context_override", None)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+    config_store.create_context("alpha", "https://shared.example.com", org_slug="alpha-org")
+    config_store.create_context(
+        "beta", "https://shared.example.com", org_slug="beta-org", set_active=True
+    )
+    monkeypatch.setattr(auth, "_login_auto", lambda **kwargs: calls.append(kwargs))
+
+    result = CliRunner().invoke(app, ["auth", "login", "https://shared.example.com"])
+
+    assert result.exit_code == 0
+    # The scope the next command reads back, not whichever context sorts first.
+    assert calls[0]["credential_scope_name"] == auth._current_credential_scope()
+    assert calls[0]["credential_scope_name"] == "context:beta:org:beta-org"
+    # The selected context agrees with the URL, so there is nothing to warn about.
+    assert "not the selected context" not in _plain(result.stdout)
+
+
+def test_a_shared_server_the_selection_does_not_name_demands_disambiguation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guessing between two candidate credentials would overwrite one of them."""
+    from sibyl_cli import state
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(state, "_context_override", None)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+    config_store.create_context("alpha", "https://shared.example.com", org_slug="alpha-org")
+    config_store.create_context("beta", "https://shared.example.com", org_slug="beta-org")
+    config_store.create_context("local", "http://localhost:3334", set_active=True)
+    monkeypatch.setattr(auth, "_login_auto", lambda **kwargs: calls.append(kwargs))
+
+    result = CliRunner().invoke(app, ["auth", "login", "https://shared.example.com"])
+
+    assert result.exit_code == 1
+    assert calls == []
+    plain = _plain(result.stdout)
+    assert "alpha" in plain
+    assert "beta" in plain

--- a/apps/cli/tests/test_auth_login.py
+++ b/apps/cli/tests/test_auth_login.py
@@ -398,3 +398,68 @@ def test_auth_commands_follow_the_context_override_like_the_client(
     assert auth._compute_api_url(None) == "https://sibyl.example.com/api"
     assert auth._current_credential_scope() == "context:prod:org:acme"
     assert auth._compute_api_url(None) == SibylClient(context_name="prod").base_url
+
+
+def test_an_explicit_login_url_scopes_the_credential_to_that_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pin must not scope a credential for a server the pin does not name."""
+    from sibyl_cli import state
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(state, "_context_override", None)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+    config_store.create_context("prod", "https://prod.example.com", org_slug="acme")
+    config_store.create_context("staging", "https://staging.example.com", set_active=True)
+    # A directory pin selects prod while the login names staging outright.
+    monkeypatch.setattr(config_store, "resolve_context_from_cwd", lambda: "prod")
+    monkeypatch.setattr(auth, "_login_auto", lambda **kwargs: calls.append(kwargs))
+
+    result = CliRunner().invoke(app, ["auth", "login", "https://staging.example.com"])
+
+    assert result.exit_code == 0
+    assert calls[0]["api_url"] == "https://staging.example.com/api"
+    # The scope follows the URL that was logged in to, not the pin.
+    assert calls[0]["credential_scope_name"] == "context:staging:org:default"
+    assert "not the selected context" in _plain(result.stdout)
+
+
+def test_an_explicit_url_with_no_matching_context_stores_unscoped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sibyl_cli import state
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(state, "_context_override", None)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+    config_store.create_context("prod", "https://prod.example.com", set_active=True)
+    monkeypatch.setattr(auth, "_login_auto", lambda **kwargs: calls.append(kwargs))
+
+    result = CliRunner().invoke(app, ["auth", "login", "https://elsewhere.example.com"])
+
+    assert result.exit_code == 0
+    assert calls[0]["credential_scope_name"] is None
+
+
+def test_a_login_with_no_explicit_url_still_uses_the_selected_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sibyl_cli import state
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(state, "_context_override", None)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+    config_store.create_context("prod", "https://prod.example.com", org_slug="acme", set_active=True)
+    monkeypatch.setattr(auth, "_login_auto", lambda **kwargs: calls.append(kwargs))
+
+    result = CliRunner().invoke(app, ["auth", "login"])
+
+    assert result.exit_code == 0
+    assert calls[0]["api_url"] == "https://prod.example.com/api"
+    assert calls[0]["credential_scope_name"] == "context:prod:org:acme"

--- a/apps/cli/tests/test_context_pack.py
+++ b/apps/cli/tests/test_context_pack.py
@@ -74,7 +74,7 @@ def _context_pack() -> dict:
 @patch("sibyl_cli.context_quick.read_server_credentials")
 @patch("sibyl_cli.context_quick.resolve_project_from_cwd", return_value="project_linked")
 @patch(
-    "sibyl_cli.context_quick.get_active_context",
+    "sibyl_cli.context_quick.resolve_effective_context",
     return_value=Context(
         name="local",
         server_url="http://localhost:3334",
@@ -83,7 +83,7 @@ def _context_pack() -> dict:
     ),
 )
 def test_context_quick_json_returns_flat_local_status(
-    mock_get_active_context: MagicMock,
+    mock_resolve_effective_context: MagicMock,
     mock_resolve_project_from_cwd: MagicMock,
     mock_read_server_credentials: MagicMock,
 ) -> None:
@@ -103,7 +103,7 @@ def test_context_quick_json_returns_flat_local_status(
     assert payload["project_source"] == "linked"
     assert payload["auth"] == "valid"
     assert payload["auth_expires_in"] > 0
-    mock_get_active_context.assert_called_once_with()
+    mock_resolve_effective_context.assert_called_once_with()
     mock_resolve_project_from_cwd.assert_called_once_with()
     mock_read_server_credentials.assert_called_once_with(
         "http://localhost:3334/api",
@@ -114,9 +114,9 @@ def test_context_quick_json_returns_flat_local_status(
 @patch("sibyl_cli.context_quick.read_server_credentials", return_value={})
 @patch("sibyl_cli.context_quick.resolve_project_from_cwd", return_value=None)
 @patch("sibyl_cli.context_quick.get_effective_server_url", return_value="http://localhost:3334")
-@patch("sibyl_cli.context_quick.get_active_context", return_value=None)
+@patch("sibyl_cli.context_quick.resolve_effective_context", return_value=None)
 def test_context_quick_without_context_reports_missing_auth(
-    mock_get_active_context: MagicMock,
+    mock_resolve_effective_context: MagicMock,
     mock_get_effective_server_url: MagicMock,
     mock_resolve_project_from_cwd: MagicMock,
     mock_read_server_credentials: MagicMock,
@@ -128,7 +128,7 @@ def test_context_quick_without_context_reports_missing_auth(
     assert "Project:" in result.stdout
     assert "not linked" in result.stdout
     assert "missing" in result.stdout
-    mock_get_active_context.assert_called_once_with()
+    mock_resolve_effective_context.assert_called_once_with()
     mock_get_effective_server_url.assert_called_once_with()
     mock_resolve_project_from_cwd.assert_called_once_with()
     mock_read_server_credentials.assert_called_once_with(

--- a/apps/cli/tests/test_doctor.py
+++ b/apps/cli/tests/test_doctor.py
@@ -7,12 +7,14 @@ from typer.testing import CliRunner
 
 from sibyl_cli import config_store
 from sibyl_cli import doctor as doctor_module
+from sibyl_cli import pending_writes
 from sibyl_cli.doctor import DoctorCheck, DoctorContext
 from sibyl_cli.main import app
 
 
 def _use_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
 
 
 def test_doctor_json_reports_missing_config(
@@ -89,6 +91,7 @@ async def test_doctor_collects_healthy_local_context(
         "port",
         "embedded-lock",
         "write-test",
+        "pending-writes",
     ]
 
 

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -7,6 +7,7 @@ set is a successful answer and must not.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -540,12 +541,142 @@ def test_a_broken_selection_still_lets_you_repair_it(
     _contexts(tmp_path, monkeypatch)
     monkeypatch.setattr(state, "_ignore_selection", False)
 
-    result = CliRunner().invoke(main_app, ["-C", "stagingg", "context", "list"])
+    with patch("sibyl_cli.context.get_client") as get:
+        result = CliRunner().invoke(main_app, ["-C", "stagingg", "config", "context", "list"])
 
     # The repair command runs; the broken selection is dropped, not enforced.
+    assert result.exit_code == 0
     assert "does not exist; ignoring it" in result.stdout
     assert "Unknown context" not in result.stdout
     assert state.context_selection_ignored()
+    # Recovery reads the config file. It must never reach a server, because the
+    # only server left to reach is the one the user did not select.
+    get.assert_not_called()
+
+
+def test_the_recall_command_is_not_a_repair_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`sibyl context <goal>` fetches a pack; it shares a word with the config group."""
+    from sibyl_cli import state
+
+    _contexts(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+
+    with patch("sibyl_cli.main.get_client") as get:
+        result = CliRunner().invoke(main_app, ["-C", "stagingg", "context", "list"])
+
+    assert result.exit_code == 1
+    assert "Unknown context 'stagingg'" in result.stdout
+    get.assert_not_called()
+    assert not state.context_selection_ignored()
+
+
+def test_pack_is_not_a_repair_command_either(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The context group holds one networked leaf, and it does not inherit recovery."""
+    from sibyl_cli import state
+
+    _contexts(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+
+    with patch("sibyl_cli.context.get_client") as get:
+        result = CliRunner().invoke(main_app, ["-C", "stagingg", "config", "context", "pack"])
+
+    assert result.exit_code == 1
+    assert "Unknown context 'stagingg'" in result.stdout
+    get.assert_not_called()
+
+
+def test_doctor_drops_to_local_checks_when_the_selection_is_broken(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probing the active context would diagnose a server the user never named."""
+    from sibyl_cli import state
+
+    _contexts(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+    probes: list[str] = []
+
+    class _NoNetwork:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _NoNetwork:
+            return self
+
+        async def __aexit__(self, *args: Any) -> bool:
+            return False
+
+        async def get(self, url: str, *args: Any, **kwargs: Any) -> None:
+            probes.append(url)
+            raise AssertionError(f"doctor probed {url} after dropping the selection")
+
+    with (
+        patch("sibyl_cli.doctor.httpx.AsyncClient", _NoNetwork),
+        patch("sibyl_cli.doctor.get_client") as get,
+    ):
+        result = CliRunner().invoke(main_app, ["-C", "stagingg", "doctor", "--json"])
+
+    assert result.exit_code == 1
+    assert probes == []
+    get.assert_not_called()
+
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    names = {check["name"]: check["status"] for check in payload["checks"]}
+    assert names["context-selection"] == "fail"
+    # None of the probes that would have been aimed at the active context ran.
+    assert not {"health", "port", "write"} & set(names)
+
+
+def test_every_recovery_leaf_is_a_real_command_that_never_opens_a_connection() -> None:
+    """The carve-out is only safe while its members stay on the filesystem."""
+    import inspect
+
+    import typer
+    from typer.main import get_command
+
+    from sibyl_cli import main as main_module
+
+    root = get_command(main_app)
+    for path in sorted(main_module._CONTEXT_REPAIR_COMMANDS):
+        command = root
+        for name in path:
+            lookup = getattr(command, "get_command", None)
+            assert lookup is not None, f"{path} walks through a leaf at '{name}'"
+            command = lookup(typer.Context(command), name)
+            assert command is not None, f"{path} names a command that does not exist"
+
+        if path == ("doctor",):
+            # doctor probes servers by trade; it drops to filesystem checks when
+            # the selection is broken, which the doctor test above pins.
+            continue
+
+        source = inspect.getsource(inspect.unwrap(command.callback))
+        assert "get_client(" not in source and "SibylClient(" not in source, (
+            f"{path} is on the recovery allowlist but opens a connection, so a "
+            "dropped selection would retarget it at the active context."
+        )
+
+
+def test_an_option_before_a_repair_leaf_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unresolvable command path gets no recovery privilege, only refusal."""
+    from sibyl_cli import state
+
+    _contexts(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+
+    result = CliRunner().invoke(main_app, ["-C", "stagingg", "contexts", "--json", "list"])
+
+    assert result.exit_code == 1
+    assert "Unknown context 'stagingg'" in result.stdout
 
 
 def test_the_resolver_itself_refuses_to_fall_through(

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -467,3 +467,109 @@ def test_project_relink_exits_nonzero_when_nothing_matches() -> None:
         result = CliRunner().invoke(project_module.app, ["relink"])
 
     assert result.exit_code == 1
+
+
+def _contexts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from sibyl_cli import config_store, state
+
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(state, "_context_override", None)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+    config_store.create_context("production", "https://prod.example.com", set_active=True)
+    config_store.create_context("staging", "https://staging.example.com")
+
+
+def test_a_misspelled_context_flag_never_falls_back_to_the_active_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`-C stagingg` with production active must not mutate production."""
+    from sibyl_cli import task as task_module
+
+    _contexts(tmp_path, monkeypatch)
+    client = _client(create_task={"success": True, "task_id": "t1"})
+
+    with patch("sibyl_cli.task.get_client", return_value=client) as get:
+        result = CliRunner().invoke(
+            main_app,
+            ["-C", "stagingg", "task", "create", "--title", "x", "--project", "p"],
+        )
+
+    assert result.exit_code == 1
+    assert "Unknown context 'stagingg'" in result.stdout
+    assert "production" in result.stdout
+    get.assert_not_called()
+    _ = task_module
+
+
+def test_a_misspelled_context_env_var_is_also_a_hard_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _contexts(tmp_path, monkeypatch)
+    monkeypatch.setenv("SIBYL_CONTEXT", "stagingg")
+
+    result = CliRunner().invoke(main_app, ["task", "list"])
+
+    assert result.exit_code == 1
+    assert "SIBYL_CONTEXT" in result.stdout
+
+
+def test_a_directory_pin_at_a_deleted_context_is_a_hard_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sibyl_cli import config_store
+
+    _contexts(tmp_path, monkeypatch)
+    monkeypatch.setattr(config_store, "resolve_context_from_cwd", lambda: "deleted-ctx")
+
+    result = CliRunner().invoke(main_app, ["task", "list"])
+
+    assert result.exit_code == 1
+    assert "directory pin" in result.stdout
+
+
+def test_a_broken_selection_still_lets_you_repair_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hard-erroring every command would strand the user with no way back."""
+    from sibyl_cli import state
+
+    _contexts(tmp_path, monkeypatch)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+
+    result = CliRunner().invoke(main_app, ["-C", "stagingg", "context", "list"])
+
+    # The repair command runs; the broken selection is dropped, not enforced.
+    assert "does not exist; ignoring it" in result.stdout
+    assert "Unknown context" not in result.stdout
+    assert state.context_selection_ignored()
+
+
+def test_the_resolver_itself_refuses_to_fall_through(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard lives in the resolver, not only in the callback."""
+    from sibyl_cli import config_store
+    from sibyl_cli.client import resolve_api_base_url
+
+    _contexts(tmp_path, monkeypatch)
+
+    with pytest.raises(config_store.UnknownContextError):
+        resolve_api_base_url("stagingg")
+
+
+def test_an_unknown_context_never_inherits_the_active_tls_setting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sibyl_cli import config_store
+    from sibyl_cli.client import SibylClient
+
+    _contexts(tmp_path, monkeypatch)
+
+    with pytest.raises(config_store.UnknownContextError):
+        SibylClient(context_name="stagingg")

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -1,0 +1,176 @@
+"""Exit-code contract for CLI failure paths.
+
+Hooks, CI jobs, and agents branch on `$?`. A refused write, an expired
+session, and an unreachable server must all exit nonzero; an empty result
+set is a successful answer and must not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from sibyl_cli import entity, epic, project, task
+from sibyl_cli.client import SibylClientError
+from sibyl_cli.main import app as main_app
+
+TASK_ID = "13364346-8475-4664-8b52-eb963af2fda7"
+REFUSED: dict[str, Any] = {"success": False, "message": "Write refused"}
+
+
+def _client(**methods: Any) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    for name, value in methods.items():
+        setattr(client, name, AsyncMock(return_value=value))
+    return client
+
+
+@pytest.fixture
+def resolved_ids():
+    with (
+        patch("sibyl_cli.task._resolve_task_id", AsyncMock(side_effect=lambda _c, i: i)),
+        patch("sibyl_cli.epic._resolve_epic_id", AsyncMock(side_effect=lambda _c, i: i)),
+    ):
+        yield
+
+
+def test_task_start_exits_nonzero_when_the_write_is_refused(resolved_ids: None) -> None:
+    with patch("sibyl_cli.task.get_client", return_value=_client(start_task=REFUSED)):
+        result = CliRunner().invoke(task.app, ["start", TASK_ID])
+
+    assert result.exit_code == 1
+
+
+def test_task_complete_exits_nonzero_when_the_write_is_refused(resolved_ids: None) -> None:
+    with patch("sibyl_cli.task.get_client", return_value=_client(complete_task=REFUSED)):
+        result = CliRunner().invoke(task.app, ["complete", TASK_ID])
+
+    assert result.exit_code == 1
+
+
+def test_task_update_exits_nonzero_when_the_write_is_refused(resolved_ids: None) -> None:
+    with patch("sibyl_cli.task.get_client", return_value=_client(update_task=REFUSED)):
+        result = CliRunner().invoke(task.app, ["update", TASK_ID, "--priority", "high"])
+
+    assert result.exit_code == 1
+
+
+def test_task_create_exits_nonzero_when_the_write_is_refused() -> None:
+    with patch("sibyl_cli.task.get_client", return_value=_client(create_task=REFUSED)):
+        result = CliRunner().invoke(
+            task.app,
+            ["create", "--title", "Refused", "--project", "project_123456789abc"],
+        )
+
+    assert result.exit_code == 1
+
+
+def test_epic_start_exits_nonzero_when_the_write_is_refused(resolved_ids: None) -> None:
+    with patch("sibyl_cli.epic.get_client", return_value=_client(update_entity=REFUSED)):
+        result = CliRunner().invoke(epic.app, ["start", "epic_123"])
+
+    assert result.exit_code == 1
+
+
+def test_entity_create_exits_nonzero_when_the_write_is_refused() -> None:
+    with patch("sibyl_cli.entity.get_client", return_value=_client(create_entity={})):
+        result = CliRunner().invoke(entity.app, ["create", "--name", "Refused", "--type", "note"])
+
+    assert result.exit_code == 1
+
+
+def test_project_create_exits_nonzero_when_the_write_is_refused() -> None:
+    with patch("sibyl_cli.project.get_client", return_value=_client(create_entity={})):
+        result = CliRunner().invoke(project.app, ["create", "--name", "Refused"])
+
+    assert result.exit_code == 1
+
+
+def test_task_start_exits_nonzero_on_an_expired_session(resolved_ids: None) -> None:
+    client = _client()
+    client.start_task = AsyncMock(
+        side_effect=SibylClientError("Not authenticated", status_code=401)
+    )
+
+    with patch("sibyl_cli.task.get_client", return_value=client):
+        result = CliRunner().invoke(task.app, ["start", TASK_ID])
+
+    assert result.exit_code == 1
+
+
+def test_task_start_exits_nonzero_when_the_server_is_unreachable(resolved_ids: None) -> None:
+    client = _client()
+    client.start_task = AsyncMock(
+        side_effect=SibylClientError("Cannot connect to Sibyl server at http://localhost:3334")
+    )
+
+    with patch("sibyl_cli.task.get_client", return_value=client):
+        result = CliRunner().invoke(task.app, ["start", TASK_ID])
+
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("status_code", [403, 409, 500, 503])
+def test_task_start_exits_nonzero_on_server_error_envelopes(
+    resolved_ids: None,
+    status_code: int,
+) -> None:
+    client = _client()
+    client.start_task = AsyncMock(
+        side_effect=SibylClientError("Request failed", status_code=status_code)
+    )
+
+    with patch("sibyl_cli.task.get_client", return_value=client):
+        result = CliRunner().invoke(task.app, ["start", TASK_ID])
+
+    assert result.exit_code == 1
+
+
+def test_note_alias_exits_nonzero_when_the_write_is_refused() -> None:
+    client = _client(create_note={})
+
+    with (
+        patch("sibyl_cli.main.get_client", return_value=client),
+        patch("sibyl_cli.main.resolve_id_prefix", AsyncMock(side_effect=lambda _c, i, **_k: i)),
+    ):
+        result = CliRunner().invoke(main_app, ["note", TASK_ID, "body"])
+
+    assert result.exit_code == 1
+
+
+def test_local_stop_exits_nonzero_when_compose_fails(tmp_path: Path) -> None:
+    from sibyl_cli import local
+
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text("services: {}\n")
+    failed = MagicMock()
+    failed.returncode = 1
+
+    with (
+        patch.object(local, "SIBYL_LOCAL_COMPOSE", compose_file),
+        patch("sibyl_cli.local.is_running", return_value=True),
+        patch("sibyl_cli.local.run_compose", return_value=failed),
+    ):
+        result = CliRunner().invoke(local.app, ["stop"])
+
+    assert result.exit_code == 1
+    assert "Failed to stop Sibyl" in result.stdout
+
+
+def test_an_empty_result_set_still_exits_zero() -> None:
+    """No matches is an answer, not a failure. Scripts must not treat it as one."""
+    client = _client(explore={"entities": [], "total": 0})
+
+    with (
+        patch("sibyl_cli.task.get_client", return_value=client),
+        patch("sibyl_cli.task.resolve_project_from_cwd", return_value="project_123"),
+    ):
+        result = CliRunner().invoke(task.app, ["list"])
+
+    assert result.exit_code == 0

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -174,3 +174,27 @@ def test_an_empty_result_set_still_exits_zero() -> None:
         result = CliRunner().invoke(task.app, ["list"])
 
     assert result.exit_code == 0
+
+
+def test_the_401_remediation_names_commands_that_exist() -> None:
+    """The most-hit error path pointed at `sibyl auth signup`, which was never registered."""
+    from sibyl_cli import auth
+
+    client = _client()
+    client.get = AsyncMock(side_effect=SibylClientError("Not authenticated", status_code=401))
+
+    with patch("sibyl_cli.main.get_client", return_value=client):
+        result = CliRunner().invoke(main_app, ["health"])
+
+    assert result.exit_code == 1
+    suggested = {
+        line.split("sibyl auth ", 1)[1].split()[0]
+        for line in result.stdout.splitlines()
+        if "sibyl auth " in line
+    }
+    registered = {command.name for command in auth.app.registered_commands if command.name} | {
+        group.name for group in auth.app.registered_groups if group.name
+    }
+
+    assert suggested
+    assert suggested <= registered

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -271,3 +271,49 @@ def test_crawl_ingest_exits_zero_when_the_crawl_queues() -> None:
         result = CliRunner().invoke(crawl.app, ["ingest", "source_123"])
 
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("json_flag", [[], ["--json"]])
+def test_health_exits_nonzero_on_an_unhealthy_server(json_flag: list[str]) -> None:
+    """Table and --json must agree about the same response."""
+    client = _client()
+    client.get = AsyncMock(return_value={"status": "unhealthy", "server_name": "stub"})
+
+    with patch("sibyl_cli.main.get_client", return_value=client):
+        result = CliRunner().invoke(main_app, ["health", *json_flag])
+
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("json_flag", [[], ["--json"]])
+def test_health_exits_zero_on_a_healthy_server(json_flag: list[str]) -> None:
+    client = _client()
+    client.get = AsyncMock(return_value={"status": "healthy", "server_name": "stub"})
+
+    with patch("sibyl_cli.main.get_client", return_value=client):
+        result = CliRunner().invoke(main_app, ["health", *json_flag])
+
+    assert result.exit_code == 0
+
+
+def test_entity_list_exits_nonzero_on_an_invalid_type() -> None:
+    result = CliRunner().invoke(entity.app, ["list", "--type", "not-a-real-type"])
+
+    assert result.exit_code == 1
+    assert "Invalid entity type" in result.stdout
+
+
+def test_entity_create_exits_nonzero_on_an_invalid_type() -> None:
+    result = CliRunner().invoke(
+        entity.app, ["create", "--name", "x", "--type", "not-a-real-type"]
+    )
+
+    assert result.exit_code == 1
+
+
+def test_task_update_exits_nonzero_when_no_fields_are_given(resolved_ids: None) -> None:
+    with patch("sibyl_cli.task.get_client", return_value=_client()):
+        result = CliRunner().invoke(task.app, ["update", TASK_ID])
+
+    assert result.exit_code == 1
+    assert "No fields to update" in result.stdout

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -573,3 +573,85 @@ def test_an_unknown_context_never_inherits_the_active_tls_setting(
 
     with pytest.raises(config_store.UnknownContextError):
         SibylClient(context_name="stagingg")
+
+
+@pytest.mark.parametrize("json_flag", [[], ["--json"]])
+def test_synthesis_verify_exits_nonzero_when_verification_fails(json_flag: list[str]) -> None:
+    """Five sweep rounds passed over this one; it reports a verdict AND a failure."""
+    failed = {"verification": {"status": "gaps", "gap_count": 3, "gaps": []}}
+
+    with patch("sibyl_cli.main.get_client", return_value=_client(synthesis_draft=failed)):
+        result = CliRunner().invoke(main_app, ["synthesis", "verify", "a goal", *json_flag])
+
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("json_flag", [[], ["--json"]])
+def test_synthesis_verify_exits_zero_when_verification_passes(json_flag: list[str]) -> None:
+    passed = {"verification": {"status": "pass", "source_count": 4, "gaps": []}}
+
+    with patch("sibyl_cli.main.get_client", return_value=_client(synthesis_draft=passed)):
+        result = CliRunner().invoke(main_app, ["synthesis", "verify", "a goal", *json_flag])
+
+    assert result.exit_code == 0
+
+
+def test_setup_reports_failure_when_hooks_cannot_be_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Against the real function, not a mock of it: the previous test mocked the
+    whole of setup_agent_integration, so its broken branch never ran."""
+    from sibyl_cli import setup as setup_module
+
+    monkeypatch.setattr(setup_module, "find_sibyl_repo", lambda: tmp_path)
+    monkeypatch.setattr(setup_module, "install_skills_symlink", lambda _d: (1, 0))
+    monkeypatch.setattr(setup_module, "install_hooks_symlink", lambda _d: True)
+    monkeypatch.setattr(setup_module, "configure_claude_hooks", lambda: False)
+
+    assert setup_module.setup_agent_integration(verbose=False) is False
+
+
+def test_setup_reports_failure_when_hooks_are_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sibyl_cli import setup as setup_module
+
+    monkeypatch.setattr(setup_module, "find_sibyl_repo", lambda: tmp_path)
+    monkeypatch.setattr(setup_module, "install_skills_symlink", lambda _d: (1, 0))
+    monkeypatch.setattr(setup_module, "install_hooks_symlink", lambda _d: False)
+
+    assert setup_module.setup_agent_integration(verbose=False) is False
+
+
+def test_setup_reports_success_when_everything_lands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sibyl_cli import setup as setup_module
+
+    monkeypatch.setattr(setup_module, "find_sibyl_repo", lambda: tmp_path)
+    monkeypatch.setattr(setup_module, "install_skills_symlink", lambda _d: (1, 0))
+    monkeypatch.setattr(setup_module, "install_hooks_symlink", lambda _d: True)
+    monkeypatch.setattr(setup_module, "configure_claude_hooks", lambda: True)
+
+    assert setup_module.setup_agent_integration(verbose=False) is True
+
+
+def test_update_skills_propagates_a_failed_hook_setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`sibyl update --skills --yes` reported complete success with hooks absent."""
+    from sibyl_cli import setup as setup_module
+    from sibyl_cli import update as update_module
+
+    monkeypatch.setattr(setup_module, "find_sibyl_repo", lambda: tmp_path)
+    monkeypatch.setattr(setup_module, "install_skills_symlink", lambda _d: (1, 0))
+    monkeypatch.setattr(setup_module, "install_hooks_symlink", lambda _d: False)
+    monkeypatch.setattr(update_module, "is_dev_mode", lambda: False)
+
+    result = CliRunner().invoke(update_module.app, ["--skills", "--yes"])
+
+    assert result.exit_code == 1

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -369,3 +369,58 @@ def test_explore_dependencies_exits_nonzero_without_a_target() -> None:
 
     assert result.exit_code == 1
     assert "Must specify either" in result.stdout
+
+
+@pytest.mark.parametrize("json_flag", [[], ["--json"]])
+def test_synthesis_remember_exits_nonzero_when_nothing_was_remembered(
+    json_flag: list[str],
+) -> None:
+    """The command's whole job is to remember; a run that did not is a failure."""
+    drafted = {"artifact": {"title": "x", "remembered_memory_id": None}}
+
+    with patch("sibyl_cli.main.get_client", return_value=_client(synthesis_draft=drafted)):
+        result = CliRunner().invoke(main_app, ["synthesis", "remember", "a goal", *json_flag])
+
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("json_flag", [[], ["--json"]])
+def test_synthesis_remember_exits_zero_when_it_lands(json_flag: list[str]) -> None:
+    remembered = {
+        "artifact": {
+            "title": "x",
+            "remembered_memory_id": "mem_1",
+            "remembered_source_id": "src_1",
+            "artifact_id": "art_1",
+        }
+    }
+
+    with patch("sibyl_cli.main.get_client", return_value=_client(synthesis_draft=remembered)):
+        result = CliRunner().invoke(main_app, ["synthesis", "remember", "a goal", *json_flag])
+
+    assert result.exit_code == 0
+
+
+def test_setup_exits_nonzero_when_integration_files_are_missing() -> None:
+    from sibyl_cli import local
+
+    with patch("sibyl_cli.setup.setup_agent_integration", return_value=False):
+        result = CliRunner().invoke(local.app, ["setup"])
+
+    assert result.exit_code == 1
+
+
+def test_update_exits_nonzero_when_a_component_fails() -> None:
+    from sibyl_cli import update as update_module
+
+    with (
+        patch.object(update_module, "update_cli", return_value=False),
+        patch.object(
+            update_module, "cli_update_available", return_value=("1.0.0", "2.0.0", True)
+        ),
+        patch.object(update_module, "get_server_version", return_value=None),
+        patch.object(update_module, "is_dev_mode", return_value=False),
+    ):
+        result = CliRunner().invoke(update_module.app, ["--cli", "--yes"])
+
+    assert result.exit_code == 1

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -424,3 +424,46 @@ def test_update_exits_nonzero_when_a_component_fails() -> None:
         result = CliRunner().invoke(update_module.app, ["--cli", "--yes"])
 
     assert result.exit_code == 1
+
+
+def test_update_exits_nonzero_when_only_the_skills_refresh_fails() -> None:
+    """A failure reported through warn() and a discarded bool is still a failure."""
+    from sibyl_cli import update as update_module
+
+    with (
+        patch.object(update_module, "is_dev_mode", return_value=False),
+        patch.object(update_module, "update_skills", return_value=False),
+    ):
+        result = CliRunner().invoke(update_module.app, ["--skills", "--yes"])
+
+    assert result.exit_code == 1
+
+
+def test_update_cli_reports_a_failed_skill_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """update_cli returned True even when the skills it installs never landed."""
+    from sibyl_cli import update as update_module
+
+    completed = MagicMock()
+    completed.returncode = 0
+
+    with (
+        patch.object(update_module.subprocess, "run", return_value=completed),
+        patch.object(update_module, "get_current_cli_version", return_value="2.0.0"),
+        patch.object(update_module, "sync_skills_after_cli_update", return_value=False),
+    ):
+        assert update_module.update_cli() is False
+
+
+def test_project_relink_exits_nonzero_when_nothing_matches() -> None:
+    """relink exists to repair a link; repairing nothing is a refusal."""
+    from sibyl_cli import project as project_module
+
+    client = _client(list_projects={"projects": []})
+
+    with (
+        patch("sibyl_cli.project.get_client", return_value=client),
+        patch("sibyl_cli.project.set_path_mapping"),
+    ):
+        result = CliRunner().invoke(project_module.app, ["relink"])
+
+    assert result.exit_code == 1

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -317,3 +317,55 @@ def test_task_update_exits_nonzero_when_no_fields_are_given(resolved_ids: None) 
 
     assert result.exit_code == 1
     assert "No fields to update" in result.stdout
+
+
+@pytest.mark.parametrize("json_flag", [[], ["--json"]])
+def test_crawl_link_graph_agrees_across_renderers_on_an_error(json_flag: list[str]) -> None:
+    """Fixing one renderer and not the other is how the health blocker happened."""
+    from sibyl_cli import crawl
+
+    failed = {"status": "error", "error": "extraction blew up"}
+
+    with patch("sibyl_cli.crawl.get_client", return_value=_client(link_graph=failed)):
+        result = CliRunner().invoke(crawl.app, ["link-graph", "src_1", *json_flag])
+
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("json_flag", [[], ["--json"]])
+def test_crawl_link_graph_exits_zero_when_it_completes(json_flag: list[str]) -> None:
+    from sibyl_cli import crawl
+
+    done = {"status": "complete", "entities_created": 0, "relationships_created": 0}
+
+    with patch("sibyl_cli.crawl.get_client", return_value=_client(link_graph=done)):
+        result = CliRunner().invoke(crawl.app, ["link-graph", "src_1", *json_flag])
+
+    assert result.exit_code == 0
+
+
+def test_epic_update_exits_nonzero_when_no_fields_are_given(resolved_ids: None) -> None:
+    """The twin of the task update site, in a file this branch already edits."""
+    with patch("sibyl_cli.epic.get_client", return_value=_client()):
+        result = CliRunner().invoke(epic.app, ["update", "epic_123"])
+
+    assert result.exit_code == 1
+    assert "No fields to update" in result.stdout
+
+
+def test_explore_traverse_exits_nonzero_on_an_out_of_range_depth() -> None:
+    from sibyl_cli import explore
+
+    result = CliRunner().invoke(explore.app, ["traverse", "entity_1", "--depth", "9"])
+
+    assert result.exit_code == 1
+    assert "Depth must be between 1 and 3" in result.stdout
+
+
+def test_explore_dependencies_exits_nonzero_without_a_target() -> None:
+    from sibyl_cli import explore
+
+    result = CliRunner().invoke(explore.app, ["dependencies"])
+
+    assert result.exit_code == 1
+    assert "Must specify either" in result.stdout

--- a/apps/cli/tests/test_exit_codes.py
+++ b/apps/cli/tests/test_exit_codes.py
@@ -198,3 +198,76 @@ def test_the_401_remediation_names_commands_that_exist() -> None:
 
     assert suggested
     assert suggested <= registered
+
+
+@pytest.mark.parametrize(
+    ("command", "method"),
+    [
+        (["start", TASK_ID], "start_task"),
+        (["block", TASK_ID, "--reason", "waiting on review"], "block_task"),
+        (["unblock", TASK_ID], "unblock_task"),
+        (["review", TASK_ID], "submit_review"),
+        (["complete", TASK_ID], "complete_task"),
+        (["update", TASK_ID, "--priority", "high"], "update_task"),
+    ],
+)
+def test_json_output_still_exits_nonzero_on_a_refused_write(
+    resolved_ids: None,
+    command: list[str],
+    method: str,
+) -> None:
+    """--json is what agents invoke, so the refusal has to reach $? on that path too."""
+    import json
+
+    with patch("sibyl_cli.task.get_client", return_value=_client(**{method: REFUSED})):
+        result = CliRunner().invoke(task.app, [*command, "--json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["success"] is False
+
+
+def test_json_output_still_exits_zero_when_the_write_lands(resolved_ids: None) -> None:
+    import json
+
+    accepted = {"success": True, "data": {}}
+
+    with patch("sibyl_cli.task.get_client", return_value=_client(start_task=accepted)):
+        result = CliRunner().invoke(task.app, ["start", TASK_ID, "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["success"] is True
+
+
+def test_crawl_ingest_exits_nonzero_when_the_crawl_is_refused() -> None:
+    """The sibling of `source add` in the same module, missed by the audit's list."""
+    from sibyl_cli import crawl
+
+    refused = {"status": "failed", "message": "crawler exploded"}
+
+    with patch("sibyl_cli.crawl_shared.get_client", return_value=_client(start_crawl=refused)):
+        result = CliRunner().invoke(crawl.app, ["ingest", "source_123"])
+
+    assert result.exit_code == 1
+    assert "Crawl failed" in result.stdout
+
+
+def test_crawl_ingest_json_exits_nonzero_when_the_crawl_is_refused() -> None:
+    from sibyl_cli import crawl
+
+    refused = {"status": "failed", "message": "crawler exploded"}
+
+    with patch("sibyl_cli.crawl_shared.get_client", return_value=_client(start_crawl=refused)):
+        result = CliRunner().invoke(crawl.app, ["ingest", "source_123", "--json"])
+
+    assert result.exit_code == 1
+
+
+def test_crawl_ingest_exits_zero_when_the_crawl_queues() -> None:
+    from sibyl_cli import crawl
+
+    queued = {"status": "queued", "message": "Crawl queued"}
+
+    with patch("sibyl_cli.crawl_shared.get_client", return_value=_client(start_crawl=queued)):
+        result = CliRunner().invoke(crawl.app, ["ingest", "source_123"])
+
+    assert result.exit_code == 0

--- a/apps/cli/tests/test_logs.py
+++ b/apps/cli/tests/test_logs.py
@@ -56,6 +56,37 @@ def test_stream_logs_uses_resolved_client_url_and_token(
 
     import asyncio
 
-    asyncio.run(_stream_logs(client, None, None))
+    # The stream ends only when the server or the network ends it, so a
+    # supervised follow that loses its connection has to exit nonzero.
+    with pytest.raises(typer.Exit) as exc:
+        asyncio.run(_stream_logs(client, None, None))
 
+    assert exc.value.exit_code == 1
     assert connect_urls == ["wss://sibyl.example/api/logs/stream?token=scoped-access-token"]
+
+
+def test_stream_logs_exits_nonzero_when_the_connection_drops(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A dropped stream must not look like a clean finish to a supervisor."""
+    monkeypatch.setitem(
+        sys.modules,
+        "websockets",
+        SimpleNamespace(
+            connect=lambda _url: _FakeWebSocket(),
+            ConnectionClosed=_FakeConnectionClosed,
+        ),
+    )
+    client = SimpleNamespace(base_url="https://sibyl.example/api", auth_token="tok")
+
+    import asyncio
+
+    with pytest.raises(typer.Exit) as exc:
+        asyncio.run(_stream_logs(client, None, None))
+
+    assert exc.value.exit_code == 1
+    out = capsys.readouterr().out
+    assert "Connection closed" in out
+    # The broad handler below must not relabel the clean exit.
+    assert "WebSocket error" not in out

--- a/apps/cli/tests/test_pending_cli.py
+++ b/apps/cli/tests/test_pending_cli.py
@@ -259,3 +259,43 @@ def test_pending_writes_flush_failure_summary_names_both_classes(
     assert "1 replayed, 1 failed" in result.stdout
     assert "safe to flush again" in result.stdout
     assert "flush again shortly" in result.stdout
+
+
+def test_pending_writes_discard_exits_nonzero_when_an_id_matches_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named id that matched nothing is a refusal, and the write is still queued."""
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    _create_pending()
+
+    result = CliRunner().invoke(pending.app, ["discard", "deadbeef"])
+
+    assert result.exit_code == 1
+    assert len(pending_writes.list_pending_writes()) == 1
+
+
+def test_pending_writes_discard_exits_zero_when_it_removes_what_was_named(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    item = _create_pending()
+
+    result = CliRunner().invoke(pending.app, ["discard", str(item["id"])])
+
+    assert result.exit_code == 0
+    assert pending_writes.list_pending_writes() == []
+
+
+def test_pending_writes_discard_read_like_exits_zero_when_nothing_matches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No read-like leftovers is an empty result, not a refusal."""
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    _create_pending()
+
+    result = CliRunner().invoke(pending.app, ["discard", "--read-like"])
+
+    assert result.exit_code == 0

--- a/apps/cli/tests/test_pending_cli.py
+++ b/apps/cli/tests/test_pending_cli.py
@@ -299,3 +299,32 @@ def test_pending_writes_discard_read_like_exits_zero_when_nothing_matches(
     result = CliRunner().invoke(pending.app, ["discard", "--read-like"])
 
     assert result.exit_code == 0
+
+
+def test_pending_writes_discard_counts_a_repeated_id_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same id twice discards once; the second pass is not a miss."""
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    item = _create_pending()
+    write_id = str(item["id"])
+
+    result = CliRunner().invoke(pending.app, ["discard", write_id, write_id])
+
+    assert result.exit_code == 0
+    assert pending_writes.list_pending_writes() == []
+
+
+def test_pending_writes_discard_reports_what_it_removed_on_a_partial_match(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    item = _create_pending()
+
+    result = CliRunner().invoke(pending.app, ["discard", str(item["id"]), "deadbeef"])
+
+    assert result.exit_code == 1
+    assert "Discarded 1 pending write" in result.stdout
+    assert "No pending write matched 1" in result.stdout

--- a/apps/cli/tests/test_pending_visibility.py
+++ b/apps/cli/tests/test_pending_visibility.py
@@ -1,0 +1,158 @@
+"""Buffered writes must be visible wherever a user looks.
+
+A write the server refuses is filed into ~/.config/sibyl/pending_writes/
+and the command otherwise carries on. Nothing about that queue reached the
+user before: `sibyl doctor` did not check it and `sibyl debug status` needs
+the OWNER role.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from sibyl_cli import doctor as doctor_module
+from sibyl_cli import pending_writes
+from sibyl_cli.main import app as cli_app
+from sibyl_cli.main import main as cli_main
+
+
+def _buffer(count: int) -> None:
+    for index in range(count):
+        pending_writes.create_pending_write(
+            method="POST",
+            path="/memory/raw",
+            base_url="http://testserver/api",
+            json_payload={"title": f"queued {index}"},
+            params=None,
+        )
+
+
+@pytest.fixture
+def sandbox_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    return tmp_path
+
+
+def test_a_queued_write_warns_on_stderr_at_command_completion(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _buffer(2)
+    monkeypatch.setattr("sys.argv", ["sibyl", "version"])
+
+    with pytest.raises(SystemExit):
+        cli_main()
+
+    captured = capsys.readouterr()
+    assert "2 writes buffered locally" in captured.err
+    assert "sibyl pending-writes flush" in captured.err
+    assert "buffered locally" not in captured.out
+
+
+def test_an_empty_queue_stays_quiet(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("sys.argv", ["sibyl", "version"])
+
+    with pytest.raises(SystemExit):
+        cli_main()
+
+    assert "buffered locally" not in capsys.readouterr().err
+
+
+def test_the_notice_survives_a_failing_command(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The commands that fill the queue are exactly the ones that exit nonzero."""
+    _buffer(1)
+    monkeypatch.setattr("sys.argv", ["sibyl", "no-such-command"])
+
+    with pytest.raises(SystemExit):
+        cli_main()
+
+    assert "1 write buffered locally" in capsys.readouterr().err
+
+
+def test_the_pending_writes_commands_do_not_double_report(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _buffer(1)
+    monkeypatch.setattr("sys.argv", ["sibyl", "pending-writes", "list"])
+
+    with pytest.raises(SystemExit):
+        cli_main()
+
+    assert "buffered locally" not in capsys.readouterr().err
+
+
+def _health_client(payload: dict[str, Any]) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(return_value=payload)
+    return client
+
+
+def test_health_reports_a_non_empty_buffer(sandbox_home: Path) -> None:
+    _buffer(3)
+    client = _health_client({"status": "healthy", "server_name": "sibyl"})
+
+    with patch("sibyl_cli.main.get_client", return_value=client):
+        result = CliRunner().invoke(cli_app, ["health"])
+
+    assert result.exit_code == 0
+    assert "3 writes buffered locally" in result.stdout
+
+
+def test_health_reports_an_empty_buffer(sandbox_home: Path) -> None:
+    client = _health_client({"status": "healthy", "server_name": "sibyl"})
+
+    with patch("sibyl_cli.main.get_client", return_value=client):
+        result = CliRunner().invoke(cli_app, ["health"])
+
+    assert result.exit_code == 0
+    assert "Pending writes: 0" in result.stdout
+
+
+def test_health_json_carries_the_queue_depth(sandbox_home: Path) -> None:
+    import json
+
+    _buffer(2)
+    client = _health_client({"status": "healthy", "server_name": "sibyl"})
+
+    with patch("sibyl_cli.main.get_client", return_value=client):
+        result = CliRunner().invoke(cli_app, ["health", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "healthy"
+    assert payload["pending_writes"]["count"] == 2
+
+
+def test_doctor_checks_the_queue(sandbox_home: Path) -> None:
+    _buffer(1)
+
+    check = doctor_module._check_pending_writes()
+
+    assert check.status == "warn"
+    assert "1 write buffered locally" in check.message
+    assert check.detail is not None
+    assert "sibyl pending-writes flush" in check.detail
+
+
+def test_doctor_passes_on_an_empty_queue(sandbox_home: Path) -> None:
+    check = doctor_module._check_pending_writes()
+
+    assert check.status == "pass"

--- a/apps/cli/tests/test_pending_visibility.py
+++ b/apps/cli/tests/test_pending_visibility.py
@@ -296,3 +296,25 @@ def test_the_notice_prints_only_once_per_process(
         entrypoint.main()
 
     assert capsys.readouterr().err.count("2 writes buffered locally") == 1
+
+
+def test_a_broken_stderr_cannot_change_the_exit_status(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rich reports a closed stream as ValueError and a broken pipe as SystemExit."""
+    _buffer(1)
+
+    for boom in (
+        ValueError("I/O operation on closed file"),
+        SystemExit(1),
+        BrokenPipeError(),
+    ):
+
+        def explode(*_args: object, **_kwargs: object) -> None:
+            raise boom
+
+        monkeypatch.setattr(common, "_pending_writes_reported", False)
+        monkeypatch.setattr(common.err_console, "print", explode)
+
+        common.notify_pending_writes()

--- a/apps/cli/tests/test_pending_visibility.py
+++ b/apps/cli/tests/test_pending_visibility.py
@@ -249,3 +249,50 @@ def test_a_value_that_merely_looks_like_the_group_name_still_gets_the_notice(
     _run_entry_point(["sibyl", "search", "pending-writes"], monkeypatch)
 
     assert "1 write buffered locally" in capsys.readouterr().err
+
+
+def test_the_quick_context_fast_path_still_warns(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Agent hooks take this path, and it never reaches sibyl_cli.main."""
+    from sibyl_cli import entrypoint
+
+    _buffer(1)
+    monkeypatch.setattr("sys.argv", ["sibyl", "context", "--quick", "--json"])
+
+    entrypoint.main()
+
+    assert "1 write buffered locally" in capsys.readouterr().err
+
+
+def test_discarding_an_unknown_id_leaves_the_queue_reported(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """discard can leave the queue untouched, so it must not claim the report."""
+    _buffer(1)
+    monkeypatch.setattr("sys.argv", ["sibyl", "pending-writes", "discard"])
+
+    _run_entry_point(["sibyl", "pending-writes", "discard"], monkeypatch)
+
+    assert "1 write buffered locally" in capsys.readouterr().err
+
+
+def test_the_notice_prints_only_once_per_process(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Two entry points nest around one command, so the notice has to be idempotent."""
+    from sibyl_cli import entrypoint
+
+    _buffer(2)
+    monkeypatch.setattr("sys.argv", ["sibyl", "version"])
+
+    with pytest.raises(SystemExit):
+        entrypoint.main()
+
+    assert capsys.readouterr().err.count("2 writes buffered locally") == 1

--- a/apps/cli/tests/test_pending_visibility.py
+++ b/apps/cli/tests/test_pending_visibility.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from sibyl_cli import common
 from sibyl_cli import doctor as doctor_module
 from sibyl_cli import pending_writes
 from sibyl_cli.main import app as cli_app
@@ -30,6 +31,12 @@ def _buffer(count: int) -> None:
             json_payload={"title": f"queued {index}"},
             params=None,
         )
+
+
+@pytest.fixture(autouse=True)
+def _unclaimed_queue_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real invocation is one command per process; a test session is not."""
+    monkeypatch.setattr(common, "_pending_writes_reported", False)
 
 
 @pytest.fixture
@@ -175,3 +182,70 @@ def test_an_unreadable_home_does_not_break_a_working_command(
 
     assert exc.value.code == 0
     assert "buffered locally" not in capsys.readouterr().err
+
+
+def _run_entry_point(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drive the real console-script path so the finally-block notice runs."""
+    monkeypatch.setattr("sys.argv", argv)
+    with pytest.raises(SystemExit):
+        cli_main()
+
+
+def test_health_reports_the_queue_exactly_once(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`sibyl health` renders the queue itself, so the global notice must stand down."""
+    _buffer(1)
+    client = _health_client({"status": "healthy", "server_name": "sibyl"})
+
+    with patch("sibyl_cli.main.get_client", return_value=client):
+        _run_entry_point(["sibyl", "health"], monkeypatch)
+
+    captured = capsys.readouterr()
+    assert captured.out.count("1 write buffered locally") == 1
+    assert "buffered locally" not in captured.err
+
+
+def test_health_json_does_not_add_a_stderr_notice(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+
+    _buffer(1)
+    client = _health_client({"status": "healthy", "server_name": "sibyl"})
+
+    with patch("sibyl_cli.main.get_client", return_value=client):
+        _run_entry_point(["sibyl", "health", "--json"], monkeypatch)
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["pending_writes"]["count"] == 1
+    assert "buffered locally" not in captured.err
+
+
+def test_the_pending_writes_group_reports_the_queue_exactly_once(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _buffer(1)
+
+    _run_entry_point(["sibyl", "pending-writes", "list"], monkeypatch)
+
+    assert "buffered locally" not in capsys.readouterr().err
+
+
+def test_a_value_that_merely_looks_like_the_group_name_still_gets_the_notice(
+    sandbox_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Suppression follows the command that ran, not a string anywhere in argv."""
+    _buffer(1)
+
+    _run_entry_point(["sibyl", "search", "pending-writes"], monkeypatch)
+
+    assert "1 write buffered locally" in capsys.readouterr().err

--- a/apps/cli/tests/test_pending_visibility.py
+++ b/apps/cli/tests/test_pending_visibility.py
@@ -156,3 +156,22 @@ def test_doctor_passes_on_an_empty_queue(sandbox_home: Path) -> None:
     check = doctor_module._check_pending_writes()
 
     assert check.status == "pass"
+
+
+def test_an_unreadable_home_does_not_break_a_working_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The notice is best-effort. It must never be the thing that fails a command."""
+
+    def no_home() -> Path:
+        raise RuntimeError("Could not determine home directory")
+
+    monkeypatch.setattr(pending_writes.Path, "home", no_home)
+    monkeypatch.setattr("sys.argv", ["sibyl", "version"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main()
+
+    assert exc.value.code == 0
+    assert "buffered locally" not in capsys.readouterr().err

--- a/apps/cli/tests/test_project.py
+++ b/apps/cli/tests/test_project.py
@@ -112,7 +112,9 @@ def test_project_relink_requires_explicit_id_for_ambiguous_matches() -> None:
     ):
         result = CliRunner().invoke(app, ["relink", "--path", "/tmp/hypercolor"])
 
-    assert result.exit_code == 0
+    # relink exists to write a mapping; refusing to write one is a failure,
+    # and the candidate list is the remediation rather than the result.
+    assert result.exit_code == 1
     assert "Multiple accessible projects matched" in result.stdout
     assert "project_123" in result.stdout
     assert "project_456" in result.stdout

--- a/apps/cli/tests/test_resolver_is_single.py
+++ b/apps/cli/tests/test_resolver_is_single.py
@@ -1,0 +1,92 @@
+"""The server URL has exactly one resolver.
+
+Two independent resolutions is the defect this branch exists to remove: auth
+ranked SIBYL_API_URL above the selected context while the client ranked it
+below, and a login stored its token under a key no other command read. Naming
+the sites was not enough, because new ones keep appearing, so this pins the
+class instead of the instances.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "sibyl_cli"
+
+# The resolver itself, the context store that backs it, and the commands whose
+# subject IS the raw configuration rather than the effective server.
+ALLOWED_ACTIVE_CONTEXT_READERS = {
+    "client.py",  # defines resolve_api_base_url
+    "config_store.py",  # defines the context store and the effective helpers
+    "context.py",  # `sibyl context` reports the raw configuration by design
+    "auth.py",  # scopes credentials per stored context, not per request
+    "doctor.py",  # diagnoses the configuration, so it must see it unresolved
+    "pending.py",  # matches a buffered write's recorded base_url to a context
+}
+
+RAW_READERS = {"get_active_context", "get_active_context_name"}
+
+
+def _calls(path: pathlib.Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            found.add(node.func.id)
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            found.add(node.func.attr)
+    return found
+
+
+def test_no_module_resolves_the_server_url_on_its_own() -> None:
+    """A module that reads the active context directly ignores -C and the pin."""
+    offenders: list[str] = []
+    for path in sorted(SRC.glob("*.py")):
+        if path.name in ALLOWED_ACTIVE_CONTEXT_READERS:
+            continue
+        if RAW_READERS & _calls(path):
+            offenders.append(path.name)
+
+    assert not offenders, (
+        "These modules read the active context directly instead of going "
+        f"through resolve_api_base_url / resolve_effective_context: {offenders}. "
+        "A staging-pinned directory would report production state."
+    )
+
+
+def test_the_effective_url_helper_delegates_to_the_resolver() -> None:
+    """get_effective_server_url used to omit SIBYL_API_URL entirely."""
+    source = (SRC / "config_store.py").read_text(encoding="utf-8")
+    body = source.split("def get_effective_server_url")[1].split("\ndef ")[0]
+
+    assert "resolve_api_base_url" in body
+
+
+def _reads_env(path: pathlib.Path, key: str) -> bool:
+    """True when the module reads os.environ[key], ignoring modules that write it."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == "get" and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and first.value == key:
+                    return True
+        if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant):
+            if node.slice.value == key and isinstance(node.value, ast.Attribute):
+                if node.value.attr == "environ":
+                    return True
+    return False
+
+
+def test_the_env_var_is_read_in_exactly_one_place() -> None:
+    """SIBYL_API_URL is a fallback inside the resolver, not a second entry point.
+
+    docker.py and local.py write this key into a generated compose file for the
+    web container, which is a different concern and not a resolution path.
+    """
+    readers = [
+        path.name for path in sorted(SRC.glob("*.py")) if _reads_env(path, "SIBYL_API_URL")
+    ]
+
+    assert readers == ["client.py"], f"SIBYL_API_URL is read outside the resolver: {readers}"

--- a/apps/cli/tests/test_resolver_is_single.py
+++ b/apps/cli/tests/test_resolver_is_single.py
@@ -3,8 +3,15 @@
 Two independent resolutions is the defect this branch exists to remove: auth
 ranked SIBYL_API_URL above the selected context while the client ranked it
 below, and a login stored its token under a key no other command read. Naming
-the sites was not enough, because new ones keep appearing, so this pins the
-class instead of the instances.
+the modules was not enough either, because a module-wide exemption hands every
+future function in that file the same privilege. Ownership is therefore pinned
+per function: each site that may reach the raw active context or read
+SIBYL_API_URL is listed below with the reason it is allowed, and any other site
+anywhere in the package fails these tests.
+
+Reaching the active context at all is the thing being fenced, which covers
+reading its ``server_url`` field: a function that never gets the context object
+cannot read a URL off it.
 """
 
 from __future__ import annotations
@@ -14,79 +21,163 @@ import pathlib
 
 SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "sibyl_cli"
 
-# The resolver itself, the context store that backs it, and the commands whose
-# subject IS the raw configuration rather than the effective server.
-ALLOWED_ACTIVE_CONTEXT_READERS = {
-    "client.py",  # defines resolve_api_base_url
-    "config_store.py",  # defines the context store and the effective helpers
-    "context.py",  # `sibyl context` reports the raw configuration by design
-    "auth.py",  # scopes credentials per stored context, not per request
-    "doctor.py",  # diagnoses the configuration, so it must see it unresolved
-    "pending.py",  # matches a buffered write's recorded base_url to a context
-}
-
 RAW_READERS = {"get_active_context", "get_active_context_name"}
 
+# (module, enclosing function) pairs allowed to reach the raw active context.
+ALLOWED_ACTIVE_CONTEXT_READERS = {
+    # The resolver itself, and the two settings that travel with the context it
+    # picks (credential key, TLS verification).
+    ("client.py", "resolve_api_base_url"),
+    ("client.py", "_auth_credential_scope"),
+    ("client.py", "SibylClient._get_insecure_from_context"),
+    # The store defines the active-context accessors and its own selection order.
+    ("config_store.py", "get_active_context"),
+    ("config_store.py", "resolve_context_name"),
+    # `sibyl config context ...` reports the stored configuration by design; an
+    # effective-context view would hide exactly what these commands exist to show.
+    ("context.py", "list_cmd"),
+    ("context.py", "show_cmd"),
+    ("context.py", "update_cmd"),
+    ("context.py", "delete_cmd"),
+    # Maps a buffered write's recorded base_url back to a context name.
+    ("pending.py", "_context_name_for_base_url"),
+}
 
-def _calls(path: pathlib.Path) -> set[str]:
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    found: set[str] = set()
+# (module, enclosing function) pairs allowed to read SIBYL_API_URL.
+ALLOWED_ENV_READERS = {
+    # Rank 3 of the one resolution order.
+    ("client.py", "resolve_api_base_url"),
+    # Presence check, not a resolution: an implicit-localhost write is refused
+    # unless a context or this legacy variable exists.
+    ("client.py", "SibylClient._request"),
+}
+
+ENV_KEY = "SIBYL_API_URL"
+
+
+class _SiteFinder(ast.NodeVisitor):
+    """Collects call sites with the qualified name of the function around them."""
+
+    def __init__(self) -> None:
+        self.scope: list[str] = []
+        self.raw_readers: set[str] = set()
+        self.env_readers: set[str] = set()
+
+    def _qualname(self) -> str:
+        return ".".join(self.scope) or "<module>"
+
+    def _enter(self, node: ast.AST) -> None:
+        self.scope.append(getattr(node, "name", "<anonymous>"))
+        self.generic_visit(node)
+        self.scope.pop()
+
+    visit_FunctionDef = _enter
+    visit_AsyncFunctionDef = _enter
+    visit_ClassDef = _enter
+
+    def visit_Call(self, node: ast.Call) -> None:
+        name: str | None = None
+        if isinstance(node.func, ast.Name):
+            name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            name = node.func.attr
+
+        if name in RAW_READERS:
+            self.raw_readers.add(self._qualname())
+        # os.environ.get(KEY), environ.get(KEY), os.getenv(KEY)
+        if name in {"get", "getenv"} and node.args:
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and first.value == ENV_KEY:
+                self.env_readers.add(self._qualname())
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        # os.environ[KEY] / environ[KEY]; a dict literal key is not a Subscript,
+        # so the compose files docker.py and local.py generate stay invisible here.
+        target = node.value
+        environ_access = isinstance(target, ast.Attribute) and target.attr == "environ"
+        environ_access = environ_access or (isinstance(target, ast.Name) and target.id == "environ")
+        if environ_access and isinstance(node.slice, ast.Constant) and node.slice.value == ENV_KEY:
+            self.env_readers.add(self._qualname())
+        self.generic_visit(node)
+
+
+def _sites() -> tuple[set[tuple[str, str]], set[tuple[str, str]]]:
+    raw: set[tuple[str, str]] = set()
+    env: set[tuple[str, str]] = set()
+    for path in sorted(SRC.rglob("*.py")):
+        finder = _SiteFinder()
+        finder.visit(ast.parse(path.read_text(encoding="utf-8")))
+        raw |= {(path.name, fn) for fn in finder.raw_readers}
+        env |= {(path.name, fn) for fn in finder.env_readers}
+    return raw, env
+
+
+def _function(module: str, name: str) -> ast.FunctionDef:
+    tree = ast.parse((SRC / module).read_text(encoding="utf-8"))
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-            found.add(node.func.id)
-        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            found.add(node.func.attr)
-    return found
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{module} no longer defines {name}()")
 
 
-def test_no_module_resolves_the_server_url_on_its_own() -> None:
-    """A module that reads the active context directly ignores -C and the pin."""
-    offenders: list[str] = []
-    for path in sorted(SRC.glob("*.py")):
-        if path.name in ALLOWED_ACTIVE_CONTEXT_READERS:
-            continue
-        if RAW_READERS & _calls(path):
-            offenders.append(path.name)
+def test_only_named_functions_reach_the_raw_active_context() -> None:
+    """A function that reads the active context directly ignores -C and the pin."""
+    raw, _ = _sites()
+    offenders = sorted(raw - ALLOWED_ACTIVE_CONTEXT_READERS)
 
     assert not offenders, (
-        "These modules read the active context directly instead of going "
-        f"through resolve_api_base_url / resolve_effective_context: {offenders}. "
-        "A staging-pinned directory would report production state."
+        f"These functions read the active context directly: {offenders}. Route them "
+        "through resolve_api_base_url / resolve_effective_context, or add the site "
+        "here with the reason it owns a raw read. A staging-pinned directory would "
+        "otherwise report production state."
     )
+
+
+def test_every_named_active_context_reader_still_exists() -> None:
+    """A stale allowlist is a silent exemption for whatever replaces the site."""
+    raw, _ = _sites()
+    stale = sorted(ALLOWED_ACTIVE_CONTEXT_READERS - raw)
+
+    assert not stale, f"These allowlisted readers no longer read the active context: {stale}"
 
 
 def test_the_effective_url_helper_delegates_to_the_resolver() -> None:
     """get_effective_server_url used to omit SIBYL_API_URL entirely."""
-    source = (SRC / "config_store.py").read_text(encoding="utf-8")
-    body = source.split("def get_effective_server_url")[1].split("\ndef ")[0]
+    node = _function("config_store.py", "get_effective_server_url")
+    calls = {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+    calls |= {
+        call.func.attr
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+    }
 
-    assert "resolve_api_base_url" in body
+    assert "resolve_api_base_url" in calls, (
+        "get_effective_server_url must delegate to the resolver instead of "
+        f"assembling a URL of its own; it calls {sorted(calls)}"
+    )
+    assert not (calls & RAW_READERS), (
+        "get_effective_server_url resolves the active context on its own again"
+    )
 
 
-def _reads_env(path: pathlib.Path, key: str) -> bool:
-    """True when the module reads os.environ[key], ignoring modules that write it."""
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            if node.func.attr == "get" and node.args:
-                first = node.args[0]
-                if isinstance(first, ast.Constant) and first.value == key:
-                    return True
-        if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant):
-            if node.slice.value == key and isinstance(node.value, ast.Attribute):
-                if node.value.attr == "environ":
-                    return True
-    return False
+def test_the_env_var_is_read_only_by_named_functions() -> None:
+    """SIBYL_API_URL is a fallback inside the resolver, not a second entry point."""
+    _, env = _sites()
+    offenders = sorted(env - ALLOWED_ENV_READERS)
+
+    assert not offenders, (
+        f"{ENV_KEY} is read outside the resolver by: {offenders}. Every read is a "
+        "second resolution order waiting to disagree with the first."
+    )
 
 
-def test_the_env_var_is_read_in_exactly_one_place() -> None:
-    """SIBYL_API_URL is a fallback inside the resolver, not a second entry point.
+def test_every_named_env_reader_still_exists() -> None:
+    _, env = _sites()
+    stale = sorted(ALLOWED_ENV_READERS - env)
 
-    docker.py and local.py write this key into a generated compose file for the
-    web container, which is a different concern and not a resolution path.
-    """
-    readers = [
-        path.name for path in sorted(SRC.glob("*.py")) if _reads_env(path, "SIBYL_API_URL")
-    ]
-
-    assert readers == ["client.py"], f"SIBYL_API_URL is read outside the resolver: {readers}"
+    assert not stale, f"These allowlisted {ENV_KEY} readers are gone: {stale}"

--- a/apps/cli/tests/test_session.py
+++ b/apps/cli/tests/test_session.py
@@ -24,11 +24,11 @@ class _FakeClientContext:
 @patch(
     "sibyl_cli.session.get_current_context", return_value=("project_123", "/Users/bliss/dev/sibyl")
 )
-@patch("sibyl_cli.session.get_active_context")
+@patch("sibyl_cli.session.resolve_effective_context")
 @patch("sibyl_cli.session.get_client")
 def test_session_bundle_json_packages_context_tasks_and_memories(
     mock_get_client: MagicMock,
-    mock_get_active_context: MagicMock,
+    mock_resolve_effective_context: MagicMock,
     mock_get_current_context: MagicMock,
     mock_get_effective_project: MagicMock,
     mock_get_effective_server_url: MagicMock,
@@ -36,7 +36,7 @@ def test_session_bundle_json_packages_context_tasks_and_memories(
     context = MagicMock()
     context.name = "local"
     context.org_slug = "hyper"
-    mock_get_active_context.return_value = context
+    mock_resolve_effective_context.return_value = context
 
     mock_client = MagicMock()
     mock_client.get_entity = AsyncMock(
@@ -143,11 +143,11 @@ def test_session_bundle_json_packages_context_tasks_and_memories(
 @patch(
     "sibyl_cli.session.get_current_context", return_value=("project_123", "/Users/bliss/dev/sibyl")
 )
-@patch("sibyl_cli.session.get_active_context")
+@patch("sibyl_cli.session.resolve_effective_context")
 @patch("sibyl_cli.session.get_client")
 def test_session_bundle_json_blends_raw_memory(
     mock_get_client: MagicMock,
-    mock_get_active_context: MagicMock,
+    mock_resolve_effective_context: MagicMock,
     mock_get_current_context: MagicMock,
     mock_get_effective_project: MagicMock,
     mock_get_effective_server_url: MagicMock,
@@ -155,7 +155,7 @@ def test_session_bundle_json_blends_raw_memory(
     context = MagicMock()
     context.name = "local"
     context.org_slug = "hyper"
-    mock_get_active_context.return_value = context
+    mock_resolve_effective_context.return_value = context
 
     mock_client = MagicMock()
     mock_client.get_entity = AsyncMock(return_value={"id": "project_123", "name": "Sibyl"})
@@ -223,11 +223,11 @@ def test_session_bundle_json_blends_raw_memory(
 @patch(
     "sibyl_cli.session.get_current_context", return_value=("project_123", "/Users/bliss/dev/sibyl")
 )
-@patch("sibyl_cli.session.get_active_context")
+@patch("sibyl_cli.session.resolve_effective_context")
 @patch("sibyl_cli.session.get_client")
 def test_session_bundle_dedupes_same_memory_with_different_ids(
     mock_get_client: MagicMock,
-    mock_get_active_context: MagicMock,
+    mock_resolve_effective_context: MagicMock,
     mock_get_current_context: MagicMock,
     mock_get_effective_project: MagicMock,
     mock_get_effective_server_url: MagicMock,
@@ -235,7 +235,7 @@ def test_session_bundle_dedupes_same_memory_with_different_ids(
     context = MagicMock()
     context.name = "local"
     context.org_slug = "hyper"
-    mock_get_active_context.return_value = context
+    mock_resolve_effective_context.return_value = context
 
     mock_client = MagicMock()
     mock_client.get_entity = AsyncMock(return_value={"id": "project_123", "name": "Sibyl"})
@@ -282,11 +282,11 @@ def test_session_bundle_dedupes_same_memory_with_different_ids(
 @patch("sibyl_cli.session.get_effective_server_url", return_value="http://localhost:3334")
 @patch("sibyl_cli.session.get_effective_project", return_value=None)
 @patch("sibyl_cli.session.get_current_context", return_value=(None, None))
-@patch("sibyl_cli.session.get_active_context", return_value=None)
+@patch("sibyl_cli.session.resolve_effective_context", return_value=None)
 @patch("sibyl_cli.session.get_client")
 def test_session_bundle_without_project_guides_user_to_link_one(
     mock_get_client: MagicMock,
-    mock_get_active_context: MagicMock,
+    mock_resolve_effective_context: MagicMock,
     mock_get_current_context: MagicMock,
     mock_get_effective_project: MagicMock,
     mock_get_effective_server_url: MagicMock,
@@ -324,11 +324,11 @@ def test_session_bundle_without_project_guides_user_to_link_one(
 @patch(
     "sibyl_cli.session.get_current_context", return_value=("project_123", "/Users/bliss/dev/sibyl")
 )
-@patch("sibyl_cli.session.get_active_context")
+@patch("sibyl_cli.session.resolve_effective_context")
 @patch("sibyl_cli.session.get_client")
 def test_session_bundle_renders_human_output(
     mock_get_client: MagicMock,
-    mock_get_active_context: MagicMock,
+    mock_resolve_effective_context: MagicMock,
     mock_get_current_context: MagicMock,
     mock_get_effective_project: MagicMock,
     mock_get_effective_server_url: MagicMock,
@@ -336,7 +336,7 @@ def test_session_bundle_renders_human_output(
     context = MagicMock()
     context.name = "local"
     context.org_slug = "hyper"
-    mock_get_active_context.return_value = context
+    mock_resolve_effective_context.return_value = context
 
     mock_client = MagicMock()
     mock_client.get_entity = AsyncMock(return_value={"id": "project_123", "name": "Sibyl"})

--- a/apps/cli/tests/test_task.py
+++ b/apps/cli/tests/test_task.py
@@ -420,7 +420,9 @@ def test_task_complete_json_preserves_api_policy_metadata(
         ],
     )
 
-    assert result.exit_code == 0
+    # A denied completion is a failure on --json too, and the payload still
+    # carries the policy metadata a caller needs to act on it.
+    assert result.exit_code == 1
     payload = json.loads(result.stdout)
     assert payload["data"]["policy_reason"] == "unverified_membership"
 

--- a/docs/cli/context.md
+++ b/docs/cli/context.md
@@ -524,27 +524,31 @@ Using legacy server.url from config
 
 ## Context Priority
 
-When resolving project context, the CLI checks in this order:
+When resolving which context a command runs against, the CLI checks in this order:
 
 1. `--context` / `-C` global flag (highest priority)
 2. `SIBYL_CONTEXT` environment variable
-3. Active context's default project
-4. Path-based project link (from current directory)
+3. Directory pin (`sibyl config context link`)
+4. Active context (`sibyl config context use`)
+
+Every one of these takes a context **name**, never a project ID, and a name with no matching context
+stops the command. Nothing falls back to the active context, so a typo cannot send a write to the
+wrong server.
 
 ### Override with Flag
 
 ```bash
-# Use different project for one command
-sibyl --context proj_other task list
-sibyl -C proj_other task list
+# Run one command against another context
+sibyl --context staging task list
+sibyl -C staging task list
 ```
 
 ### Override with Environment
 
 ```bash
-# Use different project for shell session
-export SIBYL_CONTEXT=proj_other
-sibyl task list  # Uses proj_other
+# Use another context for the shell session
+export SIBYL_CONTEXT=staging
+sibyl task list  # Runs against staging
 ```
 
 ---
@@ -586,8 +590,8 @@ sibyl config context create ci \
   --org "$SIBYL_ORG" \
   --use
 
-# Or use environment variable
-export SIBYL_CONTEXT=proj_ci
+# Or select the context by name, without making it active
+export SIBYL_CONTEXT=ci
 sibyl task list --status todo
 ```
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -169,9 +169,9 @@ sibyl task list --csv > tasks.csv            # CSV export
 | `SIBYL_API_URL`      | Server URL (legacy)        | `http://localhost:3334/api` |
 | `SIBYL_ACCESS_TOKEN` | Auth token (rarely needed) | `eyJhbG...`                 |
 
-`SIBYL_API_URL` is a legacy fallback, not an override. Server selection resolves in this
-order, and `sibyl auth login` follows the same order as every other command so a login
-always writes its token under the server key the next command reads:
+`SIBYL_API_URL` is a legacy fallback, not an override. Server selection resolves in this order, and
+`sibyl auth login` follows the same order as every other command so a login always writes its token
+under the server key the next command reads:
 
 1. An explicit server argument (`sibyl auth login https://...`, `--server`)
 2. The selected context (`--context` / `-C`, `SIBYL_CONTEXT`, directory pin, active context)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -138,8 +138,8 @@ Auth, organizations, configuration, and operations.
 These options are available on the root command:
 
 ```bash
-sibyl --context <project_id_or_name> <command>   # Override project context
-sibyl -C <project_id_or_name> <command>          # Short form
+sibyl --context <context_name> <command>         # Override the server/org context
+sibyl -C <context_name> <command>                # Short form
 sibyl --version                                  # Show CLI version
 sibyl -V                                         # Short form
 ```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -169,6 +169,16 @@ sibyl task list --csv > tasks.csv            # CSV export
 | `SIBYL_API_URL`      | Server URL (legacy)        | `http://localhost:3334/api` |
 | `SIBYL_ACCESS_TOKEN` | Auth token (rarely needed) | `eyJhbG...`                 |
 
+`SIBYL_API_URL` is a legacy fallback, not an override. Server selection resolves in this
+order, and `sibyl auth login` follows the same order as every other command so a login
+always writes its token under the server key the next command reads:
+
+1. An explicit server argument (`sibyl auth login https://...`, `--server`)
+2. The selected context (`--context` / `-C`, `SIBYL_CONTEXT`, directory pin, active context)
+3. `SIBYL_API_URL`
+4. `[server] url` in the legacy config file
+5. `http://localhost:3334/api`
+
 ## Configuration
 
 ### Config File Location

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -163,11 +163,16 @@ sibyl task list --csv > tasks.csv            # CSV export
 
 ## Environment Variables
 
-| Variable             | Description                | Example                     |
-| -------------------- | -------------------------- | --------------------------- |
-| `SIBYL_CONTEXT`      | Override project context   | `proj_abc123`               |
-| `SIBYL_API_URL`      | Server URL (legacy)        | `http://localhost:3334/api` |
-| `SIBYL_ACCESS_TOKEN` | Auth token (rarely needed) | `eyJhbG...`                 |
+| Variable             | Description                       | Example                     |
+| -------------------- | --------------------------------- | --------------------------- |
+| `SIBYL_CONTEXT`      | Named context (server/org bundle) | `prod`                      |
+| `SIBYL_API_URL`      | Server URL (legacy)               | `http://localhost:3334/api` |
+| `SIBYL_ACCESS_TOKEN` | Auth token (rarely needed)        | `eyJhbG...`                 |
+
+`SIBYL_CONTEXT` names a context created with `sibyl config context create`, not a project ID. A name
+with no matching context is a hard error: the command stops instead of quietly running against the
+active context, so a typo in a CI variable can never write to the wrong server. Scope a command to a
+project with `--project` instead.
 
 `SIBYL_API_URL` is a legacy fallback, not an override. Server selection resolves in this order, and
 `sibyl auth login` follows the same order as every other command so a login always writes its token
@@ -211,14 +216,16 @@ org_slug = "myorg"
 default_project = "proj_main"
 ```
 
-### Context Priority
+### Project Priority
 
-When resolving project context, the CLI checks in this order:
+When resolving which project a command scopes to, the CLI checks in this order:
 
-1. `--context` / `-C` flag (highest priority)
-2. `SIBYL_CONTEXT` environment variable
-3. Active context's default project
-4. Path-based project link (from the current directory)
+1. `--project` flag (highest priority)
+2. Path-based project link (from the current directory)
+3. `default_project` on the selected context
+
+`--context` / `-C` and `SIBYL_CONTEXT` select the context, which decides the server and org. The
+project comes from the list above.
 
 ## Common Patterns
 

--- a/docs/cli/pending-writes.md
+++ b/docs/cli/pending-writes.md
@@ -20,6 +20,16 @@ write safely without creating a duplicate if part of it already landed. Inspect 
 `list`, replay it with `flush` once connectivity is back, or drop entries you no longer want with
 `discard`.
 
+## How You Find Out
+
+A non-empty buffer is reported in three places, so a queued write is never silent:
+
+- Every command prints a one-line warning to **stderr** as it finishes, carrying the queue depth
+  and the flush command. It goes to stderr, so `--json` output stays parseable.
+- `sibyl health` reports the queue depth alongside server health, and `sibyl health --json`
+  carries it under `pending_writes`.
+- `sibyl doctor` runs a `pending-writes` check that warns while anything is queued.
+
 ---
 
 ## pending-writes list

--- a/docs/cli/pending-writes.md
+++ b/docs/cli/pending-writes.md
@@ -24,10 +24,10 @@ write safely without creating a duplicate if part of it already landed. Inspect 
 
 A non-empty buffer is reported in three places, so a queued write is never silent:
 
-- Every command prints a one-line warning to **stderr** as it finishes, carrying the queue depth
-  and the flush command. It goes to stderr, so `--json` output stays parseable.
-- `sibyl health` reports the queue depth alongside server health, and `sibyl health --json`
-  carries it under `pending_writes`.
+- Every command prints a one-line warning to **stderr** as it finishes, carrying the queue depth and
+  the flush command. It goes to stderr, so `--json` output stays parseable.
+- `sibyl health` reports the queue depth alongside server health, and `sibyl health --json` carries
+  it under `pending_writes`.
 - `sibyl doctor` runs a `pending-writes` check that warns while anything is queued.
 
 ---

--- a/docs/guide/multi-tenancy.md
+++ b/docs/guide/multi-tenancy.md
@@ -193,16 +193,17 @@ sibyl org switch my-org
 sibyl task list  # Lists tasks in my-org
 ```
 
-### Per-Command Project Override
+### Per-Command Context Override
 
-The `--context` flag and `SIBYL_CONTEXT` override the active **project** for a single command, not
-the organization. Switch organizations with `sibyl org switch`.
+The `--context` flag and `SIBYL_CONTEXT` select a named **context** for a single command, which
+carries that context's server and org. Scope to a project with `--project`, and switch the active
+organization inside one server with `sibyl org switch`.
 
 ```bash
-# Override project context for a single command
-sibyl --context proj_xyz task list
+# Run a single command against another context
+sibyl --context staging task list
 # Or
-SIBYL_CONTEXT=proj_xyz sibyl task list
+SIBYL_CONTEXT=staging sibyl task list
 ```
 
 ## Auth Schema

--- a/docs/guide/project-organization.md
+++ b/docs/guide/project-organization.md
@@ -169,8 +169,8 @@ To repair a stale link after a directory moves, use `sibyl project relink`.
 When determining project context:
 
 1. `--project` flag (highest priority)
-2. `SIBYL_CONTEXT` environment variable
-3. Linked directory
+2. Linked directory
+3. `default_project` on the selected context
 4. No context (shows all)
 
 ### Bypassing Context
@@ -179,8 +179,8 @@ When determining project context:
 # See all tasks regardless of context
 sibyl task list --all
 
-# Override context for one command
-sibyl --context proj_xyz task list
+# Scope one command to another project
+sibyl --project proj_xyz task list
 ```
 
 ## Task Organization

--- a/docs/guide/task-management.md
+++ b/docs/guide/task-management.md
@@ -287,8 +287,8 @@ sibyl task list --status todo  # Only shows tasks for linked project
 ### Context Priority
 
 1. `--project` flag (highest)
-2. `SIBYL_CONTEXT` environment variable
-3. Linked directory context
+2. Linked directory context
+3. `default_project` on the selected context
 4. No filter (shows all tasks)
 
 ### Bypassing Context


### PR DESCRIPTION
# 🎯 Three ways a CLI write went missing without saying so

> Tier 3 reliability from the 1.3 rethink audit, findings C1, C3, C4 and C6 in
> `docs/architecture/AUDIT_2026-08-13/debt-web-cli-infra.md`. Scope is `apps/cli` plus its docs.

## 💡 What this is

Three defects in the client CLI that compose into one failure: a memory you asked Sibyl to save
never reaches the server, and every signal you could have used to notice says everything is fine.
`sibyl auth login` writes its token under a server key no later command reads, so every later
command 401s. A refused write prints `✗ Failed to ...` and exits 0, so the hook or agent that
checked `$?` records a success. The write itself lands in a local buffer that no user-facing
command reports. Each one is small; together they are how memories go missing quietly.

The fix is not three error messages. Server selection collapses to one resolver, refusals reach
the exit status, and the buffer reports itself in three places a user actually looks.

## 🤔 Why we need it and what it replaces

**Server selection had two rankings.** `SibylClient` ranked the selected context above
`SIBYL_API_URL` (`client.py:54-91`), while `sibyl auth` read the environment variable first and
only fell back to the client (`auth.py:43-55` before this change). The precondition is precise: an
active context and `SIBYL_API_URL` pointing somewhere else. Login then stores its token under the
environment host's key while every command reads the context host's key. Login prints
`✓ Login complete` and exits 0, so the failure presents as a server-side auth problem. Auth had a
second, independent divergence: it resolved its context with `get_active_context()` while every
command resolves through `config_store.resolve_context_name()`, which also honours `-C`,
`SIBYL_CONTEXT`, and the directory pin. Two rankings and two context resolvers are the same bug
by two routes, so both collapse into the client's.

**Nineteen failure tails fell off the end of a coroutine.** The pattern is
`else: error("Failed to ...")` as the last statement of a `@run_async` body, with nothing after
it. Python returns, `asyncio.run` returns, the command returns, the process exits 0. Sibyl's own
session hooks branch on `$?`, so the CLI was reporting refused writes to its own tooling as
successes.

**The buffer had exactly one reader, and it needs the OWNER role.** Every POST, PATCH, and DELETE
is filed into `~/.config/sibyl/pending_writes/` before it is sent, and a write the server refuses
stays there. Queue depth was exposed only by `sibyl debug status` (`debug.py:345`). `sibyl doctor`
never checked it. On a connection failure the user saw `Is the server running?` and had no way to
learn that three memories were sitting on disk.

Deliberately not built: the streams are left as they are. Audit finding C5 (errors printing to
stdout, which corrupts `--json`) is a separate change touching every command's output path, and
mixing it into an exit-code change would make both unreviewable. The new pending-writes notice
does go to stderr, so it does not add to that problem.

## 🎯 The invariant

Anchor the review on one property: **for a given invocation, `sibyl auth <cmd>` and every other
command resolve the same `(server URL, credential scope)` pair.** Everything else in the auth
change follows from it. The test that pins it asserts equality against a live `SibylClient`
rather than against a literal, so the two cannot drift apart again without failing
(`tests/test_auth_login.py:369-400`).

## 🛠️ How it works

### 1. One resolver for the server URL

`_get_default_api_url` becomes the public `resolve_api_base_url` (`client.py:54`) and is now the
single source of truth. `auth._compute_api_url` (`auth.py:55-67`) keeps only the explicit
`--server`/positional-URL branch and delegates everything else to it. The precedence, unchanged
from the client and now documented in `docs/cli/index.md`:

1. An explicit server argument (`sibyl auth login https://...`, `--server`)
2. The selected context (`-C`, `SIBYL_CONTEXT`, directory pin, active context)
3. `SIBYL_API_URL`
4. `[server] url` in the legacy config file
5. `http://localhost:3334/api`

The client's ordering wins because the environment variable is documented as the legacy fallback
(`docs/cli/index.md`, "Server URL (legacy)") while a context is the explicit, per-machine
selection a user made on purpose. Ranking a legacy fallback above an explicit selection is what
produced the defect.

**An explicit selection fails closed.** A context named by `-C`, `SIBYL_CONTEXT`, or a directory
pin that does not exist used to fall through to the active context, and the client inherited that
context's TLS setting with it. With production active, `sibyl -C stagingg task create` wrote to
production silently. The root callback now stops before any command logic, and the resolver raises
rather than falling through, so a caller reached without the callback cannot retarget either. The
commands that repair a context (`context`, `init`, `config`, `doctor`) warn and drop the selection
instead, because failing closed everywhere would strand the user.

**An explicit login URL defines its own credential scope.** Credentials are keyed by server URL and
scope together, so `sibyl auth login https://staging...` inside a prod-pinned directory stored the
token under (staging URL, prod scope), a key nothing reads. The scope now comes from the context
that actually points at the login target, or is left unscoped when none does, and a disagreement
with the ambient selection is said out loud.

`auth._effective_context_name` (`auth.py:48-52`) routes context resolution through
`config_store.resolve_context_name()`, the same function `get_client()` uses, so
`_current_credential_scope` now agrees with the client too.

**One resolver, pinned by test.** Eight call sites still resolved independently, two of them
agent-facing: `sibyl context --quick` and the session bundle read the active context directly, so a
staging-pinned directory reported production state to an agent. `get_effective_server_url` resolved
on its own and omitted `SIBYL_API_URL` entirely. All eight now delegate.
`tests/test_resolver_is_single.py` rejects any module reading the active context outside an
allowlist of modules whose subject is the raw configuration, requires the effective-URL helper to
delegate, and requires `SIBYL_API_URL` to be read in exactly one file. One consequence worth naming:
`sibyl auth login -c prod` against an existing `prod` context now logs in to that context's
server instead of the active context's server it was about to overwrite. For a context name that
does not exist yet, `resolve_api_base_url` falls through to the active context exactly as before.

### 2. Refusals reach the exit status

Forty-one sites raise `typer.Exit(1)` immediately after their existing `error(...)` call. No
message text changed, because scripts parse this output. `typer.Exit` is a `RuntimeError`
subclass and none of the enclosing handlers catch `Exception` or `RuntimeError` (they catch
`SibylClientError` and `ValueError`), so it propagates through `asyncio.run` to the CLI boundary.

**Table output and `--json` both count.** Every one of these commands puts its
`if json_out: print_json(response); return` branch above the success check, so an exit code added
only to the renderer leaves `--json` at 0, and `--json` is what agents and CI invoke. The new
`print_json_result` helper (`common.py:70-79`) prints the payload and then raises on a refusal,
matching the shape `task archive` already used at `task.py:911`. A caller still parses the same
JSON and now reads a truthful status alongside it.

The audit named nineteen sites. Fixing a named list turned out to be the wrong method, and so
did sweeping for syntactic shapes: each round of review found another shape the previous sweep
had not thought of, including two defects this branch created by moving a table renderer and
leaving its `--json` branch behind. The class is closed by a control-flow question instead. For
every `error(...)` call in the package, does any path from it reach the end of its command
without a raise? That finds every shape at once, and it is the check to re-run rather than the
list to re-read. Thirty-six sites, by origin:

| File                 | Command                  | Failure condition                        | Source        |
| -------------------- | ------------------------ | ---------------------------------------- | ------------- |
| `task.py:581`        | `task start`             | `success` false in the response envelope | audit         |
| `task.py:624`        | `task block`             | `success` false                          | audit         |
| `task.py:666`        | `task unblock`           | `success` false                          | audit         |
| `task.py:721`        | `task review`            | `success` false                          | audit         |
| `task.py:811`        | `task complete`          | `success` false                          | audit         |
| `task.py:1044`       | `task create`            | no `success` and no task id              | audit         |
| `task.py:1163`       | `task update`            | `success` false                          | audit         |
| `task.py:1253`       | `task note`              | no note id and no `success`              | audit         |
| `epic.py:494`        | `epic create`            | no epic id                               | audit         |
| `epic.py:537`        | `epic start`             | no `success` and no id                   | audit         |
| `epic.py:584`        | `epic complete`          | no `success` and no id                   | audit         |
| `epic.py:628`        | `epic archive`           | no `success` and no id                   | audit         |
| `epic.py:703`        | `epic update`            | no `success` and no id                   | audit         |
| `entity.py:263`      | `entity create`          | no entity id                             | audit         |
| `project.py:277`     | `project create`         | no project id                            | audit         |
| `crawl.py:304`       | `source delete`          | `deleted` false                          | audit         |
| `crawl_shared.py:54` | `source add`             | no source id                             | audit         |
| `local.py:432`       | `local stop`             | nonzero `docker compose down` exit       | audit         |
| `main.py:2110`       | `sibyl note` (task note) | no note id and no `success`              | audit         |
| `crawl_shared.py:135`| `crawl ingest`           | crawl status neither queued nor running  | own AST sweep |
| `crawl.py:270`       | `crawl health`           | Crawl4AI unavailable                     | own AST sweep |
| `main.py:1517`       | `health --json`          | server status not healthy                | verification  |
| `entity.py:119`      | `entity list`            | `--type` outside the known set           | verification  |
| `entity.py:233`      | `entity create`          | `--type` outside the known set           | verification  |
| `task.py:1125`       | `task update`            | no field options given                   | verification  |
| `crawl.py:411`       | `crawl link-graph`       | run status is `error`                    | verification  |
| `crawl.py:395`       | `crawl link-graph --json`| run status is `error`                    | own sweep     |
| `epic.py:665`        | `epic update`            | no field options given                   | own sweep     |
| `explore.py:107`     | `explore traverse`       | `--depth` outside 1..3                   | own sweep     |
| `explore.py:177`     | `explore dependencies`   | neither an id nor `--project`            | own sweep     |
| `pending.py:164`     | `pending-writes discard` | a named id matched nothing               | own sweep     |
| `main.py:2447`       | `synthesis remember`     | artifact drafted but never remembered    | control flow  |
| `update.py:516`      | `sibyl update`           | a CLI or container update failed         | control flow  |
| `local.py:576`       | `sibyl setup`            | skill and hook sources not found         | control flow  |
| `main.py:2401`       | `synthesis verify`       | verification reports gaps                | review        |
| `logs.py:204`        | `logs tail -f`           | the log stream was closed on us          | review        |
| `setup.py:412`       | `sibyl setup` / `update` | hooks not installed or not configurable  | review        |
| `project.py:448`     | `project relink`         | no project matched, nothing was written  | control flow  |
| `update.py:510`      | `sibyl update --skills`  | the skills refresh failed                | control flow  |

Each was adjudicated against the tree. All thirty-one are genuine refusals rather than empty
results, so none of them keep exit 0. `health` is the sharpest of them: its table renderer and
its `--json` branch disagreed about the same response, which is the exact shape of defect this
section exists to remove. Empty result sets are unaffected, pinned by
`tests/test_exit_codes.py::test_an_empty_result_set_still_exits_zero`.

What the sweep leaves behind is twenty-four sites, adjudicated in full: six branches inside
`handle_client_error` and two loop bodies whose raise sits in an enclosing block; the
`Last Error:` field inside two status renders (a reportable state, not a refusal); `check_docker`'s
three `return False` paths, where both callers convert False into a raise; a log stream reporting
that it ended; the synthesis verification verdict at `main.py:838`, which reports rather than
mutates and whose renderers agree; and the sites whose raise now lives in the calling command.
Branching on a falsy return is not the same as exiting on one, which is what put `sibyl update`
and `sibyl setup` in the fixed column. The sweep also found `_output_response` (`task.py:51`), an
exit-0 helper with zero callers, deleted rather than fixed.

One site needed more than an exit code. `task note` treated a bare `{"success": true}` envelope
as a failure while its `sibyl note` sibling, which posts to the same `/tasks/{id}/notes`
endpoint, treated it as a success. Left alone, the new exit code would have converted a wrong
message into a wrong exit status, so the two now agree (`task.py:1246-1253`).

### 3. The buffer reports itself

Three surfaces, because the three moments a user might notice are different:

- **Every command**, through a one-line stderr warning carrying the depth and the flush command.
  It is emitted from a `finally` block in `sibyl_cli.main.main()`, which is what
  `sibyl_cli.entrypoint:main` (the console script) calls, so the failing commands that fill the
  queue still emit it on their way out.
- **`sibyl health`**, which prints `Pending writes: 0` next to the entity and relationship counts
  and warns with the depth and remediation when the queue is not empty. `sibyl health --json`
  carries the same under a `pending_writes` key.
- **`sibyl doctor`**, which gains a `pending-writes` check that warns while anything is queued and
  names both the flush command and the queue directory.

A command that renders the queue itself claims the report through
`mark_pending_writes_reported()`, and the end-of-command notice stands down for it. Without that,
`sibyl health` printed the identical sentence twice, once on stdout from its own report and once
on stderr from the notice. Suppression follows the command that actually ran, so
`sibyl search "pending-writes"` still gets its warning.

The claim sits on `pending-writes list` and `flush` rather than on the group, because `discard`
can leave the queue untouched (an unknown id discards nothing) and a group-wide claim suppressed
the only line that would have said so. `notify_pending_writes` claims the report before printing
rather than after, so it is idempotent across nesting, and it is installed at the console-script
boundary in `entrypoint.py` as well: the `context --quick` fast path returns before reaching
`sibyl_cli.main`, and agent hooks take that path.

The per-command path calls the new `pending_write_count()` (`pending_writes.py:120-131`), which
counts directory entries rather than parsing every queued payload, and returns 0 rather than
raising if the directory is missing or unreadable. Colors come from the existing SilkCircuit
constants in `sibyl_core.logging.colors`; the only new console object is
`common.err_console`, a stderr twin of the existing one so the notice cannot land in a `--json`
pipe.

### 4. The 401 panel names a command that exists

`sibyl auth signup` was never registered. The auth group registers `status`, `set-token`,
`clear-token`, `login`, `local-signup`, and the `api-key` group, so the busiest error path in the
CLI was telling users to run something that only produces a usage error. It now says
`sibyl auth local-signup`. The test derives the accepted set from the Typer group's own
registrations, so a future rename breaks the test rather than the advice.

## 🧪 Validation

`moon run cli:check` at `4c0ffea0`:

```
cli:lint       | All checks passed!
cli:typecheck  | All checks passed!
cli:test       | 553 passed in 8.38s
```

Root `moon run :lint` (12 tasks) and `moon run :typecheck` (7 tasks) are clean at the same head.
The full CI matrix went green at `1958b1e8`: Build, E2E, Package Tests, Static Checks, live
SurrealDB 3.x ingestion, Dependency Audit, CodeRabbit.

New coverage: 64 tests in `tests/test_exit_codes.py`, 18 in `tests/test_pending_visibility.py`, 3
in `tests/test_resolver_is_single.py`, 5 in `tests/test_pending_cli.py`, 5 in
`tests/test_auth_login.py`, 2 in `tests/test_logs.py`.

Every new test was run against the source without its fix to confirm it fails for the right
reason. Counts by round: 9 for the original refused-write exits, 8 for `--json` and crawl ingest,
4 for report-once, 6 and 5 and 6 for verification rounds two through four, then 6 for the context
blocker, 2 for login scope, and 7 for the review's three exit-0 cases. The remainder pass on `main`
by design, being regression guards or negative assertions whose discriminating twin sits beside
them. Eight drafts passed against the unfixed source for unrelated reasons and were rewritten
until they exercised the real branch.

Both renderers proven to agree on one stubbed response each, for every command where they diverged:

```
health      unhealthy  table 1 | json 1     link-graph   error      table 1 | json 1
health      healthy    table 0 | json 0     link-graph   complete   table 0 | json 0
synth rem   not saved  table 1 | json 1     synth verify gaps       table 1 | json 1
synth rem   saved      table 0 | json 0     synth verify pass       table 0 | json 0
```

`pending-writes discard` probed live against a three-write queue:

```
$ sibyl pending-writes discard aaaa1111 aaaa1111   ✓ Discarded 1 pending write        exit 0
$ sibyl pending-writes discard bbbb2222 deadbeef   ✓ Discarded 1 / ✗ 1 no match       exit 1
```

Live probe against a dead port with a sandboxed `HOME`:

```
$ sibyl note "smoke test note body"
  × Cannot connect to Sibyl server
! 1 write buffered locally and not saved on the server. Run 'sibyl pending-writes flush' to replay them.
EXIT=1
$ sibyl task start <uuid> --json   -> exit 1, parseable JSON on stdout
$ sibyl pending-writes list 2>&1 1>/dev/null   -> no duplicate notice
$ sibyl version 2>&1 1>/dev/null               -> notice present, so it is on stderr
```

Five rounds of independent adversarial verification plus one hostile external review ran against
this branch, and every one found another member of the same class. The method changed in response
each time: from fixing named sites, to sweeping one syntactic shape, to two, to the control-flow
question, and finally to sweeping the other two reporting channels (`warn()` and discarded
booleans) that an `error()`-only sweep is structurally blind to. Two AST passes now confirm no
`typer.Exit` is raised under a broad handler and no `--json` branch returns before a failure
determination its table twin acts on. Everything found is fixed here rather than deferred.

⚠️ Not covered: the browser e2e suite and `apps/e2e` were not run locally, since neither exercises
these paths and both need a live stack; CI ran them. The exit-code change is behavioural for
anything scripting the CLI, so a caller that treats a refused write as success will start seeing
failures. That is the point, and a repo-wide grep found no such caller in this repo
(`hooks/session-start.py:23` checks `returncode == 0` on a read). The `-C` hard error is likewise
behavioural: a script passing a stale context name now fails instead of silently retargeting.

## 🔍 What reviewers should focus on

- **The credential-scope change.** `_current_credential_scope()` now resolves through
  `resolve_context_name()` rather than `get_active_context()`. For a user with no directory pin
  and no `SIBYL_CONTEXT`, the two are identical. For a user who has one, tokens now write under
  the context they are actually using. That is the intended fix, but it is the one change that
  can move where an existing token is read from.
- **The `finally` block in `main()`.** It runs on every exit path including `SystemExit` from
  `--help` and usage errors. Confirm the excluded-command check (`"pending-writes" not in
  sys.argv[1:]`) is the behaviour you want, and that a filesystem hiccup in `pending_write_count`
  cannot turn a successful command into a failing one.
- **`sibyl health --json` gained a key.** Additive, but it is a machine-readable surface.
- **`task note` accepting a bare `success` envelope.** The API's `NoteResponse`
  (`apps/api/src/sibyl/api/routes/tasks.py:1000-1010`) always carries an `id`, so this is
  tolerance rather than a contract change, and it makes the two note commands agree.

Out of scope on purpose: audit findings C2 (dead `--yes` on `entity delete`), C5 (errors on
stdout), C7 (the dead silent-relogin path), C8, C9, and C10 (the `main.py` god-module split).

## 📌 Follow-ups

- **C5, error output on stdout.** It corrupts `--json` for every command that can fail. Fixing it
  means moving `error()` and `warn()` to stderr across the package, which is its own PR with its
  own output-shape review. `err_console` added here is the seam that change would build on.
- **No age or size bound on the pending-writes queue.** The queue is now visible, so an unbounded
  one is at least noticeable. Bounding it is a separate decision about what to do with writes
  that have been queued for weeks.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pending-write visibility to health checks, diagnostics, and command output, including replay guidance.
  * Added consistent context-aware server selection and authentication handling.
  * Added structured JSON results with success indicators for write operations.

* **Bug Fixes**
  * Failed operations now return nonzero exit codes across CLI commands.
  * Unknown contexts fail clearly instead of silently falling back.
  * Improved pending-write discard validation and authentication guidance.

* **Documentation**
  * Documented context and server selection precedence, project resolution, and pending-write notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


