### PR TITLE
fix(evals): let sealed paid arms run concurrently

### DIFF
--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -214,7 +214,7 @@ defaults:
 concurrency:
   group:
     ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' &&
-    inputs.run_official_full && 'official-full' || 'standard' }}
+    inputs.run_official_full && github.run_id || 'standard' }}
   cancel-in-progress:
     ${{ github.event_name != 'workflow_dispatch' || !inputs.run_official_full }}
 

--- a/tools/tests/test_longmemeval_v2_probe.py
+++ b/tools/tests/test_longmemeval_v2_probe.py
@@ -134,7 +134,8 @@ def test_longmemeval_v2_workflow_gates_official_full_run() -> None:
     assert "inputs.official_domain == 'enterprise'" in workflow
     assert "(inputs.official_domain || 'both') == 'both'" in workflow
     assert "if: github.event_name == 'workflow_dispatch' && inputs.run_official_full" in workflow
-    assert "'official-full' || 'standard'" in workflow
+    assert "inputs.run_official_full && github.run_id || 'standard'" in workflow
+    assert "inputs.run_official_full && 'official-full' || 'standard'" not in workflow
     assert "github.event_name != 'workflow_dispatch' || !inputs.run_official_full" in workflow
     assert "moon run bench-longmemeval-v2-official-full" in workflow
     assert "OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}" in workflow


### PR DESCRIPTION
## Why

The paid LongMemEval workflow grouped every approval-bound arm under one
repository-wide concurrency key. GitHub would therefore run the 21 planned
arms serially even though each arm has isolated runners, databases, artifacts,
and spend accounting.

No shared resource requires that serialization. The environment approval and
per-arm cost reservation remain the spending boundary.

## What changed

- Use `github.run_id` as the concurrency suffix for sealed paid dispatches.
- Keep the existing stable `standard` group for push and pull request runs.
- Keep cancellation disabled for paid work and enabled for ordinary runs.
- Assert that the old global `official-full` group cannot return.

## Validation

- `actionlint .github/workflows/longmemeval-v2.yml`: passed.
- Focused LongMemEval workflow contract: 8 passed.
- Release workflow contract: 51 passed.
- Inventory lint and typecheck: passed.
- `git diff --check`: passed.

## Blast radius

The change affects concurrency scheduling only. A duplicate paid dispatch gets
its own approval-bound run instead of canceling or queueing behind another arm.
Domain jobs inside an arm, manifest validation, provider caps, artifacts, and
decision receipts are unchanged.
