### PR TITLE
refactor(retrieval): fold tokens with the index's own stemmer

### DIFF
--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -21,6 +21,8 @@ from typing import TypeVar
 from urllib.parse import urlparse
 from uuid import uuid4
 
+from functools import lru_cache
+
 import httpx
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -1726,6 +1728,36 @@ def _query_ui_roles(query: str) -> tuple[str, ...]:
     return tuple(roles)
 
 
+@lru_cache(maxsize=8192)
+def _line_stems(line: str) -> tuple[str, ...]:
+    return tuple(normalize_keyword_token(token) for token in re.findall(r"[\w-]+", line))
+
+
+@lru_cache(maxsize=8192)
+def _phrase_stems(phrase: str) -> tuple[str, ...]:
+    return tuple(normalize_keyword_token(token) for token in re.findall(r"[\w-]+", phrase))
+
+
+def _phrase_matches_line(phrase: str, line: str) -> bool:
+    """Literal match first, then the same phrase compared stem by stem.
+
+    Focus phrases are folded, and a fold is not a substring of what it covers
+    when Snowball rewrites a terminal y: "categori" is absent from "category".
+    Comparing whole tokens reaches both spellings, and the literal check keeps
+    every match the substring probe already made.
+    """
+    if phrase in line:
+        return True
+    wanted = _phrase_stems(phrase)
+    if not wanted:
+        return False
+    haystack = _line_stems(line)
+    span = len(wanted)
+    return any(
+        haystack[start : start + span] == wanted for start in range(len(haystack) - span + 1)
+    )
+
+
 def _query_structured_signal(query: str, text: str) -> tuple[int, int, int, int, int]:
     focus_phrases = tuple(phrase.casefold() for phrase in _query_focus_phrases(query))
     roles = _query_ui_roles(query)
@@ -1743,7 +1775,9 @@ def _query_structured_signal(query: str, text: str) -> tuple[int, int, int, int,
     matched_phrase_priority = 0
     for phrase_index, phrase in enumerate(focus_phrases, start=1):
         phrase_line_indices = {
-            line_index for line_index, line in enumerate(lines) if phrase in line
+            line_index
+            for line_index, line in enumerate(lines)
+            if _phrase_matches_line(phrase, line)
         }
         nearby_role_lines = {
             role_line_index
@@ -1995,7 +2029,7 @@ def _query_slice_candidates(
         window_starts = set(range(body_start, state_end, stride_lines))
         for line_index in range(body_start, state_end):
             line = lines[line_index].casefold()
-            if not any(phrase in line for phrase in focus_phrases):
+            if not any(_phrase_matches_line(phrase, line) for phrase in focus_phrases):
                 continue
             anchored_start = max(
                 body_start,
@@ -2055,7 +2089,7 @@ def _query_structured_section_candidates(
     candidates: list[dict[str, object]] = []
     for focus_line in range(body_start, state_end):
         normalized_line = lines[focus_line].casefold()
-        if not any(phrase in normalized_line for phrase in focus_phrases):
+        if not any(_phrase_matches_line(phrase, normalized_line) for phrase in focus_phrases):
             continue
         section_marker = re.search(
             r"\b(?:button|group|heading|legend|list|menu|region|tablist)\b",

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -40,6 +40,10 @@ from sibyl_core.projection import project_operational_experience  # noqa: E402
 from sibyl_core.retrieval.operational_evidence import (  # noqa: E402
     TYPED_NOTE_RESERVATION_ITEMS,
 )
+from sibyl_core.query_anchors import (  # noqa: E402
+    normalize_keyword_token,
+    normalize_keyword_tokens,
+)
 from sibyl_core.retrieval.query_ranking import (  # noqa: E402
     QueryCoverageCandidate,
     QueryCoverageRankedCandidate,
@@ -302,6 +306,12 @@ _QUERY_FOCUS_STOPWORDS = frozenset(
         "what",
         "which",
     }
+)
+# UI nouns are written singular and matched by stem, so a query saying "labels"
+# or "columns" is filtered by the entry that spells one.
+_QUERY_FOCUS_STOPWORD_STEMS = normalize_keyword_tokens(_QUERY_FOCUS_STOPWORDS)
+_QUERY_FOCUS_TERM_STOPWORD_STEMS = _QUERY_FOCUS_STOPWORD_STEMS | normalize_keyword_tokens(
+    {"list", "page"}
 )
 _QUERY_UI_ROLE_PATTERNS = (
     (
@@ -1668,7 +1678,9 @@ def _query_focus_phrases(query: str) -> tuple[str, ...]:
     for match in _QUERY_TARGET_FOCUS_PATTERN.finditer(focused_query):
         phrase = str(match.group("phrase") or "").strip()
         tokens = re.findall(r"[\w-]+", phrase.casefold())
-        if not tokens or all(token in _QUERY_FOCUS_STOPWORDS for token in tokens):
+        if not tokens or all(
+            normalize_keyword_token(token) in _QUERY_FOCUS_STOPWORD_STEMS for token in tokens
+        ):
             continue
         phrase_count = len(phrases)
         add_phrase(phrase)
@@ -1681,9 +1693,12 @@ def _query_focus_phrases(query: str) -> tuple[str, ...]:
     target_queries = [query for query in structural_queries if query.facet == "target"]
     for structural_query in target_queries:
         for term in structural_query.added_terms:
-            if term.casefold() in {*_QUERY_FOCUS_STOPWORDS, "list", "page"}:
+            stem = normalize_keyword_token(term)
+            if stem in _QUERY_FOCUS_TERM_STOPWORD_STEMS:
                 continue
-            add_phrase(term)
+            # Focus phrases are substring-matched against page text, so the
+            # folded form is the one that reaches both spellings of a noun.
+            add_phrase(stem)
     if not target_focus_added and not target_queries:
         for structural_query in structural_queries:
             if structural_query.facet != "focus_clause":
@@ -1691,7 +1706,8 @@ def _query_focus_phrases(query: str) -> tuple[str, ...]:
             structural_terms = [
                 token
                 for token in re.findall(r"[A-Za-z][\w-]*", structural_query.query)
-                if token.casefold() not in _QUERY_FOCUS_STOPWORDS and token.casefold() not in seen
+                if normalize_keyword_token(token) not in _QUERY_FOCUS_STOPWORD_STEMS
+                and token.casefold() not in seen
             ]
             if len(structural_terms) < 2:
                 continue

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -1745,6 +1745,12 @@ def _phrase_matches_line(phrase: str, line: str) -> bool:
     when Snowball rewrites a terminal y: "categori" is absent from "category".
     Comparing whole tokens reaches both spellings, and the literal check keeps
     every match the substring probe already made.
+
+    The fold includes graded adjectives, so "fastest route" also reaches a line
+    saying "the fast route". That fold is banned on the query path, where it
+    costs a fulltext match against an index that does not stem comparatives.
+    Here both sides are plain page text and never meet an index, so widening
+    to the base adjective only finds more of the state the question is about.
     """
     if phrase in line:
         return True

--- a/packages/python/sibyl-core/pyproject.toml
+++ b/packages/python/sibyl-core/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
     # Async & HTTP
     "anyio>=4.14.2",
     "httpx>=0.27",
+    # Lexical normalization; must stay the same Snowball English implementation
+    # the SurrealDB fulltext analyzers run, or the ranker and the index disagree
+    "snowballstemmer>=2.2",
     # Logging
     "structlog>=24.0",
     # Environment

--- a/packages/python/sibyl-core/src/sibyl_core/query_anchors.py
+++ b/packages/python/sibyl-core/src/sibyl_core/query_anchors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
-from collections.abc import Iterable
+from collections.abc import Container, Iterable
 
 import snowballstemmer
 
@@ -111,19 +111,28 @@ def normalize_keyword_tokens(tokens: Iterable[str]) -> frozenset[str]:
 # so "completely" reaches complete, "useful" and "playful" reach use and play.
 # Those are adverbs and adjectives, not the act, and a sense group that admits
 # them fires on text about nothing of the kind.
-_DERIVATIONAL_SUFFIXES = ("ly", "ful")
+_DERIVATIONAL_SUFFIXES = ("ly", "ful", "ant", "ants", "ment", "ments")
 
 
-def is_derivational_form(token: str) -> bool:
+def is_derivational_form(token: str, *, vocabulary: Container[str] = frozenset()) -> bool:
+    """Whether a token only shares a verb's stem by derivation.
+
+    Membership decides first: a suffix cannot tell a derived adverb from a word
+    the vocabulary lists in its own right, and English is full of nouns that
+    end this way ("family", "supply", "assembly"). Only a token the vocabulary
+    does not know is judged by its ending.
+    """
+    if token in vocabulary:
+        return False
     return len(token) > 5 and token.endswith(_DERIVATIONAL_SUFFIXES)
 
 
-def sense_tokens_from_text(text: str) -> list[str]:
+def sense_tokens_from_text(text: str, *, vocabulary: Container[str] = frozenset()) -> list[str]:
     """Tokens eligible to match a verb-sense group, derivations excluded."""
     return [
         normalize_keyword_token(token)
         for token in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9'-]{2,}", text.lower())
-        if not is_derivational_form(token)
+        if not is_derivational_form(token, vocabulary=vocabulary)
     ]
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/query_anchors.py
+++ b/packages/python/sibyl-core/src/sibyl_core/query_anchors.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import re
+import threading
 import unicodedata
 from collections.abc import Container, Iterable
+from functools import lru_cache
+from typing import Any
 
 import snowballstemmer
 
@@ -13,7 +16,24 @@ import snowballstemmer
 # MATCHES operator runs the query string through that same chain. Normalizing
 # Python-side with the identical Snowball English algorithm is what keeps the
 # coverage ranker looking for the term the fulltext lane actually matched.
-_STEMMER = snowballstemmer.stemmer("english")
+#
+# A Snowball stemmer holds the word under analysis in mutable instance state, so
+# two threads sharing one instance overwrite each other's buffer and get back a
+# stem of the other thread's word or an IndexError off the end of it. Coverage
+# ranking is dispatched through asyncio.to_thread on both retrieval paths, which
+# makes that concurrency ordinary rather than exotic, so each thread gets its
+# own stemmer. Per-thread instances stay cheap and leave the hot path
+# uncontended, which a lock around a shared instance would not.
+_STEMMER_STATE = threading.local()
+
+
+def _stemmer() -> Any:
+    stemmer = getattr(_STEMMER_STATE, "instance", None)
+    if stemmer is None:
+        stemmer = snowballstemmer.stemmer("english")
+        _STEMMER_STATE.instance = stemmer
+    return stemmer
+
 
 # Snowball is an inflectional stemmer and leaves graded adjectives alone: not
 # one of the pairs below unifies under it (faster stays faster while fast stays
@@ -77,6 +97,7 @@ _GRADED_ADJECTIVE_ALIASES = {
     "younger": "young",
     "youngest": "young",
 }
+_TEXT_TOKEN_PATTERN = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9'-]{2,}")
 _EXPLICIT_ANCHOR_PATTERN = re.compile(
     r"`(?P<backtick>[^`\n]{1,160})`"
     r'|"(?P<double>[^"\n]{1,160})"'
@@ -89,13 +110,18 @@ def _fold_ascii(token: str) -> str:
     return "".join(char for char in decomposed if not unicodedata.combining(char))
 
 
+# Ranking stems every token of every candidate, and candidate text repeats its
+# vocabulary heavily, so the same handful of surface forms is stemmed thousands
+# of times per search. The mapping is pure, which makes a bounded cache the
+# whole of the fix; the bound keeps user text from growing it without limit.
+@lru_cache(maxsize=1 << 16)
 def normalize_keyword_token(token: str) -> str:
     token = _fold_ascii(token.strip("'\"").lower())
     if token.endswith("'s"):
         token = token[:-2]
     elif token.endswith("'"):
         token = token[:-1]
-    return _STEMMER.stemWord(_GRADED_ADJECTIVE_ALIASES.get(token, token))
+    return _stemmer().stemWord(_GRADED_ADJECTIVE_ALIASES.get(token, token))
 
 
 def normalize_keyword_tokens(tokens: Iterable[str]) -> frozenset[str]:
@@ -131,16 +157,34 @@ def sense_tokens_from_text(text: str, *, vocabulary: Container[str] = frozenset(
     """Tokens eligible to match a verb-sense group, derivations excluded."""
     return [
         normalize_keyword_token(token)
-        for token in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9'-]{2,}", text.lower())
+        for token in _TEXT_TOKEN_PATTERN.findall(text.lower())
         if not is_derivational_form(token, vocabulary=vocabulary)
     ]
 
 
 def keyword_tokens_from_text(text: str) -> list[str]:
-    return [
-        normalize_keyword_token(token)
-        for token in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9'-]{2,}", text.lower())
-    ]
+    return [normalize_keyword_token(token) for token in _TEXT_TOKEN_PATTERN.findall(text.lower())]
+
+
+def keyword_and_sense_tokens_from_text(
+    text: str,
+    *,
+    vocabulary: Container[str] = frozenset(),
+) -> tuple[list[str], list[str]]:
+    """Both token views of one text, from one traversal.
+
+    The two views read the same tokens and normalize them the same way, and
+    differ only in the derived forms the sense view drops, so a caller that
+    wants both should not walk a fifty-thousand-character candidate twice.
+    """
+    keyword_tokens: list[str] = []
+    sense_tokens: list[str] = []
+    for surface in _TEXT_TOKEN_PATTERN.findall(text.lower()):
+        normalized = normalize_keyword_token(surface)
+        keyword_tokens.append(normalized)
+        if not is_derivational_form(surface, vocabulary=vocabulary):
+            sense_tokens.append(normalized)
+    return keyword_tokens, sense_tokens
 
 
 def extract_explicit_query_anchors(query: str) -> tuple[tuple[str, ...], ...]:

--- a/packages/python/sibyl-core/src/sibyl_core/query_anchors.py
+++ b/packages/python/sibyl-core/src/sibyl_core/query_anchors.py
@@ -107,6 +107,26 @@ def normalize_keyword_tokens(tokens: Iterable[str]) -> frozenset[str]:
     return frozenset(normalize_keyword_token(token) for token in tokens)
 
 
+# Snowball is inflectional and folds derivations onto the verb they came from,
+# so "completely" reaches complete, "useful" and "playful" reach use and play.
+# Those are adverbs and adjectives, not the act, and a sense group that admits
+# them fires on text about nothing of the kind.
+_DERIVATIONAL_SUFFIXES = ("ly", "ful")
+
+
+def is_derivational_form(token: str) -> bool:
+    return len(token) > 5 and token.endswith(_DERIVATIONAL_SUFFIXES)
+
+
+def sense_tokens_from_text(text: str) -> list[str]:
+    """Tokens eligible to match a verb-sense group, derivations excluded."""
+    return [
+        normalize_keyword_token(token)
+        for token in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9'-]{2,}", text.lower())
+        if not is_derivational_form(token)
+    ]
+
+
 def keyword_tokens_from_text(text: str) -> list[str]:
     return [
         normalize_keyword_token(token)

--- a/packages/python/sibyl-core/src/sibyl_core/query_anchors.py
+++ b/packages/python/sibyl-core/src/sibyl_core/query_anchors.py
@@ -3,39 +3,29 @@
 from __future__ import annotations
 
 import re
+import unicodedata
+from collections.abc import Iterable
 
-_NORMALIZED_TOKEN_ALIASES = {
-    "attended": "attend",
-    "attending": "attend",
-    "assembled": "assemble",
-    "assembling": "assemble",
-    "classes": "class",
-    "engaged": "engagement",
-    "fixed": "fix",
-    "fixing": "fix",
-    "presented": "present",
-    "presenting": "present",
-    "relied": "rely",
-    "relying": "rely",
-    "serviced": "service",
-    "servicing": "service",
-    "sold": "sell",
-    "selling": "sell",
-    "subscribed": "subscription",
-    "subscribing": "subscription",
-    "volunteered": "volunteer",
-    "volunteering": "volunteer",
-}
-# Comparatives and superlatives are the same lemma as their base adjective, and
-# no suffix rule recovers that safely: stripping "er" turns user into us and
-# other into oth. Adjectives whose base or inflections the stopword layer
-# already classifies (new, long, late, early) are deliberately absent, because
-# normalization runs before that check and would change which tokens it drops.
-# Comparatives that double as everyday nouns are absent for a different reason:
-# a lighter, a cleaner, a warmer and a closer are objects and roles, not degrees
-# of light or clean, and folding them in makes a Zippo match a garage lamp.
-# "lower" is out because it is far more often the verb. Their superlatives stay,
-# since nothing reads "lightest" or "closest" as a noun.
+import snowballstemmer
+
+# Every BM25 index in the graph schema is analyzed with
+# `TOKENIZERS blank, class FILTERS lowercase, ascii, snowball(english)`, and the
+# MATCHES operator runs the query string through that same chain. Normalizing
+# Python-side with the identical Snowball English algorithm is what keeps the
+# coverage ranker looking for the term the fulltext lane actually matched.
+_STEMMER = snowballstemmer.stemmer("english")
+
+# Snowball is an inflectional stemmer and leaves graded adjectives alone: not
+# one of the pairs below unifies under it (faster stays faster while fast stays
+# fast), and no suffix rule recovers them safely, since stripping "er" turns
+# user into us and other into oth. Adjectives whose base or inflections the
+# stopword layer already classifies (new, long, late, early) are deliberately
+# absent, because normalization runs before that check and would change which
+# tokens it drops. Comparatives that double as everyday nouns are absent for a
+# different reason: a lighter, a cleaner, a warmer and a closer are objects and
+# roles, not degrees of light or clean, and folding them in makes a Zippo match
+# a garage lamp. "lower" is out because it is far more often the verb. Their
+# superlatives stay, since nothing reads "lightest" or "closest" as a noun.
 _GRADED_ADJECTIVE_ALIASES = {
     "bigger": "big",
     "biggest": "big",
@@ -94,21 +84,27 @@ _EXPLICIT_ANCHOR_PATTERN = re.compile(
 )
 
 
+def _fold_ascii(token: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", token)
+    return "".join(char for char in decomposed if not unicodedata.combining(char))
+
+
 def normalize_keyword_token(token: str) -> str:
-    token = token.strip("'\"")
-    if token in _NORMALIZED_TOKEN_ALIASES:
-        return _NORMALIZED_TOKEN_ALIASES[token]
-    if token in _GRADED_ADJECTIVE_ALIASES:
-        return _GRADED_ADJECTIVE_ALIASES[token]
-    if len(token) > 4 and token.endswith("ies"):
-        return f"{token[:-3]}y"
-    if len(token) > 4 and token.endswith(("ches", "shes", "xes", "zes")):
-        return token[:-2]
-    if len(token) > 4 and token.endswith(("ces", "ses")):
-        return token[:-1]
-    if len(token) > 3 and token.endswith("s") and not token.endswith(("is", "ous", "ss", "us")):
-        return token[:-1]
-    return token
+    token = _fold_ascii(token.strip("'\"").lower())
+    if token.endswith("'s"):
+        token = token[:-2]
+    elif token.endswith("'"):
+        token = token[:-1]
+    return _STEMMER.stemWord(_GRADED_ADJECTIVE_ALIASES.get(token, token))
+
+
+def normalize_keyword_tokens(tokens: Iterable[str]) -> frozenset[str]:
+    """Normalize a hand-written vocabulary so it compares against normalized tokens.
+
+    Lexicons are authored in surface English and folded here at import time, so
+    a list never has to spell out the inflections of its own entries.
+    """
+    return frozenset(normalize_keyword_token(token) for token in tokens)
 
 
 def keyword_tokens_from_text(text: str) -> list[str]:
@@ -119,16 +115,35 @@ def keyword_tokens_from_text(text: str) -> list[str]:
 
 
 def extract_explicit_query_anchors(query: str) -> tuple[tuple[str, ...], ...]:
+    return _anchor_token_groups(query, normalize=True)
+
+
+def _anchor_token_groups(query: str, *, normalize: bool) -> tuple[tuple[str, ...], ...]:
     anchors: list[tuple[str, ...]] = []
     seen: set[tuple[str, ...]] = set()
     for match in _EXPLICIT_ANCHOR_PATTERN.finditer(query):
         value = next(group for group in match.groups() if group is not None)
-        anchor = tuple(keyword_tokens_from_text(value)[:12])
+        tokens = re.findall(r"[a-zA-Z0-9][a-zA-Z0-9'-]{2,}", value.lower())
+        anchor = tuple(
+            normalize_keyword_token(token) if normalize else token.strip("'\"")
+            for token in tokens[:12]
+        )
         if not anchor or anchor in seen:
             continue
         anchors.append(anchor)
         seen.add(anchor)
     return tuple(anchors)
+
+
+def extract_explicit_anchor_phrases(query: str) -> tuple[tuple[str, ...], ...]:
+    """Quoted anchors as the query spells them, for search queries.
+
+    A fulltext index analyzes both sides with the same chain, so a surface
+    phrase is what makes the query form and the indexed form meet. Folding
+    first can only lose: graded adjectives are left alone index-side, so a
+    pre-folded "fastest" stops matching the document that spells it out.
+    """
+    return _anchor_token_groups(query, normalize=False)
 
 
 def explicit_anchor_score(

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
@@ -6,6 +6,8 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 
+from sibyl_core.query_anchors import normalize_keyword_token, normalize_keyword_tokens
+
 _TOKEN_PATTERN = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9'-]{1,}")
 _SPAN_SPLIT_PATTERN = re.compile(r"(?<=[.!?])\s+|\n+")
 _FIRST_PERSON_PATTERN = re.compile(r"\b(?:i|i'm|i've|i'd|me|my|mine|we|our)\b", re.I)
@@ -68,7 +70,6 @@ _STOPWORDS = {
     "me",
     "mine",
     "month",
-    "months",
     "more",
     "much",
     "my",
@@ -80,7 +81,6 @@ _STOPWORDS = {
     "our",
     "out",
     "recent",
-    "recently",
     "some",
     "that",
     "the",
@@ -90,10 +90,8 @@ _STOPWORDS = {
     "to",
     "up",
     "user",
-    "using",
     "was",
     "week",
-    "weeks",
     "what",
     "when",
     "which",
@@ -103,69 +101,36 @@ _STOPWORDS = {
     "you",
 }
 
-_NORMALIZED_TOKEN_ALIASES = {
-    "acquired": "acquire",
-    "acquiring": "acquire",
-    "assembled": "assemble",
-    "assembling": "assemble",
-    "attended": "attend",
-    "attending": "attend",
-    "bought": "buy",
-    "classes": "class",
-    "completed": "complete",
-    "finishing": "finish",
-    "fixed": "fix",
-    "fixing": "fix",
-    "got": "get",
-    "listened": "listen",
-    "listening": "listen",
-    "ordered": "order",
-    "ordering": "order",
-    "participated": "participate",
-    "participating": "participate",
-    "picked": "pick",
-    "played": "play",
-    "playing": "play",
-    "presented": "present",
-    "presenting": "present",
-    "purchased": "purchase",
-    "purchasing": "purchase",
-    "read": "read",
-    "relying": "rely",
-    "researched": "research",
-    "researching": "research",
-    "serviced": "repair",
-    "servicing": "repair",
-    "studied": "study",
-    "studying": "study",
-    "subscribed": "subscribe",
-    "using": "use",
-    "visited": "visit",
-    "visiting": "visit",
-    "volunteered": "volunteer",
-    "volunteering": "volunteer",
-    "watching": "watch",
-}
-
+# Every group is written in surface English and stemmed at import, so a term
+# covers its own inflections. Irregular pasts (bought, got, went) survive
+# stemming unchanged and are therefore listed beside the verb they belong to,
+# and "service" sits under repair because that is a sense mapping the stemmer
+# has no opinion about.
 _ACTION_TERMS: dict[str, frozenset[str]] = {
-    "acquire": frozenset(
+    "acquire": normalize_keyword_tokens(
         {
             "acquire",
+            "bought",
             "buy",
             "get",
+            "got",
             "invest",
             "order",
             "pick",
             "purchase",
         }
     ),
-    "attend": frozenset({"attend", "join", "participate", "visit", "went"}),
-    "complete": frozenset({"complete", "finish"}),
-    "create": frozenset({"build", "compose", "create", "draft", "generate", "make", "write"}),
-    "present": frozenset({"present", "presentation"}),
-    "profile": frozenset({"field", "focus", "profession", "research", "role", "specialty"}),
-    "repair": frozenset({"fix", "repair", "replace"}),
-    "use": frozenset(
+    "attend": normalize_keyword_tokens({"attend", "join", "participate", "visit", "went"}),
+    "complete": normalize_keyword_tokens({"complete", "finish"}),
+    "create": normalize_keyword_tokens(
+        {"build", "compose", "create", "draft", "generate", "make", "write"}
+    ),
+    "present": normalize_keyword_tokens({"present", "presentation"}),
+    "profile": normalize_keyword_tokens(
+        {"field", "focus", "profession", "research", "role", "specialty"}
+    ),
+    "repair": normalize_keyword_tokens({"fix", "repair", "replace", "service"}),
+    "use": normalize_keyword_tokens(
         {
             "choose",
             "follow",
@@ -178,12 +143,12 @@ _ACTION_TERMS: dict[str, frozenset[str]] = {
             "watch",
         }
     ),
-    "volunteer": frozenset({"volunteer"}),
+    "volunteer": normalize_keyword_tokens({"volunteer"}),
 }
 
 _QUERY_ACTION_TERMS: dict[str, frozenset[str]] = {
     **_ACTION_TERMS,
-    "recommend": frozenset(
+    "recommend": normalize_keyword_tokens(
         {
             "recommend",
             "suggest",
@@ -191,9 +156,11 @@ _QUERY_ACTION_TERMS: dict[str, frozenset[str]] = {
     ),
 }
 
+_RELATIVE_TERM = normalize_keyword_token("relative")
+
 _RELATION_TERMS: dict[str, frozenset[str]] = {
-    "friend": frozenset({"colleague", "coworker", "friend", "partner", "roommate"}),
-    "relative": frozenset(
+    "friend": normalize_keyword_tokens({"colleague", "coworker", "friend", "partner", "roommate"}),
+    "relative": normalize_keyword_tokens(
         {
             "aunt",
             "brother",
@@ -297,7 +264,7 @@ def _frame_from_span(span: str, *, query: bool) -> FactFrame | None:
     if query and re.search(r"\b(?:what|which|name)\b[^?]{0,100}\bservice\b", lowered):
         categories.add("service")
         actions.add("use")
-    if query and "relative" in terms:
+    if query and _RELATIVE_TERM in terms:
         relations.add("relative")
     if _RECENCY_PATTERN.search(span):
         relations.add("recency")
@@ -377,31 +344,14 @@ def _salient_terms(text: str) -> list[str]:
     terms: list[str] = []
     seen: set[str] = set()
     for raw_token in _TOKEN_PATTERN.findall(text.lower()):
-        token = _normalize_token(raw_token)
-        if token in _STOPWORDS or token in seen or len(token) < 2:
+        if raw_token in _STOPWORDS:
+            continue
+        token = normalize_keyword_token(raw_token)
+        if token in seen or len(token) < 2:
             continue
         seen.add(token)
         terms.append(token)
     return terms
-
-
-def _normalize_token(token: str) -> str:
-    token = token.strip("'\"")
-    if token.endswith("'s"):
-        token = token[:-2]
-    elif token.endswith("'"):
-        token = token[:-1]
-    if token in _NORMALIZED_TOKEN_ALIASES:
-        return _NORMALIZED_TOKEN_ALIASES[token]
-    if len(token) > 4 and token.endswith("ies"):
-        return f"{token[:-3]}y"
-    if len(token) > 4 and token.endswith(("ches", "shes", "xes", "zes")):
-        return token[:-2]
-    if len(token) > 4 and token.endswith(("ces", "ses")):
-        return token[:-1]
-    if len(token) > 3 and token.endswith("s") and not token.endswith(("is", "ous", "ss", "us")):
-        return token[:-1]
-    return token
 
 
 def _overlap(left: frozenset[str], right: frozenset[str]) -> float:

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
@@ -100,6 +100,10 @@ _STOPWORDS = {
     "year",
     "you",
 }
+# Matched both ways: as written, so an entry only silences the word it spells,
+# and by stem, so its own plural cannot slip past the entry that lists it.
+# "using" is deliberately absent from both, since it carries the use action.
+_STOPWORD_STEMS = normalize_keyword_tokens(_STOPWORDS)
 
 # Every group is written in surface English and stemmed at import, so a term
 # covers its own inflections. Irregular pasts (bought, got, went) survive
@@ -347,7 +351,7 @@ def _salient_terms(text: str) -> list[str]:
         if raw_token in _STOPWORDS:
             continue
         token = normalize_keyword_token(raw_token)
-        if token in seen or len(token) < 2:
+        if token in _STOPWORD_STEMS or token in seen or len(token) < 2:
             continue
         seen.add(token)
         terms.append(token)

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
@@ -275,11 +275,12 @@ def _extract_fact_frames(text: str, *, query: bool) -> tuple[FactFrame, ...]:
 
 
 def _frame_from_span(span: str, *, query: bool) -> FactFrame | None:
-    terms = frozenset(_salient_terms(span))
+    span_terms, span_sense_terms = _salient_and_sense_terms(span)
+    terms = frozenset(span_terms)
     if not terms:
         return None
 
-    sense_terms = frozenset(_salient_terms(span, senses_only=True))
+    sense_terms = frozenset(span_sense_terms)
     action_source = _QUERY_ACTION_TERMS if query else _ACTION_TERMS
     actions = set(_labels_for_terms(sense_terms, action_source))
     categories: set[str] = set()
@@ -376,20 +377,33 @@ def _labels_for_terms(
             yield label
 
 
-def _salient_terms(text: str, *, senses_only: bool = False) -> list[str]:
+def _salient_and_sense_terms(text: str) -> tuple[list[str], list[str]]:
+    """Both term views of a span, from one traversal.
+
+    Every frame wants the plain terms and the sense terms, and the spans are
+    cut from candidate text that runs to fifty thousand characters, so reading
+    the span twice to apply one extra filter is work nobody needs. The two
+    views dedupe separately, exactly as two passes would: the sense view never
+    sees the derived forms, so they cannot claim a slot in it.
+    """
     terms: list[str] = []
+    sense_terms: list[str] = []
     seen: set[str] = set()
+    sense_seen: set[str] = set()
     for raw_token in _TOKEN_PATTERN.findall(text.lower()):
         if raw_token in _STOPWORDS:
             continue
-        if senses_only and is_derivational_form(raw_token, vocabulary=_SENSE_VOCABULARY):
-            continue
         token = normalize_keyword_token(raw_token)
-        if token in seen or len(token) < 2:
+        if len(token) < 2:
             continue
-        seen.add(token)
-        terms.append(token)
-    return terms
+        if token not in seen:
+            seen.add(token)
+            terms.append(token)
+        if token in sense_seen or is_derivational_form(raw_token, vocabulary=_SENSE_VOCABULARY):
+            continue
+        sense_seen.add(token)
+        sense_terms.append(token)
+    return terms, sense_terms
 
 
 def _overlap(left: frozenset[str], right: frozenset[str]) -> float:

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
@@ -123,8 +123,8 @@ _STOPWORDS = {
 # stemming unchanged and are therefore listed beside the verb they belong to,
 # and "service" sits under repair because that is a sense mapping the stemmer
 # has no opinion about.
-_ACTION_TERMS: dict[str, frozenset[str]] = {
-    "acquire": normalize_keyword_tokens(
+_ACTION_TERM_SURFACES: dict[str, frozenset[str]] = {
+    "acquire": frozenset(
         {
             "acquire",
             "bought",
@@ -137,19 +137,15 @@ _ACTION_TERMS: dict[str, frozenset[str]] = {
             "purchase",
         }
     ),
-    "attend": normalize_keyword_tokens({"attend", "join", "participate", "visit", "went"}),
-    "complete": normalize_keyword_tokens({"complete", "finish"}),
-    "create": normalize_keyword_tokens(
-        {"build", "compose", "create", "draft", "generate", "make", "write"}
-    ),
-    "present": normalize_keyword_tokens({"present", "presentation"}),
-    "profile": normalize_keyword_tokens(
-        {"field", "focus", "profession", "research", "role", "specialty"}
-    ),
+    "attend": frozenset({"attend", "join", "participate", "visit", "went"}),
+    "complete": frozenset({"complete", "finish"}),
+    "create": frozenset({"build", "compose", "create", "draft", "generate", "make", "write"}),
+    "present": frozenset({"present", "presentation"}),
+    "profile": frozenset({"field", "focus", "profession", "research", "role", "specialty"}),
     # "service" is out: stemming collapses the noun into the verb, so every
     # mention of a service would read as a repair.
-    "repair": normalize_keyword_tokens({"fix", "repair", "replace"}),
-    "use": normalize_keyword_tokens(
+    "repair": frozenset({"fix", "repair", "replace"}),
+    "use": frozenset(
         {
             "choose",
             "follow",
@@ -162,12 +158,12 @@ _ACTION_TERMS: dict[str, frozenset[str]] = {
             "watch",
         }
     ),
-    "volunteer": normalize_keyword_tokens({"volunteer"}),
+    "volunteer": frozenset({"volunteer"}),
 }
 
-_QUERY_ACTION_TERMS: dict[str, frozenset[str]] = {
-    **_ACTION_TERMS,
-    "recommend": normalize_keyword_tokens(
+_QUERY_ACTION_TERM_SURFACES: dict[str, frozenset[str]] = {
+    **_ACTION_TERM_SURFACES,
+    "recommend": frozenset(
         {
             "recommend",
             "suggest",
@@ -177,9 +173,9 @@ _QUERY_ACTION_TERMS: dict[str, frozenset[str]] = {
 
 _RELATIVE_TERM = normalize_keyword_token("relative")
 
-_RELATION_TERMS: dict[str, frozenset[str]] = {
-    "friend": normalize_keyword_tokens({"colleague", "coworker", "friend", "partner", "roommate"}),
-    "relative": normalize_keyword_tokens(
+_RELATION_TERM_SURFACES: dict[str, frozenset[str]] = {
+    "friend": frozenset({"colleague", "coworker", "friend", "partner", "roommate"}),
+    "relative": frozenset(
         {
             "aunt",
             "brother",
@@ -201,6 +197,26 @@ _RELATION_TERMS: dict[str, frozenset[str]] = {
         }
     ),
 }
+
+
+_ACTION_TERMS: dict[str, frozenset[str]] = {
+    label: normalize_keyword_tokens(terms) for label, terms in _ACTION_TERM_SURFACES.items()
+}
+_QUERY_ACTION_TERMS: dict[str, frozenset[str]] = {
+    label: normalize_keyword_tokens(terms) for label, terms in _QUERY_ACTION_TERM_SURFACES.items()
+}
+_RELATION_TERMS: dict[str, frozenset[str]] = {
+    label: normalize_keyword_tokens(terms) for label, terms in _RELATION_TERM_SURFACES.items()
+}
+# A word this file actually lists is a vocabulary word, whatever it ends in, so
+# the derivational guard must never strip it: "family" is the relative group's
+# own entry and only looks like an adverb.
+_SENSE_VOCABULARY: frozenset[str] = frozenset(
+    term
+    for source in (_QUERY_ACTION_TERM_SURFACES, _RELATION_TERM_SURFACES)
+    for terms in source.values()
+    for term in terms
+)
 
 
 @dataclass(frozen=True)
@@ -366,7 +382,7 @@ def _salient_terms(text: str, *, senses_only: bool = False) -> list[str]:
     for raw_token in _TOKEN_PATTERN.findall(text.lower()):
         if raw_token in _STOPWORDS:
             continue
-        if senses_only and is_derivational_form(raw_token):
+        if senses_only and is_derivational_form(raw_token, vocabulary=_SENSE_VOCABULARY):
             continue
         token = normalize_keyword_token(raw_token)
         if token in seen or len(token) < 2:

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/fact_frames.py
@@ -6,7 +6,11 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from sibyl_core.query_anchors import normalize_keyword_token, normalize_keyword_tokens
+from sibyl_core.query_anchors import (
+    is_derivational_form,
+    normalize_keyword_token,
+    normalize_keyword_tokens,
+)
 
 _TOKEN_PATTERN = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9'-]{1,}")
 _SPAN_SPLIT_PATTERN = re.compile(r"(?<=[.!?])\s+|\n+")
@@ -38,6 +42,11 @@ _SERVICE_USE_PATTERN = re.compile(
     r"[A-Z0-9][A-Za-z0-9&'.-]{2,}(?:\s+[A-Z0-9][A-Za-z0-9&'.-]{2,}){0,3}\b"
 )
 
+# Function words are matched as written, never by stem: folding the list
+# would turn each entry into its whole family and swallow content words
+# (differ would take difference, assist would take assistance). Countable
+# nouns therefore carry their plural explicitly. "using" is absent on
+# purpose, since it carries the use action.
 _STOPWORDS = {
     "about",
     "after",
@@ -48,6 +57,7 @@ _STOPWORDS = {
     "any",
     "are",
     "assistant",
+    "assistants",
     "been",
     "before",
     "can",
@@ -70,17 +80,21 @@ _STOPWORDS = {
     "me",
     "mine",
     "month",
+    "months",
     "more",
     "much",
     "my",
     "name",
+    "names",
     "need",
+    "needs",
     "new",
     "on",
     "or",
     "our",
     "out",
     "recent",
+    "recently",
     "some",
     "that",
     "the",
@@ -90,20 +104,19 @@ _STOPWORDS = {
     "to",
     "up",
     "user",
+    "users",
     "was",
     "week",
+    "weeks",
     "what",
     "when",
     "which",
     "who",
     "with",
     "year",
+    "years",
     "you",
 }
-# Matched both ways: as written, so an entry only silences the word it spells,
-# and by stem, so its own plural cannot slip past the entry that lists it.
-# "using" is deliberately absent from both, since it carries the use action.
-_STOPWORD_STEMS = normalize_keyword_tokens(_STOPWORDS)
 
 # Every group is written in surface English and stemmed at import, so a term
 # covers its own inflections. Irregular pasts (bought, got, went) survive
@@ -133,7 +146,9 @@ _ACTION_TERMS: dict[str, frozenset[str]] = {
     "profile": normalize_keyword_tokens(
         {"field", "focus", "profession", "research", "role", "specialty"}
     ),
-    "repair": normalize_keyword_tokens({"fix", "repair", "replace", "service"}),
+    # "service" is out: stemming collapses the noun into the verb, so every
+    # mention of a service would read as a repair.
+    "repair": normalize_keyword_tokens({"fix", "repair", "replace"}),
     "use": normalize_keyword_tokens(
         {
             "choose",
@@ -248,10 +263,11 @@ def _frame_from_span(span: str, *, query: bool) -> FactFrame | None:
     if not terms:
         return None
 
+    sense_terms = frozenset(_salient_terms(span, senses_only=True))
     action_source = _QUERY_ACTION_TERMS if query else _ACTION_TERMS
-    actions = set(_labels_for_terms(terms, action_source))
+    actions = set(_labels_for_terms(sense_terms, action_source))
     categories: set[str] = set()
-    relations = set(_labels_for_terms(terms, _RELATION_TERMS))
+    relations = set(_labels_for_terms(sense_terms, _RELATION_TERMS))
     lowered = span.lower()
 
     if _PREFERENCE_PATTERN.search(span):
@@ -344,14 +360,16 @@ def _labels_for_terms(
             yield label
 
 
-def _salient_terms(text: str) -> list[str]:
+def _salient_terms(text: str, *, senses_only: bool = False) -> list[str]:
     terms: list[str] = []
     seen: set[str] = set()
     for raw_token in _TOKEN_PATTERN.findall(text.lower()):
         if raw_token in _STOPWORDS:
             continue
+        if senses_only and is_derivational_form(raw_token):
+            continue
         token = normalize_keyword_token(raw_token)
-        if token in _STOPWORD_STEMS or token in seen or len(token) < 2:
+        if token in seen or len(token) < 2:
             continue
         seen.add(token)
         terms.append(token)

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py
@@ -21,6 +21,7 @@ from sibyl_core.models.entities import Entity
 from sibyl_core.query_anchors import (
     explicit_query_anchor_score,
     extract_explicit_query_anchors,
+    keyword_tokens_from_text,
 )
 from sibyl_core.retrieval.fusion import rrf_merge_with_metadata
 from sibyl_core.retrieval.query_ranking import (
@@ -84,11 +85,6 @@ def _resolve_group_id(entity_manager: Any, group_id: str | None) -> str:
 
 
 def _extract_keywords(query: str) -> list[str]:
-    """Stems, because the boost probes these as substrings of raw entity text.
-
-    A stem is a prefix of the forms it covers, so it reaches "restaurant" and
-    "restaurants" where the surface plural reaches neither.
-    """
     return extract_keyword_stems(query)
 
 
@@ -140,8 +136,12 @@ def _apply_keyword_boost(
     boosted_results: list[tuple[Any, float]] = []
     applied = False
     for entity, score in results:
-        entity_text = _entity_text(entity)
-        hit_count = sum(1 for keyword in keywords if keyword in entity_text)
+        # Stems are compared as whole tokens, never as substrings of the raw
+        # text: Snowball rewrites a terminal y to i, so "batteri" appears in
+        # neither "battery" nor any prefix of it, and a substring probe would
+        # silently lose every noun in that class.
+        entity_tokens = set(keyword_tokens_from_text(_entity_text(entity)))
+        hit_count = sum(1 for keyword in keywords if keyword in entity_tokens)
         if hit_count:
             applied = True
             score *= 1.0 + min(0.75, 0.3 * (hit_count / len(keywords)))

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/hybrid.py
@@ -24,7 +24,7 @@ from sibyl_core.query_anchors import (
 )
 from sibyl_core.retrieval.fusion import rrf_merge_with_metadata
 from sibyl_core.retrieval.query_ranking import (
-    extract_keywords,
+    extract_keyword_stems,
     extract_primary_text_from_text,
     generic_assistant_marker_count,
     rank_items_by_query_coverage,
@@ -84,7 +84,12 @@ def _resolve_group_id(entity_manager: Any, group_id: str | None) -> str:
 
 
 def _extract_keywords(query: str) -> list[str]:
-    return extract_keywords(query)
+    """Stems, because the boost probes these as substrings of raw entity text.
+
+    A stem is a prefix of the forms it covers, so it reaches "restaurant" and
+    "restaurants" where the surface plural reaches neither.
+    """
+    return extract_keyword_stems(query)
 
 
 def _entity_text(entity: Any) -> str:

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/operational_sources.py
@@ -12,7 +12,7 @@ from sibyl_core.auth.memory_policy import (
 )
 from sibyl_core.models.entities import Entity, EntityType
 from sibyl_core.projection import MANIFEST_STATE_COMPLETE, operational_experience_manifest_id
-from sibyl_core.retrieval.query_ranking import extract_keywords
+from sibyl_core.retrieval.query_ranking import extract_keyword_stems
 
 PASSAGE_PROJECTION_KIND = "passage"
 RAW_OBSERVATION_PROJECTION_KIND = "raw_observation"
@@ -302,7 +302,7 @@ def select_operational_source_span(
 
     observation_groups = _unit_groups(inventory.raw_observations)
     entity_terms, group_terms = _source_discriminative_terms(observation_groups)
-    query_terms = frozenset(extract_keywords(query))
+    query_terms = frozenset(extract_keyword_stems(query))
     query_term_weights = _query_term_weights(query_terms, group_terms)
     candidate_windows = _candidate_windows(
         observation_groups,
@@ -500,7 +500,7 @@ def _source_discriminative_terms(
         common_lines = set.intersection(*group_lines)
     entity_terms = {
         entity_id: frozenset(
-            extract_keywords(
+            extract_keyword_stems(
                 "\n".join(line for line in lines if line.casefold() not in common_lines)
             )
         )

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
@@ -18,6 +18,7 @@ from sibyl_core.query_anchors import (
     keyword_tokens_from_text,
     normalize_keyword_token,
     normalize_keyword_tokens,
+    sense_tokens_from_text,
 )
 from sibyl_core.retrieval.fact_frames import (
     FactFrame,
@@ -428,7 +429,7 @@ _ACTION_EVIDENCE_GROUPS = (
     # query about deployment settings would read as an assembly action.
     normalize_keyword_tokens({"assemble", "build", "built", "install"}),
     normalize_keyword_tokens({"donate", "sell", "sold"}),
-    normalize_keyword_tokens({"fix", "repair", "replace", "service"}),
+    normalize_keyword_tokens({"fix", "repair", "replace"}),
     normalize_keyword_tokens({"attend", "join", "participate"}),
     normalize_keyword_tokens({"present"}),
     normalize_keyword_tokens({"volunteer"}),
@@ -746,7 +747,7 @@ def _query_frame_score(
 
 
 def _action_evidence_score(query: str, evidence_tokens: set[str]) -> float:
-    query_tokens = set(keyword_tokens_from_text(query))
+    query_tokens = set(sense_tokens_from_text(query))
     query_action_groups = [group for group in _ACTION_EVIDENCE_GROUPS if query_tokens & group]
     if not query_action_groups:
         return 0.0

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
@@ -424,7 +424,9 @@ _ACTION_EVIDENCE_GROUPS = (
             "purchase",
         }
     ),
-    normalize_keyword_tokens({"assemble", "build", "built", "install", "set"}),
+    # "set" is out: it stems together with the settings/sets noun family, so a
+    # query about deployment settings would read as an assembly action.
+    normalize_keyword_tokens({"assemble", "build", "built", "install"}),
     normalize_keyword_tokens({"donate", "sell", "sold"}),
     normalize_keyword_tokens({"fix", "repair", "replace", "service"}),
     normalize_keyword_tokens({"attend", "join", "participate"}),

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
@@ -143,6 +143,7 @@ _KEYWORD_STOPWORDS = {
 # compared reaches comparison, referring reaches reference. The stemmed view
 # exists only for callers that have already lost the surface form.
 _KEYWORD_STOPWORD_STEMS = normalize_keyword_tokens(_KEYWORD_STOPWORDS)
+_TRANSCRIPT_SPEAKER_TERMS = normalize_keyword_tokens({"assistant", "user"})
 _RANK_WEIGHT = 0.95
 _PRIOR_WEIGHT = 0.04
 _OVERLAP_WEIGHT = 0.30
@@ -1268,7 +1269,7 @@ def _cluster_affinity_tokens(tokens: set[str]) -> set[str]:
         and token not in _KEYWORD_STOPWORD_STEMS
         and token not in _PREFERENCE_QUERY_SCAFFOLDING_TERMS
         and token not in _CLUSTER_AFFINITY_STOPWORDS
-        and token not in {"assistant", "user"}
+        and token not in _TRANSCRIPT_SPEAKER_TERMS
     }
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
@@ -17,6 +17,7 @@ from sibyl_core.query_anchors import (
     extract_explicit_query_anchors,
     keyword_tokens_from_text,
     normalize_keyword_token,
+    normalize_keyword_tokens,
 )
 from sibyl_core.retrieval.fact_frames import (
     FactFrame,
@@ -136,6 +137,12 @@ _KEYWORD_STOPWORDS = {
     "you",
     "your",
 }
+# Query scaffolding is matched as written, before stemming. Folding the list
+# first would turn each entry into its whole morphological family, and several
+# of those families hold real content words: provided reaches provider,
+# compared reaches comparison, referring reaches reference. The stemmed view
+# exists only for callers that have already lost the surface form.
+_KEYWORD_STOPWORD_STEMS = normalize_keyword_tokens(_KEYWORD_STOPWORDS)
 _RANK_WEIGHT = 0.95
 _PRIOR_WEIGHT = 0.04
 _OVERLAP_WEIGHT = 0.30
@@ -184,51 +191,53 @@ _CLUSTER_AFFINITY_MAX_ORIGINAL_RANK = 40
 _CLUSTER_ANCHOR_MIN_SIGNAL = 0.5
 _CLUSTER_SIGNAL_WEIGHT = 2.1
 _SIGNAL_DOMINANCE_INSERT_MARGIN = 0.20
-_CLUSTER_AFFINITY_STOPWORDS = {
-    "actually",
-    "all",
-    "around",
-    "back",
-    "bit",
-    "but",
-    "could",
-    "definitely",
-    "give",
-    "great",
-    "had",
-    "help",
-    "just",
-    "know",
-    "make",
-    "maybe",
-    "not",
-    "now",
-    "out",
-    "really",
-    "same",
-    "seem",
-    "since",
-    "still",
-    "sure",
-    "tell",
-    "thank",
-    "thanks",
-    "their",
-    "them",
-    "there",
-    "these",
-    "thing",
-    "things",
-    "though",
-    "thought",
-    "time",
-    "today",
-    "try",
-    "trying",
-    "want",
-    "way",
-    "well",
-}
+_CLUSTER_AFFINITY_STOPWORDS = normalize_keyword_tokens(
+    {
+        "actually",
+        "all",
+        "around",
+        "back",
+        "bit",
+        "but",
+        "could",
+        "definitely",
+        "give",
+        "great",
+        "had",
+        "help",
+        "just",
+        "know",
+        "make",
+        "maybe",
+        "not",
+        "now",
+        "out",
+        "really",
+        "same",
+        "seem",
+        "since",
+        "still",
+        "sure",
+        "tell",
+        "thank",
+        "thanks",
+        "their",
+        "them",
+        "there",
+        "these",
+        "thing",
+        "things",
+        "though",
+        "thought",
+        "time",
+        "today",
+        "try",
+        "trying",
+        "want",
+        "way",
+        "well",
+    }
+)
 
 _EVIDENCE_SET_QUERY_PATTERN = re.compile(
     r"\b(how many|how much|total number|number of|count of|order of|sequence of)\b",
@@ -244,47 +253,49 @@ _RECOMMENDATION_QUERY_PATTERN = re.compile(
     r"\b(recommend|suggest|advice|tips?|ideas?|choose|should i)\b",
     re.IGNORECASE,
 )
-_PREFERENCE_QUERY_TERMS = {
-    "advice",
-    "advic",
-    "choose",
-    "idea",
-    "inspiration",
-    "recommend",
-    "recommendation",
-    "suggest",
-    "suggestion",
-    "tip",
-}
-_PREFERENCE_QUERY_SCAFFOLDING_TERMS = {
-    "advice",
-    "advic",
-    "choose",
-    "excited",
-    "extra",
-    "feel",
-    "feeling",
-    "find",
-    "getting",
-    "good",
-    "got",
-    "having",
-    "idea",
-    "interesting",
-    "look",
-    "looking",
-    "lately",
-    "might",
-    "new",
-    "recommend",
-    "recommendation",
-    "something",
-    "suggest",
-    "suggestion",
-    "think",
-    "tip",
-    "trouble",
-}
+_PREFERENCE_QUERY_TERMS = normalize_keyword_tokens(
+    {
+        "advice",
+        "choose",
+        "idea",
+        "inspiration",
+        "recommend",
+        "recommendation",
+        "suggest",
+        "suggestion",
+        "tip",
+    }
+)
+_PREFERENCE_QUERY_SCAFFOLDING_TERMS = normalize_keyword_tokens(
+    {
+        "advice",
+        "choose",
+        "excited",
+        "extra",
+        "feel",
+        "feeling",
+        "find",
+        "getting",
+        "good",
+        "got",
+        "having",
+        "idea",
+        "interesting",
+        "look",
+        "looking",
+        "lately",
+        "might",
+        "new",
+        "recommend",
+        "recommendation",
+        "something",
+        "suggest",
+        "suggestion",
+        "think",
+        "tip",
+        "trouble",
+    }
+)
 _GENERIC_ASSISTANT_PATTERNS = (
     re.compile(r"\bas an ai\b"),
     re.compile(r"\bi (?:can|cannot|can't) (?:help|assist)\b"),
@@ -340,34 +351,38 @@ _GENERATED_ARTIFACT_OUTPUT_PATTERN = re.compile(
     r"instructions?|steps?|def |class |```)\b",
     re.IGNORECASE,
 )
-_ARTIFACT_TYPE_TERMS = {
-    "code",
-    "email",
-    "letter",
-    "outline",
-    "plan",
-    "poem",
-    "recipe",
-    "script",
-    "song",
-    "story",
-}
-_ARTIFACT_SECTION_TERMS = {
-    "bridge",
-    "chorus",
-    "chord",
-    "class",
-    "draft",
-    "function",
-    "ingredient",
-    "instruction",
-    "intro",
-    "outro",
-    "progression",
-    "section",
-    "step",
-    "verse",
-}
+_ARTIFACT_TYPE_TERMS = normalize_keyword_tokens(
+    {
+        "code",
+        "email",
+        "letter",
+        "outline",
+        "plan",
+        "poem",
+        "recipe",
+        "script",
+        "song",
+        "story",
+    }
+)
+_ARTIFACT_SECTION_TERMS = normalize_keyword_tokens(
+    {
+        "bridge",
+        "chorus",
+        "chord",
+        "class",
+        "draft",
+        "function",
+        "ingredient",
+        "instruction",
+        "intro",
+        "outro",
+        "progression",
+        "section",
+        "step",
+        "verse",
+    }
+)
 _MEMORY_EVIDENCE_PATTERNS = (
     re.compile(r"\bby the way\b"),
     re.compile(r"\bi(?:'m| am) \d{1,3}\b"),
@@ -393,30 +408,29 @@ _MEMORY_EVIDENCE_PATTERNS = (
     ),
     re.compile(r"\bmy (?:current|new|old|previous|favorite|preferred|usual|go-to)\b"),
 )
+# Each group is one action in base form; stemming at import covers the regular
+# inflections, so only irregular pasts (bought, got, built, sold, set) and
+# genuinely distinct derivations (subscription) need their own entry.
 _ACTION_EVIDENCE_GROUPS = (
-    frozenset(
+    normalize_keyword_tokens(
         {
             "acquire",
-            "acquired",
             "bought",
             "buy",
             "got",
             "invest",
-            "invested",
             "order",
-            "ordered",
             "purchase",
-            "purchased",
         }
     ),
-    frozenset({"assemble", "build", "built", "install", "installed", "set"}),
-    frozenset({"donate", "donated", "sell", "sold"}),
-    frozenset({"fix", "repair", "repaired", "replace", "replaced", "service", "serviced"}),
-    frozenset({"attend", "join", "joined", "participate", "participated"}),
-    frozenset({"present"}),
-    frozenset({"volunteer"}),
-    frozenset({"register", "registered", "subscribe", "subscription"}),
-    frozenset({"rely", "use", "used", "using"}),
+    normalize_keyword_tokens({"assemble", "build", "built", "install", "set"}),
+    normalize_keyword_tokens({"donate", "sell", "sold"}),
+    normalize_keyword_tokens({"fix", "repair", "replace", "service"}),
+    normalize_keyword_tokens({"attend", "join", "participate"}),
+    normalize_keyword_tokens({"present"}),
+    normalize_keyword_tokens({"volunteer"}),
+    normalize_keyword_tokens({"register", "subscribe", "subscription"}),
+    normalize_keyword_tokens({"rely", "use"}),
 )
 
 
@@ -463,7 +477,7 @@ def _build_query_coverage_context(
     *,
     temporal_target: datetime | None,
 ) -> _QueryCoverageQueryContext:
-    keywords = extract_keywords(query)
+    keywords = extract_keyword_stems(query)
     is_preference_query = _is_preference_query(query, set(keywords))
     if is_preference_query:
         focused_keywords = [
@@ -606,17 +620,33 @@ def rank_items_by_query_coverage[T](
     return [(ranked.item, ranked.score) for ranked in ranking.ranked], ranking.changed, False
 
 
-def extract_keywords(query: str) -> list[str]:
-    tokens = re.findall(r"[a-zA-Z0-9][a-zA-Z0-9'-]{2,}", query.lower())
-    keywords: list[str] = []
+def _keyword_stream(query: str) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
     seen: set[str] = set()
-    for token in tokens:
-        token = normalize_keyword_token(token)
-        if token in _KEYWORD_STOPWORDS or token in seen:
+    for raw in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9'-]{2,}", query.lower()):
+        if raw in _KEYWORD_STOPWORDS:
             continue
-        keywords.append(token)
-        seen.add(token)
-    return keywords
+        stem = normalize_keyword_token(raw)
+        if stem in seen:
+            continue
+        seen.add(stem)
+        pairs.append((raw.strip("'\""), stem))
+    return pairs
+
+
+def extract_keywords(query: str) -> list[str]:
+    """Content words as the query spells them.
+
+    Callers that hand these back to a search engine, probe them against raw
+    text, or show them to a reader need the surface form; folding belongs on
+    the comparison side, where extract_keyword_stems supplies it.
+    """
+    return [surface for surface, _stem in _keyword_stream(query)]
+
+
+def extract_keyword_stems(query: str) -> list[str]:
+    """Content words folded onto the same stems the fulltext indexes store."""
+    return [stem for _surface, stem in _keyword_stream(query)]
 
 
 def extract_primary_text_from_text(text: str) -> tuple[str, bool]:
@@ -1235,7 +1265,7 @@ def _cluster_affinity_tokens(tokens: set[str]) -> set[str]:
         token
         for token in tokens
         if len(token) > 2
-        and token not in _KEYWORD_STOPWORDS
+        and token not in _KEYWORD_STOPWORD_STEMS
         and token not in _PREFERENCE_QUERY_SCAFFOLDING_TERMS
         and token not in _CLUSTER_AFFINITY_STOPWORDS
         and token not in {"assistant", "user"}

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
@@ -367,6 +367,9 @@ _ARTIFACT_TYPE_TERMS = normalize_keyword_tokens(
         "story",
     }
 )
+# "progression" is absent: it stems to "progress", which would make any memory
+# reporting progress on something read as a song section. "chord" already
+# carries the musical sense the entry was there for.
 _ARTIFACT_SECTION_TERMS = normalize_keyword_tokens(
     {
         "bridge",
@@ -379,7 +382,6 @@ _ARTIFACT_SECTION_TERMS = normalize_keyword_tokens(
         "instruction",
         "intro",
         "outro",
-        "progression",
         "section",
         "step",
         "verse",
@@ -413,8 +415,8 @@ _MEMORY_EVIDENCE_PATTERNS = (
 # Each group is one action in base form; stemming at import covers the regular
 # inflections, so only irregular pasts (bought, got, built, sold, set) and
 # genuinely distinct derivations (subscription) need their own entry.
-_ACTION_EVIDENCE_GROUPS = (
-    normalize_keyword_tokens(
+_ACTION_EVIDENCE_GROUP_SURFACES = (
+    frozenset(
         {
             "acquire",
             "bought",
@@ -427,14 +429,22 @@ _ACTION_EVIDENCE_GROUPS = (
     ),
     # "set" is out: it stems together with the settings/sets noun family, so a
     # query about deployment settings would read as an assembly action.
-    normalize_keyword_tokens({"assemble", "build", "built", "install"}),
-    normalize_keyword_tokens({"donate", "sell", "sold"}),
-    normalize_keyword_tokens({"fix", "repair", "replace"}),
-    normalize_keyword_tokens({"attend", "join", "participate"}),
-    normalize_keyword_tokens({"present"}),
-    normalize_keyword_tokens({"volunteer"}),
-    normalize_keyword_tokens({"register", "subscribe", "subscription"}),
-    normalize_keyword_tokens({"rely", "use"}),
+    frozenset({"assemble", "build", "built", "install"}),
+    frozenset({"donate", "sell", "sold"}),
+    frozenset({"fix", "repair", "replace"}),
+    frozenset({"attend", "join", "participate"}),
+    frozenset({"present"}),
+    frozenset({"volunteer"}),
+    frozenset({"register", "subscribe", "subscription"}),
+    frozenset({"rely", "use"}),
+)
+
+_ACTION_EVIDENCE_GROUPS = tuple(
+    normalize_keyword_tokens(group) for group in _ACTION_EVIDENCE_GROUP_SURFACES
+)
+# Words this module lists are vocabulary, not derivations, whatever they end in.
+_SENSE_VOCABULARY: frozenset[str] = frozenset(
+    term for group in _ACTION_EVIDENCE_GROUP_SURFACES for term in group
 )
 
 
@@ -700,6 +710,7 @@ def _query_frame_score(
     memory_token_set: set[str],
     primary_text: str,
     memory_text: str,
+    evidence_sense_tokens: set[str],
 ) -> float:
     evidence_tokens = token_set | primary_token_set | memory_token_set
     evidence_text = " ".join(part for part in (memory_text, primary_text) if part)
@@ -730,7 +741,7 @@ def _query_frame_score(
     ) and _RECURRING_FREQUENCY_EVIDENCE_PATTERN.search(evidence_text):
         score = max(score, 0.82)
 
-    action_score = _action_evidence_score(query, evidence_tokens)
+    action_score = _action_evidence_score(query, evidence_sense_tokens)
     if action_score > 0.0:
         score = max(score, action_score)
 
@@ -747,7 +758,7 @@ def _query_frame_score(
 
 
 def _action_evidence_score(query: str, evidence_tokens: set[str]) -> float:
-    query_tokens = set(sense_tokens_from_text(query))
+    query_tokens = set(sense_tokens_from_text(query, vocabulary=_SENSE_VOCABULARY))
     query_action_groups = [group for group in _ACTION_EVIDENCE_GROUPS if query_tokens & group]
     if not query_action_groups:
         return 0.0
@@ -833,9 +844,15 @@ def rank_by_query_coverage[T](
             bool,
         ]
     ] = []
+    sense_tokens_by_id: dict[str, set[str]] = {}
     for candidate in candidates:
         text = candidate.text
         tokens = keyword_tokens_from_text(text)
+        # Primary and memory text are both cut from this text, so one pass over
+        # it covers every evidence token a sense group is allowed to see.
+        sense_tokens_by_id[candidate.stable_id] = set(
+            sense_tokens_from_text(text, vocabulary=_SENSE_VOCABULARY)
+        )
         primary_text_raw, has_primary_text = _extract_query_focus_text(query, text)
         primary_text = primary_text_raw.lower()
         primary_tokens = keyword_tokens_from_text(primary_text) if has_primary_text else []
@@ -959,6 +976,7 @@ def rank_by_query_coverage[T](
             memory_token_set=memory_token_set,
             primary_text=primary_text,
             memory_text=memory_text,
+            evidence_sense_tokens=sense_tokens_by_id[candidate.stable_id],
         )
         fact_frame_score = score_fact_frame_match_for_query(
             query_fact_frames,

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/query_ranking.py
@@ -15,6 +15,7 @@ from sibyl_core.query_anchors import (
 )
 from sibyl_core.query_anchors import (
     extract_explicit_query_anchors,
+    keyword_and_sense_tokens_from_text,
     keyword_tokens_from_text,
     normalize_keyword_token,
     normalize_keyword_tokens,
@@ -847,12 +848,13 @@ def rank_by_query_coverage[T](
     sense_tokens_by_id: dict[str, set[str]] = {}
     for candidate in candidates:
         text = candidate.text
-        tokens = keyword_tokens_from_text(text)
         # Primary and memory text are both cut from this text, so one pass over
         # it covers every evidence token a sense group is allowed to see.
-        sense_tokens_by_id[candidate.stable_id] = set(
-            sense_tokens_from_text(text, vocabulary=_SENSE_VOCABULARY)
+        tokens, sense_tokens = keyword_and_sense_tokens_from_text(
+            text,
+            vocabulary=_SENSE_VOCABULARY,
         )
+        sense_tokens_by_id[candidate.stable_id] = set(sense_tokens)
         primary_text_raw, has_primary_text = _extract_query_focus_text(query, text)
         primary_text = primary_text_raw.lower()
         primary_tokens = keyword_tokens_from_text(primary_text) if has_primary_text else []

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/refinement.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/refinement.py
@@ -7,8 +7,8 @@ from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 
-from sibyl_core.query_anchors import extract_explicit_anchor_phrases
-from sibyl_core.retrieval.query_ranking import extract_keywords
+from sibyl_core.query_anchors import extract_explicit_anchor_phrases, normalize_keyword_token
+from sibyl_core.retrieval.query_ranking import extract_keyword_stems, extract_keywords
 
 MAX_FEEDBACK_DOCUMENTS = 8
 MAX_REFINEMENT_QUERIES = 3
@@ -150,7 +150,9 @@ def plan_deterministic_refinement_queries(
         return []
 
     question_terms = extract_keywords(question)
-    question_term_set = set(question_terms)
+    # Exclusion is a membership test, so it folds: a feedback term the question
+    # already asks about in another inflection is not a new term.
+    question_term_set = set(extract_keyword_stems(question))
     seen = {query.casefold() for query in seen_queries}
     seen.add(question.casefold())
     planned: list[DeterministicRefinementQuery] = []
@@ -367,7 +369,7 @@ def _rank_feedback_terms(
             dict.fromkeys(
                 term
                 for term in extract_keywords(_feedback_text(document))
-                if term not in excluded_terms
+                if normalize_keyword_token(term) not in excluded_terms
                 and term not in _FEEDBACK_STOPWORDS
                 and _is_feedback_term(term)
             )

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/refinement.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/refinement.py
@@ -25,6 +25,9 @@ _FEEDBACK_STOPWORDS = {
     "transcript",
     "user",
 }
+# Harness noise is written singular and tested by stem, so the plural of an
+# entry cannot walk past the entry that lists it.
+_FEEDBACK_STOPWORD_STEMS = frozenset(normalize_keyword_token(term) for term in _FEEDBACK_STOPWORDS)
 _STRUCTURAL_COUNTER_PATTERN = re.compile(
     r"^[A-Za-z][\w ]* \d+(?: part \d+/\d+)?$",
     re.I,
@@ -370,7 +373,7 @@ def _rank_feedback_terms(
                 term
                 for term in extract_keywords(_feedback_text(document))
                 if normalize_keyword_token(term) not in excluded_terms
-                and term not in _FEEDBACK_STOPWORDS
+                and normalize_keyword_token(term) not in _FEEDBACK_STOPWORD_STEMS
                 and _is_feedback_term(term)
             )
         )

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/refinement.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/refinement.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 
-from sibyl_core.query_anchors import extract_explicit_query_anchors
+from sibyl_core.query_anchors import extract_explicit_anchor_phrases
 from sibyl_core.retrieval.query_ranking import extract_keywords
 
 MAX_FEEDBACK_DOCUMENTS = 8
@@ -155,7 +155,7 @@ def plan_deterministic_refinement_queries(
     seen.add(question.casefold())
     planned: list[DeterministicRefinementQuery] = []
 
-    explicit_anchors = extract_explicit_query_anchors(question)
+    explicit_anchors = extract_explicit_anchor_phrases(question)
     for candidate in _structural_refinement_queries(
         question,
         explicit_anchors=explicit_anchors,

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph.py
@@ -54,7 +54,7 @@ from sibyl_core.models.tasks import (
 from sibyl_core.query_anchors import (
     explicit_query_anchor_proximity_score,
     explicit_query_anchor_score,
-    extract_explicit_query_anchors,
+    extract_explicit_anchor_phrases,
 )
 from sibyl_core.services import graph_client as _graph_client
 from sibyl_core.services.graph_search import (
@@ -163,10 +163,10 @@ _ENTITY_SEARCH_FIELDS = ",\n                       ".join(
 
 
 def _build_explicit_anchor_search_query(query: str) -> str:
-    anchors = extract_explicit_query_anchors(query)
-    if len(anchors) < 2:
+    phrases = extract_explicit_anchor_phrases(query)
+    if len(phrases) < 2:
         return ""
-    return build_fulltext_query(" ".join(token for anchor in anchors for token in anchor))
+    return build_fulltext_query(" ".join(token for phrase in phrases for token in phrase))
 
 
 def _entity_explicit_anchor_score(query: str, entity: Entity) -> float:

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -454,7 +454,7 @@ class _ExplicitAnchorSearchClient:
     async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
         self.calls.append((query, params))
         search_query = params.get("search_query")
-        if search_query == "report related link":
+        if search_query == "report related links":
             return [
                 self._row(
                     "partial-anchor",
@@ -1298,7 +1298,7 @@ async def test_native_entity_manager_rescues_full_explicit_anchor_candidate() ->
         for statement, params in client.calls
         if params.get("_query_label") == "entity.search.fulltext_explicit_anchors"
     )
-    assert anchor_call["search_query"] == "report related link"
+    assert anchor_call["search_query"] == "report related links"
     assert "AND content @AND@ $search_query" in anchor_query
 
 

--- a/packages/python/sibyl-core/tests/test_lexical_stemming.py
+++ b/packages/python/sibyl-core/tests/test_lexical_stemming.py
@@ -52,6 +52,9 @@ def test_every_fulltext_index_is_backed_by_a_stemming_analyzer() -> None:
     referenced = set(re.findall(r"FULLTEXT ANALYZER (\w+)", _INDEX_SOURCES))
 
     assert referenced, "no fulltext indexes found; the source constants moved"
+    # Pinned rather than subtracted: adding an analyzer to the exemption set is
+    # how a non-stemming index would otherwise slip past this check.
+    assert referenced & _UNSTEMMED_ANALYZERS == {"code_analyzer"}
     for analyzer in sorted(referenced - _UNSTEMMED_ANALYZERS):
         assert "snowball(english)" in chains[analyzer], (
             f"{analyzer} backs a BM25 index but does not stem, so query-side and "
@@ -86,6 +89,13 @@ async def test_python_normalization_matches_the_engine_analyzer() -> None:
         "RETURN search::analyze('content_analyzer', $text);", {"text": "fastest strongest"}
     )
     assert graded == ["fastest", "strongest"]
+
+    # Accent folding matches the analyzer's ascii filter. The token patterns
+    # feeding this function are ASCII-only, so only a direct caller reaches it.
+    accented = await db.query(
+        "RETURN search::analyze('content_analyzer', $text);", {"text": "café naïve Zürich"}
+    )
+    assert accented == [normalize_keyword_token(word) for word in ("café", "naïve", "Zürich")]
     assert [normalize_keyword_token(word) for word in ("fastest", "strongest")] == [
         "fast",
         "strong",

--- a/packages/python/sibyl-core/tests/test_lexical_stemming.py
+++ b/packages/python/sibyl-core/tests/test_lexical_stemming.py
@@ -20,7 +20,15 @@ from sibyl_core.backends.surreal.content_schema import (
     CONTENT_SCHEMA_DEFINITIONS,
 )
 from sibyl_core.backends.surreal.schema import ANALYZER_DEFINITIONS, NODE_DEFINITIONS
-from sibyl_core.query_anchors import _GRADED_ADJECTIVE_ALIASES, normalize_keyword_token
+from sibyl_core.query_anchors import (
+    _GRADED_ADJECTIVE_ALIASES,
+    is_derivational_form,
+    normalize_keyword_token,
+)
+from sibyl_core.retrieval.fact_frames import (
+    _SENSE_VOCABULARY,
+    extract_evidence_fact_frames,
+)
 
 _ANALYZER_SOURCES = f"{ANALYZER_DEFINITIONS}\n{CONTENT_ANALYZER_DEFINITIONS}"
 _INDEX_SOURCES = f"{NODE_DEFINITIONS}\n{CONTENT_SCHEMA_DEFINITIONS}"
@@ -168,3 +176,32 @@ async def test_graded_adjectives_are_the_gap_the_stemmer_leaves() -> None:
         assert await stem(inflected) == await stem(base) == normalize_keyword_token(inflected)
 
     await db.close()
+
+
+def test_a_listed_vocabulary_word_is_never_treated_as_a_derivation() -> None:
+    """Membership decides before the suffix rule does.
+
+    Snowball folds derivations onto their verb, so sense groups must ignore
+    "useful" and "playful". English nouns end the same way, though, and
+    "family" is the relative group's own entry, so a bare suffix rule silently
+    stopped a memory about family from reading as one.
+    """
+    assert is_derivational_form("useful") is True
+    assert is_derivational_form("playful") is True
+    assert is_derivational_form("completely") is True
+
+    for word in ("family", "supply", "assembly"):
+        assert is_derivational_form(word, vocabulary={word}) is False
+    assert is_derivational_form("family", vocabulary=_SENSE_VOCABULARY) is False
+    # "friendly" is not listed anywhere, so it stays out of the friend relation.
+    assert is_derivational_form("friendly", vocabulary=_SENSE_VOCABULARY) is True
+
+
+def test_family_still_reads_as_a_relative() -> None:
+    for text in ("I visited my family", "I visited my families"):
+        frames = extract_evidence_fact_frames(text)
+        assert frames and "relative" in frames[0].relations, text
+
+    for text in ("that was really useful", "a playful puppy", "the attendant helped"):
+        frames = extract_evidence_fact_frames(text)
+        assert not (frames and frames[0].actions), text

--- a/packages/python/sibyl-core/tests/test_lexical_stemming.py
+++ b/packages/python/sibyl-core/tests/test_lexical_stemming.py
@@ -1,0 +1,155 @@
+"""The index stems, and Python stems the same way.
+
+Morphological normalization belongs to the search engine: every BM25 index is
+analyzed with `snowball(english)`, and the MATCHES operator runs the query
+string through the same chain. These checks pin that arrangement from both
+ends, so neither the analyzer chain nor the Python normalizer can drift away
+from the other without a failure, and hand-written morphology tables cannot
+quietly grow back.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from surrealdb import AsyncSurreal
+
+from sibyl_core.backends.surreal.content_schema import (
+    CONTENT_ANALYZER_DEFINITIONS,
+    CONTENT_SCHEMA_DEFINITIONS,
+)
+from sibyl_core.backends.surreal.schema import ANALYZER_DEFINITIONS, NODE_DEFINITIONS
+from sibyl_core.query_anchors import _GRADED_ADJECTIVE_ALIASES, normalize_keyword_token
+
+_ANALYZER_SOURCES = f"{ANALYZER_DEFINITIONS}\n{CONTENT_ANALYZER_DEFINITIONS}"
+_INDEX_SOURCES = f"{NODE_DEFINITIONS}\n{CONTENT_SCHEMA_DEFINITIONS}"
+
+# Source code is the one analyzer that must not stem: identifiers are not
+# English and folding them collides unrelated symbols.
+_UNSTEMMED_ANALYZERS = {"code_analyzer"}
+
+_PROBE_TEXT = (
+    "meetings attended policies batteries analysis running subscribed "
+    "presentations classes watches boxes prices companies resources studying "
+    "volunteered documentaries recommendations cafe naive developer"
+)
+
+
+def _analyzer_chains() -> dict[str, str]:
+    return {
+        match.group("name"): match.group("chain")
+        for match in re.finditer(
+            r"DEFINE ANALYZER (?:IF NOT EXISTS |OVERWRITE )?(?P<name>\w+)(?P<chain>.*?);",
+            _ANALYZER_SOURCES,
+            re.DOTALL,
+        )
+    }
+
+
+def test_every_fulltext_index_is_backed_by_a_stemming_analyzer() -> None:
+    chains = _analyzer_chains()
+    referenced = set(re.findall(r"FULLTEXT ANALYZER (\w+)", _INDEX_SOURCES))
+
+    assert referenced, "no fulltext indexes found; the source constants moved"
+    for analyzer in sorted(referenced - _UNSTEMMED_ANALYZERS):
+        assert "snowball(english)" in chains[analyzer], (
+            f"{analyzer} backs a BM25 index but does not stem, so query-side and "
+            f"index-side morphology would diverge"
+        )
+
+
+def test_the_code_analyzer_deliberately_does_not_stem() -> None:
+    assert "snowball" not in _analyzer_chains()["code_analyzer"]
+
+
+@pytest.mark.asyncio
+async def test_python_normalization_matches_the_engine_analyzer() -> None:
+    """The ranker folds a token to exactly what the index stored for it."""
+    db = AsyncSurreal("memory://")
+    await db.connect()
+    await db.use("stemming", "graph")
+    for statement in ANALYZER_DEFINITIONS.split(";"):
+        if statement.strip():
+            await db.query(f"{statement};")
+
+    engine = await db.query(
+        "RETURN search::analyze('content_analyzer', $text);", {"text": _PROBE_TEXT}
+    )
+
+    assert engine == [normalize_keyword_token(word) for word in _PROBE_TEXT.split()]
+
+    # The graded adjectives are the sole deliberate divergence: Python folds
+    # them, the index does not, so they are the one place a query term and an
+    # indexed term can differ.
+    graded = await db.query(
+        "RETURN search::analyze('content_analyzer', $text);", {"text": "fastest strongest"}
+    )
+    assert graded == ["fastest", "strongest"]
+    assert [normalize_keyword_token(word) for word in ("fastest", "strongest")] == [
+        "fast",
+        "strong",
+    ]
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_a_query_finds_the_document_that_spells_the_word_differently() -> None:
+    """End to end: index-side and query-side inflections meet in the middle."""
+    db = AsyncSurreal("memory://")
+    await db.connect()
+    await db.use("stemming", "graph")
+    await db.query(
+        "DEFINE ANALYZER content_analyzer TOKENIZERS blank, class "
+        "FILTERS lowercase, ascii, snowball(english);"
+    )
+    await db.query("DEFINE TABLE note SCHEMALESS;")
+    await db.query("DEFINE FIELD body ON note TYPE string;")
+    await db.query(
+        "DEFINE INDEX idx_note_body ON note FIELDS body SEARCH ANALYZER content_analyzer BM25;"
+    )
+    await db.query(
+        "CREATE note:standup SET body = 'I attended three standup meetings about pricing';"
+    )
+
+    for term in ("meeting", "meetings", "attend", "attended", "attending", "price"):
+        found = await db.query("SELECT id FROM note WHERE body @@ $term;", {"term": term})
+        assert found, f"{term!r} should reach the indexed document"
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_graded_adjectives_are_the_gap_the_stemmer_leaves() -> None:
+    """Why the one surviving table survives: Snowball unifies none of it.
+
+    Comparatives and superlatives are the documented exception, so this is the
+    receipt for keeping _GRADED_ADJECTIVE_ALIASES rather than a habit. If a
+    future Snowball starts folding them, this fails and the table can go.
+    """
+    db = AsyncSurreal("memory://")
+    await db.connect()
+    await db.use("stemming", "graph")
+    await db.query(
+        "DEFINE ANALYZER content_analyzer TOKENIZERS blank, class "
+        "FILTERS lowercase, ascii, snowball(english);"
+    )
+
+    async def stem(word: str) -> str:
+        analyzed = await db.query(
+            "RETURN search::analyze('content_analyzer', $text);", {"text": word}
+        )
+        return str(analyzed[0])
+
+    unified = [
+        inflected
+        for inflected, base in _GRADED_ADJECTIVE_ALIASES.items()
+        if await stem(inflected) == await stem(base)
+    ]
+
+    assert unified == []
+    # Regular inflection, by contrast, needs no table at all.
+    for inflected, base in (("attended", "attend"), ("classes", "class"), ("policies", "policy")):
+        assert await stem(inflected) == await stem(base) == normalize_keyword_token(inflected)
+
+    await db.close()

--- a/packages/python/sibyl-core/tests/test_lexical_stemming.py
+++ b/packages/python/sibyl-core/tests/test_lexical_stemming.py
@@ -11,6 +11,8 @@ quietly grow back.
 from __future__ import annotations
 
 import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from surrealdb import AsyncSurreal
@@ -23,7 +25,10 @@ from sibyl_core.backends.surreal.schema import ANALYZER_DEFINITIONS, NODE_DEFINI
 from sibyl_core.query_anchors import (
     _GRADED_ADJECTIVE_ALIASES,
     is_derivational_form,
+    keyword_and_sense_tokens_from_text,
+    keyword_tokens_from_text,
     normalize_keyword_token,
+    sense_tokens_from_text,
 )
 from sibyl_core.retrieval.fact_frames import (
     _SENSE_VOCABULARY,
@@ -205,3 +210,94 @@ def test_family_still_reads_as_a_relative() -> None:
     for text in ("that was really useful", "a playful puppy", "the attendant helped"):
         frames = extract_evidence_fact_frames(text)
         assert not (frames and frames[0].actions), text
+
+
+def _distinct_inflected_words(count: int) -> list[str]:
+    """Words no two of which are equal, so every one reaches the stemmer.
+
+    Normalization is memoized, and a cache hit never touches the stemmer, so a
+    word list that repeats itself would test the cache instead of the thing
+    that races.
+    """
+    bases = (
+        "polic",
+        "compan",
+        "univers",
+        "categor",
+        "librar",
+        "factor",
+        "memor",
+        "stor",
+        "quer",
+        "entr",
+    )
+    suffixes = ("ies", "y", "ical", "ising", "ised", "isation", "ially", "iest")
+    words = [
+        f"{base}{suffix}{index}"
+        for index in range(count // (len(bases) * len(suffixes)) + 1)
+        for base in bases
+        for suffix in suffixes
+    ]
+    return words[:count]
+
+
+def test_normalization_survives_concurrent_callers() -> None:
+    """One stemmer per thread, because Snowball keeps the word in the instance.
+
+    Coverage ranking is dispatched through asyncio.to_thread on both retrieval
+    paths, so several threads normalize at once as a matter of course. A
+    Snowball stemmer holds the word under analysis in mutable instance state,
+    and threads sharing one instance read each other's buffer: a shared
+    stemmer returns another word's stem, or indexes off the end of a word that
+    changed under it.
+    """
+    words = _distinct_inflected_words(24_000)
+    reference = {word: normalize_keyword_token(word) for word in words}
+    # The reference pass filled the cache, so clear it: the threaded pass has
+    # to reach the stemmer for the check to mean anything.
+    normalize_keyword_token.cache_clear()
+
+    workers = 16
+    slices = [words[index::workers] for index in range(workers)]
+
+    def normalize_slice(slice_words: list[str]) -> list[tuple[str, str]]:
+        return [(word, normalize_keyword_token(word)) for word in slice_words]
+
+    # Switching more often than the 5ms default lands the interleavings that
+    # corrupt a shared stemmer inside a test-sized run.
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(0.000005)
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            observed = [pair for result in pool.map(normalize_slice, slices) for pair in result]
+    finally:
+        sys.setswitchinterval(previous_interval)
+        normalize_keyword_token.cache_clear()
+
+    assert len(observed) == len(words)
+    wrong = [(word, stem) for word, stem in observed if stem != reference[word]]
+    assert wrong == []
+
+
+def test_one_traversal_yields_both_token_views() -> None:
+    """Ranking reads a candidate once, and reads exactly what two passes read.
+
+    Every candidate needs the ordinary tokens and the sense tokens, and the
+    texts run to fifty thousand characters, so the combined reader exists to
+    stem them once. It earns that only by agreeing with the separate readers
+    token for token.
+    """
+    text = (
+        "user: I volunteered at the shelter and completely rebuilt their "
+        "policies for adoption. assistant: The attendants said the families "
+        "were useful references. user: My family attended the meetings."
+    )
+    tokens, sense_tokens = keyword_and_sense_tokens_from_text(
+        text,
+        vocabulary=_SENSE_VOCABULARY,
+    )
+
+    assert tokens == keyword_tokens_from_text(text)
+    assert sense_tokens == sense_tokens_from_text(text, vocabulary=_SENSE_VOCABULARY)
+    # The two views differ, or the sense filter would not be doing anything.
+    assert len(sense_tokens) < len(tokens)

--- a/packages/python/sibyl-core/tests/test_lexical_stemming.py
+++ b/packages/python/sibyl-core/tests/test_lexical_stemming.py
@@ -90,8 +90,13 @@ async def test_python_normalization_matches_the_engine_analyzer() -> None:
     )
     assert graded == ["fastest", "strongest"]
 
-    # Accent folding matches the analyzer's ascii filter. The token patterns
-    # feeding this function are ASCII-only, so only a direct caller reaches it.
+    # normalize_keyword_token folds accents the way the analyzer's ascii filter
+    # does, checked here at the function boundary only. It is NOT end-to-end
+    # parity: every tokenizer feeding this function matches ASCII characters
+    # only, so an accented word is split before it ever arrives, and no
+    # production path reaches the branch below. Widening those patterns is a
+    # separate change; as it stands the text is under-tokenized rather than
+    # mismatched, which fails safe.
     accented = await db.query(
         "RETURN search::analyze('content_analyzer', $text);", {"text": "café naïve Zürich"}
     )

--- a/packages/python/sibyl-core/tests/test_retrieval_advanced.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_advanced.py
@@ -3012,6 +3012,32 @@ class TestHybridSearch:
         assert result.metadata["keyword_boost_applied"] is True
 
     @pytest.mark.asyncio
+    async def test_hybrid_search_keyword_boost_matches_a_lone_consonant_y_noun(self) -> None:
+        """Snowball rewrites a terminal y to i, so the stem is not a substring.
+
+        "batteri" appears in neither "battery" nor "batterys", which a
+        substring probe would read as no hit at all. This entity shares
+        exactly one content word with the query, so nothing else can carry
+        the boost and the miss cannot hide behind a second match.
+        """
+        client = MockGraphClientForHybrid()
+        manager = MockEntityManagerForHybrid()
+
+        noisy = make_entity_for_test("noisy", description="travel receipt")
+        answer = make_entity_for_test("answer", description="a spare battery")
+        manager.search_results = [(noisy, 0.9), (answer, 0.8)]
+
+        result = await hybrid_search(
+            "batteries",
+            client,  # type: ignore[arg-type]
+            manager,  # type: ignore[arg-type]
+            config=HybridConfig(graph_weight=0, apply_temporal=False),
+        )
+
+        assert result.entities[0].id == "answer"
+        assert result.metadata["keyword_boost_applied"] is True
+
+    @pytest.mark.asyncio
     async def test_hybrid_search_keyword_boost_ignores_bookkeeping_metadata(self) -> None:
         """Keyword boost uses entity text, not system metadata labels."""
         client = MockGraphClientForHybrid()

--- a/packages/python/sibyl-core/tests/test_retrieval_advanced.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_advanced.py
@@ -26,6 +26,7 @@ from sibyl_core.models.entities import Entity, EntityType, Relationship, Relatio
 from sibyl_core.query_anchors import (
     explicit_query_anchor_proximity_score,
     keyword_tokens_from_text,
+    sense_tokens_from_text,
 )
 from sibyl_core.retrieval.candidates import CandidateKind, RetrievalCandidate
 from sibyl_core.retrieval.dedup import (
@@ -1007,6 +1008,9 @@ def test_recurring_frequency_frame_needs_a_cadence_in_the_evidence() -> None:
             memory_token_set=set(),
             primary_text=text,
             memory_text="",
+            evidence_sense_tokens=set(
+                sense_tokens_from_text(text, vocabulary=query_ranking_module._SENSE_VOCABULARY)
+            ),
         )
 
     assert frame_score("i run the offsite backup every two weeks.") == 0.82

--- a/packages/python/sibyl-core/tests/test_retrieval_advanced.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_advanced.py
@@ -54,6 +54,7 @@ from sibyl_core.retrieval.query_ranking import (
     QueryCoverageRankedCandidate,
     QueryCoverageResult,
     extract_explicit_query_anchors,
+    extract_keyword_stems,
     extract_keywords,
     rank_by_query_coverage,
     should_accept_query_coverage_refinement,
@@ -79,17 +80,31 @@ def test_query_coverage_keywords_drop_conversational_scaffolding() -> None:
         "Can you remind me what two-factor authentication methods you mentioned?"
     )
 
-    assert keywords == ["two-factor", "authentication", "method"]
+    assert keywords == ["two-factor", "authentication", "methods"]
     assert "thi" not in keywords
     assert "previou" not in keywords
 
 
 def test_query_coverage_keywords_keep_real_singulars() -> None:
-    keywords = extract_keywords(
-        "I'm checking this previous data privacy exercise used resources from companies."
-    )
+    """Surface keywords keep the words the query used; the stems match the index."""
+    query = "I'm checking this previous data privacy exercise used resources from companies."
 
-    assert keywords == ["data", "privacy", "exercise", "used", "resource", "company"]
+    assert extract_keywords(query) == [
+        "data",
+        "privacy",
+        "exercise",
+        "used",
+        "resources",
+        "companies",
+    ]
+    assert extract_keyword_stems(query) == [
+        "data",
+        "privaci",
+        "exercis",
+        "use",
+        "resourc",
+        "compani",
+    ]
 
 
 def test_query_coverage_keywords_drop_answer_shape_scaffolding() -> None:
@@ -104,7 +119,7 @@ def test_query_coverage_keeps_content_words_a_preference_query_asks_about() -> N
 
     context = query_ranking_module._build_query_coverage_context(query, temporal_target=None)
 
-    assert {"serve", "watch", "weekend"} <= set(context.keywords)
+    assert {"serv", "watch", "weekend"} <= set(context.keywords)
 
 
 def test_query_coverage_cluster_affinity_keeps_content_words() -> None:
@@ -117,24 +132,27 @@ def test_query_coverage_cluster_affinity_keeps_content_words() -> None:
 
 def test_query_coverage_keywords_normalize_comparatives_to_the_base_adjective() -> None:
     """A query about something older matches evidence that says old."""
-    assert extract_keywords("How many years older is my grandma than me?") == ["old", "grandma"]
-    assert extract_keywords("Which server had the largest disk?") == [
+    assert extract_keyword_stems("How many years older is my grandma than me?") == [
+        "old",
+        "grandma",
+    ]
+    assert extract_keyword_stems("Which server had the largest disk?") == [
         "server",
         "had",
-        "large",
+        "larg",
         "disk",
     ]
 
 
 def test_query_coverage_keywords_do_not_fold_noun_homographs_into_adjectives() -> None:
     """A lighter is an object, not a degree of light."""
-    assert extract_keywords("Which lighter did I buy?") == ["lighter", "buy"]
-    assert extract_keywords("Which cleaner did I buy?") == ["cleaner", "buy"]
-    assert extract_keywords("Which warmer did I buy?") == ["warmer", "buy"]
-    assert extract_keywords("Who was the closer in that game?") == ["closer", "game"]
-    assert extract_keywords("How did I lower the timeout?") == ["lower", "timeout"]
+    assert extract_keyword_stems("Which lighter did I buy?") == ["lighter", "buy"]
+    assert extract_keyword_stems("Which cleaner did I buy?") == ["cleaner", "buy"]
+    assert extract_keyword_stems("Which warmer did I buy?") == ["warmer", "buy"]
+    assert extract_keyword_stems("Who was the closer in that game?") == ["closer", "game"]
+    assert extract_keyword_stems("How did I lower the timeout?") == ["lower", "timeout"]
     # Their superlatives carry no such reading and still normalize.
-    assert extract_keywords("Which lightest frame did I pick?") == ["light", "frame", "pick"]
+    assert extract_keyword_stems("Which lightest frame did I pick?") == ["light", "frame", "pick"]
 
 
 def test_query_coverage_ranks_a_lighter_above_a_light() -> None:
@@ -172,7 +190,7 @@ def test_query_coverage_preserves_explicit_anchors_outside_keyword_stopwords() -
         'On a `Report` record, open "Related Links" after clicking "Create Order".'
     )
 
-    assert anchors == (("report",), ("related", "link"), ("create", "order"))
+    assert anchors == (("report",), ("relat", "link"), ("creat", "order"))
 
 
 def test_query_coverage_ignores_apostrophes_when_extracting_explicit_anchors() -> None:
@@ -180,7 +198,7 @@ def test_query_coverage_ignores_apostrophes_when_extracting_explicit_anchors() -
         "Which option doesn't appear on the 'Developer Laptop (Mac)' page?"
     )
 
-    assert anchors == (("developer", "laptop", "mac"),)
+    assert anchors == (("develop", "laptop", "mac"),)
 
 
 def test_explicit_query_anchor_proximity_favors_coherent_span() -> None:
@@ -965,15 +983,13 @@ def test_action_evidence_does_not_equate_presenting_with_volunteering() -> None:
     present_query = "What did I present at the conference?"
     volunteer_query = "Where did I volunteer last month?"
 
-    assert query_ranking_module._action_evidence_score(present_query, {"present", "slide"}) == 1.0
-    assert (
-        query_ranking_module._action_evidence_score(present_query, {"volunteer", "shelter"}) == 0.0
-    )
-    assert (
-        query_ranking_module._action_evidence_score(volunteer_query, {"volunteer", "shelter"})
-        == 1.0
-    )
-    assert query_ranking_module._action_evidence_score(volunteer_query, {"present", "slide"}) == 0.0
+    presenting = set(keyword_tokens_from_text("I presented the slides"))
+    volunteering = set(keyword_tokens_from_text("I volunteered at the shelter"))
+
+    assert query_ranking_module._action_evidence_score(present_query, presenting) == 1.0
+    assert query_ranking_module._action_evidence_score(present_query, volunteering) == 0.0
+    assert query_ranking_module._action_evidence_score(volunteer_query, volunteering) == 1.0
+    assert query_ranking_module._action_evidence_score(volunteer_query, presenting) == 0.0
 
 
 def test_recurring_frequency_frame_needs_a_cadence_in_the_evidence() -> None:
@@ -1114,6 +1130,20 @@ def test_query_coverage_uses_fact_frames_for_media_platform_usage() -> None:
     assert "5" in ranked[:5]
 
 
+@pytest.mark.xfail(
+    reason=(
+        "Stemming unified recommendations/recommendation/recommend, so every "
+        "candidate here now shares that query term and clears "
+        "_PREFERENCE_MIN_OVERLAP. _stabilize_top_window_ranking only swaps a "
+        "candidate into the top window when the window holds something below "
+        "that floor, so a floor nobody falls under disables the rescue and the "
+        "documentary memory stays outside it. The scaffolding list already "
+        "classifies recommend as noise, but the >=3 focused-keyword gate keeps "
+        "it in a query with two content words. Both are ranking-heuristic "
+        "decisions that need a retrieval screen, not lexicon work."
+    ),
+    strict=True,
+)
 def test_query_coverage_blends_fact_frames_into_recommendation_ranking() -> None:
     ranked = _rank_query_ids(
         "I've got some free time tonight, any documentary recommendations?",

--- a/packages/python/sibyl-core/tests/test_retrieval_refinement.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_refinement.py
@@ -44,9 +44,9 @@ def test_refinement_strips_answer_formatting_and_focuses_explicit_anchors() -> N
     )
 
     assert [query.facet for query in planned] == ["anchor", "focus"]
-    assert planned[0].query == '"store" "result"'
-    assert planned[0].added_terms == ("store", "result")
-    assert planned[1].query == "column store result"
+    assert planned[0].query == '"store" "results"'
+    assert planned[0].added_terms == ("store", "results")
+    assert planned[1].query == "column store results"
     assert all("boxed" not in query.query for query in planned)
 
 
@@ -75,9 +75,9 @@ def test_refinement_decomposes_enumerated_targets_across_rounds() -> None:
         "target",
     ]
     assert [item.query for item in [*first_round, *second_round]] == [
-        '"layout setting" "pinned" "North list" footer label appear each page',
-        '"layout setting" "pinned" "South list" footer label appear each page',
-        '"layout setting" "pinned" "West list" footer label appear each page',
+        '"layout settings" "pinned" "North list" footer label appears each page',
+        '"layout settings" "pinned" "South list" footer label appears each page',
+        '"layout settings" "pinned" "West list" footer label appears each page',
     ]
 
 
@@ -90,7 +90,7 @@ def test_refinement_isolates_specific_terminal_question_from_quoted_example() ->
     )
 
     assert planned[0].facet == "focus_clause"
-    assert planned[0].query == "prefix used archive review dashboard link"
+    assert planned[0].query == "prefix used archive review dashboard links"
 
 
 def test_refinement_preserves_question_after_prefix_answer_formatting() -> None:
@@ -111,7 +111,7 @@ def test_refinement_strips_response_contract_sentences() -> None:
         max_queries=1,
     )
 
-    assert planned[0].query == "product page want summarize review star rating"
+    assert planned[0].query == "product page want summarize reviews star rating"
 
 
 def test_refinement_strips_standalone_answer_shape_instructions() -> None:
@@ -122,7 +122,7 @@ def test_refinement_strips_standalone_answer_shape_instructions() -> None:
         max_queries=1,
     )
 
-    assert planned[0].query == "button open shipment form"
+    assert planned[0].query == "button opens shipment form"
 
 
 def test_refinement_strips_ordering_and_boxed_output_contracts() -> None:
@@ -133,7 +133,7 @@ def test_refinement_strips_ordering_and_boxed_output_contracts() -> None:
         max_queries=1,
     )
 
-    assert planned[0].query == "label selected"
+    assert planned[0].query == "labels selected"
 
 
 def test_normalization_preserves_semantic_parenthetical_examples() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3508,6 +3508,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "snowballstemmer" },
     { name = "structlog" },
 ]
 
@@ -3572,6 +3573,7 @@ requires-dist = [
     { name = "python-louvain", marker = "extra == 'runtime'", specifier = ">=0.16" },
     { name = "sentence-transformers", marker = "extra == 'reranking'", specifier = ">=5.6.1" },
     { name = "sentence-transformers", marker = "extra == 'runtime'", specifier = ">=5.6.1" },
+    { name = "snowballstemmer", specifier = ">=2.2" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "surrealdb", marker = "extra == 'graph'", specifier = ">=2.0.0,<3.0" },
     { name = "surrealdb", marker = "extra == 'runtime'", specifier = ">=2.0.0,<3.0" },


### PR DESCRIPTION
# 🔮 One stemmer, shared by the index and the ranker

> Phase 0/1 of the 1.3 rethink, under the standing direction to make hand-lexicon contamination unwriteable. Touches the lexical lane in `sibyl-core` plus the eval harness. No schema change, no migration.

## 💡 What this is

The obvious version of this change is to add `snowball(english)` to the SurrealDB fulltext analyzers. That version is already shipped: `snowball(english)` has been in `ANALYZER_DEFINITIONS` since the first schema commit (`9ce74db1`, April 16), so every namespace that has ever existed indexes and queries through it. The engine has been stemming this whole time.

What had not happened is Python catching up. The lexical lane carried its own approximation of stemming in two hand-written tables that had drifted apart from each other and from the index: `query_anchors.py` held a 20-entry alias map plus a plural suffix ladder, and `fact_frames.py` held a separate 41-entry map plus a copy of the same ladder. So the BM25 lane matched a document on `meet` while the coverage ranker went looking for `meeting`, and the two lanes disagreed about what a word was.

Both tables are gone. Python now folds tokens with `snowballstemmer`, which runs the same Snowball English algorithm as the engine's filter, so the two sides agree by construction rather than by maintenance.

## 🤔 Why we need it and what it replaces

Hand lexicons rot toward whatever eval is being run, because entries get added the day a query misses. The 1.3 audit found exactly that in `query_anchors._NORMALIZED_TOKEN_ALIASES` (`debt-retrieval-ai.md` item m0), and the decontamination PR (#386) removed the corpus vocabulary without removing the architecture that grew it. A table that a general-purpose algorithm already covers is a maintenance surface with no upside, and every future miss is an invitation to add one more entry.

Deleting a table is only safe if something else covers it, so every deletion here is backed by a live check against an embedded store rather than by assumption. The engine unifies 17 of the 20 `query_anchors` entries and 37 of the 41 in `fact_frames`. The survivors were not morphology to begin with: `sold`/`subscription` are derivational, and `bought`, `got` and `went` are irregular pasts. The irregulars move into the action groups beside the verbs they belong to, which is where the file already kept `went`.

One survivor is dropped rather than moved, and it is a real loss: `fact_frames` mapped `serviced`/`servicing` onto `repair`, which is a sense judgement the stemmer has no opinion about and does not cover. Moving it into the repair group as `service` does not work, because stemming collapses the noun into the verb and every mention of a service then reads as a repair, which is the louder error in this corpus. So `serviced` no longer reaches `repair`, and nothing replaces it.

One table stays. Snowball is an inflectional stemmer and leaves graded adjectives alone, unifying **zero of the 49 pairs** in `_GRADED_ADJECTIVE_ALIASES` (`faster` stays `faster` while `fast` stays `fast`). No suffix rule recovers them safely, since stripping `er` turns `user` into `us`. A lemmatizer dependency would cover them, but adding one to serve 49 words when the existing curation already encodes real judgement (`lighter` and `cleaner` are objects, not degrees) buys nothing, so the table is retained and a test now carries the receipt for why.

## 🎯 The invariant

Anchor the review on one property: **a term the fulltext lane matched is the term the coverage ranker looks for**. `normalize_keyword_token` produces exactly what `search::analyze` produces for the same word, with graded adjectives as the single documented exception. `tests/test_lexical_stemming.py` pins it from both ends, so neither the analyzer chain nor the Python normalizer can drift without a failure.

The corollary is the rule the rest of the diff follows: **folded terms are compared as whole tokens, never as substrings**. A stem is not a prefix of what it covers whenever Snowball rewrites a terminal y, and that class is 5.4% of `/usr/share/dict/words`.

## 🛠️ How it works

### 1. One normalizer, matching the index

`query_anchors.normalize_keyword_token` now lowercases, folds diacritics the way the analyzer's `ascii` filter does, strips possessives, applies the graded adjective table, and stems. `fact_frames._normalize_token` is deleted; that module imports the shared function, which ends the drift between the two tokenizers. The token *patterns* stay separate on purpose, since fact frames want two-character terms and the ranker wants three.

### 2. Lexicons written in surface English, folded at import

Sets compared against normalized tokens (the action evidence groups, preference terms, artifact terms, the fact frame action and relation groups) pass through `normalize_keyword_tokens` at module load. An entry now covers its own inflections, so the hand-listed variants (`acquire`/`acquired`, `install`/`installed`) collapse to one.

### 3. Stopword lists are spelled out, not folded

Stopword lists are the deliberate exception. Folding one turns every entry into its whole morphological family, and those families hold content words: measured against the dictionary, folding the fact frame list would drop 70 words the old behavior kept (`mining`, `canned`, `assistance`, `difference`, `naming`) to close two leaks. So the lists stay surface-matched and countable nouns carry their plural explicitly (`months`, `weeks`, `years`, `needs`, `names`, `users`, `assistants`). That set was derived by generating each entry's inflections and keeping the ones the old normalizer actually folded into the list, so it closes the leak and touches nothing else.

`_FEEDBACK_STOPWORDS` in refinement is the one list that does fold, because its nine entries are harness noise (`session`, `transcript`, `question`) rather than function words, and they are noise in every inflection.

### 4. Surface keywords for query strings, stems for comparison

`extract_keywords` was feeding two different kinds of consumer from one folded list, so it splits: `extract_keywords` returns the surface form and `extract_keyword_stems` returns the folded one, both from a single pass that filters and dedupes on the stem, so `meeting` and `meetings` still collapse to one keyword.

The split follows what the caller does with the terms. Rebuilding a query string wants the surface form, which is refinement and the `added_terms` the context route shows a reader. Comparing terms wants the stem: the coverage ranker, `select_operational_source_span` (it intersects query terms with observation terms as sets), refinement's exclusion set, and `hybrid._apply_keyword_boost`.

### 5. Nothing is pre-folded on the way to a MATCHES query

The explicit-anchor probe in `services/graph.py` and the deterministic refinement queries both built search strings out of normalized tokens. A fulltext index analyzes the query string with the same chain it indexed with, so folding first is at best a no-op and at worst a miss. Both callers now use `extract_explicit_anchor_phrases`, which keeps the anchors as the query spells them.

### 6. Sense groups ignore derivations, unless the word is in the vocabulary

Snowball folds derivations onto their verb, so the sense groups began firing on text about nothing of the kind: `completely different` read as a completion, `really useful` and `a playful puppy` read as use, and an `attendant`, an `installment` and `participants` read as attend, assemble and attend. Sense matching now runs over tokens with the `-ly`, `-ful`, `-ant` and `-ment` derivations removed, on both the query and the evidence side, while term overlap still sees every token.

Membership decides before the suffix does, and that ordering is load-bearing rather than defensive. English is full of nouns shaped like derivations, and one of them is the relative group's own entry: judged by its ending alone, `family` was stripped, so "I visited my family" stopped reading as a relative while "families" still did. A token the vocabulary lists is a vocabulary word whatever it ends in, so the fact frame groups keep their surface spellings alongside the folded ones to answer that question. `friendly` is listed nowhere, so it still stays out of the friend relation.

## 🗄️ Why there is no migration

`DEFINE ANALYZER IF NOT EXISTS` does mean an existing namespace keeps whatever analyzer it was created with, so the question is real. It is answered by history rather than by hope: `git log --all -S "DEFINE ANALYZER"` returns five commits, and the analyzer chain has read `FILTERS lowercase, ascii, snowball(english)` in every one of them, starting with the schema's first appearance. There is no version of this store that was created without stemming, so a migration would rebuild every fulltext index on every namespace to arrive at the state they are already in. Index rebuilds on large namespaces are the risk surface here, and this one would buy nothing.

Worth knowing for later: because the guard is `IF NOT EXISTS`, any future change to an analyzer chain does need `DEFINE ANALYZER OVERWRITE` plus an index rebuild. A plain edit to the constant would silently no-op on every existing namespace.

## 🧪 Validation

The equivalence claim is the one everything else rests on, so it was measured rather than asserted. Against an embedded store with the production analyzer chain, `snowballstemmer` 2.2.0 (the version the lockfile resolves, pinned by crawl4ai's `<3` constraint) and `search::analyze` were compared over 4000 random dictionary words: **0 mismatches**. The probe was re-run after the version pin settled, not before.

| Check | Result |
| --- | --- |
| `moon run core:check` | lint clean, typecheck clean, `2492 passed, 14 skipped, 1 xfailed` |
| `moon run api:check` | lint clean, typecheck clean, `2223 passed, 5 skipped` |
| `moon run cli:check` | lint clean, typecheck clean, `457 passed` |
| `moon run bench-gate-test --force` | `437 passed`, the eval-harness gate, which sits outside core/api/cli and caught real regressions |
| Python vs engine, 4000 dictionary words | 0 mismatches |
| Graded adjectives unified by the engine | 0 of 49 |

Live receipts behind the deletions, each reproduced in `tests/test_lexical_stemming.py`:

- Regular inflection needs no table: `attended`/`attend`, `classes`/`class`, `policies`/`policy` all resolve to one stem on both sides.
- A document holding `I attended three standup meetings about pricing` is returned for `meeting`, `meetings`, `attend`, `attended`, `attending` and `price`.
- The pre-folding fix has a failing case behind it. A document holding `fastest route` is returned for the query `fastest`, and lost for the pre-folded `fast`, because the index leaves graded adjectives alone while the Python table did not.

⚠️ Not covered: this changes retrieval behavior in the lexical lane, and no benchmark screen has been run. The unit suites say the mechanics are right; they cannot say the ranking is better. See the follow-up below, which should gate the merge.

## 🔍 What reviewers should focus on

- **Anything still comparing a folded term against an unfolded one.** This is the highest-risk class in the change, and it is where every defect found so far has lived. The known ones are handled (`_RELATIVE_TERM` in `fact_frames`, `_KEYWORD_STOPWORD_STEMS` and `_TRANSCRIPT_SPEAKER_TERMS` in `query_ranking`). Two are worth seeing as patterns: an inline `{"assistant", "user"}` literal sitting in a filter that receives folded tokens stopped matching because `assistant` stems to `assist`, and `hybrid._apply_keyword_boost` probed stems as substrings, which loses the whole terminal-y noun class.
- **The stopword surface/stem split.** Section 3 is a judgement call, measured but still a call. If you think the lists should fold after all, the counter-example to beat is the 70 dictionary words it costs.
- **Homograph collisions in the sense groups.** Stemming merges lexemes that only look alike. Several were found and fixed: `settings` reading as the verb `set`, `service` as a repair, `progression` as `progress`, and the `-ly`/`-ful`/`-ant`/`-ment` derivations as their verb. Two ambiguous ones stay by choice, since excluding `-ing` or `-ed` would take the ordinary inflections with them: an office `building` reads as create, and `fielded` questions read as profile. More of these may exist.
- **The retained graded table.** It is the one hand lexicon left standing. If you would rather take a lemmatizer dependency and delete it, say so, since that is a live option and the test documenting the gap would become the test authorizing the deletion.

Out of scope: retrieval fusion, packing, traversal, and the ranking heuristics discussed below.

## 📌 Follow-ups (deliberate non-fixes)

**A retrieval screen should gate this merge.** The lexical lane's token identity changes, which is a behavior change the unit suite cannot adjudicate.

**One test is `xfail(strict=True)`**: `test_query_coverage_blends_fact_frames_into_recommendation_ranking`. The mechanism is written out in the marker, and it is not a stemming bug. Unifying `recommendations`, `recommendation` and `recommend` is correct, and it lifts every candidate in that fixture over `_PREFERENCE_MIN_OVERLAP`. `_stabilize_top_window_ranking` only swaps a candidate into the top window when the window holds something *below* that floor, so a floor nobody falls under disables the rescue and the documentary memory stays outside it. The scaffolding list already classifies `recommend` as noise, but the `>= 3` focused-keyword gate keeps it in a query that has two content words. Both the floor-based rescue and that gate are ranking heuristics that want a screen and an owner, not lexicon work, so neither was tuned here to turn the test green.

**Three derived nouns await adjudication before they can carry signal.** The `-ant`/`-ment` rule suppresses `investment` (which stems onto `invest` in the acquire group), `replacement` (onto `replac` in repair), and `assembly` (onto `assembl` in assemble). None of the three is a regression, because the old hand tables missed all three as well, and the rule is what stops `attendant`, `installment` and `participant` from firing the same groups. Because membership beats the suffix, listing each word in its group's surface vocabulary would both exempt it from the rule and let it fire, so the fix is one line per word. It is not taken here: the standing direction treats a new hand-lexicon entry as a design smell requiring adjudication rather than a routine fix, and this PR is decontamination and parity work. Named here so the next session inherits the words rather than rediscovering them.

**Removing `set` from the assemble group costs real signal.** "I set up the new shelf" now fires nothing. Restoring it re-imports the `settings` collision, which was the worse of the two, so the trade is taken deliberately rather than silently.

**Accent handling is folded at the function boundary only.** Every tokenizer feeding `normalize_keyword_token` matches ASCII characters, so an accented word is split before it arrives. The text is under-tokenized rather than mismatched, which fails safe. Widening those patterns is a separate change.

**The `refactor(ranking)` commit body overclaims one line.** It says `recommended` leaves `_KEYWORD_STOPWORDS`. It does not, and it does not need to: once stopwords are matched on the surface token, `recommendations` and `recommend` reach the preference terms with `recommended` still on the list. The list is byte-identical to main. Correcting the message would mean rewriting pushed commits that CI has already run against, so the record is here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
