### PR TITLE
fix(evals): register adapter with official harness

### DIFF
--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import importlib
 import importlib.util
 import json
 import math
@@ -229,8 +230,7 @@ def main(argv: list[str] | None = None) -> int:
 
     official_repo = resolve_official_repo(args.official_repo)
     require_pinned_source(official_repo)
-    sys.path.insert(0, str(official_repo))
-    import benchmarks.longmemeval_v2_memory.sibyl_memory  # noqa: F401, PLC0415
+    install_official_memory_adapter(official_repo)
     import evaluation.harness as official_harness  # noqa: PLC0415
     import evaluation.qa_eval_metrics as official_metrics  # noqa: PLC0415
 
@@ -263,6 +263,27 @@ def main(argv: list[str] | None = None) -> int:
     if args.experiment_id:
         enforce_actual_spend_cap(receipt, max_spend_usd=args.max_spend_usd)
     return 0
+
+
+def install_official_memory_adapter(official_repo: Path) -> type[Any]:
+    """Bind the Sibyl adapter to the pinned harness memory registry."""
+
+    official_path = str(official_repo)
+    if official_path not in sys.path:
+        sys.path.insert(0, official_path)
+    adapter_name = "benchmarks.longmemeval_v2_memory.sibyl_memory"
+    adapter_module = sys.modules.get(adapter_name)
+    if adapter_module is None:
+        adapter_module = importlib.import_module(adapter_name)
+    else:
+        adapter_module = importlib.reload(adapter_module)
+    memory_module = importlib.import_module("memory_modules.memory")
+    memory_cls = getattr(adapter_module, "SibylLiveApiMemory", None)
+    memory_types = getattr(memory_module, "MEMORY_TYPES", {})
+    if memory_cls is None or memory_types.get("sibyl_live_api") is not memory_cls:
+        raise RuntimeError("Sibyl memory adapter did not register with the official harness")
+    globals()["SibylLiveApiMemory"] = memory_cls
+    return memory_cls
 
 
 def _redacted_command_args(command_args: Sequence[str]) -> list[str]:

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -269,15 +269,25 @@ def install_official_memory_adapter(official_repo: Path) -> type[Any]:
     """Bind the Sibyl adapter to the pinned harness memory registry."""
 
     official_path = str(official_repo)
-    if official_path not in sys.path:
-        sys.path.insert(0, official_path)
+    while official_path in sys.path:
+        sys.path.remove(official_path)
+    sys.path.insert(0, official_path)
+    for module_name in tuple(sys.modules):
+        if module_name == "memory_modules" or module_name.startswith("memory_modules."):
+            del sys.modules[module_name]
+    importlib.invalidate_caches()
+    memory_module = importlib.import_module("memory_modules.memory")
+    registry_file = getattr(memory_module, "__file__", None)
+    if not isinstance(registry_file, str) or not Path(registry_file).resolve().is_relative_to(
+        official_repo.resolve()
+    ):
+        raise RuntimeError("Official memory registry did not load from the pinned checkout")
     adapter_name = "benchmarks.longmemeval_v2_memory.sibyl_memory"
     adapter_module = sys.modules.get(adapter_name)
     if adapter_module is None:
         adapter_module = importlib.import_module(adapter_name)
     else:
         adapter_module = importlib.reload(adapter_module)
-    memory_module = importlib.import_module("memory_modules.memory")
     memory_cls = getattr(adapter_module, "SibylLiveApiMemory", None)
     memory_types = getattr(memory_module, "MEMORY_TYPES", {})
     if memory_cls is None or memory_types.get("sibyl_live_api") is not memory_cls:

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -464,6 +464,37 @@ def test_official_runner_plan_materializes_honest_runtime_inputs(  # noqa: PLR09
     _assert_question_id_hash_propagates(module, data_root=data_root, plan=plan)
 
 
+def test_official_runner_rebinds_adapter_to_official_registry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_runner_module()
+    adapter_name = "benchmarks.longmemeval_v2_memory.sibyl_memory"
+    original_adapter = sys.modules[adapter_name]
+    official_memory = type("OfficialSibylMemory", (), {})
+    reloaded_adapter = SimpleNamespace(SibylLiveApiMemory=official_memory)
+    memory_package = ModuleType("memory_modules")
+    memory_module = ModuleType("memory_modules.memory")
+    cast("Any", memory_module).MEMORY_TYPES = {"sibyl_live_api": official_memory}
+    monkeypatch.setitem(sys.modules, "memory_modules", memory_package)
+    monkeypatch.setitem(sys.modules, "memory_modules.memory", memory_module)
+    path_visible_during_reload = False
+
+    def reload_adapter(adapter: ModuleType) -> SimpleNamespace:
+        nonlocal path_visible_during_reload
+        path_visible_during_reload = str(tmp_path) in sys.path
+        assert adapter is original_adapter
+        return reloaded_adapter
+
+    monkeypatch.setattr(module.importlib, "reload", reload_adapter)
+
+    installed = module.install_official_memory_adapter(tmp_path)
+
+    assert path_visible_during_reload is True
+    assert installed is official_memory
+    assert module.SibylLiveApiMemory is official_memory
+
+
 def test_official_runner_refuses_existing_provider_usage_before_work(tmp_path: Path) -> None:
     module = _load_runner_module()
     output_dir = tmp_path / "output"

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -467,12 +467,18 @@ def test_official_runner_plan_materializes_honest_runtime_inputs(  # noqa: PLR09
 def test_official_runner_rebinds_adapter_to_official_registry(
     tmp_path: Path,
 ) -> None:
+    fallback_repo = tmp_path / "fallback"
     official_repo = tmp_path / "official"
-    memory_package = official_repo / "memory_modules"
-    memory_package.mkdir(parents=True)
-    (memory_package / "__init__.py").write_text("", encoding="utf-8")
-    (memory_package / "memory.py").write_text(
-        """MEMORY_TYPES = {}
+    for registry_root, origin in (
+        (fallback_repo, "fallback"),
+        (official_repo, "official"),
+    ):
+        memory_package = registry_root / "memory_modules"
+        memory_package.mkdir(parents=True)
+        (memory_package / "__init__.py").write_text("", encoding="utf-8")
+        (memory_package / "memory.py").write_text(
+            f'''ORIGIN = "{origin}"
+MEMORY_TYPES = {{}}
 
 
 class Memory:
@@ -488,28 +494,34 @@ MemoryContextItem = dict[str, str]
 def register_memory(memory_cls):
     MEMORY_TYPES[memory_cls.memory_type] = memory_cls
     return memory_cls
-""",
-        encoding="utf-8",
-    )
+''',
+            encoding="utf-8",
+        )
     project_root = Path(__file__).parents[2]
     probe = """
 import sys
 from pathlib import Path
 
+sys.path.insert(0, sys.argv[2])
 import benchmarks.longmemeval_v2_official as runner
 from benchmarks.longmemeval_v2_memory import sibyl_memory as fallback_adapter
+from memory_modules import memory as fallback_registry
 
-assert fallback_adapter._register_memory.__module__ == fallback_adapter.__name__
+assert fallback_registry.ORIGIN == "fallback"
+assert fallback_registry.MEMORY_TYPES["sibyl_live_api"] is fallback_adapter.SibylLiveApiMemory
 installed = runner.install_official_memory_adapter(Path(sys.argv[1]))
-from memory_modules.memory import MEMORY_TYPES
+from memory_modules import memory as official_registry
 
-assert MEMORY_TYPES["sibyl_live_api"] is installed
+assert sys.path[0] == sys.argv[1]
+assert official_registry.ORIGIN == "official"
+assert official_registry is not fallback_registry
+assert official_registry.MEMORY_TYPES["sibyl_live_api"] is installed
 assert runner.SibylLiveApiMemory is installed
 print("real_registry_rebind=PASS")
 """
 
     result = subprocess.run(  # noqa: S603 - current interpreter with test-owned input.
-        [sys.executable, "-c", probe, str(official_repo)],
+        [sys.executable, "-c", probe, str(official_repo), str(fallback_repo)],
         cwd=project_root,
         check=False,
         capture_output=True,

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -466,33 +466,58 @@ def test_official_runner_plan_materializes_honest_runtime_inputs(  # noqa: PLR09
 
 def test_official_runner_rebinds_adapter_to_official_registry(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = _load_runner_module()
-    adapter_name = "benchmarks.longmemeval_v2_memory.sibyl_memory"
-    original_adapter = sys.modules[adapter_name]
-    official_memory = type("OfficialSibylMemory", (), {})
-    reloaded_adapter = SimpleNamespace(SibylLiveApiMemory=official_memory)
-    memory_package = ModuleType("memory_modules")
-    memory_module = ModuleType("memory_modules.memory")
-    cast("Any", memory_module).MEMORY_TYPES = {"sibyl_live_api": official_memory}
-    monkeypatch.setitem(sys.modules, "memory_modules", memory_package)
-    monkeypatch.setitem(sys.modules, "memory_modules.memory", memory_module)
-    path_visible_during_reload = False
+    official_repo = tmp_path / "official"
+    memory_package = official_repo / "memory_modules"
+    memory_package.mkdir(parents=True)
+    (memory_package / "__init__.py").write_text("", encoding="utf-8")
+    (memory_package / "memory.py").write_text(
+        """MEMORY_TYPES = {}
 
-    def reload_adapter(adapter: ModuleType) -> SimpleNamespace:
-        nonlocal path_visible_during_reload
-        path_visible_during_reload = str(tmp_path) in sys.path
-        assert adapter is original_adapter
-        return reloaded_adapter
 
-    monkeypatch.setattr(module.importlib, "reload", reload_adapter)
+class Memory:
+    memory_type = ""
 
-    installed = module.install_official_memory_adapter(tmp_path)
+    def __init__(self, memory_params):
+        self.memory_params = memory_params
 
-    assert path_visible_during_reload is True
-    assert installed is official_memory
-    assert module.SibylLiveApiMemory is official_memory
+
+MemoryContextItem = dict[str, str]
+
+
+def register_memory(memory_cls):
+    MEMORY_TYPES[memory_cls.memory_type] = memory_cls
+    return memory_cls
+""",
+        encoding="utf-8",
+    )
+    project_root = Path(__file__).parents[2]
+    probe = """
+import sys
+from pathlib import Path
+
+import benchmarks.longmemeval_v2_official as runner
+from benchmarks.longmemeval_v2_memory import sibyl_memory as fallback_adapter
+
+assert fallback_adapter._register_memory.__module__ == fallback_adapter.__name__
+installed = runner.install_official_memory_adapter(Path(sys.argv[1]))
+from memory_modules.memory import MEMORY_TYPES
+
+assert MEMORY_TYPES["sibyl_live_api"] is installed
+assert runner.SibylLiveApiMemory is installed
+print("real_registry_rebind=PASS")
+"""
+
+    result = subprocess.run(  # noqa: S603 - current interpreter with test-owned input.
+        [sys.executable, "-c", probe, str(official_repo)],
+        cwd=project_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "real_registry_rebind=PASS"
 
 
 def test_official_runner_refuses_existing_provider_usage_before_work(tmp_path: Path) -> None:


### PR DESCRIPTION
## 🔮 Why

The first paid v1.3 release run stopped before any provider request with
`Unknown memory_type: sibyl_live_api`.

The release runner imported the Sibyl memory adapter when the local benchmark
module loaded. At that point, the pinned official LongMemEval checkout was not
on `sys.path`, so the adapter could bind to its fallback registry. A cached
foreign `memory_modules` package could also survive a later adapter reload.
Either path left the official harness unable to see the adapter.

## 🛠️ What changed

The paid runner now moves the pinned official checkout to import priority,
evicts cached registry modules, invalidates import caches, and loads the
official registry before reloading the adapter. It verifies the registry file
resolves inside the pinned checkout and that `sibyl_live_api` maps to the exact
reloaded class. Any mismatch stops before provider work.

The regression test forks a clean interpreter with competing fallback and
official registry packages. It proves the fallback registry starts cached,
then executes the real reload and decorator path and proves the pinned registry
owns the exact reloaded class.

## 🧪 Verification

- `moon run root:bench-gate-test --force`: 818 passed
- `moon run :lint :typecheck --force`: 19 tasks passed
- independent verification passed the exact final commit and added a hostile
  foreign-registry probe
- no provider calls or paid spend during verification

## 🐇 CodeRabbit

CodeRabbit found both weak proof in the first test and the cached foreign
registry case in production. Commits `4a188a0f` and `35696fbf` close both
findings. All review threads are addressed, and the latest incremental review
reported no new finding.

## 🌿 4:20 release harness tribute

```text
             .
            / \
       .---/---\---.
      /   / 420 \   \
      \  /  BAYBEE\ /
       `-----------'
            | |
          __| |__
         /_______\
```

Small fix, extremely consequential registry. The sealed run can now reach the
actual experiment instead of face-planting in Python import state.

~ via nova ⚡
