### PR TITLE
fix(ci): materialize the frontend E2E build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,7 +658,9 @@ jobs:
         run: cd apps/web && pnpm install --frozen-lockfile
 
       - name: Build frontend for E2E
-        run: moon run web:build
+        run: |
+          moon run --force web:build
+          test -f apps/web/.next/BUILD_ID
 
       - name: Start backend server
         run: |
@@ -693,15 +695,22 @@ jobs:
         run: |
           cd apps/web
           pnpm start > /tmp/sibyl-web.log 2>&1 &
+          web_pid=$!
           echo "Waiting for frontend to start..."
           for i in {1..60}; do
             if curl -fsS http://localhost:3337 > /dev/null; then
               echo "Frontend is ready!"
               break
             fi
+            if ! kill -0 "$web_pid" 2>/dev/null; then
+              echo "Frontend exited before becoming ready."
+              cat /tmp/sibyl-web.log
+              exit 1
+            fi
             echo "Attempt $i: Frontend not ready yet..."
             sleep 1
           done
+          curl -fsS http://localhost:3337 > /dev/null
 
       - name: Run e2e tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,7 +659,7 @@ jobs:
 
       - name: Build frontend for E2E
         run: |
-          moon run --force web:build
+          moon run web:build
           test -f apps/web/.next/BUILD_ID
 
       - name: Start backend server

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -133,6 +133,8 @@ tasks:
     inputs:
       - "@group(sources)"
       - "@group(configs)"
+    options:
+      cache: false
     # Note: .next excluded from outputs - Next.js manages its own cache,
     # and the directory contains symlinks that break moon's archiver
 

--- a/moon.yml
+++ b/moon.yml
@@ -604,6 +604,7 @@ tasks:
       # asserts the three stay in agreement. Without these the cache would
       # report a stale green after the gate itself changed.
       - .github/workflows/ci.yml
+      - apps/web/moon.yml
       - .github/workflows/image-cve-gate.yml
       - .github/actions/trivy-image-gate/action.yml
       - .trivyignore

--- a/tools/tests/test_release_workflow.py
+++ b/tools/tests/test_release_workflow.py
@@ -237,13 +237,17 @@ def test_ci_e2e_build_is_materialized_and_frontend_readiness_fails_closed() -> N
     steps = workflow["jobs"]["e2e"]["steps"]
     steps_by_name = {step.get("name"): step for step in steps}
 
+    web_tasks = yaml.safe_load((REPO_ROOT / "apps/web/moon.yml").read_text(encoding="utf-8"))
+    assert web_tasks["tasks"]["build"]["options"]["cache"] is False
+
     build_script = steps_by_name["Build frontend for E2E"]["run"]
-    assert "moon run --force web:build" in build_script
+    assert "moon run web:build" in build_script
     assert "test -f apps/web/.next/BUILD_ID" in build_script
 
     start_script = steps_by_name["Start frontend server"]["run"]
     assert "web_pid=$!" in start_script
     assert 'kill -0 "$web_pid"' in start_script
+    assert "cat /tmp/sibyl-web.log\n    exit 1" in start_script
     assert start_script.rstrip().endswith("curl -fsS http://localhost:3337 > /dev/null")
 
 

--- a/tools/tests/test_release_workflow.py
+++ b/tools/tests/test_release_workflow.py
@@ -232,6 +232,25 @@ def test_image_cve_gate_is_shared_by_every_caller() -> None:
     assert ".trivyignore" in ci
 
 
+def test_ci_e2e_build_is_materialized_and_frontend_readiness_fails_closed() -> None:
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["e2e"]["steps"]
+    steps_by_name = {step.get("name"): step for step in steps}
+
+    build_script = steps_by_name["Build frontend for E2E"]["run"]
+    assert "moon run --force web:build" in build_script
+    assert "test -f apps/web/.next/BUILD_ID" in build_script
+
+    start_script = steps_by_name["Start frontend server"]["run"]
+    assert "web_pid=$!" in start_script
+    assert 'kill -0 "$web_pid"' in start_script
+    assert start_script.rstrip().endswith(
+        "curl -fsS http://localhost:3337 > /dev/null"
+    )
+
+
 def test_release_is_promoted_only_after_publish_succeeds() -> None:
     # A release object created before distribution is a claim the pipeline has
     # not yet earned. Release creates the version as a pre-release that is not

--- a/tools/tests/test_release_workflow.py
+++ b/tools/tests/test_release_workflow.py
@@ -233,9 +233,7 @@ def test_image_cve_gate_is_shared_by_every_caller() -> None:
 
 
 def test_ci_e2e_build_is_materialized_and_frontend_readiness_fails_closed() -> None:
-    workflow = yaml.safe_load(
-        (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-    )
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
     steps = workflow["jobs"]["e2e"]["steps"]
     steps_by_name = {step.get("name"): step for step in steps}
 
@@ -246,9 +244,7 @@ def test_ci_e2e_build_is_materialized_and_frontend_readiness_fails_closed() -> N
     start_script = steps_by_name["Start frontend server"]["run"]
     assert "web_pid=$!" in start_script
     assert 'kill -0 "$web_pid"' in start_script
-    assert start_script.rstrip().endswith(
-        "curl -fsS http://localhost:3337 > /dev/null"
-    )
+    assert start_script.rstrip().endswith("curl -fsS http://localhost:3337 > /dev/null")
 
 
 def test_release_is_promoted_only_after_publish_succeeds() -> None:


### PR DESCRIPTION
## ⚡ Why

The E2E workflow cached `web:build`, but the Moon task intentionally does not archive `.next`. A cache hit replayed successful build output without restoring the production artifact, so `next start` exited immediately. The readiness loop then completed successfully after 60 failed probes and hid the real failure until browser tests ran.

## 🛠️ What changed

- Disable Moon caching for the outputless `web:build` task so every caller receives a real `.next` artifact.
- Assert `.next/BUILD_ID` before the E2E workflow starts services.
- Detect an early frontend exit and print its log at the failing step.
- Require one final successful readiness probe after the retry loop.
- Pin the task and workflow contracts with a structural regression test.

## 🧪 Verification

- `moon run inventory-lint release-workflow-test` with 44 passing tests
- `moon run web:build` produced `apps/web/.next/BUILD_ID` without a cached replay
- `git diff --check`
- Independent Claude review: PASS

The full production startup path runs in this PR's E2E job. Local port 3337 was already occupied, so I left that existing process untouched.
