### PR TITLE
feat(evals): execute v1.3 release A/A in GitHub Actions

### DIFF
--- a/.github/workflows/longmemeval-v2-release-aa.yml
+++ b/.github/workflows/longmemeval-v2-release-aa.yml
@@ -42,10 +42,6 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       OFFICIAL_DATASET_REVISION: f152293e235517d504809563c833d7190b8c713b
       PLAN_PATH: .moon/cache/evals/longmemeval-v2-release-ci/dispatch-plan.json
-      RUNS_PATH: .moon/cache/evals/longmemeval-v2-release-ci/runs.json
-      RUN_MAP_PATH: .moon/cache/evals/longmemeval-v2-release-ci/run-map.json
-      CHILD_ARTIFACTS: .moon/cache/evals/longmemeval-v2-release-ci/child-artifacts
-      BUNDLE_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/aa-bundle
     steps:
       - uses: actions/checkout@v7
         with:
@@ -83,7 +79,7 @@ jobs:
             echo "::error::Requested source SHA differs from the controller checkout."
             exit 1
           fi
-          orchestration_id="aa-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          orchestration_id="aa-${GITHUB_RUN_ID}"
           mkdir -p "$(dirname "$PLAN_PATH")"
           moon run bench-longmemeval-v2-release-ci -- \
             plan \
@@ -96,12 +92,38 @@ jobs:
           printf 'SOURCE_SHA=%s\n' "$source_sha" >> "$GITHUB_ENV"
           printf 'ORCHESTRATION_ID=%s\n' "$orchestration_id" >> "$GITHUB_ENV"
 
-      - name: Dispatch six independent paid arms
-        env:
-          EXPERIMENT_ID: ${{ inputs.experiment_id }}
+      - name: Upload sealed controller plan
+        uses: actions/upload-artifact@v7
+        with:
+          name: longmemeval-v2-release-aa-controller-${{ github.run_id }}
+          path: .moon/cache/evals/longmemeval-v2-release-ci/dispatch-plan.json
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 30
+
+      - name: Dispatch the frozen baseline builder
         run: |
           set -euo pipefail
-          runs='{}'
+
+          existing_child_run() {
+            local arm_id="$1"
+            local title="LongMemEval V2 ${ORCHESTRATION_ID} ${arm_id}"
+            local matches
+            matches="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow longmemeval-v2.yml \
+              --event workflow_dispatch \
+              --branch "$GITHUB_REF_NAME" \
+              --limit 100 \
+              --json databaseId,displayTitle,headSha \
+              --jq ".[] | select(.displayTitle == \"${title}\" and .headSha == \"${SOURCE_SHA}\") | .databaseId")"
+            if [[ "$(wc -w <<< "$matches")" -gt 1 ]]; then
+              echo "::error::Multiple child runs matched ${arm_id}." >&2
+              return 2
+            fi
+            [[ -n "$matches" ]] || return 1
+            printf '%s\n' "$matches"
+          }
 
           find_child_run() {
             local arm_id="$1"
@@ -138,6 +160,13 @@ jobs:
             local ci_context
             local manifest
             local run_id
+            if run_id="$(existing_child_run "$arm_id")"; then
+              echo "Reusing child workflow ${run_id} for ${arm_id}." >&2
+            else
+              lookup_status=$?
+              if [[ "$lookup_status" -ne 1 ]]; then
+                return "$lookup_status"
+              fi
             manifest="$(jq -er \
               --arg arm "$arm_id" \
               '.arms[] | select(.arm_id == $arm) | .official_arm_manifest_json' \
@@ -155,7 +184,7 @@ jobs:
                 memory_mode: $memory_mode,
                 memory_source_run_id: $memory_source_run_id
               }')"
-            gh workflow run longmemeval-v2.yml \
+              gh workflow run longmemeval-v2.yml \
               --repo "$GITHUB_REPOSITORY" \
               --ref "$GITHUB_REF_NAME" \
               -f run_official_full=true \
@@ -182,8 +211,207 @@ jobs:
               -f official_api_retry_attempts=3 \
               -f official_prompt_build_max_workers=1 \
               -f official_evaluator_model=gpt-5.2 \
-              -f official_include_screenshots=false
-            run_id="$(find_child_run "$arm_id")"
+                -f official_include_screenshots=false
+              run_id="$(find_child_run "$arm_id")"
+            fi
+            printf 'BUILDER_RUN_ID=%s\n' "$run_id" >> "$GITHUB_ENV"
+          }
+
+          dispatch_arm aa-1-left save ""
+
+  dispatch-consumers:
+    name: Dispatch frozen baseline consumers
+    if: >-
+      github.event_name == 'workflow_run' &&
+      endsWith(github.event.workflow_run.display_title, ' aa-1-left')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      OFFICIAL_DATASET_REVISION: f152293e235517d504809563c833d7190b8c713b
+      STATE_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/controller
+      PLAN_PATH: .moon/cache/evals/longmemeval-v2-release-ci/controller/dispatch-plan.json
+      RUNS_PATH: .moon/cache/evals/longmemeval-v2-release-ci/controller/runs.json
+      RUN_MAP_PATH: .moon/cache/evals/longmemeval-v2-release-ci/controller/run-map.json
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup moonrepo toolchain
+        uses: moonrepo/setup-toolchain@v0.6.4
+        with:
+          proto-version: "0.61.1"
+          auto-install: true
+          auto-setup: true
+          cache-version: longmemeval-v2-release-aa-v1
+
+      - name: Recover and validate the builder state
+        env:
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+          TRIGGER_TITLE: ${{ github.event.workflow_run.display_title }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TRIGGER_TITLE" =~ ^LongMemEval\ V2\ (aa-([1-9][0-9]*))\ aa-1-left$ ]]; then
+            echo "::error::The builder trigger identity is invalid."
+            exit 1
+          fi
+          orchestration_id="${BASH_REMATCH[1]}"
+          controller_run_id="${BASH_REMATCH[2]}"
+          trigger_json="$(gh run view "$TRIGGER_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json conclusion,displayTitle,event,headSha,workflowName)"
+          if ! jq -e \
+            --arg sha "$TRIGGER_SHA" \
+            --arg title "$TRIGGER_TITLE" \
+            '.conclusion == "success" and
+             .event == "workflow_dispatch" and
+             .headSha == $sha and
+             .displayTitle == $title and
+             .workflowName == "LongMemEval V2"' \
+            <<< "$trigger_json" >/dev/null; then
+            echo "::error::The frozen baseline builder did not succeed cleanly."
+            exit 1
+          fi
+          controller_json="$(gh run view "$controller_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json conclusion,event,headSha,status,workflowName)"
+          if ! jq -e \
+            --arg sha "$TRIGGER_SHA" \
+            '.status == "completed" and
+             (.conclusion | IN("success", "failure")) and
+             .event == "workflow_dispatch" and
+             .headSha == $sha and
+             .workflowName == "LongMemEval V2 Release A/A"' \
+            <<< "$controller_json" >/dev/null; then
+            echo "::error::The A/A controller provenance is invalid."
+            exit 1
+          fi
+          mkdir -p "$STATE_ROOT"
+          gh run download "$controller_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "longmemeval-v2-release-aa-controller-${controller_run_id}" \
+            --dir "$STATE_ROOT"
+          if ! jq -e \
+            --arg orchestration "$orchestration_id" \
+            --arg sha "$TRIGGER_SHA" \
+            '.orchestration_id == $orchestration and .source.sha == $sha and
+             .source.ref == "refs/heads/main"' \
+            "$PLAN_PATH" >/dev/null; then
+            echo "::error::The builder differs from its sealed dispatch plan."
+            exit 1
+          fi
+          {
+            printf 'BUILDER_RUN_ID=%s\n' "$TRIGGER_RUN_ID"
+            printf 'CONTROLLER_RUN_ID=%s\n' "$controller_run_id"
+            printf 'ORCHESTRATION_ID=%s\n' "$orchestration_id"
+            printf 'SOURCE_SHA=%s\n' "$TRIGGER_SHA"
+          } >> "$GITHUB_ENV"
+
+      - name: Dispatch five frozen baseline consumers
+        run: |
+          set -euo pipefail
+          runs="$(jq -cn --arg run "$BUILDER_RUN_ID" '{"aa-1-left": $run}')"
+
+          existing_child_run() {
+            local arm_id="$1"
+            local title="LongMemEval V2 ${ORCHESTRATION_ID} ${arm_id}"
+            local matches
+            matches="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow longmemeval-v2.yml \
+              --event workflow_dispatch \
+              --branch main \
+              --limit 100 \
+              --json databaseId,displayTitle,headSha \
+              --jq ".[] | select(.displayTitle == \"${title}\" and .headSha == \"${SOURCE_SHA}\") | .databaseId")"
+            if [[ "$(wc -w <<< "$matches")" -gt 1 ]]; then
+              echo "::error::Multiple child runs matched ${arm_id}." >&2
+              return 2
+            fi
+            [[ -n "$matches" ]] || return 1
+            printf '%s\n' "$matches"
+          }
+
+          find_child_run() {
+            local arm_id="$1"
+            for attempt in {1..60}; do
+              if run_id="$(existing_child_run "$arm_id")"; then
+                printf '%s\n' "$run_id"
+                return 0
+              fi
+              lookup_status=$?
+              if [[ "$lookup_status" -ne 1 ]]; then
+                return "$lookup_status"
+              fi
+              echo "Attempt $attempt: waiting for ${arm_id} workflow identity." >&2
+              sleep 5
+            done
+            echo "::error::Child workflow identity never appeared for ${arm_id}." >&2
+            return 1
+          }
+
+          dispatch_arm() {
+            local arm_id="$1"
+            local ci_context
+            local manifest
+            local run_id
+            if run_id="$(existing_child_run "$arm_id")"; then
+              echo "Reusing child workflow ${run_id} for ${arm_id}." >&2
+            else
+              lookup_status=$?
+              if [[ "$lookup_status" -ne 1 ]]; then
+                return "$lookup_status"
+              fi
+              manifest="$(jq -er \
+                --arg arm "$arm_id" \
+                '.arms[] | select(.arm_id == $arm) | .official_arm_manifest_json' \
+                "$PLAN_PATH")"
+              ci_context="$(jq -cn \
+                --arg orchestration_id "$ORCHESTRATION_ID" \
+                --arg arm_id "$arm_id" \
+                --arg source_sha "$SOURCE_SHA" \
+                --arg memory_source_run_id "$BUILDER_RUN_ID" \
+                '{
+                  orchestration_id: $orchestration_id,
+                  arm_id: $arm_id,
+                  source_sha: $source_sha,
+                  memory_mode: "load",
+                  memory_source_run_id: $memory_source_run_id
+                }')"
+              gh workflow run longmemeval-v2.yml \
+                --repo "$GITHUB_REPOSITORY" \
+                --ref main \
+                -f run_official_full=true \
+                -f official_ci_context_json="$ci_context" \
+                -f official_arm_manifest_json="$manifest" \
+                -f official_tier=small \
+                -f official_domain=both \
+                -f official_limit= \
+                -f official_validation_slice=none \
+                -f official_dataset_revision="$OFFICIAL_DATASET_REVISION" \
+                -f official_reader_base_url=https://openrouter.ai/api/v1 \
+                -f official_reader_model=qwen/qwen3.5-9b \
+                -f official_reader_api_key_env=OPENROUTER_API_KEY \
+                -f official_reader_max_concurrent_requests=16 \
+                -f official_reader_retry_attempts=4 \
+                -f official_evidence_composition_mode=shared_relevance \
+                -f official_source_evidence_bundling=false \
+                -f official_retrieval_max_planned_queries=3 \
+                -f official_max_context_chars_per_item=18000 \
+                -f official_typed_stream_retrieval=false \
+                -f official_typed_stream_limit=8 \
+                -f official_note_distillation=false \
+                -f official_note_distillation_model=gpt-5.4-nano \
+                -f official_api_retry_attempts=3 \
+                -f official_prompt_build_max_workers=1 \
+                -f official_evaluator_model=gpt-5.2 \
+                -f official_include_screenshots=false
+              run_id="$(find_child_run "$arm_id")"
+            fi
             runs="$(jq -cn \
               --argjson current "$runs" \
               --arg arm "$arm_id" \
@@ -191,12 +419,9 @@ jobs:
               '$current + {($arm): $run}')"
           }
 
-          dispatch_arm aa-1-left save ""
-          builder_run_id="$(jq -er '.["aa-1-left"]' <<< "$runs")"
           while IFS= read -r arm_id; do
-            dispatch_arm "$arm_id" load "$builder_run_id"
+            dispatch_arm "$arm_id"
           done < <(jq -r '.arms[1:][] | .arm_id' "$PLAN_PATH")
-
           printf '%s\n' "$runs" > "$RUNS_PATH"
           moon run bench-longmemeval-v2-release-ci -- \
             run-map \
@@ -204,15 +429,13 @@ jobs:
             --runs "$RUNS_PATH" \
             --output "$RUN_MAP_PATH"
 
-      - name: Upload controller evidence
+      - name: Upload sealed consumer run map
         uses: actions/upload-artifact@v7
         with:
-          name: longmemeval-v2-release-aa-controller-${{ github.run_id }}
-          path: |
-            .moon/cache/evals/longmemeval-v2-release-ci/dispatch-plan.json
-            .moon/cache/evals/longmemeval-v2-release-ci/runs.json
-            .moon/cache/evals/longmemeval-v2-release-ci/run-map.json
+          name: longmemeval-v2-release-aa-run-map-${{ env.CONTROLLER_RUN_ID }}
+          path: .moon/cache/evals/longmemeval-v2-release-ci/controller/run-map.json
           if-no-files-found: error
+          overwrite: true
           retention-days: 30
 
   aggregate:
@@ -224,7 +447,7 @@ jobs:
     timeout-minutes: 360
     env:
       GH_TOKEN: ${{ github.token }}
-      CONTROLLER_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/controller
+      STATE_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/controller
       RUN_MAP_PATH: .moon/cache/evals/longmemeval-v2-release-ci/controller/run-map.json
       CHILD_ARTIFACTS: .moon/cache/evals/longmemeval-v2-release-ci/child-artifacts
       BUNDLE_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/aa-bundle
@@ -249,7 +472,7 @@ jobs:
           TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          if [[ ! "$TRIGGER_TITLE" =~ ^LongMemEval\ V2\ (aa-([1-9][0-9]*)-([1-9][0-9]*))\ aa-3-right$ ]]; then
+          if [[ ! "$TRIGGER_TITLE" =~ ^LongMemEval\ V2\ (aa-([1-9][0-9]*))\ aa-3-right$ ]]; then
             echo "::error::The aggregation trigger identity is invalid."
             exit 1
           fi
@@ -268,11 +491,25 @@ jobs:
             echo "::error::The A/A controller provenance is invalid."
             exit 1
           fi
-          mkdir -p "$CONTROLLER_ROOT"
-          gh run download "$controller_run_id" \
+          dispatcher_title="LongMemEval V2 Release A/A LongMemEval V2 ${orchestration_id} aa-1-left"
+          dispatcher_runs="$(gh run list \
             --repo "$GITHUB_REPOSITORY" \
-            --name "longmemeval-v2-release-aa-controller-${controller_run_id}" \
-            --dir "$CONTROLLER_ROOT"
+            --workflow longmemeval-v2-release-aa.yml \
+            --event workflow_run \
+            --branch main \
+            --limit 100 \
+            --json conclusion,databaseId,displayTitle,headSha,status \
+            --jq ".[] | select(.displayTitle == \"${dispatcher_title}\" and .headSha == \"${TRIGGER_SHA}\" and .status == \"completed\" and .conclusion == \"success\") | .databaseId")"
+          if [[ "$(wc -w <<< "$dispatcher_runs")" -ne 1 ]]; then
+            echo "::error::Exactly one successful consumer dispatcher is required."
+            exit 1
+          fi
+          dispatcher_run_id="$dispatcher_runs"
+          mkdir -p "$STATE_ROOT"
+          gh run download "$dispatcher_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "longmemeval-v2-release-aa-run-map-${controller_run_id}" \
+            --dir "$STATE_ROOT"
           if [[ ! -s "$RUN_MAP_PATH" ]]; then
             echo "::error::The sealed A/A run map is missing."
             exit 1

--- a/.github/workflows/longmemeval-v2-release-aa.yml
+++ b/.github/workflows/longmemeval-v2-release-aa.yml
@@ -1,0 +1,353 @@
+name: LongMemEval V2 Release A/A
+run-name: >-
+  LongMemEval V2 Release A/A ${{ github.event_name == 'workflow_dispatch' &&
+  inputs.experiment_id || github.event.workflow_run.display_title }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      experiment_id:
+        description: "Path-safe identity for this v1.3 release evaluation"
+        type: string
+        required: true
+      source_sha:
+        description: "Exact main commit to evaluate; blank uses the controller SHA"
+        type: string
+        default: ""
+  workflow_run:
+    workflows: ["LongMemEval V2"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: >-
+    longmemeval-v2-release-aa-${{ github.event_name == 'workflow_dispatch' &&
+    inputs.experiment_id || github.event.workflow_run.display_title }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  orchestrate:
+    name: Dispatch, verify, and seal A/A
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      OFFICIAL_DATASET_REVISION: f152293e235517d504809563c833d7190b8c713b
+      PLAN_PATH: .moon/cache/evals/longmemeval-v2-release-ci/dispatch-plan.json
+      RUNS_PATH: .moon/cache/evals/longmemeval-v2-release-ci/runs.json
+      RUN_MAP_PATH: .moon/cache/evals/longmemeval-v2-release-ci/run-map.json
+      CHILD_ARTIFACTS: .moon/cache/evals/longmemeval-v2-release-ci/child-artifacts
+      BUNDLE_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/aa-bundle
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup moonrepo toolchain
+        uses: moonrepo/setup-toolchain@v0.6.4
+        with:
+          proto-version: "0.61.1"
+          auto-install: true
+          auto-setup: true
+          cache-version: longmemeval-v2-release-aa-v1
+
+      - name: Cache uv
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/uv
+          key: uv-longmemeval-v2-release-aa-${{ runner.os }}-${{ hashFiles('**/uv.lock') }}
+          restore-keys: |
+            uv-longmemeval-v2-release-aa-${{ runner.os }}-
+
+      - name: Seal distributed A/A dispatch plan
+        env:
+          REQUESTED_SOURCE_SHA: ${{ inputs.source_sha }}
+          EXPERIMENT_ID: ${{ inputs.experiment_id }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::The release A/A controller only runs from main."
+            exit 1
+          fi
+          source_sha="${REQUESTED_SOURCE_SHA:-$GITHUB_SHA}"
+          if [[ "$source_sha" != "$GITHUB_SHA" ]]; then
+            echo "::error::Requested source SHA differs from the controller checkout."
+            exit 1
+          fi
+          orchestration_id="aa-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$(dirname "$PLAN_PATH")"
+          moon run bench-longmemeval-v2-release-ci -- \
+            plan \
+            --experiment-id "$EXPERIMENT_ID" \
+            --orchestration-id "$orchestration_id" \
+            --repository "$GITHUB_REPOSITORY" \
+            --ref "$GITHUB_REF" \
+            --sha "$source_sha" \
+            --output "$PLAN_PATH"
+          printf 'SOURCE_SHA=%s\n' "$source_sha" >> "$GITHUB_ENV"
+          printf 'ORCHESTRATION_ID=%s\n' "$orchestration_id" >> "$GITHUB_ENV"
+
+      - name: Dispatch six independent paid arms
+        env:
+          EXPERIMENT_ID: ${{ inputs.experiment_id }}
+        run: |
+          set -euo pipefail
+          runs='{}'
+
+          find_child_run() {
+            local arm_id="$1"
+            local title="LongMemEval V2 ${ORCHESTRATION_ID} ${arm_id}"
+            local matches
+            for attempt in {1..60}; do
+              matches="$(gh run list \
+                --repo "$GITHUB_REPOSITORY" \
+                --workflow longmemeval-v2.yml \
+                --event workflow_dispatch \
+                --branch "$GITHUB_REF_NAME" \
+                --limit 100 \
+                --json databaseId,displayTitle,headSha \
+                --jq ".[] | select(.displayTitle == \"${title}\" and .headSha == \"${SOURCE_SHA}\") | .databaseId")"
+              if [[ "$(wc -w <<< "$matches")" -eq 1 ]]; then
+                printf '%s\n' "$matches"
+                return 0
+              fi
+              if [[ "$(wc -w <<< "$matches")" -gt 1 ]]; then
+                echo "::error::Multiple child runs matched ${arm_id}." >&2
+                return 1
+              fi
+              echo "Attempt $attempt: waiting for ${arm_id} workflow identity." >&2
+              sleep 5
+            done
+            echo "::error::Child workflow identity never appeared for ${arm_id}." >&2
+            return 1
+          }
+
+          dispatch_arm() {
+            local arm_id="$1"
+            local memory_mode="$2"
+            local memory_source_run_id="$3"
+            local ci_context
+            local manifest
+            local run_id
+            manifest="$(jq -er \
+              --arg arm "$arm_id" \
+              '.arms[] | select(.arm_id == $arm) | .official_arm_manifest_json' \
+              "$PLAN_PATH")"
+            ci_context="$(jq -cn \
+              --arg orchestration_id "$ORCHESTRATION_ID" \
+              --arg arm_id "$arm_id" \
+              --arg source_sha "$SOURCE_SHA" \
+              --arg memory_mode "$memory_mode" \
+              --arg memory_source_run_id "$memory_source_run_id" \
+              '{
+                orchestration_id: $orchestration_id,
+                arm_id: $arm_id,
+                source_sha: $source_sha,
+                memory_mode: $memory_mode,
+                memory_source_run_id: $memory_source_run_id
+              }')"
+            gh workflow run longmemeval-v2.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref "$GITHUB_REF_NAME" \
+              -f run_official_full=true \
+              -f official_ci_context_json="$ci_context" \
+              -f official_arm_manifest_json="$manifest" \
+              -f official_tier=small \
+              -f official_domain=both \
+              -f official_limit= \
+              -f official_validation_slice=none \
+              -f official_dataset_revision="$OFFICIAL_DATASET_REVISION" \
+              -f official_reader_base_url=https://openrouter.ai/api/v1 \
+              -f official_reader_model=qwen/qwen3.5-9b \
+              -f official_reader_api_key_env=OPENROUTER_API_KEY \
+              -f official_reader_max_concurrent_requests=16 \
+              -f official_reader_retry_attempts=4 \
+              -f official_evidence_composition_mode=shared_relevance \
+              -f official_source_evidence_bundling=false \
+              -f official_retrieval_max_planned_queries=3 \
+              -f official_max_context_chars_per_item=18000 \
+              -f official_typed_stream_retrieval=false \
+              -f official_typed_stream_limit=8 \
+              -f official_note_distillation=false \
+              -f official_note_distillation_model=gpt-5.4-nano \
+              -f official_api_retry_attempts=3 \
+              -f official_prompt_build_max_workers=1 \
+              -f official_evaluator_model=gpt-5.2 \
+              -f official_include_screenshots=false
+            run_id="$(find_child_run "$arm_id")"
+            runs="$(jq -cn \
+              --argjson current "$runs" \
+              --arg arm "$arm_id" \
+              --arg run "$run_id" \
+              '$current + {($arm): $run}')"
+          }
+
+          dispatch_arm aa-1-left save ""
+          builder_run_id="$(jq -er '.["aa-1-left"]' <<< "$runs")"
+          while IFS= read -r arm_id; do
+            dispatch_arm "$arm_id" load "$builder_run_id"
+          done < <(jq -r '.arms[1:][] | .arm_id' "$PLAN_PATH")
+
+          printf '%s\n' "$runs" > "$RUNS_PATH"
+          moon run bench-longmemeval-v2-release-ci -- \
+            run-map \
+            --dispatch-plan "$PLAN_PATH" \
+            --runs "$RUNS_PATH" \
+            --output "$RUN_MAP_PATH"
+
+      - name: Upload controller evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: longmemeval-v2-release-aa-controller-${{ github.run_id }}
+          path: |
+            .moon/cache/evals/longmemeval-v2-release-ci/dispatch-plan.json
+            .moon/cache/evals/longmemeval-v2-release-ci/runs.json
+            .moon/cache/evals/longmemeval-v2-release-ci/run-map.json
+          if-no-files-found: error
+          retention-days: 30
+
+  aggregate:
+    name: Verify and seal completed A/A
+    if: >-
+      github.event_name == 'workflow_run' &&
+      endsWith(github.event.workflow_run.display_title, ' aa-3-right')
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      GH_TOKEN: ${{ github.token }}
+      CONTROLLER_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/controller
+      RUN_MAP_PATH: .moon/cache/evals/longmemeval-v2-release-ci/controller/run-map.json
+      CHILD_ARTIFACTS: .moon/cache/evals/longmemeval-v2-release-ci/child-artifacts
+      BUNDLE_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/aa-bundle
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup moonrepo toolchain
+        uses: moonrepo/setup-toolchain@v0.6.4
+        with:
+          proto-version: "0.61.1"
+          auto-install: true
+          auto-setup: true
+          cache-version: longmemeval-v2-release-aa-v1
+
+      - name: Recover sealed controller state
+        env:
+          TRIGGER_TITLE: ${{ github.event.workflow_run.display_title }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TRIGGER_TITLE" =~ ^LongMemEval\ V2\ (aa-([1-9][0-9]*)-([1-9][0-9]*))\ aa-3-right$ ]]; then
+            echo "::error::The aggregation trigger identity is invalid."
+            exit 1
+          fi
+          orchestration_id="${BASH_REMATCH[1]}"
+          controller_run_id="${BASH_REMATCH[2]}"
+          controller_json="$(gh run view "$controller_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json conclusion,event,headSha,workflowName)"
+          if ! jq -e \
+            --arg sha "$TRIGGER_SHA" \
+            '.conclusion == "success" and
+             .event == "workflow_dispatch" and
+             .headSha == $sha and
+             .workflowName == "LongMemEval V2 Release A/A"' \
+            <<< "$controller_json" >/dev/null; then
+            echo "::error::The A/A controller provenance is invalid."
+            exit 1
+          fi
+          mkdir -p "$CONTROLLER_ROOT"
+          gh run download "$controller_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "longmemeval-v2-release-aa-controller-${controller_run_id}" \
+            --dir "$CONTROLLER_ROOT"
+          if [[ ! -s "$RUN_MAP_PATH" ]]; then
+            echo "::error::The sealed A/A run map is missing."
+            exit 1
+          fi
+          if ! jq -e \
+            --arg orchestration "$orchestration_id" \
+            --arg sha "$TRIGGER_SHA" \
+            '.orchestration_id == $orchestration and .source.sha == $sha' \
+            "$RUN_MAP_PATH" >/dev/null; then
+            echo "::error::The sealed A/A run map differs from its trigger."
+            exit 1
+          fi
+          {
+            printf 'CONTROLLER_RUN_ID=%s\n' "$controller_run_id"
+            printf 'ORCHESTRATION_ID=%s\n' "$orchestration_id"
+            printf 'SOURCE_SHA=%s\n' "$TRIGGER_SHA"
+          } >> "$GITHUB_ENV"
+
+      - name: Wait for every paid arm
+        run: |
+          set -euo pipefail
+          while true; do
+            pending=0
+            while IFS=$'\t' read -r arm_id run_id; do
+              run_json="$(gh run view "$run_id" \
+                --repo "$GITHUB_REPOSITORY" \
+                --json conclusion,displayTitle,event,headSha,status,workflowName)"
+              if ! jq -e \
+                --arg sha "$SOURCE_SHA" \
+                --arg title "LongMemEval V2 ${ORCHESTRATION_ID} ${arm_id}" \
+                '.event == "workflow_dispatch" and
+                 .headSha == $sha and
+                 .displayTitle == $title and
+                 .workflowName == "LongMemEval V2"' \
+                <<< "$run_json" >/dev/null; then
+                echo "::error::Child workflow provenance drifted for ${arm_id}."
+                exit 1
+              fi
+              status="$(jq -r '.status' <<< "$run_json")"
+              conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
+              if [[ "$status" == "completed" && "$conclusion" != "success" ]]; then
+                echo "::error::Child workflow ${arm_id} completed as ${conclusion}."
+                exit 1
+              fi
+              if [[ "$status" != "completed" ]]; then
+                pending=$((pending + 1))
+              fi
+            done < <(jq -r '.runs | to_entries[] | [.key, .value] | @tsv' "$RUN_MAP_PATH")
+            if [[ "$pending" -eq 0 ]]; then
+              break
+            fi
+            echo "Waiting for ${pending} of 6 paid arms."
+            sleep 30
+          done
+
+      - name: Download and seal portable A/A evidence
+        run: |
+          set -euo pipefail
+          mkdir -p "$CHILD_ARTIFACTS"
+          while IFS=$'\t' read -r arm_id run_id; do
+            gh run download "$run_id" \
+              --repo "$GITHUB_REPOSITORY" \
+              --name "longmemeval-v2-combined-small-${SOURCE_SHA}-${run_id}" \
+              --dir "$CHILD_ARTIFACTS/$arm_id"
+          done < <(jq -r '.runs | to_entries[] | [.key, .value] | @tsv' "$RUN_MAP_PATH")
+          moon run bench-longmemeval-v2-release-ci -- \
+            aggregate \
+            --artifacts-root "$CHILD_ARTIFACTS" \
+            --run-map "$RUN_MAP_PATH" \
+            --output-root "$BUNDLE_ROOT"
+
+      - name: Upload authoritative A/A bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: longmemeval-v2-release-aa-${{ env.SOURCE_SHA }}-${{ env.CONTROLLER_RUN_ID }}
+          path: .moon/cache/evals/longmemeval-v2-release-ci/aa-bundle
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/longmemeval-v2-release-aa.yml
+++ b/.github/workflows/longmemeval-v2-release-aa.yml
@@ -22,20 +22,36 @@ permissions:
   actions: read
   contents: read
 
-concurrency:
-  group: >-
-    longmemeval-v2-release-aa-${{ github.event_name == 'workflow_dispatch' &&
-    inputs.experiment_id || github.event.workflow_run.head_sha }}
-  cancel-in-progress: false
-
 defaults:
   run:
     shell: bash
 
 jobs:
+  identify-workflow-run:
+    name: Identify release orchestration
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    outputs:
+      orchestration_id: ${{ steps.identity.outputs.orchestration_id }}
+      arm_id: ${{ steps.identity.outputs.arm_id }}
+    steps:
+      - name: Parse sealed child identity
+        id: identity
+        env:
+          TRIGGER_TITLE: ${{ github.event.workflow_run.display_title }}
+        run: |
+          set -euo pipefail
+          if [[ "$TRIGGER_TITLE" =~ ^LongMemEval\ V2\ (aa-[1-9][0-9]*)\ (aa-(1-left|1-right|2-left|2-right|3-left|3-right))$ ]]; then
+            printf 'orchestration_id=%s\n' "${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            printf 'arm_id=%s\n' "${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+          fi
+
   orchestrate:
     name: Dispatch, verify, and seal A/A
     if: github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: longmemeval-v2-release-aa-${{ inputs.experiment_id }}-controller
+      cancel-in-progress: false
     permissions:
       actions: write
       contents: read
@@ -224,9 +240,11 @@ jobs:
 
   dispatch-consumers:
     name: Dispatch frozen baseline consumers
-    if: >-
-      github.event_name == 'workflow_run' &&
-      endsWith(github.event.workflow_run.display_title, ' aa-1-left')
+    needs: identify-workflow-run
+    if: needs.identify-workflow-run.outputs.arm_id == 'aa-1-left'
+    concurrency:
+      group: longmemeval-v2-release-aa-${{ needs.identify-workflow-run.outputs.orchestration_id }}-dispatch
+      cancel-in-progress: false
     permissions:
       actions: write
       contents: read
@@ -446,13 +464,16 @@ jobs:
 
   aggregate:
     name: Verify and seal completed A/A
+    needs: identify-workflow-run
     if: >-
-      github.event_name == 'workflow_run' &&
-      (endsWith(github.event.workflow_run.display_title, ' aa-1-right') ||
-      endsWith(github.event.workflow_run.display_title, ' aa-2-left') ||
-      endsWith(github.event.workflow_run.display_title, ' aa-2-right') ||
-      endsWith(github.event.workflow_run.display_title, ' aa-3-left') ||
-      endsWith(github.event.workflow_run.display_title, ' aa-3-right'))
+      needs.identify-workflow-run.outputs.arm_id == 'aa-1-right' ||
+      needs.identify-workflow-run.outputs.arm_id == 'aa-2-left' ||
+      needs.identify-workflow-run.outputs.arm_id == 'aa-2-right' ||
+      needs.identify-workflow-run.outputs.arm_id == 'aa-3-left' ||
+      needs.identify-workflow-run.outputs.arm_id == 'aa-3-right'
+    concurrency:
+      group: longmemeval-v2-release-aa-${{ needs.identify-workflow-run.outputs.orchestration_id }}-aggregate
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/longmemeval-v2-release-aa.yml
+++ b/.github/workflows/longmemeval-v2-release-aa.yml
@@ -25,7 +25,7 @@ permissions:
 concurrency:
   group: >-
     longmemeval-v2-release-aa-${{ github.event_name == 'workflow_dispatch' &&
-    inputs.experiment_id || github.event.workflow_run.display_title }}
+    inputs.experiment_id || github.event.workflow_run.head_sha }}
   cancel-in-progress: false
 
 defaults:
@@ -442,9 +442,13 @@ jobs:
     name: Verify and seal completed A/A
     if: >-
       github.event_name == 'workflow_run' &&
-      endsWith(github.event.workflow_run.display_title, ' aa-3-right')
+      (endsWith(github.event.workflow_run.display_title, ' aa-1-right') ||
+      endsWith(github.event.workflow_run.display_title, ' aa-2-left') ||
+      endsWith(github.event.workflow_run.display_title, ' aa-2-right') ||
+      endsWith(github.event.workflow_run.display_title, ' aa-3-left') ||
+      endsWith(github.event.workflow_run.display_title, ' aa-3-right'))
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 60
     env:
       GH_TOKEN: ${{ github.token }}
       STATE_ROOT: .moon/cache/evals/longmemeval-v2-release-ci/controller
@@ -472,7 +476,7 @@ jobs:
           TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          if [[ ! "$TRIGGER_TITLE" =~ ^LongMemEval\ V2\ (aa-([1-9][0-9]*))\ aa-3-right$ ]]; then
+          if [[ ! "$TRIGGER_TITLE" =~ ^LongMemEval\ V2\ (aa-([1-9][0-9]*))\ aa-(1-right|2-left|2-right|3-left|3-right)$ ]]; then
             echo "::error::The aggregation trigger identity is invalid."
             exit 1
           fi
@@ -500,11 +504,11 @@ jobs:
             --limit 100 \
             --json conclusion,databaseId,displayTitle,headSha,status \
             --jq ".[] | select(.displayTitle == \"${dispatcher_title}\" and .headSha == \"${TRIGGER_SHA}\" and .status == \"completed\" and .conclusion == \"success\") | .databaseId")"
-          if [[ "$(wc -w <<< "$dispatcher_runs")" -ne 1 ]]; then
-            echo "::error::Exactly one successful consumer dispatcher is required."
+          if [[ -z "$dispatcher_runs" ]]; then
+            echo "::error::A successful consumer dispatcher is required."
             exit 1
           fi
-          dispatcher_run_id="$dispatcher_runs"
+          dispatcher_run_id="$(sort -n <<< "$dispatcher_runs" | tail -1)"
           mkdir -p "$STATE_ROOT"
           gh run download "$dispatcher_run_id" \
             --repo "$GITHUB_REPOSITORY" \
@@ -528,44 +532,45 @@ jobs:
             printf 'SOURCE_SHA=%s\n' "$TRIGGER_SHA"
           } >> "$GITHUB_ENV"
 
-      - name: Wait for every paid arm
+      - name: Check whether every paid arm is complete
+        id: readiness
         run: |
           set -euo pipefail
-          while true; do
-            pending=0
-            while IFS=$'\t' read -r arm_id run_id; do
-              run_json="$(gh run view "$run_id" \
-                --repo "$GITHUB_REPOSITORY" \
-                --json conclusion,displayTitle,event,headSha,status,workflowName)"
-              if ! jq -e \
-                --arg sha "$SOURCE_SHA" \
-                --arg title "LongMemEval V2 ${ORCHESTRATION_ID} ${arm_id}" \
-                '.event == "workflow_dispatch" and
-                 .headSha == $sha and
-                 .displayTitle == $title and
-                 .workflowName == "LongMemEval V2"' \
-                <<< "$run_json" >/dev/null; then
-                echo "::error::Child workflow provenance drifted for ${arm_id}."
-                exit 1
-              fi
-              status="$(jq -r '.status' <<< "$run_json")"
-              conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
-              if [[ "$status" == "completed" && "$conclusion" != "success" ]]; then
-                echo "::error::Child workflow ${arm_id} completed as ${conclusion}."
-                exit 1
-              fi
-              if [[ "$status" != "completed" ]]; then
-                pending=$((pending + 1))
-              fi
-            done < <(jq -r '.runs | to_entries[] | [.key, .value] | @tsv' "$RUN_MAP_PATH")
-            if [[ "$pending" -eq 0 ]]; then
-              break
+          pending=0
+          while IFS=$'\t' read -r arm_id run_id; do
+            run_json="$(gh run view "$run_id" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json conclusion,displayTitle,event,headSha,status,workflowName)"
+            if ! jq -e \
+              --arg sha "$SOURCE_SHA" \
+              --arg title "LongMemEval V2 ${ORCHESTRATION_ID} ${arm_id}" \
+              '.event == "workflow_dispatch" and
+               .headSha == $sha and
+               .displayTitle == $title and
+               .workflowName == "LongMemEval V2"' \
+              <<< "$run_json" >/dev/null; then
+              echo "::error::Child workflow provenance drifted for ${arm_id}."
+              exit 1
             fi
-            echo "Waiting for ${pending} of 6 paid arms."
-            sleep 30
-          done
+            status="$(jq -r '.status' <<< "$run_json")"
+            conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
+            if [[ "$status" == "completed" && "$conclusion" != "success" ]]; then
+              echo "::error::Child workflow ${arm_id} completed as ${conclusion}."
+              exit 1
+            fi
+            if [[ "$status" != "completed" ]]; then
+              pending=$((pending + 1))
+            fi
+          done < <(jq -r '.runs | to_entries[] | [.key, .value] | @tsv' "$RUN_MAP_PATH")
+          if [[ "$pending" -gt 0 ]]; then
+            echo "Deferring aggregation until the remaining ${pending} arms complete."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
 
       - name: Download and seal portable A/A evidence
+        if: steps.readiness.outputs.ready == 'true'
         run: |
           set -euo pipefail
           mkdir -p "$CHILD_ARTIFACTS"
@@ -582,9 +587,11 @@ jobs:
             --output-root "$BUNDLE_ROOT"
 
       - name: Upload authoritative A/A bundle
+        if: steps.readiness.outputs.ready == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: longmemeval-v2-release-aa-${{ env.SOURCE_SHA }}-${{ env.CONTROLLER_RUN_ID }}
           path: .moon/cache/evals/longmemeval-v2-release-ci/aa-bundle
           if-no-files-found: error
+          overwrite: true
           retention-days: 30

--- a/.github/workflows/longmemeval-v2-release-aa.yml
+++ b/.github/workflows/longmemeval-v2-release-aa.yml
@@ -19,7 +19,7 @@ on:
     types: [completed]
 
 permissions:
-  actions: write
+  actions: read
   contents: read
 
 concurrency:
@@ -36,6 +36,9 @@ jobs:
   orchestrate:
     name: Dispatch, verify, and seal A/A
     if: github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -224,6 +227,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_run' &&
       endsWith(github.event.workflow_run.display_title, ' aa-1-left')
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -484,10 +490,11 @@ jobs:
           controller_run_id="${BASH_REMATCH[2]}"
           controller_json="$(gh run view "$controller_run_id" \
             --repo "$GITHUB_REPOSITORY" \
-            --json conclusion,event,headSha,workflowName)"
+            --json conclusion,event,headSha,status,workflowName)"
           if ! jq -e \
             --arg sha "$TRIGGER_SHA" \
-            '.conclusion == "success" and
+            '.status == "completed" and
+             (.conclusion | IN("success", "failure")) and
              .event == "workflow_dispatch" and
              .headSha == $sha and
              .workflowName == "LongMemEval V2 Release A/A"' \

--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -411,25 +411,22 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.run_official_full
     needs: official-preflight
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read
     env:
       GH_TOKEN: ${{ github.token }}
-      MEMORY_MODE: ${{ fromJSON(inputs.official_ci_context_json).memory_mode }}
+      MEMORY_MODE: ${{ fromJSON(inputs.official_ci_context_json || '{}').memory_mode }}
       MEMORY_SOURCE_RUN_ID:
-        ${{ fromJSON(inputs.official_ci_context_json).memory_source_run_id }}
+        ${{ fromJSON(inputs.official_ci_context_json || '{}').memory_source_run_id }}
       SOURCE_SHA:
-        ${{ fromJSON(inputs.official_ci_context_json).source_sha || github.sha }}
+        ${{ fromJSON(inputs.official_ci_context_json || '{}').source_sha || github.sha }}
     steps:
-      - name: Wait for the frozen baseline builder
+      - name: Validate the completed frozen baseline builder
         if: env.MEMORY_MODE == 'load'
         run: |
           set -euo pipefail
-          gh run watch "$MEMORY_SOURCE_RUN_ID" \
-            --repo "$GITHUB_REPOSITORY" \
-            --exit-status
           run_json="$(gh run view "$MEMORY_SOURCE_RUN_ID" \
             --repo "$GITHUB_REPOSITORY" \
             --json conclusion,event,headSha,workflowName)"
@@ -466,16 +463,16 @@ jobs:
       OUTPUT_ROOT: .moon/cache/evals/longmemeval-v2-official
       OFFICIAL_TIER: ${{ inputs.official_tier || 'small' }}
       FROZEN_MEMORY_ROOT: /tmp/longmemeval-v2-frozen-memory
-      MEMORY_MODE: ${{ fromJSON(inputs.official_ci_context_json).memory_mode }}
+      MEMORY_MODE: ${{ fromJSON(inputs.official_ci_context_json || '{}').memory_mode }}
       MEMORY_SOURCE_RUN_ID:
-        ${{ fromJSON(inputs.official_ci_context_json).memory_source_run_id }}
+        ${{ fromJSON(inputs.official_ci_context_json || '{}').memory_source_run_id }}
       SOURCE_SHA:
-        ${{ fromJSON(inputs.official_ci_context_json).source_sha || github.sha }}
+        ${{ fromJSON(inputs.official_ci_context_json || '{}').source_sha || github.sha }}
       LME_SIBYL_EMAIL:
-        longmemeval-v2-${{ fromJSON(inputs.official_ci_context_json).orchestration_id ||
+        longmemeval-v2-${{ fromJSON(inputs.official_ci_context_json || '{}').orchestration_id ||
         github.run_id }}-${{ matrix.domain }}@example.invalid
       LME_SIBYL_PASSWORD:
-        SibylLongMemEvalV2-${{ fromJSON(inputs.official_ci_context_json).orchestration_id ||
+        SibylLongMemEvalV2-${{ fromJSON(inputs.official_ci_context_json || '{}').orchestration_id ||
         github.run_id }}-${{ matrix.domain }}-password
       OFFICIAL_LIMIT: ${{ inputs.official_limit || '' }}
       OFFICIAL_VALIDATION_SLICE: ${{ inputs.official_validation_slice || 'none' }}
@@ -1122,8 +1119,26 @@ jobs:
               kill -TERM "$(cat "$pid_file")" 2>/dev/null || true
             fi
           done
-          sleep 3
-          pkill -TERM -f 'sibyld (serve|worker)' 2>/dev/null || true
+          pkill -TERM -f '[s]ibyld (serve|worker)' 2>/dev/null || true
+          for attempt in {1..60}; do
+            active=false
+            for pid_file in /tmp/sibyl-worker.pid /tmp/sibyld.pid; do
+              if [[ -s "$pid_file" ]] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+                active=true
+              fi
+            done
+            if pgrep -f '[s]ibyld (serve|worker)' >/dev/null; then
+              active=true
+            fi
+            if [[ "$active" == "false" ]]; then
+              break
+            fi
+            if [[ "$attempt" -eq 60 ]]; then
+              echo "::error::Sibyl services did not stop before the database snapshot."
+              exit 1
+            fi
+            sleep 1
+          done
           docker compose --env-file /dev/null --profile redis stop redis
           docker compose --env-file /dev/null stop surrealdb
           tar -C "$database_root" -cf "$snapshot" .
@@ -1223,7 +1238,7 @@ jobs:
       OFFICIAL_DATASET_REVISION: ${{ inputs.official_dataset_revision || '' }}
       OFFICIAL_INCLUDE_SCREENSHOTS: ${{ inputs.official_include_screenshots || false }}
       SOURCE_SHA:
-        ${{ fromJSON(inputs.official_ci_context_json).source_sha || github.sha }}
+        ${{ fromJSON(inputs.official_ci_context_json || '{}').source_sha || github.sha }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -1,10 +1,16 @@
 name: LongMemEval V2
+run-name: >-
+  LongMemEval V2 ${{ inputs.official_ci_context_json &&
+  fromJSON(inputs.official_ci_context_json).orchestration_id || github.run_id }}
+  ${{ inputs.official_ci_context_json &&
+  fromJSON(inputs.official_ci_context_json).arm_id || github.event_name }}
 
 on:
   push:
     branches: [main]
     paths:
       - ".github/workflows/longmemeval-v2.yml"
+      - ".github/workflows/longmemeval-v2-release-aa.yml"
       - "benchmarks/longmemeval_v2_download.py"
       - "benchmarks/longmemeval_v2_memory/**"
       - "benchmarks/longmemeval_v2_live_retrieval.py"
@@ -47,6 +53,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/longmemeval-v2.yml"
+      - ".github/workflows/longmemeval-v2-release-aa.yml"
       - "benchmarks/longmemeval_v2_download.py"
       - "benchmarks/longmemeval_v2_memory/**"
       - "benchmarks/longmemeval_v2_live_retrieval.py"
@@ -91,6 +98,11 @@ on:
         description: "Run the approval-bound official full harness"
         type: boolean
         default: false
+      official_ci_context_json:
+        description: "Sealed controller, source, arm, and frozen-memory identity"
+        type: string
+        default: >-
+          {"orchestration_id":"","arm_id":"","source_sha":"","memory_mode":"save","memory_source_run_id":""}
       official_arm_manifest_json:
         description: "Sealed experiment identity, substrate, geometry, and render profile"
         type: string
@@ -205,6 +217,7 @@ on:
         default: false
 
 permissions:
+  actions: read
   contents: read
 
 defaults:
@@ -221,6 +234,7 @@ concurrency:
 jobs:
   probe:
     name: Probe ${{ matrix.tier }}
+    if: github.event_name != 'workflow_dispatch' || !inputs.run_official_full
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -317,6 +331,7 @@ jobs:
     steps:
       - name: Reject incomplete or unpackageable paid runs
         env:
+          OFFICIAL_CI_CONTEXT_JSON: ${{ inputs.official_ci_context_json }}
           OFFICIAL_DOMAIN: ${{ inputs.official_domain || 'both' }}
           OFFICIAL_LIMIT: ${{ inputs.official_limit || '' }}
           OFFICIAL_TIER: ${{ inputs.official_tier || 'small' }}
@@ -339,11 +354,101 @@ jobs:
             echo "::error::Sealed paid arms cannot use a validation slice."
             exit 1
           fi
+          if ! jq -e '
+            type == "object" and
+            ((keys | sort) == ([
+              "arm_id",
+              "memory_mode",
+              "memory_source_run_id",
+              "orchestration_id",
+              "source_sha"
+            ] | sort)) and
+            (.arm_id | type == "string") and
+            (.memory_mode | IN("save", "load")) and
+            (.memory_source_run_id | type == "string") and
+            (.orchestration_id | type == "string") and
+            (.source_sha | type == "string")
+          ' <<< "$OFFICIAL_CI_CONTEXT_JSON" >/dev/null; then
+            echo "::error::official_ci_context_json does not match the sealed schema."
+            exit 1
+          fi
+          OFFICIAL_MEMORY_MODE="$(jq -r '.memory_mode' <<< "$OFFICIAL_CI_CONTEXT_JSON")"
+          OFFICIAL_MEMORY_SOURCE_RUN_ID="$(
+            jq -r '.memory_source_run_id' <<< "$OFFICIAL_CI_CONTEXT_JSON"
+          )"
+          OFFICIAL_ORCHESTRATION_ID="$(jq -r '.orchestration_id' <<< "$OFFICIAL_CI_CONTEXT_JSON")"
+          OFFICIAL_ARM_ID="$(jq -r '.arm_id' <<< "$OFFICIAL_CI_CONTEXT_JSON")"
+          OFFICIAL_SOURCE_SHA="$(jq -r '.source_sha' <<< "$OFFICIAL_CI_CONTEXT_JSON")"
+          OFFICIAL_SOURCE_SHA="${OFFICIAL_SOURCE_SHA:-$GITHUB_SHA}"
+          if [[ "$OFFICIAL_SOURCE_SHA" != "$GITHUB_SHA" ]]; then
+            echo "::error::Paid arm source SHA differs from the controller pin."
+            exit 1
+          fi
+          if [[ -n "$OFFICIAL_ORCHESTRATION_ID" || -n "$OFFICIAL_ARM_ID" ]]; then
+            if [[ ! "$OFFICIAL_ORCHESTRATION_ID" =~ ^[a-z0-9]([a-z0-9._-]{0,62}[a-z0-9])?$ ]] ||
+              [[ ! "$OFFICIAL_ARM_ID" =~ ^aa-[1-3]-(left|right)$ ]]; then
+              echo "::error::Distributed release identities are invalid."
+              exit 1
+            fi
+          fi
+          if [[ "$OFFICIAL_MEMORY_MODE" == "save" ]]; then
+            if [[ -n "$OFFICIAL_MEMORY_SOURCE_RUN_ID" ]]; then
+              echo "::error::A memory builder cannot name an upstream run."
+              exit 1
+            fi
+          elif [[ "$OFFICIAL_MEMORY_MODE" == "load" ]]; then
+            if [[ ! "$OFFICIAL_MEMORY_SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::A memory consumer requires one canonical builder run ID."
+              exit 1
+            fi
+          else
+            echo "::error::official_memory_mode must be save or load."
+            exit 1
+          fi
+
+  official-memory-source:
+    name: Validate frozen memory source
+    if: github.event_name == 'workflow_dispatch' && inputs.run_official_full
+    needs: official-preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      MEMORY_MODE: ${{ fromJSON(inputs.official_ci_context_json).memory_mode }}
+      MEMORY_SOURCE_RUN_ID:
+        ${{ fromJSON(inputs.official_ci_context_json).memory_source_run_id }}
+      SOURCE_SHA:
+        ${{ fromJSON(inputs.official_ci_context_json).source_sha || github.sha }}
+    steps:
+      - name: Wait for the frozen baseline builder
+        if: env.MEMORY_MODE == 'load'
+        run: |
+          set -euo pipefail
+          gh run watch "$MEMORY_SOURCE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --exit-status
+          run_json="$(gh run view "$MEMORY_SOURCE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json conclusion,event,headSha,workflowName)"
+          if ! jq -e \
+            --arg sha "$SOURCE_SHA" \
+            '.conclusion == "success" and
+             .event == "workflow_dispatch" and
+             .headSha == $sha and
+             .workflowName == "LongMemEval V2"' \
+            <<< "$run_json" >/dev/null; then
+            echo "::error::Frozen memory builder provenance is invalid."
+            jq . <<< "$run_json"
+            exit 1
+          fi
 
   official-full:
     name: Official ${{ matrix.domain }} ${{ inputs.official_tier || 'small' }}
     if: github.event_name == 'workflow_dispatch' && inputs.run_official_full
-    needs: official-preflight
+    needs: [official-preflight, official-memory-source]
     runs-on: ubuntu-latest
     environment: longmemeval-paid
     timeout-minutes: 720
@@ -360,6 +465,18 @@ jobs:
       OFFICIAL_REPO_DIR: .moon/cache/longmemeval-v2-official
       OUTPUT_ROOT: .moon/cache/evals/longmemeval-v2-official
       OFFICIAL_TIER: ${{ inputs.official_tier || 'small' }}
+      FROZEN_MEMORY_ROOT: /tmp/longmemeval-v2-frozen-memory
+      MEMORY_MODE: ${{ fromJSON(inputs.official_ci_context_json).memory_mode }}
+      MEMORY_SOURCE_RUN_ID:
+        ${{ fromJSON(inputs.official_ci_context_json).memory_source_run_id }}
+      SOURCE_SHA:
+        ${{ fromJSON(inputs.official_ci_context_json).source_sha || github.sha }}
+      LME_SIBYL_EMAIL:
+        longmemeval-v2-${{ fromJSON(inputs.official_ci_context_json).orchestration_id ||
+        github.run_id }}-${{ matrix.domain }}@example.invalid
+      LME_SIBYL_PASSWORD:
+        SibylLongMemEvalV2-${{ fromJSON(inputs.official_ci_context_json).orchestration_id ||
+        github.run_id }}-${{ matrix.domain }}-password
       OFFICIAL_LIMIT: ${{ inputs.official_limit || '' }}
       OFFICIAL_VALIDATION_SLICE: ${{ inputs.official_validation_slice || 'none' }}
       VALIDATION_MANIFEST:
@@ -400,11 +517,16 @@ jobs:
       SIBYL_AUTH_STORE: surreal
       SIBYL_PUBLIC_SIGNUPS_ENABLED: "true"
       SIBYL_LOCAL_AUTH_ENABLED: "true"
-      SIBYL_COORDINATION_BACKEND: local
+      SIBYL_COORDINATION_BACKEND: redis
       SIBYL_SURREAL_URL: ws://localhost:8000/rpc
       SIBYL_SURREAL_USERNAME: sibyl_ci
       SIBYL_SURREAL_PASSWORD: sibyl_ci_password
       SIBYL_SURREAL_PATH: rocksdb:///data/sibyl-longmemeval-v2.db
+      SIBYL_REDIS_HOST: 127.0.0.1
+      SIBYL_REDIS_PORT: "6381"
+      SIBYL_GRAPH_EMBEDDING_PROVIDER: local
+      SIBYL_GRAPH_EMBEDDING_MODEL: sentence-transformers/all-MiniLM-L6-v2
+      SIBYL_GRAPH_EMBEDDING_DIMENSIONS: "384"
       SIBYL_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SIBYL_LLM_MEMORY_PROVIDER: openai
       SIBYL_LLM_MEMORY_MODEL: gpt-5.4-nano
@@ -422,6 +544,66 @@ jobs:
           ref: 2cc8c540bdb87fe6761629b585e727e1c4704520
           path: .moon/cache/longmemeval-v2-official
           persist-credentials: false
+
+      - name: Download frozen baseline memory
+        if: env.MEMORY_MODE == 'load'
+        uses: actions/download-artifact@v8
+        with:
+          name:
+            longmemeval-v2-frozen-memory-${{ matrix.domain }}-${{
+            env.SOURCE_SHA }}-${{ env.MEMORY_SOURCE_RUN_ID }}
+          path: /tmp/longmemeval-v2-frozen-memory/${{ matrix.domain }}
+          github-token: ${{ github.token }}
+          run-id: ${{ env.MEMORY_SOURCE_RUN_ID }}
+
+      - name: Validate frozen baseline memory
+        if: env.MEMORY_MODE == 'load'
+        run: |
+          set -euo pipefail
+          memory="$FROZEN_MEMORY_ROOT/${{ matrix.domain }}/memory_state"
+          snapshot="$FROZEN_MEMORY_ROOT/${{ matrix.domain }}/surrealdb_snapshot.tar"
+          snapshot_manifest="$FROZEN_MEMORY_ROOT/${{ matrix.domain }}/database_snapshot_manifest.json"
+          if [[ ! -s "$memory/memory_manifest.json" ]]; then
+            echo "::error::Frozen baseline memory is incomplete for ${{ matrix.domain }}."
+            exit 1
+          fi
+          if ! jq -e \
+            --arg domain "${{ matrix.domain }}" \
+            --arg sha "$SOURCE_SHA" \
+            --arg run "$MEMORY_SOURCE_RUN_ID" \
+            '.schema_version == "sibyl-longmemeval-v2-database-snapshot-v1" and
+             .domain == $domain and
+             .source_sha == $sha and
+             .builder_run_id == $run and
+             (.snapshot_sha256 | test("^sha256:[0-9a-f]{64}$")) and
+             (.memory_manifest_sha256 | test("^sha256:[0-9a-f]{64}$")) and
+             (.snapshot_size_bytes | type == "number" and . > 0)' \
+            "$snapshot_manifest" >/dev/null; then
+            echo "::error::Frozen database snapshot manifest is invalid."
+            exit 1
+          fi
+          expected_snapshot="$(jq -r '.snapshot_sha256 | sub("^sha256:"; "")' "$snapshot_manifest")"
+          expected_memory="$(jq -r '.memory_manifest_sha256 | sub("^sha256:"; "")' "$snapshot_manifest")"
+          printf '%s  %s\n' "$expected_snapshot" "$snapshot" | sha256sum -c -
+          printf '%s  %s\n' "$expected_memory" "$memory/memory_manifest.json" | sha256sum -c -
+          if [[ "$(stat -c %s "$snapshot")" != "$(jq -r '.snapshot_size_bytes' "$snapshot_manifest")" ]]; then
+            echo "::error::Frozen database snapshot size differs from its manifest."
+            exit 1
+          fi
+          if tar -tf "$snapshot" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
+            echo "::error::Frozen database snapshot contains an unsafe path."
+            exit 1
+          fi
+
+      - name: Restore frozen baseline database
+        if: env.MEMORY_MODE == 'load'
+        run: |
+          set -euo pipefail
+          database_root="$RUNNER_TEMP/sibyl-surrealdb"
+          mkdir -p "$database_root"
+          tar -xf "$FROZEN_MEMORY_ROOT/${{ matrix.domain }}/surrealdb_snapshot.tar" \
+            -C "$database_root"
+          chmod -R u+rwX "$database_root"
 
       - name: Guard paid-run dependencies
         run: |
@@ -581,7 +763,7 @@ jobs:
             exit 1
           fi
           if [[ -z "${OPENAI_API_KEY}" ]]; then
-            echo "::error::OPENAI_API_KEY repo secret is required for evaluator and Sibyl embeddings."
+            echo "::error::OPENAI_API_KEY is required for evaluation and memory distillation."
             exit 1
           fi
           if [[ -z "${READER_BASE_URL}" ]]; then
@@ -605,6 +787,21 @@ jobs:
 
       - name: Start SurrealDB
         uses: ./.github/actions/start-surrealdb
+
+      - name: Start Redis coordination
+        run: |
+          set -euo pipefail
+          docker compose --env-file /dev/null --profile redis up -d redis
+          for attempt in {1..30}; do
+            if docker compose --env-file /dev/null --profile redis \
+              exec -T redis valkey-cli ping | grep -qx PONG; then
+              exit 0
+            fi
+            echo "Attempt $attempt: Redis coordination is not ready yet."
+            sleep 1
+          done
+          docker compose --env-file /dev/null --profile redis logs redis
+          exit 1
 
       - name: Start SurrealDB runtime telemetry
         run: |
@@ -669,12 +866,22 @@ jobs:
           restore-keys: |
             uv-longmemeval-v2-official-${{ runner.os }}-
 
+      - name: Cache local embedding model
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/huggingface
+          key: hf-minilm-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            hf-minilm-${{ runner.os }}-
+
       - name: Start backend server
         run: |
           set -euo pipefail
           cd apps/api
-          uv run sibyld serve > /tmp/sibyld.log 2>&1 &
-          for _ in {1..60}; do
+          uv run --with sentence-transformers==6.0.0 sibyld serve \
+            > /tmp/sibyld.log 2>&1 &
+          printf '%s\n' "$!" > /tmp/sibyld.pid
+          for _ in {1..180}; do
             if curl -fsS http://localhost:3334/api/health > /dev/null; then
               sleep 2
               curl -fsS http://localhost:3334/api/health | head -c 200
@@ -688,7 +895,9 @@ jobs:
       - name: Start background job worker
         run: |
           cd apps/api
-          uv run sibyld worker > /tmp/sibyl-worker.log 2>&1 &
+          uv run --with sentence-transformers==6.0.0 sibyld worker \
+            > /tmp/sibyl-worker.log 2>&1 &
+          printf '%s\n' "$!" > /tmp/sibyl-worker.pid
           sleep 2
 
       - name: Fetch LongMemEval-V2 full dataset
@@ -780,6 +989,8 @@ jobs:
           args+=(--note-distillation-model "$NOTE_DISTILLATION_MODEL")
           args+=(--api-retry-attempts "$API_RETRY_ATTEMPTS")
           args+=(--prompt-build-max-workers "$PROMPT_BUILD_MAX_WORKERS")
+          args+=(--require-embedding-provider local)
+          args+=(--require-embedding-model sentence-transformers/all-MiniLM-L6-v2)
           if [[ "$TYPED_STREAM_RETRIEVAL" == "true" ]]; then
             args+=(--typed-stream-retrieval)
           fi
@@ -801,14 +1012,17 @@ jobs:
           if [[ "$SOURCE_EVIDENCE_BUNDLING" == "true" ]]; then
             args+=(--source-evidence-bundling)
           fi
+          if [[ "$MEMORY_MODE" == "save" ]]; then
+            args+=(--save-memory --checkpoint-dir "$domain_output/ingest_checkpoint")
+          else
+            args+=(--load-memory-dir "$FROZEN_MEMORY_ROOT/${{ matrix.domain }}/memory_state")
+          fi
           moon run bench-longmemeval-v2-official-full -- \
             --official-repo "$OFFICIAL_REPO_DIR" \
             --data-root "$DATA_ROOT" \
             --domain "${{ matrix.domain }}" \
             --tier "$OFFICIAL_TIER" \
             --output-dir "$domain_output" \
-            --save-memory \
-            --checkpoint-dir "$domain_output/ingest_checkpoint" \
             --api-url http://127.0.0.1:3334/api \
             --allow-localhost \
             --reader-base-url "$READER_BASE_URL" \
@@ -820,18 +1034,6 @@ jobs:
             --evaluator-api-key-env OPENAI_API_KEY \
             "${args[@]}"
           rm -rf "$domain_output/ingest_checkpoint"
-
-      - name: Upload official domain artifact
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name:
-            longmemeval-v2-${{ matrix.domain }}-${{ inputs.official_tier || 'small' }}-${{
-            github.sha }}
-          path:
-            .moon/cache/evals/longmemeval-v2-official/${{ matrix.domain }}_${{ inputs.official_tier
-            || 'small' }}
-          if-no-files-found: error
 
       - name: Capture service diagnostics
         if: always()
@@ -882,6 +1084,8 @@ jobs:
           fi
           docker compose --env-file /dev/null logs --no-color surrealdb \
             > /tmp/surrealdb.log 2>&1
+          docker compose --env-file /dev/null --profile redis logs --no-color redis \
+            > /tmp/redis.log 2>&1
           free -h > /tmp/runner-memory.txt 2>&1
           df -h > /tmp/runner-disk.txt 2>&1
           ps -eo pid,ppid,stat,%mem,rss,cmd --sort=-rss \
@@ -903,19 +1107,88 @@ jobs:
             --output-dir "$telemetry" \
             | tee "$telemetry/runtime-gate.log"
 
+      - name: Freeze baseline database snapshot
+        if: success() && env.MEMORY_MODE == 'save'
+        run: |
+          set -euo pipefail
+          domain_output="$OUTPUT_ROOT/${{ matrix.domain }}_${OFFICIAL_TIER}"
+          database_root="$RUNNER_TEMP/sibyl-surrealdb"
+          frozen_root="$FROZEN_MEMORY_ROOT/${{ matrix.domain }}"
+          snapshot="$frozen_root/surrealdb_snapshot.tar"
+          memory_manifest="$domain_output/memory_state/memory_manifest.json"
+          mkdir -p "$frozen_root"
+          for pid_file in /tmp/sibyl-worker.pid /tmp/sibyld.pid; do
+            if [[ -s "$pid_file" ]]; then
+              kill -TERM "$(cat "$pid_file")" 2>/dev/null || true
+            fi
+          done
+          sleep 3
+          pkill -TERM -f 'sibyld (serve|worker)' 2>/dev/null || true
+          docker compose --env-file /dev/null --profile redis stop redis
+          docker compose --env-file /dev/null stop surrealdb
+          tar -C "$database_root" -cf "$snapshot" .
+          snapshot_sha="$(sha256sum "$snapshot" | awk '{print $1}')"
+          memory_sha="$(sha256sum "$memory_manifest" | awk '{print $1}')"
+          snapshot_size="$(stat -c %s "$snapshot")"
+          cp -a "$domain_output/memory_state" "$frozen_root/memory_state"
+          jq -n \
+            --arg domain "${{ matrix.domain }}" \
+            --arg sha "$SOURCE_SHA" \
+            --arg run "$GITHUB_RUN_ID" \
+            --arg snapshot_sha "sha256:${snapshot_sha}" \
+            --arg memory_sha "sha256:${memory_sha}" \
+            --argjson snapshot_size "$snapshot_size" \
+            '{
+              schema_version: "sibyl-longmemeval-v2-database-snapshot-v1",
+              domain: $domain,
+              source_sha: $sha,
+              builder_run_id: $run,
+              snapshot_sha256: $snapshot_sha,
+              snapshot_size_bytes: $snapshot_size,
+              memory_manifest_sha256: $memory_sha
+            }' > "$frozen_root/database_snapshot_manifest.json"
+
+      - name: Upload frozen baseline memory
+        if: success() && env.MEMORY_MODE == 'save'
+        uses: actions/upload-artifact@v7
+        with:
+          name:
+            longmemeval-v2-frozen-memory-${{ matrix.domain }}-${{
+            env.SOURCE_SHA }}-${{ github.run_id }}
+          path: /tmp/longmemeval-v2-frozen-memory/${{ matrix.domain }}
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 7
+
+      - name: Upload official domain artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name:
+            longmemeval-v2-${{ matrix.domain }}-${{ inputs.official_tier || 'small' }}-${{
+            env.SOURCE_SHA }}-${{ github.run_id }}
+          path:
+            .moon/cache/evals/longmemeval-v2-official/${{ matrix.domain }}_${{ inputs.official_tier
+            || 'small' }}
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 7
+
       - name: Upload service diagnostics
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name:
             longmemeval-v2-${{ matrix.domain }}-${{ inputs.official_tier || 'small'
-            }}-service-diagnostics-${{ github.sha }}
+            }}-service-diagnostics-${{ env.SOURCE_SHA }}-${{
+            github.run_id }}
           path: |
             /tmp/sibyld.log
             /tmp/sibyl-worker.log
             /tmp/surrealdb-compose-ps.txt
             /tmp/surrealdb-inspect.json
             /tmp/surrealdb.log
+            /tmp/redis.log
             /tmp/runner-memory.txt
             /tmp/runner-disk.txt
             /tmp/runner-processes.txt
@@ -949,6 +1222,8 @@ jobs:
         'bench-longmemeval-v2-validation-slice' }}
       OFFICIAL_DATASET_REVISION: ${{ inputs.official_dataset_revision || '' }}
       OFFICIAL_INCLUDE_SCREENSHOTS: ${{ inputs.official_include_screenshots || false }}
+      SOURCE_SHA:
+        ${{ fromJSON(inputs.official_ci_context_json).source_sha || github.sha }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -981,13 +1256,17 @@ jobs:
       - name: Download web artifact
         uses: actions/download-artifact@v8
         with:
-          name: longmemeval-v2-web-${{ inputs.official_tier || 'small' }}-${{ github.sha }}
+          name:
+            longmemeval-v2-web-${{ inputs.official_tier || 'small' }}-${{
+            env.SOURCE_SHA }}-${{ github.run_id }}
           path: .moon/cache/evals/longmemeval-v2-official/web_${{ inputs.official_tier || 'small' }}
 
       - name: Download enterprise artifact
         uses: actions/download-artifact@v8
         with:
-          name: longmemeval-v2-enterprise-${{ inputs.official_tier || 'small' }}-${{ github.sha }}
+          name:
+            longmemeval-v2-enterprise-${{ inputs.official_tier || 'small' }}-${{
+            env.SOURCE_SHA }}-${{ github.run_id }}
           path:
             .moon/cache/evals/longmemeval-v2-official/enterprise_${{ inputs.official_tier || 'small'
             }}
@@ -1094,7 +1373,9 @@ jobs:
         if: inputs.official_validation_slice == 'none'
         uses: actions/upload-artifact@v7
         with:
-          name: longmemeval-v2-combined-${{ inputs.official_tier || 'small' }}-${{ github.sha }}
+          name:
+            longmemeval-v2-combined-${{ inputs.official_tier || 'small' }}-${{
+            env.SOURCE_SHA }}-${{ github.run_id }}
           path: |
             .moon/cache/evals/longmemeval-v2-official/longmemeval_v2_${{ inputs.official_tier || 'small' }}_receipt.json
             .moon/cache/evals/longmemeval-v2-official/arm_run.json

--- a/benchmarks/longmemeval_v2_release_ci.py
+++ b/benchmarks/longmemeval_v2_release_ci.py
@@ -212,6 +212,37 @@ def require_run_map(raw: object) -> dict[str, Any]:
     return {**raw, "source": source, "runs": dict(runs)}
 
 
+def build_run_map(
+    *,
+    dispatch_plan: dict[str, Any],
+    runs: dict[str, str],
+) -> dict[str, Any]:
+    """Bind every planned arm to the distinct workflow run that executed it."""
+
+    if dispatch_plan.get("schema_version") != DISPATCH_PLAN_SCHEMA_VERSION:
+        raise StagePlanError("CI dispatch plan schema is invalid")
+    unsigned_plan = {
+        key: value for key, value in dispatch_plan.items() if key != "dispatch_plan_sha256"
+    }
+    if dispatch_plan.get("dispatch_plan_sha256") != rig.canonical_sha256(unsigned_plan):
+        raise StagePlanError("CI dispatch plan digest is invalid")
+    planned_arms = dispatch_plan.get("arms")
+    if not isinstance(planned_arms, list) or [
+        arm.get("arm_id") for arm in planned_arms if isinstance(arm, dict)
+    ] != list(ARM_IDS):
+        raise StagePlanError("CI dispatch plan arm order or membership is invalid")
+    payload = {
+        "schema_version": RUN_MAP_SCHEMA_VERSION,
+        "experiment_id": dispatch_plan["experiment_id"],
+        "orchestration_id": dispatch_plan["orchestration_id"],
+        "source": dispatch_plan["source"],
+        "builder_run_id": runs.get(BUILDER_ARM_ID),
+        "runs": runs,
+    }
+    payload["run_map_sha256"] = rig.canonical_sha256(payload)
+    return require_run_map(payload)
+
+
 def _find_arm_run(root: Path, arm_id: str) -> Path:
     arm_root = (root / arm_id).resolve()
     if not arm_root.is_dir() or not arm_root.is_relative_to(root.resolve()):
@@ -407,6 +438,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     aggregate.add_argument("--artifacts-root", required=True)
     aggregate.add_argument("--run-map", required=True)
     aggregate.add_argument("--output-root", required=True)
+    run_map = commands.add_parser("run-map")
+    run_map.add_argument("--dispatch-plan", required=True)
+    run_map.add_argument("--runs", required=True)
+    run_map.add_argument("--output", required=True)
     import_aa = commands.add_parser("import-aa")
     import_aa.add_argument("--bundle-root", required=True)
     import_aa.add_argument("--output", required=True)
@@ -420,6 +455,12 @@ def main(argv: list[str] | None = None) -> int:
             experiment_id=args.experiment_id,
             orchestration_id=args.orchestration_id,
             source={"repository": args.repository, "ref": args.ref, "sha": args.sha},
+        )
+        release_io.write_json_once_atomic(Path(args.output).resolve(), payload)
+    elif args.command == "run-map":
+        payload = build_run_map(
+            dispatch_plan=load_json(Path(args.dispatch_plan)),
+            runs=load_json(Path(args.runs)),
         )
         release_io.write_json_once_atomic(Path(args.output).resolve(), payload)
     elif args.command == "aggregate":

--- a/benchmarks/longmemeval_v2_release_ci.py
+++ b/benchmarks/longmemeval_v2_release_ci.py
@@ -1,0 +1,441 @@
+"""CI orchestration and portable handoff for the v1.3 A/A release stage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from benchmarks import longmemeval_v2_release_authorization_package as authorization_package
+from benchmarks import longmemeval_v2_release_contract as contract
+from benchmarks import longmemeval_v2_release_io as release_io
+from benchmarks.longmemeval_v2_release_inputs import (
+    StagePlanError,
+    load_json,
+    require_exact_keys,
+    require_source_identity,
+    require_string,
+    sha256_file,
+)
+from tools.bench import longmemeval_v2_artifact_bridge as bridge
+from tools.bench import longmemeval_v2_rig as rig
+
+DISPATCH_PLAN_SCHEMA_VERSION = "sibyl-longmemeval-v2-ci-dispatch-plan-v1"
+RUN_MAP_SCHEMA_VERSION = "sibyl-longmemeval-v2-ci-run-map-v1"
+BUNDLE_MANIFEST_SCHEMA_VERSION = "sibyl-longmemeval-v2-ci-aa-bundle-v1"
+PASS_SEEDS = {"aa-1": 1301, "aa-2": 1302, "aa-3": 1303}
+ARM_IDS = tuple(f"{pass_id}-{side}" for pass_id in PASS_SEEDS for side in ("left", "right"))
+BUILDER_ARM_ID = "aa-1-left"
+RUN_ID_PATTERN = re.compile(r"^[1-9][0-9]*$")
+ORCHESTRATION_ID_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$")
+
+
+def _runtime() -> dict[str, Any]:
+    return {
+        "api_url": "http://127.0.0.1:3334/api",
+        "allow_localhost": True,
+        **contract.RELEASE_RUNTIME_PINS,
+    }
+
+
+def _manifest(*, experiment_id: str, pass_id: str, seed: int) -> dict[str, Any]:
+    return {
+        "experiment_id": experiment_id,
+        "experiment_phase": "aa",
+        "pass_id": pass_id,
+        "pass_seed": seed,
+        "arm_role": "machine",
+        "substrate": "machine",
+        "preregistration_sha256": "",
+        "max_spend_usd": contract.RELEASE_ROLE_CAPS_USD["machine"],
+        "retrieval_mode": "fast",
+        "max_context_total_chars": contract.BASE_CONTEXT_TOTAL_CHARS,
+        "operational_note_dedupe_mode": "source",
+        "operational_note_lane_mode": "reserved",
+        "operational_note_distillation_profile": "baseline",
+        "render_group_lanes": False,
+        "render_action_spines": False,
+        "configuration": {
+            "retrieval_mode": "fast",
+            "max_context_chars_per_item": contract.RELEASE_RUNTIME_PINS[
+                "max_context_chars_per_item"
+            ],
+            "operational_note_dedupe_mode": "source",
+            "operational_note_lane_mode": "reserved",
+            "operational_note_distillation_profile": "baseline",
+            "render_group_lanes": False,
+            "render_action_spines": False,
+        },
+        "geometry": {
+            "max_context_items": contract.MAX_CONTEXT_ITEMS,
+            "max_context_chars_per_item": contract.RELEASE_RUNTIME_PINS[
+                "max_context_chars_per_item"
+            ],
+            "max_context_total_chars": contract.BASE_CONTEXT_TOTAL_CHARS,
+        },
+    }
+
+
+def build_aa_stage_spec(experiment_id: str) -> dict[str, Any]:
+    """Build and validate the immutable initial A/A schedule used by CI."""
+
+    passes: list[dict[str, Any]] = []
+    for pass_id, seed in PASS_SEEDS.items():
+        arms = []
+        for side in ("left", "right"):
+            arm_id = f"{pass_id}-{side}"
+            arms.append(
+                {
+                    "arm_id": arm_id,
+                    "memory_source": ("build_baseline" if arm_id == BUILDER_ARM_ID else "baseline"),
+                    "manifest": _manifest(
+                        experiment_id=experiment_id,
+                        pass_id=pass_id,
+                        seed=seed,
+                    ),
+                }
+            )
+        passes.append({"kind": "paired", "pass_id": pass_id, "seed": seed, "arms": arms})
+    spec = {
+        "schema_version": contract.STAGE_SPEC_SCHEMA_VERSION,
+        "experiment_id": experiment_id,
+        "stage": "aa",
+        "mode": "initial",
+        "runtime": _runtime(),
+        "memory_roots": {"baseline": None, "render": None},
+        "upstream": {
+            "aa_authorization": None,
+            "preregistration_authorization": None,
+        },
+        "passes": passes,
+    }
+    return contract.require_stage_spec(spec)
+
+
+def _official_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    projected = deepcopy(manifest)
+    projected.pop("configuration")
+    projected.pop("geometry")
+    return projected
+
+
+def build_dispatch_plan(
+    *,
+    experiment_id: str,
+    orchestration_id: str,
+    source: dict[str, str],
+) -> dict[str, Any]:
+    """Return the exact six child workflow dispatches for initial A/A."""
+
+    if not ORCHESTRATION_ID_PATTERN.fullmatch(orchestration_id):
+        raise StagePlanError("CI orchestration ID is not path-safe")
+    validated_source = require_source_identity(source)
+    spec = build_aa_stage_spec(experiment_id)
+    arms = []
+    for pass_spec in spec["passes"]:
+        for arm in pass_spec["arms"]:
+            arm_id = str(arm["arm_id"])
+            arms.append(
+                {
+                    "arm_id": arm_id,
+                    "pass_id": pass_spec["pass_id"],
+                    "seed": pass_spec["seed"],
+                    "side": arm_id.rsplit("-", 1)[1],
+                    "memory_mode": "save" if arm_id == BUILDER_ARM_ID else "load",
+                    "official_arm_manifest_json": json.dumps(
+                        _official_manifest(arm["manifest"]),
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                }
+            )
+    payload = {
+        "schema_version": DISPATCH_PLAN_SCHEMA_VERSION,
+        "experiment_id": experiment_id,
+        "orchestration_id": orchestration_id,
+        "source": validated_source,
+        "builder_arm_id": BUILDER_ARM_ID,
+        "arms": arms,
+    }
+    payload["dispatch_plan_sha256"] = rig.canonical_sha256(payload)
+    return payload
+
+
+def require_run_map(raw: object) -> dict[str, Any]:
+    """Validate the controller's immutable mapping from arms to workflow runs."""
+
+    if not isinstance(raw, dict):
+        raise StagePlanError("CI run map is missing")
+    require_exact_keys(
+        raw,
+        frozenset(
+            {
+                "schema_version",
+                "experiment_id",
+                "orchestration_id",
+                "source",
+                "builder_run_id",
+                "runs",
+                "run_map_sha256",
+            }
+        ),
+        name="CI run map",
+    )
+    unsigned = {key: value for key, value in raw.items() if key != "run_map_sha256"}
+    if raw.get("schema_version") != RUN_MAP_SCHEMA_VERSION or raw.get(
+        "run_map_sha256"
+    ) != rig.canonical_sha256(unsigned):
+        raise StagePlanError("CI run map schema or digest is invalid")
+    require_string(raw.get("experiment_id"), name="CI run map experiment ID")
+    orchestration_id = require_string(
+        raw.get("orchestration_id"), name="CI run map orchestration ID"
+    )
+    if not ORCHESTRATION_ID_PATTERN.fullmatch(orchestration_id):
+        raise StagePlanError("CI run map orchestration ID is not path-safe")
+    source = require_source_identity(raw.get("source"))
+    runs = raw.get("runs")
+    if not isinstance(runs, dict) or tuple(runs) != ARM_IDS:
+        raise StagePlanError("CI run map arm order or membership is invalid")
+    if any(
+        not isinstance(run_id, str) or not RUN_ID_PATTERN.fullmatch(run_id)
+        for run_id in runs.values()
+    ):
+        raise StagePlanError("CI run map contains a non-canonical workflow run ID")
+    if len(set(runs.values())) != len(ARM_IDS):
+        raise StagePlanError("CI run map reused a workflow run ID")
+    if raw.get("builder_run_id") != runs[BUILDER_ARM_ID]:
+        raise StagePlanError("CI run map builder identity is inconsistent")
+    return {**raw, "source": source, "runs": dict(runs)}
+
+
+def _find_arm_run(root: Path, arm_id: str) -> Path:
+    arm_root = (root / arm_id).resolve()
+    if not arm_root.is_dir() or not arm_root.is_relative_to(root.resolve()):
+        raise StagePlanError(f"CI arm artifact root is missing: {arm_id}")
+    matches = sorted(arm_root.rglob("arm_run.json"))
+    if len(matches) != 1:
+        raise StagePlanError(f"CI arm artifact count is not exact: {arm_id}")
+    return matches[0]
+
+
+def aggregate_aa_bundle(
+    *,
+    artifacts_root: Path,
+    run_map_path: Path,
+    output_root: Path,
+) -> dict[str, Any]:
+    """Validate six child arms and publish one portable A/A evidence bundle."""
+
+    run_map = require_run_map(load_json(run_map_path))
+    artifacts = artifacts_root.resolve()
+    output = output_root.resolve()
+    if output.exists():
+        raise StagePlanError("CI A/A bundle output already exists")
+    arm_runs: dict[str, dict[str, Any]] = {}
+    for arm_id, expected_run_id in run_map["runs"].items():
+        arm = load_json(_find_arm_run(artifacts, arm_id))
+        execution = arm.get("execution")
+        if not isinstance(execution, dict):
+            raise StagePlanError(f"CI arm execution is missing: {arm_id}")
+        expected_identity = {
+            **run_map["source"],
+            "run_id": expected_run_id,
+        }
+        if any(execution.get(key) != value for key, value in expected_identity.items()):
+            raise StagePlanError(f"CI arm execution differs from its run map: {arm_id}")
+        if arm.get("experiment_id") != run_map["experiment_id"]:
+            raise StagePlanError(f"CI arm experiment differs from its run map: {arm_id}")
+        pass_id, side = arm_id.rsplit("-", 1)
+        expected_arm = {
+            "experiment_phase": "aa",
+            "pass_id": pass_id,
+            "seed": PASS_SEEDS[pass_id],
+            "name": "machine",
+            "substrate": "machine",
+            "preregistration_sha256": "",
+        }
+        if any(arm.get(key) != value for key, value in expected_arm.items()):
+            raise StagePlanError(f"CI arm differs from the fixed A/A schedule: {arm_id}")
+        if side not in {"left", "right"}:
+            raise StagePlanError(f"CI arm side is invalid: {arm_id}")
+        arm_runs[arm_id] = arm
+
+    paired: list[dict[str, Any]] = []
+    for pass_id in PASS_SEEDS:
+        paired.append(
+            bridge.build_paired_pass(
+                arm_runs[f"{pass_id}-left"],
+                arm_runs[f"{pass_id}-right"],
+            )
+        )
+    receipt = rig.build_aa_receipt(paired)
+
+    output.mkdir(parents=True)
+    passes_root = output / "passes"
+    passes_root.mkdir()
+    receipt_path = output / "aa_receipt.json"
+    release_io.write_json_once_atomic(receipt_path, receipt)
+    pass_bindings = []
+    for pass_id, payload in zip(PASS_SEEDS, paired, strict=True):
+        path = passes_root / f"{pass_id}.json"
+        release_io.write_json_once_atomic(path, payload)
+        pass_bindings.append(
+            {
+                "pass_id": pass_id,
+                "path": f"passes/{pass_id}.json",
+                "sha256": sha256_file(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+    release_io.write_json_once_atomic(output / "run_map.json", run_map)
+    manifest = {
+        "schema_version": BUNDLE_MANIFEST_SCHEMA_VERSION,
+        "experiment_id": run_map["experiment_id"],
+        "orchestration_id": run_map["orchestration_id"],
+        "source": run_map["source"],
+        "status": receipt["status"],
+        "aa_receipt": {
+            "path": "aa_receipt.json",
+            "sha256": sha256_file(receipt_path),
+            "size_bytes": receipt_path.stat().st_size,
+        },
+        "passes": pass_bindings,
+        "run_map": {
+            "path": "run_map.json",
+            "sha256": sha256_file(output / "run_map.json"),
+            "size_bytes": (output / "run_map.json").stat().st_size,
+        },
+    }
+    manifest["bundle_manifest_sha256"] = rig.canonical_sha256(manifest)
+    release_io.write_json_once_atomic(output / "bundle_manifest.json", manifest)
+    return manifest
+
+
+def _bound_bundle_file(root: Path, raw: object, *, name: str) -> Path:
+    if not isinstance(raw, dict):
+        raise StagePlanError(f"{name} binding is missing")
+    require_exact_keys(raw, frozenset({"path", "sha256", "size_bytes"}), name=name)
+    relative = Path(require_string(raw.get("path"), name=f"{name}.path"))
+    path = (root / relative).resolve()
+    if relative.is_absolute() or not path.is_relative_to(root):
+        raise StagePlanError(f"{name} escapes the CI bundle")
+    if (
+        not path.is_file()
+        or path.stat().st_size != raw.get("size_bytes")
+        or sha256_file(path) != raw.get("sha256")
+    ):
+        raise StagePlanError(f"{name} bytes differ from the CI bundle manifest")
+    return path
+
+
+def import_aa_bundle(*, bundle_root: Path, output: Path) -> dict[str, Any]:
+    """Rebind a downloaded CI bundle to canonical local artifact paths."""
+
+    root = bundle_root.expanduser().resolve()
+    manifest = load_json(root / "bundle_manifest.json")
+    require_exact_keys(
+        manifest,
+        frozenset(
+            {
+                "schema_version",
+                "experiment_id",
+                "orchestration_id",
+                "source",
+                "status",
+                "aa_receipt",
+                "passes",
+                "run_map",
+                "bundle_manifest_sha256",
+            }
+        ),
+        name="CI A/A bundle manifest",
+    )
+    unsigned = {key: value for key, value in manifest.items() if key != "bundle_manifest_sha256"}
+    if manifest.get("schema_version") != BUNDLE_MANIFEST_SCHEMA_VERSION or manifest.get(
+        "bundle_manifest_sha256"
+    ) != rig.canonical_sha256(unsigned):
+        raise StagePlanError("CI A/A bundle manifest schema or digest is invalid")
+    receipt_path = _bound_bundle_file(root, manifest.get("aa_receipt"), name="A/A receipt")
+    _bound_bundle_file(root, manifest.get("run_map"), name="CI run map")
+    raw_passes = manifest.get("passes")
+    if not isinstance(raw_passes, list) or [
+        item.get("pass_id") for item in raw_passes if isinstance(item, dict)
+    ] != list(PASS_SEEDS):
+        raise StagePlanError("CI A/A bundle pass order or membership is invalid")
+    pass_paths = []
+    for item in raw_passes:
+        assert isinstance(item, dict)
+        binding = {key: item.get(key) for key in ("path", "sha256", "size_bytes")}
+        pass_paths.append(
+            _bound_bundle_file(
+                root,
+                binding,
+                name=f"A/A paired pass {item['pass_id']}",
+            )
+        )
+    payload = authorization_package.package_aa_authorization(
+        receipt_path,
+        paired_pass_paths=pass_paths,
+    )
+    authorization_package.write_authorization(
+        output.expanduser().resolve(),
+        payload,
+        paid_output_root=root,
+    )
+    return payload
+
+
+def _write_stdout(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    plan = commands.add_parser("plan")
+    plan.add_argument("--experiment-id", required=True)
+    plan.add_argument("--orchestration-id", required=True)
+    plan.add_argument("--repository", required=True)
+    plan.add_argument("--ref", required=True)
+    plan.add_argument("--sha", required=True)
+    plan.add_argument("--output", required=True)
+    aggregate = commands.add_parser("aggregate")
+    aggregate.add_argument("--artifacts-root", required=True)
+    aggregate.add_argument("--run-map", required=True)
+    aggregate.add_argument("--output-root", required=True)
+    import_aa = commands.add_parser("import-aa")
+    import_aa.add_argument("--bundle-root", required=True)
+    import_aa.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command == "plan":
+        payload = build_dispatch_plan(
+            experiment_id=args.experiment_id,
+            orchestration_id=args.orchestration_id,
+            source={"repository": args.repository, "ref": args.ref, "sha": args.sha},
+        )
+        release_io.write_json_once_atomic(Path(args.output).resolve(), payload)
+    elif args.command == "aggregate":
+        payload = aggregate_aa_bundle(
+            artifacts_root=Path(args.artifacts_root),
+            run_map_path=Path(args.run_map),
+            output_root=Path(args.output_root),
+        )
+    else:
+        payload = import_aa_bundle(
+            bundle_root=Path(args.bundle_root),
+            output=Path(args.output),
+        )
+    _write_stdout(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/longmemeval_v2_release_ci.py
+++ b/benchmarks/longmemeval_v2_release_ci.py
@@ -391,7 +391,12 @@ def import_aa_bundle(*, bundle_root: Path, output: Path) -> dict[str, Any]:
     ) != rig.canonical_sha256(unsigned):
         raise StagePlanError("CI A/A bundle manifest schema or digest is invalid")
     receipt_path = _bound_bundle_file(root, manifest.get("aa_receipt"), name="A/A receipt")
-    _bound_bundle_file(root, manifest.get("run_map"), name="CI run map")
+    run_map_path = _bound_bundle_file(root, manifest.get("run_map"), name="CI run map")
+    run_map = require_run_map(load_json(run_map_path))
+    if any(
+        run_map[key] != manifest.get(key) for key in ("experiment_id", "orchestration_id", "source")
+    ):
+        raise StagePlanError("CI A/A bundle manifest differs from its run map")
     raw_passes = manifest.get("passes")
     if not isinstance(raw_passes, list) or [
         item.get("pass_id") for item in raw_passes if isinstance(item, dict)

--- a/docs/testing/longmemeval-v2.md
+++ b/docs/testing/longmemeval-v2.md
@@ -69,8 +69,9 @@ moon run bench-longmemeval-v2-release-ci -- \
   --output /absolute/path/to/aa-authorization.json
 ```
 
-The import command rechecks every file size and digest, validates the six distinct workflow
-executions, and rewrites only the local artifact paths. Keep the downloaded bundle with the
+The import command rechecks every file size and digest. It also validates the six distinct workflow
+executions, builder binding, source identity, experiment, and orchestration against the bundle
+manifest before rewriting only the local artifact paths. Keep the downloaded bundle with the
 generated authorization. Frozen database artifacts expire after seven days. The final A/A bundle and
 controller evidence remain available for 30 days.
 

--- a/docs/testing/longmemeval-v2.md
+++ b/docs/testing/longmemeval-v2.md
@@ -49,8 +49,9 @@ reader, evaluator, runtime geometry, and shared baseline identity. The builder u
 database separately from scored evidence. Consumer jobs validate its manifest and byte digests
 before restoring it.
 
-After the completion-triggered controller run succeeds, download and import its authoritative
-bundle. Replace the two run IDs with the dispatch run and completion-triggered run shown by GitHub:
+After the completion-triggered controller publishes the authoritative bundle, download and import
+it. Replace the two run IDs with the dispatch run and the completion-triggered run that owns the
+bundle:
 
 ```bash
 controller_run_id=<dispatch-run-id>

--- a/docs/testing/longmemeval-v2.md
+++ b/docs/testing/longmemeval-v2.md
@@ -15,11 +15,69 @@ The adapter writes trajectories through the live Sibyl API and queries `/api/sea
 gold answer from official query context before backend code can read it, and it never sees gold
 trajectory IDs.
 
-## v1.3 sealed local release experiment
+## v1.3 sealed release experiment
 
-The v1.3 release experiment runs locally from a clean `main` checkout. The release runner is the
-primary execution path for its paid Small-corpus evidence. The lower-level commands later in this
-page remain useful for development, but their outputs do not replace the sealed v1.3 stage receipts.
+The authoritative initial A/A stage runs in GitHub Actions. The `LongMemEval V2 Release A/A`
+workflow dispatches six separate paid workflow runs, builds one frozen baseline for the other five
+arms, and publishes one digest-bound bundle after all six runs pass. A completion-triggered job
+handles aggregation, so no controller job has to remain alive while the builder and consumers
+execute.
+
+The local release runner remains available for later stages and investigation. Its lower-level
+commands are also useful during development, but neither path replaces the sealed CI A/A receipt.
+
+### Run initial A/A in CI
+
+Set `OPENROUTER_API_KEY` and `OPENAI_API_KEY` as repository secrets. The paid child jobs use the
+`longmemeval-paid` environment. Approve the builder first, then approve the five consumers after the
+builder publishes the frozen web and enterprise databases.
+
+Dispatch from the exact `main` commit under evaluation:
+
+```bash
+git fetch origin main
+source_sha="$(git rev-parse origin/main)"
+gh workflow run longmemeval-v2-release-aa.yml \
+  --ref main \
+  -f experiment_id=sibyl-v1.3-aa \
+  -f source_sha="$source_sha"
+```
+
+The controller rejects a non-`main` ref or a requested SHA that differs from its checkout. The six
+child runs bind their workflow run IDs, source SHA, fixed A/A seeds, official dataset revision,
+reader, evaluator, runtime geometry, and shared baseline identity. The builder uploads each frozen
+database separately from scored evidence. Consumer jobs validate its manifest and byte digests
+before restoring it.
+
+After the completion-triggered controller run succeeds, download and import its authoritative
+bundle. Replace the two run IDs with the dispatch run and completion-triggered run shown by GitHub:
+
+```bash
+controller_run_id=<dispatch-run-id>
+aggregation_run_id=<completion-triggered-run-id>
+bundle_root="/absolute/path/to/v1.3-aa-ci-bundle"
+
+gh run download "$aggregation_run_id" \
+  --repo hyperb1iss/sibyl \
+  --name "longmemeval-v2-release-aa-${source_sha}-${controller_run_id}" \
+  --dir "$bundle_root"
+
+moon run bench-longmemeval-v2-release-ci -- \
+  import-aa \
+  --bundle-root "$bundle_root" \
+  --output /absolute/path/to/aa-authorization.json
+```
+
+The import command rechecks every file size and digest, validates the six distinct workflow
+executions, and rewrites only the local artifact paths. Keep the downloaded bundle with the
+generated authorization. Frozen database artifacts expire after seven days. The final A/A bundle and
+controller evidence remain available for 30 days.
+
+If a child run fails, preserve its diagnostics and rerun the controller with a new experiment ID. Do
+not mix successful arms from separate controller runs. The run map and bundle validator reject that
+splice.
+
+### Run a local sealed stage
 
 Do not generate a paid plan from a feature branch. Merge the runner first, create a clean checkout
 of `main`, fetch the remote, and confirm that local `main` and `origin/main` name the same commit.

--- a/moon.yml
+++ b/moon.yml
@@ -635,6 +635,7 @@ tasks:
       benchmarks/longmemeval_v2_official_source.py
       benchmarks/longmemeval_v2_release_authorization.py
       benchmarks/longmemeval_v2_release_authorization_package.py
+      benchmarks/longmemeval_v2_release_ci.py
       benchmarks/longmemeval_v2_release_cli.py
       benchmarks/longmemeval_v2_release_contract.py
       benchmarks/longmemeval_v2_release_evidence.py
@@ -691,6 +692,7 @@ tasks:
       - benchmarks/longmemeval_v2_official_source.py
       - benchmarks/longmemeval_v2_release_authorization.py
       - benchmarks/longmemeval_v2_release_authorization_package.py
+      - benchmarks/longmemeval_v2_release_ci.py
       - benchmarks/longmemeval_v2_release_cli.py
       - benchmarks/longmemeval_v2_release_contract.py
       - benchmarks/longmemeval_v2_release_evidence.py

--- a/moon.yml
+++ b/moon.yml
@@ -1045,6 +1045,7 @@ tasks:
       - tools/**/*.py
       - .github/workflows/eval.yml
       - .github/workflows/longmemeval-v2.yml
+      - .github/workflows/longmemeval-v2-release-aa.yml
       - benchmarks/context_pack_eval.py
       - benchmarks/compare_eval_reports.py
       - benchmarks/git_provenance.py
@@ -1788,6 +1789,8 @@ tasks:
     command:
       uv run pytest tools/tests/test_longmemeval_v2_release_ci.py -v
     inputs:
+      - .github/workflows/longmemeval-v2.yml
+      - .github/workflows/longmemeval-v2-release-aa.yml
       - benchmarks/longmemeval_v2_release_ci.py
       - benchmarks/longmemeval_v2_release_authorization*.py
       - benchmarks/longmemeval_v2_release_contract.py

--- a/moon.yml
+++ b/moon.yml
@@ -347,6 +347,7 @@ tasks:
       benchmarks/local_execution_identity.py benchmarks/longmemeval_v2_official_source.py
       benchmarks/longmemeval_v2_release_authorization.py
       benchmarks/longmemeval_v2_release_authorization_package.py
+      benchmarks/longmemeval_v2_release_ci.py
       benchmarks/longmemeval_v2_release_cli.py
       benchmarks/longmemeval_v2_release_contract.py
       benchmarks/longmemeval_v2_release_evidence.py
@@ -399,6 +400,7 @@ tasks:
       benchmarks/local_execution_identity.py benchmarks/longmemeval_v2_official_source.py
       benchmarks/longmemeval_v2_release_authorization.py
       benchmarks/longmemeval_v2_release_authorization_package.py
+      benchmarks/longmemeval_v2_release_ci.py
       benchmarks/longmemeval_v2_release_cli.py
       benchmarks/longmemeval_v2_release_contract.py
       benchmarks/longmemeval_v2_release_evidence.py
@@ -454,6 +456,7 @@ tasks:
       - benchmarks/longmemeval_v2_official_source.py
       - benchmarks/longmemeval_v2_release_authorization.py
       - benchmarks/longmemeval_v2_release_authorization_package.py
+      - benchmarks/longmemeval_v2_release_ci.py
       - benchmarks/longmemeval_v2_release_cli.py
       - benchmarks/longmemeval_v2_release_contract.py
       - benchmarks/longmemeval_v2_release_evidence.py
@@ -516,6 +519,7 @@ tasks:
       benchmarks/local_execution_identity.py benchmarks/longmemeval_v2_official_source.py
       benchmarks/longmemeval_v2_release_authorization.py
       benchmarks/longmemeval_v2_release_authorization_package.py
+      benchmarks/longmemeval_v2_release_ci.py
       benchmarks/longmemeval_v2_release_cli.py
       benchmarks/longmemeval_v2_release_contract.py
       benchmarks/longmemeval_v2_release_evidence.py
@@ -569,6 +573,7 @@ tasks:
       - benchmarks/longmemeval_v2_official_source.py
       - benchmarks/longmemeval_v2_release_authorization.py
       - benchmarks/longmemeval_v2_release_authorization_package.py
+      - benchmarks/longmemeval_v2_release_ci.py
       - benchmarks/longmemeval_v2_release_cli.py
       - benchmarks/longmemeval_v2_release_contract.py
       - benchmarks/longmemeval_v2_release_evidence.py
@@ -1035,6 +1040,7 @@ tasks:
       tools/tests/test_longmemeval_v2_release_fd_lifecycle.py -v
       tools/tests/test_longmemeval_v2_release_transaction.py -v
       tools/tests/test_longmemeval_v2_release_cli.py -v
+      tools/tests/test_longmemeval_v2_release_ci.py -v
     inputs:
       - tools/**/*.py
       - .github/workflows/eval.yml
@@ -1051,6 +1057,7 @@ tasks:
       - benchmarks/longmemeval_v2_official_source.py
       - benchmarks/longmemeval_v2_release_authorization.py
       - benchmarks/longmemeval_v2_release_authorization_package.py
+      - benchmarks/longmemeval_v2_release_ci.py
       - benchmarks/longmemeval_v2_release_cli.py
       - benchmarks/longmemeval_v2_release_contract.py
       - benchmarks/longmemeval_v2_release_evidence.py
@@ -1758,6 +1765,38 @@ tasks:
       - benchmarks/longmemeval_v2_release_assets/SYSTEM_DESCRIPTION.md
       - benchmarks/longmemeval_v2_memory/**/*.py
       - tools/bench/longmemeval_v2_*.py
+      - pyproject.toml
+    options:
+      cache: false
+
+  bench-longmemeval-v2-release-ci:
+    command:
+      uv run python -m benchmarks.longmemeval_v2_release_ci
+    inputs:
+      - benchmarks/longmemeval_v2_release_ci.py
+      - benchmarks/longmemeval_v2_release_authorization*.py
+      - benchmarks/longmemeval_v2_release_contract.py
+      - benchmarks/longmemeval_v2_release_inputs.py
+      - benchmarks/longmemeval_v2_release_io.py
+      - tools/bench/longmemeval_v2_artifact_bridge.py
+      - tools/bench/longmemeval_v2_rig.py
+      - pyproject.toml
+    options:
+      cache: false
+
+  bench-longmemeval-v2-release-ci-test:
+    command:
+      uv run pytest tools/tests/test_longmemeval_v2_release_ci.py -v
+    inputs:
+      - benchmarks/longmemeval_v2_release_ci.py
+      - benchmarks/longmemeval_v2_release_authorization*.py
+      - benchmarks/longmemeval_v2_release_contract.py
+      - benchmarks/longmemeval_v2_release_inputs.py
+      - benchmarks/longmemeval_v2_release_io.py
+      - tools/bench/longmemeval_v2_artifact_bridge.py
+      - tools/bench/longmemeval_v2_rig.py
+      - tools/tests/test_longmemeval_v2_release_ci.py
+      - tools/tests/test_longmemeval_v2_rig.py
       - pyproject.toml
     options:
       cache: false

--- a/tools/tests/test_longmemeval_v2_release_ci.py
+++ b/tools/tests/test_longmemeval_v2_release_ci.py
@@ -237,6 +237,7 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
         'workflows: ["LongMemEval V2"]',
         'orchestration_id="aa-${GITHUB_RUN_ID}"',
         "endsWith(github.event.workflow_run.display_title, ' aa-1-left')",
+        "endsWith(github.event.workflow_run.display_title, ' aa-1-right')",
         "endsWith(github.event.workflow_run.display_title, ' aa-3-right')",
         "dispatch_arm aa-1-left save",
         "Dispatch five frozen baseline consumers",
@@ -249,6 +250,8 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
         "run-map",
         "aggregate",
         "longmemeval-v2-release-aa-run-map-",
+        'dispatcher_run_id="$(sort -n <<< "$dispatcher_runs" | tail -1)"',
+        'echo "ready=false" >> "$GITHUB_OUTPUT"',
         "Recover sealed controller state",
         "Upload authoritative A/A bundle",
     ):
@@ -257,3 +260,4 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
     assert controller.index("Upload sealed controller plan") < controller.index(
         "Dispatch the frozen baseline builder"
     )
+    assert "Waiting for ${pending} of 6 paid arms." not in controller

--- a/tools/tests/test_longmemeval_v2_release_ci.py
+++ b/tools/tests/test_longmemeval_v2_release_ci.py
@@ -172,6 +172,43 @@ def test_import_rejects_tampered_download(tmp_path: Path) -> None:
         )
 
 
+def test_aggregate_rejects_arm_run_id_outside_the_run_map(tmp_path: Path) -> None:
+    passes = _paired_passes()
+    artifacts = tmp_path / "artifacts"
+    for paired in passes:
+        for side in ("left", "right"):
+            arm_id = f"{paired['pass_id']}-{side}"
+            arm = paired["arms"][side]
+            if arm_id == "aa-2-right":
+                arm["execution"]["run_id"] = "999999"
+            _write_json(artifacts / arm_id / "arm_run.json", arm)
+    run_map_path = tmp_path / "run-map.json"
+    _write_json(run_map_path, _run_map(_paired_passes()))
+
+    with pytest.raises(StagePlanError, match="execution differs from its run map"):
+        release_ci.aggregate_aa_bundle(
+            artifacts_root=artifacts,
+            run_map_path=run_map_path,
+            output_root=tmp_path / "bundle",
+        )
+
+
+def test_import_rejects_bundle_path_traversal(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    manifest_path = bundle / "bundle_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["passes"][0]["path"] = "../aa-1.json"
+    unsigned = {key: value for key, value in manifest.items() if key != "bundle_manifest_sha256"}
+    manifest["bundle_manifest_sha256"] = rig.canonical_sha256(unsigned)
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(StagePlanError, match="escapes the CI bundle"):
+        release_ci.import_aa_bundle(
+            bundle_root=bundle,
+            output=tmp_path / "aa-authorization.json",
+        )
+
+
 def test_release_workflows_preserve_distributed_execution_contract() -> None:
     child = (REPO_ROOT / ".github/workflows/longmemeval-v2.yml").read_text(encoding="utf-8")
     controller = (REPO_ROOT / ".github/workflows/longmemeval-v2-release-aa.yml").read_text(
@@ -190,6 +227,7 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
         "--load-memory-dir",
         "database_snapshot_manifest.json",
         "longmemeval-v2-frozen-memory-",
+        "Sibyl services did not stop before the database snapshot",
         "github-token: ${{ github.token }}",
         "${{ github.run_id }}",
     ):
@@ -197,16 +235,25 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
     for fragment in (
         "actions: write",
         'workflows: ["LongMemEval V2"]',
+        'orchestration_id="aa-${GITHUB_RUN_ID}"',
+        "endsWith(github.event.workflow_run.display_title, ' aa-1-left')",
         "endsWith(github.event.workflow_run.display_title, ' aa-3-right')",
         "dispatch_arm aa-1-left save",
-        'dispatch_arm "$arm_id" load "$builder_run_id"',
+        "Dispatch five frozen baseline consumers",
+        'memory_mode: "load"',
+        "Reusing child workflow",
         'official_ci_context_json="$ci_context"',
         'official_dataset_revision="$OFFICIAL_DATASET_REVISION"',
         "official_reader_model=qwen/qwen3.5-9b",
         "official_evaluator_model=gpt-5.2",
         "run-map",
         "aggregate",
+        "longmemeval-v2-release-aa-run-map-",
         "Recover sealed controller state",
         "Upload authoritative A/A bundle",
     ):
         assert fragment in controller
+    assert "gh run watch" not in child
+    assert controller.index("Upload sealed controller plan") < controller.index(
+        "Dispatch the frozen baseline builder"
+    )

--- a/tools/tests/test_longmemeval_v2_release_ci.py
+++ b/tools/tests/test_longmemeval_v2_release_ci.py
@@ -16,6 +16,8 @@ from tools.tests.test_longmemeval_v2_rig import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+DISPATCHING_JOB_COUNT = 2
+CONTROLLER_ACCEPTANCE_GATE_COUNT = 2
 
 
 @pytest.fixture(autouse=True)
@@ -172,6 +174,32 @@ def test_import_rejects_tampered_download(tmp_path: Path) -> None:
         )
 
 
+def test_import_rejects_self_consistent_run_map_splice(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    run_map_path = bundle / "run_map.json"
+    run_map = json.loads(run_map_path.read_text(encoding="utf-8"))
+    run_map["source"]["sha"] = "b" * 40
+    unsigned_run_map = {key: value for key, value in run_map.items() if key != "run_map_sha256"}
+    run_map["run_map_sha256"] = rig.canonical_sha256(unsigned_run_map)
+    _write_json(run_map_path, run_map)
+
+    manifest_path = bundle / "bundle_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["run_map"]["sha256"] = release_ci.sha256_file(run_map_path)
+    manifest["run_map"]["size_bytes"] = run_map_path.stat().st_size
+    unsigned_manifest = {
+        key: value for key, value in manifest.items() if key != "bundle_manifest_sha256"
+    }
+    manifest["bundle_manifest_sha256"] = rig.canonical_sha256(unsigned_manifest)
+    _write_json(manifest_path, manifest)
+
+    with pytest.raises(StagePlanError, match="manifest differs from its run map"):
+        release_ci.import_aa_bundle(
+            bundle_root=bundle,
+            output=tmp_path / "aa-authorization.json",
+        )
+
+
 def test_aggregate_rejects_arm_run_id_outside_the_run_map(tmp_path: Path) -> None:
     passes = _paired_passes()
     artifacts = tmp_path / "artifacts"
@@ -233,6 +261,7 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
     ):
         assert fragment in child
     for fragment in (
+        "actions: read",
         "actions: write",
         'workflows: ["LongMemEval V2"]',
         'orchestration_id="aa-${GITHUB_RUN_ID}"',
@@ -256,6 +285,11 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
         "Upload authoritative A/A bundle",
     ):
         assert fragment in controller
+    assert controller.count("actions: write") == DISPATCHING_JOB_COUNT
+    assert (
+        controller.count('(.conclusion | IN("success", "failure"))')
+        == CONTROLLER_ACCEPTANCE_GATE_COUNT
+    )
     assert "gh run watch" not in child
     assert controller.index("Upload sealed controller plan") < controller.index(
         "Dispatch the frozen baseline builder"

--- a/tools/tests/test_longmemeval_v2_release_ci.py
+++ b/tools/tests/test_longmemeval_v2_release_ci.py
@@ -15,6 +15,8 @@ from tools.tests.test_longmemeval_v2_rig import (
     _paired_pass,
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 @pytest.fixture(autouse=True)
 def _use_synthetic_official_corpus(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -124,6 +126,24 @@ def test_run_map_rejects_reused_workflow_execution() -> None:
         release_ci.require_run_map(run_map)
 
 
+def test_run_map_binds_the_exact_dispatch_plan() -> None:
+    dispatch = release_ci.build_dispatch_plan(
+        experiment_id="experiment-v1.3",
+        orchestration_id="release-aa-test",
+        source={
+            "repository": "hyperb1iss/sibyl",
+            "ref": "refs/heads/main",
+            "sha": "a" * 40,
+        },
+    )
+    runs = {arm_id: str(index) for index, arm_id in enumerate(release_ci.ARM_IDS, start=1)}
+
+    run_map = release_ci.build_run_map(dispatch_plan=dispatch, runs=runs)
+
+    assert run_map["builder_run_id"] == "1"
+    assert run_map["runs"] == runs
+
+
 def test_aggregate_and_import_publish_portable_authority(tmp_path: Path) -> None:
     bundle = _bundle(tmp_path)
     output = tmp_path / "aa-authorization.json"
@@ -150,3 +170,43 @@ def test_import_rejects_tampered_download(tmp_path: Path) -> None:
             bundle_root=bundle,
             output=tmp_path / "aa-authorization.json",
         )
+
+
+def test_release_workflows_preserve_distributed_execution_contract() -> None:
+    child = (REPO_ROOT / ".github/workflows/longmemeval-v2.yml").read_text(encoding="utf-8")
+    controller = (REPO_ROOT / ".github/workflows/longmemeval-v2-release-aa.yml").read_text(
+        encoding="utf-8"
+    )
+
+    for fragment in (
+        "official_ci_context_json:",
+        '"memory_source_run_id"',
+        "needs: [official-preflight, official-memory-source]",
+        "environment: longmemeval-paid",
+        "SIBYL_GRAPH_EMBEDDING_PROVIDER: local",
+        "SIBYL_COORDINATION_BACKEND: redis",
+        "sentence-transformers/all-MiniLM-L6-v2",
+        "--save-memory --checkpoint-dir",
+        "--load-memory-dir",
+        "database_snapshot_manifest.json",
+        "longmemeval-v2-frozen-memory-",
+        "github-token: ${{ github.token }}",
+        "${{ github.run_id }}",
+    ):
+        assert fragment in child
+    for fragment in (
+        "actions: write",
+        'workflows: ["LongMemEval V2"]',
+        "endsWith(github.event.workflow_run.display_title, ' aa-3-right')",
+        "dispatch_arm aa-1-left save",
+        'dispatch_arm "$arm_id" load "$builder_run_id"',
+        'official_ci_context_json="$ci_context"',
+        'official_dataset_revision="$OFFICIAL_DATASET_REVISION"',
+        "official_reader_model=qwen/qwen3.5-9b",
+        "official_evaluator_model=gpt-5.2",
+        "run-map",
+        "aggregate",
+        "Recover sealed controller state",
+        "Upload authoritative A/A bundle",
+    ):
+        assert fragment in controller

--- a/tools/tests/test_longmemeval_v2_release_ci.py
+++ b/tools/tests/test_longmemeval_v2_release_ci.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from benchmarks import longmemeval_v2_release_ci as release_ci
+from benchmarks import longmemeval_v2_release_contract as contract
+from benchmarks.longmemeval_v2_release_inputs import StagePlanError
+from tools.bench import longmemeval_v2_rig as rig
+from tools.tests.test_longmemeval_v2_rig import (
+    QUESTION_COUNT_PER_DOMAIN,
+    _arm,
+    _paired_pass,
+)
+
+
+@pytest.fixture(autouse=True)
+def _use_synthetic_official_corpus(monkeypatch: pytest.MonkeyPatch) -> None:
+    question_ids = {
+        domain: [f"{domain}-{index}" for index in range(QUESTION_COUNT_PER_DOMAIN)]
+        for domain in rig.DOMAINS
+    }
+    monkeypatch.setattr(
+        rig,
+        "OFFICIAL_SMALL_QUESTION_COUNTS",
+        {domain: len(ids) for domain, ids in question_ids.items()},
+    )
+    monkeypatch.setattr(
+        rig,
+        "OFFICIAL_SMALL_QUESTION_IDS_SHA256",
+        {domain: rig.canonical_sha256(sorted(ids)) for domain, ids in question_ids.items()},
+    )
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _run_map(passes: list[dict[str, Any]]) -> dict[str, Any]:
+    runs = {
+        f"{paired['pass_id']}-{side}": paired["arms"][side]["execution"]["run_id"]
+        for paired in passes
+        for side in ("left", "right")
+    }
+    payload = {
+        "schema_version": release_ci.RUN_MAP_SCHEMA_VERSION,
+        "experiment_id": "experiment-v1.3",
+        "orchestration_id": "release-aa-test",
+        "source": {
+            "repository": "hyperb1iss/sibyl",
+            "ref": "refs/heads/main",
+            "sha": "a" * 40,
+        },
+        "builder_run_id": runs[release_ci.BUILDER_ARM_ID],
+        "runs": runs,
+    }
+    payload["run_map_sha256"] = rig.canonical_sha256(payload)
+    return payload
+
+
+def _paired_passes() -> list[dict[str, Any]]:
+    return [
+        _paired_pass(
+            pass_id,
+            seed=seed,
+            left=_arm("machine", mode="fast", accuracy=0.7),
+            right=_arm("machine", mode="fast", accuracy=0.7),
+        )
+        for pass_id, seed in release_ci.PASS_SEEDS.items()
+    ]
+
+
+def _bundle(tmp_path: Path) -> Path:
+    passes = _paired_passes()
+    artifacts = tmp_path / "artifacts"
+    for paired in passes:
+        for side in ("left", "right"):
+            arm_id = f"{paired['pass_id']}-{side}"
+            _write_json(artifacts / arm_id / "arm_run.json", paired["arms"][side])
+    run_map_path = tmp_path / "run-map.json"
+    _write_json(run_map_path, _run_map(passes))
+    bundle = tmp_path / "bundle"
+    release_ci.aggregate_aa_bundle(
+        artifacts_root=artifacts,
+        run_map_path=run_map_path,
+        output_root=bundle,
+    )
+    return bundle
+
+
+def test_dispatch_plan_matches_the_fixed_release_contract() -> None:
+    payload = release_ci.build_dispatch_plan(
+        experiment_id="sibyl-v1.3-ci-aa",
+        orchestration_id="release-aa-123",
+        source={
+            "repository": "hyperb1iss/sibyl",
+            "ref": "refs/heads/main",
+            "sha": "a" * 40,
+        },
+    )
+
+    assert [arm["arm_id"] for arm in payload["arms"]] == list(release_ci.ARM_IDS)
+    assert payload["arms"][0]["memory_mode"] == "save"
+    assert all(arm["memory_mode"] == "load" for arm in payload["arms"][1:])
+    assert [arm["seed"] for arm in payload["arms"]] == [1301, 1301, 1302, 1302, 1303, 1303]
+    for arm in payload["arms"]:
+        manifest = json.loads(arm["official_arm_manifest_json"])
+        assert manifest["max_spend_usd"] == contract.RELEASE_ROLE_CAPS_USD["machine"]
+        assert "configuration" not in manifest
+        assert "geometry" not in manifest
+
+
+def test_run_map_rejects_reused_workflow_execution() -> None:
+    passes = _paired_passes()
+    run_map = _run_map(passes)
+    run_map["runs"]["aa-1-right"] = run_map["runs"]["aa-1-left"]
+    unsigned = {key: value for key, value in run_map.items() if key != "run_map_sha256"}
+    run_map["run_map_sha256"] = rig.canonical_sha256(unsigned)
+
+    with pytest.raises(StagePlanError, match="reused a workflow run ID"):
+        release_ci.require_run_map(run_map)
+
+
+def test_aggregate_and_import_publish_portable_authority(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    output = tmp_path / "aa-authorization.json"
+
+    authority = release_ci.import_aa_bundle(bundle_root=bundle, output=output)
+
+    assert output.is_file()
+    assert authority["status"] == "PASS"
+    assert Path(authority["source_receipt"]["path"]) == bundle / "aa_receipt.json"
+    assert [Path(item["paired_pass_artifact"]["path"]).name for item in authority["passes"]] == [
+        "aa-1.json",
+        "aa-2.json",
+        "aa-3.json",
+    ]
+
+
+def test_import_rejects_tampered_download(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    with (bundle / "passes" / "aa-2.json").open("a", encoding="utf-8") as handle:
+        handle.write("\n")
+
+    with pytest.raises(StagePlanError, match="bytes differ"):
+        release_ci.import_aa_bundle(
+            bundle_root=bundle,
+            output=tmp_path / "aa-authorization.json",
+        )

--- a/tools/tests/test_longmemeval_v2_release_ci.py
+++ b/tools/tests/test_longmemeval_v2_release_ci.py
@@ -264,10 +264,13 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
         "actions: read",
         "actions: write",
         'workflows: ["LongMemEval V2"]',
+        "identify-workflow-run:",
+        "needs: identify-workflow-run",
+        "needs.identify-workflow-run.outputs.orchestration_id",
         'orchestration_id="aa-${GITHUB_RUN_ID}"',
-        "endsWith(github.event.workflow_run.display_title, ' aa-1-left')",
-        "endsWith(github.event.workflow_run.display_title, ' aa-1-right')",
-        "endsWith(github.event.workflow_run.display_title, ' aa-3-right')",
+        "needs.identify-workflow-run.outputs.arm_id == 'aa-1-left'",
+        "needs.identify-workflow-run.outputs.arm_id == 'aa-1-right'",
+        "needs.identify-workflow-run.outputs.arm_id == 'aa-3-right'",
         "dispatch_arm aa-1-left save",
         "Dispatch five frozen baseline consumers",
         'memory_mode: "load"',
@@ -286,6 +289,8 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
     ):
         assert fragment in controller
     assert controller.count("actions: write") == DISPATCHING_JOB_COUNT
+    assert "github.event.workflow_run.head_sha }}\n  cancel-in-progress" not in controller
+    assert controller.count("needs: identify-workflow-run") == 2
     assert (
         controller.count('(.conclusion | IN("success", "failure"))')
         == CONTROLLER_ACCEPTANCE_GATE_COUNT

--- a/tools/tests/test_longmemeval_v2_release_ci.py
+++ b/tools/tests/test_longmemeval_v2_release_ci.py
@@ -18,6 +18,7 @@ from tools.tests.test_longmemeval_v2_rig import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DISPATCHING_JOB_COUNT = 2
 CONTROLLER_ACCEPTANCE_GATE_COUNT = 2
+IDENTITY_CONSUMER_JOB_COUNT = 2
 
 
 @pytest.fixture(autouse=True)
@@ -290,7 +291,7 @@ def test_release_workflows_preserve_distributed_execution_contract() -> None:
         assert fragment in controller
     assert controller.count("actions: write") == DISPATCHING_JOB_COUNT
     assert "github.event.workflow_run.head_sha }}\n  cancel-in-progress" not in controller
-    assert controller.count("needs: identify-workflow-run") == 2
+    assert controller.count("needs: identify-workflow-run") == IDENTITY_CONSUMER_JOB_COUNT
     assert (
         controller.count('(.conclusion | IN("success", "failure"))')
         == CONTROLLER_ACCEPTANCE_GATE_COUNT


### PR DESCRIPTION
# 🎯 LongMemEval V2 release evidence, executed in CI

> Moves the v1.3 A/A release evaluation from one long-lived laptop process to a sealed, resumable GitHub Actions graph.
> The paid path remains dark until a reviewer approves the `longmemeval-paid` environment.

## 💡 What this is

The release A/A run is six independent paid evaluations against one frozen
baseline. One GitHub-hosted job cannot safely own that entire lifecycle, so
this change gives each arm its own run and carries authority through signed-off
JSON manifests and artifact hashes.

The controller starts one builder arm. A completion event validates its frozen
SurrealDB snapshot before dispatching the five consumers. Later completion
events aggregate the six scored artifacts into one portable release bundle.

## 🤔 Why we need it and what it replaces

The local runner proved the evaluation path, but the complete A/A exceeds a
reasonable interactive laptop session. Keeping one Actions job alive while
five sibling runs finish would also collide with hosted job limits and waste
runner time.

The new path uses short event-driven stages. Each stage can be retried without
duplicating paid runs, and the final bundle can be imported locally without
trusting the machine that downloaded it.

No paid evaluation runs automatically on pushes or pull requests. The release
controller only accepts `main`, requires an exact source SHA, and enters the
existing protected `longmemeval-paid` environment before any model-backed work.

## 🎯 The review anchor

Anchor on one property: every accepted artifact must resolve to the same source
SHA, sealed six-arm schedule, builder snapshot, experiment identity, and unique
GitHub run ID. Missing, duplicate, stale, or mismatched evidence fails closed.

## 🛠️ How it works

```mermaid
flowchart LR
    C[Manual controller on main] --> P[Seal six-arm plan]
    P --> B[Builder: aa-1-left]
    B --> S[Freeze SurrealDB snapshot]
    S --> D[Completion event validates builder]
    D --> R[Dispatch five consumers]
    R --> A[Completion events check readiness]
    A -->|all six successful| E[Seal portable A/A bundle]
    E --> I[Local import validates hashes and provenance]
```

1. The release controller in
   `.github/workflows/longmemeval-v2-release-aa.yml` seals the schedule before
   dispatch and assigns the stable orchestration ID `aa-${GITHUB_RUN_ID}`.
2. The builder path in `.github/workflows/longmemeval-v2.yml` executes both
   domains, stops the writers cleanly, freezes the RocksDB directory, and
   records the snapshot size and SHA-256 alongside the memory manifest.
3. A sealed identity job resolves the controller run and arm before scheduling
   event handlers. The consumer dispatcher validates the successful builder
   event, reuses any exact existing child runs during retries, and dispatches
   only missing arms.
4. Each consumer restores the frozen database into its own runner, validates
   archive containment and hashes, then scores its assigned schedule arm.
5. The aggregator performs one readiness check per completion event. The first
   event that observes six successful arms validates the full run map and
   publishes the authoritative bundle with overwrite-safe retry behavior.
6. The helper in `benchmarks/longmemeval_v2_release_ci.py` owns plan generation,
   run-map validation, aggregation, and local import. Focused tests pin malformed
   archives, source mismatches, duplicate arms, and incomplete schedules.

## 🚦 Release operation

After merge, dispatch `LongMemEval V2 Release A/A` from `main` with the exact
release SHA. Approve the builder, then approve the five consumer runs after the
builder snapshot has passed validation. Download the final artifact and run the
documented `import-aa` command to produce the local authorization receipt.

The workflow is safe to stop before either approval. No paid run was dispatched
while developing this change.

## 🔁 What changed after automated review

CodeRabbit identified three release blockers and one permission-scope issue.
The final patch now accepts the same completed controller outcomes in both
recovery stages, semantically validates the bundled run map during local
import, and limits `actions: write` to the two jobs that dispatch child
workflows.

Workflow-run handlers no longer share a source-SHA concurrency group. The
sealed identity job parses the orchestration and arm before job scheduling,
then dispatch and aggregation serialize only within that orchestration.
Independent evaluations of the same SHA therefore cannot cancel each other.

The import regression suite now includes a self-consistent source splice. The
tampered bundle recomputes both digests and still fails on the identity mismatch.

## 🧪 Validation

- `actionlint .github/workflows/longmemeval-v2.yml .github/workflows/longmemeval-v2-release-aa.yml` → clean
- `moon run root:inventory-lint` → 215 files formatted and lint-clean
- `moon run root:inventory-typecheck` → passed
- `moon run root:release-workflow-test` → 59 passed
- `moon run root:bench-gate-test` → 873 passed
- `moon run docs:lint` → passed
- `moon run root:doc-claim-gate-test` → 10 passed
- Focused release helper suite → 9 passed
- `git diff --check` → clean
- Independent adversarial review → PASS

The paid six-arm evaluation is intentionally not part of PR validation. The
protected environment and manual controller are the execution gate after merge.

## 🔍 What reviewers should focus on

- The authority chain across controller, builder, consumer dispatcher, and
  aggregator events.
- Retry idempotency when GitHub redelivers a successful completion event.
- Frozen RocksDB archive validation and path containment before extraction.
- The distinction between scored evidence artifacts and the multi-gigabyte
  frozen baseline artifact.
- The final exact-set checks across six run IDs and six schedule arms.

Dependency upgrades and product runtime behavior are outside this change. The
workflow only changes how the existing release evaluation is orchestrated and
attested.
