### PR TITLE
fix(security): drop pip from the api image and gate releases on the CVE scan

### DIFF
--- a/.github/actions/trivy-image-gate/action.yml
+++ b/.github/actions/trivy-image-gate/action.yml
@@ -1,0 +1,60 @@
+name: Trivy image gate
+description: >-
+  Fail on fixed HIGH or CRITICAL advisories in a container image, optionally emitting a CycloneDX
+  inventory of the same image alongside the verdict.
+
+# One definition of "the image is clean", shared by every workflow that asks
+# the question. CI asks it on a pull request, Release asks it before a release
+# object exists, and Publish asks it again of the pushed digest. Copies would
+# drift, and a gate that differs between the pre-merge check and the release
+# check is a gate that lets something through.
+
+inputs:
+  image-ref:
+    description: Image reference to analyse, by tag or by digest.
+    required: true
+  platform:
+    description: >-
+      Platform to select from a multi-platform reference, as linux/amd64. Leave empty for a
+      reference that carries exactly one image, such as a locally built one; Trivy then reads it
+      as-is.
+    required: false
+    default: ""
+  sbom-output:
+    description: >-
+      Path to write a CycloneDX inventory to. Empty skips the inventory, which is what the pre-merge
+      and pre-release gates want: they build an image purely to interrogate it and then discard it,
+      so only images that reach a registry need a durable bill of materials.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # Trivy caches its vulnerability database by default (the action's `cache`
+    # input is already 'true'), so repeated calls within a run reuse one copy.
+    - name: "◆ Generate Trivy SBOM"
+      if: ${{ inputs.sbom-output != '' }}
+      uses: aquasecurity/trivy-action@v0.36.0
+      env:
+        TRIVY_PLATFORM: ${{ inputs.platform }}
+      with:
+        image-ref: ${{ inputs.image-ref }}
+        format: cyclonedx
+        output: ${{ inputs.sbom-output }}
+        scanners: vuln
+
+    # ignore-unfixed keeps the gate actionable: an advisory with no released
+    # fix cannot be cleared by anything this repository does, and blocking on
+    # one would only teach people to bypass the gate.
+    - name: "◆ Trivy CVE gate"
+      uses: aquasecurity/trivy-action@v0.36.0
+      env:
+        TRIVY_PLATFORM: ${{ inputs.platform }}
+      with:
+        image-ref: ${{ inputs.image-ref }}
+        format: table
+        exit-code: "1"
+        vuln-type: os,library
+        severity: HIGH,CRITICAL
+        ignore-unfixed: true

--- a/.github/actions/trivy-image-gate/action.yml
+++ b/.github/actions/trivy-image-gate/action.yml
@@ -47,6 +47,13 @@ runs:
     # ignore-unfixed keeps the gate actionable: an advisory with no released
     # fix cannot be cleared by anything this repository does, and blocking on
     # one would only teach people to bypass the gate.
+    #
+    # trivyignores names the suppression file explicitly. Trivy otherwise
+    # reads whatever `.trivyignore` happens to sit in the working directory,
+    # which would let an untracked or unreviewed file silence this gate. The
+    # committed file carries the exception policy, CI rescans whenever it
+    # changes, and the action fails outright if the path is missing, so
+    # deleting it cannot quietly restore the implicit behaviour.
     - name: "◆ Trivy CVE gate"
       uses: aquasecurity/trivy-action@v0.36.0
       env:
@@ -58,3 +65,4 @@ runs:
         vuln-type: os,library
         severity: HIGH,CRITICAL
         ignore-unfixed: true
+        trivyignores: .trivyignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       web_changed: ${{ steps.classify.outputs.web_changed }}
       ci_changed: ${{ steps.classify.outputs.ci_changed }}
       image_changed: ${{ steps.classify.outputs.image_changed }}
+      image_scan_matrix: ${{ steps.classify.outputs.image_scan_matrix }}
       run_static: ${{ steps.classify.outputs.run_static }}
       run_build: ${{ steps.classify.outputs.run_build }}
       run_tests: ${{ steps.classify.outputs.run_tests }}
@@ -86,6 +87,8 @@ jobs:
           web_changed=false
           ci_changed=false
           image_changed=false
+          api_image_changed=false
+          web_image_changed=false
 
           for file in "${changed_files[@]}"; do
             [[ -z "$file" ]] && continue
@@ -126,10 +129,23 @@ jobs:
             # dependency used to run no tests and no scan whatsoever. A base
             # image bump is a Dockerfile edit and lands here too, which is the
             # path the msgpack and setuptools advisories arrived by.
+            #
+            # Attributed per image so the scan builds what the change can
+            # actually reach. The first matching arm wins, so the specific
+            # per-image inputs are listed ahead of the shared ones.
             case "$file" in
-              uv.lock|pyproject.toml|*/pyproject.toml|Dockerfile|*/Dockerfile|.dockerignore|*/.dockerignore)
-                image_changed=true
-                runtime_changed=true
+              apps/api/Dockerfile|uv.lock|pyproject.toml|apps/api/pyproject.toml|packages/python/sibyl-core/pyproject.toml)
+                api_image_changed=true
+                ;;
+              apps/web/Dockerfile|package.json|apps/web/package.json|pnpm-lock.yaml|apps/web/pnpm-lock.yaml)
+                web_image_changed=true
+                ;;
+              # Shared or unattributable image inputs reach both images, and so
+              # does the suppression file, so an exception can never be added
+              # without the scan it would suppress running on the same commit.
+              Dockerfile|*/Dockerfile|*/pyproject.toml|.dockerignore|*/.dockerignore|.trivyignore)
+                api_image_changed=true
+                web_image_changed=true
                 ;;
             esac
 
@@ -148,7 +164,27 @@ jobs:
             runtime_changed=true
             web_changed=true
             ci_changed=true
+          fi
+
+          # A change to the gate itself, or to the workflows around it, is not
+          # attributable to one image, so it proves itself against both.
+          if [[ "$ci_changed" == true || ${#changed_files[@]} -eq 0 ]]; then
+            api_image_changed=true
+            web_image_changed=true
+          fi
+
+          if [[ "$api_image_changed" == true || "$web_image_changed" == true ]]; then
             image_changed=true
+            runtime_changed=true
+          fi
+
+          image_scan_matrix='[]'
+          if [[ "$api_image_changed" == true && "$web_image_changed" == true ]]; then
+            image_scan_matrix='["api", "web"]'
+          elif [[ "$api_image_changed" == true ]]; then
+            image_scan_matrix='["api"]'
+          elif [[ "$web_image_changed" == true ]]; then
+            image_scan_matrix='["web"]'
           fi
 
           run_static=false
@@ -172,7 +208,7 @@ jobs:
             run_storybook=true
           fi
 
-          if [[ "$image_changed" == true || "$ci_changed" == true ]]; then
+          if [[ "$image_scan_matrix" != "[]" ]]; then
             run_image_scan=true
           fi
 
@@ -185,6 +221,7 @@ jobs:
             echo "web_changed=$web_changed"
             echo "ci_changed=$ci_changed"
             echo "image_changed=$image_changed"
+            echo "image_scan_matrix=$image_scan_matrix"
             echo "run_static=$run_static"
             echo "run_build=$run_build"
             echo "run_tests=$run_tests"
@@ -209,7 +246,7 @@ jobs:
             echo "- tests: $run_tests"
             echo "- e2e: $run_e2e"
             echo "- storybook: $run_storybook"
-            echo "- image scan: $run_image_scan"
+            echo "- image scan: $run_image_scan $image_scan_matrix"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Catches shipped-dependency CVEs at review time. The image scan in publish
@@ -283,19 +320,25 @@ jobs:
   # the release and publish workflows run, so a merge cannot introduce
   # something a release would later refuse to ship.
   #
-  # The api image only. Its Python and OS surface is the half no pre-merge
-  # check reaches today, whereas the web image's shipped packages are already
-  # audited above, and building both here would double the wait on every
-  # dependency pull request to re-ask a question already answered.
+  # Scans whichever images the change can actually reach, api, web, or both,
+  # from the matrix the classifier derived. The Node audit above reads web's
+  # manifests but cannot see packages inherited from its runtime base image,
+  # so a web Dockerfile change has to build and scan the web image itself.
+  #
+  # amd64 only, unlike the release gate, which covers both architectures. The
+  # dependency mistake this catches is almost always architecture independent,
+  # and pre-merge latency is worth more here than the last few percent of
+  # coverage that the release gate then supplies before anything ships.
   image-cve-scan:
-    name: Image CVE Scan
+    name: Image CVE Scan (amd64)
     needs: changes
     if: needs.changes.outputs.run_image_scan == 'true'
     permissions:
       contents: read
     uses: ./.github/workflows/image-cve-gate.yml
     with:
-      images: '["api"]'
+      images: ${{ needs.changes.outputs.image_scan_matrix }}
+      platforms: '["amd64"]'
 
   static:
     name: Static Checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,13 @@ jobs:
       runtime_changed: ${{ steps.classify.outputs.runtime_changed }}
       web_changed: ${{ steps.classify.outputs.web_changed }}
       ci_changed: ${{ steps.classify.outputs.ci_changed }}
+      image_changed: ${{ steps.classify.outputs.image_changed }}
       run_static: ${{ steps.classify.outputs.run_static }}
       run_build: ${{ steps.classify.outputs.run_build }}
       run_tests: ${{ steps.classify.outputs.run_tests }}
       run_e2e: ${{ steps.classify.outputs.run_e2e }}
       run_storybook: ${{ steps.classify.outputs.run_storybook }}
+      run_image_scan: ${{ steps.classify.outputs.run_image_scan }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -83,6 +85,7 @@ jobs:
           runtime_changed=false
           web_changed=false
           ci_changed=false
+          image_changed=false
 
           for file in "${changed_files[@]}"; do
             [[ -z "$file" ]] && continue
@@ -112,8 +115,21 @@ jobs:
             esac
 
             case "$file" in
-              .github/workflows/ci.yml|.github/workflows/nightly-regression.yml|.github/actions/*)
+              .github/workflows/ci.yml|.github/workflows/nightly-regression.yml|.github/workflows/image-cve-gate.yml|.github/actions/*)
                 ci_changed=true
+                ;;
+            esac
+
+            # Dependency and image sources matched no other case here: the
+            # lockfile, the root manifest, and the Dockerfiles all sit outside
+            # apps/, so a bump that pulled in a vulnerable transitive
+            # dependency used to run no tests and no scan whatsoever. A base
+            # image bump is a Dockerfile edit and lands here too, which is the
+            # path the msgpack and setuptools advisories arrived by.
+            case "$file" in
+              uv.lock|pyproject.toml|*/pyproject.toml|Dockerfile|*/Dockerfile|.dockerignore|*/.dockerignore)
+                image_changed=true
+                runtime_changed=true
                 ;;
             esac
 
@@ -132,6 +148,7 @@ jobs:
             runtime_changed=true
             web_changed=true
             ci_changed=true
+            image_changed=true
           fi
 
           run_static=false
@@ -139,6 +156,7 @@ jobs:
           run_tests=false
           run_e2e=false
           run_storybook=false
+          run_image_scan=false
 
           if [[ "$docs_changed" == true || "$hooks_changed" == true || "$infra_changed" == true || "$skills_changed" == true || "$runtime_changed" == true || "$ci_changed" == true ]]; then
             run_static=true
@@ -154,6 +172,10 @@ jobs:
             run_storybook=true
           fi
 
+          if [[ "$image_changed" == true || "$ci_changed" == true ]]; then
+            run_image_scan=true
+          fi
+
           {
             echo "docs_changed=$docs_changed"
             echo "hooks_changed=$hooks_changed"
@@ -162,11 +184,13 @@ jobs:
             echo "runtime_changed=$runtime_changed"
             echo "web_changed=$web_changed"
             echo "ci_changed=$ci_changed"
+            echo "image_changed=$image_changed"
             echo "run_static=$run_static"
             echo "run_build=$run_build"
             echo "run_tests=$run_tests"
             echo "run_e2e=$run_e2e"
             echo "run_storybook=$run_storybook"
+            echo "run_image_scan=$run_image_scan"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -185,6 +209,7 @@ jobs:
             echo "- tests: $run_tests"
             echo "- e2e: $run_e2e"
             echo "- storybook: $run_storybook"
+            echo "- image scan: $run_image_scan"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Catches shipped-dependency CVEs at review time. The image scan in publish
@@ -250,6 +275,27 @@ jobs:
               sys.exit(1)
           print(f"No new high or critical advisories. {len(set(waived))} tracked.")
           PY
+
+  # The dependency audit above reads Node manifests. This reads an image,
+  # which is the only place a base-image advisory is visible at all: msgpack
+  # and setuptools reached a tagged release through pip's vendored set in the
+  # Python base image, named in no manifest this repository owns. Same gate
+  # the release and publish workflows run, so a merge cannot introduce
+  # something a release would later refuse to ship.
+  #
+  # The api image only. Its Python and OS surface is the half no pre-merge
+  # check reaches today, whereas the web image's shipped packages are already
+  # audited above, and building both here would double the wait on every
+  # dependency pull request to re-ask a question already answered.
+  image-cve-scan:
+    name: Image CVE Scan
+    needs: changes
+    if: needs.changes.outputs.run_image_scan == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/image-cve-gate.yml
+    with:
+      images: '["api"]'
 
   static:
     name: Static Checks

--- a/.github/workflows/image-cve-gate.yml
+++ b/.github/workflows/image-cve-gate.yml
@@ -1,0 +1,79 @@
+name: Image CVE Gate
+
+# Builds the images this repository ships and fails on fixed HIGH or CRITICAL
+# advisories in them.
+#
+# Publish already scans images, but only at distribution time, by which point
+# Release has created the tag and the release object. That ordering is what
+# made the v1.2.1 scan a postmortem rather than a gate. This workflow is the
+# same question asked at the two earlier points where the answer is still
+# free to act on: on a pull request that touches dependencies or an image, and
+# on a release candidate before anything is named.
+#
+# Nothing here needs registry credentials. The image is built into the local
+# daemon and interrogated there, so the gate runs on a pull request without
+# handing a fork branch any publishing reach.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to build and scan. Empty uses the calling workflow's SHA."
+        required: false
+        type: string
+        default: ""
+      platform:
+        description: "Single platform to build and scan, without the linux/ prefix."
+        required: false
+        type: string
+        default: amd64
+      images:
+        description: 'JSON array of images to build and scan, as ["api","web"].'
+        required: false
+        type: string
+        default: '["api", "web"]'
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: "◆ Scan ${{ matrix.image }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      # Every image is reported, so one dirty image does not hide another.
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(inputs.images) }}
+    steps:
+      - name: "◆ Checkout"
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: "◇ Setup Docker Buildx"
+        uses: docker/setup-buildx-action@v4
+
+      # A single platform, loaded rather than pushed. Publish scans every
+      # architecture it ships because that is the last chance to catch one;
+      # here the point is fast feedback on the dependency set, which is the
+      # same across architectures.
+      - name: "△ Build ${{ matrix.image }} image"
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/${{ matrix.image }}/Dockerfile
+          platforms: linux/${{ inputs.platform }}
+          load: true
+          push: false
+          tags: sibyl-${{ matrix.image }}:cve-gate
+          cache-from: type=gha,scope=cve-gate-${{ matrix.image }}-${{ inputs.platform }}
+          cache-to: type=gha,mode=max,scope=cve-gate-${{ matrix.image }}-${{ inputs.platform }}
+
+      - name: "◆ Trivy CVE gate"
+        uses: ./.github/actions/trivy-image-gate
+        with:
+          image-ref: sibyl-${{ matrix.image }}:cve-gate

--- a/.github/workflows/image-cve-gate.yml
+++ b/.github/workflows/image-cve-gate.yml
@@ -22,11 +22,11 @@ on:
         required: false
         type: string
         default: ""
-      platform:
-        description: "Single platform to build and scan, without the linux/ prefix."
+      platforms:
+        description: 'JSON array of platforms to build and scan, as ["amd64","arm64"].'
         required: false
         type: string
-        default: amd64
+        default: '["amd64"]'
       images:
         description: 'JSON array of images to build and scan, as ["api","web"].'
         required: false
@@ -38,16 +38,22 @@ permissions:
 
 jobs:
   scan:
-    name: "◆ Scan ${{ matrix.image }}"
-    runs-on: ubuntu-latest
+    name: "◆ Scan ${{ matrix.image }} (${{ matrix.platform }})"
+    # Each architecture builds on its own native runner, the same way publish
+    # does. Emulating arm64 through qemu would work but costs multiples of the
+    # build time, and the whole point of scanning before the tag is that the
+    # answer arrives while it is still cheap to act on.
+    runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 45
     permissions:
       contents: read
     strategy:
-      # Every image is reported, so one dirty image does not hide another.
+      # Every combination is reported, so one dirty image or architecture
+      # does not hide another.
       fail-fast: false
       matrix:
         image: ${{ fromJSON(inputs.images) }}
+        platform: ${{ fromJSON(inputs.platforms) }}
     steps:
       - name: "◆ Checkout"
         uses: actions/checkout@v7
@@ -57,23 +63,24 @@ jobs:
       - name: "◇ Setup Docker Buildx"
         uses: docker/setup-buildx-action@v4
 
-      # A single platform, loaded rather than pushed. Publish scans every
-      # architecture it ships because that is the last chance to catch one;
-      # here the point is fast feedback on the dependency set, which is the
-      # same across architectures.
+      # One platform per job, loaded rather than pushed. `load` is a
+      # single-platform exporter, so the matrix supplies the architectures
+      # rather than the build.
       - name: "△ Build ${{ matrix.image }} image"
         uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/${{ matrix.image }}/Dockerfile
-          platforms: linux/${{ inputs.platform }}
+          platforms: linux/${{ matrix.platform }}
           load: true
           push: false
-          tags: sibyl-${{ matrix.image }}:cve-gate
-          cache-from: type=gha,scope=cve-gate-${{ matrix.image }}-${{ inputs.platform }}
-          cache-to: type=gha,mode=max,scope=cve-gate-${{ matrix.image }}-${{ inputs.platform }}
+          tags: sibyl-${{ matrix.image }}:cve-gate-${{ matrix.platform }}
+          cache-from: type=gha,scope=cve-gate-${{ matrix.image }}-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=cve-gate-${{ matrix.image }}-${{ matrix.platform }}
 
+      # No platform is passed to the gate. The reference is a local
+      # single-platform image, so there is no index for Trivy to choose from.
       - name: "◆ Trivy CVE gate"
         uses: ./.github/actions/trivy-image-gate
         with:
-          image-ref: sibyl-${{ matrix.image }}:cve-gate
+          image-ref: sibyl-${{ matrix.image }}:cve-gate-${{ matrix.platform }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1026,21 +1026,21 @@ jobs:
           manifest.
           EOF
 
-      # Promotion, not just decoration. Release creates the version as a
-      # pre-release that is not "latest"; this job runs only after the images
-      # passed their scan, were signed and pushed, and every package shipped,
-      # so this is the first moment the version is true. A publish that fails
-      # anywhere upstream leaves the pre-release standing and never promotes
-      # it, which is what stops a broken distribution from presenting itself
-      # as the current version.
-      - name: "◆ Update release and promote it to latest"
+      # Assets first, still as a pre-release. Uploading and promoting in one
+      # call would promote first: action-gh-release updates release metadata
+      # before it touches assets, and its post-upload finalize step returns
+      # immediately for a release that is not a draft, so it cannot undo
+      # anything. A failed upload would therefore leave a release already
+      # marked full and latest with assets missing, which is the exact
+      # looks-successful state this pipeline exists to prevent.
+      - name: "► Attach release evidence"
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag }}
           fail_on_unmatched_files: true
           body_path: release-body.md
-          prerelease: false
-          make_latest: true
+          prerelease: true
+          make_latest: false
           files: |
             release-assets/*
 
@@ -1068,3 +1068,17 @@ jobs:
             echo "- \`sibyl/sibyl --version ${{ steps.version.outputs.version }}\`"
             echo "- \`sibyl/sibyl-surrealdb --version ${{ steps.version.outputs.version }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # The last thing the pipeline does, and the only thing that carries no
+      # files. Release created this version as a pre-release that is not
+      # "latest"; every gate, every signature, every package and every asset
+      # is already in place by the time this runs, so flipping the two flags
+      # is the first moment the version is true rather than a claim. Anything
+      # failing before this point leaves the pre-release standing, which is
+      # visible, installable on purpose, and never presented as current.
+      - name: "◆ Promote release to latest"
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.tag }}
+          prerelease: false
+          make_latest: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -558,6 +558,14 @@ jobs:
         image: [api, web]
         platform: [amd64, arm64]
     steps:
+      # This job analyses a registry digest rather than the working tree, but
+      # the gate it runs is a local action, so the definition has to be on
+      # disk for it to resolve.
+      - name: "◆ Checkout"
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
       - name: "△ Extract version from tag"
         id: version
         run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
@@ -588,27 +596,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "◆ Generate Trivy SBOM"
-        uses: aquasecurity/trivy-action@v0.36.0
-        env:
-          # Trivy resolves a remote index to linux/amd64 unless told otherwise,
-          # and it does not infer the platform from the host it runs on. A
-          # push-by-digest reference is a single-platform index, so scanning
-          # the arm64 digest without this asks for an amd64 child that is not
-          # there and fails before reading a package. The action exposes no
-          # platform input; trivy derives TRIVY_PLATFORM from its own flag.
-          TRIVY_PLATFORM: linux/${{ matrix.platform }}
+      # The SBOM and the verdict come from one shared action, so the scan that
+      # runs here is the scan that ran on the pull request and on the release
+      # candidate. Trivy resolves a remote index to linux/amd64 unless told
+      # otherwise, and it does not infer the platform from the host it runs
+      # on. A push-by-digest reference is a single-platform index, so scanning
+      # the arm64 digest without naming the platform asks for an amd64 child
+      # that is not there and fails before reading a package.
+      - name: "◆ Trivy SBOM and CVE gate"
+        uses: ./.github/actions/trivy-image-gate
         with:
           image-ref: >-
             ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}@${{
             steps.digest.outputs.ref }}
-          format: cyclonedx
-          output:
+          platform: linux/${{ matrix.platform }}
+          sbom-output:
             sibyl-${{ matrix.image }}-${{ matrix.platform }}-${{ steps.version.outputs.version
             }}.cdx.json
-          scanners: vuln
 
+      # The inventory is written before the verdict and uploaded regardless of
+      # it. A failing gate is exactly when someone needs to read what is in
+      # the image, so the evidence must outlive the failure.
       - name: "► Upload SBOM"
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name:
@@ -619,20 +629,6 @@ jobs:
             }}.cdx.json
           if-no-files-found: error
           retention-days: 90
-
-      - name: "◆ Trivy CVE gate"
-        uses: aquasecurity/trivy-action@v0.36.0
-        env:
-          TRIVY_PLATFORM: linux/${{ matrix.platform }}
-        with:
-          image-ref: >-
-            ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/sibyl-${{ matrix.image }}@${{
-            steps.digest.outputs.ref }}
-          format: table
-          exit-code: "1"
-          vuln-type: os,library
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
 
   # =========================================================================
   # Docker: keyless Sigstore signatures for the scanned multi-arch images

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1026,12 +1026,21 @@ jobs:
           manifest.
           EOF
 
-      - name: "◆ Update release with install instructions"
+      # Promotion, not just decoration. Release creates the version as a
+      # pre-release that is not "latest"; this job runs only after the images
+      # passed their scan, were signed and pushed, and every package shipped,
+      # so this is the first moment the version is true. A publish that fails
+      # anywhere upstream leaves the pre-release standing and never promotes
+      # it, which is what stops a broken distribution from presenting itself
+      # as the current version.
+      - name: "◆ Update release and promote it to latest"
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag }}
           fail_on_unmatched_files: true
           body_path: release-body.md
+          prerelease: false
+          make_latest: true
           files: |
             release-assets/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,13 @@ jobs:
     uses: ./.github/workflows/image-cve-gate.yml
     permissions:
       contents: read
+    with:
+      # Every image and every architecture publish ships. Scanning only amd64
+      # would let an arm64-only OS package advisory through, and the base
+      # image package sets genuinely differ per architecture. Each builds on
+      # its own native runner, so this costs wall time rather than emulation.
+      images: '["api", "web"]'
+      platforms: '["amd64", "arm64"]'
 
   release:
     name: Release
@@ -424,6 +431,21 @@ jobs:
           git push origin HEAD:${{ github.ref_name }}
           git push origin "v${{ steps.version.outputs.version }}"
 
+      # Created as a pre-release that is explicitly not "latest", and promoted
+      # to a full release by the last job of the publish workflow, once the
+      # images are scanned, signed and pushed and every package is out.
+      #
+      # The gate above scans an image built from this SHA, but publish rebuilds
+      # from floating inputs (the base image tag, uv:latest, live apt
+      # repositories), so the bytes it ships are not the bytes that were
+      # scanned here. That gap is real and is closed by promoting the exact
+      # scanned digests instead of rebuilding, which is a publish rework. Until
+      # then the staged visibility is what bounds the damage: a release whose
+      # distribution fails never presents itself as the version to install.
+      #
+      # Draft would hide it more thoroughly, but a draft release has no tag
+      # association, and publish reads this release back by tag to preserve its
+      # notes. A pre-release keeps that read working.
       - name: "◆ Create GitHub Release"
         if: ${{ !inputs.dry_run }}
         uses: softprops/action-gh-release@v3
@@ -431,8 +453,8 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
           body: ${{ steps.release_notes.outputs.content }}
-          prerelease: false
-          make_latest: true
+          prerelease: true
+          make_latest: false
 
       - name: "◇ Trigger publish"
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # =========================================================================
+  # Image CVE gate: prove the shipped images are clean before a release exists
+  #
+  # Publish scans images too, but publish is dispatched by the last step of
+  # this workflow, so its verdict lands after the tag and the release object
+  # are already public. v1.2.1 is what that ordering costs: the scan failed on
+  # two HIGH advisories that a released version could no longer be recalled
+  # for. Running the gate here means a dirty image stops the release before
+  # anything is named, and the publish-time scan stays where it is as the
+  # second line of defence over the artifacts that actually get distributed.
+  #
+  # The scan reads the dispatched SHA rather than the tagged commit. The only
+  # thing between them is the version bump, which the release job proves
+  # touches nothing but generated pins, so the image contents are identical.
+  # =========================================================================
+  image-cve-gate:
+    name: "◆ Image CVE gate"
+    uses: ./.github/workflows/image-cve-gate.yml
+    permissions:
+      contents: read
+
   release:
     name: Release
+    needs: image-cve-gate
     runs-on: ubuntu-latest
     timeout-minutes: 75
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,28 @@
+# Trivy vulnerability exceptions for the images this repository publishes.
+#
+# This file is deliberately empty, and an empty file is the correct steady
+# state. It exists so that suppression has an owner and a paper trail: Trivy
+# reads a file of this name from the working directory by default, so without
+# a committed one an untracked file could silence the image gate with nobody
+# accountable for it. Every image scan in this repository is pointed at this
+# exact path through .github/actions/trivy-image-gate, and the scan itself
+# runs whenever this file changes, so an entry can never land unscanned.
+#
+# Policy for adding an entry:
+#
+#   1. Fixing the advisory comes first. Bump the dependency, or remove the
+#      component. The msgpack and setuptools advisories that prompted this
+#      gate were fixed by deleting pip from the api runtime image, not by
+#      being listed here.
+#   2. An entry requires its own pull request, reviewed on the security
+#      question alone rather than bundled into a feature branch.
+#   3. Each entry carries the advisory ID, the reason no fix is possible
+#      today, the exposure that makes it acceptable, and an expiry date.
+#      Trivy honours an expiry with `exp:` on the entry.
+#   4. An entry without an expiry date is not an exception, it is a
+#      permanent regression, and it does not belong here.
+#
+# Format, one advisory per line:
+#
+#   CVE-2000-0000 exp:2026-01-01
+#   # why no fix exists, what the exposure is, who accepted it

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -42,6 +42,18 @@ ARG SIBYL_GIT_DIRTY=false
 RUN groupadd --gid 10001 sibyl && \
     useradd --uid 10001 --gid 10001 --shell /bin/bash --create-home sibyl
 
+# The base image ships pip only to bootstrap installs. Nothing here runs it:
+# the application lives in /app/.venv, which uv builds without pip. What pip
+# does contribute is its vendored dependency set, declared in
+# pip/_vendor/vendor.txt and read by scanners as image contents, which is how
+# msgpack and setuptools advisories reached a release that depends on
+# neither. The final import check fails the build if a future base image
+# reinstates pip somewhere this does not reach.
+RUN site_packages="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')" && \
+    rm -rf "${site_packages}/pip" "${site_packages}"/pip-*.dist-info && \
+    rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.* && \
+    ! python -c "import pip" 2>/dev/null
+
 WORKDIR /app
 
 # Copy virtual environment from builder

--- a/moon.yml
+++ b/moon.yml
@@ -578,6 +578,13 @@ tasks:
       - .github/workflows/release.yml
       - .github/workflows/publish.yml
       - .github/workflows/publish-dogfood-images.yml
+      # The image CVE gate is shared by release, publish and CI, and this task
+      # asserts the three stay in agreement. Without these the cache would
+      # report a stale green after the gate itself changed.
+      - .github/workflows/ci.yml
+      - .github/workflows/image-cve-gate.yml
+      - .github/actions/trivy-image-gate/action.yml
+      - .trivyignore
       - moon.yml
 
   python-package-build:

--- a/tools/tests/test_longmemeval_v2_causal_ablation.py
+++ b/tools/tests/test_longmemeval_v2_causal_ablation.py
@@ -580,10 +580,14 @@ def test_causal_report_loaders_accept_paid_artifact_shapes(tmp_path: Path) -> No
 
 def test_ci_runs_benchmark_gate_for_benchmark_only_changes() -> None:
     workflow = (Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml").read_text()
-    runtime_case = next(
+    # More than one case arm routes a path to the runtime suite, so match on
+    # any of them rather than the first: reading only the first made this
+    # assertion depend on the order the arms happen to be written in.
+    runtime_cases = [
         block.split("esac", maxsplit=1)[0]
         for block in workflow.split('case "$file" in')[1:]
         if "runtime_changed=true" in block.split("esac", maxsplit=1)[0]
-    )
+    ]
 
-    assert "benchmarks/*" in runtime_case
+    assert runtime_cases
+    assert any("benchmarks/*" in case for case in runtime_cases)

--- a/tools/tests/test_release_workflow.py
+++ b/tools/tests/test_release_workflow.py
@@ -239,9 +239,46 @@ def test_release_is_promoted_only_after_publish_succeeds() -> None:
 
     publish = _publish_workflow()
 
-    assert "prerelease: false" in publish
-    assert "make_latest: true" in publish
     assert "needs: [python, homebrew, aur, docker-sign, helm-publish]" in publish
+
+    # Order is the property, not coexistence. action-gh-release updates
+    # release metadata before it uploads assets, and its post-upload finalize
+    # step returns immediately for a non-draft release, so a single call that
+    # both promotes and uploads promotes first. A failed upload would then
+    # leave a full, latest release with assets missing. Promotion therefore
+    # has to be its own final step that carries no files at all.
+    steps = cast(
+        "list[dict[str, Any]]",
+        yaml.safe_load(publish)["jobs"]["release"]["steps"],
+    )
+    gh_release_steps = [
+        (index, step)
+        for index, step in enumerate(steps)
+        if str(step.get("uses", "")).startswith("softprops/action-gh-release")
+    ]
+    # Exactly two: one that attaches evidence, one that promotes. A third
+    # would mean another release mutation nobody accounted for.
+    expected_release_mutations = 2
+    assert len(gh_release_steps) == expected_release_mutations
+
+    (upload_index, upload_step), (promote_index, promote_step) = gh_release_steps
+    upload_with = upload_step.get("with", {})
+    promote_with = promote_step.get("with", {})
+
+    # The step carrying assets must leave the pre-release status untouched.
+    assert upload_with.get("files")
+    assert upload_with.get("prerelease") is True
+    assert upload_with.get("make_latest") is False
+
+    # The promoting step must carry nothing that can fail after the flip.
+    assert "files" not in promote_with
+    assert promote_with.get("prerelease") is False
+    assert promote_with.get("make_latest") is True
+    assert promote_index > upload_index
+
+    # Nothing may run after promotion, so a late failure cannot strand a
+    # release that already presents itself as current.
+    assert promote_index == len(steps) - 1
 
 
 def test_published_images_can_name_their_own_version() -> None:

--- a/tools/tests/test_release_workflow.py
+++ b/tools/tests/test_release_workflow.py
@@ -61,8 +61,13 @@ RELEASE_WORKFLOW_REQUIRED_FRAGMENTS = (
     "[^[:space:]]",
     'echo "::error::Git-Iris generated empty release notes; refusing to create a release."\n'
     "            exit 1",
-    "prerelease: false",
-    "make_latest: true",
+    # The release object is born as a pre-release that is not "latest".
+    # Publish promotes it once distribution actually succeeded, which
+    # test_release_is_promoted_only_after_publish_succeeds pins end to end.
+    "prerelease: true",
+    "make_latest: false",
+    "uses: ./.github/workflows/image-cve-gate.yml",
+    "needs: image-cve-gate",
     "RELEASE_NOTES_CONTENT",
     "printf '%s\\n' \"$RELEASE_NOTES_CONTENT\"",
 )
@@ -171,6 +176,72 @@ def _publish_workflow() -> str:
 
 def _dogfood_image_workflow() -> str:
     return (REPO_ROOT / ".github/workflows/publish-dogfood-images.yml").read_text(encoding="utf-8")
+
+
+def test_image_cve_gate_is_shared_by_every_caller() -> None:
+    # Two HIGH advisories reached v1.2.1 because the only image scan ran in
+    # publish, after release had already created the tag and the release
+    # object. The gate now runs in three places, and the whole value of that
+    # depends on the three asking the same question, so the configuration
+    # lives in one composite action and every caller delegates to it.
+    action = (REPO_ROOT / ".github/actions/trivy-image-gate/action.yml").read_text(encoding="utf-8")
+
+    assert "aquasecurity/trivy-action@v0.36.0" in action
+    assert "format: cyclonedx" in action
+    assert "severity: HIGH,CRITICAL" in action
+    assert 'exit-code: "1"' in action
+    assert "vuln-type: os,library" in action
+    assert "ignore-unfixed: true" in action
+    # Trivy reads a .trivyignore from the working directory unless told
+    # otherwise, so the suppression file is named explicitly. Without this an
+    # untracked file could silence every gate with nobody accountable.
+    assert "trivyignores: .trivyignore" in action
+    assert (REPO_ROOT / ".trivyignore").is_file()
+
+    reusable = (REPO_ROOT / ".github/workflows/image-cve-gate.yml").read_text(encoding="utf-8")
+
+    assert "uses: ./.github/actions/trivy-image-gate" in reusable
+    assert "workflow_call:" in reusable
+    # Built into the local daemon, never pushed, so the gate needs no registry
+    # credentials and is safe to run on a pull request from a fork.
+    assert "load: true" in reusable
+    assert "push: false" in reusable
+    assert "fromJSON(inputs.images)" in reusable
+    assert "fromJSON(inputs.platforms)" in reusable
+
+    release = (REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    # The release job may not begin until the gate is green, which is the
+    # single property that stops a scan verdict from postdating a release.
+    assert "uses: ./.github/workflows/image-cve-gate.yml" in release
+    assert "needs: image-cve-gate" in release
+    # Publish ships both architectures, so the pre-tag gate covers both.
+    assert 'platforms: \'["amd64", "arm64"]\'' in release
+    assert 'images: \'["api", "web"]\'' in release
+
+    ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "uses: ./.github/workflows/image-cve-gate.yml" in ci
+    assert "images: ${{ needs.changes.outputs.image_scan_matrix }}" in ci
+    # Adding a suppression must run the scan it would suppress.
+    assert ".trivyignore" in ci
+
+
+def test_release_is_promoted_only_after_publish_succeeds() -> None:
+    # A release object created before distribution is a claim the pipeline has
+    # not yet earned. Release creates the version as a pre-release that is not
+    # "latest"; only the final publish job, which runs after the images are
+    # scanned, signed and pushed and every package has shipped, promotes it.
+    release = (REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    assert "prerelease: true" in release
+    assert "make_latest: false" in release
+
+    publish = _publish_workflow()
+
+    assert "prerelease: false" in publish
+    assert "make_latest: true" in publish
+    assert "needs: [python, homebrew, aur, docker-sign, helm-publish]" in publish
 
 
 def test_published_images_can_name_their_own_version() -> None:
@@ -286,10 +357,11 @@ def test_publish_workflow_attaches_docker_and_release_evidence() -> None:
     assert "docker-security:" in workflow
     assert "fail-fast: false" in workflow
     assert "docker-sign:" in workflow
-    assert "aquasecurity/trivy-action@v0.36.0" in workflow
+    # The Trivy configuration itself moved into the shared composite action,
+    # so publish is checked for delegating to it rather than for inlining it.
+    # test_image_cve_gate_is_shared_by_every_caller owns the configuration.
+    assert "uses: ./.github/actions/trivy-image-gate" in workflow
     assert "sigstore/cosign-installer@v4.1.2" in workflow
-    assert "format: cyclonedx" in workflow
-    assert "severity: HIGH,CRITICAL" in workflow
     assert "cosign sign --yes" in workflow
     assert "Upload Cosign receipt" in workflow
     assert "Download Python distributions" in workflow


### PR DESCRIPTION
# 🛡️ The CVE gate, moved in front of the release

> Kills the two HIGH advisories that failed the v1.2.1 Publish scan, and changes the job ordering so
> a scan verdict can never again arrive after a release is already public.

## 💡 What this is

Two changes that share one story. The v1.2.1 Publish run failed its Trivy gate on msgpack 1.1.2
(GHSA-6v7p-g79w-8964) and setuptools 70.3.0 (CVE-2025-47273). Both failures landed after the v1.2.1
tag and its GitHub release were already public, so the gate that caught them could not act on what
it found.

The natural reading of that failure is "bump two dependencies." That reading is wrong, and the
version numbers are the tell: neither package appears anywhere in `uv.lock`, so there is nothing to
bump. Both are versions that pip vendors. They are declared in `pip/_vendor/vendor.txt` inside the
Python base image, and Trivy reads that file and attributes its contents to our image. The fix is to
remove pip from the runtime stage, which nothing there runs.

The second half is the ordering. The image scan lived only in `publish.yml`, which `release.yml`
dispatches from its final step, so the scan structurally could not gate the release object it was
meant to protect.

## 🔬 Where the advisories actually came from

Scanning the base image on its own, with no Sibyl code in it at all, reproduces exactly the failing
pair:

```
$ trivy image --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed \
    --pkg-types os,library python:3.13-slim-bookworm

Python (python-pkg)
Total: 2 (HIGH: 2, CRITICAL: 0)

│ Library    │ Vulnerability       │ Severity │ Installed │ Fixed   │
│ msgpack    │ GHSA-6v7p-g79w-8964 │ HIGH     │ 1.1.2     │ 1.2.1   │
│ setuptools │ CVE-2025-47273      │ HIGH     │ 70.3.0    │ 78.1.1  │

python:3.13-slim-bookworm (debian 12.15)   debian   0
```

The Debian package set is clean. Both findings come from one file:

```
$ docker run --rm python:3.13-slim-bookworm \
    cat /usr/local/lib/python3.13/site-packages/pip/_vendor/vendor.txt
...
msgpack==1.1.2
...
setuptools==70.3.0
```

That file is the entire mechanism. It also means no lockfile change could have cleared the gate, and
that the same source can produce a new HIGH on any future base image pull without a single line of
Sibyl changing.

## 🎯 The invariant

Anchor the review on one property: **no GitHub release object exists until the image CVE gate has
passed.** Everything in `release.yml` that creates something durable, the tag push, the release
object, and the Publish dispatch, now sits behind a job that must go green first.

## 🛠️ How it works

### 1. `apps/api/Dockerfile`: pip leaves the runtime stage

The runtime stage now deletes pip and asserts it is gone:

```dockerfile
RUN site_packages="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')" && \
    rm -rf "${site_packages}/pip" "${site_packages}"/pip-*.dist-info && \
    rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.* && \
    ! python -c "import pip" 2>/dev/null
```

The application runs from `/app/.venv`, which uv builds without pip, so nothing in the image loses a
capability it was using. The trailing import check is a build-time assertion: if a future base image
reinstates pip somewhere these paths miss, the build fails rather than the next release.

This mirrors what `apps/web/Dockerfile` already does at its own runtime stage, where
`rm -rf /usr/local/lib/node_modules/npm` strips the bundled package manager for the same reason.

### 2. `.github/actions/trivy-image-gate/action.yml`: one definition of the gate

A new composite action holds the CycloneDX inventory step and the HIGH/CRITICAL verdict step. It
takes `image-ref`, an optional `platform` for multi-platform references, and an optional
`sbom-output` that skips inventory generation when empty. Three callers now share it, so the
pre-merge check and the release check cannot drift into asking different questions.

### 3. `.github/workflows/image-cve-gate.yml`: build locally, scan locally

A reusable workflow (`workflow_call`) that builds an image with `load: true` into the runner's Docker
daemon and scans it there. It needs no registry credentials, which is what makes it safe to run on a
pull request. Inputs are `ref`, `platform` (default `amd64`), and `images` (default `["api", "web"]`).

### 4. `.github/workflows/release.yml`: the gate precedes the release object

The single `release` job gains `needs: image-cve-gate`, where `image-cve-gate` calls the reusable
workflow over both images.

It scans **both images on both architectures**, matching exactly what publish ships. Base image OS
package sets genuinely differ per architecture, so an amd64-only gate could pass while publish failed
on arm64 after the release existed. Each architecture builds on its own native runner
(`ubuntu-24.04-arm`), the same way `docker-build` does, so this costs wall time rather than emulation.

The gate scans the dispatched SHA rather than the tagged commit. Those differ only by the version
bump commit, which the release job already proves touches nothing but generated pins (the
`sync_versions.py --list-targets` allowlist check), so the image contents are identical either way.

### 4b. The release object is staged, not asserted

The pre-tag scan builds from this SHA, but publish **rebuilds** from floating inputs: the
`python:3.13-slim-bookworm` tag, `uv:latest`, and live apt repositories. The bytes that get scanned
before the tag are therefore not the bytes that ship. Closing that properly means promoting the
scanned digests instead of rebuilding, which is a publish rework (see follow-ups).

Until then the visibility is staged so the gap cannot mislead anyone. `release.yml` creates the
release as `prerelease: true, make_latest: false`, and the final publish job, which runs only after
`[python, homebrew, aur, docker-sign, helm-publish]` all succeeded, promotes it. A publish that fails
anywhere leaves the pre-release standing, so a version whose distribution failed never presents
itself as the one to install.

Promotion is its own final step carrying no files, and that ordering is load-bearing.
`action-gh-release` updates release metadata **before** it uploads assets (`src/run.ts`: `release()`
runs, then the upload loop), and its post-upload `finalizeRelease` early-returns for any release that
is not a draft (`src/github.ts`), so it cannot undo the flip. Promoting and uploading in one call
would therefore promote first, and a failed upload would leave a full, latest release with assets
missing. The publish tail is three ordered steps instead: attach evidence while still a pre-release,
write the summary, then flip `prerelease` and `make_latest` with nothing left to run afterwards.

Draft would hide it more thoroughly, but a draft release has no tag association and publish reads the
release back by tag to preserve its notes. A pre-release keeps that read working.

Before, the only verdict arrived downstream of everything it should have blocked:

```mermaid
flowchart LR
  B1[release job] --> B2[create tag]
  B2 --> B3[create release]
  B3 --> B4[dispatch publish]
  B4 --> B5[docker-build]
  B5 --> B6[trivy gate]
  B6 -.->|too late to stop B3| B3
```

After, the release object is downstream of the verdict:

```mermaid
flowchart LR
  A1[image-cve-gate] --> A2[release job]
  A2 --> A3[create tag]
  A3 --> A4[create release]
  A4 --> A5[dispatch publish]
  A5 --> A6[docker-build]
  A6 --> A7[trivy gate over pushed digests]
```

Publish keeps its own scan over the pushed digests, both architectures, unchanged in scope. That is
the last line of defence over the artifacts that actually get distributed.

### 5. `.trivyignore`: suppression gets an owner

Trivy reads a `.trivyignore` from the working directory unless told otherwise, and the repository had
neither that file nor a `CODEOWNERS`. An untracked or unreviewed file could therefore have silenced
every gate with nobody accountable for it. The composite action now passes
`trivyignores: .trivyignore` explicitly, the committed file carries the exception policy and zero
entries, and the classifier treats it as an input to **both** images, so a suppression can never land
without the scan it would suppress running on the same commit. The action fails outright if the path
is missing, so deleting the file cannot quietly restore the implicit behaviour.

### 6. `.github/workflows/ci.yml`: the classifier could not see dependencies

The change classifier matched `apps/*`, `docs/*`, `hooks/*`, `skills/*`, and `infra/*`, and nothing
else. `uv.lock`, the root `pyproject.toml`, and every `Dockerfile` sit outside all of those, so a
pull request that changed only the lockfile ran **zero** jobs: no static checks, no tests, no build,
no scan. A base image bump was equally invisible.

A new case marks those paths as both `image_changed` and `runtime_changed`:

```bash
uv.lock|pyproject.toml|*/pyproject.toml|Dockerfile|*/Dockerfile|.dockerignore|*/.dockerignore)
```

Adding that arm broke `test_ci_runs_benchmark_gate_for_benchmark_only_changes`, which read the
*first* case arm setting `runtime_changed=true` and required `benchmarks/*` inside it. That held
only while exactly one such arm existed. The test now collects every runtime-setting arm and asserts
`benchmarks/*` appears in one of them, which is the contract it was written to defend, minus the
dependence on arm order. Deleting `benchmarks/*` from `ci.yml` still fails it.

A new `image-cve-scan` job then calls the same reusable workflow when `run_image_scan` is true, over
**whichever images the change can actually reach**. The classifier attributes each dependency and
image input to an image (`uv.lock` and the Python manifests to api, `pnpm-lock.yaml` and the web
manifests to web, shared inputs like `.dockerignore` and `.trivyignore` to both) and emits an
`image_scan_matrix` the job consumes. A web Dockerfile edit builds and scans the web image, which
matters because the Node audit reads web's manifests but cannot see packages inherited from its
runtime base.

CI stays amd64-only for latency; the release gate supplies arm64 before anything ships. The job name
says `Image CVE Scan (amd64)` so that scope is visible in the checks list.

## 🧪 Validation

The fixed api image was built and scanned locally (`docker build -f apps/api/Dockerfile .`, then
`trivy image` with the exact flags `publish.yml` uses):

| Check                                     | Result                                             |
| ----------------------------------------- | -------------------------------------------------- |
| Trivy HIGH/CRITICAL on the rebuilt image  | **0 findings**, exit code 0, across 301 packages   |
| msgpack in the image inventory            | absent                                             |
| setuptools in the image inventory         | absent                                             |
| pip in the image inventory                | absent                                             |
| `python -c "import pip"` inside the image | `ModuleNotFoundError: No module named 'pip'`       |
| `sibyld --version` inside the image       | `sibyld 1.2.1`, server boots                       |

Workflow and repo gates:

| Check                                                       | Result                          |
| ----------------------------------------------------------- | ------------------------------- |
| `actionlint .github/workflows/*.yml` (all nine workflows)   | exit 0, no findings             |
| `prettier --check` on all five touched YAML files            | all match repo style            |
| `moon run inventory-test` (covers `.github/**/*.yml`)        | 175 passed                      |
| `moon run release-workflow-test` (required by `:check`)      | 23 passed                       |
| `moon run bench-gate-test`                                   | 437 passed                      |
| `moon run inventory-lint`                                    | clean                           |
| `moon run core:check`                                        | 4 tasks completed, 2485 passed, 14 skipped                 |
| `moon run api:test`                                          | 2223 passed, 5 skipped                   |

The classifier's new case was executed against real paths rather than reasoned about, confirming
that `uv.lock`, root and nested `pyproject.toml`, all four Dockerfiles, and `.dockerignore` now set
both flags, while `docs/`, `skills/`, and `apps/web` source changes do not pay the scan cost.

The new gate ran against this very PR, because changing `ci.yml` sets `ci_changed`, which sets
`run_image_scan`. `Image CVE Scan / ◆ Scan api` **passed in 3m57s cold and 1m49s on the warm GHA cache**, on run
[31764060111](https://github.com/hyperb1iss/sibyl/actions/runs/31764060111), building the api image
on linux/amd64 and scanning it with no registry credentials. That is the reusable workflow, the
composite action resolution, the `fromJSON` matrix, the local build, and the verdict all exercised
end to end, plus independent confirmation that the Dockerfile change builds on amd64 (local
verification was arm64).

⚠️ The Release side of the topology cannot run without cutting a release. What a dry review
verified: `actionlint` accepts
the `workflow_call` contract and every `uses:` job's inputs against the new action's declared inputs;
the needs-graph makes `release` unreachable until `image-cve-gate` succeeds; no job in the new path
references a secret, and the CI job holds only `contents: read`. That review also caught two real
defects in this change before it was pushed, both now fixed: `publish.yml`'s `docker-security` job
had no `actions/checkout`, so the local action path would not have resolved, and the original
standalone Trivy gate step was left behind after the composite action replaced it. CI caught a
third, the order-dependent workflow contract test described above.

The web image was scanned for the first time on this PR and **passed in 4m25s**, which is a better
result than it looks. The `node:24-alpine` base carries seven fixed HIGH advisories (`brace-expansion`
x3, `ip-address`, `tar` x2, `undici`), and every one of them lives under
`/usr/local/lib/node_modules/npm/node_modules/`, which `apps/web/Dockerfile:67` already deletes. The
same class of defect as the api image, already fixed there before anyone was scanning for it, and now
there is a gate that would notice if that line were ever removed.

The `.trivyignore` wiring was falsified in both directions against the base image: with the committed
file, both known HIGHs are still reported (it suppresses nothing); with a probe file naming
`CVE-2025-47273`, that advisory drops and the other remains. So the file is genuinely read, and
genuinely empty.

## 🔁 What changed since the first review round

Round 1 returned four blockers and one major, all verified before fixing rather than taken on trust.

- 🛡️ **The release object no longer asserts success it has not earned.** Created as a pre-release
  that is not "latest", promoted by publish only after distribution completed.
- 🛡️ **The pre-tag gate covers both images on both architectures**, not amd64 alone.
- 🛡️ **`.trivyignore` is committed, explicitly pinned, and classifier-covered**, closing a silent
  bypass of every gate.
- 🚨 **A required test was broken on this branch and CI could not see it.**
  `test_publish_workflow_attaches_docker_and_release_evidence` still asserted inline Trivy config in
  `publish.yml` after it moved to the composite action. It is owned by `moon run :check`, which CI
  does not run: CI's Package Tests runs the four `test-cov` suites plus the bench gates, so a green
  PR and a broken required gate were both true at once. The assertions now target the composite
  action and all three call sites, and the new shared files are in the task's `moon.yml` inputs so a
  cached false green is impossible.
- **The CI scan matrix is derived from which image changed** instead of hardcoding `["api"]`.

Round 2 returned a single blocker, upheld after reading the action's source: promotion and asset
upload shared one `action-gh-release` call, and that call promotes before it uploads.

- 🚨 **The publish tail is now three ordered steps**, so an asset failure can no longer strand a
  release that already reads as current. The test that covered this only checked that both flag
  values appeared somewhere in the file, which the broken shape satisfied; it now parses the job and
  asserts the order, and was falsified against three regression shapes including the exact one it
  replaces.

⚠️ CI running a strict subset of `moon run :check` is a real hole this PR only worked around. Nothing
here makes CI run the release-workflow test, so the next contract drift in that file is equally
invisible until someone runs `:check` locally. Worth its own change.

## 🔍 What reviewers should focus on

- **The `TRIVY_PLATFORM` move.** Publish's arm64 scan depends on that environment variable, which
  now gets set on a step inside the composite action rather than directly on a workflow step. The
  mechanism is the same, but only the next Publish run proves it end to end.
- **PR latency.** Any change to `uv.lock` or a `pyproject.toml` now triggers static checks, build,
  tests, e2e, and an api image build. Measured on this PR, the scan job adds 1m49s warm and 3m57s
  cold, well inside the existing Package Tests and E2E envelope, so it does not extend the critical
  path. It is a real cost either way, and the intended one: a dependency bump previously ran nothing
  at all.
- **Over-broad Dockerfile matching.** `*/Dockerfile` also matches `.devcontainer/Dockerfile` and the
  Caddy one under `infra/`, so editing either now runs the full runtime path. Conservative on
  purpose, and cheap to narrow if it grates.
- **Whether the release gate should also block a dry run.** As written it does, so `dry_run: true`
  is a genuine rehearsal of the gate. The alternative saves roughly fifteen minutes on a rehearsal
  that then proves less.

## 📌 Follow-ups (deliberate non-fixes)

- **Digest promotion is the real end state, and this PR does not reach it.** Publish rebuilds images
  after the tag rather than promoting the exact digests the pre-tag gate scanned, so a floating base
  image or apt repository can still change between the two. The end state is: build and scan the
  final digests before tagging, then have publish push those digests rather than rebuild. That is a
  publish rework rather than an addition, which is why it is not bundled here. Staged release
  visibility bounds the damage in the meantime.
- **`charts/**` and `VERSION` remain unclassified.** Audit item I1 names them alongside the paths
  fixed here, but they need a Helm-lint target decision that this change should not make on its own.
  A `charts/` edit still runs no CI job.
- **`publish-dogfood-images.yml` builds the same images without a gate.** Dogfood images are not
  release artifacts, so this is a smaller exposure, and it is a one-line addition once the shape
  here settles.
- **No lockfile change was needed or made.** `uv lock --upgrade-package msgpack` would have been a
  no-op, since msgpack is not in the dependency graph. `uv.lock` is untouched by this PR.
