### PR TITLE
fix(cli): replay buffered writes automatically

### DIFF
--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -24,6 +24,7 @@ from sibyl_cli.client_transport import (
     ErrorPayload,
     SibylClientError,
     _auth_credential_scope,
+    _auth_replay_scope,
     _is_read_like_post,
     _is_refresh_revoked,
     _load_default_auth_token,
@@ -98,6 +99,8 @@ class SibylClient(
             if auth_token is not None
             else _load_default_auth_token(self.base_url, self.credential_scope)
         )
+        replay_credential_scope = self.credential_scope if self._uses_stored_auth else None
+        self._replay_scope = _auth_replay_scope(replay_credential_scope, self.auth_token)
         self._client: httpx.AsyncClient | None = None
         # Load insecure setting from context
         self.insecure = self._get_insecure_from_context(context_name)

--- a/apps/cli/src/sibyl_cli/client_transport.py
+++ b/apps/cli/src/sibyl_cli/client_transport.py
@@ -456,21 +456,26 @@ class ClientTransportMixin:
             with pending_replay_lock() as acquired:
                 if not acquired:
                     return
-                candidates = [
+                matching = [
                     item
                     for item in list_pending_writes()
                     if not is_corrupt_pending_write(item)
                     and str(item.get("base_url")) == self.base_url
                     and item.get("replay_scope") == self._replay_scope
                     and self._replay_scope is not None
-                    and _ready_for_auto_replay(item)
                     and not (
                         str(item.get("method") or "").upper() == "POST"
                         and _is_read_like_post(str(item.get("path") or ""))
                     )
                 ]
-                candidates.sort(key=lambda item: str(item.get("created_at") or ""))
-                batch = candidates[:AUTO_REPLAY_LIMIT]
+                matching.sort(key=lambda item: str(item.get("created_at") or ""))
+                batch: list[dict[str, Any]] = []
+                for item in matching:
+                    if not _ready_for_auto_replay(item):
+                        break
+                    batch.append(item)
+                    if len(batch) == AUTO_REPLAY_LIMIT:
+                        break
                 for item in batch:
                     write_id = str(item["id"])
                     try:

--- a/apps/cli/src/sibyl_cli/client_transport.py
+++ b/apps/cli/src/sibyl_cli/client_transport.py
@@ -6,6 +6,8 @@ import sys
 import time
 from collections import deque
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
 from typing import Any, Self, cast
 
 import httpx
@@ -19,6 +21,10 @@ from sibyl_cli.pending_writes import (
     PendingMetric,
     create_pending_write,
     delete_pending_write,
+    increment_attempts,
+    is_corrupt_pending_write,
+    list_pending_writes,
+    pending_replay_lock,
     record_pending_metric,
 )
 
@@ -28,7 +34,13 @@ FAILURE_WINDOW_SECONDS = 10.0
 FAILURE_THRESHOLD = 3
 _FAILURE_WINDOWS: dict[tuple[str, str], deque[float]] = {}
 BUFFERED_WRITE_METHODS = {"POST", "PATCH", "DELETE"}
-PENDING_WRITE_REMEDIATION = "Run 'sibyl auth login' then 'sibyl pending-writes flush'."
+AUTO_REPLAY_LIMIT = 8
+AUTO_REPLAY_GRACE_SECONDS = 30.0
+AUTO_REPLAY_BACKOFF_BASE_SECONDS = 2.0
+AUTO_REPLAY_BACKOFF_MAX_SECONDS = 300.0
+PENDING_WRITE_REMEDIATION = (
+    "Run 'sibyl auth login'; buffered writes retry after the next successful API request."
+)
 INIT_REMEDIATION = "Run 'sibyl init' for local mode or 'sibyl init --remote <url>'."
 
 
@@ -211,6 +223,15 @@ def _failure_key(base_url: str) -> tuple[str, str]:
     return (_subcommand_key(), base_url)
 
 
+def _auth_replay_scope(credential_scope_name: str | None, auth_token: str | None) -> str | None:
+    if credential_scope_name:
+        return credential_scope_name
+    if auth_token:
+        digest = sha256(auth_token.encode("utf-8")).hexdigest()
+        return f"token-sha256:{digest}"
+    return None
+
+
 def _prune_failures(window: deque[float], now: float) -> None:
     while window and now - window[0] > FAILURE_WINDOW_SECONDS:
         window.popleft()
@@ -273,6 +294,34 @@ def _should_buffer_request(method: str, path: str) -> bool:
     if path.startswith("/auth/"):
         return False
     return not _is_read_like_post(path)
+
+
+def _ready_for_auto_replay(item: dict[str, Any]) -> bool:
+    try:
+        created_at = datetime.fromisoformat(str(item.get("created_at") or ""))
+    except ValueError:
+        return False
+    if created_at.tzinfo is None:
+        return False
+    age = datetime.now(UTC) - created_at
+    if age.total_seconds() < AUTO_REPLAY_GRACE_SECONDS:
+        return False
+
+    attempts = int(item.get("attempts") or 0)
+    last_attempt_text = item.get("last_attempt_at")
+    if attempts == 0 or not isinstance(last_attempt_text, str):
+        return True
+    try:
+        last_attempt_at = datetime.fromisoformat(last_attempt_text)
+    except ValueError:
+        return False
+    if last_attempt_at.tzinfo is None:
+        return False
+    backoff_seconds = min(
+        AUTO_REPLAY_BACKOFF_BASE_SECONDS * (2 ** min(attempts - 1, 16)),
+        AUTO_REPLAY_BACKOFF_MAX_SECONDS,
+    )
+    return (datetime.now(UTC) - last_attempt_at).total_seconds() >= backoff_seconds
 
 
 def _requires_initialized_context(method: str, path: str) -> bool:
@@ -399,6 +448,51 @@ class ClientTransportMixin:
             await self._client.aclose()
             self._client = None
 
+    async def _maybe_replay_pending_writes(self) -> None:
+        """Replay a bounded batch after this client proves the API is healthy."""
+        try:
+            if not list_pending_writes():
+                return
+            with pending_replay_lock() as acquired:
+                if not acquired:
+                    return
+                candidates = [
+                    item
+                    for item in list_pending_writes()
+                    if not is_corrupt_pending_write(item)
+                    and str(item.get("base_url")) == self.base_url
+                    and item.get("replay_scope") == self._replay_scope
+                    and self._replay_scope is not None
+                    and _ready_for_auto_replay(item)
+                    and not (
+                        str(item.get("method") or "").upper() == "POST"
+                        and _is_read_like_post(str(item.get("path") or ""))
+                    )
+                ]
+                candidates.sort(key=lambda item: str(item.get("created_at") or ""))
+                batch = candidates[:AUTO_REPLAY_LIMIT]
+                for item in batch:
+                    write_id = str(item["id"])
+                    try:
+                        current = increment_attempts(write_id)
+                        await self._request(
+                            str(current["method"]),
+                            str(current["path"]),
+                            json=current.get("json"),
+                            params=current.get("params"),
+                            _buffer_pending=False,
+                            _pending_write_id=write_id,
+                            _idempotency_key=str(current["idempotency_key"]),
+                        )
+                        record_pending_metric("replayed")
+                    except SibylClientError as exc:
+                        if exc.status_code not in UNAPPLIED_WRITE_STATUS_CODES:
+                            break
+                    except (FileNotFoundError, OSError, ValueError):
+                        break
+        except Exception:
+            return
+
     async def __aenter__(self) -> Self:
         """Async context manager entry."""
         return self
@@ -459,6 +553,7 @@ class ClientTransportMixin:
                 base_url=self.base_url,
                 json_payload=json,
                 params=params,
+                replay_scope=self._replay_scope,
             )
             pending_write_id = str(pending["id"])
             pending_write_created = True
@@ -557,11 +652,15 @@ class ClientTransportMixin:
             if response.status_code == 204:
                 _resolve_pending_write(pending_write_id, applied_outcome)
                 _record_success(breaker_key)
+                if pending_write_id is None or pending_write_created:
+                    await self._maybe_replay_pending_writes()
                 return {}
 
             data = response.json()
             _resolve_pending_write(pending_write_id, applied_outcome)
             _record_success(breaker_key)
+            if pending_write_id is None or pending_write_created:
+                await self._maybe_replay_pending_writes()
             return data
 
         except httpx.ConnectError as e:

--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -217,7 +217,8 @@ def pending_writes_summary(count: int) -> str:
     plural = "s" if count != 1 else ""
     return (
         f"{count} write{plural} buffered locally and not saved on the server. "
-        "Run 'sibyl pending-writes flush' to replay them."
+        "Sibyl retries replayable writes after the next successful API request; "
+        "run 'sibyl pending-writes list' if the count stops falling."
     )
 
 

--- a/apps/cli/src/sibyl_cli/data/skill-packs/core.md
+++ b/apps/cli/src/sibyl_cli/data/skill-packs/core.md
@@ -42,11 +42,12 @@ These rules exist because real agent sessions consistently fail without them.
    non-interactively, STOP treating memory as available. State in your final output that memory was
    unavailable and list any learnings that could not be captured. The failure hint may say
    `Run 'sibyl auth login'`. Do NOT run `auth login` while `sibyl health` fails; a down server
-   produces the same message and login cannot fix it. After the server recovers, run
-   `sibyl pending-writes flush`; expect it to skip read-like queued requests (rerun those commands
-   instead) and explicitly re-run any writes it reports as failed. In a sandboxed environment,
-   `sibyl config context --quick` succeeding from local state while context retrieval or health
-   cannot connect means blocked network egress, not a server outage.
+   produces the same message and login cannot fix it. Sibyl retries buffered writes automatically
+   after the next successful API request. Use `sibyl pending-writes list` to inspect anything still
+   queued. Older read-like entries are not replayed, because reads should be rerun instead. Remove
+   those with `sibyl pending-writes discard --read-like`. In a sandboxed environment, `sibyl config
+   context --quick` succeeding from local state while context retrieval or health cannot connect
+   means blocked network egress, not a server outage.
 
 6. **Never invent subcommands, flags, or enum values.** If you're unsure whether a command exists,
    run `sibyl <group> --help`. Do not guess, and do not pass any flag you have not seen in this

--- a/apps/cli/src/sibyl_cli/data/skill-packs/core.md
+++ b/apps/cli/src/sibyl_cli/data/skill-packs/core.md
@@ -69,14 +69,16 @@ These rules exist because real agent sessions consistently fail without them.
    quote the separator (`echo "==="`, not `echo ===`): zsh equals-expansion turns bare `===` into a
    phantom exit-1 that makes a successful sibyl call look failed.
 
-8. **A failed write is lost knowledge.** A non-zero exit from `remember` means nothing was saved.
-   Retry exactly once after applying the printed remediation; if it still fails, include the unsaved
-   learning verbatim in your final message so the user can capture it. Never claim a memory was
-   stored unless you can quote the returned entity ID (e.g. `error_pattern_5f40ca...`) as the
-   receipt. On `internal_error`, retry once at most, then walk the fallback ladder instead of
-   spiraling: for a completion, `task complete` → `task update <id> -s done` plus a separate
-   `remember` for the learnings. Never silently drop a capture because the server is sick. Write the
-   body to a scratch file and say so.
+8. **A failed write needs a receipt.** A non-zero exit from `remember` does not confirm a server
+   save. If the CLI says the write was buffered, do not rerun it with a new idempotency key. Wait for
+   automatic replay or inspect it with `sibyl pending-writes list`. Retry exactly once after applying
+   the printed remediation only when the failure was not buffered. If that retry still fails,
+   include the unsaved learning verbatim in your final message so the user can capture it. Never
+   claim a memory was stored unless you can quote the returned entity ID (e.g.
+   `error_pattern_5f40ca...`) as the receipt. On an unbuffered `internal_error`, retry once at most,
+   then walk the fallback ladder instead of spiraling: for a completion, `task complete` → `task
+   update <id> -s done` plus a separate `remember` for the learnings. Never silently drop a capture
+   because the server is sick. Write the body to a scratch file and say so.
 
 9. **Fetch IDs fresh.** Re-run the list command immediately before `show`/`update`/`complete`; never
    reuse an entity or task UUID remembered from earlier in a long session, and never run the list

--- a/apps/cli/src/sibyl_cli/doctor.py
+++ b/apps/cli/src/sibyl_cli/doctor.py
@@ -510,7 +510,10 @@ def _check_pending_writes() -> DoctorCheck:
         "pending-writes",
         "warn",
         f"{count} write{plural} buffered locally and not saved on the server.",
-        f"Replay with 'sibyl pending-writes flush'; queued at {pending_writes_dir()}.",
+        (
+            "Sibyl retries replayable writes after the next successful API request; "
+            f"inspect the queue at {pending_writes_dir()}."
+        ),
     )
 
 

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 
 import typer
 
-from sibyl_cli.auth_store import normalize_api_url
+from sibyl_cli.auth_store import credential_scope, normalize_api_url
 from sibyl_cli.client import SibylClient, SibylClientError, _is_read_like_post
 from sibyl_cli.common import (
     console,
@@ -25,6 +25,7 @@ from sibyl_cli.pending_writes import (
     is_canonical_pending_write_id,
     is_corrupt_pending_write,
     list_pending_writes,
+    pending_replay_lock,
     pending_write_label,
     pending_writes_dir,
     read_pending_write,
@@ -80,8 +81,19 @@ def _partition_replayable(
     return replayable, skipped
 
 
-def _context_name_for_base_url(base_url: str) -> str | None:
+def _context_name_for_base_url(
+    base_url: str,
+    replay_scope: object = None,
+) -> str | None:
     from sibyl_cli import config_store
+
+    if isinstance(replay_scope, str) and replay_scope:
+        for ctx in config_store.list_contexts():
+            context_url = normalize_api_url(f"{ctx.server_url}/api")
+            context_scope = credential_scope(ctx.name, ctx.org_slug)
+            if context_url == normalize_api_url(base_url) and context_scope == replay_scope:
+                return ctx.name
+        return None
 
     ctx = config_store.get_active_context()
     if ctx is None:
@@ -235,19 +247,35 @@ def flush_writes(
         replayed = 0
         contended = 0
         async with AsyncExitStack() as stack:
-            clients: dict[tuple[str, str | None], SibylClient] = {}
+            clients: dict[tuple[str, str | None, str | None], SibylClient] = {}
             for item in replayable:
                 write_id = str(item["id"])
-                current = increment_attempts(write_id)
+                try:
+                    current = increment_attempts(write_id)
+                except FileNotFoundError:
+                    continue
                 base_url = str(current["base_url"])
-                context_name = _context_name_for_base_url(base_url)
-                client_key = (normalize_api_url(base_url), context_name)
+                replay_scope = current.get("replay_scope")
+                context_name = _context_name_for_base_url(base_url, replay_scope)
+                client_key = (
+                    normalize_api_url(base_url),
+                    context_name,
+                    str(replay_scope) if replay_scope else None,
+                )
                 client = clients.get(client_key)
                 if client is None:
                     client = await stack.enter_async_context(
                         SibylClient(base_url=base_url, context_name=context_name)
                     )
                     clients[client_key] = client
+                if replay_scope and client._replay_scope != replay_scope:
+                    failures += 1
+                    replay_failures += 1
+                    error(
+                        f"Failed {write_id[:12]}: no configured credential scope matches "
+                        "the buffered write"
+                    )
+                    continue
                 try:
                     await client._request(
                         str(current["method"]),
@@ -290,4 +318,8 @@ def flush_writes(
                 )
             raise typer.Exit(code=1)
 
-    run_flush()
+    with pending_replay_lock() as acquired:
+        if not acquired:
+            warn("Another pending-write replay is already running.")
+            return
+        run_flush()

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -7,6 +7,8 @@ import os
 import re
 import stat
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, get_args
@@ -39,6 +41,45 @@ def pending_writes_dir() -> Path:
 
 def pending_metrics_path() -> Path:
     return Path.home() / ".config" / "sibyl" / "pending_writes_metrics.json"
+
+
+@contextmanager
+def pending_replay_lock() -> Iterator[bool]:
+    """Try to serialize pending-write replay without delaying the caller."""
+    root = pending_writes_dir()
+    _ensure_secure_dir(root)
+    path = root / ".replay.lock"
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    locked = False
+    try:
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                if os.fstat(fd).st_size == 0:
+                    os.write(fd, b"\0")
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            locked = True
+        except OSError:
+            yield False
+            return
+        yield True
+    finally:
+        if locked and os.name == "nt":
+            import msvcrt
+
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        elif locked:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 def _ensure_secure_dir(path: Path) -> None:
@@ -200,6 +241,7 @@ def create_pending_write(
     base_url: str,
     json_payload: dict[str, Any] | None,
     params: dict[str, Any] | None,
+    replay_scope: str | None = None,
 ) -> dict[str, Any]:
     write_id = uuid4().hex
     idempotency_key = str(uuid4())
@@ -208,6 +250,7 @@ def create_pending_write(
         "idempotency_key": idempotency_key,
         "created_at": datetime.now(UTC).isoformat(),
         "base_url": base_url,
+        "replay_scope": replay_scope,
         "method": method.upper(),
         "path": path,
         "json": json_payload,

--- a/apps/cli/tests/test_client_errors.py
+++ b/apps/cli/tests/test_client_errors.py
@@ -307,6 +307,49 @@ async def test_automatic_replay_stops_after_the_first_transient_failure(
 
 
 @pytest.mark.asyncio
+async def test_automatic_replay_does_not_pass_an_older_write_in_cooldown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_BACKOFF_BASE_SECONDS", 60.0)
+    requests: list[str] = []
+
+    def healthy(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        return httpx.Response(200, json={"status": "healthy"})
+
+    client = _client_with_transport(httpx.MockTransport(healthy))
+    older = pending_writes.create_pending_write(
+        method="POST",
+        path="/entities",
+        base_url=client.base_url,
+        json_payload={"name": "Create first"},
+        params=None,
+        replay_scope=client._replay_scope,
+    )
+    pending_writes.increment_attempts(str(older["id"]))
+    newer = pending_writes.create_pending_write(
+        method="PATCH",
+        path="/entities/entity_123",
+        base_url=client.base_url,
+        json_payload={"name": "Update second"},
+        params=None,
+        replay_scope=client._replay_scope,
+    )
+
+    result = await client.get("/health")
+
+    await client.close()
+    queued = pending_writes.list_pending_writes()
+    attempts = {str(item["id"]): int(item["attempts"]) for item in queued}
+    assert result == {"status": "healthy"}
+    assert requests == ["GET"]
+    assert attempts == {str(older["id"]): 1, str(newer["id"]): 0}
+
+
+@pytest.mark.asyncio
 async def test_automatic_replay_never_crosses_credential_scopes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/cli/tests/test_client_errors.py
+++ b/apps/cli/tests/test_client_errors.py
@@ -190,6 +190,240 @@ async def test_mutating_request_survives_connect_drop_and_replays(
 
 
 @pytest.mark.asyncio
+async def test_successful_api_request_replays_buffered_writes_automatically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+    requests: list[tuple[str, str, str | None]] = []
+
+    def healthy_then_replay(request: httpx.Request) -> httpx.Response:
+        requests.append(
+            (
+                request.method,
+                request.url.path,
+                request.headers.get("Idempotency-Key"),
+            )
+        )
+        return httpx.Response(200, json={"ok": True})
+
+    client = _client_with_transport(httpx.MockTransport(healthy_then_replay))
+    queued = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="http://testserver/api",
+        json_payload={"title": "Recover me", "raw_content": "Body"},
+        params=None,
+        replay_scope=client._replay_scope,
+    )
+    result = await client.get("/health")
+
+    await client.close()
+    assert result == {"ok": True}
+    assert requests == [
+        ("GET", "/api/health", None),
+        ("POST", "/api/memory/raw", queued["idempotency_key"]),
+    ]
+    assert pending_writes.list_pending_writes() == []
+    assert pending_writes.read_pending_metrics()["replayed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_automatic_replay_does_not_fail_the_triggering_request(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+
+    def healthy_but_replay_fails(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, json={"status": "healthy"})
+        return httpx.Response(
+            500,
+            json={"error": "internal_error", "message": "SurrealDB unavailable"},
+        )
+
+    client = _client_with_transport(httpx.MockTransport(healthy_but_replay_fails))
+    pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="http://testserver/api",
+        json_payload={"title": "Keep me", "raw_content": "Body"},
+        params=None,
+        replay_scope=client._replay_scope,
+    )
+    result = await client.get("/health")
+
+    await client.close()
+    queued = pending_writes.list_pending_writes()
+    assert result == {"status": "healthy"}
+    assert len(queued) == 1
+    assert queued[0]["attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_automatic_replay_stops_after_the_first_transient_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+    client_transport_module._FAILURE_WINDOWS.clear()
+    posts = 0
+
+    def healthy_then_unavailable(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        if request.method == "GET":
+            return httpx.Response(200, json={"status": "healthy"})
+        posts += 1
+        return httpx.Response(
+            503,
+            json={"error": "unavailable", "message": "SurrealDB unavailable"},
+        )
+
+    client = _client_with_transport(httpx.MockTransport(healthy_then_unavailable))
+    for index in range(8):
+        pending_writes.create_pending_write(
+            method="POST",
+            path="/memory/raw",
+            base_url=client.base_url,
+            json_payload={"title": f"queued {index}", "raw_content": "Body"},
+            params=None,
+            replay_scope=client._replay_scope,
+        )
+
+    result = await client.get("/health")
+
+    await client.close()
+    attempts = sorted(int(item["attempts"]) for item in pending_writes.list_pending_writes())
+    assert result == {"status": "healthy"}
+    assert posts == 1
+    assert attempts == [0] * 7 + [1]
+    key = client_transport_module._failure_key(client.base_url)
+    assert len(client_transport_module._FAILURE_WINDOWS[key]) == 1
+    client_transport_module._FAILURE_WINDOWS.clear()
+
+
+@pytest.mark.asyncio
+async def test_automatic_replay_never_crosses_credential_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+    requests: list[str] = []
+
+    def healthy(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        return httpx.Response(200, json={"status": "healthy"})
+
+    client = _client_with_transport(httpx.MockTransport(healthy))
+    pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url=client.base_url,
+        json_payload={"title": "Org alpha", "raw_content": "Body"},
+        params=None,
+        replay_scope=client_transport_module._auth_replay_scope(None, "token-for-org-alpha"),
+    )
+
+    result = await client.get("/health")
+
+    await client.close()
+    assert result == {"status": "healthy"}
+    assert requests == ["GET"]
+    assert len(pending_writes.list_pending_writes()) == 1
+
+
+@pytest.mark.asyncio
+async def test_environment_token_scope_overrides_active_context_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+    monkeypatch.setenv("SIBYL_AUTH_TOKEN", "automation-token")
+    monkeypatch.setattr(
+        client_module,
+        "_auth_credential_scope",
+        lambda _context_name: "context:alpha:org:alpha-org",
+    )
+    monkeypatch.setattr(
+        SibylClient,
+        "_get_insecure_from_context",
+        lambda _self, _context_name: False,
+    )
+    requests: list[str] = []
+
+    def healthy(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        return httpx.Response(200, json={"status": "healthy"})
+
+    client = SibylClient(base_url="http://testserver/api", context_name="alpha")
+    client._client = httpx.AsyncClient(
+        base_url=client.base_url,
+        transport=httpx.MockTransport(healthy),
+        headers=client._default_headers(),
+    )
+    pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url=client.base_url,
+        json_payload={"title": "Alpha only", "raw_content": "Body"},
+        params=None,
+        replay_scope="context:alpha:org:alpha-org",
+    )
+
+    result = await client.get("/health")
+
+    await client.close()
+    assert result == {"status": "healthy"}
+    assert client._replay_scope == client_transport_module._auth_replay_scope(
+        None, "automation-token"
+    )
+    assert requests == ["GET"]
+    assert len(pending_writes.list_pending_writes()) == 1
+
+
+@pytest.mark.asyncio
+async def test_automatic_replay_uses_backoff_without_abandoning_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+    monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_BACKOFF_BASE_SECONDS", 0.0)
+    posts = 0
+
+    def recovered(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        if request.method == "POST":
+            posts += 1
+        return httpx.Response(200, json={"status": "healthy"})
+
+    client = _client_with_transport(httpx.MockTransport(recovered))
+    queued = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url=client.base_url,
+        json_payload={"title": "Eventually", "raw_content": "Body"},
+        params=None,
+        replay_scope=client._replay_scope,
+    )
+    for _ in range(5):
+        pending_writes.increment_attempts(str(queued["id"]))
+
+    result = await client.get("/health")
+
+    await client.close()
+    assert result == {"status": "healthy"}
+    assert posts == 1
+    assert pending_writes.list_pending_writes() == []
+
+
+@pytest.mark.asyncio
 async def test_mutating_request_refreshes_401_and_retries_same_pending_write(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/cli/tests/test_pending_visibility.py
+++ b/apps/cli/tests/test_pending_visibility.py
@@ -58,7 +58,7 @@ def test_a_queued_write_warns_on_stderr_at_command_completion(
 
     captured = capsys.readouterr()
     assert "2 writes buffered locally" in captured.err
-    assert "sibyl pending-writes flush" in captured.err
+    assert "retries replayable writes" in captured.err
     assert "buffered locally" not in captured.out
 
 
@@ -156,7 +156,7 @@ def test_doctor_checks_the_queue(sandbox_home: Path) -> None:
     assert check.status == "warn"
     assert "1 write buffered locally" in check.message
     assert check.detail is not None
-    assert "sibyl pending-writes flush" in check.detail
+    assert "retries replayable writes" in check.detail
 
 
 def test_doctor_passes_on_an_empty_queue(sandbox_home: Path) -> None:

--- a/apps/cli/tests/test_pending_writes.py
+++ b/apps/cli/tests/test_pending_writes.py
@@ -52,6 +52,18 @@ def test_pending_write_list_and_prefix_delete(
     assert pending_writes.list_pending_writes() == []
 
 
+def test_pending_replay_lock_is_nonblocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+
+    with pending_writes.pending_replay_lock() as first:
+        with pending_writes.pending_replay_lock() as second:
+            assert first is True
+            assert second is False
+
+
 def test_corrupt_pending_write_remains_counted_as_a_structured_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# 🔄 Durable writes that recover themselves

> The CLI already buffers mutations before transmission. This change makes
> recovery automatic once the API is healthy again.

## 💡 What this is

Buffered writes now replay after any successful API request. The replay path
uses the original idempotency key, so an ambiguous transport failure can be
retried without creating a second mutation.

Automatic recovery stays inside the credential boundary that created the
write. Stored contexts use their context and organization scope. Explicit and
environment tokens use a non-secret token digest.

## 🤔 Why we need it

The durable queue protected writes from connection failures, but recovery
required `sibyl pending-writes flush`. A user had to notice the queue, choose
the right context, and replay it by hand.

The manual path also had no safe way to infer ownership for old queue entries.
Those legacy entries remain visible for explicit inspection. New writes carry
enough scope to recover automatically without crossing organizations or
automation credentials.

## 🎯 Review anchor

A buffered write may replay only against the same normalized API URL and the
same credential scope, using the same idempotency key.

## 🛠️ How it works

1. The transport stores `replay_scope` with every durable write before sending
   the original request.
2. A successful API response sorts matching writes by creation time, then
   attempts up to eight ready writes without passing an older write in
   cooldown.
3. A shared nonblocking file lock allows only one automatic or manual replayer
   to own the queue at a time.
4. A 30-second grace period keeps replay away from another process's original
   in-flight request.
5. The first transient failure stops the batch. Persisted exponential cooldown
   grows to five minutes, then keeps retrying after later successful requests.
6. Validation failures remove only payloads the server proves it did not apply.
   Ambiguous outcomes remain queued.

The implementation lives in `client_transport.py` and `pending_writes.py`.
The manual command in `pending.py` shares the same lock and credential checks.
CLI notices, doctor output, and the bundled Sibyl contract now describe the
automatic behavior.

## 🔁 What changed after automated review

CodeRabbit caught two ordering hazards. The replay selector now sorts the full
matching queue before checking readiness, so a newer dependent mutation cannot
pass an older write in cooldown. The bundled contract also tells agents not to
rerun writes already reported as buffered, preserving the original idempotency
key instead of creating a duplicate operation.

## 🧪 Validation

- `moon run cli:lint cli:test` on commit `03d278c3` produced clean lint and
  `616 passed`.
- `uvx ty@0.0.73 check apps/cli/src` produced `All checks passed!`.
- An independent verifier reproduced credential isolation, five failed replay
  attempts followed by recovery, first-failure batch stopping, and queue lock
  contention. The final verdict was PASS.

## 🔍 What reviewers should focus on

- Check scope selection when `SIBYL_AUTH_TOKEN` overrides an active context.
- Check cooldown eligibility after repeated split-health failures.
- Check deletion behavior for definitive 400 and 422 responses versus
  ambiguous server and transport failures.
- Check lock ownership across automatic replay and manual flush.

The SurrealDB WebSocket keepalive instability is outside this diff. The queue
now recovers ordinary writes from that failure automatically, but the transport
failure itself still deserves separate diagnosis.

## 🔄 420 tribute

```text
          .-.
      _  /420\  _
     / \ \___/ / \
    |   AUTO    |
    |  REPLAY   |
     \__\___/__/
```
