### PR TITLE
fix(context): keep graph-only packs off raw memory

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -1272,6 +1272,7 @@ async def _compile_fallback_sections(
         "include_content": True,
         "content_max_chars": FALLBACK_SEARCH_CONTENT_MAX_CHARS,
         "include_documents": include_documents,
+        "include_raw_memory": include_documents,
         "include_graph": True,
         "organization_id": organization_id,
     }

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -1581,6 +1581,7 @@ async def _compile_native_sections(
     raw_memory_recall_fn: RawMemoryRecallFn,
     audit: bool = False,
     naive_retrieval: bool = False,
+    include_raw_memory: bool = True,
 ) -> list[ContextSection]:
     search_limit = min(50, max(limit, per_facet_limit * len(facets)))
     facet = ContextFacet.RECENT_MEMORY if ContextFacet.RECENT_MEMORY in facets else None
@@ -1603,9 +1604,15 @@ async def _compile_native_sections(
             limit=search_limit,
             include_content=True,
             embedding_provider=configured_embedding_provider(),
-            raw_memory_recall_fn=raw_memory_recall_fn,
+            raw_memory_recall_fn=(
+                raw_memory_recall_fn if include_raw_memory else _empty_raw_memory_recall
+            ),
         )
     return _sections_from_response(response, facets=facets, audit=audit)
+
+
+async def _empty_raw_memory_recall(**_kwargs: Any) -> list[Any]:
+    return []
 
 
 async def compile_context(
@@ -1639,6 +1646,9 @@ async def compile_context(
     `naive_retrieval` swaps the 8-lane retrieval for the naive-strong control
     arm and drops the one-hop related-item walk, so a pack compiled under the
     arm carries no graph traversal at all. It is off unless a caller selects it.
+
+    `include_documents=False` keeps both native and fallback retrieval on the
+    graph, excluding raw content memory as well as imported documents.
     """
 
     goal = goal.strip()
@@ -1680,6 +1690,7 @@ async def compile_context(
             raw_memory_recall_fn=raw_memory_recall_fn,
             audit=audit,
             naive_retrieval=naive_retrieval,
+            include_raw_memory=include_documents,
         )
     except Exception as exc:
         if naive_retrieval:

--- a/packages/python/sibyl-core/tests/test_context_pack.py
+++ b/packages/python/sibyl-core/tests/test_context_pack.py
@@ -507,6 +507,7 @@ async def test_compile_context_can_keep_native_and_degraded_retrieval_graph_only
 
     assert len(native_calls) == 1
     assert fallback_calls[0]["include_documents"] is False
+    assert fallback_calls[0]["include_raw_memory"] is False
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/tests/test_context_pack.py
+++ b/packages/python/sibyl-core/tests/test_context_pack.py
@@ -477,16 +477,22 @@ async def test_compile_context_falls_back_when_batched_native_search_fails(
 
 
 @pytest.mark.asyncio
-async def test_compile_context_can_keep_degraded_retrieval_graph_only(
+async def test_compile_context_can_keep_native_and_degraded_retrieval_graph_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[dict[str, Any]] = []
+    native_calls: list[dict[str, Any]] = []
+    fallback_calls: list[dict[str, Any]] = []
 
-    async def fake_native_context_search(**_kwargs: Any) -> SearchResponse:
+    async def forbidden_raw_recall(**_kwargs: Any) -> list[Any]:
+        raise AssertionError("raw memory recall should stay disabled")
+
+    async def fake_native_context_search(**kwargs: Any) -> SearchResponse:
+        native_calls.append(kwargs)
+        assert await kwargs["raw_memory_recall_fn"]() == []
         raise RuntimeError("native search unavailable")
 
     async def fallback_search(**kwargs: Any) -> SearchResponse:
-        calls.append(kwargs)
+        fallback_calls.append(kwargs)
         return SearchResponse(results=[], total=0, query=kwargs["query"], filters={})
 
     monkeypatch.setattr(context_module, "context_search", fake_native_context_search)
@@ -495,10 +501,12 @@ async def test_compile_context_can_keep_degraded_retrieval_graph_only(
         "sealed local retrieval",
         organization_id="org-123",
         search_fn=fallback_search,
+        raw_memory_recall_fn=forbidden_raw_recall,
         include_documents=False,
     )
 
-    assert calls[0]["include_documents"] is False
+    assert len(native_calls) == 1
+    assert fallback_calls[0]["include_documents"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

The sealed v1.3 LongMemEval runner requires every serving API embedding to use the pinned local MiniLM model. The evidence route already disabled imported documents, but native context compilation still queried raw content memory. That path used the configured OpenAI content embedder and turned an otherwise local receipt into `mixed/mixed`.

A live r9 preflight caught the boundary before another paid wave. The request made one local graph query and one OpenAI raw-memory query, even with `include_documents=false`.

## What changed

The graph-only context contract now applies to both retrieval paths:

- native context search receives an empty raw-memory source when documents are disabled
- fallback search keeps its existing `include_documents=false` behavior
- ordinary context packs retain raw memory and document retrieval by default

The regression test exercises both native and degraded paths. A supplied raw-memory callback raises if the native path touches it, while the fallback assertion verifies the document flag remains sealed.

## Verification

- `moon run core:check`
- 2,749 passed
- 16 skipped
- 1 documented xfail
- Ruff lint and formatting passed
- ty type checking passed

## Blast radius

The change only affects callers that explicitly set `include_documents=false`. The v1.3 evidence context route is such a caller. Default context behavior is unchanged.

## Tribute

```text
             .
          .  |  .
       .  \  |  /  .
        \  \ | /  /
      ---  \|/  ---
        .--/|\--.
           /|\
            |
          4:20
```

~ via nova ⚡
