### PR TITLE
docs(web): track generated Next agent guidance

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
# 🧹 Version-matched Next agent guidance

> Tracks the files that Next 16 generates whenever the web development server
> starts.

## 💡 What this is

Next writes `apps/web/AGENTS.md` with a warning to read the version-matched
documentation in `node_modules/next/dist/docs/`. It also writes
`apps/web/CLAUDE.md` as a pointer to that guidance.

Tracking both files keeps the development tree clean and gives coding agents
the same instructions that the installed Next release expects.

## 🧪 Validation

- Both files compare byte-for-byte with the output already generated by the
  installed Next package.
- `git diff --check` passes.
- The generator source at
  `apps/web/node_modules/next/dist/server/lib/generate-agent-files.js` defines
  the same files and content.

## 🔍 What reviewers should focus on

The diff should remain the exact generated content. No application code,
runtime configuration, or dependency state changes here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for consulting versioned framework documentation and checking for deprecations or breaking changes.
  * Added a reference directing contributors to the applicable project guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->