### PR TITLE
fix(evals): load internal arms from saved memory state

### DIFF
--- a/benchmarks/longmemeval_v2_release_plan.py
+++ b/benchmarks/longmemeval_v2_release_plan.py
@@ -299,7 +299,7 @@ def _memory_path(
         return Path(external[domain]["path"]), False
     if memory_source not in builders:
         raise StagePlanError(f"memory source {memory_source!r} has no earlier builder")
-    return builders[memory_source] / domain / "checkpoint", True
+    return builders[memory_source] / domain / "memory_state", True
 
 
 def _domain_run(

--- a/tools/tests/test_longmemeval_v2_release_runner.py
+++ b/tools/tests/test_longmemeval_v2_release_runner.py
@@ -245,11 +245,19 @@ def test_stage_plan_expands_exact_domains_waves_and_local_execution(
         "immutable_descendant_rename": True,
     }
     first_saved_memory = str(
-        sealed_inputs["output_root"] / "runs" / "aa-1-left" / "web" / "checkpoint"
+        sealed_inputs["output_root"] / "runs" / "aa-1-left" / "web" / "memory_state"
     )
     right_web = stage_plan["runs"][1]["domains"]["web"]
     assert right_web["planning_memory_dir"] == first_saved_memory
     assert right_web["execution_memory_dir"] == first_saved_memory
+    assert (
+        right_web["plan_command"][right_web["plan_command"].index("--checkpoint-dir") + 1]
+        == first_saved_memory
+    )
+    assert (
+        right_web["run_command"][right_web["run_command"].index("--load-memory-dir") + 1]
+        == first_saved_memory
+    )
     plan.require_stage_plan(stage_plan, check_checkout=False)
 
 


### PR DESCRIPTION
# 🧠 Canonical saved memory for dependent eval waves

> The official harness already emits the complete saved-memory artifact set.
> The sealed release plan now sends dependent arms to that exact directory.

## 💡 What this is

The official LongMemEval harness writes canonical saved memory under each
builder domain's `memory_state` directory. The release planner instead pointed
later arms at the ingest `checkpoint` directory, which has a different schema
and no `memory_manifest.json`.

The mismatch let the first paid wave finish, then stopped every dependent wave
before provider work with `dependent wave memory is not complete`.

## 🎯 The invariant

Every dependent arm must attest and load the same canonical directory emitted
by its earlier builder arm.

## 🛠️ How it works

1. The internal builder path in `longmemeval_v2_release_plan.py` now resolves to
   `<builder>/<domain>/memory_state`.
2. Future plan-only reservations still use `--checkpoint-dir`. Before the
   builder runs, the absent path stays a reservation. After the builder runs,
   the same command detects `memory_manifest.json` and performs live remote
   attestation.
3. Paid dependent execution uses `--load-memory-dir` against the identical
   sealed path.
4. The regression test pins both stored path fields and both generated command
   flags, then revalidates the complete sealed plan.

## 🧪 Validation

- The induced regression against the old mapping failed on `/checkpoint`:
  `1 failed, 863 deselected`.
- The focused corrected-path test passed: `1 passed, 863 deselected`.
- The full benchmark gate passed: `864 passed`.
- The root lint and typecheck gates passed: `18 tasks green`.
- A fresh-context independent verifier returned `PASS` with no findings. The
  reviewed diff digest is
  `9ca5ce2c7f60c7e442ec394ab6e94589391fa9ad7783cf8c98b850e7b41ce922`.

## 🔍 What reviewers should focus on

- Confirm `memory_state` is the canonical five-file output consumed by the
  official harness loader.
- Confirm the `--checkpoint-dir` flag remains intentional for future plan-only
  reservation and post-builder attestation.
- Confirm both planning and paid execution remain bound by sealed plan
  re-expansion.

The change does not alter memory contents, provider geometry, scoring, or paid
execution concurrency.

## 🌿 4:20 tribute

```text
              .
             .:.
            .:::.
        .:::::::::::.
          ':::::::'
            ':::'
              |
            4:20
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated memory paths to use the correct `memory_state` directory.
  * Improved release planning and execution to correctly reference saved memory from previous runs.
* **Tests**
  * Updated validation to confirm memory state is preserved and loaded correctly across subsequent stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->