### PR TITLE
fix(evals): unblock sealed v1.3 release preflight

### DIFF
--- a/apps/api/src/sibyl/runtime_provenance.py
+++ b/apps/api/src/sibyl/runtime_provenance.py
@@ -27,7 +27,7 @@ def _git_output(*args: str) -> str | None:
         )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
-    return result.stdout.strip() or None
+    return result.stdout.strip()
 
 
 def _optional_bool(value: str | None) -> bool | None:

--- a/apps/api/tests/test_runtime_provenance.py
+++ b/apps/api/tests/test_runtime_provenance.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import sibyl.runtime_provenance as provenance_module
+
+
+def test_git_output_preserves_successful_empty_stdout(monkeypatch) -> None:
+    monkeypatch.setattr(provenance_module.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        provenance_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(stdout="\n"),
+    )
+
+    assert provenance_module._git_output("status", "--porcelain") == ""
 
 
 def test_runtime_provenance_prefers_explicit_build_environment(monkeypatch) -> None:
@@ -34,5 +47,27 @@ def test_runtime_provenance_reports_unknown_without_env_or_git(monkeypatch) -> N
         "git_dirty": None,
         "git_status": "unknown",
         "dirty_source": "unknown",
+    }
+    provenance_module.get_runtime_provenance.cache_clear()
+
+
+def test_runtime_provenance_reports_clean_git_checkout(monkeypatch) -> None:
+    monkeypatch.delenv("SIBYL_GIT_COMMIT", raising=False)
+    monkeypatch.delenv("SIBYL_GIT_DIRTY", raising=False)
+    monkeypatch.setattr(
+        provenance_module,
+        "_git_output",
+        lambda *args: "abc123" if args[0] == "rev-parse" else "",
+    )
+    provenance_module.get_runtime_provenance.cache_clear()
+
+    provenance = provenance_module.get_runtime_provenance()
+
+    assert provenance == {
+        "commit": "abc123",
+        "commit_source": "git",
+        "git_dirty": False,
+        "git_status": "clean",
+        "dirty_source": "git",
     }
     provenance_module.get_runtime_provenance.cache_clear()

--- a/benchmarks/longmemeval_v2_release_contract.py
+++ b/benchmarks/longmemeval_v2_release_contract.py
@@ -50,10 +50,10 @@ RELEASE_RUNTIME_PINS = {
     "prompt_build_max_workers": 1,
 }
 RELEASE_ROLE_CAPS_USD = {
-    "machine": 3.0,
-    "naive": 3.0,
-    "render_control": 3.0,
-    "render_treatment": 3.6,
+    "machine": 4.25,
+    "naive": 4.25,
+    "render_control": 4.25,
+    "render_treatment": 4.75,
 }
 SPEC_KEYS = frozenset(
     {

--- a/docs/testing/longmemeval-v2.md
+++ b/docs/testing/longmemeval-v2.md
@@ -66,8 +66,8 @@ Set both provider variables in the parent shell before the paid command:
 Do not pass a token value or a credential-file path as a CLI argument. Plans, public identities,
 receipts, and redacted logs contain environment variable names only. The runner refuses provider
 work unless every domain first produces an exact official plan-only reservation for the full Small
-corpus. The fixed cap is \$3.00 per domain for machine, naive, and render-control arms. The
-render-treatment cap is \$3.60 per domain. Any reservation or actual summed cost above its sealed
+corpus. The fixed cap is \$4.25 per domain for machine, naive, and render-control arms. The
+render-treatment cap is \$4.75 per domain. Any reservation or actual summed cost above its sealed
 cap stops the stage.
 
 ### One stage at a time

--- a/tools/tests/longmemeval_v2_release_support.py
+++ b/tools/tests/longmemeval_v2_release_support.py
@@ -57,7 +57,7 @@ def manifest(
         "arm_role": role,
         "substrate": "naive" if naive else "machine",
         "preregistration_sha256": preregistration,
-        "max_spend_usd": 3.6 if treatment else 3.0,
+        "max_spend_usd": 4.75 if treatment else 4.25,
         "retrieval_mode": retrieval_mode,
         "max_context_total_chars": total_chars,
         "operational_note_dedupe_mode": dedupe_mode,

--- a/tools/tests/test_longmemeval_v2_release_contract.py
+++ b/tools/tests/test_longmemeval_v2_release_contract.py
@@ -9,6 +9,7 @@ from threading import Barrier
 from typing import Any
 
 import pytest
+from benchmarks import longmemeval_v2_official as official
 from benchmarks import longmemeval_v2_release_authorization as authorization
 from benchmarks import (
     longmemeval_v2_release_authorization_package as authorization_package,
@@ -27,6 +28,8 @@ from tools.tests.longmemeval_v2_release_support import (
     race_spec,
     render_spec,
 )
+
+MAX_CAP_HEADROOM_USD = 0.15
 
 
 @pytest.fixture(autouse=True)
@@ -106,6 +109,45 @@ def test_stage_spec_rejects_role_cap_retrieval_and_geometry_drift() -> None:
         arm["manifest"]["geometry"]["max_context_items"] = 7
     with pytest.raises(contract.StagePlanError, match="geometry"):
         contract.require_stage_spec(geometry_drift)
+
+
+def test_release_caps_cover_pinned_full_corpus_reservations(tmp_path: Path) -> None:
+    domain_counts = {
+        "web": (240, 86),
+        "enterprise": (211, 70),
+    }
+    for role, cap in contract.RELEASE_ROLE_CAPS_USD.items():
+        treatment = role == "render_treatment"
+        reservations = []
+        for domain, (question_count, llm_eval_count) in domain_counts.items():
+            argv = [
+                "--data-root",
+                str(tmp_path / "data"),
+                "--domain",
+                domain,
+                "--output-dir",
+                str(tmp_path / role / domain),
+                "--plan-only",
+                "--max-spend-usd",
+                str(cap),
+                "--max-context-total-chars",
+                "72000" if treatment else "60000",
+            ]
+            if treatment:
+                argv.append("--note-distillation")
+            args = official.parse_args(argv)
+            reservation = official.build_spend_reservation(
+                args=args,
+                question_count=question_count,
+                llm_eval_count=llm_eval_count,
+                required_trajectory_count=100,
+            )
+            reserved_total = reservation["reserved_total_usd"]
+            assert isinstance(reserved_total, (int, float))
+            reservations.append(float(reserved_total))
+            assert reservation["status"] == "PASS"
+
+        assert 0 <= cap - max(reservations) < MAX_CAP_HEADROOM_USD
 
 
 @pytest.mark.parametrize(

--- a/tools/tests/test_longmemeval_v2_release_executor.py
+++ b/tools/tests/test_longmemeval_v2_release_executor.py
@@ -61,8 +61,8 @@ def _run(root: Path, arm_id: str, index: int) -> dict[str, Any]:
         "domains": {domain: _domain_run(root, arm_id, domain) for domain in ("web", "enterprise")},
         "spend_reservation": {
             "currency": "USD",
-            "max_spend_usd_per_domain": 3.0,
-            "max_spend_usd_total": 6.0,
+            "max_spend_usd_per_domain": 4.25,
+            "max_spend_usd_total": 8.5,
             "enforcement": "official plan-only reservation before provider calls",
         },
     }
@@ -572,7 +572,7 @@ def test_runner_rejects_actual_cost_over_sealed_arm_reservation(
     monkeypatch.setattr(
         runner.evidence,
         "require_completed_domain",
-        lambda *_args: (3.1, {}),
+        lambda *_args: (4.3, {}),
     )
 
     with pytest.raises(StagePlanError, match="total reservation"):

--- a/tools/tests/test_longmemeval_v2_release_package.py
+++ b/tools/tests/test_longmemeval_v2_release_package.py
@@ -106,7 +106,7 @@ def executed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ExecutedStage:
             domain: {"output_dir": str(paid_root / "runs" / "aa-1-left" / domain)}
             for domain in ("web", "enterprise")
         },
-        "spend_reservation": {"max_spend_usd_total": 6.0},
+        "spend_reservation": {"max_spend_usd_total": 8.5},
     }
     for domain in ("web", "enterprise"):
         _artifact(Path(run["domains"][domain]["output_dir"]) / "aggregated_metrics.json")

--- a/tools/tests/test_longmemeval_v2_release_runner.py
+++ b/tools/tests/test_longmemeval_v2_release_runner.py
@@ -318,8 +318,8 @@ def test_stage_plan_seals_immutable_dataset_and_fixed_domain_caps(
     for run in stage_plan["runs"]:
         assert run["spend_reservation"] == {
             "currency": "USD",
-            "max_spend_usd_per_domain": 3.0,
-            "max_spend_usd_total": 6.0,
+            "max_spend_usd_per_domain": 4.25,
+            "max_spend_usd_total": 8.5,
             "enforcement": "official plan-only reservation before provider calls",
         }
 


### PR DESCRIPTION
## Why

The first sealed v1.3 A/A attempt stopped before any provider call. Its
full-corpus reservation was $4.102088 per baseline domain, but the release
contract capped the same arm at $3.00.

The live API also reported a clean checkout as `git_dirty: unknown` because
successful empty `git status --porcelain` output was treated as command
failure. That would invalidate release evidence after the spend preflight.

## What changed

- Raise machine, naive, and render-control caps to $4.25 per domain.
- Raise render-treatment caps to $4.75 per domain.
- Preserve the existing 25 percent contingency, $2 unmetered reserve, and
  pre-run plus post-run fail-closed accounting.
- Assert every pinned domain and role fits its cap with less than fifteen
  cents of worst-case headroom.
- Preserve successful empty git output so a clean runtime reports
  `git_dirty: false`, `git_status: clean`, and `dirty_source: git`.

## Verification

- `moon run root:bench-gate-test -- -q`: 817 passed
- `moon run api:test -- tests/test_runtime_provenance.py -q`: 4 passed
- `moon run :lint :typecheck`: 19 tasks passed

## Blast radius

The cap change only affects the sealed local LongMemEval v1.3 release
contract. The provenance fix only changes successful clean git status from
unknown to clean. Provider work still stops on incomplete accounting or any
actual cost above the sealed cap.

<details>
<summary>the 420 preflight did exactly what we built it to do</summary>

<pre>
       .-.
      (   )   $0 spent
       `-'    contradiction caught
      /| |\   receipts intact
       | |
      /   \

  4.20 baybee, guardian of the release gate
</pre>
</details>

~ via nova ⚡
