### PR TITLE
build(e2e): refresh local lock metadata

### DIFF
--- a/apps/e2e/uv.lock
+++ b/apps/e2e/uv.lock
@@ -791,8 +791,8 @@ requires-dist = [
     { name = "mistune", marker = "extra == 'runtime'", specifier = ">=3.3.4" },
     { name = "packaging", specifier = ">=26.0" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], marker = "extra == 'llm'", specifier = ">=2.30.0,<3" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], marker = "extra == 'runtime'", specifier = ">=2.30.0,<3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], marker = "extra == 'llm'", specifier = ">=2.32.0,<3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], marker = "extra == 'runtime'", specifier = ">=2.32.0,<3" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyjwt", specifier = ">=2.10" },
     { name = "python-louvain", marker = "extra == 'graphrag'", specifier = ">=0.16" },
@@ -810,12 +810,13 @@ provides-extras = ["crawler", "embeddings", "graph", "graphrag", "llm", "reranki
 dev = [
     { name = "anthropic", specifier = ">=0.120.2,<1" },
     { name = "numpy", specifier = ">=2.5.1" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], specifier = ">=2.30.0,<3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "google", "openai"], specifier = ">=2.32.0,<3" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff" },
     { name = "surrealdb", specifier = ">=2.0.0,<3.0" },
+    { name = "ty", specifier = ">=0.0.69" },
 ]
 
 [[package]]


### PR DESCRIPTION
## why

The isolated E2E lock drifted from the current `sibyl-core` development metadata. A fresh lock check could repair the file locally, but the committed lock still advertised the old pydantic-ai minimum and omitted `ty`.

## what changed

Regenerated `apps/e2e/uv.lock` from the current package declarations. The update is metadata-only:

- raises the recorded pydantic-ai minimum from 2.30 to 2.32
- records the existing `ty>=0.0.69` development dependency
- leaves the resolved package graph unchanged

## verification

- `uv 0.12.5`
- `uv lock` from `apps/e2e`
- `uv lock --check`
- `git diff --check`

## blast radius

Only the standalone E2E lockfile changes. Runtime code, published dependencies, and resolved package versions are unchanged.
