### PR TITLE
fix(evals): retain per-item context in sealed configuration

### DIFF
--- a/tools/bench/longmemeval_v2_artifact_bridge.py
+++ b/tools/bench/longmemeval_v2_artifact_bridge.py
@@ -315,7 +315,7 @@ CONFIG_EXCLUDED_KEYS = frozenset(
         "project_id",
         "run_id",
         "runner_provenance",
-        *rig.GEOMETRY_KEYS,
+        *(rig.GEOMETRY_KEYS - {"max_context_chars_per_item"}),
     }
 )
 PLAN_PROFILE_KEYS = frozenset(

--- a/tools/tests/test_longmemeval_v2_artifact_bridge.py
+++ b/tools/tests/test_longmemeval_v2_artifact_bridge.py
@@ -17,6 +17,8 @@ from benchmarks.longmemeval_v2_official_source import (
 from tools.bench import longmemeval_v2_artifact_bridge as bridge
 from tools.bench import longmemeval_v2_rig as rig
 
+TEST_CONTEXT_CHARS_PER_ITEM = 12_000
+
 
 @pytest.fixture(autouse=True)
 def _use_synthetic_official_corpus(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -389,7 +391,7 @@ def _domain_run(
                 "retrieval_mode": mode,
                 "content_max_chars": 18_000,
                 "max_context_items": 8,
-                "max_context_chars_per_item": 12_000,
+                "max_context_chars_per_item": TEST_CONTEXT_CHARS_PER_ITEM,
                 "max_context_total_chars": 60_000,
                 "operational_note_dedupe_mode": "canonical",
                 "operational_note_lane_mode": "grouped",
@@ -533,6 +535,8 @@ def test_bridge_builds_signed_arm_from_official_artifacts(tmp_path: Path) -> Non
         "web": 2,
     }
     assert "longmemeval_v2_domain" not in arm["configuration"]
+    assert arm["configuration"]["max_context_chars_per_item"] == TEST_CONTEXT_CHARS_PER_ITEM
+    assert arm["geometry"]["max_context_chars_per_item"] == TEST_CONTEXT_CHARS_PER_ITEM
 
 
 def test_bridge_builds_signed_arm_from_local_execution(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

The r13 release evaluation completed both paid `aa-1-left` domains, then rejected their evidence with `effective memory configuration differs from the sealed arm`.

The completed runtime configuration was correct. The release contract intentionally records `max_context_chars_per_item` in both normalized configuration and geometry, but the artifact bridge removed every geometry key from normalized configuration. Every valid completed arm therefore failed the sealed comparison after provider work.

## What changed

- Keep `max_context_chars_per_item` in normalized configuration while continuing to validate it as geometry.
- Assert that the artifact bridge emits the per-item context limit on both evidence surfaces.
- Preserve all other geometry exclusions and evidence checks unchanged.

## Proof

- `moon run root:bench-gate-test`: 864 passed.
- `moon run :lint :typecheck`: 19 tasks completed.
- The corrected validator accepted both immutable r13 outputs without modifying them:
  - enterprise: `$0.80385832`, 13 bound artifacts
  - web: `$0.97009503`, 13 bound artifacts
- The r13 Sibyl API key was revoked and independently returned 401 after the terminal run.

## Blast radius

The change affects only LongMemEval-V2 artifact normalization. It does not relax runtime, source, dataset, provider, cost, geometry, or artifact-integrity checks.

## 4:20 tribute

```text
             .
          .  |  .
       .  \  |  /  .
        \  \ | /  /
      ---  \|/  ---
        .--/|\--.
           /|\
            |
          4:20
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration handling so the per-item context limit is preserved during normalization.
  * Ensured geometry-related settings are excluded appropriately without affecting the supported context limit.

* **Tests**
  * Added coverage confirming that the configured per-item context limit remains consistent in generated runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->