### PR TITLE
fix(graph): batch embedding backfill writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,6 +626,13 @@ jobs:
       - name: Run live ingestion primitives
         run: moon run api:test-live
 
+      - name: Run local embedding dimension backfill
+        env:
+          PYTEST_ADDOPTS: >-
+            -k live_surreal_server_batches_fenced_entity_embedding_backfill -x
+          SIBYL_GRAPH_EMBEDDING_DIMENSIONS: "384"
+        run: moon run api:test-live --force
+
   e2e:
     name: E2E
     needs: changes

--- a/apps/api/tests/test_surreal_live_runtime.py
+++ b/apps/api/tests/test_surreal_live_runtime.py
@@ -17,7 +17,10 @@ from sibyl_core.backends.surreal.content_schema import (
     EMBEDDING_DIM,
 )
 from sibyl_core.backends.surreal.dedicated_client import DedicatedSurrealClient
-from sibyl_core.backends.surreal.schema import bootstrap_schema
+from sibyl_core.backends.surreal.schema import (
+    EMBEDDING_DIM as GRAPH_EMBEDDING_DIM,
+    bootstrap_schema,
+)
 from sibyl_core.backends.surreal.schema_version import (
     GRAPH_SCHEMA_NAME,
     get_schema_version,
@@ -534,6 +537,38 @@ async def test_live_surreal_server_round_trips_native_entity() -> None:
                 await _drop_surreal_namespace(client.namespace)
         else:
             await _drop_surreal_namespace(client.namespace)
+
+
+@pytest.mark.asyncio
+async def test_live_surreal_server_batches_fenced_entity_embedding_backfill() -> None:
+    async with _live_graph_manager() as (client, _manager):
+        manager = EntityManager(
+            client,
+            group_id=client.group_id,
+            embedding_provider=_StaticEmbeddingProvider([0.25] * GRAPH_EMBEDDING_DIM),
+        )
+        entities = tuple(
+            Entity(
+                id=f"live-batched-{index}-{uuid4().hex}",
+                entity_type=EntityType.SESSION,
+                name=f"Live batched entity {index}",
+                content=f"Live content {index}",
+                organization_id=client.group_id,
+            )
+            for index in range(2)
+        )
+        await manager.create_direct_bulk(entities)
+
+        ready_ids = await manager.backfill_embeddings_if_current(entities)
+        stored = [await manager.get(entity.id) for entity in entities]
+
+        changed = entities[1].model_copy(update={"content": "Changed live content"})
+        await manager.create_direct_bulk((changed,))
+        stale_ids = await manager.backfill_embeddings_if_current((entities[1],))
+
+        assert ready_ids == [entity.id for entity in entities]
+        assert all(entity.embedding for entity in stored)
+        assert stale_ids == []
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/pyproject.toml
+++ b/packages/python/sibyl-core/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
     "surrealdb>=2.0.0,<3.0",
     "numpy>=2.5.1",
     "pydantic-ai-slim[anthropic,google,openai]>=2.30.0,<3",
+    "ty>=0.0.69",
 ]
 
 [project.urls]

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entities.py
@@ -139,11 +139,16 @@ class EntityManager(_EntityWorkItemManager):
             generate_embeddings=True,
             embedding_batch_size=embedding_batch_size,
         )
-        written_ids = await _update_entity_embeddings_if_current(
-            self._client,
-            prepared,
-            group_id=self._group_id,
-        )
+        written_ids: set[str] = set()
+        batch_size = max(int(embedding_batch_size), 1)
+        for index in range(0, len(prepared), batch_size):
+            written_ids.update(
+                await _update_entity_embeddings_if_current(
+                    self._client,
+                    prepared[index : index + batch_size],
+                    group_id=self._group_id,
+                )
+            )
         ready_ids.update(written_ids)
         return [entity.id for entity in current_entities if entity.id in ready_ids]
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entities.py
@@ -25,7 +25,7 @@ from sibyl_core.services.graph_entity_store import (
     _persisted_entity_embedding_text,
     _replace_entities_bulk,
     _replace_entity,
-    _update_entity_embedding_if_current,
+    _update_entity_embeddings_if_current,
 )
 from sibyl_core.services.graph_entity_work_items import _EntityWorkItemManager
 from sibyl_core.services.graph_records import _entity_from_row, entity_from_surreal_row
@@ -139,19 +139,12 @@ class EntityManager(_EntityWorkItemManager):
             generate_embeddings=True,
             embedding_batch_size=embedding_batch_size,
         )
-        written = await asyncio.gather(
-            *(
-                _update_entity_embedding_if_current(
-                    self._client,
-                    entity,
-                    group_id=self._group_id,
-                )
-                for entity in prepared
-            )
+        written_ids = await _update_entity_embeddings_if_current(
+            self._client,
+            prepared,
+            group_id=self._group_id,
         )
-        ready_ids.update(
-            entity.id for entity, persisted in zip(prepared, written, strict=True) if persisted
-        )
+        ready_ids.update(written_ids)
         return [entity.id for entity in current_entities if entity.id in ready_ids]
 
     async def create(self, entity: Entity) -> str:

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
@@ -441,7 +441,7 @@ UPDATE (
     FROM entity
     WHERE group_id = $group_id AND uuid IN $uuids
 ) SET
-    name_embedding = $rows_by_uuid[uuid].name_embedding,
+    name_embedding = <array<float, 1024>>$rows_by_uuid[uuid].name_embedding,
     attributes.embedding_metadata = $rows_by_uuid[uuid].embedding_metadata,
     attributes.updated_at = $rows_by_uuid[uuid].updated_at,
     updated_at = $rows_by_uuid[uuid].updated_at,

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
@@ -435,51 +435,64 @@ def _parsed_metadata_snapshot(raw: object) -> dict[str, object] | None:
     return None
 
 
-async def _update_entity_embedding_if_current(
+_ENTITY_EMBEDDING_BACKFILL_QUERY = """
+UPDATE (
+    SELECT VALUE id
+    FROM entity
+    WHERE group_id = $group_id AND uuid IN $uuids
+) SET
+    name_embedding = $rows_by_uuid[uuid].name_embedding,
+    attributes.embedding_metadata = $rows_by_uuid[uuid].embedding_metadata,
+    attributes.updated_at = $rows_by_uuid[uuid].updated_at,
+    updated_at = $rows_by_uuid[uuid].updated_at,
+    revision = (revision ?? 0) + 1
+WHERE group_id = $group_id
+  AND entity_type = $rows_by_uuid[uuid].entity_type
+  AND name = $rows_by_uuid[uuid].name
+  AND description = $rows_by_uuid[uuid].description
+  AND content = $rows_by_uuid[uuid].content
+  AND (attributes.summary ?? '') = $rows_by_uuid[uuid].summary
+RETURN AFTER;
+"""
+
+
+async def _update_entity_embeddings_if_current(
     client: SurrealGraphClient,
-    entity: Entity,
+    entities: Sequence[Entity],
     *,
     group_id: str,
-) -> bool:
-    if not entity.embedding:
-        return False
+) -> set[str]:
+    rows = [
+        {
+            "uuid": entity.id,
+            "entity_type": entity.entity_type.value,
+            "name": entity.name,
+            "description": entity.description or "",
+            "content": entity.content or "",
+            "summary": str(entity.metadata.get("summary") or ""),
+            "name_embedding": entity.embedding,
+            "embedding_metadata": entity.metadata.get("embedding_metadata"),
+            "updated_at": datetime.now(UTC),
+        }
+        for entity in entities
+        if entity.embedding
+    ]
+    if not rows:
+        return set()
+    rows_by_uuid = {str(row["uuid"]): row for row in rows}
     rows = normalize_records(
         await client.execute_query(
-            # Addressed through a subquery because the UPDATE planner (unlike
-            # SELECT's) abandons idx_entity_uuid once the if-current guards are
-            # stacked on and iterates the whole table: 2.8s/statement at 43K
-            # rows vs 20ms addressed, and the backfill runs eight of these
-            # concurrently. The guards still evaluate atomically inside the
-            # UPDATE, so if-current semantics are unchanged.
-            """
-            UPDATE (SELECT VALUE id FROM entity WHERE group_id = $group_id AND uuid = $uuid LIMIT 1) SET
-                name_embedding = $name_embedding,
-                attributes.embedding_metadata = $embedding_metadata,
-                attributes.updated_at = $updated_at,
-                updated_at = $updated_at,
-                revision = (revision ?? 0) + 1
-            WHERE group_id = $group_id
-              AND uuid = $uuid
-              AND entity_type = $entity_type
-              AND name = $name
-              AND description = $description
-              AND content = $content
-              AND (attributes.summary ?? '') = $summary
-            RETURN AFTER;
-            """,
+            # Each row is still addressed through idx_entity_uuid and fenced
+            # atomically against its current text. Sending the batch as one
+            # query keeps HNSW writes on one database request instead of
+            # flooding every pool socket with an independent indexed UPDATE.
+            _ENTITY_EMBEDDING_BACKFILL_QUERY,
             group_id=group_id,
-            uuid=entity.id,
-            entity_type=entity.entity_type.value,
-            name=entity.name,
-            description=entity.description or "",
-            content=entity.content or "",
-            summary=str(entity.metadata.get("summary") or ""),
-            name_embedding=entity.embedding,
-            embedding_metadata=entity.metadata.get("embedding_metadata"),
-            updated_at=datetime.now(UTC),
+            uuids=list(rows_by_uuid),
+            rows_by_uuid=rows_by_uuid,
         )
     )
-    return any(str(row.get("uuid") or "") == entity.id for row in rows)
+    return {str(row["uuid"]) for row in rows if str(row.get("uuid") or "")}
 
 
 def _persisted_entity_embedding_text(entity: Entity) -> str:

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from sibyl_core.backends.surreal.connection import _is_transient_connection_error
+from sibyl_core.backends.surreal.schema import EMBEDDING_DIM
 from sibyl_core.embeddings.providers import entity_embedding_text
 from sibyl_core.memory_pipeline.retrieval_keys import coerce_retrieval_keys
 from sibyl_core.models.entities import Entity, EntityType
@@ -435,13 +436,13 @@ def _parsed_metadata_snapshot(raw: object) -> dict[str, object] | None:
     return None
 
 
-_ENTITY_EMBEDDING_BACKFILL_QUERY = """
+_ENTITY_EMBEDDING_BACKFILL_QUERY = f"""
 UPDATE (
     SELECT VALUE id
     FROM entity
     WHERE group_id = $group_id AND uuid IN $uuids
 ) SET
-    name_embedding = <array<float, 1024>>$rows_by_uuid[uuid].name_embedding,
+    name_embedding = <array<float, {EMBEDDING_DIM}>>$rows_by_uuid[uuid].name_embedding,
     attributes.embedding_metadata = $rows_by_uuid[uuid].embedding_metadata,
     attributes.updated_at = $rows_by_uuid[uuid].updated_at,
     updated_at = $rows_by_uuid[uuid].updated_at,

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -76,6 +76,9 @@ class _EmbeddingWriteClient:
         if "INSERT INTO entity $rows ON DUPLICATE KEY UPDATE" in query:
             rows = cast("list[dict[str, object]]", params["rows"])
             return [{"uuid": row["uuid"], "name_embedding": row["name_embedding"]} for row in rows]
+        if "WHERE group_id = $group_id AND uuid IN $uuids" in query:
+            rows = cast("dict[str, dict[str, object]]", params["rows_by_uuid"]).values()
+            return [{"uuid": row["uuid"]} for row in rows]
         if "RELATE $src->$rel->$tgt" in query:
             return [{"uuid": params["uuid"], "fact_embedding": params["fact_embedding"]}]
         return []
@@ -2017,6 +2020,35 @@ async def test_native_embedding_backfill_cannot_overwrite_or_resurrect_stale_ent
     assert stored.content == "  version two\n"
     assert stored.embedding
     assert deleted_ids == []
+
+
+@pytest.mark.asyncio
+async def test_native_embedding_backfill_batches_indexed_updates() -> None:
+    client = _EmbeddingWriteClient()
+    entities = [
+        Entity(
+            id=f"session_batched_{index}",
+            entity_type=EntityType.SESSION,
+            name=f"Batched session {index}",
+            content=f"Evidence {index}",
+            embedding=[float(index)] * 1024,
+            organization_id=client.group_id,
+        )
+        for index in range(2)
+    ]
+
+    updated_ids = await graph_entity_store_module._update_entity_embeddings_if_current(
+        cast("Any", client),
+        entities,
+        group_id=client.group_id,
+    )
+
+    assert updated_ids == {entity.id for entity in entities}
+    assert len(client.calls) == 1
+    query, params = client.calls[0]
+    assert "WHERE group_id = $group_id AND uuid IN $uuids" in query
+    assert cast("list[str]", params["uuids"]) == [entity.id for entity in entities]
+    assert len(cast("dict[str, object]", params["rows_by_uuid"])) == len(entities)
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -2048,6 +2048,7 @@ async def test_native_embedding_backfill_batches_indexed_updates() -> None:
     assert len(client.calls) == 1
     query, params = client.calls[0]
     assert "WHERE group_id = $group_id AND uuid IN $uuids" in query
+    assert f"<array<float, {EMBEDDING_DIM}>>" in query
     assert cast("list[str]", params["uuids"]) == [entity.id for entity in entities]
     assert len(cast("dict[str, object]", params["rows_by_uuid"])) == len(entities)
 

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -11,6 +11,7 @@ import pytest
 
 import sibyl_core.services.graph as graph_module
 import sibyl_core.services.graph_client as graph_client_module
+import sibyl_core.services.graph_entities as graph_entities_module
 import sibyl_core.services.graph_entity_search as graph_entity_search_module
 import sibyl_core.services.graph_entity_store as graph_entity_store_module
 import sibyl_core.services.graph_runtime as graph_runtime_module
@@ -2049,6 +2050,59 @@ async def test_native_embedding_backfill_batches_indexed_updates() -> None:
     assert "WHERE group_id = $group_id AND uuid IN $uuids" in query
     assert cast("list[str]", params["uuids"]) == [entity.id for entity in entities]
     assert len(cast("dict[str, object]", params["rows_by_uuid"])) == len(entities)
+
+
+@pytest.mark.asyncio
+async def test_native_embedding_backfill_bounds_each_write_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SurrealGraphClient(group_id="org-native-bounded-embedding", url="memory://")
+    provider = DeterministicEmbeddingProvider(
+        EmbeddingMetadata(
+            provider="deterministic",
+            model="unit-test",
+            dimensions=1024,
+            cache_namespace="native-bounded-embedding-test",
+            tokenizer_estimate_method="utf8-byte-length",
+        )
+    )
+    entities = tuple(
+        Entity(
+            id=f"session_bounded_{index}",
+            entity_type=EntityType.SESSION,
+            name=f"Bounded session {index}",
+            content=f"Evidence {index}",
+            organization_id=client.group_id,
+        )
+        for index in range(3)
+    )
+    update_batch = AsyncMock(
+        side_effect=lambda _client, batch, **_kwargs: {entity.id for entity in batch}
+    )
+    monkeypatch.setattr(
+        graph_entities_module,
+        "_update_entity_embeddings_if_current",
+        update_batch,
+    )
+    try:
+        await prepare_graph_schema(client)
+        manager = EntityManager(
+            client,
+            group_id=client.group_id,
+            embedding_provider=provider,
+        )
+        await manager.create_direct_bulk(entities)
+
+        ready_ids = await manager.backfill_embeddings_if_current(
+            entities,
+            embedding_batch_size=2,
+        )
+    finally:
+        await client.close()
+
+    assert ready_ids == [entity.id for entity in entities]
+    assert update_batch.await_count == 2
+    assert [len(call.args[1]) for call in update_batch.await_args_list] == [2, 1]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -3605,6 +3605,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "surrealdb" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -3646,6 +3647,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff" },
     { name = "surrealdb", specifier = ">=2.0.0,<3.0" },
+    { name = "ty", specifier = ">=0.0.69" },
 ]
 
 [[package]]


### PR DESCRIPTION
## why

The v1.3 A/A release evaluation exposed a database saturation failure during
concurrent ingestion. Each embedding batch launched one indexed HNSW update per
entity across all eight SurrealDB pool sockets. At roughly 100 entities per
batch, those writes occupied the database long enough to block new WebSocket
handshakes, including unrelated authentication reads.

The failure was not the macOS file descriptor regression. The release lane had
the corrected limits and failed inside SurrealDB after both domains had begun
embedding backfill.

## what changed

The entity backfill now sends one set-based, UUID-addressed `UPDATE` per bounded
batch. A keyed parameter map supplies each entity's embedding and expected text
snapshot without duplicating the vector payload.

Every row keeps the existing currency fence across type, name, description,
content, and summary. Stale rows remain untouched, deleted rows stay deleted,
and the query returns only rows that were actually updated.

The dynamic vector lookup is cast to the graph schema's configured float-array
dimension. Dedicated live tests protect the 1,024-dimension OpenAI path and the
384-dimension local MiniLM path against SurrealDB 3.x coercion drift.

The core package also declares `ty` in its own development group. Moon runs the
core typecheck from that package context, so fresh worktrees no longer depend on
a separately populated root environment.

## verification

- `moon run core:check --force`
  - 2,740 passed
  - 14 skipped
  - 1 expected failure
  - Ruff and ty passed
- `PYTEST_ADDOPTS='-k native_embedding_backfill -x' moon run core:test --force`
  - 5 passed
  - Covers current, stale, deleted, hydrated-default, metadata-fallback, and
    multi-entity bounded-write behavior
- `PYTEST_ADDOPTS='-k backfill -x' moon run api:test --force`
  - 22 passed
  - Covers job retries, stale expectations, manifests, routes, and queueing
- `moon run api:test-live --force` against SurrealDB 3.2.3
  - 9 passed at 1,024 dimensions
  - The fenced batch test also passed in a separate 384-dimension process
- `moon run core:lint core:typecheck api:lint api:typecheck --force`
  - All checks passed
- Independent adversarial verification on `fca0f58c`
  - Passed with no findings
  - Confirmed both live dimensions and the `idx_entity_uuid` union plan

## blast radius

The runtime change is confined to deferred graph entity embedding persistence.
Embedding generation, relationship backfill, provider concurrency, graph pool
sizing, and request concurrency are unchanged. The CI change adds one focused
live 384-dimension backfill process.

A fresh full release evaluation remains the final workload-scale proof after
merge.

## 4:20 tribute

```text
              .
          .   |   .
           \  |  /
       .----\ | /----.
         \   \|/   /
          \   |   /
           \  |  /
            \ | /
             \|/
              |
            4:20
```
