### PR TITLE
perf(retrieval): scale context packs on release corpus

### DIFF
--- a/benchmarks/longmemeval_v2_memory/sibyl_memory.py
+++ b/benchmarks/longmemeval_v2_memory/sibyl_memory.py
@@ -5578,11 +5578,7 @@ class SibylLiveApiMemory(Memory):
                 "inserted_trajectories",
                 len(self._chunk_catalog),
             ),
-            "created_entities": getattr(
-                self,
-                "created_entities",
-                sum(len(chunks) for chunks in self._chunk_catalog.values()),
-            ),
+            "created_entities": sum(len(chunks) for chunks in self._chunk_catalog.values()),
             "ingest_api_runtime": dict(getattr(self, "ingest_api_runtime", {})),
             "ingest_embedding_usage": dict(getattr(self, "ingest_embedding_usage", {})),
             "completed_trajectory_ids": sorted(

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/_search_sources.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/_search_sources.py
@@ -184,7 +184,9 @@ async def _node_fulltext_candidates(
     terms = build_fulltext_terms(plan.query)
     if not terms:
         return []
-    result_limit = max(int(limit), 1)
+    result_limit = int(limit)
+    if result_limit <= 0:
+        return []
     filter_clauses, filter_params = _node_filter_clause(search_filter)
     field_rows = await asyncio.gather(
         *(

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/_search_sources.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/_search_sources.py
@@ -43,6 +43,7 @@ type RawMemoryRecallFn = Callable[..., Awaitable[list[RawMemory] | RawMemoryReca
 
 EDGE_FULLTEXT_MATCH_HEADROOM = 8
 EDGE_FULLTEXT_MIN_MATCH_LIMIT = 32
+NODE_FULLTEXT_FIELDS = ("name", "summary", "description", "content")
 _RAW_MEMORY_CONTEXT_TYPES = {"raw_memory", "session", "episode", "note"}
 log = structlog.get_logger()
 
@@ -180,14 +181,56 @@ async def _node_fulltext_candidates(
     search_filter: SearchFilter,
     limit: int,
 ) -> list[RetrievalCandidate]:
-    match = build_match_disjunction(
-        ["name", "summary", "description", "content"],
-        build_fulltext_terms(plan.query),
-    )
-    if match is None:
+    terms = build_fulltext_terms(plan.query)
+    if not terms:
         return []
+    result_limit = max(int(limit), 1)
     filter_clauses, filter_params = _node_filter_clause(search_filter)
-    rows = await _execute_query_records(
+    field_rows = await asyncio.gather(
+        *(
+            _node_fulltext_field_rows(
+                client=client,
+                field=field,
+                terms=terms,
+                organization_id=plan.organization_id,
+                filter_clauses=filter_clauses,
+                filter_params=filter_params,
+                limit=result_limit,
+            )
+            for field in NODE_FULLTEXT_FIELDS
+        )
+    )
+    best_by_uuid: dict[str, RetrievalCandidate] = {}
+    for rows in field_rows:
+        for row in rows:
+            candidate = _candidate_from_node_record(
+                row,
+                signal=RetrievalSignal.NODE_FULLTEXT,
+                score=_record_score(row),
+            )
+            current = best_by_uuid.get(candidate.id)
+            if current is None or candidate.score > current.score:
+                best_by_uuid[candidate.id] = candidate
+    return sorted(
+        best_by_uuid.values(),
+        key=_node_fulltext_candidate_sort_key,
+        reverse=True,
+    )[:result_limit]
+
+
+async def _node_fulltext_field_rows(
+    *,
+    client: Any,
+    field: str,
+    terms: list[str],
+    organization_id: str,
+    filter_clauses: list[str],
+    filter_params: Mapping[str, Any],
+    limit: int,
+) -> list[dict[str, Any]]:
+    match = build_match_disjunction([field], terms)
+    assert match is not None
+    return await _execute_query_records(
         client,
         f"""
         SELECT *,
@@ -200,19 +243,20 @@ async def _node_fulltext_candidates(
         ORDER BY score DESC, created_at DESC, uuid DESC
         LIMIT $limit;
         """,
-        group_id=plan.organization_id,
-        limit=max(int(limit), 1),
+        group_id=organization_id,
+        limit=limit,
         **match.params,
         **filter_params,
     )
-    return [
-        _candidate_from_node_record(
-            row,
-            signal=RetrievalSignal.NODE_FULLTEXT,
-            score=_record_score(row),
-        )
-        for row in rows
-    ]
+
+
+def _node_fulltext_candidate_sort_key(
+    candidate: RetrievalCandidate,
+) -> tuple[float, float, str]:
+    created_at = (
+        candidate.created_at.timestamp() if candidate.created_at is not None else float("-inf")
+    )
+    return candidate.score, created_at, candidate.id
 
 
 async def _exact_key_candidates(

--- a/packages/python/sibyl-core/tests/test_search.py
+++ b/packages/python/sibyl-core/tests/test_search.py
@@ -1608,6 +1608,84 @@ class _SurrealErrorEnvelopeClient:
         return [{"status": "ERR", "result": "fulltext index unavailable", "time": "1ms"}]
 
 
+class _NodeFulltextClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+        self.calls.append((query, params))
+        rows_by_field = {
+            "name": [
+                self._row("shared", score=0.8, day=1),
+                self._row("name-only", score=0.9, day=2),
+            ],
+            "summary": [self._row("summary-only", score=0.9, day=3)],
+            "description": [],
+            "content": [
+                self._row("shared", score=0.95, day=1),
+                self._row("content-only", score=0.85, day=4),
+            ],
+        }
+        field = next(
+            field for field in source_module.NODE_FULLTEXT_FIELDS if f"{field} @0@" in query
+        )
+        return rows_by_field[field]
+
+    @staticmethod
+    def _row(uuid: str, *, score: float, day: int) -> dict[str, object]:
+        return {
+            "uuid": uuid,
+            "name": uuid,
+            "entity_type": "note",
+            "content": uuid,
+            "group_id": "org-123",
+            "project_id": "project_123",
+            "attributes": {},
+            "created_at": datetime(2026, 8, day, tzinfo=UTC),
+            "score": score,
+        }
+
+
+@pytest.mark.asyncio
+async def test_node_fulltext_queries_each_index_and_merges_global_top_k() -> None:
+    client = _NodeFulltextClient()
+    plan = build_context_retrieval_plan(
+        query="surreal replay verification",
+        organization_id="org-123",
+        facets=[ContextFacet.RECENT_MEMORY],
+        facet_types={ContextFacet.RECENT_MEMORY: ["note"]},
+        principal_id="user-123",
+        project="project_123",
+        accessible_projects={"project_123"},
+    )
+
+    candidates = await source_module._node_fulltext_candidates(
+        client=client,
+        plan=plan,
+        search_filter=search_module.SearchFilter(
+            node_types=("note",),
+            project_ids=("project_123",),
+        ),
+        limit=3,
+    )
+
+    assert [(candidate.id, candidate.score) for candidate in candidates] == [
+        ("shared", 0.95),
+        ("summary-only", 0.9),
+        ("name-only", 0.9),
+    ]
+    assert len(client.calls) == len(source_module.NODE_FULLTEXT_FIELDS)
+    for field in source_module.NODE_FULLTEXT_FIELDS:
+        [(query, params)] = [call for call in client.calls if f"{field} @0@" in call[0]]
+        assert all(
+            other == field or f"{other} @" not in query
+            for other in source_module.NODE_FULLTEXT_FIELDS
+        )
+        assert params["limit"] == 3
+        assert params["node_types"] == ["note"]
+        assert params["project_ids"] == ["project_123"]
+
+
 @pytest.mark.asyncio
 async def test_surreal_rrf_backend_uses_database_fusion_scores() -> None:
     plan = build_context_retrieval_plan(

--- a/packages/python/sibyl-core/tests/test_search.py
+++ b/packages/python/sibyl-core/tests/test_search.py
@@ -1658,14 +1658,26 @@ async def test_node_fulltext_queries_each_index_and_merges_global_top_k() -> Non
         project="project_123",
         accessible_projects={"project_123"},
     )
+    search_filter = search_module.SearchFilter(
+        node_types=("note",),
+        project_ids=("project_123",),
+    )
+
+    assert (
+        await source_module._node_fulltext_candidates(
+            client=client,
+            plan=plan,
+            search_filter=search_filter,
+            limit=0,
+        )
+        == []
+    )
+    assert client.calls == []
 
     candidates = await source_module._node_fulltext_candidates(
         client=client,
         plan=plan,
-        search_filter=search_module.SearchFilter(
-            node_types=("note",),
-            project_ids=("project_123",),
-        ),
+        search_filter=search_filter,
         limit=3,
     )
 

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -4660,8 +4660,10 @@ def test_sibyl_memory_chunk_catalog_round_trips(tmp_path: Path) -> None:
         "t1": {
             0: _search_result("t1", chunk_index=0, state_index=0, score=0.0),
             1: _search_result("t1", chunk_index=1, state_index=1, score=0.0),
-        }
+        },
+        "t2": {0: _search_result("t2", chunk_index=0, state_index=0, score=0.0)},
     }
+    catalog_entity_count = sum(len(chunks) for chunks in catalog.values())
     memory = module.SibylLiveApiMemory.__new__(module.SibylLiveApiMemory)
     module.Memory.__init__(memory, {})
     memory._chunk_catalog = catalog
@@ -4700,10 +4702,10 @@ def test_sibyl_memory_chunk_catalog_round_trips(tmp_path: Path) -> None:
     assert (tmp_path / module.MEMORY_MANIFEST_FILENAME).is_file()
     manifest = json.loads((tmp_path / module.MEMORY_MANIFEST_FILENAME).read_text(encoding="utf-8"))
     assert manifest["longmemeval_v2_domain"] == "web"
-    assert manifest["created_entities"] == len(catalog["t1"])
+    assert manifest["created_entities"] == catalog_entity_count
     assert memory.created_entities == operational_created_entities
     assert restored._chunk_catalog == catalog
-    assert restored.created_entities == len(catalog["t1"])
+    assert restored.created_entities == catalog_entity_count
     assert restored.inserted_trajectories == len(catalog)
     assert restored._ingest_finalized is True
     assert restored.ingest_api_runtime == {"version": "test"}

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -4655,6 +4655,7 @@ def test_sibyl_memory_refines_split_state_without_spending_context_slot() -> Non
 
 def test_sibyl_memory_chunk_catalog_round_trips(tmp_path: Path) -> None:
     module = _load_memory_module()
+    operational_created_entities = 17
     catalog = {
         "t1": {
             0: _search_result("t1", chunk_index=0, state_index=0, score=0.0),
@@ -4679,6 +4680,7 @@ def test_sibyl_memory_chunk_catalog_round_trips(tmp_path: Path) -> None:
         "requests": EXPECTED_SAVED_USAGE_REQUESTS,
         "provider_reported_cost_usd": EXPECTED_SAVED_USAGE_COST_USD,
     }
+    memory.created_entities = operational_created_entities
     (tmp_path / "memory_config.json").write_text(
         json.dumps(memory.memory_config),
         encoding="utf-8",
@@ -4698,6 +4700,8 @@ def test_sibyl_memory_chunk_catalog_round_trips(tmp_path: Path) -> None:
     assert (tmp_path / module.MEMORY_MANIFEST_FILENAME).is_file()
     manifest = json.loads((tmp_path / module.MEMORY_MANIFEST_FILENAME).read_text(encoding="utf-8"))
     assert manifest["longmemeval_v2_domain"] == "web"
+    assert manifest["created_entities"] == len(catalog["t1"])
+    assert memory.created_entities == operational_created_entities
     assert restored._chunk_catalog == catalog
     assert restored.created_entities == len(catalog["t1"])
     assert restored.inserted_trajectories == len(catalog)


### PR DESCRIPTION
## 🔮 Why

The sealed v1.3 LongMemEval run exposed two release blockers after both
100-trajectory domains had been ingested into one 167,331-entity organization.

The project-scoped node full-text lane issued one scored `OR` across four
SurrealDB full-text indexes. Individual context packs spent 96 to 194 seconds
inside that query. The same run also saved cumulative API write counts in the
portable memory manifest, while the loader and release validator define that
field as deterministic chunk-catalog cardinality.

## ⚡ What changed

The node full-text lane now queries `name`, `summary`, `description`, and
`content` independently and concurrently. Each indexed lane is bounded to the
requested top-k before results are merged by maximum BM25 score and globally
ordered by score, creation time, and identifier.

The bounded merge preserves the previous ranking contract. A candidate outside
a field's top-k cannot enter the global top-k because that field already has k
candidates with equal or greater scores.

Saved memory manifests now serialize chunk-catalog cardinality directly. The
live `created_entities` counter remains untouched for operational API write
accounting.

## 🧪 Evidence

The performance commit `669082cd` was exercised against the surviving r9 database
with 167,331 entities. The later review-only commit `b49bbc37` changes only
zero-limit behavior and test coverage:

- The previous full-text union took 96.4 to 193.6 seconds.
- Warm per-index full-text scans took 3 to 136 milliseconds.
- The web context pack completed in 6.31 seconds.
- The enterprise context pack completed in 6.66 seconds.
- Concurrent web and enterprise packs completed in 6.56 seconds each.
- Both successful packs returned HTTP 200 with local MiniLM embedding
  provenance.

Local gates:

- `moon run core:lint core:typecheck root:inventory-lint root:inventory-typecheck`
- `moon run core:test -- tests/test_search.py -q`
  - 2,752 passed, 14 skipped, 1 known xfail
- `moon run root:bench-gate-test -- -k test_sibyl_memory_chunk_catalog_round_trips`
  - 1 passed, 859 deselected

## 🎯 Release boundary

The r9 database is performance evidence only. Its interrupted outputs and old
manifest lineage cannot become release evidence. The next paid evaluation must
use a fresh sealed plan, output root, database, and memory build from the merged
commit.

One cold local embedding startup request hit the existing five-second vector
timeout before the model finished loading. Warm and concurrent replays were
stable. The cold-start path is separate from the full-text scaling fix and is
not hidden by this change.

## 🌿 4:20 tribute

```text
             .
          .  |  .
       .  \  |  /  .
        \  \ | /  /
      ---  \|/  ---
        .--/|\--.
           /|\
            |
          4:20
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full-text search now considers node names, summaries, descriptions, and content independently.
  * Search results are combined and deduplicated across fields, retaining the best match.

* **Improvements**
  * Results are ranked consistently by relevance and creation time.
  * Search filters and result limits are applied reliably across combined results.

* **Bug Fixes**
  * Memory manifests now accurately record created entities based on the saved catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
