### PR TITLE
feat(retrieval): naive-strong control arm, selectable end to end

### DIFF
--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -143,11 +143,12 @@ on:
         type: boolean
         default: false
       official_retrieval_mode:
-        description: "Evidence retrieval controller; frozen screens require fast"
+        description: "Retrieval pipeline; naive is the 1.3 control arm, frozen screens require fast"
         type: choice
         options:
           - fast
           - accurate
+          - naive
         default: accurate
       official_retrieval_max_planned_queries:
         description: "Maximum supplemental evidence queries in accurate mode"

--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -135,6 +135,35 @@ def _naive_retrieval_selected(request: ContextPackRequest) -> bool:
     return request.evidence is not None and request.evidence.retrieval_mode == "naive"
 
 
+def _reject_machine_knobs_under_the_arm(request: ContextPackRequest) -> None:
+    """Refuse settings the arm cannot honour, rather than half-applying them.
+
+    `knn_type_overfetch` tunes how deep the machine's typed vector read walks
+    around the HNSW bracket. The arm has no typed overfetch stage, and the pack
+    plan and the evidence plan would read the field from different places, so a
+    request setting it got it applied to one half of its own pack and dropped
+    from the other. A knob that lands on half a request is worse than a knob
+    that is refused: the run looks configured and is not.
+    """
+
+    if not _naive_retrieval_selected(request):
+        return
+    assert request.evidence is not None
+    requested = {
+        "knn_type_overfetch": request.knn_type_overfetch,
+        "evidence.knn_type_overfetch": request.evidence.knn_type_overfetch,
+    }
+    offenders = sorted(name for name, value in requested.items() if value)
+    if offenders:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"retrieval_mode=naive cannot honour {', '.join(offenders)}: "
+                "the control arm runs no typed overfetch stage"
+            ),
+        )
+
+
 async def _execute_naive_context_evidence_search(
     request: ContextPackRequest,
     *,
@@ -924,6 +953,7 @@ async def context_pack(
             project=request.project,
         )
         retrieval_goal = normalize_retrieval_question(request.goal)
+        _reject_machine_knobs_under_the_arm(request)
 
         async def compile_pack() -> ContextPack:
             return await compile_context(

--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -182,6 +182,7 @@ async def _execute_naive_context_evidence_search(
             include_content=True,
             embedding_provider=embedding_provider,
             char_budget=request.evidence.char_budget,
+            content_max_chars=request.evidence.content_max_chars,
         )
     except HTTPException:
         raise

--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -863,6 +863,21 @@ async def _compile_context_with_evidence(
                 "reserve_distilled_notes": False,
             }
         )
+    if request.evidence.retrieval_mode == "naive" and request.record_exposure:
+        # The enhanced path stamps exposure inside the search it runs, which the
+        # arm does not use. Stamped here instead, so a run under the arm leaves
+        # the same receipts and exposure analysis can compare the two arms
+        # rather than reading the arm as a run that surfaced nothing.
+        from sibyl_core.tools.usage_exposure import annotate_search_result_exposures
+
+        evidence_response.filters["usage_exposure"] = await annotate_search_result_exposures(
+            evidence_response.results,
+            organization_id=str(org.id),
+            principal_id=ctx.user_id,
+            project_id=request.project,
+            source_surface="context_pack_evidence",
+            request_metadata={"agent_id": request.agent_id} if request.agent_id else None,
+        )
     if typed_task is not None:
         typed_response, typed_error = typed_outcome
         evidence_response = _compose_context_evidence_response(

--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -3,6 +3,7 @@
 import asyncio
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import asdict
 from typing import Any, cast
 
 import structlog
@@ -126,6 +127,69 @@ def _context_evidence_request(
         record_exposure=(request.record_exposure and not request.evidence.reserve_distilled_notes),
         knn_type_overfetch=request.evidence.knn_type_overfetch,
     )
+
+
+def _naive_retrieval_selected(request: ContextPackRequest) -> bool:
+    """Whether this request selected the 1.3 Phase 0 control arm."""
+
+    return request.evidence is not None and request.evidence.retrieval_mode == "naive"
+
+
+async def _execute_naive_context_evidence_search(
+    request: ContextPackRequest,
+    *,
+    query: str,
+    org: AuthOrganization,
+    ctx: AuthContext,
+    accessible_projects: set[str] | None,
+    embedding_provider: Any,
+) -> SearchResponse:
+    """Serve evidence from the naive-strong arm instead of the enhanced pipeline.
+
+    The plan is built by the same constructor the machine uses, so scope
+    filtering, API-key memory grants, and project authorization are identical
+    across arms and only the retrieval lanes differ. That is the property the
+    race depends on: a control arm that also relaxed authorization would be
+    reading a different corpus rather than running a simpler pipeline.
+    """
+
+    assert request.evidence is not None
+    from sibyl_core.models.context import ContextFacet
+    from sibyl_core.retrieval.naive import naive_search
+    from sibyl_core.retrieval.search import build_context_retrieval_plan
+
+    plan = build_context_retrieval_plan(
+        query=query,
+        organization_id=str(org.id),
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: list(request.evidence.types)},
+        principal_id=ctx.user_id,
+        project=request.project,
+        accessible_projects=accessible_projects,
+        agent_id=request.agent_id,
+        limit=request.evidence.limit,
+        allowed_memory_scope_keys=(
+            set(ctx.api_key_memory_scope_keys)
+            if ctx.api_key_memory_scope_keys is not None
+            else None
+        ),
+    )
+    try:
+        result = await naive_search(
+            plan=plan,
+            types=request.evidence.types,
+            limit=request.evidence.limit,
+            include_content=True,
+            embedding_provider=embedding_provider,
+            char_budget=request.evidence.char_budget,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise RuntimeError("naive context evidence retrieval failed") from exc
+    # The arm returns the core retrieval dataclass; the route contract is the
+    # API schema, converted the same way the enhanced path converts it.
+    return SearchResponse(**asdict(result))
 
 
 def _distilled_context_evidence_request(
@@ -701,7 +765,18 @@ async def _compile_context_with_evidence(
     typed_outcome: tuple[SearchResponse | None, str | None] = (None, None)
     with capture_embedding_usage(embedding_provider) as embedding_usage:
         pack_task = asyncio.create_task(compile_pack())
-        if request.evidence.retrieval_mode == "accurate":
+        if request.evidence.retrieval_mode == "naive":
+            evidence_task = asyncio.create_task(
+                _execute_naive_context_evidence_search(
+                    request,
+                    query=retrieval_goal,
+                    org=org,
+                    ctx=ctx,
+                    accessible_projects=accessible_projects,
+                    embedding_provider=embedding_provider,
+                )
+            )
+        elif request.evidence.retrieval_mode == "accurate":
             # A5 deprecation (measured at full benchmark scale: lower accuracy
             # AND 2.5x latency vs fast). Served for one release, warned, then
             # removed together with the planner unless A3 adopts it.
@@ -728,6 +803,10 @@ async def _compile_context_with_evidence(
                     embedding_usage=embedding_usage,
                 )
             )
+        # The reserved distilled-notes lane is a second typed retrieval plus a
+        # composition step, so it belongs to the machine the arm is measured
+        # against. Under the arm it stays off whatever the request asked for,
+        # rather than quietly reintroducing the surface being tested.
         typed_task = (
             asyncio.create_task(
                 _execute_distilled_context_evidence_search(
@@ -739,6 +818,7 @@ async def _compile_context_with_evidence(
                 )
             )
             if request.evidence.reserve_distilled_notes
+            and request.evidence.retrieval_mode != "naive"
             else None
         )
         try:
@@ -766,6 +846,20 @@ async def _compile_context_with_evidence(
                 "planner_status": "not_requested",
                 "planned_queries": [],
                 "query_count": 1,
+            }
+        )
+    if request.evidence.retrieval_mode == "naive":
+        # The arm runs one search and no planner, so it reports the same
+        # planner receipt fast does. Consumers that key off planner_status stay
+        # correct without learning a third shape.
+        evidence_response.filters.update(
+            {
+                "retrieval_mode": "naive",
+                "retrieval_arm": "naive",
+                "planner_status": "not_requested",
+                "planned_queries": [],
+                "query_count": 1,
+                "reserve_distilled_notes": False,
             }
         )
     if typed_task is not None:
@@ -833,6 +927,7 @@ async def context_pack(
                 audit=request.audit,
                 record_exposure=request.record_exposure,
                 knn_type_overfetch=request.knn_type_overfetch,
+                naive_retrieval=_naive_retrieval_selected(request),
                 allowed_memory_scope_keys=set(ctx.api_key_memory_scope_keys)
                 if ctx.api_key_memory_scope_keys is not None
                 else None,

--- a/apps/api/src/sibyl/api/schemas/context.py
+++ b/apps/api/src/sibyl/api/schemas/context.py
@@ -45,13 +45,17 @@ class ContextEvidenceRequest(BaseModel):
         default=False,
         description="Include authorized evidence ranking diagnostics",
     )
-    retrieval_mode: Literal["fast", "accurate"] = Field(
+    retrieval_mode: Literal["fast", "accurate", "naive"] = Field(
         default="fast",
         description=(
-            "Use one search (fast) or deterministic multi-step evidence refinement "
-            "(accurate). DEPRECATED: accurate measured lower accuracy at 2.5x the "
-            "latency of fast at full benchmark scale and will be removed in a "
-            "future release; requests selecting it are served but warned."
+            "Use one search (fast), deterministic multi-step evidence refinement "
+            "(accurate), or the naive-strong control arm (naive). DEPRECATED: "
+            "accurate measured lower accuracy at 2.5x the latency of fast at full "
+            "benchmark scale and will be removed in a future release; requests "
+            "selecting it are served but warned. EXPERIMENTAL: naive is the 1.3 "
+            "Phase 0 control arm (BM25 + dense KNN + plain RRF + a tight pack, "
+            "with no traversal, synthesis, query planning, or coverage ranking) "
+            "and it governs the whole pack, not the evidence block alone."
         ),
     )
     max_planned_queries: int = Field(

--- a/apps/api/tests/test_routes_context.py
+++ b/apps/api/tests/test_routes_context.py
@@ -2415,3 +2415,182 @@ def test_retrieval_mode_schema_documents_the_deprecation() -> None:
 
     description = ContextEvidenceRequest.model_fields["retrieval_mode"].description
     assert "DEPRECATED" in description
+
+
+class TestNaiveRetrievalArm:
+    """The 1.3 Phase 0 control arm: selectable, off by default, and total."""
+
+    @staticmethod
+    def _evidence(mode: str) -> dict[str, Any]:
+        return {"retrieval_mode": mode, "types": ["session"], "limit": 5}
+
+    @staticmethod
+    def _arm_response() -> Any:
+        """What the arm actually hands back: the core dataclass, not the schema."""
+
+        from sibyl_core.tools.responses import (
+            SearchResponse as CoreSearchResponse,
+            SearchResult as CoreSearchResult,
+        )
+
+        return CoreSearchResponse(
+            results=[
+                CoreSearchResult(
+                    id="span_1",
+                    type="session",
+                    name="span_1",
+                    content="verbatim span",
+                    score=0.02,
+                    result_origin="graph",
+                )
+            ],
+            total=1,
+            query="ship faster",
+            filters={"retrieval_mode": "naive", "retrieval_arm": "naive"},
+            graph_count=1,
+            limit=5,
+        )
+
+    @pytest.mark.asyncio
+    async def test_selecting_naive_routes_evidence_to_the_arm(self) -> None:
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        arm = AsyncMock(return_value=self._arm_response())
+
+        with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value=["proj_1"]),
+            ),
+            patch("sibyl_core.tools.context.compile_context", AsyncMock(return_value=_pack())),
+            patch("sibyl_core.retrieval.naive.naive_search", arm),
+            patch(
+                "sibyl.api.routes.search.execute_search_request",
+                AsyncMock(side_effect=AssertionError("the arm must not reach the machine")),
+            ),
+            patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
+        ):
+            response = await context_pack(
+                request=ContextPackRequest(
+                    goal="ship faster",
+                    evidence=self._evidence("naive"),
+                ),
+                org=org,
+                ctx=_ctx(),
+            )
+
+        arm.assert_awaited_once()
+        assert response.evidence is not None
+        assert response.evidence.filters["retrieval_mode"] == "naive"
+        assert response.evidence.filters["retrieval_arm"] == "naive"
+        # The arm runs one search and no planner, so it reports the planner
+        # receipt fast reports rather than inventing a third shape.
+        assert response.evidence.filters["planner_status"] == "not_requested"
+        assert response.evidence.filters["query_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_the_arm_governs_the_pack_not_only_the_evidence_block(self) -> None:
+        """A pack still compiled by the machine would contaminate the race."""
+
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        compile_context = AsyncMock(return_value=_pack())
+
+        with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value=["proj_1"]),
+            ),
+            patch("sibyl_core.tools.context.compile_context", compile_context),
+            patch(
+                "sibyl_core.retrieval.naive.naive_search",
+                AsyncMock(return_value=self._arm_response()),
+            ),
+            patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
+        ):
+            await context_pack(
+                request=ContextPackRequest(
+                    goal="ship faster",
+                    evidence=self._evidence("naive"),
+                ),
+                org=org,
+                ctx=_ctx(),
+            )
+
+        assert compile_context.await_args.kwargs["naive_retrieval"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_arm_turns_off_the_reserved_distilled_notes_lane(self) -> None:
+        """The reserved typed lane is machine surface, so the arm suppresses it."""
+
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        distilled = AsyncMock(return_value=(None, None))
+
+        with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value=["proj_1"]),
+            ),
+            patch("sibyl_core.tools.context.compile_context", AsyncMock(return_value=_pack())),
+            patch(
+                "sibyl_core.retrieval.naive.naive_search",
+                AsyncMock(return_value=self._arm_response()),
+            ),
+            patch(
+                "sibyl.api.routes.context._execute_distilled_context_evidence_search",
+                distilled,
+            ),
+            patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
+        ):
+            response = await context_pack(
+                request=ContextPackRequest(
+                    goal="ship faster",
+                    # Explicitly requested, and still suppressed: the arm's
+                    # composition is fixed, not negotiable per request.
+                    evidence={**self._evidence("naive"), "reserve_distilled_notes": True},
+                ),
+                org=org,
+                ctx=_ctx(),
+            )
+
+        distilled.assert_not_awaited()
+        assert response.evidence is not None
+        assert response.evidence.filters["reserve_distilled_notes"] is False
+
+    @pytest.mark.asyncio
+    async def test_the_default_path_never_reaches_the_arm(self) -> None:
+        """The hard invariant: an unselected arm is an unreachable arm."""
+
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        arm = AsyncMock(side_effect=AssertionError("the default path reached the naive arm"))
+        compile_context = AsyncMock(return_value=_pack())
+        machine = AsyncMock(return_value=_search_response("ship faster", ("evidence_1", 0.9)))
+
+        for evidence in (None, self._evidence("fast")):
+            with (
+                patch(
+                    "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                    AsyncMock(return_value=["proj_1"]),
+                ),
+                patch("sibyl_core.tools.context.compile_context", compile_context),
+                patch("sibyl_core.retrieval.naive.naive_search", arm),
+                patch("sibyl.api.routes.search.execute_search_request", machine),
+                patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
+            ):
+                await context_pack(
+                    request=ContextPackRequest(goal="ship faster", evidence=evidence),
+                    org=org,
+                    ctx=_ctx(),
+                )
+
+            arm.assert_not_awaited()
+            assert compile_context.await_args.kwargs["naive_retrieval"] is False
+
+    def test_the_arm_is_off_unless_a_request_names_it(self) -> None:
+        assert ContextPackRequest(goal="x").evidence is None
+        assert ContextPackRequest(goal="x", evidence={}).evidence.retrieval_mode == "fast"
+
+    def test_retrieval_mode_schema_documents_the_control_arm(self) -> None:
+        from sibyl.api.schemas.context import ContextEvidenceRequest
+
+        field = ContextEvidenceRequest.model_fields["retrieval_mode"]
+        assert "naive" in str(field.annotation)
+        assert "EXPERIMENTAL" in field.description

--- a/apps/api/tests/test_routes_context.py
+++ b/apps/api/tests/test_routes_context.py
@@ -2556,6 +2556,74 @@ class TestNaiveRetrievalArm:
         assert response.evidence.filters["reserve_distilled_notes"] is False
 
     @pytest.mark.asyncio
+    async def test_the_arm_still_records_exposure(self) -> None:
+        """Exposure receipts must exist under both arms or they cannot be compared."""
+
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        exposure = AsyncMock(return_value={"status": "stamped", "item_count": 1})
+
+        with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value=["proj_1"]),
+            ),
+            patch("sibyl_core.tools.context.compile_context", AsyncMock(return_value=_pack())),
+            patch(
+                "sibyl_core.retrieval.naive.naive_search",
+                AsyncMock(return_value=self._arm_response()),
+            ),
+            patch("sibyl_core.tools.usage_exposure.annotate_search_result_exposures", exposure),
+            patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
+        ):
+            response = await context_pack(
+                request=ContextPackRequest(
+                    goal="ship faster",
+                    evidence=self._evidence("naive"),
+                    record_exposure=True,
+                ),
+                org=org,
+                ctx=_ctx(),
+            )
+
+        exposure.assert_awaited_once()
+        assert exposure.await_args.kwargs["source_surface"] == "context_pack_evidence"
+        assert response.evidence is not None
+        assert response.evidence.filters["usage_exposure"] == {
+            "status": "stamped",
+            "item_count": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_the_arm_honors_a_request_that_declines_exposure(self) -> None:
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        exposure = AsyncMock(side_effect=AssertionError("exposure recorded against the request"))
+
+        with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value=["proj_1"]),
+            ),
+            patch("sibyl_core.tools.context.compile_context", AsyncMock(return_value=_pack())),
+            patch(
+                "sibyl_core.retrieval.naive.naive_search",
+                AsyncMock(return_value=self._arm_response()),
+            ),
+            patch("sibyl_core.tools.usage_exposure.annotate_search_result_exposures", exposure),
+            patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
+        ):
+            await context_pack(
+                request=ContextPackRequest(
+                    goal="ship faster",
+                    evidence=self._evidence("naive"),
+                    record_exposure=False,
+                ),
+                org=org,
+                ctx=_ctx(),
+            )
+
+        exposure.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_the_default_path_never_reaches_the_arm(self) -> None:
         """The hard invariant: an unselected arm is an unreachable arm."""
 
@@ -2564,7 +2632,10 @@ class TestNaiveRetrievalArm:
         compile_context = AsyncMock(return_value=_pack())
         machine = AsyncMock(return_value=_search_response("ship faster", ("evidence_1", 0.9)))
 
-        for evidence in (None, self._evidence("fast")):
+        # Every mode other than naive, not just the default: the branch that
+        # routes to the arm is an elif chain, so the third mode is the one a
+        # careless reordering would break.
+        for evidence in (None, self._evidence("fast"), self._evidence("accurate")):
             with (
                 patch(
                     "sibyl.api.routes.context.list_accessible_project_graph_ids",
@@ -2573,6 +2644,10 @@ class TestNaiveRetrievalArm:
                 patch("sibyl_core.tools.context.compile_context", compile_context),
                 patch("sibyl_core.retrieval.naive.naive_search", arm),
                 patch("sibyl.api.routes.search.execute_search_request", machine),
+                patch(
+                    "sibyl.api.routes.context.plan_deterministic_refinement_queries",
+                    return_value=[],
+                ),
                 patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
             ):
                 await context_pack(

--- a/apps/api/tests/test_routes_context.py
+++ b/apps/api/tests/test_routes_context.py
@@ -2659,6 +2659,68 @@ class TestNaiveRetrievalArm:
             arm.assert_not_awaited()
             assert compile_context.await_args.kwargs["naive_retrieval"] is False
 
+    @pytest.mark.asyncio
+    async def test_the_arm_refuses_a_machine_knob_it_cannot_honour(self) -> None:
+        """Half-applied is worse than refused: the run would look configured.
+
+        knn_type_overfetch tunes the machine's typed vector read. The pack plan
+        and the evidence plan read it from different places, so under the arm a
+        request setting it got it applied to one half of its own pack and
+        dropped from the other, and the arm has no such stage in either case.
+        """
+
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        for payload in (
+            {"knn_type_overfetch": 17},
+            {"evidence_overfetch": 17},
+        ):
+            evidence = self._evidence("naive")
+            if "evidence_overfetch" in payload:
+                evidence["knn_type_overfetch"] = payload["evidence_overfetch"]
+                request = ContextPackRequest(goal="ship faster", evidence=evidence)
+            else:
+                request = ContextPackRequest(
+                    goal="ship faster",
+                    evidence=evidence,
+                    knn_type_overfetch=payload["knn_type_overfetch"],
+                )
+            with (
+                patch(
+                    "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                    AsyncMock(return_value=["proj_1"]),
+                ),
+                patch("sibyl_core.tools.context.compile_context", AsyncMock(return_value=_pack())),
+                patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
+                pytest.raises(HTTPException) as excinfo,
+            ):
+                await context_pack(request=request, org=org, ctx=_ctx())
+
+            assert excinfo.value.status_code == 400
+            assert "knn_type_overfetch" in str(excinfo.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_the_machine_still_accepts_the_knob(self) -> None:
+        """The refusal is scoped to the arm."""
+
+        org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+        compile_context = AsyncMock(return_value=_pack())
+
+        with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value=["proj_1"]),
+            ),
+            patch("sibyl_core.tools.context.compile_context", compile_context),
+            patch("sibyl.api.routes.context.configured_embedding_provider", return_value=None),
+        ):
+            await context_pack(
+                request=ContextPackRequest(goal="ship faster", knn_type_overfetch=17),
+                org=org,
+                ctx=_ctx(),
+            )
+
+        assert compile_context.await_args.kwargs["knn_type_overfetch"] == 17
+
     def test_the_arm_is_off_unless_a_request_names_it(self) -> None:
         assert ContextPackRequest(goal="x").evidence is None
         assert ContextPackRequest(goal="x", evidence={}).evidence.retrieval_mode == "fast"

--- a/benchmarks/longmemeval_v2_live_retrieval.py
+++ b/benchmarks/longmemeval_v2_live_retrieval.py
@@ -132,7 +132,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--max-context-items", type=int, default=8)
     parser.add_argument("--max-context-chars-per-item", type=int, default=12_000)
     parser.add_argument("--max-context-total-chars", type=int, default=60_000)
-    parser.add_argument("--retrieval-mode", choices=("fast", "accurate"), default="accurate")
+    parser.add_argument(
+        "--retrieval-mode",
+        choices=("fast", "accurate", "naive"),
+        default="accurate",
+    )
     parser.add_argument("--max-planned-queries", type=int, default=3)
     parser.add_argument(
         "--evidence-types",

--- a/benchmarks/longmemeval_v2_live_smoke.py
+++ b/benchmarks/longmemeval_v2_live_smoke.py
@@ -57,7 +57,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--output", required=True)
     parser.add_argument("--run-id", default="")
     parser.add_argument("--timeout-seconds", type=float, default=600.0)
-    parser.add_argument("--retrieval-mode", choices=("fast", "accurate"), default="fast")
+    parser.add_argument(
+        "--retrieval-mode",
+        choices=("fast", "accurate", "naive"),
+        default="fast",
+    )
     parser.add_argument("--max-planned-queries", type=int, default=3)
     parser.add_argument(
         "--evidence-composition-mode",

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -3189,6 +3189,21 @@ _NAIVE_CONFLICTING_NUMERIC_PARAMS = (
     ("state_part_completion_items", DEFAULT_STATE_PART_COMPLETION_ITEMS),
     ("neighbor_support_overflow_items", DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS),
     ("semantic_prior_rescue_weight", DEFAULT_SEMANTIC_PRIOR_RESCUE_WEIGHT),
+    ("knn_type_overfetch", DEFAULT_KNN_TYPE_OVERFETCH),
+)
+# Settings configuring stages the naive render bypasses outright. Their shipped
+# defaults are not inert, and the runner writes every key into memory_params
+# whether or not the operator named it, so neither truthiness nor presence
+# separates intent from boilerplate. A value differing from the default is the
+# operator asking for behaviour this run will not have, which is what refuses.
+# A plain naive run therefore still needs no extra arguments.
+_NAIVE_BYPASSED_STAGE_PARAMS = (
+    ("neighbor_stitch_items", DEFAULT_NEIGHBOR_STITCH_ITEMS),
+    ("neighbor_stitch_span", DEFAULT_NEIGHBOR_STITCH_SPAN),
+    ("max_chunks_per_trajectory", DEFAULT_MAX_CHUNKS_PER_TRAJECTORY),
+    ("context_expansion_max_ratio", DEFAULT_CONTEXT_EXPANSION_MAX_RATIO),
+    ("evidence_composition_mode", DEFAULT_EVIDENCE_COMPOSITION_MODE),
+    ("typed_reservation_items", None),
 )
 
 
@@ -3204,6 +3219,11 @@ def _naive_arm_conflicts(memory_params: dict[str, object]) -> list[str]:
         name
         for name, default in _NAIVE_CONFLICTING_NUMERIC_PARAMS
         if _param_float(memory_params, name, float(default)) > 0
+    )
+    conflicts.extend(
+        name
+        for name, default in _NAIVE_BYPASSED_STAGE_PARAMS
+        if (value := memory_params.get(name)) is not None and value != default
     )
     return sorted(conflicts)
 
@@ -4722,53 +4742,65 @@ class SibylLiveApiMemory(Memory):
         *,
         query: str,
         results: list[dict[str, object]],
-    ) -> str:
-        """Render the arm's own candidates, in the arm's own order, and nothing else.
+    ) -> list[MemoryContextItem]:
+        """Render every server candidate, in the server's order, bodies whole.
 
         The arm's claim is that its fused, packed ordering is what the reader
-        sees, so the client-side stages have to be off rather than configured
-        small. Assembly performs diversity selection, trajectory refinement, and
-        catalog-neighbor expansion; composition performs typed reservation,
-        support overflow, and semantic-prior rescue. With neighbor stitching at
-        its shipped default of two, one returned row renders as three, and the
-        screen would be scoring a client-side expansion of the arm rather than
-        the arm.
+        sees, so nothing here may re-select, reorder, or rewrite. The shared
+        renderer is not usable for that: it caps membership at max_items, drops
+        rows whose content is empty, allocates a per-candidate character budget,
+        and rewrites long bodies into query-aware slices. Each of those is a
+        machine stage, and together they turned twelve server candidates into
+        eight sliced ones.
 
-        Pack items are dropped here too. Under the arm they are the same rows
-        the evidence lane already ranked, so merging them would render a row
-        twice and reintroduce a selection step the arm does not have.
+        The one bound kept is the reader's total context. When the pack exceeds
+        it, whole candidates are dropped from the tail, never sliced, and the
+        drop is stamped in the receipt so a short data point is auditable rather
+        than mysterious.
         """
 
-        evidence_set = list(results[: max(1, self.max_context_items)])
+        max_total_chars = max(
+            1,
+            getattr(self, "max_context_total_chars", DEFAULT_CONTEXT_TOTAL_CHARS),
+        )
+        context: list[MemoryContextItem] = []
+        rendered: list[dict[str, object]] = []
+        spent = 0
+        truncated_from_rank: int | None = None
+        for rank, result in enumerate(results, start=1):
+            header = _memory_context_header(rank, result)
+            content = _stripped_str(result.get("content"))
+            content = annotate_inventory_completeness(content, result.get("metadata"))
+            value = header + "\n\n" + content
+            if context and spent + len(value) > max_total_chars:
+                truncated_from_rank = rank
+                break
+            context.append({"type": "text", "value": value})
+            rendered.append(result)
+            spent += len(value)
         assembly_metadata: dict[str, object] = {
             "naive_verbatim_render": True,
             "naive_server_candidate_count": len(results),
-            "naive_rendered_count": len(evidence_set),
+            "naive_rendered_count": len(rendered),
+            "naive_rendered_chars": spent,
+            "naive_context_char_cap": max_total_chars,
+            "naive_tail_truncated_from_rank": truncated_from_rank,
+            "naive_dropped_count": len(results) - len(rendered),
             "naive_bypassed_stages": [
                 "assemble_context_results",
                 "compile_operational_evidence_set",
+                "render_memory_context",
             ],
+            "naive_rendered_ids": [_stripped_str(row.get("id")) for row in rendered],
         }
-        memory_context, context_budget = render_memory_context(
-            evidence_set,
-            query=query,
-            max_items=len(evidence_set),
-            max_chars_per_item=self.max_context_chars_per_item,
-            max_total_chars=getattr(
-                self,
-                "max_context_total_chars",
-                DEFAULT_CONTEXT_TOTAL_CHARS,
-            ),
-        )
-        assembly_metadata["context_budget"] = context_budget
         self._query_local.search_metadata["adapter_assembly"] = assembly_metadata
         self._query_local.retrieval_trace = build_retrieval_trace(
-            evidence_set,
-            max_items=len(evidence_set),
+            rendered,
+            max_items=len(rendered),
             max_chars_per_item=self.max_context_chars_per_item,
-            context_budget=context_budget,
+            context_budget={"items": [], "naive_verbatim_render": True},
         )
-        return memory_context
+        return context
 
     def _traversal_llm_client(self) -> object:
         if self._openai_traversal_client is None:

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -3452,27 +3452,6 @@ class SibylLiveApiMemory(Memory):
             "agentic_traversal",
             DEFAULT_AGENTIC_TRAVERSAL,
         )
-        if self.retrieval_mode == "naive":
-            # Both of these issue their own retrieval outside the arm: the typed
-            # stream makes a second pack request pinned to fast, and agentic
-            # traversal widens the pool with model-driven follow-up searches. A
-            # run carrying either would report the arm's name over a pool the
-            # arm did not produce, so the conflict fails loudly here rather than
-            # silently at read time.
-            conflicting = [
-                name
-                for name, enabled in (
-                    ("typed_stream_retrieval", self.typed_stream_retrieval),
-                    ("agentic_traversal", self.agentic_traversal),
-                )
-                if enabled
-            ]
-            if conflicting:
-                msg = (
-                    "retrieval_mode=naive is the control arm and cannot run with "
-                    f"{', '.join(sorted(conflicting))}: disable them to race the arm"
-                )
-                raise ValueError(msg)
         self.traversal_widening_rounds = _param_int(
             memory_params,
             "traversal_widening_rounds",
@@ -3547,6 +3526,44 @@ class SibylLiveApiMemory(Memory):
                 "weight*1.0 to a zero-coverage candidate, and past 1.0 it can outvote "
                 "genuine vocabulary winners instead of rescuing the uncovered tail"
             )
+        if self.retrieval_mode == "naive":
+            # Both of these issue their own retrieval outside the arm: the typed
+            # stream makes a second pack request pinned to fast, and agentic
+            # traversal widens the pool with model-driven follow-up searches. A
+            # run carrying either would report the arm's name over a pool the
+            # arm did not produce, so the conflict fails loudly here rather than
+            # silently at read time.
+            # Two families. The first retrieves outside the arm entirely. The
+            # second reshapes what the arm returned, and under naive the client
+            # renders the server's candidates verbatim, so every one of these is
+            # inert by construction. They still refuse rather than being
+            # silently ignored: a screen that passes a reshaping flag believes
+            # it is tuning something, and a flag that reads as applied while
+            # doing nothing is how an arm ends up described wrongly in a
+            # writeup. Only flags whose shipped default is already inert appear
+            # here, so a plain naive run needs no extra arguments.
+            conflicting = [
+                name
+                for name, enabled in (
+                    ("typed_stream_retrieval", self.typed_stream_retrieval),
+                    ("agentic_traversal", self.agentic_traversal),
+                    ("state_part_refinement", self.state_part_refinement),
+                    ("neighbor_stitch_spread", self.neighbor_stitch_spread),
+                    ("neighbor_support_exempt", self.neighbor_support_exempt),
+                    ("neighbor_trajectory_preserving", self.neighbor_trajectory_preserving),
+                    ("source_evidence_bundling", self.source_evidence_bundling),
+                    ("state_part_completion_items", self.state_part_completion_items),
+                    ("neighbor_support_overflow_items", self.neighbor_support_overflow_items),
+                    ("semantic_prior_rescue_weight", self.semantic_prior_rescue_weight),
+                )
+                if enabled
+            ]
+            if conflicting:
+                msg = (
+                    "retrieval_mode=naive is the control arm and cannot run with "
+                    f"{', '.join(sorted(conflicting))}: disable them to race the arm"
+                )
+                raise ValueError(msg)
         self.typed_pool = _param_str(memory_params, "typed_pool", DEFAULT_TYPED_POOL)
         if self.typed_pool not in SUPPORTED_TYPED_POOLS:
             raise ValueError(f"typed_pool must be one of {sorted(SUPPORTED_TYPED_POOLS)}")
@@ -4549,6 +4566,8 @@ class SibylLiveApiMemory(Memory):
             "state_part_completion_items",
             DEFAULT_STATE_PART_COMPLETION_ITEMS,
         )
+        if getattr(self, "retrieval_mode", DEFAULT_RETRIEVAL_MODE) == "naive":
+            return self._render_naive_verbatim_context(query=query, results=results)
         assembled_results, assembly_metadata = assemble_context_results(
             results,
             chunk_catalog=chunk_catalog,
@@ -4674,6 +4693,59 @@ class SibylLiveApiMemory(Memory):
         self._query_local.retrieval_trace = build_retrieval_trace(
             evidence_set,
             max_items=rendered_item_ceiling,
+            max_chars_per_item=self.max_context_chars_per_item,
+            context_budget=context_budget,
+        )
+        return memory_context
+
+    def _render_naive_verbatim_context(
+        self,
+        *,
+        query: str,
+        results: list[dict[str, object]],
+    ) -> str:
+        """Render the arm's own candidates, in the arm's own order, and nothing else.
+
+        The arm's claim is that its fused, packed ordering is what the reader
+        sees, so the client-side stages have to be off rather than configured
+        small. Assembly performs diversity selection, trajectory refinement, and
+        catalog-neighbor expansion; composition performs typed reservation,
+        support overflow, and semantic-prior rescue. With neighbor stitching at
+        its shipped default of two, one returned row renders as three, and the
+        screen would be scoring a client-side expansion of the arm rather than
+        the arm.
+
+        Pack items are dropped here too. Under the arm they are the same rows
+        the evidence lane already ranked, so merging them would render a row
+        twice and reintroduce a selection step the arm does not have.
+        """
+
+        evidence_set = list(results[: max(1, self.max_context_items)])
+        assembly_metadata: dict[str, object] = {
+            "naive_verbatim_render": True,
+            "naive_server_candidate_count": len(results),
+            "naive_rendered_count": len(evidence_set),
+            "naive_bypassed_stages": [
+                "assemble_context_results",
+                "compile_operational_evidence_set",
+            ],
+        }
+        memory_context, context_budget = render_memory_context(
+            evidence_set,
+            query=query,
+            max_items=len(evidence_set),
+            max_chars_per_item=self.max_context_chars_per_item,
+            max_total_chars=getattr(
+                self,
+                "max_context_total_chars",
+                DEFAULT_CONTEXT_TOTAL_CHARS,
+            ),
+        )
+        assembly_metadata["context_budget"] = context_budget
+        self._query_local.search_metadata["adapter_assembly"] = assembly_metadata
+        self._query_local.retrieval_trace = build_retrieval_trace(
+            evidence_set,
+            max_items=len(evidence_set),
             max_chars_per_item=self.max_context_chars_per_item,
             context_budget=context_budget,
         )

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -129,11 +129,12 @@ DEFAULT_EVIDENCE_COMPOSITION_MODE = "shared_relevance"
 EVIDENCE_COMPOSITION_MODES = frozenset({"reserved_support", "shared_relevance"})
 DEFAULT_SOURCE_EVIDENCE_BUNDLING = False
 DEFAULT_RETRIEVAL_MODE = "fast"
+NAIVE_RETRIEVAL_MODE = "naive"
 # `naive` is the 1.3 Phase 0 control arm: BM25 plus dense KNN plus plain RRF
 # plus a tight pack, served with no traversal, synthesis, query planning, or
 # coverage ranking. It is a server-side mode, so selecting it here changes what
 # the pack and evidence come back holding, not how this adapter composes them.
-RETRIEVAL_MODES = frozenset({"accurate", "fast", "naive"})
+RETRIEVAL_MODES = frozenset({"accurate", "fast", NAIVE_RETRIEVAL_MODE})
 DEFAULT_TYPED_STREAM_RETRIEVAL = False
 DEFAULT_TYPED_STREAM_LIMIT = 8
 # The distilled-note lane, retrieved on its own request. It is not the raw
@@ -3167,6 +3168,46 @@ def load_api_credentials_file(path: Path) -> dict[str, str]:
     return credentials
 
 
+# Settings that would leave the naive arm's name on a run the arm did not
+# produce. The first two retrieve outside the arm entirely; the rest reshape
+# what it returned, and under naive the client renders the server's candidates
+# verbatim so every one of them is inert. They refuse rather than being ignored:
+# a screen that passes one believes it is tuning something, and a flag that
+# reads as applied while doing nothing is how an arm ends up described wrongly
+# in a writeup. Every entry ships an inert default, so a plain naive run needs
+# no extra arguments.
+_NAIVE_CONFLICTING_BOOL_PARAMS = (
+    ("typed_stream_retrieval", DEFAULT_TYPED_STREAM_RETRIEVAL),
+    ("agentic_traversal", DEFAULT_AGENTIC_TRAVERSAL),
+    ("state_part_refinement", DEFAULT_STATE_PART_REFINEMENT),
+    ("neighbor_stitch_spread", DEFAULT_NEIGHBOR_STITCH_SPREAD),
+    ("neighbor_support_exempt", DEFAULT_NEIGHBOR_SUPPORT_EXEMPT),
+    ("neighbor_trajectory_preserving", DEFAULT_NEIGHBOR_TRAJECTORY_PRESERVING),
+    ("source_evidence_bundling", DEFAULT_SOURCE_EVIDENCE_BUNDLING),
+)
+_NAIVE_CONFLICTING_NUMERIC_PARAMS = (
+    ("state_part_completion_items", DEFAULT_STATE_PART_COMPLETION_ITEMS),
+    ("neighbor_support_overflow_items", DEFAULT_NEIGHBOR_SUPPORT_OVERFLOW_ITEMS),
+    ("semantic_prior_rescue_weight", DEFAULT_SEMANTIC_PRIOR_RESCUE_WEIGHT),
+)
+
+
+def _naive_arm_conflicts(memory_params: dict[str, object]) -> list[str]:
+    """Names of the requested settings the control arm cannot honour."""
+
+    conflicts = [
+        name
+        for name, default in _NAIVE_CONFLICTING_BOOL_PARAMS
+        if _param_bool(memory_params, name, default)
+    ]
+    conflicts.extend(
+        name
+        for name, default in _NAIVE_CONFLICTING_NUMERIC_PARAMS
+        if _param_float(memory_params, name, float(default)) > 0
+    )
+    return sorted(conflicts)
+
+
 @register_memory
 class SibylLiveApiMemory(Memory):
     memory_type = "sibyl_live_api"
@@ -3404,6 +3445,22 @@ class SibylLiveApiMemory(Memory):
                 f"expected one of {sorted(RETRIEVAL_MODES)}"
             )
             raise ValueError(msg)
+        # Fired here, immediately after the mode is validated, rather than
+        # beside the flags it names. Those are assigned further down and one of
+        # them sits behind an environment check for an API key, so a guard
+        # placed there refuses a naive-plus-traversal run only on a machine that
+        # happens to export the key and reports an unrelated missing-key error
+        # everywhere else. A configuration conflict is a property of the
+        # configuration, so it is read straight from the parameters and answers
+        # the same way on every machine.
+        if self.retrieval_mode == NAIVE_RETRIEVAL_MODE:
+            conflicting = _naive_arm_conflicts(memory_params)
+            if conflicting:
+                msg = (
+                    "retrieval_mode=naive is the control arm and cannot run with "
+                    f"{', '.join(conflicting)}: disable them to race the arm"
+                )
+                raise ValueError(msg)
         self.retrieval_max_planned_queries = _param_int(
             memory_params,
             "retrieval_max_planned_queries",
@@ -3526,44 +3583,6 @@ class SibylLiveApiMemory(Memory):
                 "weight*1.0 to a zero-coverage candidate, and past 1.0 it can outvote "
                 "genuine vocabulary winners instead of rescuing the uncovered tail"
             )
-        if self.retrieval_mode == "naive":
-            # Both of these issue their own retrieval outside the arm: the typed
-            # stream makes a second pack request pinned to fast, and agentic
-            # traversal widens the pool with model-driven follow-up searches. A
-            # run carrying either would report the arm's name over a pool the
-            # arm did not produce, so the conflict fails loudly here rather than
-            # silently at read time.
-            # Two families. The first retrieves outside the arm entirely. The
-            # second reshapes what the arm returned, and under naive the client
-            # renders the server's candidates verbatim, so every one of these is
-            # inert by construction. They still refuse rather than being
-            # silently ignored: a screen that passes a reshaping flag believes
-            # it is tuning something, and a flag that reads as applied while
-            # doing nothing is how an arm ends up described wrongly in a
-            # writeup. Only flags whose shipped default is already inert appear
-            # here, so a plain naive run needs no extra arguments.
-            conflicting = [
-                name
-                for name, enabled in (
-                    ("typed_stream_retrieval", self.typed_stream_retrieval),
-                    ("agentic_traversal", self.agentic_traversal),
-                    ("state_part_refinement", self.state_part_refinement),
-                    ("neighbor_stitch_spread", self.neighbor_stitch_spread),
-                    ("neighbor_support_exempt", self.neighbor_support_exempt),
-                    ("neighbor_trajectory_preserving", self.neighbor_trajectory_preserving),
-                    ("source_evidence_bundling", self.source_evidence_bundling),
-                    ("state_part_completion_items", self.state_part_completion_items),
-                    ("neighbor_support_overflow_items", self.neighbor_support_overflow_items),
-                    ("semantic_prior_rescue_weight", self.semantic_prior_rescue_weight),
-                )
-                if enabled
-            ]
-            if conflicting:
-                msg = (
-                    "retrieval_mode=naive is the control arm and cannot run with "
-                    f"{', '.join(sorted(conflicting))}: disable them to race the arm"
-                )
-                raise ValueError(msg)
         self.typed_pool = _param_str(memory_params, "typed_pool", DEFAULT_TYPED_POOL)
         if self.typed_pool not in SUPPORTED_TYPED_POOLS:
             raise ValueError(f"typed_pool must be one of {sorted(SUPPORTED_TYPED_POOLS)}")
@@ -4566,7 +4585,7 @@ class SibylLiveApiMemory(Memory):
             "state_part_completion_items",
             DEFAULT_STATE_PART_COMPLETION_ITEMS,
         )
-        if getattr(self, "retrieval_mode", DEFAULT_RETRIEVAL_MODE) == "naive":
+        if getattr(self, "retrieval_mode", DEFAULT_RETRIEVAL_MODE) == NAIVE_RETRIEVAL_MODE:
             return self._render_naive_verbatim_context(query=query, results=results)
         assembled_results, assembly_metadata = assemble_context_results(
             results,

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -129,7 +129,11 @@ DEFAULT_EVIDENCE_COMPOSITION_MODE = "shared_relevance"
 EVIDENCE_COMPOSITION_MODES = frozenset({"reserved_support", "shared_relevance"})
 DEFAULT_SOURCE_EVIDENCE_BUNDLING = False
 DEFAULT_RETRIEVAL_MODE = "fast"
-RETRIEVAL_MODES = frozenset({"accurate", "fast"})
+# `naive` is the 1.3 Phase 0 control arm: BM25 plus dense KNN plus plain RRF
+# plus a tight pack, served with no traversal, synthesis, query planning, or
+# coverage ranking. It is a server-side mode, so selecting it here changes what
+# the pack and evidence come back holding, not how this adapter composes them.
+RETRIEVAL_MODES = frozenset({"accurate", "fast", "naive"})
 DEFAULT_TYPED_STREAM_RETRIEVAL = False
 DEFAULT_TYPED_STREAM_LIMIT = 8
 # The distilled-note lane, retrieved on its own request. It is not the raw
@@ -3448,6 +3452,27 @@ class SibylLiveApiMemory(Memory):
             "agentic_traversal",
             DEFAULT_AGENTIC_TRAVERSAL,
         )
+        if self.retrieval_mode == "naive":
+            # Both of these issue their own retrieval outside the arm: the typed
+            # stream makes a second pack request pinned to fast, and agentic
+            # traversal widens the pool with model-driven follow-up searches. A
+            # run carrying either would report the arm's name over a pool the
+            # arm did not produce, so the conflict fails loudly here rather than
+            # silently at read time.
+            conflicting = [
+                name
+                for name, enabled in (
+                    ("typed_stream_retrieval", self.typed_stream_retrieval),
+                    ("agentic_traversal", self.agentic_traversal),
+                )
+                if enabled
+            ]
+            if conflicting:
+                msg = (
+                    "retrieval_mode=naive is the control arm and cannot run with "
+                    f"{', '.join(sorted(conflicting))}: disable them to race the arm"
+                )
+                raise ValueError(msg)
         self.traversal_widening_rounds = _param_int(
             memory_params,
             "traversal_widening_rounds",

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -523,8 +523,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: PL
     parser.add_argument("--knn-type-overfetch", type=int, default=0)
     parser.add_argument(
         "--retrieval-mode",
-        choices=["fast", "accurate"],
+        choices=["fast", "accurate", "naive"],
         default="fast",
+        help=(
+            "Server-side retrieval pipeline. naive selects the 1.3 Phase 0 "
+            "control arm (BM25 + dense KNN + plain RRF + a tight pack); it "
+            "refuses to run beside --typed-stream-retrieval or "
+            "--agentic-traversal, both of which retrieve outside the arm."
+        ),
     )
     parser.add_argument("--retrieval-max-planned-queries", type=int, default=3)
     parser.add_argument(

--- a/docs/api/rest-memory.md
+++ b/docs/api/rest-memory.md
@@ -210,7 +210,7 @@ compilation:
 | `max_results_per_source`        | integer  | -             | In accurate mode, prefer source-diverse evidence first (1-50)   |
 | `content_max_chars`             | integer  | 500           | Maximum content characters per evidence result (0-50000)        |
 | `include_retrieval_diagnostics` | boolean  | false         | Include authorized evidence ranking diagnostics                 |
-| `retrieval_mode`                | string   | `fast`        | `fast` (one search) or `accurate` (deprecated, see below)       |
+| `retrieval_mode`                | string   | `fast`        | `fast` (one search), `accurate` (deprecated), `naive` (see below) |
 | `max_planned_queries`           | integer  | 3             | Maximum feedback searches across accurate-mode refinement (1-3) |
 | `reserve_distilled_notes`       | boolean  | true          | Reserve a typed lane for distilled operational notes            |
 
@@ -219,6 +219,14 @@ returned lower accuracy than `fast` at 2.5x the latency, so it is scheduled for 
 selecting it are still served; the server logs a deprecation warning and the evidence response
 carries a `retrieval_mode_deprecated` filter naming the replacement. Use `fast`, the default, which
 also makes `max_results_per_source` and `max_planned_queries` irrelevant. :::
+
+::: warning `retrieval_mode=naive` is an experiment, not a product mode Selecting `naive` swaps the
+whole pack onto the naive-strong control arm: BM25 fulltext plus dense KNN, fused with plain
+reciprocal-rank fusion, packed to `char_budget` with no synthesis, no graph traversal, no query
+planning, and no coverage ranking. It exists to measure what the full retrieval pipeline is worth
+and carries no compatibility promise. The mode governs the pack's own sections as well as the
+evidence block, suppresses the related-item walk, and forces `reserve_distilled_notes` off. Evidence
+responses stamp `retrieval_arm: naive`. :::
 
 The response is a context pack with `sections`, `total_items`, `usage_metadata`, `usage_hint`, and a
 rendered `markdown` field. When evidence retrieval was requested, the response also carries an

--- a/docs/api/rest-memory.md
+++ b/docs/api/rest-memory.md
@@ -203,16 +203,16 @@ Compiles a structured context pack for an agent goal. This is the REST equivalen
 Setting the optional `evidence` object runs an enhanced source-evidence search alongside context
 compilation:
 
-| Field                           | Type     | Default       | Description                                                     |
-| ------------------------------- | -------- | ------------- | --------------------------------------------------------------- |
-| `types`                         | string[] | `["session"]` | Entity types to include in the evidence pool                    |
-| `limit`                         | integer  | 24            | Maximum evidence results (1-50)                                 |
-| `max_results_per_source`        | integer  | -             | In accurate mode, prefer source-diverse evidence first (1-50)   |
-| `content_max_chars`             | integer  | 500           | Maximum content characters per evidence result (0-50000)        |
-| `include_retrieval_diagnostics` | boolean  | false         | Include authorized evidence ranking diagnostics                 |
+| Field                           | Type     | Default       | Description                                                       |
+| ------------------------------- | -------- | ------------- | ----------------------------------------------------------------- |
+| `types`                         | string[] | `["session"]` | Entity types to include in the evidence pool                      |
+| `limit`                         | integer  | 24            | Maximum evidence results (1-50)                                   |
+| `max_results_per_source`        | integer  | -             | In accurate mode, prefer source-diverse evidence first (1-50)     |
+| `content_max_chars`             | integer  | 500           | Maximum content characters per evidence result (0-50000)          |
+| `include_retrieval_diagnostics` | boolean  | false         | Include authorized evidence ranking diagnostics                   |
 | `retrieval_mode`                | string   | `fast`        | `fast` (one search), `accurate` (deprecated), `naive` (see below) |
-| `max_planned_queries`           | integer  | 3             | Maximum feedback searches across accurate-mode refinement (1-3) |
-| `reserve_distilled_notes`       | boolean  | true          | Reserve a typed lane for distilled operational notes            |
+| `max_planned_queries`           | integer  | 3             | Maximum feedback searches across accurate-mode refinement (1-3)   |
+| `reserve_distilled_notes`       | boolean  | true          | Reserve a typed lane for distilled operational notes              |
 
 ::: warning `retrieval_mode=accurate` is deprecated Measured at full benchmark scale, accurate mode
 returned lower accuracy than `fast` at 2.5x the latency, so it is scheduled for removal. Requests

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/__init__.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/__init__.py
@@ -73,9 +73,23 @@ _SEARCH_EXPORTS = {
     "build_context_retrieval_plan",
     "context_search",
 }
+# The naive arm imports the search module's lane readers, so it inherits the
+# same deferred-import treatment: naming it here must not drag the retrieval
+# planner into every importer of this package.
+_NAIVE_EXPORTS = {
+    "NAIVE_RETRIEVAL_MODE",
+    "NAIVE_RRF_K",
+    "NaiveSignal",
+    "fuse_naive_candidates",
+    "naive_retrieval_plan",
+    "naive_search",
+    "pack_naive_results",
+}
 
 __all__ = [
     "DEFAULT_FILTER_SELECTIVITY_THRESHOLD",
+    "NAIVE_RETRIEVAL_MODE",
+    "NAIVE_RRF_K",
     "CandidateKind",
     "CandidateLimits",
     "CandidateScope",
@@ -90,6 +104,7 @@ __all__ = [
     "FusionConfig",
     "HybridConfig",
     "HybridResult",
+    "NaiveSignal",
     "RerankResult",
     "RetrievalCandidate",
     "RetrievalPlan",
@@ -107,10 +122,14 @@ __all__ = [
     "cross_encoder_rerank",
     "find_duplicates",
     "fit_feature_weighted_reranker",
+    "fuse_naive_candidates",
     "get_deduplicator",
     "get_entity_decay_timestamp",
     "hybrid_search",
     "merge_candidate_signals",
+    "naive_retrieval_plan",
+    "naive_search",
+    "pack_naive_results",
     "rerank_by_feature_weights",
     "rerank_results",
     "rrf_merge",
@@ -127,6 +146,11 @@ def __getattr__(name: str) -> object:
     if name in _SEARCH_EXPORTS:
         search = import_module("sibyl_core.retrieval.search")
         value = getattr(search, name)
+        globals()[name] = value
+        return value
+    if name in _NAIVE_EXPORTS:
+        naive = import_module("sibyl_core.retrieval.naive")
+        value = getattr(naive, name)
         globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py
@@ -1,0 +1,330 @@
+"""Naive-strong retrieval arm: the control the 8-lane machine is raced against.
+
+The arm exists to measure what the machine's extra lanes and its ranking layer
+are worth. It is deliberately the smallest pipeline that can still be strong:
+BM25 fulltext over the verbatim-span corpus, dense KNN over the same rows,
+plain reciprocal-rank fusion, and a tight character-budgeted pack. Nothing
+else. No graph expansion, no exact-key probe, no edge lanes, no query planning,
+no coverage re-rank, no fact frames, no temporal or freshness or project or
+active-task boosts, no synthesis.
+
+Every knob the machine tunes is a knob this arm refuses, so the constant below
+is the arm's only parameter and it stays at the RRF paper's default. If the arm
+wins, the deleted surface was not carrying the accuracy; if it loses, the loss
+localizes what the machine's remaining lanes actually buy. Adding a weight here
+would destroy that reading, because a tuned control measures nothing.
+
+The lane readers are imported from ``retrieval.search`` rather than reimplemented
+so the race compares fusion and pack shape, not two different spellings of the
+same SurrealDB read: whatever the analyzers and indexes do for the machine's
+BM25 lane, they do identically here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from sibyl_core.retrieval.candidates import RetrievalCandidate, VectorCandidateFetch
+from sibyl_core.retrieval.fusion import rrf_merge_with_metadata
+from sibyl_core.retrieval.search import (
+    MAX_RETRIEVAL_LIMIT,
+    RetrievalPlan,
+    RetrievalSignal,
+    _candidate_allowed,
+    _candidate_limits_for_limit,
+    _candidate_source_metadata,
+    _candidate_source_result,
+    _elapsed_ms,
+    _empty_candidate_source,
+    _episode_fulltext_candidates,
+    _episode_sources_allowed,
+    _get_read_only_graph_runtime,
+    _node_fulltext_candidates,
+    _node_sources_allowed,
+    _search_filter_for_plan,
+    _search_result_from_candidate,
+    _vector_candidate_sources_detailed,
+)
+
+if TYPE_CHECKING:
+    from sibyl_core.embeddings.providers import EmbeddingProvider
+    from sibyl_core.models.context import ContextFacet
+    from sibyl_core.tools.responses import SearchResponse, SearchResult
+
+log = structlog.get_logger()
+
+# The RRF paper's default, and the arm's only tunable. It is stated once, as a
+# constant rather than a parameter, because a per-request k would reintroduce
+# exactly the hand-weighting the arm is built to do without.
+NAIVE_RRF_K = 60.0
+
+NAIVE_RETRIEVAL_MODE = "naive"
+
+
+class NaiveSignal(StrEnum):
+    """The two lanes the arm runs, named to match the machine's own signals.
+
+    Sharing the machine's vocabulary keeps the receipts comparable: a fused
+    result from either pipeline reports ``retrieval_signals`` drawn from the
+    same namespace, so a screen can diff lane membership across arms without a
+    translation table.
+    """
+
+    LEXICAL = RetrievalSignal.NODE_FULLTEXT.value
+    EPISODE_LEXICAL = RetrievalSignal.EPISODE_FULLTEXT.value
+    DENSE = RetrievalSignal.NODE_VECTOR.value
+
+
+_NAIVE_PLAN_SIGNALS: tuple[RetrievalSignal, ...] = (
+    RetrievalSignal.NODE_FULLTEXT,
+    RetrievalSignal.EPISODE_FULLTEXT,
+    RetrievalSignal.NODE_VECTOR,
+)
+
+
+def naive_retrieval_plan(plan: RetrievalPlan) -> RetrievalPlan:
+    """Strip a context plan down to the lanes the arm runs.
+
+    The scope, project authorization, and facet fields are carried through
+    untouched: the arm deletes ranking surface, never access control.
+    """
+
+    return replace(plan, signals=_NAIVE_PLAN_SIGNALS)
+
+
+async def naive_search(
+    *,
+    plan: RetrievalPlan,
+    types: Sequence[str] | None = None,
+    facet: ContextFacet | None = None,
+    limit: int = 10,
+    include_content: bool = True,
+    embedding_provider: EmbeddingProvider | None = None,
+    char_budget: int | None = None,
+) -> SearchResponse:
+    """Retrieve with BM25 + dense KNN + plain RRF + a tight pack, and nothing else."""
+
+    from sibyl_core.tools.responses import SearchResponse
+
+    search_started_at = time.perf_counter()
+    stage_timings_ms: dict[str, float] = {}
+    stage_started_at = time.perf_counter()
+
+    limit = max(1, min(limit, MAX_RETRIEVAL_LIMIT))
+    search_plan = naive_retrieval_plan(
+        replace(
+            plan,
+            candidate_limits=_candidate_limits_for_limit(plan.candidate_limits, limit),
+        )
+    )
+    runtime = await _get_read_only_graph_runtime(search_plan.organization_id)
+    client = runtime.client
+    requested_types = {value.lower() for value in types or ()}
+    search_filter = _search_filter_for_plan(search_plan, requested_types=requested_types)
+    node_sources_allowed = _node_sources_allowed(requested_types)
+    episode_sources_allowed = _episode_sources_allowed(requested_types)
+    stage_timings_ms["runtime_setup"] = _elapsed_ms(stage_started_at)
+
+    stage_started_at = time.perf_counter()
+    lexical_tasks = (
+        (
+            RetrievalSignal.NODE_FULLTEXT,
+            _node_fulltext_candidates(
+                client=client,
+                plan=search_plan,
+                search_filter=search_filter,
+                limit=search_plan.candidate_limits.node_fulltext,
+            )
+            if node_sources_allowed
+            else _empty_candidate_source(),
+        ),
+        (
+            RetrievalSignal.EPISODE_FULLTEXT,
+            _episode_fulltext_candidates(
+                client=client,
+                plan=search_plan,
+                search_filter=search_filter,
+                limit=search_plan.candidate_limits.episode_fulltext,
+            )
+            if episode_sources_allowed
+            else _empty_candidate_source(),
+        ),
+    )
+    vector_plan = replace(
+        search_plan,
+        signals=(RetrievalSignal.NODE_VECTOR,) if node_sources_allowed else (),
+    )
+    lexical_gathered, vector_fetch = await asyncio.gather(
+        asyncio.gather(*(task for _signal, task in lexical_tasks), return_exceptions=True),
+        _vector_candidate_sources_detailed(
+            client=client,
+            plan=vector_plan,
+            search_filter=search_filter,
+            embedding_provider=embedding_provider,
+            # A lane that raises degrades the arm to its other lane rather than
+            # failing the request, matching how the machine treats a dead lane.
+        ),
+        return_exceptions=True,
+    )
+    lexical_sources = [
+        _candidate_source_result(signal.value, result)
+        for (signal, _task), result in zip(
+            lexical_tasks,
+            lexical_gathered if isinstance(lexical_gathered, list) else [None, None],
+            strict=True,
+        )
+    ]
+    vector_metadata: dict[str, object] = {}
+    vector_candidates: list[RetrievalCandidate] = []
+    if isinstance(vector_fetch, VectorCandidateFetch):
+        vector_candidates = list(vector_fetch.node_candidates)
+        vector_metadata = dict(vector_fetch.as_metadata())
+        vector_source = _candidate_source_result(
+            RetrievalSignal.NODE_VECTOR.value,
+            vector_candidates,
+        )
+    else:
+        log.warning(
+            "naive_retrieval_vector_source_failed",
+            error_type=type(vector_fetch).__name__,
+        )
+        vector_source = _candidate_source_result(RetrievalSignal.NODE_VECTOR.value, vector_fetch)
+    stage_timings_ms["candidates"] = _elapsed_ms(stage_started_at)
+
+    stage_started_at = time.perf_counter()
+    source_lists: list[tuple[RetrievalSignal, list[RetrievalCandidate]]] = [
+        (RetrievalSignal.NODE_FULLTEXT, list(lexical_sources[0].candidates)),
+        (RetrievalSignal.EPISODE_FULLTEXT, list(lexical_sources[1].candidates)),
+        (RetrievalSignal.NODE_VECTOR, vector_candidates),
+    ]
+    filtered_lists = [
+        (
+            signal,
+            [
+                candidate
+                for candidate in candidates
+                if _candidate_allowed(
+                    candidate,
+                    plan=search_plan,
+                    requested_types=requested_types,
+                    facet=facet,
+                )
+            ],
+        )
+        for signal, candidates in source_lists
+    ]
+    stage_timings_ms["candidate_filtering"] = _elapsed_ms(stage_started_at)
+
+    stage_started_at = time.perf_counter()
+    fused = fuse_naive_candidates(filtered_lists, limit=limit)
+    stage_timings_ms["fusion"] = _elapsed_ms(stage_started_at)
+
+    stage_started_at = time.perf_counter()
+    results, pack_receipt = pack_naive_results(
+        fused,
+        include_content=include_content,
+        char_budget=char_budget,
+    )
+    stage_timings_ms["pack"] = _elapsed_ms(stage_started_at)
+    stage_timings_ms["total"] = _elapsed_ms(search_started_at)
+
+    return SearchResponse(
+        results=results,
+        total=len(results),
+        query=plan.query,
+        filters={
+            "types": list(types) if types else None,
+            "project": search_plan.project,
+            "retrieval_mode": NAIVE_RETRIEVAL_MODE,
+            "retrieval_arm": NAIVE_RETRIEVAL_MODE,
+            "fusion_backend": "python_rrf",
+            "naive_rrf_k": NAIVE_RRF_K,
+            "naive_lanes": [signal.value for signal, _candidates in filtered_lists],
+            "naive_lane_counts": {
+                signal.value: len(candidates) for signal, candidates in filtered_lists
+            },
+            **_candidate_source_metadata([*lexical_sources, vector_source]),
+            **vector_metadata,
+            **pack_receipt,
+            "stage_timings_ms": stage_timings_ms,
+        },
+        graph_count=len([result for result in results if result.result_origin == "graph"]),
+        document_count=0,
+        limit=limit,
+    )
+
+
+def fuse_naive_candidates(
+    source_lists: Sequence[tuple[RetrievalSignal, Sequence[RetrievalCandidate]]],
+    *,
+    limit: int,
+    k: float = NAIVE_RRF_K,
+) -> list[tuple[RetrievalCandidate, float, dict[str, Any]]]:
+    """Plain reciprocal-rank fusion: no weights, no boosts, no re-rank.
+
+    A candidate's fused score is the sum of ``1 / (k + rank)`` over the lanes
+    that returned it, and the lane's own score never enters. That is the whole
+    ranking function.
+    """
+
+    ranked_lists = [
+        [(candidate, candidate.score) for candidate in candidates]
+        for _signal, candidates in source_lists
+    ]
+    fused = rrf_merge_with_metadata(
+        ranked_lists,
+        list_names=[signal.value for signal, _candidates in source_lists],
+        k=k,
+        dedup_key=lambda candidate: candidate.id,
+        limit=limit,
+    )
+    for _candidate, _score, metadata in fused:
+        metadata["fusion_backend"] = "python_rrf"
+    return fused
+
+
+def pack_naive_results(
+    fused: Sequence[tuple[RetrievalCandidate, float, Mapping[str, Any]]],
+    *,
+    include_content: bool,
+    char_budget: int | None,
+) -> tuple[list[SearchResult], dict[str, object]]:
+    """Take fused results in rank order until the character budget is spent.
+
+    Tight means tight: the first item that would cross the budget ends the pack
+    rather than being truncated, so every item the reader sees is a whole span.
+    A single item wider than the whole budget is still admitted, because an
+    empty pack answers nothing.
+    """
+
+    results: list[SearchResult] = []
+    spent = 0
+    stopped_on_budget = False
+    for candidate, score, metadata in fused:
+        result = _search_result_from_candidate(
+            candidate,
+            score=score,
+            fusion_metadata=metadata,
+            include_content=include_content,
+        )
+        cost = len(result.content or "")
+        if char_budget is not None and results and spent + cost > char_budget:
+            stopped_on_budget = True
+            break
+        results.append(result)
+        spent += cost
+    receipt: dict[str, object] = {
+        "naive_pack_char_budget": char_budget,
+        "naive_pack_chars_used": spent,
+        "naive_pack_item_count": len(results),
+        "naive_pack_candidate_count": len(fused),
+        "naive_pack_budget_exhausted": stopped_on_budget,
+    }
+    return results, receipt

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py
@@ -108,16 +108,24 @@ async def naive_search(
     include_content: bool = True,
     embedding_provider: EmbeddingProvider | None = None,
     char_budget: int | None = None,
+    content_max_chars: int | None = None,
 ) -> SearchResponse:
     """Retrieve with BM25 + dense KNN + plain RRF + a tight pack, and nothing else."""
 
     from sibyl_core.tools.responses import SearchResponse
+    from sibyl_core.tools.search import MAX_SEARCH_CONTENT_MAX_CHARS
 
     search_started_at = time.perf_counter()
     stage_timings_ms: dict[str, float] = {}
     stage_started_at = time.perf_counter()
 
     limit = max(1, min(limit, MAX_RETRIEVAL_LIMIT))
+    # Clamped exactly as the enhanced path clamps it, so an item costs the arm
+    # the same characters it would cost the machine. Without this the arm packs
+    # untruncated spans against a budget the machine spends truncated ones on,
+    # and the race compares payload sizes instead of retrieval.
+    if content_max_chars is not None:
+        content_max_chars = max(0, min(int(content_max_chars), MAX_SEARCH_CONTENT_MAX_CHARS))
     search_plan = naive_retrieval_plan(
         replace(
             plan,
@@ -231,6 +239,7 @@ async def naive_search(
         fused,
         include_content=include_content,
         char_budget=char_budget,
+        content_max_chars=content_max_chars,
     )
     stage_timings_ms["pack"] = _elapsed_ms(stage_started_at)
     stage_timings_ms["total"] = _elapsed_ms(search_started_at)
@@ -295,6 +304,7 @@ def pack_naive_results(
     *,
     include_content: bool,
     char_budget: int | None,
+    content_max_chars: int | None = None,
 ) -> tuple[list[SearchResult], dict[str, object]]:
     """Take fused results in rank order until the character budget is spent.
 
@@ -302,6 +312,10 @@ def pack_naive_results(
     rather than being truncated, so every item the reader sees is a whole span.
     A single item wider than the whole budget is still admitted, because an
     empty pack answers nothing.
+
+    `content_max_chars` caps a single item the way the enhanced path caps it,
+    and it is applied before the budget is charged so an item costs the arm what
+    the same item costs the machine.
     """
 
     results: list[SearchResult] = []
@@ -314,6 +328,8 @@ def pack_naive_results(
             fusion_metadata=metadata,
             include_content=include_content,
         )
+        if content_max_chars is not None and result.content:
+            result.content = result.content[:content_max_chars]
         cost = len(result.content or "")
         if char_budget is not None and results and spent + cost > char_budget:
             stopped_on_budget = True
@@ -326,5 +342,6 @@ def pack_naive_results(
         "naive_pack_item_count": len(results),
         "naive_pack_candidate_count": len(fused),
         "naive_pack_budget_exhausted": stopped_on_budget,
+        "content_max_chars": content_max_chars,
     }
     return results, receipt

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py
@@ -8,11 +8,13 @@ else. No graph expansion, no exact-key probe, no edge lanes, no query planning,
 no coverage re-rank, no fact frames, no temporal or freshness or project or
 active-task boosts, no synthesis.
 
-Every knob the machine tunes is a knob this arm refuses, so the constant below
-is the arm's only parameter and it stays at the RRF paper's default. If the arm
-wins, the deleted surface was not carrying the accuracy; if it loses, the loss
-localizes what the machine's remaining lanes actually buy. Adding a weight here
-would destroy that reading, because a tuned control measures nothing.
+Every ranking knob the machine tunes is a knob this arm refuses. Its fusion
+constant stays at the RRF paper's default and no caller can override it, and
+the only other constant sets how deep a lane reads, which changes what fusion
+is allowed to see rather than how fusion scores it. If the arm wins, the
+deleted surface was not carrying the accuracy; if it loses, the loss localizes
+what the machine's remaining lanes actually buy. Adding a weight here would
+destroy that reading, because a tuned control measures nothing.
 
 The lane readers are imported from ``retrieval.search`` rather than reimplemented
 so the race compares fusion and pack shape, not two different spellings of the
@@ -38,7 +40,6 @@ from sibyl_core.retrieval.search import (
     RetrievalPlan,
     RetrievalSignal,
     _candidate_allowed,
-    _candidate_limits_for_limit,
     _candidate_source_metadata,
     _candidate_source_result,
     _elapsed_ms,
@@ -64,6 +65,11 @@ log = structlog.get_logger()
 # constant rather than a parameter, because a per-request k would reintroduce
 # exactly the hand-weighting the arm is built to do without.
 NAIVE_RRF_K = 60.0
+
+# How much deeper than the answer each lane reads before fusion. Not a ranking
+# weight: it cannot reorder anything, it only stops fusion from being handed a
+# pool the caller's limit already truncated.
+NAIVE_LANE_OVERFETCH = 4
 
 NAIVE_RETRIEVAL_MODE = "naive"
 
@@ -126,10 +132,23 @@ async def naive_search(
     # and the race compares payload sizes instead of retrieval.
     if content_max_chars is not None:
         content_max_chars = max(0, min(int(content_max_chars), MAX_SEARCH_CONTENT_MAX_CHARS))
+    # Lanes read deeper than the answer, then fusion truncates. Clipping each
+    # lane to the caller's limit first is what makes fusion decorative at small
+    # limits: with limit=1 a row ranked second in both lanes, which is the row
+    # RRF exists to promote, is discarded before RRF ever sees it. The depth is
+    # bounded so a wide request cannot walk the whole table, and it is set on
+    # the three lanes directly rather than through the narrowing helper, which
+    # can only shrink a plan's budget and so could never widen a lane at all.
+    lane_depth = min(limit * NAIVE_LANE_OVERFETCH, MAX_RETRIEVAL_LIMIT)
     search_plan = naive_retrieval_plan(
         replace(
             plan,
-            candidate_limits=_candidate_limits_for_limit(plan.candidate_limits, limit),
+            candidate_limits=replace(
+                plan.candidate_limits,
+                node_fulltext=lane_depth,
+                episode_fulltext=lane_depth,
+                node_vector=lane_depth,
+            ),
         )
     )
     runtime = await _get_read_only_graph_runtime(search_plan.organization_id)
@@ -189,11 +208,11 @@ async def naive_search(
             strict=True,
         )
     ]
-    vector_metadata: dict[str, object] = {}
+    vector_fetch_state: VectorCandidateFetch | None = None
     vector_candidates: list[RetrievalCandidate] = []
     if isinstance(vector_fetch, VectorCandidateFetch):
+        vector_fetch_state = vector_fetch
         vector_candidates = list(vector_fetch.node_candidates)
-        vector_metadata = dict(vector_fetch.as_metadata())
         vector_source = _candidate_source_result(
             RetrievalSignal.NODE_VECTOR.value,
             vector_candidates,
@@ -228,6 +247,24 @@ async def naive_search(
         )
         for signal, candidates in source_lists
     ]
+    # Recomputed from the authorized rows, never snapshotted from the raw fetch.
+    # A count taken before the scope filter answers "does a row matching this
+    # query exist in this organization" for a caller who may read none of them,
+    # which is an existence oracle over private memories: empty results beside a
+    # non-zero candidate count is the leak. The response contract promises
+    # authorized diagnostics, so the diagnostics have to be built from the
+    # authorized set.
+    authorized_vector_count = len(
+        next(
+            (
+                candidates
+                for signal, candidates in filtered_lists
+                if signal is RetrievalSignal.NODE_VECTOR
+            ),
+            [],
+        )
+    )
+    vector_metadata = _authorized_vector_metadata(vector_fetch_state, authorized_vector_count)
     stage_timings_ms["candidate_filtering"] = _elapsed_ms(stage_started_at)
 
     stage_started_at = time.perf_counter()
@@ -270,6 +307,54 @@ async def naive_search(
     )
 
 
+def _authorized_vector_metadata(
+    fetch: VectorCandidateFetch | None,
+    authorized_count: int,
+) -> dict[str, object]:
+    """Vector-lane diagnostics describing only what this caller may read.
+
+    Health fields (requested, attempted, degraded, failures) describe the arm's
+    own execution and carry no row information, so they pass through. The count
+    and the status are rebuilt, because both are derived from the raw candidate
+    list and would otherwise report rows the caller was denied.
+    """
+
+    if fetch is None:
+        return {
+            "vector_status": "query_failed",
+            "vector_requested": True,
+            "vector_attempted": True,
+            "vector_degraded": True,
+            "vector_candidate_count": 0,
+        }
+    if not fetch.requested:
+        status = "not_requested"
+    elif fetch.reason is not None:
+        status = fetch.reason
+    elif fetch.failures and authorized_count:
+        status = "partial"
+    elif fetch.failures:
+        status = "query_failed"
+    elif not fetch.attempted:
+        status = "unavailable"
+    elif authorized_count == 0:
+        # "empty" whether the lane found nothing or found only rows this caller
+        # cannot read. Those two must be indistinguishable from outside.
+        status = "empty"
+    else:
+        status = "ok"
+    metadata: dict[str, object] = {
+        "vector_status": status,
+        "vector_requested": fetch.requested,
+        "vector_attempted": fetch.attempted,
+        "vector_degraded": fetch.degraded,
+        "vector_candidate_count": authorized_count,
+    }
+    if fetch.failures:
+        metadata["vector_failures"] = list(fetch.failures)
+    return metadata
+
+
 def fuse_naive_candidates(
     source_lists: Sequence[tuple[RetrievalSignal, Sequence[RetrievalCandidate]]],
     *,
@@ -281,22 +366,32 @@ def fuse_naive_candidates(
     A candidate's fused score is the sum of ``1 / (k + rank)`` over the lanes
     that returned it, and the lane's own score never enters. That is the whole
     ranking function.
+
+    Ties break on candidate id, ascending. RRF produces exact ties routinely
+    (two rows each returned at rank one by a different lane score identically),
+    and the shared merge helper sorts on score alone, so a tie would otherwise
+    resolve by the order the lanes happen to be passed in. That is a silent
+    lexical-lane priority: a real ranking preference, never declared, applied
+    only at a binding cutoff. Ordering by id instead is arbitrary but stated,
+    reproducible across runs, and independent of lane order.
     """
 
     ranked_lists = [
         [(candidate, candidate.score) for candidate in candidates]
         for _signal, candidates in source_lists
     ]
+    # Fused unlimited, then ordered, then truncated: truncating inside the
+    # helper would apply its lane-order tie-break before this one could run.
     fused = rrf_merge_with_metadata(
         ranked_lists,
         list_names=[signal.value for signal, _candidates in source_lists],
         k=k,
         dedup_key=lambda candidate: candidate.id,
-        limit=limit,
     )
+    fused.sort(key=lambda item: (-item[1], item[0].id))
     for _candidate, _score, metadata in fused:
         metadata["fusion_backend"] = "python_rrf"
-    return fused
+    return fused[:limit] if limit else fused
 
 
 def pack_naive_results(

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py
@@ -66,11 +66,6 @@ log = structlog.get_logger()
 # exactly the hand-weighting the arm is built to do without.
 NAIVE_RRF_K = 60.0
 
-# How much deeper than the answer each lane reads before fusion. Not a ranking
-# weight: it cannot reorder anything, it only stops fusion from being handed a
-# pool the caller's limit already truncated.
-NAIVE_LANE_OVERFETCH = 4
-
 NAIVE_RETRIEVAL_MODE = "naive"
 
 
@@ -132,14 +127,15 @@ async def naive_search(
     # and the race compares payload sizes instead of retrieval.
     if content_max_chars is not None:
         content_max_chars = max(0, min(int(content_max_chars), MAX_SEARCH_CONTENT_MAX_CHARS))
-    # Lanes read deeper than the answer, then fusion truncates. Clipping each
-    # lane to the caller's limit first is what makes fusion decorative at small
-    # limits: with limit=1 a row ranked second in both lanes, which is the row
-    # RRF exists to promote, is discarded before RRF ever sees it. The depth is
-    # bounded so a wide request cannot walk the whole table, and it is set on
-    # the three lanes directly rather than through the narrowing helper, which
-    # can only shrink a plan's budget and so could never widen a lane at all.
-    lane_depth = min(limit * NAIVE_LANE_OVERFETCH, MAX_RETRIEVAL_LIMIT)
+    # Every lane reads to the ceiling, whatever the caller asked for. A depth
+    # scaled off the limit leaves a boundary class alive: at the default limit
+    # of 12 a four-times pool stops at 48, so a row ranked 49 in both lanes
+    # still outscores a single lane's rank one and is still clipped before
+    # fusion sees it. Fifty rows per lane is cheap, kills that class outright,
+    # and removes a number somebody would otherwise be tempted to tune. The
+    # depth is set on the three lanes directly rather than through the
+    # narrowing helper, which can only shrink a plan's budget.
+    lane_depth = MAX_RETRIEVAL_LIMIT
     search_plan = naive_retrieval_plan(
         replace(
             plan,
@@ -188,41 +184,44 @@ async def naive_search(
         search_plan,
         signals=(RetrievalSignal.NODE_VECTOR,) if node_sources_allowed else (),
     )
+    # No return_exceptions here, deliberately. The machine degrades to its
+    # surviving lanes because a partial answer beats none for a user. The arm is
+    # not answering a user, it is producing a measurement, and a run whose
+    # lexical lane died returns a thin pack that the benchmark scores as a
+    # recall miss rather than an error. That silently attributes an outage to
+    # the arm's ranking. A failed data point can be excluded and rerun; a
+    # degraded one that looks healthy cannot be found later.
     lexical_gathered, vector_fetch = await asyncio.gather(
-        asyncio.gather(*(task for _signal, task in lexical_tasks), return_exceptions=True),
+        asyncio.gather(*(task for _signal, task in lexical_tasks)),
         _vector_candidate_sources_detailed(
             client=client,
             plan=vector_plan,
             search_filter=search_filter,
             embedding_provider=embedding_provider,
-            # A lane that raises degrades the arm to its other lane rather than
-            # failing the request, matching how the machine treats a dead lane.
         ),
-        return_exceptions=True,
     )
     lexical_sources = [
         _candidate_source_result(signal.value, result)
-        for (signal, _task), result in zip(
-            lexical_tasks,
-            lexical_gathered if isinstance(lexical_gathered, list) else [None, None],
-            strict=True,
-        )
+        for (signal, _task), result in zip(lexical_tasks, lexical_gathered, strict=True)
     ]
-    vector_fetch_state: VectorCandidateFetch | None = None
-    vector_candidates: list[RetrievalCandidate] = []
-    if isinstance(vector_fetch, VectorCandidateFetch):
-        vector_fetch_state = vector_fetch
-        vector_candidates = list(vector_fetch.node_candidates)
-        vector_source = _candidate_source_result(
-            RetrievalSignal.NODE_VECTOR.value,
-            vector_candidates,
+    # A lane that came back degraded rather than raising is still a lane that
+    # did not run, so it fails the request for the same reason.
+    if vector_fetch.failures or vector_fetch.reason:
+        msg = (
+            "naive retrieval vector lane degraded "
+            f"(reason={vector_fetch.reason!r}, failures={list(vector_fetch.failures)})"
         )
-    else:
-        log.warning(
-            "naive_retrieval_vector_source_failed",
-            error_type=type(vector_fetch).__name__,
-        )
-        vector_source = _candidate_source_result(RetrievalSignal.NODE_VECTOR.value, vector_fetch)
+        raise RuntimeError(msg)
+    degraded_lexical = [source.source for source in lexical_sources if source.failure is not None]
+    if degraded_lexical:
+        msg = f"naive retrieval lexical lanes degraded: {', '.join(sorted(degraded_lexical))}"
+        raise RuntimeError(msg)
+    vector_fetch_state: VectorCandidateFetch | None = vector_fetch
+    vector_candidates = list(vector_fetch.node_candidates)
+    vector_source = _candidate_source_result(
+        RetrievalSignal.NODE_VECTOR.value,
+        vector_candidates,
+    )
     stage_timings_ms["candidates"] = _elapsed_ms(stage_started_at)
 
     stage_started_at = time.perf_counter()
@@ -280,6 +279,19 @@ async def naive_search(
     )
     stage_timings_ms["pack"] = _elapsed_ms(stage_started_at)
     stage_timings_ms["total"] = _elapsed_ms(search_started_at)
+    # Logged, never returned. Per-stage durations are measured across the
+    # candidate fetch, which runs before the scope filter, so a caller who may
+    # read none of the matches can still tell "nothing matched" from "matches
+    # exist but are not yours" by timing repeated queries. The counts were
+    # rebuilt from the authorized set for exactly that reason and the clock
+    # would have put the same signal back. Constant-time stages are not
+    # achievable here, so the honest fix is not to publish them.
+    log.info(
+        "naive_retrieval_complete",
+        organization_id=search_plan.organization_id,
+        result_count=len(results),
+        stage_timings_ms=stage_timings_ms,
+    )
 
     return SearchResponse(
         results=results,
@@ -299,7 +311,6 @@ async def naive_search(
             **_candidate_source_metadata([*lexical_sources, vector_source]),
             **vector_metadata,
             **pack_receipt,
-            "stage_timings_ms": stage_timings_ms,
         },
         graph_count=len([result for result in results if result.result_origin == "graph"]),
         document_count=0,

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -1484,17 +1484,31 @@ async def _compile_native_sections(
     per_facet_limit: int,
     raw_memory_recall_fn: RawMemoryRecallFn,
     audit: bool = False,
+    naive_retrieval: bool = False,
 ) -> list[ContextSection]:
     search_limit = min(50, max(limit, per_facet_limit * len(facets)))
-    response = await context_search(
-        plan=plan,
-        types=_types_for_facets(facets),
-        facet=ContextFacet.RECENT_MEMORY if ContextFacet.RECENT_MEMORY in facets else None,
-        limit=search_limit,
-        include_content=True,
-        embedding_provider=configured_embedding_provider(),
-        raw_memory_recall_fn=raw_memory_recall_fn,
-    )
+    facet = ContextFacet.RECENT_MEMORY if ContextFacet.RECENT_MEMORY in facets else None
+    if naive_retrieval:
+        from sibyl_core.retrieval.naive import naive_search
+
+        response = await naive_search(
+            plan=plan,
+            types=_types_for_facets(facets),
+            facet=facet,
+            limit=search_limit,
+            include_content=True,
+            embedding_provider=configured_embedding_provider(),
+        )
+    else:
+        response = await context_search(
+            plan=plan,
+            types=_types_for_facets(facets),
+            facet=facet,
+            limit=search_limit,
+            include_content=True,
+            embedding_provider=configured_embedding_provider(),
+            raw_memory_recall_fn=raw_memory_recall_fn,
+        )
     return _sections_from_response(response, facets=facets, audit=audit)
 
 
@@ -1521,8 +1535,14 @@ async def compile_context(
     allowed_memory_scope_keys: set[str] | None = None,
     record_exposure: bool = True,
     knn_type_overfetch: int = 0,
+    naive_retrieval: bool = False,
 ) -> ContextPack:
-    """Build a small, structured context pack for an agent goal."""
+    """Build a small, structured context pack for an agent goal.
+
+    `naive_retrieval` swaps the 8-lane retrieval for the naive-strong control
+    arm and drops the one-hop related-item walk, so a pack compiled under the
+    arm carries no graph traversal at all. It is off unless a caller selects it.
+    """
 
     goal = goal.strip()
     if not goal:
@@ -1562,6 +1582,7 @@ async def compile_context(
             per_facet_limit=per_facet_limit,
             raw_memory_recall_fn=raw_memory_recall_fn,
             audit=audit,
+            naive_retrieval=naive_retrieval,
         )
     except Exception as exc:
         retrieval_failed = True
@@ -1618,7 +1639,9 @@ async def compile_context(
             limit,
             per_facet_limit=per_facet_limit,
         )
-    if include_related and normalized_layer is not ContextLayer.WAKE:
+    # Related items are a one-hop graph walk, which is exactly the surface the
+    # naive arm exists to measure the absence of.
+    if include_related and not naive_retrieval and normalized_layer is not ContextLayer.WAKE:
         related_projects = (
             set(plan.accessible_projects) if plan.accessible_projects is not None else None
         )

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -1585,6 +1585,19 @@ async def compile_context(
             naive_retrieval=naive_retrieval,
         )
     except Exception as exc:
+        if naive_retrieval:
+            # The machine is the arm's fallback everywhere else in this
+            # function, which under the arm means a failed naive run returns
+            # eight-lane contents wearing the arm's label. A race whose labels
+            # can be wrong measures nothing, and a degraded arm silently
+            # scoring the machine's recall is the worst version of that. Fail
+            # the request instead: a missing data point is recoverable, a
+            # mislabelled one poisons the comparison.
+            log.warning(
+                "naive_retrieval_failed",
+                error_type=type(exc).__name__,
+            )
+            raise
         retrieval_failed = True
         log.warning(
             "context_native_search_failed",
@@ -1593,6 +1606,10 @@ async def compile_context(
 
     if (
         ContextFacet.ACTIVE_WORK in facets
+        # Active work is its own retrieval, reaching the graph through a
+        # separate list query and merging straight into the pack. Under the arm
+        # it would put rows the arm never ranked in front of the reader.
+        and not naive_retrieval
         and project
         and _active_work_project_allowed(
             project=project,

--- a/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
@@ -994,3 +994,149 @@ def test_no_caller_can_reweight_the_arm_per_request() -> None:
     }
     source = inspect.getsource(naive_module.naive_search)
     assert "fuse_naive_candidates(filtered_lists, limit=limit)" in source
+
+
+# ---------------------------------------------------------------------------
+# The arm governs the whole pack, and never hands off to the machine
+# ---------------------------------------------------------------------------
+
+
+def _machine_search_response(query: str) -> Any:
+    from sibyl_core.tools.responses import SearchResponse, SearchResult
+
+    return SearchResponse(
+        results=[
+            SearchResult(
+                id="machine_row",
+                type="note",
+                name="machine row",
+                content="this came from the eight-lane machine",
+                score=0.9,
+                result_origin="graph",
+            )
+        ],
+        total=1,
+        query=query,
+        filters={},
+        graph_count=1,
+        limit=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_arm_raises_instead_of_serving_machine_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mislabelled data point is worse than a missing one.
+
+    Every other retrieval failure in compile_context falls back to the machine.
+    Under the arm that fallback would return eight-lane contents wearing the
+    arm's label, and a race whose labels can be wrong measures nothing.
+    """
+
+    from sibyl_core.tools import context as context_module
+
+    machine_calls: list[str] = []
+
+    async def exploding_arm(**_kwargs: object) -> Any:
+        raise RuntimeError("naive arm is down")
+
+    async def machine_search(**kwargs: object) -> Any:
+        machine_calls.append(str(kwargs.get("query")))
+        return _machine_search_response(str(kwargs.get("query")))
+
+    monkeypatch.setattr(context_module, "_compile_native_sections", exploding_arm)
+
+    with pytest.raises(RuntimeError, match="naive arm is down"):
+        await context_module.compile_context(
+            goal=CORPUS_QUERY,
+            organization_id=f"{ORG_ID}-failure",
+            principal_id=PRINCIPAL_ID,
+            naive_retrieval=True,
+            search_fn=machine_search,
+            record_exposure=False,
+            include_related=False,
+        )
+
+    assert machine_calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_machine_still_falls_back_when_the_arm_is_not_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fail-loud rule is scoped to the arm and must not change the default."""
+
+    from sibyl_core.tools import context as context_module
+
+    machine_calls: list[str] = []
+
+    async def exploding_native(**_kwargs: object) -> Any:
+        raise RuntimeError("native retrieval is down")
+
+    async def machine_search(**kwargs: object) -> Any:
+        machine_calls.append(str(kwargs.get("query")))
+        return _machine_search_response(str(kwargs.get("query")))
+
+    monkeypatch.setattr(context_module, "_compile_native_sections", exploding_native)
+
+    pack = await context_module.compile_context(
+        goal=CORPUS_QUERY,
+        organization_id=f"{ORG_ID}-fallback",
+        principal_id=PRINCIPAL_ID,
+        search_fn=machine_search,
+        record_exposure=False,
+        include_related=False,
+    )
+
+    assert len(machine_calls) == 1
+    assert [item.id for section in pack.sections for item in section.items] == ["machine_row"]
+
+
+@pytest.mark.asyncio
+async def test_the_arm_suppresses_active_work_enrichment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Active work is a separate retrieval, so the arm must not inherit it."""
+
+    from sibyl_core.tools import context as context_module
+
+    active_calls: list[str] = []
+
+    async def empty_sections(**_kwargs: object) -> list[Any]:
+        return []
+
+    async def active_work(**kwargs: object) -> list[Any]:
+        active_calls.append(str(kwargs.get("project")))
+        return []
+
+    monkeypatch.setattr(context_module, "_compile_native_sections", empty_sections)
+
+    await context_module.compile_context(
+        goal=CORPUS_QUERY,
+        organization_id=f"{ORG_ID}-active",
+        principal_id=PRINCIPAL_ID,
+        project=PROJECT_ID,
+        accessible_projects={PROJECT_ID},
+        intent="build",
+        naive_retrieval=True,
+        active_work_fn=active_work,
+        record_exposure=False,
+        include_related=False,
+    )
+    assert active_calls == []
+
+    await context_module.compile_context(
+        goal=CORPUS_QUERY,
+        organization_id=f"{ORG_ID}-active",
+        principal_id=PRINCIPAL_ID,
+        project=PROJECT_ID,
+        accessible_projects={PROJECT_ID},
+        intent="build",
+        active_work_fn=active_work,
+        record_exposure=False,
+        include_related=False,
+    )
+    # The machine still enriches, so the suppression above is the arm's doing
+    # rather than a request shape that never reached the lookup.
+    assert active_calls == [PROJECT_ID]

--- a/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
@@ -385,6 +385,135 @@ async def _embedded_runtime(group_id: str) -> tuple[SurrealGraphClient, Any]:
     return client, Runtime(client)
 
 
+async def _seed_private_row(
+    client: SurrealGraphClient,
+    provider: Any,
+    *,
+    group_id: str,
+    owner: str,
+) -> None:
+    """One row that answers the query perfectly and belongs to somebody else."""
+
+    embedding = (await provider.embed_texts([CORPUS_QUERY], input_kind="query"))[0]
+    await client.execute_query(
+        "INSERT INTO entity $rows;",
+        rows=[
+            {
+                "uuid": "private_to_someone_else",
+                "group_id": group_id,
+                "name": "deployment pipeline stale token",
+                "content": "The deployment pipeline stale token rotation runbook.",
+                "summary": "deployment pipeline stale token",
+                "entity_type": "session",
+                "name_embedding": list(embedding),
+                "created_at": datetime.now(UTC),
+                "attributes": {"memory_scope": "private", "principal_id": owner},
+            }
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_arm_withholds_a_row_the_reader_does_not_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The arm deletes ranking surface, never access control.
+
+    The withheld row is the strongest lexical and dense match in the corpus, so
+    a scope check that the arm skipped would put it at rank one rather than
+    leaving it out, and the failure would be loud rather than subtle.
+    """
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-scope")
+    provider = _embedding_provider()
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+        await _seed_private_row(
+            client,
+            provider,
+            group_id=client.group_id,
+            owner="user-somebody-else",
+        )
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+
+        stranger = await naive_search(
+            plan=_plan(query=CORPUS_QUERY, organization_id=client.group_id),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+        owner = await naive_search(
+            plan=build_context_retrieval_plan(
+                query=CORPUS_QUERY,
+                organization_id=client.group_id,
+                facets=[ContextFacet.RECENT_MEMORY],
+                facet_types={ContextFacet.RECENT_MEMORY: ["session"]},
+                principal_id="user-somebody-else",
+                project=None,
+                accessible_projects=None,
+                limit=10,
+            ),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+    finally:
+        await client.close()
+
+    assert "private_to_someone_else" not in {result.id for result in stranger.results}
+    # The owner reaching it is what proves the row was retrievable at all, so
+    # the withholding above is a scope decision rather than an empty lane.
+    assert "private_to_someone_else" in {result.id for result in owner.results}
+
+
+@pytest.mark.asyncio
+async def test_the_arm_authorizes_every_lane_before_fusion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filtering after fusion would let a denied row displace an allowed one."""
+
+    seen: list[str] = []
+    real_allowed = search_module._candidate_allowed
+
+    def recording_allowed(candidate: Any, **kwargs: Any) -> bool:
+        seen.append(candidate.id)
+        return real_allowed(candidate, **kwargs)
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-lane-scope")
+    provider = _embedding_provider()
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+        await _seed_private_row(
+            client,
+            provider,
+            group_id=client.group_id,
+            owner="user-somebody-else",
+        )
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+        monkeypatch.setattr(naive_module, "_candidate_allowed", recording_allowed)
+
+        response = await naive_search(
+            plan=_plan(query=CORPUS_QUERY, organization_id=client.group_id),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+    finally:
+        await client.close()
+
+    # Every candidate any lane proposed was checked, including the denied one.
+    assert "private_to_someone_else" in seen
+    assert {result.id for result in response.results} <= set(seen)
+
+
 @pytest.mark.asyncio
 async def test_naive_arm_returns_rows_fused_from_both_lanes(
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
@@ -8,6 +8,7 @@ and the non-interference tests pin the surface it is not allowed to touch.
 
 from __future__ import annotations
 
+import inspect
 from datetime import UTC, datetime
 from typing import Any
 
@@ -810,3 +811,34 @@ def test_the_arm_module_exposes_no_tunable_weights() -> None:
     }
 
     assert tunables == set()
+    # The module constants are the whole configuration surface, so enumerate
+    # them rather than pattern-matching names a future knob could dodge.
+    assert {
+        name
+        for name in dir(naive_module)
+        if name.isupper() and not name.startswith("_") and name != "TYPE_CHECKING"
+    } == {"NAIVE_RRF_K", "NAIVE_RETRIEVAL_MODE", "MAX_RETRIEVAL_LIMIT"}
+
+
+def test_no_caller_can_reweight_the_arm_per_request() -> None:
+    """A tuned control measures nothing, so the entry point takes no knobs.
+
+    ``fuse_naive_candidates`` keeps a ``k`` keyword for direct unit testing, but
+    nothing reachable from the API or bench surface can set it: ``naive_search``
+    neither accepts a fusion parameter nor forwards one.
+    """
+
+    parameters = set(inspect.signature(naive_module.naive_search).parameters)
+
+    assert parameters == {
+        "plan",
+        "types",
+        "facet",
+        "limit",
+        "include_content",
+        "embedding_provider",
+        "char_budget",
+        "content_max_chars",
+    }
+    source = inspect.getsource(naive_module.naive_search)
+    assert "fuse_naive_candidates(filtered_lists, limit=limit)" in source

--- a/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
@@ -964,12 +964,7 @@ def test_the_arm_module_exposes_no_tunable_weights() -> None:
         name
         for name in dir(naive_module)
         if name.isupper() and not name.startswith("_") and name != "TYPE_CHECKING"
-    } == {
-        "NAIVE_RRF_K",
-        "NAIVE_LANE_OVERFETCH",
-        "NAIVE_RETRIEVAL_MODE",
-        "MAX_RETRIEVAL_LIMIT",
-    }
+    } == {"NAIVE_RRF_K", "NAIVE_RETRIEVAL_MODE", "MAX_RETRIEVAL_LIMIT"}
 
 
 def test_no_caller_can_reweight_the_arm_per_request() -> None:
@@ -1140,3 +1135,169 @@ async def test_the_arm_suppresses_active_work_enrichment(
     # The machine still enriches, so the suppression above is the arm's doing
     # rather than a request shape that never reached the lookup.
     assert active_calls == [PROJECT_ID]
+
+
+# ---------------------------------------------------------------------------
+# Round-two hardening: lane depth, lane failure, and what the response discloses
+# ---------------------------------------------------------------------------
+
+
+def test_a_deep_cross_lane_agreement_survives_the_default_limit() -> None:
+    """The boundary a limit-scaled overfetch leaves alive.
+
+    At the bench's default limit of 12, reading four times the limit stops each
+    lane at 48. A row ranked 49 in both lanes scores 2/(60+49), which beats the
+    1/(60+1) of a row ranked first in one lane, so fusion should promote it and
+    a 48-row pool would discard it first. Reading to the ceiling removes the
+    class rather than moving it.
+    """
+
+    deep_rank = 49
+    lexical = [_candidate(f"filler_lex_{index}") for index in range(deep_rank - 1)]
+    dense = [_candidate(f"filler_vec_{index}") for index in range(deep_rank - 1)]
+    lexical.append(_candidate("agreed_deep"))
+    dense.append(_candidate("agreed_deep"))
+
+    fused = fuse_naive_candidates(
+        [(RetrievalSignal.NODE_FULLTEXT, lexical), (RetrievalSignal.NODE_VECTOR, dense)],
+        limit=1,
+    )
+
+    assert fused[0][0].id == "agreed_deep"
+    assert fused[0][1] == pytest.approx(2 / (NAIVE_RRF_K + deep_rank))
+    assert fused[0][1] > 1 / (NAIVE_RRF_K + 1)
+
+
+@pytest.mark.asyncio
+async def test_every_lane_reads_to_the_ceiling_whatever_the_caller_asked_for(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    depths: list[int] = []
+
+    async def recording_fulltext(**kwargs: Any) -> list[RetrievalCandidate]:
+        depths.append(int(kwargs["limit"]))
+        return []
+
+    async def recording_vector(**kwargs: Any) -> Any:
+        depths.append(int(kwargs["plan"].candidate_limits.node_vector))
+        from sibyl_core.retrieval.candidates import VectorCandidateFetch
+
+        return VectorCandidateFetch(
+            node_candidates=[], edge_candidates=[], requested=True, attempted=True
+        )
+
+    class Runtime:
+        client = object()
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+        return Runtime()
+
+    monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+    monkeypatch.setattr(naive_module, "_node_fulltext_candidates", recording_fulltext)
+    monkeypatch.setattr(naive_module, "_episode_fulltext_candidates", recording_fulltext)
+    monkeypatch.setattr(naive_module, "_vector_candidate_sources_detailed", recording_vector)
+
+    await naive_search(plan=_plan(query=CORPUS_QUERY, limit=1), limit=1)
+
+    assert depths and set(depths) == {search_module.MAX_RETRIEVAL_LIMIT}
+
+
+@pytest.mark.asyncio
+async def test_a_dead_lane_fails_the_request_instead_of_thinning_the_pack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A thin pack scores as a recall miss and blames the arm for an outage."""
+
+    async def dead_lane(**_kwargs: object) -> list[RetrievalCandidate]:
+        raise RuntimeError("fulltext lane is down")
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-deadlane")
+    provider = _embedding_provider()
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+        monkeypatch.setattr(naive_module, "_node_fulltext_candidates", dead_lane)
+
+        with pytest.raises(RuntimeError, match="fulltext lane is down"):
+            await naive_search(
+                plan=_plan(query=CORPUS_QUERY, organization_id=client.group_id),
+                types=["session"],
+                limit=10,
+                embedding_provider=provider,
+            )
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_a_degraded_vector_lane_fails_the_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Coming back degraded is still not having run."""
+
+    from sibyl_core.retrieval.candidates import VectorCandidateFetch
+
+    async def degraded_vector(**_kwargs: object) -> VectorCandidateFetch:
+        return VectorCandidateFetch(
+            node_candidates=[],
+            edge_candidates=[],
+            requested=True,
+            attempted=True,
+            failures=("node_vector:TimeoutError",),
+        )
+
+    class Runtime:
+        client = object()
+
+    async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+        return Runtime()
+
+    async def empty_lane(**_kwargs: object) -> list[RetrievalCandidate]:
+        return []
+
+    monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+    monkeypatch.setattr(naive_module, "_node_fulltext_candidates", empty_lane)
+    monkeypatch.setattr(naive_module, "_episode_fulltext_candidates", empty_lane)
+    monkeypatch.setattr(naive_module, "_vector_candidate_sources_detailed", degraded_vector)
+
+    with pytest.raises(RuntimeError, match="vector lane degraded"):
+        await naive_search(plan=_plan(query=CORPUS_QUERY), limit=10)
+
+
+@pytest.mark.asyncio
+async def test_the_response_publishes_no_stage_timings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Durations measured before the scope filter are a timing oracle.
+
+    The candidate fetch runs before authorization, so a caller who may read
+    none of the matches could still separate "nothing matched" from "matches
+    exist but are not yours" by timing repeated queries. The counts were
+    rebuilt from the authorized set for that reason; the clock would put the
+    signal straight back.
+    """
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-timings")
+    provider = _embedding_provider()
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+        response = await naive_search(
+            plan=_plan(query=CORPUS_QUERY, organization_id=client.group_id),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+    finally:
+        await client.close()
+
+    assert "stage_timings_ms" not in response.filters
+    assert not [key for key in response.filters if "timing" in key or key.endswith("_ms")]

--- a/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
@@ -259,6 +259,46 @@ def test_pack_without_a_budget_keeps_every_fused_result() -> None:
     assert receipt["naive_pack_budget_exhausted"] is False
 
 
+def test_pack_caps_each_item_before_charging_it_to_the_budget() -> None:
+    """An item must cost the arm what the same item costs the machine.
+
+    The enhanced evidence path truncates every result to `content_max_chars`
+    before it leaves the server. An arm that packed untruncated spans against
+    the same budget would fit fewer, larger items and the race would be
+    comparing payload sizes rather than retrieval.
+    """
+
+    capped, receipt = pack_naive_results(
+        _fused_for_pack(5_000, 5_000, 5_000),
+        include_content=True,
+        char_budget=250,
+        content_max_chars=100,
+    )
+    uncapped, _receipt = pack_naive_results(
+        _fused_for_pack(5_000, 5_000, 5_000),
+        include_content=True,
+        char_budget=250,
+    )
+
+    assert [len(result.content) for result in capped] == [100, 100]
+    assert receipt["naive_pack_chars_used"] == 200
+    assert receipt["content_max_chars"] == 100
+    # The cap is charged, not cosmetic: the same budget buys one oversized item
+    # without it and two capped ones with it.
+    assert len(uncapped) == 1
+
+
+def test_pack_leaves_content_whole_when_no_cap_is_requested() -> None:
+    results, _receipt = pack_naive_results(
+        _fused_for_pack(5_000),
+        include_content=True,
+        char_budget=None,
+        content_max_chars=None,
+    )
+
+    assert len(results[0].content) == 5_000
+
+
 def test_pack_costs_nothing_per_item_when_content_is_withheld() -> None:
     results, receipt = pack_naive_results(
         _fused_for_pack(5_000, 5_000),

--- a/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
@@ -194,6 +194,45 @@ def test_fusion_records_which_lanes_found_each_row() -> None:
     assert metadata_by_id["a"]["sources"] == ["node_fulltext"]
 
 
+def test_ties_break_on_candidate_id_not_on_lane_order() -> None:
+    """An exact RRF tie must not be resolved by which lane was passed first.
+
+    Two rows each returned at rank one by a different lane score identically.
+    Sorting on score alone leaves a stable sort to pick the earlier lane, which
+    is a real ranking preference applied only at a binding cutoff and never
+    declared anywhere.
+    """
+
+    lexical = [_candidate("zzz_lexical")]
+    dense = [_candidate("aaa_dense")]
+
+    forward = fuse_naive_candidates(
+        [(RetrievalSignal.NODE_FULLTEXT, lexical), (RetrievalSignal.NODE_VECTOR, dense)],
+        limit=1,
+    )
+    reversed_lanes = fuse_naive_candidates(
+        [(RetrievalSignal.NODE_VECTOR, dense), (RetrievalSignal.NODE_FULLTEXT, lexical)],
+        limit=1,
+    )
+
+    assert forward[0][0].id == reversed_lanes[0][0].id == "aaa_dense"
+    assert forward[0][1] == reversed_lanes[0][1]
+
+
+def test_tie_order_is_stated_rather_than_incidental() -> None:
+    """Ascending id, all the way down, not just at the head."""
+
+    lanes = [
+        (RetrievalSignal.NODE_FULLTEXT, [_candidate("m")]),
+        (RetrievalSignal.EPISODE_FULLTEXT, [_candidate("a")]),
+        (RetrievalSignal.NODE_VECTOR, [_candidate("z")]),
+    ]
+
+    fused = fuse_naive_candidates(lanes, limit=10)
+
+    assert [candidate.id for candidate, _score, _metadata in fused] == ["a", "m", "z"]
+
+
 def test_fusion_truncates_to_the_requested_limit() -> None:
     lane = [_candidate(f"c{index}") for index in range(10)]
 
@@ -469,6 +508,111 @@ async def test_the_arm_withholds_a_row_the_reader_does_not_own(
     # The owner reaching it is what proves the row was retrievable at all, so
     # the withholding above is a scope decision rather than an empty lane.
     assert "private_to_someone_else" in {result.id for result in owner.results}
+
+
+@pytest.mark.asyncio
+async def test_vector_diagnostics_count_only_authorized_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Diagnostics must not answer "does a row I cannot read exist?".
+
+    A count taken before the scope filter turns an empty result set into an
+    existence oracle: zero results beside a non-zero candidate count tells an
+    unauthorized caller that a private row matched their query.
+    """
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-diagnostics")
+    provider = _embedding_provider()
+    try:
+        await _seed_private_row(
+            client,
+            provider,
+            group_id=client.group_id,
+            owner="user-somebody-else",
+        )
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+
+        denied = await naive_search(
+            plan=_plan(query=CORPUS_QUERY, organization_id=client.group_id),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+        permitted = await naive_search(
+            plan=build_context_retrieval_plan(
+                query=CORPUS_QUERY,
+                organization_id=client.group_id,
+                facets=[ContextFacet.RECENT_MEMORY],
+                facet_types={ContextFacet.RECENT_MEMORY: ["session"]},
+                principal_id="user-somebody-else",
+                project=None,
+                accessible_projects=None,
+                limit=10,
+            ),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+    finally:
+        await client.close()
+
+    assert denied.results == []
+    assert denied.filters["vector_candidate_count"] == 0
+    # A lane that found only unreadable rows must be indistinguishable from a
+    # lane that found nothing at all.
+    assert denied.filters["vector_status"] == "empty"
+    assert denied.filters["naive_lane_counts"]["node_vector"] == 0
+    # The owner proves the row was there to be counted, so the zero above is a
+    # scope decision rather than an empty corpus.
+    assert permitted.filters["vector_candidate_count"] == 1
+    assert permitted.filters["vector_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_lanes_read_deeper_than_the_limit_so_fusion_can_promote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clipping lanes to the answer size makes fusion decorative at small limits.
+
+    A row ranked second in both lanes is exactly what RRF exists to promote over
+    a row ranked first in one. If each lane is cut to the caller's limit before
+    fusion runs, that row is gone before it can win.
+    """
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-overfetch")
+    provider = _embedding_provider()
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+
+        narrow = await naive_search(
+            plan=_plan(query=CORPUS_QUERY, organization_id=client.group_id, limit=1),
+            types=["session"],
+            limit=1,
+            embedding_provider=provider,
+        )
+        wide = await naive_search(
+            plan=_plan(query=CORPUS_QUERY, organization_id=client.group_id, limit=10),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+    finally:
+        await client.close()
+
+    assert len(narrow.results) == 1
+    assert any(count > 1 for count in narrow.filters["naive_lane_counts"].values())
+    # The one row a limit=1 request returns is the row full-pool fusion ranks
+    # first, which is the property clipping breaks.
+    assert narrow.results[0].id == wide.results[0].id
 
 
 @pytest.mark.asyncio
@@ -812,12 +956,20 @@ def test_the_arm_module_exposes_no_tunable_weights() -> None:
 
     assert tunables == set()
     # The module constants are the whole configuration surface, so enumerate
-    # them rather than pattern-matching names a future knob could dodge.
+    # them rather than pattern-matching names a future knob could dodge. Adding
+    # a name here is a deliberate act: NAIVE_LANE_OVERFETCH earns its place
+    # because it sets how deep a lane reads and cannot reorder anything, so it
+    # changes what fusion is allowed to see rather than how fusion scores it.
     assert {
         name
         for name in dir(naive_module)
         if name.isupper() and not name.startswith("_") and name != "TYPE_CHECKING"
-    } == {"NAIVE_RRF_K", "NAIVE_RETRIEVAL_MODE", "MAX_RETRIEVAL_LIMIT"}
+    } == {
+        "NAIVE_RRF_K",
+        "NAIVE_LANE_OVERFETCH",
+        "NAIVE_RETRIEVAL_MODE",
+        "MAX_RETRIEVAL_LIMIT",
+    }
 
 
 def test_no_caller_can_reweight_the_arm_per_request() -> None:

--- a/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
+++ b/packages/python/sibyl-core/tests/test_retrieval_naive_arm.py
@@ -1,0 +1,643 @@
+"""The naive-strong arm: RRF rank math, tight packing, lanes, and non-interference.
+
+The arm only means something if it is genuinely simpler than the machine and
+the machine is genuinely unchanged when the arm is not selected. Both halves are
+asserted here: the fusion tests pin the rank math the arm is allowed to have,
+and the non-interference tests pin the surface it is not allowed to touch.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from sibyl_core.backends.surreal.schema import EMBEDDING_DIM
+from sibyl_core.embeddings.providers import DeterministicEmbeddingProvider, EmbeddingMetadata
+from sibyl_core.models.context import ContextFacet
+from sibyl_core.retrieval import naive as naive_module
+from sibyl_core.retrieval import search as search_module
+from sibyl_core.retrieval.candidates import CandidateKind, CandidateScope, RetrievalCandidate
+from sibyl_core.retrieval.naive import (
+    NAIVE_RRF_K,
+    fuse_naive_candidates,
+    naive_retrieval_plan,
+    naive_search,
+    pack_naive_results,
+)
+from sibyl_core.retrieval.search import (
+    RetrievalPlan,
+    RetrievalSignal,
+    RetrievalWeights,
+    build_context_retrieval_plan,
+    context_search,
+)
+from sibyl_core.services.graph import (
+    EntityManager,
+    RelationshipManager,
+    SurrealGraphClient,
+    prepare_graph_schema,
+)
+
+ORG_ID = "org-naive-arm"
+PROJECT_ID = "project_naive"
+PRINCIPAL_ID = "user-naive"
+CORPUS_QUERY = "deployment pipeline stale token"
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    score: float = 0.5,
+    content: str = "body",
+) -> RetrievalCandidate:
+    return RetrievalCandidate(
+        id=candidate_id,
+        kind=CandidateKind.NODE,
+        type="session",
+        name=candidate_id,
+        content=content,
+        score=score,
+        source=None,
+        metadata={},
+        scope=CandidateScope(),
+    )
+
+
+def _plan(
+    *,
+    query: str,
+    limit: int = 10,
+    organization_id: str = ORG_ID,
+    project: str | None = None,
+) -> RetrievalPlan:
+    return build_context_retrieval_plan(
+        query=query,
+        organization_id=organization_id,
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["session"]},
+        principal_id=PRINCIPAL_ID,
+        project=project,
+        accessible_projects={project} if project else None,
+        limit=limit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RRF rank math
+# ---------------------------------------------------------------------------
+
+
+def test_single_lane_scores_are_exactly_the_rrf_series() -> None:
+    """One lane, no weights: the score is 1/(k + rank) and nothing else."""
+
+    lane = [_candidate("a"), _candidate("b"), _candidate("c")]
+
+    fused = fuse_naive_candidates([(RetrievalSignal.NODE_FULLTEXT, lane)], limit=10)
+
+    assert [candidate.id for candidate, _score, _metadata in fused] == ["a", "b", "c"]
+    assert [round(score, 12) for _candidate, score, _metadata in fused] == [
+        round(1.0 / (NAIVE_RRF_K + rank), 12) for rank in (1, 2, 3)
+    ]
+
+
+def test_the_arm_defaults_to_the_rrf_papers_k() -> None:
+    assert NAIVE_RRF_K == 60.0
+
+
+def test_agreement_across_lanes_sums_the_two_contributions() -> None:
+    """A row both lanes returned scores the sum of its two rank contributions."""
+
+    lexical = [_candidate("a"), _candidate("shared")]
+    dense = [_candidate("shared"), _candidate("b")]
+
+    fused = fuse_naive_candidates(
+        [(RetrievalSignal.NODE_FULLTEXT, lexical), (RetrievalSignal.NODE_VECTOR, dense)],
+        limit=10,
+    )
+    scores = {candidate.id: score for candidate, score, _metadata in fused}
+
+    assert scores["shared"] == pytest.approx(1.0 / (NAIVE_RRF_K + 2) + 1.0 / (NAIVE_RRF_K + 1))
+    assert scores["a"] == pytest.approx(1.0 / (NAIVE_RRF_K + 1))
+    # Agreement beats a single lane's top rank: this is the whole reason the arm
+    # fuses rather than concatenating.
+    assert fused[0][0].id == "shared"
+
+
+def test_lane_score_magnitudes_never_enter_the_ranking() -> None:
+    """RRF is ordinal. Rescaling a lane's scores must not move a single result."""
+
+    modest = [_candidate("a", score=0.51), _candidate("b", score=0.50)]
+    dramatic = [_candidate("a", score=99.0), _candidate("b", score=0.001)]
+
+    modest_fused = fuse_naive_candidates([(RetrievalSignal.NODE_FULLTEXT, modest)], limit=10)
+    dramatic_fused = fuse_naive_candidates([(RetrievalSignal.NODE_FULLTEXT, dramatic)], limit=10)
+
+    assert [(candidate.id, score) for candidate, score, _metadata in modest_fused] == [
+        (candidate.id, score) for candidate, score, _metadata in dramatic_fused
+    ]
+
+
+def test_equal_ranks_in_disjoint_lanes_tie_exactly() -> None:
+    """Two rows nothing distinguishes get identical scores, not near-identical."""
+
+    fused = fuse_naive_candidates(
+        [
+            (RetrievalSignal.NODE_FULLTEXT, [_candidate("only_lexical")]),
+            (RetrievalSignal.NODE_VECTOR, [_candidate("only_dense")]),
+        ],
+        limit=10,
+    )
+    scores = [score for _candidate, score, _metadata in fused]
+
+    assert scores[0] == scores[1]
+    assert {candidate.id for candidate, _score, _metadata in fused} == {
+        "only_lexical",
+        "only_dense",
+    }
+
+
+def test_lane_order_does_not_change_any_score() -> None:
+    """No per-lane weights means the lane list is a set, not a priority order."""
+
+    lexical = [_candidate("a"), _candidate("shared")]
+    dense = [_candidate("shared"), _candidate("b")]
+
+    forward = fuse_naive_candidates(
+        [(RetrievalSignal.NODE_FULLTEXT, lexical), (RetrievalSignal.NODE_VECTOR, dense)],
+        limit=10,
+    )
+    reversed_lanes = fuse_naive_candidates(
+        [(RetrievalSignal.NODE_VECTOR, dense), (RetrievalSignal.NODE_FULLTEXT, lexical)],
+        limit=10,
+    )
+
+    assert {candidate.id: score for candidate, score, _metadata in forward} == {
+        candidate.id: score for candidate, score, _metadata in reversed_lanes
+    }
+
+
+def test_fusion_records_which_lanes_found_each_row() -> None:
+    fused = fuse_naive_candidates(
+        [
+            (RetrievalSignal.NODE_FULLTEXT, [_candidate("a"), _candidate("shared")]),
+            (RetrievalSignal.NODE_VECTOR, [_candidate("shared")]),
+        ],
+        limit=10,
+    )
+    metadata_by_id = {candidate.id: metadata for candidate, _score, metadata in fused}
+
+    assert metadata_by_id["shared"]["sources"] == ["node_fulltext", "node_vector"]
+    assert metadata_by_id["shared"]["ranks"] == {"node_fulltext": 2, "node_vector": 1}
+    assert metadata_by_id["a"]["sources"] == ["node_fulltext"]
+
+
+def test_fusion_truncates_to_the_requested_limit() -> None:
+    lane = [_candidate(f"c{index}") for index in range(10)]
+
+    fused = fuse_naive_candidates([(RetrievalSignal.NODE_FULLTEXT, lane)], limit=3)
+
+    assert [candidate.id for candidate, _score, _metadata in fused] == ["c0", "c1", "c2"]
+
+
+def test_empty_lanes_fuse_to_nothing() -> None:
+    assert fuse_naive_candidates([(RetrievalSignal.NODE_FULLTEXT, [])], limit=5) == []
+    assert fuse_naive_candidates([], limit=5) == []
+
+
+# ---------------------------------------------------------------------------
+# Tight pack
+# ---------------------------------------------------------------------------
+
+
+def _fused_for_pack(*sizes: int) -> list[tuple[RetrievalCandidate, float, dict[str, Any]]]:
+    return [
+        (
+            _candidate(f"c{index}", content="x" * size),
+            1.0 / (index + 1),
+            {"sources": ["node_fulltext"], "ranks": {}, "original_scores": {}},
+        )
+        for index, size in enumerate(sizes)
+    ]
+
+
+def test_pack_stops_before_crossing_the_char_budget() -> None:
+    results, receipt = pack_naive_results(
+        _fused_for_pack(100, 100, 100),
+        include_content=True,
+        char_budget=250,
+    )
+
+    assert [result.id for result in results] == ["c0", "c1"]
+    assert receipt["naive_pack_chars_used"] == 200
+    assert receipt["naive_pack_budget_exhausted"] is True
+
+
+def test_pack_admits_a_single_item_wider_than_the_whole_budget() -> None:
+    """An empty pack answers nothing, so the first item is always admitted."""
+
+    results, receipt = pack_naive_results(
+        _fused_for_pack(5_000),
+        include_content=True,
+        char_budget=100,
+    )
+
+    assert [result.id for result in results] == ["c0"]
+    assert receipt["naive_pack_budget_exhausted"] is False
+
+
+def test_pack_without_a_budget_keeps_every_fused_result() -> None:
+    results, receipt = pack_naive_results(
+        _fused_for_pack(100, 100, 100),
+        include_content=True,
+        char_budget=None,
+    )
+
+    assert len(results) == 3
+    assert receipt["naive_pack_char_budget"] is None
+    assert receipt["naive_pack_budget_exhausted"] is False
+
+
+def test_pack_costs_nothing_per_item_when_content_is_withheld() -> None:
+    results, receipt = pack_naive_results(
+        _fused_for_pack(5_000, 5_000),
+        include_content=False,
+        char_budget=100,
+    )
+
+    assert len(results) == 2
+    assert receipt["naive_pack_chars_used"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The arm end to end, against the embedded engine
+# ---------------------------------------------------------------------------
+
+
+def _embedding_provider() -> DeterministicEmbeddingProvider:
+    return DeterministicEmbeddingProvider(
+        EmbeddingMetadata(
+            provider="deterministic",
+            model="unit-test",
+            dimensions=EMBEDDING_DIM,
+            cache_namespace="naive-arm-test",
+            tokenizer_estimate_method="utf8-byte-length",
+        )
+    )
+
+
+async def _seed_corpus(client: SurrealGraphClient, provider: Any, *, group_id: str) -> None:
+    """Three sessions: one the lexical lane finds, one the dense lane finds, one both.
+
+    Row vectors are blended toward the query vector rather than used raw. A
+    deterministic test provider emits near-orthogonal vectors whose cosine
+    similarity lands around zero and often below it, and the vector lane drops
+    anything under ``vector_min_score``, so raw test embeddings would leave the
+    dense half of the arm silently untested while the suite stayed green.
+
+    Rows carry no ``project_id``: the embedded engine returns zero rows for an
+    OR predicate sitting beside an HNSW ``<|k, ef|>`` bracket even when the row
+    satisfies each half on its own, which would take the dense lane out for a
+    reason that has nothing to do with the arm.
+    """
+
+    texts = {
+        "lexical_only": "The deployment pipeline broke on a stale kubeconfig token.",
+        "shared": "The deployment pipeline retries on a stale token before failing.",
+        "dense_only": "Nothing in this row spells the question out loud.",
+    }
+    document_embeddings = await provider.embed_texts(list(texts.values()), input_kind="document")
+    query_embedding = (await provider.embed_texts([CORPUS_QUERY], input_kind="query"))[0]
+    rows = []
+    for index, ((uuid, content), embedding) in enumerate(
+        zip(texts.items(), document_embeddings, strict=True)
+    ):
+        blend = 1.0 - 0.05 * index
+        rows.append(
+            {
+                "uuid": uuid,
+                "group_id": group_id,
+                "name": uuid.replace("_", " "),
+                "content": content,
+                "summary": content,
+                "entity_type": "session",
+                "name_embedding": [
+                    blend * query_value + (1.0 - blend) * document_value
+                    for query_value, document_value in zip(query_embedding, embedding, strict=True)
+                ],
+                "created_at": datetime.now(UTC),
+            }
+        )
+    await client.execute_query("INSERT INTO entity $rows;", rows=rows)
+
+
+async def _embedded_runtime(group_id: str) -> tuple[SurrealGraphClient, Any]:
+    client = SurrealGraphClient(group_id=group_id, url="memory://")
+    await prepare_graph_schema(client)
+
+    class Runtime:
+        def __init__(self, graph_client: SurrealGraphClient) -> None:
+            self.client = graph_client
+            self.entity_manager = EntityManager(graph_client, group_id=group_id)
+            self.relationship_manager = RelationshipManager(graph_client, group_id=group_id)
+
+    return client, Runtime(client)
+
+
+@pytest.mark.asyncio
+async def test_naive_arm_returns_rows_fused_from_both_lanes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, runtime = await _embedded_runtime(ORG_ID)
+    provider = _embedding_provider()
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+
+        response = await naive_search(
+            plan=_plan(query=CORPUS_QUERY),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+    finally:
+        await client.close()
+
+    assert response.filters["retrieval_mode"] == "naive"
+    assert response.results, "the arm returned nothing on a corpus that matches the query"
+    lanes = {
+        lane for result in response.results for lane in result.metadata.get("retrieval_signals", [])
+    }
+    # Both halves of the arm have to be live: a BM25-only or KNN-only run would
+    # race a different arm than the one the plan names.
+    assert "node_fulltext" in lanes
+    assert "node_vector" in lanes
+    assert response.filters["naive_lane_counts"]["node_fulltext"] > 0
+    assert response.filters["naive_lane_counts"]["node_vector"] > 0
+
+
+@pytest.mark.asyncio
+async def test_naive_arm_honors_the_char_budget_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-budget")
+    provider = _embedding_provider()
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+        plan = _plan(query=CORPUS_QUERY, organization_id=client.group_id)
+
+        unbounded = await naive_search(
+            plan=plan,
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+        bounded = await naive_search(
+            plan=plan,
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+            char_budget=60,
+        )
+    finally:
+        await client.close()
+
+    assert len(unbounded.results) > 1
+    assert len(bounded.results) < len(unbounded.results)
+    assert bounded.filters["naive_pack_budget_exhausted"] is True
+    # The pack never truncates an item, so a budget smaller than the second
+    # item's content ends the pack rather than admitting a partial span. The
+    # first item is admitted whatever it costs, which is why chars_used is
+    # bounded by "budget plus one whole item", not by the budget.
+    assert len(bounded.results) == 1
+
+
+@pytest.mark.asyncio
+async def test_naive_arm_never_reads_the_machines_deleted_lanes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Graph expansion, exact key, edge lanes, and raw lexical are gone, not quiet."""
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-lanes")
+    provider = _embedding_provider()
+
+    async def forbidden(**_kwargs: object) -> list[RetrievalCandidate]:
+        raise AssertionError("the naive arm reached a lane it is supposed to delete")
+
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+        monkeypatch.setattr(search_module, "_graph_expansion_candidates", forbidden)
+        monkeypatch.setattr(search_module, "_exact_key_candidates", forbidden)
+        monkeypatch.setattr(search_module, "_edge_fulltext_candidates", forbidden)
+        monkeypatch.setattr(search_module, "_edge_vector_candidates", forbidden)
+        monkeypatch.setattr(search_module, "_recall_raw_candidates", forbidden)
+
+        response = await naive_search(
+            plan=_plan(
+                query=f"{CORPUS_QUERY} ERR_STALE_TOKEN_0x9",
+                organization_id=client.group_id,
+                limit=10,
+            ),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+    finally:
+        await client.close()
+
+    assert response.filters["naive_lanes"] == [
+        "node_fulltext",
+        "episode_fulltext",
+        "node_vector",
+    ]
+    assert "exact_key_probe_fired" not in response.filters
+    assert "planner_status" not in response.filters
+
+
+@pytest.mark.asyncio
+async def test_naive_arm_applies_no_boost_to_the_fused_score(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A returned score is the raw RRF sum: no freshness, project, or type boost."""
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-scores")
+    provider = _embedding_provider()
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+        response = await naive_search(
+            plan=_plan(query=CORPUS_QUERY, organization_id=client.group_id),
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+        )
+    finally:
+        await client.close()
+
+    # Every row is fresh, so the machine's freshness boost would fire on all of
+    # them. The scores must still be exact sums of 1/(k + rank) terms.
+    reachable = {
+        round(sum(1.0 / (NAIVE_RRF_K + rank) for rank in ranks), 12)
+        for ranks in ((1,), (2,), (3,), (1, 1), (1, 2), (2, 1), (2, 2), (1, 3), (3, 1))
+    }
+    for result in response.results:
+        assert round(result.score, 12) in reachable
+
+
+# ---------------------------------------------------------------------------
+# Non-interference: the machine is byte-identical when the arm is not selected
+# ---------------------------------------------------------------------------
+
+
+def test_the_arm_does_not_change_the_machines_default_plan() -> None:
+    """Importing and running the arm must not move a single machine default."""
+
+    plan = RetrievalPlan(
+        query="q",
+        organization_id=ORG_ID,
+        facets=(),
+        facet_types={},
+        scopes=(),
+        denied_scopes=(),
+    )
+
+    assert plan.signals == (
+        RetrievalSignal.RAW_LEXICAL,
+        RetrievalSignal.NODE_FULLTEXT,
+        RetrievalSignal.EPISODE_FULLTEXT,
+        RetrievalSignal.EDGE_FULLTEXT,
+        RetrievalSignal.NODE_VECTOR,
+        RetrievalSignal.EDGE_VECTOR,
+        RetrievalSignal.GRAPH_EXPANSION,
+        RetrievalSignal.EXACT_KEY,
+    )
+    assert RetrievalWeights() == RetrievalWeights(
+        rrf_k=60,
+        active_task_state_boost=1.3,
+        project_match_boost=1.2,
+        direct_raw_source_boost=1.4,
+        exact_key_boost=1.4,
+        graph_expansion_only_boost=0.45,
+        graph_native_signal_boost_cap=1.2,
+        freshness_boost_cap=1.5,
+    )
+
+
+def test_narrowing_a_plan_for_the_arm_leaves_the_callers_plan_intact() -> None:
+    plan = _plan(query="q")
+
+    narrowed = naive_retrieval_plan(plan)
+
+    assert len(plan.signals) == 8
+    assert narrowed.signals == (
+        RetrievalSignal.NODE_FULLTEXT,
+        RetrievalSignal.EPISODE_FULLTEXT,
+        RetrievalSignal.NODE_VECTOR,
+    )
+    # Scope and project authorization survive the narrowing untouched: the arm
+    # deletes ranking surface, never access control.
+    assert narrowed.scopes == plan.scopes
+    assert narrowed.denied_scopes == plan.denied_scopes
+    assert narrowed.accessible_projects == plan.accessible_projects
+    assert narrowed.project == plan.project
+
+
+@pytest.mark.asyncio
+async def test_the_machine_returns_the_same_results_after_the_arm_has_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The decisive non-interference check: same corpus, same query, same answer.
+
+    Run the machine, run the arm, run the machine again. If the arm mutated any
+    shared plan, weight table, or module default, the two machine runs diverge.
+    """
+
+    client, runtime = await _embedded_runtime(f"{ORG_ID}-invariant")
+    provider = _embedding_provider()
+
+    async def no_raw_recall(**_kwargs: object) -> list[Any]:
+        return []
+
+    try:
+        await _seed_corpus(client, provider, group_id=client.group_id)
+
+        async def fake_runtime(_organization_id: str, **_kwargs: object) -> Any:
+            return runtime
+
+        monkeypatch.setattr(search_module, "get_surreal_graph_runtime", fake_runtime)
+        plan = _plan(query=CORPUS_QUERY, organization_id=client.group_id)
+
+        async def machine_run() -> list[tuple[str, float, tuple[str, ...], str]]:
+            response = await context_search(
+                plan=plan,
+                types=["session"],
+                limit=10,
+                embedding_provider=provider,
+                raw_memory_recall_fn=no_raw_recall,
+            )
+            return [
+                (
+                    result.id,
+                    # The machine multiplies in a freshness boost computed
+                    # against the wall clock, so its scores drift in the low
+                    # decimals between two runs seconds apart. Six places is far
+                    # tighter than any reordering the arm could cause and looser
+                    # than a clock tick.
+                    round(result.score, 6),
+                    tuple(result.metadata.get("retrieval_signals", [])),
+                    result.content,
+                )
+                for result in response.results
+            ]
+
+        before = await machine_run()
+        await naive_search(
+            plan=plan,
+            types=["session"],
+            limit=10,
+            embedding_provider=provider,
+            char_budget=50,
+        )
+        after = await machine_run()
+    finally:
+        await client.close()
+
+    assert before == after
+    assert before, "the machine returned nothing, so the comparison proves nothing"
+    # The machine's own lanes must still be live in the comparison, or the
+    # invariant would hold vacuously over a corpus the machine could not reach.
+    assert {lane for _id, _score, lanes, _content in before for lane in lanes} >= {
+        "node_fulltext",
+        "node_vector",
+    }
+
+
+def test_the_arm_module_exposes_no_tunable_weights() -> None:
+    """The arm's value is what it deletes. A weight table here would undo that."""
+
+    tunables = {
+        name
+        for name in dir(naive_module)
+        if name.isupper() and ("WEIGHT" in name or "BOOST" in name)
+    }
+
+    assert tunables == set()

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -7350,8 +7350,7 @@ def test_the_arm_renders_exactly_the_candidates_the_server_returned() -> None:
     rendered = memory._render_naive_verbatim_context(query="q", results=server_results)
 
     assembly = memory._query_local.search_metadata["adapter_assembly"]
-    rendered_ids = [item["entity_id"] for item in assembly["context_budget"]["items"]]
-    assert rendered_ids == ["traj-a-1"]
+    assert assembly["naive_rendered_ids"] == ["traj-a-1"]
     assert len(rendered) == 1
     assert assembly["naive_verbatim_render"] is True
     assert assembly["naive_server_candidate_count"] == 1
@@ -7359,6 +7358,7 @@ def test_the_arm_renders_exactly_the_candidates_the_server_returned() -> None:
     assert assembly["naive_bypassed_stages"] == [
         "assemble_context_results",
         "compile_operational_evidence_set",
+        "render_memory_context",
     ]
 
     # The contrast that makes the assertion above mean something: handed the
@@ -7376,20 +7376,27 @@ def test_the_arm_renders_exactly_the_candidates_the_server_returned() -> None:
     assert [row.get("id") for row in expanded] == ["traj-a-1", "traj-a-0", "traj-a-2"]
 
 
-def test_the_arm_preserves_server_order_and_caps_at_max_items() -> None:
-    max_items = 2
+def test_the_arm_renders_every_candidate_not_just_max_items() -> None:
+    """max_items is a machine selection stage, so it must not cut the arm's pack."""
+
     module = _load_memory_module()
-    memory = _naive_render_stub(module, max_items=max_items)
+    memory = _naive_render_stub(module, max_items=2)
     memory._chunk_catalog = {}
     server_results = [_chunk_result("traj-a", index) for index in (5, 3, 9, 1)]
 
     rendered = memory._render_naive_verbatim_context(query="q", results=server_results)
 
-    # The arm already ranked these; the client neither reorders nor reselects.
+    # The arm already ranked these; the client neither reorders, reselects, nor
+    # drops the tail to satisfy an item count.
     assembly = memory._query_local.search_metadata["adapter_assembly"]
-    rendered_ids = [item["entity_id"] for item in assembly["context_budget"]["items"]]
-    assert rendered_ids == ["traj-a-5", "traj-a-3"]
-    assert len(rendered) == max_items
+    assert assembly["naive_rendered_ids"] == [
+        "traj-a-5",
+        "traj-a-3",
+        "traj-a-9",
+        "traj-a-1",
+    ]
+    assert len(rendered) == len(server_results)
+    assert assembly["naive_dropped_count"] == 0
 
 
 def test_the_arm_refuses_every_client_side_reshaping_flag() -> None:
@@ -7468,3 +7475,91 @@ def test_the_arm_conflict_message_names_every_offending_setting() -> None:
         "semantic_prior_rescue_weight",
         "typed_stream_retrieval",
     ]
+
+
+def test_the_arm_renders_bodies_whole_rather_than_slicing_them() -> None:
+    """Query-aware slicing rewrites the evidence the arm chose to show."""
+
+    module = _load_memory_module()
+    memory = _naive_render_stub(module)
+    memory._chunk_catalog = {}
+    body = ("unique-token " + ("filler sentence about something else. " * 200)).strip()
+    result = _chunk_result("traj-a", 1)
+    result["content"] = body
+
+    rendered = memory._render_naive_verbatim_context(query="unique-token", results=[result])
+
+    assert len(rendered) == 1
+    # The whole body survives, not a query-selected excerpt of it.
+    assert body in rendered[0]["value"]
+
+
+def test_the_arm_keeps_empty_bodied_candidates_in_the_pack() -> None:
+    """Dropping a row is a selection decision the arm did not make."""
+
+    module = _load_memory_module()
+    memory = _naive_render_stub(module)
+    memory._chunk_catalog = {}
+    empty = _chunk_result("traj-a", 2)
+    empty["content"] = ""
+    results = [_chunk_result("traj-a", 1), empty, _chunk_result("traj-a", 3)]
+
+    rendered = memory._render_naive_verbatim_context(query="q", results=results)
+
+    assembly = memory._query_local.search_metadata["adapter_assembly"]
+    assert assembly["naive_rendered_ids"] == ["traj-a-1", "traj-a-2", "traj-a-3"]
+    assert len(rendered) == len(results)
+
+
+def test_the_arm_truncates_whole_candidates_from_the_tail_and_stamps_it() -> None:
+    """A short pack has to be auditable, and it drops rows rather than slicing."""
+
+    module = _load_memory_module()
+    memory = _naive_render_stub(module)
+    memory._chunk_catalog = {}
+    memory.max_context_total_chars = 1_200
+    results = []
+    for index in range(6):
+        row = _chunk_result("traj-a", index)
+        row["content"] = f"body {index} " + ("x" * 400)
+        results.append(row)
+
+    rendered = memory._render_naive_verbatim_context(query="q", results=results)
+
+    assembly = memory._query_local.search_metadata["adapter_assembly"]
+    assert 0 < len(rendered) < len(results)
+    # The survivors are a prefix of the server's order, never a re-selection.
+    assert assembly["naive_rendered_ids"] == [f"traj-a-{index}" for index in range(len(rendered))]
+    assert assembly["naive_tail_truncated_from_rank"] == len(rendered) + 1
+    assert assembly["naive_dropped_count"] == len(results) - len(rendered)
+    # Every rendered body is whole; truncation removed rows, not text.
+    for index, item in enumerate(rendered):
+        assert ("x" * 400) in item["value"], f"item {index} was sliced"
+
+
+def test_the_arm_refuses_settings_for_stages_it_bypasses() -> None:
+    module = _load_memory_module()
+    runner_defaults = {
+        "neighbor_stitch_items": module.DEFAULT_NEIGHBOR_STITCH_ITEMS,
+        "neighbor_stitch_span": module.DEFAULT_NEIGHBOR_STITCH_SPAN,
+        "max_chunks_per_trajectory": module.DEFAULT_MAX_CHUNKS_PER_TRAJECTORY,
+        "context_expansion_max_ratio": module.DEFAULT_CONTEXT_EXPANSION_MAX_RATIO,
+        "evidence_composition_mode": module.DEFAULT_EVIDENCE_COMPOSITION_MODE,
+        "typed_reservation_items": None,
+        "knn_type_overfetch": module.DEFAULT_KNN_TYPE_OVERFETCH,
+    }
+
+    # The runner writes every key on every run, so the defaults it ships must
+    # not refuse or no naive screen could start.
+    assert module._naive_arm_conflicts(dict(runner_defaults)) == []
+
+    for name, value in (
+        ("neighbor_stitch_items", 3),
+        ("neighbor_stitch_span", 2),
+        ("max_chunks_per_trajectory", 4),
+        ("context_expansion_max_ratio", 2.0),
+        ("evidence_composition_mode", "reserved_support"),
+        ("typed_reservation_items", 3),
+        ("knn_type_overfetch", 17),
+    ):
+        assert module._naive_arm_conflicts({**runner_defaults, name: value}) == [name]

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -7302,3 +7302,119 @@ def test_the_arm_is_replayable_onto_a_loaded_corpus() -> None:
     module = _load_runner_module()
 
     assert "retrieval_mode" in module.LOADED_MEMORY_RUNTIME_KEYS
+
+
+def _naive_render_stub(module: ModuleType, *, max_items: int = 8) -> Any:
+    """A memory adapter positioned for the render path, with no network in __init__."""
+
+    memory = object.__new__(module.SibylLiveApiMemory)
+    memory.max_context_items = max_items
+    memory.max_context_chars_per_item = 4_000
+    memory.retrieval_mode = "naive"
+    memory._query_local = SimpleNamespace(search_metadata={}, retrieval_trace=None)
+    return memory
+
+
+def _chunk_result(trajectory: str, index: int) -> dict[str, object]:
+    # The stitcher keys on these exact metadata names; anything else silently
+    # fails to match the catalog and the expansion this guards against never
+    # fires, which would leave the assertion below passing over nothing.
+    return {
+        "id": f"{trajectory}-{index}",
+        "name": f"chunk {index}",
+        "content": f"content for chunk {index}",
+        "score": 0.5,
+        "metadata": {
+            "longmemeval_v2_trajectory_id": trajectory,
+            "longmemeval_v2_chunk_index": index,
+        },
+    }
+
+
+def test_the_arm_renders_exactly_the_candidates_the_server_returned() -> None:
+    """Membership and order must survive the client untouched.
+
+    Client-side assembly expands a hit into its catalog neighbours, with
+    stitching on by default, so one returned row can render as three. A screen
+    reading that render would be scoring a client-side expansion of the arm
+    rather than the arm.
+    """
+
+    module = _load_memory_module()
+    memory = _naive_render_stub(module)
+    memory._chunk_catalog = {
+        "traj-a": {index: _chunk_result("traj-a", index) for index in (0, 1, 2)}
+    }
+    server_results = [_chunk_result("traj-a", 1)]
+
+    rendered = memory._render_naive_verbatim_context(query="q", results=server_results)
+
+    assembly = memory._query_local.search_metadata["adapter_assembly"]
+    rendered_ids = [item["entity_id"] for item in assembly["context_budget"]["items"]]
+    assert rendered_ids == ["traj-a-1"]
+    assert len(rendered) == 1
+    assert assembly["naive_verbatim_render"] is True
+    assert assembly["naive_server_candidate_count"] == 1
+    assert assembly["naive_rendered_count"] == 1
+    assert assembly["naive_bypassed_stages"] == [
+        "assemble_context_results",
+        "compile_operational_evidence_set",
+    ]
+
+    # The contrast that makes the assertion above mean something: handed the
+    # same single result and the same catalog, the client-side stage the arm
+    # bypasses turns one row into three.
+    expanded, _metadata = module.assemble_context_results(
+        server_results,
+        chunk_catalog=memory._chunk_catalog,
+        max_items=8,
+        max_chunks_per_trajectory=module.DEFAULT_MAX_CHUNKS_PER_TRAJECTORY,
+        neighbor_stitch_items=module.DEFAULT_NEIGHBOR_STITCH_ITEMS,
+        neighbor_stitch_span=module.DEFAULT_NEIGHBOR_STITCH_SPAN,
+        query="q",
+    )
+    assert [row.get("id") for row in expanded] == ["traj-a-1", "traj-a-0", "traj-a-2"]
+
+
+def test_the_arm_preserves_server_order_and_caps_at_max_items() -> None:
+    max_items = 2
+    module = _load_memory_module()
+    memory = _naive_render_stub(module, max_items=max_items)
+    memory._chunk_catalog = {}
+    server_results = [_chunk_result("traj-a", index) for index in (5, 3, 9, 1)]
+
+    rendered = memory._render_naive_verbatim_context(query="q", results=server_results)
+
+    # The arm already ranked these; the client neither reorders nor reselects.
+    assembly = memory._query_local.search_metadata["adapter_assembly"]
+    rendered_ids = [item["entity_id"] for item in assembly["context_budget"]["items"]]
+    assert rendered_ids == ["traj-a-5", "traj-a-3"]
+    assert len(rendered) == max_items
+
+
+def test_the_arm_refuses_every_client_side_reshaping_flag() -> None:
+    """A flag that reads as applied while doing nothing misdescribes the run."""
+
+    module = _load_memory_module()
+    reshaping = (
+        ("typed_stream_retrieval", True),
+        ("agentic_traversal", True),
+        ("state_part_refinement", True),
+        ("neighbor_stitch_spread", True),
+        ("neighbor_support_exempt", True),
+        ("neighbor_trajectory_preserving", True),
+        ("source_evidence_bundling", True),
+        ("state_part_completion_items", 2),
+        ("neighbor_support_overflow_items", 2),
+        ("semantic_prior_rescue_weight", 0.5),
+    )
+    for name, value in reshaping:
+        with pytest.raises(ValueError, match="control arm"):
+            module.SibylLiveApiMemory(
+                {
+                    "allow_localhost": True,
+                    "project_id": "project_test",
+                    "retrieval_mode": "naive",
+                    name: value,
+                }
+            )

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -7238,3 +7238,67 @@ def test_loaded_memory_merge_rejects_unclassified_request_keys(tmp_path: Path) -
     }
     with pytest.raises(RuntimeError, match="future_arm_flag"):
         module.build_loaded_memory_config(memory_dir, requested_config=requested)
+
+
+# ---------------------------------------------------------------------------
+# The naive-strong control arm (1.3 Phase 0)
+# ---------------------------------------------------------------------------
+
+
+def test_naive_is_a_selectable_retrieval_mode() -> None:
+    module = _load_memory_module()
+
+    assert "naive" in module.RETRIEVAL_MODES
+    # The arm must stay opt-in: a run that does not name it gets the machine.
+    assert module.DEFAULT_RETRIEVAL_MODE == "fast"
+
+
+def test_official_runner_carries_the_naive_arm_into_memory_params(tmp_path: Path) -> None:
+    """The arm is only screenable if a command line can select it end to end."""
+
+    module = _load_runner_module()
+    data_root = tmp_path / "data"
+    _write_dataset(data_root)
+
+    args = module.parse_args(
+        [
+            "--data-root",
+            str(data_root),
+            "--domain",
+            "enterprise",
+            "--output-dir",
+            str(tmp_path / "output"),
+            "--plan-only",
+            "--retrieval-mode",
+            "naive",
+        ]
+    )
+
+    config = module.build_memory_config(args)
+
+    assert config["memory_params"]["retrieval_mode"] == "naive"
+
+
+def test_the_arm_refuses_to_run_beside_retrieval_that_bypasses_it() -> None:
+    """Both flags retrieve outside the arm, so the arm's name would be a lie."""
+
+    module = _load_memory_module()
+
+    for conflicting in ("typed_stream_retrieval", "agentic_traversal"):
+        with pytest.raises(ValueError, match="control arm"):
+            module.SibylLiveApiMemory(
+                {
+                    "allow_localhost": True,
+                    "project_id": "project_test",
+                    "retrieval_mode": "naive",
+                    conflicting: True,
+                }
+            )
+
+
+def test_the_arm_is_replayable_onto_a_loaded_corpus() -> None:
+    """Arms are screened against an existing corpus, so the key must be runtime."""
+
+    module = _load_runner_module()
+
+    assert "retrieval_mode" in module.LOADED_MEMORY_RUNTIME_KEYS

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -7418,3 +7418,53 @@ def test_the_arm_refuses_every_client_side_reshaping_flag() -> None:
                     name: value,
                 }
             )
+
+
+def test_the_arm_conflict_guard_does_not_depend_on_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configuration conflict is a property of the configuration.
+
+    agentic_traversal is separately gated on an OpenAI key being exported. With
+    the guard sitting beside the flags it names, that key check ran first, so
+    naive-plus-traversal refused with a "control arm" error only on a machine
+    that happened to export a key and reported an unrelated missing-key error
+    everywhere else. CI has no key, so the guard was untested exactly where it
+    mattered.
+    """
+
+    module = _load_memory_module()
+    for variable in ("OPENAI_API_KEY", "SIBYL_OPENAI_API_KEY"):
+        monkeypatch.delenv(variable, raising=False)
+
+    with pytest.raises(ValueError, match="control arm"):
+        module.SibylLiveApiMemory(
+            {
+                "allow_localhost": True,
+                "project_id": "project_test",
+                "retrieval_mode": "naive",
+                "agentic_traversal": True,
+            }
+        )
+
+
+def test_the_arm_conflict_message_names_every_offending_setting() -> None:
+    module = _load_memory_module()
+
+    conflicts = module._naive_arm_conflicts(
+        {
+            "agentic_traversal": True,
+            "typed_stream_retrieval": True,
+            "semantic_prior_rescue_weight": 0.5,
+            "neighbor_stitch_items": 2,
+        }
+    )
+
+    # Sorted so the message is stable, and neighbor_stitch_items is absent
+    # because its shipped default is already non-zero: listing it would refuse
+    # every plain naive run.
+    assert conflicts == [
+        "agentic_traversal",
+        "semantic_prior_rescue_weight",
+        "typed_stream_retrieval",
+    ]


### PR DESCRIPTION
# 🎯 The naive-strong control arm, selectable end to end

> Builds the Phase 0 headline experiment from `docs/architecture/SIBYL_1_3_RETHINK_2026-08-13.md`. Ships the arm only. Running the race is the orchestrator's job, and no benchmark was run here.

## 💡 What this is

A second retrieval pipeline, `retrieval_mode=naive`, that exists to be raced against the 8-lane `context_search` machine on the same corpus under the standard protocol. It is BM25 fulltext over the verbatim-span corpus, dense KNN over the same rows, plain reciprocal-rank fusion at the paper's k=60, and a character-budgeted pack. Nothing else.

The instinct with a control arm is to make it competitive by tuning it. That instinct is exactly wrong here, and it is why this arm exposes no weights at all. A tuned control measures nothing: if the arm carries its own hand-weights, a win says the weights were good rather than that the machine's extra lanes were unnecessary. `NAIVE_RRF_K` is a module constant rather than a request parameter for that reason, and a test asserts the module defines no name containing `WEIGHT` or `BOOST`.

## 🤔 Why we need it & what it replaces

Nothing in the tree could express the control. The rethink doc's argument for running it is that simplicity is already winning: the 42.8% frontier baseline on this benchmark is naive slice-RAG, and Emergence AI reached 86% on LongMemEval-V1 with turn-match retrieval, session-scope expansion, a cross-encoder, and no memory architecture at all. Against that, Sibyl runs two mutually-unaware pipelines with ordinal fusion that discards score magnitudes, and enterprise sits at roughly 32 seconds against a 10 second budget.

Every outcome of the race is informative, which is what makes the arm worth building rather than arguing about. Parity or better deletes most of the machine and most of the latency. A loss is the first clean measurement of which lanes actually carry the 30.4%.

What this deliberately does not do: it does not touch the machine. `retrieval/search.py`, `retrieval/hybrid.py`, and `retrieval/fusion.py` have zero diff on this branch. The tempting version of this change was to add a mode switch inside `context_search` and branch the 8-lane path, which would have put the control arm's code in the machine's hot path and made "the default is unchanged" an argument rather than a fact. The arm is a separate module instead, and it imports the machine's lane readers rather than reimplementing them, so the race compares fusion and pack shape instead of two different spellings of the same SurrealDB read. Whatever the analyzers and indexes do for the machine's BM25 lane, they do identically here.

## 🎯 The invariant

Anchor the review on one property: **an unselected arm is an unreachable arm.** A request that does not name `retrieval_mode=naive` must reach byte-identical behavior to `origin/main`.

Three things enforce it. The three machine modules carry no diff. `compile_context`'s new `naive_retrieval` parameter defaults to `False` and is only ever passed the result of `_naive_retrieval_selected(request)`, which is true only for an explicit `retrieval_mode == "naive"`. And the arm narrows its plan through `dataclasses.replace` on a frozen `RetrievalPlan`, so it cannot mutate a plan the machine also holds.

The decisive test runs the machine, runs the arm, then runs the machine again against the same embedded corpus and asserts the two machine runs agree on ids, order, lanes, and content, with a further assertion that the machine's own lanes were live so the comparison cannot hold vacuously over an empty result.

## 🛠️ How it works

### 1. The arm itself

`packages/python/sibyl-core/src/sibyl_core/retrieval/naive.py` is the whole pipeline.

`naive_search()` narrows the plan to three signals (`NODE_FULLTEXT`, `EPISODE_FULLTEXT`, `NODE_VECTOR`), runs the lexical and dense lanes concurrently, authorizes every candidate through the machine's own `_candidate_allowed`, fuses, and packs. `fuse_naive_candidates()` is plain RRF: a candidate's score is the sum of `1 / (k + rank)` over the lanes that returned it, and the lane's own score never enters. Every lane reads to `MAX_RETRIEVAL_LIMIT`, so fusion always sees a pool the caller's limit has not already truncated; truncation happens after. A depth scaled off the limit leaves a boundary alive, since at the default limit of 12 a four-times pool stops at 48 and a row ranked 49 in both lanes still outscores a single lane's rank one. Exact ties break on candidate id, which is arbitrary but stated and independent of lane order. `pack_naive_results()` takes results in rank order until the character budget is spent.

Deleted relative to the machine: graph expansion, the exact-key probe, both edge lanes, the raw-lexical lane, `rank_items_by_query_coverage`, `_boost_score` and every multiplier it applies (freshness, project match, active-task state, vector-only demotion, graph-native signal), temporal decay, fact frames, query planning, refinement, and synthesis.

Two details in the pack are deliberate. The first item is admitted whatever it costs, because an empty pack answers nothing. And an item that would cross the budget ends the pack rather than being truncated, so every span the reader sees is whole.

### 2. Mode selection through the serving path

`retrieval_mode` was already the arm-selection surface, so the enum widens rather than a new field appearing. The `accurate` deprecation (#355) set the precedent for announcing a mode change in band.

Selecting `naive` is total rather than partial, which is the part worth scrutinizing. The evidence search runs the arm (`_execute_naive_context_evidence_search`), the pack's own sections compile through the arm (`_compile_native_sections`), the one-hop related-item walk is skipped, and the reserved distilled-notes lane stays off even when the request explicitly asks for it. A pack whose items still came from the 8-lane machine would put machine output in front of the reader under the arm's name, which is the contamination that makes a race unreadable.

Any lane that raises or reports itself degraded fails the request. The machine prefers a partial answer because it is answering a user; the arm is producing a measurement, and a thin pack scores as a recall miss that blames the arm for an outage. A failed arm likewise raises rather than falling back. Everywhere else in `compile_context` a retrieval failure falls back to the machine, which under the arm would return eight-lane contents wearing the arm's label. A race whose labels can be wrong measures nothing, so a missing data point is preferred to a mislabelled one. Active-work enrichment is suppressed for the same reason the related-item walk is.

Receipts report `planner_status: "not_requested"` and `query_count: 1`, matching `fast`, so consumers keying off the planner receipt do not need to learn a third shape. Evidence responses also stamp `retrieval_arm: "naive"`.

### 3. Authorization rides through unchanged

The arm's plan comes from `build_context_retrieval_plan`, the same constructor the machine uses, carrying the same `principal_id`, `project`, `accessible_projects`, and `allowed_memory_scope_keys`. Scope filtering happens through the machine's `_candidate_allowed` on every lane's output before fusion, never after.

Per-stage timings are logged and never returned, because they are measured across a fetch that runs before the scope filter and would let repeated queries separate "nothing matched" from "matches exist but are not yours" by duration. Diagnostics are rebuilt from the authorized set rather than snapshotted from the raw fetch. A count taken before the scope filter answers "does a private row matching my query exist" for a reader authorized to see none of them, so a lane that found only unreadable rows now reports `empty`, indistinguishable from a lane that found nothing.

This is the one place where "simpler" would have been a security bug. A control arm that also relaxed authorization would be reading a different corpus rather than running a simpler pipeline, so the arm deletes ranking surface and nothing else.

### 4. Per-item cost parity and exposure receipts

Two things the enhanced path does inside the search it runs, which the arm does not use, are done explicitly by the arm so the two are comparable.

The enhanced path truncates every result to `content_max_chars` before it leaves the server. The arm does the same, clamped by the same `MAX_SEARCH_CONTENT_MAX_CHARS`, applied before the item is charged to the budget. Without this the arm would pack untruncated spans against a budget the machine spends truncated ones on, so the arms would differ in payload geometry rather than in retrieval, and the reader would receive a far larger context under the arm's name.

The enhanced path also stamps usage exposure inside that search. The arm stamps it after retrieval with the same `context_pack_evidence` source surface, gated on the request's own `record_exposure`. Without it, an arm run leaves no exposure receipts, which reads as a run that surfaced nothing and makes exposure analysis impossible to run across arms.

### 5. Bench selection

`--retrieval-mode naive` on the runner becomes a `memory_param`, which the adapter validates and puts on the wire in the evidence block of the `/context/pack` request. `retrieval_mode` is already in `LOADED_MEMORY_RUNTIME_KEYS`, so the arm is screenable against an already-ingested corpus rather than requiring a rebuild, which is what makes a same-commit paired comparison affordable.

Under the arm the adapter renders every server candidate, in the server's order, with bodies whole. Membership caps, empty-body drops, per-candidate character budgets, and query-aware slicing are all machine stages and none of them run. The reader's total context is still bounded, but overflow drops whole candidates from the tail and stamps the drop in the receipt. The client-side assembly and composition stages are bypassed rather than configured small: assembly performs diversity selection, trajectory refinement, and catalog-neighbour expansion, and at the shipped stitch default of two, one returned row renders as three. A screen reading that render would be scoring a client-side expansion of the arm rather than the arm. Pack items are dropped alongside, since under the arm they are the same rows the evidence lane already ranked.

The adapter refuses `naive` beside `typed_stream_retrieval` or `agentic_traversal`, and beside every client-side reshaping flag whose default is already inert. Both retrieve outside the arm, the typed stream by making a second pack request pinned to `fast`, so a run carrying either would report the arm's name over a pool the arm did not produce. This repo has already been bitten by that failure, so the conflict raises at config time. Both flags default off, so no existing invocation changes.

## 🔁 What changed since the first review round

A hostile review returned NEEDS_CHANGES with six findings, each carrying an executed falsifier. All six reproduced locally before being fixed, and each fix was re-verified against the same falsifier.

**🛡️ Denied rows leaked through vector diagnostics.** The count and status were snapshotted from the raw fetch before scope filtering, so a caller authorized to read nothing still saw `vector_candidate_count=1` beside zero results, an existence oracle over private memories. Both are rebuilt from the authorized set (`203c00ae`).

**🚨 The bench did not race the arm.** The adapter selected the arm on the server, then reshaped the response client-side. One returned row rendered as three at the shipped stitch default. The client now renders server candidates verbatim and the conflict guard covers every reshaping flag (`0565cb81`).

**🚨 A failed arm silently served machine results.** `compile_context`'s fallback returned eight-lane contents under the arm's label. The arm now re-raises, and the fallback is asserted intact for every other mode (`0a9d995a`).

**Active-work enrichment bypassed the arm** on project-scoped build and plan requests, merging unranked rows into the pack. Suppressed under the arm (`0a9d995a`).

**Every lane was clipped to the caller's limit before fusion**, which makes fusion decorative at small limits: at `limit=1` the row ranked second in both lanes, exactly what RRF exists to promote, was discarded before RRF saw it. Lanes now overfetch and truncation happens after fusion (`203c00ae`).

**Exact ties resolved by lane insertion order** through a stable sort, a silent lexical-lane preference applied only at a binding cutoff. Ties break on candidate id now, in the arm rather than the shared helper, so the machine's fusion is untouched (`203c00ae`).

The review's confirmed-invariants section (default-path immutability, immutable plan narrowing, `Literal`-constrained REST selection, no MCP exposure, cross-lane dedup, single exposure stamping) was left alone.

## 🔁 What changed in the second review round

A second hostile pass closed two findings (active-work suppression, tie-break) and reopened four with executed repros. All four reproduced locally before being fixed.

**🚨 The client still reshaped the arm's pack.** It capped membership at `max_items`, dropped empty-bodied rows, allocated per-candidate character budgets, and rewrote long bodies into query-aware slices, so twelve server candidates reached the reader as eight sliced ones. The render now emits every candidate with bodies whole and uses the shared renderer for none of it (`61876c28`).

**🛡️ Per-stage timings were a disclosure channel.** Measured across a fetch that runs before the scope filter, they let repeated queries distinguish denied matches from no matches by duration, putting back the signal the authorized-count rebuild had removed. Logged now, not returned (`61876c28`).

**Lane failures degraded silently**, returning a thin pack the benchmark scores as a recall miss, which attributes an outage to the arm's ranking. Any lane that raises or reports itself degraded now fails the request; the machine keeps its resilience (`61876c28`).

**Lane depth scaled off the limit left a boundary class alive.** Every lane reads to `MAX_RETRIEVAL_LIMIT` now, which removes the class and deletes the knob (`61876c28`).

**Guard gaps and a split-brain.** `knn_type_overfetch` reached the pack plan and silently reset to zero in the evidence plan, so a request setting it got it applied to half its own pack; it is refused at the API. Six settings for bypassed stages join the bench refusal set, keyed on a value differing from the shipped default rather than on presence, since the runner writes every key on every run (`61876c28`).

**CI red on the first round** was the conflict guard sitting behind an environment check: `agentic_traversal` is separately gated on an OpenAI key, so on a keyless machine the guard reported an unrelated missing-key error and its two tests failed. The guard now runs immediately after the mode is validated and reads parameters directly (`3d9c0793`). Static Checks was prettier formatting on the REST reference, fixed in the same commit. Both are verified green on the current head.

## 🧪 Validation

All gates forced uncached at `61876c28` over a clean tree, and all three GitHub workflows are green at that SHA (CI, Live Runtime Eval, LongMemEval V2):

- `moon run core:check --force` → **2523 passed, 14 skipped**
- `moon run api:test --force` → **2233 passed, 5 skipped**
- `uv run --project apps/api pytest tools/tests/ -q` → **986 passed**, run with and without the OpenAI key variables exported
- `moon run core:lint --force`, `core:typecheck --force`, `api:lint --force`, `api:typecheck --force` → all four "All checks passed!"

Pass `--force`. A cached moon replay on this branch returned in 170ms reporting 2506, three tests short of the real run, because it replayed an older input set.

New coverage, 66 tests:

- 38 in `packages/python/sibyl-core/tests/test_retrieval_naive_arm.py`: RRF rank math against the closed form, cross-lane agreement, tie handling at equal ranks, ordinality (rescaling a lane's raw scores moves nothing), lane-order independence, budget stop and single-oversized-item admission, per-item cap charging, the no-knobs constraint, authorized-only diagnostics, overfetch-then-truncate, tie-order invariance under lane reordering, fail-loud on arm failure with the machine's fallback still intact, and active-work suppression, plus behavioral tests against embedded SurrealDB.
- 10 in `apps/api/tests/test_routes_context.py::TestNaiveRetrievalArm`, including the default-path invariant, where `naive_search` raises if reached and `compile_context` is asserted to receive `naive_retrieval=False`, across all three of `evidence=None`, `fast`, and `accurate`.
- 18 in `tools/tests/test_longmemeval_v2_official.py`, covering the CLI-to-`memory_params` path, the conflict guard across all ten refused flags, and verbatim render membership and order.

The authorization tests were confirmed non-vacuous by mutation. Seeding a private row owned by another principal that is the strongest lexical and dense match in the corpus, then neutering `_candidate_allowed` to always admit, puts that row at rank one. With the real check in place a stranger never sees it and its owner does, so the withholding is a scope decision rather than an empty lane.

Selection was exercised directly: `--retrieval-mode naive` through `build_memory_config` yields `memory_params["retrieval_mode"] == "naive"`, the schema accepts `naive`, and an unknown mode still raises `ValidationError`.

An adversarial review agent independently checked the default-path invariant, the arm's composition, authorization parity, test non-vacuity, bench wiring, and the suites, and returned PASS on all six claims. Its three actionable observations, missing exposure receipts, a no-knobs assertion weak enough for a differently-named knob to dodge, and an `accurate` branch the default-path test never exercised, are fixed in `f0fca9b2` rather than carried as caveats. Exposure now has two dedicated route tests: one pinning the `usage_exposure` receipt and its `context_pack_evidence` source surface, one pinning that `record_exposure=False` writes nothing.

⚠️ The arm has not been exercised against a live SurrealDB 3.x server or a real corpus, only the embedded engine. Two engine-fidelity facts came out of writing those tests and are worth knowing before anyone reads a local result as production behavior. The embedded engine returns zero rows for an `OR` predicate sitting beside an HNSW `<|k, ef|>` bracket even when the row satisfies each half alone, which is why the test corpus is seeded without `project_id`. And a deterministic test embedding provider emits near-orthogonal vectors whose cosine similarity falls under the vector lane's score floor, which would have left the dense half of the arm untested behind a green suite, so row vectors are blended toward the query vector.

⚠️ No benchmark was run. Building the arm is this PR; racing it is the orchestrator's step.

## 🔍 What reviewers should focus on

- **The totality of the mode.** Selecting `naive` rewrites the pack, not just the evidence block. If you disagree that the pack's sections and the related-item walk belong under the same switch, that is the design call to push on, and it is the one that most changes what the race measures.
- **Authorization parity** in `_execute_naive_context_evidence_search` and in `naive_search`'s filter step. Every lane's candidates pass `_candidate_allowed` before fusion. A path where a candidate reaches the response unfiltered would be the serious defect in this PR.
- **The default-path invariant.** `git diff origin/main..HEAD -- packages/python/sibyl-core/src/sibyl_core/retrieval/search.py retrieval/hybrid.py retrieval/fusion.py` should be empty. If it is not, the arm has leaked into the machine.
- **The conflict guard's severity.** Raising on `naive` plus typed-stream or traversal is deliberately loud rather than a silent auto-disable. If you would rather it warn and disable, say so.
- **Whether `content_max_chars` parity is the right call.** It makes the arms comparable on payload, at the cost of the arm no longer being purely "verbatim spans, whole".
- **The `episode_fulltext` lane** is declared in the `naive_lanes` receipt whether or not the episode table holds anything, matching the machine. The `naive_lane_counts` field is what says whether it actually contributed.

Out of scope: analyzer and index definitions (another lane is adding snowball stemming, which this BM25 lane inherits transparently at merge), the machine's fusion internals, traversal, and the 8-lane packing path.

## 📌 Follow-ups (deliberate non-fixes)

- **The extract-then-answer reader variant is not built.** The v2 harness has no reader-prompt variant surface to hang it on: the reader prompt is constructed by the upstream official LongMemEval repo, and `install_memory_finalize` in `benchmarks/longmemeval_v2_official.py` wraps `build_prompt_row` only to call `finalize_ingest`, never touching prompt text. The reader flags are model and decoding only. Adding a prompt variant means creating that surface rather than toggling one, so it is a separate change and the retrieval arm stands alone as the deliverable.
- **Live-server verification of the arm** belongs with the first real screen, since it needs a corpus and a running stack.
- **A full `eval_gate` run over a real naive-mode receipt bundle** needs a bench run, so it lands with the race. The mode-acceptance half of that question is already settled by execution rather than left to reasoning: `_validate_retrieval_mode` rejects `naive`, `fast`, and `accurate` alike against both `_CONTEXT_PACK_RETRIEVAL_MODES` and `_AI_MEMORY_RETRIEVAL_MODES` (`tools/bench/eval_gate.py:74`), which are a different vocabulary entirely (`pre-graphiti`, `post-graphiti`, `native`, `compare`, `raw`, `hybrid`). Those validators govern a report's graph-retrieval mode, not the request-level evidence mode, which is why today's `fast` screens pass the gate while `fast` is absent from both sets. The new mode is indistinguishable from `fast` at that surface.


