### PR TITLE
fix(evals): admit official saved memory state

### DIFF
--- a/benchmarks/longmemeval_v2_release_state.py
+++ b/benchmarks/longmemeval_v2_release_state.py
@@ -113,6 +113,15 @@ _CHECKPOINT_FILES = frozenset(
         "memory_manifest.json",
     }
 )
+_MEMORY_STATE_FILES = frozenset(
+    {
+        "action_spines.jsonl.gz",
+        "chunk_catalog.jsonl.gz",
+        "distillation_receipts.jsonl.gz",
+        "memory_config.json",
+        "memory_manifest.json",
+    }
+)
 _LOG_EVENT_KEYS = {
     "start": frozenset({"event", "recorded_at", "command_sha256"}),
     "output": frozenset({"event", "text"}),
@@ -400,7 +409,7 @@ def _require_domain_tree(parent: Path, *, planning: bool, build_memory: bool) ->
     files = _PLANNING_FILES if planning else _DOMAIN_FILES
     directories = {"provider_usage", "runtime_inputs"}
     if build_memory and not planning:
-        directories.add("checkpoint")
+        directories.update({"checkpoint", "memory_state"})
     _require_subset(parent, set(files) | directories, name="domain output")
     _require_subset(parent / "runtime_inputs", set(_RUNTIME_FILES), name="runtime inputs")
     _require_subset(
@@ -410,6 +419,11 @@ def _require_domain_tree(parent: Path, *, planning: bool, build_memory: bool) ->
     )
     if build_memory and not planning:
         _require_subset(parent / "checkpoint", set(_CHECKPOINT_FILES), name="memory checkpoint")
+        _require_subset(
+            parent / "memory_state",
+            set(_MEMORY_STATE_FILES),
+            name="saved memory state",
+        )
 
 
 def require_domain_output_tree(

--- a/tools/tests/test_longmemeval_v2_release_executor.py
+++ b/tools/tests/test_longmemeval_v2_release_executor.py
@@ -668,6 +668,16 @@ def test_claimed_tree_accepts_only_declared_saved_memory_artifacts(
 
     state.require_claimed_stage_plan(stage_plan)
 
+    baseline_memory_state = (
+        Path(stage_plan["runs"][1]["domains"]["web"]["output_dir"]) / "memory_state"
+    )
+    baseline_memory_state.mkdir(parents=True)
+    (baseline_memory_state / "memory_manifest.json").write_text("{}\n", encoding="utf-8")
+    with pytest.raises(StagePlanError, match="unknown entries"):
+        state.require_claimed_stage_plan(stage_plan)
+    (baseline_memory_state / "memory_manifest.json").unlink()
+    baseline_memory_state.rmdir()
+
     (memory_state / "foreign.bin").write_bytes(b"hostile")
     with pytest.raises(StagePlanError, match="unknown entries"):
         state.require_claimed_stage_plan(stage_plan)

--- a/tools/tests/test_longmemeval_v2_release_executor.py
+++ b/tools/tests/test_longmemeval_v2_release_executor.py
@@ -651,6 +651,28 @@ def test_claimed_tree_rejects_nested_foreign_and_symlinked_domain_artifacts(
         state.require_claimed_stage_plan(stage_plan)
 
 
+def test_claimed_tree_accepts_only_declared_saved_memory_artifacts(
+    stage_plan: dict[str, Any],
+) -> None:
+    state.claim_stage(stage_plan, max_workers=4)
+    memory_state = Path(stage_plan["runs"][0]["domains"]["web"]["output_dir"]) / "memory_state"
+    memory_state.mkdir(parents=True)
+    for name in (
+        "action_spines.jsonl.gz",
+        "chunk_catalog.jsonl.gz",
+        "distillation_receipts.jsonl.gz",
+        "memory_config.json",
+        "memory_manifest.json",
+    ):
+        (memory_state / name).write_bytes(b"official adapter artifact\n")
+
+    state.require_claimed_stage_plan(stage_plan)
+
+    (memory_state / "foreign.bin").write_bytes(b"hostile")
+    with pytest.raises(StagePlanError, match="unknown entries"):
+        state.require_claimed_stage_plan(stage_plan)
+
+
 def test_completion_evidence_rejects_foreign_files_created_by_paid_command(
     stage_plan: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
## why

The fresh v1.3 A/A release run completed the official adapter's memory build,
then the sealed runner rejected the resulting `memory_state/` directory as an
unknown output. The adapter and release runner had independently strict artifact
contracts, but their accepted directory shapes were not joined at the execution
boundary.

The run also exposed a separate SurrealDB capacity failure. This PR fixes only
the evidence-contract mismatch. The next run will move the disposable database
outside OrbStack's 24 GiB cap so capacity and contract are tested independently.

## what changed

Build-memory domains may now publish a `memory_state/` directory containing the
five artifacts emitted by the official adapter:

- `action_spines.jsonl.gz`
- `chunk_catalog.jsonl.gz`
- `distillation_receipts.jsonl.gz`
- `memory_config.json`
- `memory_manifest.json`

The runner still rejects the directory during planning, for non-build arms, and
whenever any undeclared descendant appears. The new adversarial test first
accepts the exact official set, then adds `foreign.bin` and proves the claimed
tree fails closed.

## verification

- `PYTEST_ADDOPTS='-k claimed_tree --maxfail=1' moon run bench-gate-test --force`
  - 2 passed
- `moon run bench-gate-test --force`
  - 819 passed
- `moon run inventory-lint --force`
  - Ruff passed
  - 213 files formatted
- `moon run inventory-typecheck --force`
  - ty passed

## blast radius

The change affects only the sealed local LongMemEval-V2 claimed-tree validator
and its tests. Provider commands, spend caps, adapter serialization, checkpoint
validation, and production Sibyl runtime behavior are unchanged.

## 4:20 tribute

```text
             _\|/_
              /|\
           .-' | '-.
        .-'    |    '-.
       /   \   |   /   \
      /     \  |  /     \
             \ | /
              \|/
               |
             4:20
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Memory-building runs can now include validated saved-memory artifacts in the release output.
  - Only approved memory artifact files are accepted, helping prevent unexpected files from being included.

- **Bug Fixes**
  - Improved validation of release outputs containing saved-memory data.

- **Tests**
  - Added coverage confirming valid memory artifacts are accepted and unrecognized files are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->