### PR TITLE
fix(evals): bind source identity to sealed plan

### DIFF
--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -2086,6 +2086,7 @@ def build_source_runs_receipt(
     domains: dict[str, dict[str, Any]] = {}
     for source_run in source_runs:
         domain = str(source_run["domain"])
+        plan = source_run["plan"]
         run_args = source_run["run_args"]
         output_dir = source_run["output_dir"]
         api_runtime, api_runtime_consistent = _source_api_runtime(source_run["per_question_rows"])
@@ -2132,8 +2133,16 @@ def build_source_runs_receipt(
             "reader_model": run_args.get("model"),
             "reader_base_url": run_args.get("base_url"),
             "evaluator_model": run_args.get("evaluator_model"),
-            "method": run_args.get("method"),
-            "tier": run_args.get("tier"),
+            "method": _first_string(
+                plan.get("method"),
+                run_args.get("method"),
+                DEFAULT_METHOD,
+            ),
+            "tier": _first_string(
+                plan.get("tier"),
+                run_args.get("tier"),
+                getattr(args, "tier", ""),
+            ),
         }
 
     expected_domains = ("web", "enterprise") if args.domain == "combined" else (args.domain,)
@@ -2174,7 +2183,8 @@ def build_source_runs_receipt(
         ),
         "model_consistent": _source_run_values_consistent(source_runs, "model")
         and _source_run_values_consistent(source_runs, "evaluator_model"),
-        "method_consistent": _source_run_values_consistent(source_runs, "method"),
+        "method_consistent": all(domain in domains for domain in expected_domains)
+        and len({domains[domain]["method"] for domain in expected_domains}) == 1,
     }
 
 

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -711,6 +711,10 @@ def test_official_runner_receipt_only_emits_citable_contract(
     assert receipt["source_runs"]["integrity_complete"] is True
     assert receipt["source_runs"]["api_runtime_consistent"] is True
     assert set(receipt["source_runs"]["domains"]) == {"web", "enterprise"}
+    assert all(
+        source["method"] == "sibyl_live_api" and source["tier"] == "small"
+        for source in receipt["source_runs"]["domains"].values()
+    )
     assert receipt["source_runs"]["domains"]["web"]["runtime_inputs"]["questions"][
         "sha256"
     ].startswith("sha256:")
@@ -8533,7 +8537,12 @@ def _write_official_outputs(
     usage_run_id = run_id if legacy_usage_identity else f"usage-{domain}"
     runtime_dir = output_dir / "runtime_inputs"
     runtime_dir.mkdir()
-    plan = {"run_id": run_id, "domain": domain}
+    plan = {
+        "run_id": run_id,
+        "domain": domain,
+        "tier": "small",
+        "method": "sibyl_live_api",
+    }
     if not legacy_usage_identity:
         plan["provider_usage_run_id"] = usage_run_id
     (output_dir / "longmemeval_v2_official_plan.json").write_text(
@@ -8581,12 +8590,10 @@ def _write_official_outputs(
         json.dumps(
             {
                 "domain": domain,
-                "tier": "small",
                 "model": "Qwen/Qwen3.5-9B",
                 "base_url": "http://localhost:8023/v1",
                 "evaluator_model": "gpt-5.2",
                 "evaluator_reasoning_effort": "medium",
-                "method": "sibyl_live_api",
             }
         ),
         encoding="utf-8",

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -645,9 +645,16 @@ def _assert_source_prompt_artifacts(
         )
 
 
+@pytest.mark.parametrize(
+    ("run_arg_method", "run_arg_tier"),
+    [(None, None), ("unsealed_method", "medium")],
+    ids=["fallbacks-absent", "fallbacks-conflict"],
+)
 def test_official_runner_receipt_only_emits_citable_contract(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    run_arg_method: str | None,
+    run_arg_tier: str | None,
 ) -> None:
     module = _load_runner_module()
     data_root = tmp_path / "data"
@@ -664,8 +671,19 @@ def test_official_runner_receipt_only_emits_citable_contract(
         lambda repo: source_record(repo, expected_commit=fixture_commit),
     )
     _write_dataset(data_root)
-    _write_official_outputs(web_output_dir, domain="web", legacy_usage_identity=True)
-    _write_official_outputs(enterprise_output_dir, domain="enterprise")
+    _write_official_outputs(
+        web_output_dir,
+        domain="web",
+        legacy_usage_identity=True,
+        run_arg_method=run_arg_method,
+        run_arg_tier=run_arg_tier,
+    )
+    _write_official_outputs(
+        enterprise_output_dir,
+        domain="enterprise",
+        run_arg_method=run_arg_method,
+        run_arg_tier=run_arg_tier,
+    )
     _write_combined_outputs(combined_dir)
 
     assert (
@@ -8531,6 +8549,8 @@ def _write_official_outputs(
     *,
     domain: str = "enterprise",
     legacy_usage_identity: bool = False,
+    run_arg_method: str | None = None,
+    run_arg_tier: str | None = None,
 ) -> None:
     output_dir.mkdir(parents=True)
     run_id = f"run-{domain}"
@@ -8586,16 +8606,19 @@ def _write_official_outputs(
         ),
         encoding="utf-8",
     )
+    run_args = {
+        "domain": domain,
+        "model": "Qwen/Qwen3.5-9B",
+        "base_url": "http://localhost:8023/v1",
+        "evaluator_model": "gpt-5.2",
+        "evaluator_reasoning_effort": "medium",
+    }
+    if run_arg_method is not None:
+        run_args["method"] = run_arg_method
+    if run_arg_tier is not None:
+        run_args["tier"] = run_arg_tier
     (output_dir / "run_args.json").write_text(
-        json.dumps(
-            {
-                "domain": domain,
-                "model": "Qwen/Qwen3.5-9B",
-                "base_url": "http://localhost:8023/v1",
-                "evaluator_model": "gpt-5.2",
-                "evaluator_reasoning_effort": "medium",
-            }
-        ),
+        json.dumps(run_args),
         encoding="utf-8",
     )
     (output_dir / "metric_overview.json").write_text(


### PR DESCRIPTION
## What broke

The first r12 paid A/A wave completed both official domain runs, then the
release runner rejected both receipts:

```text
official source differs from its plan for method
```

The upstream harness writes `run_args.json` without `method` or `tier`.
Sibyl's receipt bridge treated that file as the authority, so both domain
source records serialized those fields as null. The immutable official plan
already carried the canonical values.

## What changed

The receipt bridge now resolves `method` and `tier` from the sealed official
plan first. Compatibility fallbacks remain for older fixture shapes. Method
consistency is checked after resolution across the exact expected domains.

The synthetic official-output fixture now matches the production artifact
shape by omitting both fields from `run_args.json` and carrying them in the
plan. The citable receipt test asserts both resolved values.

## Why this is safe

The change does not relax source validation or infer release identity from
runtime behavior. It moves authority to the content-bound artifact created
before provider execution. Missing or inconsistent resolved values still fail
at the existing release evidence boundary.

The failed r12 evidence remains terminal and unchanged. Its API key was
revoked, and its local services were removed before this branch was published.

## Validation

- `moon run root:bench-gate-test`: 864 passed
- `moon run root:lint root:typecheck`: 18 tasks passed
- `git diff --check`: clean

## Paid-run evidence

The failure reproduced only after valid settled receipts existed:

- Enterprise accuracy: `0.2417061611`
- Enterprise cost: `$0.65104114`
- Web accuracy: `0.2583333333`
- Web cost: `$0.95544699`
- Total settled cost: `$1.60648813`

## 4:20 tribute

```text
             .
          .  |  .
       .  \  |  /  .
        \  \ | /  /
      ---  \|/  ---
        .--/|\--.
           /|\
            |
          4:20
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved evaluation receipts by consistently determining method and tier from available run configuration.
  - Added reliable fallback handling when configuration values are missing.
  - Improved consistency checks across source run results.

- **Tests**
  - Updated validation to require the expected API method and tier.
  - Enhanced output fixtures to include domain, tier, and method details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
