### PR TITLE
perf(graph): batch entity store lookups

### DIFF
--- a/apps/api/src/sibyl/persistence/graph_runtime.py
+++ b/apps/api/src/sibyl/persistence/graph_runtime.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, Self
@@ -258,8 +257,7 @@ class GraphEntityStore(EntityStore):
             return None
 
     async def get_many(self, entity_ids: list[str]) -> list[Entity]:
-        entities = await asyncio.gather(*(self.get(entity_id) for entity_id in entity_ids))
-        return [entity for entity in entities if entity is not None]
+        return await self._manager.get_many(entity_ids)
 
     async def upsert(self, entity: Entity) -> Entity:
         existing = await self.get(entity.id)

--- a/apps/api/tests/test_graph_runtime.py
+++ b/apps/api/tests/test_graph_runtime.py
@@ -61,6 +61,23 @@ class _StatsPayloadClient:
 
 
 @pytest.mark.asyncio
+async def test_graph_entity_store_get_many_delegates_large_inputs_once() -> None:
+    entity_ids = [f"entity-{index}" for index in range(512)]
+    entity = Entity(id="entity-0", entity_type=EntityType.NOTE, name="First")
+    manager = SimpleNamespace(
+        get=AsyncMock(),
+        get_many=AsyncMock(return_value=[entity]),
+    )
+    store = graph_runtime.GraphEntityStore(manager, driver=object(), group_id="org-123")
+
+    entities = await store.get_many(entity_ids)
+
+    assert entities == [entity]
+    manager.get_many.assert_awaited_once_with(entity_ids)
+    manager.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_delete_project_graph_data_sweeps_project_scoped_graph(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
# ⚡ One query for entity batches

> Closes #405.

## 💡 What this is

`GraphEntityStore.get_many()` now delegates the complete ID list to the native `EntityManager.get_many()` batch reader. The adapter no longer creates one coroutine and one database lookup per requested entity.

## 🎯 The invariant

A request containing 512 entity IDs makes one manager batch call and zero point lookup calls. Result order, missing-ID behavior, and organization scope remain owned by the existing native batch implementation.

## 🛠️ How it works

The adapter in `apps/api/src/sibyl/persistence/graph_runtime.py` calls the manager's bulk operation directly. The regression in `apps/api/tests/test_graph_runtime.py` passes 512 IDs, asserts one delegation with the complete list, and proves the point lookup method was never awaited.

The native manager already deduplicates IDs, uses indexed UUID subqueries inside one SurrealDB request, restores requested order, drops missing rows, and filters the returned rows to the active organization.

## 🧪 Validation

- `moon run --force api:check` completed with 2,284 passed and 9 expected skips. Ruff and ty were clean.
- The focused 512-ID regression passed with 2,292 unrelated tests deselected.
- Claude reviewed exact head `93862fd3` and returned PASS after tracing the adapter, native batch query, index, ordering, missing-ID, and scope contracts.

## 🔍 What reviewers should focus on

- the direct delegation in `GraphEntityStore.get_many()`
- the regression's proof that large inputs cannot restart point lookup fan-out
- parity with the existing `EntityManager.get_many()` contract

No concurrency cap or throughput restriction is introduced. The change removes client-side fan-out by using the bulk primitive that already exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved bulk entity retrieval for faster, more efficient handling of large requests.
* **Bug Fixes**
  * Bulk retrieval now consistently returns the entity manager’s results without unnecessary individual lookups.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->