### PR TITLE
fix(evals): seal runtime provider boundaries

### DIFF
--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -1002,6 +1002,7 @@ async def context_pack(
                 allowed_memory_scope_keys=set(ctx.api_key_memory_scope_keys)
                 if ctx.api_key_memory_scope_keys is not None
                 else None,
+                include_documents=request.evidence is None,
             )
 
         evidence_response = None

--- a/apps/api/src/sibyl/api/routes/experience.py
+++ b/apps/api/src/sibyl/api/routes/experience.py
@@ -155,35 +155,36 @@ async def capture_operational_experience(
                         error_code=error_code,
                         error=str(exc),
                     )
-            distillation_job_id: str | None = None
-            try:
-                from sibyl.jobs.queue import enqueue_operational_note_distillation
+            if payload.note_distillation:
+                distillation_job_id: str | None = None
+                try:
+                    from sibyl.jobs.queue import enqueue_operational_note_distillation
 
-                distillation_job_id = await enqueue_operational_note_distillation(
-                    experience.model_dump(mode="json"),
-                    group_id,
-                    content_hash=result.projection.manifest.content_hash,
-                    created_by=ctx.user_id,
-                    max_tokens=settings.operational_note_distillation_max_tokens,
-                )
-                background_jobs["note_distillation"] = {
-                    "status": "queued",
-                    "job_ids": [distillation_job_id],
-                    "queued_sources": 1,
-                }
-            except Exception as exc:
-                background_jobs["note_distillation"] = {
-                    "status": "degraded",
-                    "job_ids": [distillation_job_id] if distillation_job_id else [],
-                    "queued_sources": 0,
-                    "error": "enqueue_failed",
-                }
-                log.warning(
-                    "operational_note_distillation_enqueue_failed",
-                    source_id=experience.source_id,
-                    error_code="enqueue_failed",
-                    error=str(exc),
-                )
+                    distillation_job_id = await enqueue_operational_note_distillation(
+                        experience.model_dump(mode="json"),
+                        group_id,
+                        content_hash=result.projection.manifest.content_hash,
+                        created_by=ctx.user_id,
+                        max_tokens=settings.operational_note_distillation_max_tokens,
+                    )
+                    background_jobs["note_distillation"] = {
+                        "status": "queued",
+                        "job_ids": [distillation_job_id],
+                        "queued_sources": 1,
+                    }
+                except Exception as exc:
+                    background_jobs["note_distillation"] = {
+                        "status": "degraded",
+                        "job_ids": [distillation_job_id] if distillation_job_id else [],
+                        "queued_sources": 0,
+                        "error": "enqueue_failed",
+                    }
+                    log.warning(
+                        "operational_note_distillation_enqueue_failed",
+                        source_id=experience.source_id,
+                        error_code="enqueue_failed",
+                        error=str(exc),
+                    )
     except LockAcquisitionError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/apps/api/src/sibyl/api/schemas/experience.py
+++ b/apps/api/src/sibyl/api/schemas/experience.py
@@ -15,6 +15,10 @@ class OperationalExperienceCaptureRequest(BaseModel):
         default=True,
         description="Persist lexical records first and queue embedding backfill",
     )
+    note_distillation: bool = Field(
+        default=True,
+        description="Queue provider-backed operational note distillation",
+    )
 
 
 class OperationalExperienceCaptureResponse(BaseModel):

--- a/apps/api/tests/test_routes_context.py
+++ b/apps/api/tests/test_routes_context.py
@@ -364,6 +364,7 @@ class TestContextPackRoute:
         assert compile_context.await_args.kwargs["include_related"] is True
         assert compile_context.await_args.kwargs["related_limit"] == 3
         assert compile_context.await_args.kwargs["record_exposure"] is True
+        assert compile_context.await_args.kwargs["include_documents"] is True
 
     @pytest.mark.asyncio
     async def test_context_pack_can_disable_exposure_recording(self) -> None:
@@ -713,7 +714,8 @@ class TestContextPackRoute:
             )
         )
 
-        async def compile_pack(**_kwargs: object) -> ContextPack:
+        async def compile_pack(**kwargs: object) -> ContextPack:
+            assert kwargs["include_documents"] is False
             await provider.embed_texts(["ship faster"], input_kind="query")
             return _pack()
 

--- a/apps/api/tests/test_routes_experience.py
+++ b/apps/api/tests/test_routes_experience.py
@@ -172,6 +172,47 @@ async def test_capture_persists_authorized_experience_and_queues_embeddings(
 
 
 @pytest.mark.asyncio
+async def test_capture_can_disable_provider_backed_note_distillation(
+    queue_note_distillation: AsyncMock,
+) -> None:
+    org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
+    ctx = SimpleNamespace(user_id="user-1")
+    request = _request().model_copy(update={"note_distillation": False})
+    projection = project_operational_experience(request.experience)
+    write_result = SimpleNamespace(
+        projection=projection,
+        written_entity_ids=projection.manifest.entity_ids,
+        written_relationship_ids=projection.manifest.relationship_ids,
+        deleted_entity_ids=(),
+        deleted_relationship_ids=(),
+        embedding_backfill_required=False,
+    )
+
+    with (
+        patch(
+            "sibyl.api.routes.experience.verify_entity_project_access",
+            AsyncMock(),
+        ),
+        patch(
+            "sibyl.api.routes.experience.get_experience_graph_runtime",
+            AsyncMock(return_value=_runtime()),
+        ),
+        patch(
+            "sibyl.api.routes.experience.persist_operational_experience",
+            AsyncMock(return_value=write_result),
+        ),
+    ):
+        response = await capture_operational_experience(
+            payload=request,
+            org=org,
+            ctx=ctx,
+        )
+
+    queue_note_distillation.assert_not_awaited()
+    assert "note_distillation" not in response.background_jobs
+
+
+@pytest.mark.asyncio
 async def test_capture_can_embed_synchronously_without_background_job() -> None:
     org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
     ctx = SimpleNamespace(user_id="user-1")

--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -4328,8 +4328,15 @@ class SibylLiveApiMemory(Memory):
             "operational_note_distillation_profile",
             DEFAULT_OPERATIONAL_NOTE_DISTILLATION_PROFILE,
         )
+        experience_payload["note_distillation"] = getattr(self, "note_distillation", False)
         if distillation_profile != DEFAULT_OPERATIONAL_NOTE_DISTILLATION_PROFILE:
-            experience_payload["distillation_profile"] = distillation_profile
+            experience = experience_payload.get("experience")
+            if not isinstance(experience, dict):
+                raise RuntimeError("operational experience payload is malformed")
+            metadata = experience.get("metadata")
+            if not isinstance(metadata, dict):
+                raise RuntimeError("operational experience metadata is malformed")
+            metadata["operational_note_distillation_profile"] = distillation_profile
         experience_payload["defer_embeddings"] = self.defer_embeddings
         created = self._request_json(
             "POST",

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -1255,6 +1255,7 @@ async def _compile_fallback_sections(
     principal_id: str | None = None,
     allowed_memory_scope_keys: set[str] | None = None,
     audit: bool = False,
+    include_documents: bool = True,
 ) -> list[ContextSection]:
     # The degraded path answers to the same reader as the native one. Dropping
     # the principal here only failed closed for private rows by accident, and
@@ -1270,7 +1271,7 @@ async def _compile_fallback_sections(
         "limit": limit,
         "include_content": True,
         "content_max_chars": FALLBACK_SEARCH_CONTENT_MAX_CHARS,
-        "include_documents": True,
+        "include_documents": include_documents,
         "include_graph": True,
         "organization_id": organization_id,
     }
@@ -1631,6 +1632,7 @@ async def compile_context(
     record_exposure: bool = True,
     knn_type_overfetch: int = 0,
     naive_retrieval: bool = False,
+    include_documents: bool = True,
 ) -> ContextPack:
     """Build a small, structured context pack for an agent goal.
 
@@ -1748,6 +1750,7 @@ async def compile_context(
                     principal_id=principal_id,
                     allowed_memory_scope_keys=allowed_memory_scope_keys,
                     audit=audit,
+                    include_documents=include_documents,
                 )
             ),
             limit,

--- a/packages/python/sibyl-core/tests/test_context_pack.py
+++ b/packages/python/sibyl-core/tests/test_context_pack.py
@@ -477,6 +477,31 @@ async def test_compile_context_falls_back_when_batched_native_search_fails(
 
 
 @pytest.mark.asyncio
+async def test_compile_context_can_keep_degraded_retrieval_graph_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_native_context_search(**_kwargs: Any) -> SearchResponse:
+        raise RuntimeError("native search unavailable")
+
+    async def fallback_search(**kwargs: Any) -> SearchResponse:
+        calls.append(kwargs)
+        return SearchResponse(results=[], total=0, query=kwargs["query"], filters={})
+
+    monkeypatch.setattr(context_module, "context_search", fake_native_context_search)
+
+    await compile_context(
+        "sealed local retrieval",
+        organization_id="org-123",
+        search_fn=fallback_search,
+        include_documents=False,
+    )
+
+    assert calls[0]["include_documents"] is False
+
+
+@pytest.mark.asyncio
 async def test_fallback_sections_disable_default_search_exposure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -7371,6 +7371,7 @@ def test_sibyl_memory_insert_tracks_deferred_background_jobs() -> None:
     assert isinstance(request_json, dict)
     assert calls[0]["path"] == "/memory/experience"
     assert request_json["defer_embeddings"] is True
+    assert request_json["note_distillation"] is False
     experience = cast(dict[str, object], request_json["experience"])
     assert experience["source_id"] == "longmemeval-v2:run_lme:t1"
     observations = cast(list[dict[str, object]], experience["observations"])
@@ -7386,6 +7387,56 @@ def test_sibyl_memory_insert_tracks_deferred_background_jobs() -> None:
     assert memory._pending_job_manifest_ids == {
         "embed-lme-v2-1": "artifact-lme-v2-1",
     }
+
+
+def test_sibyl_memory_requests_and_profiles_operational_note_distillation() -> None:
+    module = _load_memory_module()
+    memory = module.SibylLiveApiMemory.__new__(module.SibylLiveApiMemory)
+    module.Memory.__init__(memory, {})
+    requests: list[dict[str, object]] = []
+
+    def fake_request(
+        _method: str,
+        _path: str,
+        *,
+        json: dict[str, object] | None = None,
+        params: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        del params
+        requests.append(json or {})
+        return {
+            "written_entities": 1,
+            "background_jobs": {
+                "note_distillation": {
+                    "status": "queued",
+                    "job_ids": ["distill-lme-v2-1"],
+                },
+            },
+        }
+
+    memory.project_id = "project_lme"
+    memory.run_id = "run_lme"
+    memory.content_max_chars = TEST_CONTENT_MAX_CHARS
+    memory.embedding_backfill_max_pending_jobs = 8
+    memory.include_screenshot_refs = False
+    memory.defer_embeddings = False
+    memory.note_distillation = True
+    memory.operational_note_distillation_profile = "render_v1"
+    memory.created_entities = 0
+    memory.inserted_trajectories = 0
+    memory._pending_embedding_job_ids = set()
+    memory._pending_projection_job_ids = set()
+    memory._pending_note_distillation_job_ids = set()
+    memory._request_json = fake_request
+
+    memory.insert(_trajectory("t1"))
+
+    payload = requests[0]
+    assert payload["note_distillation"] is True
+    experience = cast(dict[str, object], payload["experience"])
+    metadata = cast(dict[str, object], experience["metadata"])
+    assert metadata["operational_note_distillation_profile"] == "render_v1"
+    assert memory._pending_note_distillation_job_ids == {"distill-lme-v2-1"}
 
 
 def test_sibyl_memory_retries_write_after_pre_checkpoint_crash(tmp_path: Path) -> None:


### PR DESCRIPTION
## why

The r8 release evaluation completed both domain ingests, then failed on its
first serving query with `mixed/mixed` embedding provenance. The run also
reported zero provider spend even though the worker had completed billed
Anthropic note distillation.

Both failures came from runtime boundaries that disagreed with the sealed
benchmark configuration:

- Evidence-mode context packs shared one embedding receipt with a degraded
  fallback that could invoke document embeddings.
- The benchmark disabled note distillation locally, but the experience API
  still queued provider-backed distillation jobs.

## what changed

The context compiler now accepts an `include_documents` fallback policy.
Evidence-mode API requests set it to false, keeping degraded retrieval on the
same local graph embedding surface as healthy retrieval. Ordinary context
packs preserve their existing document-search behavior.

The experience capture API now accepts `note_distillation`, defaulting to true
for compatibility. The live benchmark adapter sends its sealed choice on every
capture. When a treatment selects a nonbaseline distillation profile, the
adapter binds that profile into the operational experience metadata consumed
by the worker.

## invariants

- Existing API clients still receive note distillation by default.
- Evidence retrieval stays local-only even when native context retrieval
  degrades.
- A sealed opt-out cannot create untracked provider work.
- Render treatments bind their requested production profile to every job.

## validation

- `moon run api:check`: 2,286 passed, 10 live-only skips
- `moon run core:check`: 2,751 passed, 14 live-only skips, 1 documented xfail
- `moon run root:bench-gate-test`: 860 passed
- API and core lint and type checks passed

## blast radius

The API contract gains one backward-compatible boolean. Normal context packs
and existing experience clients retain their current defaults. The graph-only
fallback applies only when a context request includes the evidence contract.

## 4:20 runtime boundary protection ritual

```text
             .
          .  |  .
       .  \  |  /  .
        \  \ | /  /
      ---  \|/  ---
        .--/|\--.
           /|\
            |
          4:20
```

~ via nova ⚡


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to enable or disable operational note distillation during experience capture; it is enabled by default.
  * Added support for configuring distillation profiles and tracking queued distillation jobs.
  * Added control over whether documents are included in compiled context and fallback searches.

* **Bug Fixes**
  * Fixed document-inclusion settings so they remain consistent during degraded retrieval.
  * Prevented note-distillation jobs from being queued when the feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->