### PR TITLE
fix(cli): bind pending writes to credential lineage

### DIFF
--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov>=7.0.0",
     "ruff",
+    "ty>=0.0.69",
 ]
 
 [project.scripts]

--- a/apps/cli/src/sibyl_cli/auth.py
+++ b/apps/cli/src/sibyl_cli/auth.py
@@ -453,17 +453,10 @@ def _oauth_pkce_login(
     if not access_token:
         raise _OAuthLoginError("Token response missing access_token", tok)
 
-    # Store tokens and OAuth metadata
+    # Store OAuth metadata. The caller persists the token response once after
+    # the login method returns so one successful login creates one lineage.
     from sibyl_cli.auth_store import write_server_credentials
 
-    set_tokens(
-        api_url,
-        access_token,
-        refresh_token=refresh_token or None,
-        expires_in=expires_in_int,
-        credential_scope=credential_scope_name,
-    )
-    # Also store OAuth metadata for potential token refresh
     write_server_credentials(
         api_url,
         {

--- a/apps/cli/src/sibyl_cli/auth_store.py
+++ b/apps/cli/src/sibyl_cli/auth_store.py
@@ -22,9 +22,11 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
 
 SCOPES_KEY = "scopes"
 DEFAULT_SCOPE_PART = "default"
+PENDING_REPLAY_SCOPE_KEY = "pending_replay_scope"
 
 
 def auth_path() -> Path:
@@ -286,6 +288,18 @@ def get_refresh_token(
     return str(token) if token else None
 
 
+def get_pending_replay_scope(
+    api_url: str,
+    path: Path | None = None,
+    *,
+    credential_scope: str | None = None,
+) -> str | None:
+    """Get the durable pending-write owner for a stored credential lineage."""
+    creds = read_server_credentials(api_url, path, credential_scope=credential_scope)
+    replay_scope = creds.get(PENDING_REPLAY_SCOPE_KEY)
+    return str(replay_scope) if replay_scope else None
+
+
 def get_access_token_expires_at(
     api_url: str,
     path: Path | None = None,
@@ -321,10 +335,19 @@ def set_tokens(
     *,
     lock: bool = True,
     credential_scope: str | None = None,
+    pending_replay_scope: str | None = None,
 ) -> None:
-    """Store tokens for a specific server."""
+    """Store tokens for a specific server and credential lineage.
+
+    Explicit token writes start a new lineage by default. A server-confirmed
+    refresh passes the existing replay scope so queued writes retain their
+    owner without rewriting the queue.
+    """
     path, credential_scope = _split_path_and_scope(path, credential_scope)
-    creds: dict[str, Any] = {"access_token": access_token}
+    creds: dict[str, Any] = {
+        "access_token": access_token,
+        PENDING_REPLAY_SCOPE_KEY: pending_replay_scope or f"credential:{uuid4().hex}",
+    }
     remove_keys: list[str] = []
     if refresh_token is not None and refresh_token:
         creds["refresh_token"] = refresh_token

--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -28,6 +28,7 @@ from sibyl_cli.client_transport import (
     _is_read_like_post,
     _is_refresh_revoked,
     _load_default_auth_token,
+    _load_default_replay_scope,
     _paired_automation_api_url,
     anyio_sleep,
     resolve_api_base_url,
@@ -99,8 +100,15 @@ class SibylClient(
             if auth_token is not None
             else _load_default_auth_token(self.base_url, self.credential_scope)
         )
-        replay_credential_scope = self.credential_scope if self._uses_stored_auth else None
-        self._replay_scope = _auth_replay_scope(replay_credential_scope, self.auth_token)
+        self._replay_scope = (
+            _load_default_replay_scope(
+                self.base_url,
+                self.credential_scope,
+                self.auth_token,
+            )
+            if self._uses_stored_auth
+            else _auth_replay_scope(None, self.auth_token)
+        )
         self._client: httpx.AsyncClient | None = None
         # Load insecure setting from context
         self.insecure = self._get_insecure_from_context(context_name)

--- a/apps/cli/src/sibyl_cli/client_auth.py
+++ b/apps/cli/src/sibyl_cli/client_auth.py
@@ -23,6 +23,14 @@ class ClientAuthMixin:
         password = str(creds.get("local_login_password") or "").strip()
         if not email or not password:
             return False, "No stored local login credentials are available."
+        scope_marker = ":org:"
+        target_org_slug = (
+            self.credential_scope.rsplit(scope_marker, 1)[1]
+            if self.credential_scope and scope_marker in self.credential_scope
+            else ""
+        )
+        if not target_org_slug or target_org_slug == "default":
+            return False, "Silent local re-login requires an organization-scoped context."
 
         try:
             async with httpx.AsyncClient(
@@ -37,12 +45,28 @@ class ClientAuthMixin:
                 if response.status_code != 200:
                     return False, f"Local login returned HTTP {response.status_code}."
                 data = response.json()
+                personal_access_token = str(data.get("access_token") or "").strip()
+                if not personal_access_token:
+                    return False, "Local login response did not include an access token."
+                response = await client.post(
+                    f"/orgs/{quote(target_org_slug, safe='')}/switch",
+                    headers={"Authorization": f"Bearer {personal_access_token}"},
+                )
+                if response.status_code != 200:
+                    return False, f"Organization switch returned HTTP {response.status_code}."
+                data = response.json()
         except Exception as exc:
             return False, f"Local login failed: {exc}"
 
         new_access_token = str(data.get("access_token") or "").strip()
         if not new_access_token:
-            return False, "Local login response did not include an access token."
+            return False, "Organization switch response did not include an access token."
+        organization = data.get("organization")
+        switched_slug = (
+            str(organization.get("slug") or "").strip() if isinstance(organization, dict) else ""
+        )
+        if switched_slug != target_org_slug:
+            return False, "Organization switch response did not match the selected context."
 
         set_tokens(
             self.base_url,
@@ -51,6 +75,7 @@ class ClientAuthMixin:
             expires_in=int(data["expires_in"]) if data.get("expires_in") else None,
             lock=False,
             credential_scope=self.credential_scope,
+            pending_replay_scope=self._replay_scope,
         )
         self.auth_token = new_access_token
         if self._client and not self._client.is_closed:
@@ -74,20 +99,26 @@ class ClientAuthMixin:
                     credential_scope=self.credential_scope,
                 )
                 stored_access_token = str(creds.get("access_token") or "").strip()
-                expires_at = creds.get("access_token_expires_at")
-                if (
-                    stored_access_token
-                    and stored_access_token != self.auth_token
-                    and not is_access_token_expired(
+                stored_replay_scope = str(creds.get("pending_replay_scope") or "").strip()
+                stored_token_changed = bool(
+                    stored_access_token and stored_access_token != self.auth_token
+                )
+                if stored_token_changed:
+                    if not stored_replay_scope or stored_replay_scope != self._replay_scope:
+                        return (
+                            False,
+                            "Stored credentials changed since this command started; retry the "
+                            "command with the current login.",
+                        )
+                    if not is_access_token_expired(
                         self.base_url,
                         credential_scope=self.credential_scope,
-                    )
-                ):
-                    self.auth_token = stored_access_token
-                    if self._client and not self._client.is_closed:
-                        await self._client.aclose()
-                    self._client = None
-                    return True, None
+                    ):
+                        self.auth_token = stored_access_token
+                        if self._client and not self._client.is_closed:
+                            await self._client.aclose()
+                        self._client = None
+                        return True, None
 
                 refresh_token = get_refresh_token(
                     self.base_url,
@@ -95,17 +126,6 @@ class ClientAuthMixin:
                 )
                 if not refresh_token:
                     return False, "No refresh token is available for automatic renewal."
-
-                if (
-                    stored_access_token
-                    and expires_at is None
-                    and stored_access_token != self.auth_token
-                ):
-                    self.auth_token = stored_access_token
-                    if self._client and not self._client.is_closed:
-                        await self._client.aclose()
-                    self._client = None
-                    return True, None
 
                 async with httpx.AsyncClient(
                     base_url=self.base_url,
@@ -150,6 +170,7 @@ class ClientAuthMixin:
                         expires_in=expires_in,
                         lock=False,
                         credential_scope=self.credential_scope,
+                        pending_replay_scope=self._replay_scope,
                     )
 
                     self.auth_token = new_access_token

--- a/apps/cli/src/sibyl_cli/client_transport.py
+++ b/apps/cli/src/sibyl_cli/client_transport.py
@@ -16,6 +16,7 @@ from sibyl_cli.auth_store import (
     credential_scope,
     get_access_token,
     is_access_token_expired,
+    read_server_credentials,
 )
 from sibyl_cli.pending_writes import (
     PendingMetric,
@@ -223,13 +224,34 @@ def _failure_key(base_url: str) -> tuple[str, str]:
     return (_subcommand_key(), base_url)
 
 
-def _auth_replay_scope(credential_scope_name: str | None, auth_token: str | None) -> str | None:
-    if credential_scope_name:
-        return credential_scope_name
+def _auth_replay_scope(
+    stored_replay_scope: str | None,
+    auth_token: str | None,
+) -> str | None:
+    if stored_replay_scope:
+        return stored_replay_scope
     if auth_token:
         digest = sha256(auth_token.encode("utf-8")).hexdigest()
         return f"token-sha256:{digest}"
     return None
+
+
+def _load_default_replay_scope(
+    api_base_url: str,
+    credential_scope_name: str | None,
+    auth_token: str | None,
+) -> str | None:
+    if os.environ.get("SIBYL_AUTH_TOKEN", "").strip():
+        return _auth_replay_scope(None, auth_token)
+    stored_credentials = read_server_credentials(
+        api_base_url,
+        credential_scope=credential_scope_name,
+    )
+    stored_token = str(stored_credentials.get("access_token") or "").strip()
+    stored_scope = str(stored_credentials.get("pending_replay_scope") or "").strip()
+    if stored_token != auth_token:
+        stored_scope = ""
+    return _auth_replay_scope(stored_scope, auth_token)
 
 
 def _prune_failures(window: deque[float], now: float) -> None:
@@ -448,7 +470,7 @@ class ClientTransportMixin:
             await self._client.aclose()
             self._client = None
 
-    async def _maybe_replay_pending_writes(self) -> None:
+    async def _maybe_replay_pending_writes(self, *, ignore_backoff: bool = False) -> None:
         """Replay a bounded batch after this client proves the API is healthy."""
         try:
             if not list_pending_writes():
@@ -471,7 +493,7 @@ class ClientTransportMixin:
                 matching.sort(key=lambda item: str(item.get("created_at") or ""))
                 batch: list[dict[str, Any]] = []
                 for item in matching:
-                    if not _ready_for_auto_replay(item):
+                    if not ignore_backoff and not _ready_for_auto_replay(item):
                         break
                     batch.append(item)
                     if len(batch) == AUTO_REPLAY_LIMIT:

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -294,8 +294,8 @@ def claim_writes(
 
             with pending_replay_lock() as acquired:
                 if not acquired:
-                    warn("Another pending-write replay is already running.")
-                    return
+                    error("Another pending-write replay is already running; claim did not run.")
+                    raise typer.Exit(code=1)
                 claim_failures: list[tuple[str, str]] = []
                 claimed = 0
                 for item in matching:

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -296,15 +296,30 @@ def claim_writes(
                 if not acquired:
                     warn("Another pending-write replay is already running.")
                     return
+                claim_failures: list[tuple[str, str]] = []
+                claimed = 0
                 for item in matching:
-                    claim_pending_write_replay_scope(
-                        str(item["id"]),
-                        client._replay_scope,
-                    )
-            success(
-                f"Claimed {len(matching)} pending write"
-                f"{'s' if len(matching) != 1 else ''}; retrying now."
+                    write_id = str(item["id"])
+                    try:
+                        claim_pending_write_replay_scope(
+                            write_id,
+                            client._replay_scope,
+                        )
+                    except (FileNotFoundError, ValueError) as exc:
+                        claim_failures.append((write_id, str(exc)))
+                    else:
+                        claimed += 1
+            for write_id, reason in claim_failures:
+                error(f"Could not claim {write_id[:12]}: {reason}")
+            if claimed == 0:
+                raise typer.Exit(code=1)
+            claimed_message = (
+                f"Claimed {claimed} pending write{'s' if claimed != 1 else ''}; retrying now."
             )
+            if claim_failures:
+                warn(claimed_message)
+            else:
+                success(claimed_message)
             while True:
                 before = sum(
                     1
@@ -323,6 +338,8 @@ def claim_writes(
                 )
                 if after >= before:
                     break
+            if claim_failures:
+                raise typer.Exit(code=1)
 
     run_claim()
 

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -7,8 +7,17 @@ from typing import Annotated, Any
 
 import typer
 
-from sibyl_cli.auth_store import credential_scope, normalize_api_url
-from sibyl_cli.client import SibylClient, SibylClientError, _is_read_like_post
+from sibyl_cli.auth_store import (
+    credential_scope,
+    normalize_api_url,
+    read_server_credentials,
+)
+from sibyl_cli.client import (
+    SibylClient,
+    SibylClientError,
+    _auth_replay_scope,
+    _is_read_like_post,
+)
 from sibyl_cli.common import (
     console,
     create_table,
@@ -20,6 +29,7 @@ from sibyl_cli.common import (
     warn,
 )
 from sibyl_cli.pending_writes import (
+    claim_pending_write_replay_scope,
     delete_pending_write,
     increment_attempts,
     is_canonical_pending_write_id,
@@ -91,7 +101,14 @@ def _context_name_for_base_url(
         for ctx in config_store.list_contexts():
             context_url = normalize_api_url(f"{ctx.server_url}/api")
             context_scope = credential_scope(ctx.name, ctx.org_slug)
-            if context_url == normalize_api_url(base_url) and context_scope == replay_scope:
+            credentials = read_server_credentials(
+                context_url,
+                credential_scope=context_scope,
+            )
+            context_token = str(credentials.get("access_token") or "").strip() or None
+            stored_replay_scope = str(credentials.get("pending_replay_scope") or "").strip() or None
+            context_replay_scope = _auth_replay_scope(stored_replay_scope, context_token)
+            if context_url == normalize_api_url(base_url) and context_replay_scope == replay_scope:
                 return ctx.name
         return None
 
@@ -105,6 +122,11 @@ def _context_name_for_base_url(
 
 def _should_abort_flush(exc: SibylClientError) -> bool:
     return exc.error_code == "token_refresh_failed" or exc.status_code in {401, 429}
+
+
+def _legacy_claim_candidate(item: dict[str, Any]) -> bool:
+    scope = item.get("replay_scope")
+    return scope is None or str(scope).startswith("context:")
 
 
 @app.command("list")
@@ -197,6 +219,114 @@ def discard_writes(
         raise typer.Exit(code=1)
 
 
+@app.command("claim")
+def claim_writes(
+    write_ids: Annotated[
+        list[str] | None,
+        typer.Argument(help="Pending write IDs or prefixes. Omit to claim all legacy writes."),
+    ] = None,
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Approve the displayed user and organization."),
+    ] = False,
+) -> None:
+    """Claim ambiguous legacy writes, then retry them automatically."""
+    mark_pending_writes_reported()
+    try:
+        selected = _selected_writes(write_ids or [])
+    except (FileNotFoundError, ValueError) as exc:
+        error(str(exc))
+        raise typer.Exit(code=1) from exc
+    candidates = [
+        item
+        for item in selected
+        if not is_corrupt_pending_write(item)
+        and not _is_buffered_read_like(item)
+        and _legacy_claim_candidate(item)
+    ]
+    if not candidates:
+        success("No ambiguous legacy writes matched")
+        return
+
+    from sibyl_cli import config_store
+
+    context_name = config_store.resolve_context_name()
+
+    @run_async
+    async def run_claim() -> None:
+        async with SibylClient(context_name=context_name) as client:
+            if client._replay_scope is None:
+                error("No authenticated credential is available for this context.")
+                raise typer.Exit(code=1)
+            matching = [
+                item
+                for item in candidates
+                if normalize_api_url(str(item["base_url"])) == client.base_url
+            ]
+            if len(matching) != len(candidates):
+                error("Some selected writes belong to another server; select its context first.")
+                raise typer.Exit(code=1)
+
+            try:
+                identity = await client.get("/auth/me")
+            except SibylClientError as exc:
+                error(exc.detail or str(exc))
+                raise typer.Exit(code=1) from exc
+            user = identity.get("user") if isinstance(identity.get("user"), dict) else {}
+            organization = (
+                identity.get("organization")
+                if isinstance(identity.get("organization"), dict)
+                else {}
+            )
+            user_label = str(user.get("email") or user.get("name") or user.get("id") or "unknown")
+            org_label = str(
+                organization.get("slug")
+                or organization.get("name")
+                or organization.get("id")
+                or "unknown"
+            )
+            warn(
+                f"Claim {len(matching)} legacy write"
+                f"{'s' if len(matching) != 1 else ''} for {user_label} in {org_label}."
+            )
+            if not yes and not typer.confirm("Continue?"):
+                raise typer.Abort()
+
+            with pending_replay_lock() as acquired:
+                if not acquired:
+                    warn("Another pending-write replay is already running.")
+                    return
+                for item in matching:
+                    claim_pending_write_replay_scope(
+                        str(item["id"]),
+                        client._replay_scope,
+                    )
+            success(
+                f"Claimed {len(matching)} pending write"
+                f"{'s' if len(matching) != 1 else ''}; retrying now."
+            )
+            while True:
+                before = sum(
+                    1
+                    for item in list_pending_writes()
+                    if item.get("replay_scope") == client._replay_scope
+                    and str(item.get("base_url")) == client.base_url
+                )
+                if before == 0:
+                    break
+                await client._maybe_replay_pending_writes(ignore_backoff=True)
+                after = sum(
+                    1
+                    for item in list_pending_writes()
+                    if item.get("replay_scope") == client._replay_scope
+                    and str(item.get("base_url")) == client.base_url
+                )
+                if after >= before:
+                    break
+
+    run_claim()
+
+
 @app.command("flush")
 def flush_writes(
     write_ids: Annotated[
@@ -268,7 +398,15 @@ def flush_writes(
                         SibylClient(base_url=base_url, context_name=context_name)
                     )
                     clients[client_key] = client
-                if replay_scope and client._replay_scope != replay_scope:
+                if not replay_scope:
+                    failures += 1
+                    replay_failures += 1
+                    error(
+                        f"Failed {write_id[:12]}: legacy write has no credential owner; "
+                        "run sibyl pending-writes claim first"
+                    )
+                    continue
+                if client._replay_scope != replay_scope:
                     failures += 1
                     replay_failures += 1
                     error(

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -335,6 +335,24 @@ def increment_attempts(write_id: str) -> dict[str, Any]:
     return data
 
 
+def claim_pending_write_replay_scope(write_id: str, replay_scope: str) -> dict[str, Any]:
+    """Bind an ambiguous legacy write after explicit operator approval."""
+    if not replay_scope:
+        raise ValueError("Pending write replay scope cannot be empty")
+    path = resolve_pending_write_path(write_id)
+    data = _read_pending_path(path)
+    if is_corrupt_pending_write(data):
+        raise ValueError(f"Cannot update corrupt pending write {data['filename']}: {data['error']}")
+    current_scope = data.get("replay_scope")
+    if current_scope == replay_scope:
+        return data
+    if current_scope is not None and not str(current_scope).startswith("context:"):
+        raise ValueError("Pending write already belongs to another credential")
+    data["replay_scope"] = replay_scope
+    _secure_write_json(path, data)
+    return data
+
+
 def read_pending_metrics() -> dict[str, int]:
     path = pending_metrics_path()
     defaults: dict[str, int] = dict.fromkeys(PENDING_METRIC_NAMES, 0)

--- a/apps/cli/tests/test_auth_login.py
+++ b/apps/cli/tests/test_auth_login.py
@@ -246,6 +246,71 @@ def test_login_auto_oauth_preserves_access_token_expiry(
     ]
 
 
+def test_oauth_pkce_returns_tokens_without_persisting_them_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeServer:
+        def shutdown(self) -> None:
+            return None
+
+    class FakeDone:
+        def wait(self, *, timeout: int) -> bool:
+            assert timeout == 30
+            return True
+
+    metadata_writes: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        auth,
+        "_load_oauth_metadata",
+        lambda **_kwargs: {
+            "authorization_endpoint": "http://issuer/authorize",
+            "token_endpoint": "http://issuer/token",
+            "registration_endpoint": "http://issuer/register",
+        },
+    )
+    monkeypatch.setattr(
+        auth,
+        "_start_callback_server",
+        lambda: (
+            FakeServer(),
+            "http://127.0.0.1/callback",
+            FakeDone(),
+            {"code": "code", "state": "state"},
+        ),
+    )
+    monkeypatch.setattr(auth, "_register_oauth_client", lambda **_kwargs: ("client", "secret"))
+    monkeypatch.setattr(auth.secrets, "token_urlsafe", lambda _length: "state")
+    monkeypatch.setattr(auth.webbrowser, "open", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        auth,
+        "_exchange_oauth_code",
+        lambda **_kwargs: {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_in": 3600,
+        },
+    )
+    monkeypatch.setattr(
+        auth,
+        "set_tokens",
+        lambda *_args, **_kwargs: pytest.fail("PKCE helper must not persist tokens"),
+    )
+    monkeypatch.setattr(
+        "sibyl_cli.auth_store.write_server_credentials",
+        lambda *args, **kwargs: metadata_writes.append({"args": args, **kwargs}),
+    )
+
+    result = auth._oauth_pkce_login(
+        api_url="http://testserver/api",
+        no_browser=False,
+        timeout_seconds=30,
+        credential_scope_name="context:local:org:work",
+    )
+
+    assert result == ("access-token", "refresh-token", "http://testserver", 3600)
+    assert len(metadata_writes) == 1
+
+
 def test_login_auto_passes_break_glass_reason_to_local_login(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/cli/tests/test_auth_store.py
+++ b/apps/cli/tests/test_auth_store.py
@@ -275,6 +275,41 @@ class TestTokenOperations:
         result = auth_store.get_refresh_token("http://localhost:3334", test_file)
         assert result == "refresh123"
 
+    def test_explicit_token_write_starts_a_new_pending_replay_lineage(
+        self, tmp_path: Path
+    ) -> None:
+        test_file = tmp_path / "auth.json"
+        auth_store.set_tokens("http://localhost:3334", "first", path=test_file)
+        first_scope = auth_store.get_pending_replay_scope(
+            "http://localhost:3334", test_file
+        )
+
+        auth_store.set_tokens("http://localhost:3334", "second", path=test_file)
+        second_scope = auth_store.get_pending_replay_scope(
+            "http://localhost:3334", test_file
+        )
+
+        assert first_scope is not None
+        assert second_scope is not None
+        assert second_scope != first_scope
+
+    def test_server_refresh_preserves_pending_replay_lineage(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "auth.json"
+        replay_scope = "credential:stable-lineage"
+
+        auth_store.set_tokens(
+            "http://localhost:3334",
+            "refreshed",
+            refresh_token="refresh",
+            path=test_file,
+            pending_replay_scope=replay_scope,
+        )
+
+        assert (
+            auth_store.get_pending_replay_scope("http://localhost:3334", test_file)
+            == replay_scope
+        )
+
     def test_set_tokens_replaces_stale_refresh_credentials(self, tmp_path: Path) -> None:
         """Access-only token writes do not keep an old refresh token."""
         test_file = tmp_path / "auth.json"

--- a/apps/cli/tests/test_client_auth_refresh.py
+++ b/apps/cli/tests/test_client_auth_refresh.py
@@ -36,6 +36,30 @@ def test_invalid_refresh_token_message_is_recoverable() -> None:
     )
 
 
+def test_replay_scope_falls_back_to_loaded_token_when_credential_slot_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SIBYL_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        client_transport_module,
+        "read_server_credentials",
+        lambda _api_url, **_kwargs: {
+            "access_token": "other-user-access",
+            "pending_replay_scope": "credential:other-user",
+        },
+    )
+
+    replay_scope = client_transport_module._load_default_replay_scope(
+        "http://example.test/api",
+        None,
+        "original-access",
+    )
+
+    assert replay_scope == client_transport_module._auth_replay_scope(
+        None, "original-access"
+    )
+
+
 @pytest.mark.asyncio
 async def test_refresh_skips_manual_auth_token() -> None:
     client = SibylClient(base_url="http://example.test/api", auth_token="manual")
@@ -44,6 +68,95 @@ async def test_refresh_skips_manual_auth_token() -> None:
 
     assert refreshed is False
     assert failure == "Automatic renewal is only available for stored CLI login tokens."
+
+
+@pytest.mark.asyncio
+async def test_silent_local_relogin_switches_back_to_the_scoped_organization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, dict[str, object]]] = []
+    writes: list[dict[str, object]] = []
+
+    class FakeResponse:
+        def __init__(self, data: dict[str, object]) -> None:
+            self.status_code = 200
+            self._data = data
+
+        def json(self) -> dict[str, object]:
+            return self._data
+
+    class FakeAsyncClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def post(self, path: str, **kwargs: object) -> FakeResponse:
+            requests.append((path, kwargs))
+            if path == "/auth/local/login":
+                return FakeResponse({"access_token": "personal-token"})
+            assert path == "/orgs/work/switch"
+            return FakeResponse(
+                {
+                    "access_token": "work-token",
+                    "refresh_token": "work-refresh",
+                    "expires_in": 3600,
+                    "organization": {"slug": "work"},
+                }
+            )
+
+    monkeypatch.setattr(client_auth_module.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(
+        client_auth_module,
+        "set_tokens",
+        lambda *args, **kwargs: writes.append({"args": args, **kwargs}),
+    )
+
+    client = SibylClient(base_url="http://example.test/api", auth_token="old-token")
+    client.credential_scope = "context:local:org:work"
+    client._replay_scope = "credential:work-lineage"
+    relogged, failure = await client._silent_local_relogin(
+        {"local_login_email": "bliss@example.test", "local_login_password": "secret"}
+    )
+
+    assert relogged is True
+    assert failure is None
+    assert client.auth_token == "work-token"
+    assert client._replay_scope == "credential:work-lineage"
+    assert requests == [
+        (
+            "/auth/local/login",
+            {"json": {"email": "bliss@example.test", "password": "secret"}},
+        ),
+        (
+            "/orgs/work/switch",
+            {"headers": {"Authorization": "Bearer personal-token"}},
+        ),
+    ]
+    assert writes[0]["pending_replay_scope"] == "credential:work-lineage"
+
+
+@pytest.mark.asyncio
+async def test_silent_local_relogin_refuses_an_unscoped_organization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class UnexpectedAsyncClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise AssertionError("unscoped relogin must not contact the login endpoint")
+
+    monkeypatch.setattr(client_auth_module.httpx, "AsyncClient", UnexpectedAsyncClient)
+    client = SibylClient(base_url="http://example.test/api", auth_token="old-token")
+
+    relogged, failure = await client._silent_local_relogin(
+        {"local_login_email": "bliss@example.test", "local_login_password": "secret"}
+    )
+
+    assert relogged is False
+    assert failure == "Silent local re-login requires an organization-scoped context."
 
 
 @pytest.mark.asyncio
@@ -89,6 +202,7 @@ async def test_refresh_uses_newer_token_written_by_another_process(
         client_module, "_load_default_auth_token", lambda _api_url, _scope=None: "old-access"
     )
     monkeypatch.setattr(client_auth_module, "auth_file_lock", lambda: _noop_lock())
+    replay_scope = client_transport_module._auth_replay_scope(None, "old-access")
     monkeypatch.setattr(
         client_auth_module,
         "read_server_credentials",
@@ -96,6 +210,7 @@ async def test_refresh_uses_newer_token_written_by_another_process(
             "access_token": "new-access",
             "refresh_token": "new-refresh",
             "access_token_expires_at": int(time.time()) + 3600,
+            "pending_replay_scope": replay_scope,
         },
     )
     monkeypatch.setattr(
@@ -116,6 +231,83 @@ async def test_refresh_uses_newer_token_written_by_another_process(
     assert refreshed is True
     assert failure is None
     assert client.auth_token == "new-access"
+    assert client._replay_scope == replay_scope
+
+
+@pytest.mark.asyncio
+async def test_refresh_refuses_token_from_replaced_credential_lineage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SIBYL_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        client_module, "_load_default_auth_token", lambda _api_url, _scope=None: "old-access"
+    )
+    monkeypatch.setattr(client_auth_module, "auth_file_lock", lambda: _noop_lock())
+    monkeypatch.setattr(
+        client_auth_module,
+        "read_server_credentials",
+        lambda _api_url, **_kwargs: {
+            "access_token": "other-user-access",
+            "refresh_token": "other-user-refresh",
+            "access_token_expires_at": int(time.time()) + 3600,
+            "pending_replay_scope": "credential:other-user",
+        },
+    )
+    monkeypatch.setattr(
+        client_auth_module,
+        "is_access_token_expired",
+        lambda _api_url, **_kwargs: False,
+    )
+
+    client = SibylClient(base_url="http://example.test/api")
+    original_scope = client._replay_scope
+    refreshed, failure = await client._refresh_token()
+
+    assert refreshed is False
+    assert failure == (
+        "Stored credentials changed since this command started; retry the command with the "
+        "current login."
+    )
+    assert client.auth_token == "old-access"
+    assert client._replay_scope == original_scope
+
+
+@pytest.mark.asyncio
+async def test_refresh_refuses_expired_token_from_replaced_credential_lineage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SIBYL_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        client_module, "_load_default_auth_token", lambda _api_url, _scope=None: "old-access"
+    )
+    monkeypatch.setattr(client_auth_module, "auth_file_lock", lambda: _noop_lock())
+    monkeypatch.setattr(
+        client_auth_module,
+        "read_server_credentials",
+        lambda _api_url, **_kwargs: {
+            "access_token": "expired-other-user-access",
+            "refresh_token": "other-user-refresh",
+            "access_token_expires_at": 1,
+            "pending_replay_scope": "credential:other-user",
+        },
+    )
+
+    class UnexpectedAsyncClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise AssertionError("another credential's refresh token must never be used")
+
+    monkeypatch.setattr(client_auth_module.httpx, "AsyncClient", UnexpectedAsyncClient)
+    client = SibylClient(base_url="http://example.test/api")
+    original_scope = client._replay_scope
+    refreshed, failure = await client._refresh_token()
+
+    assert refreshed is False
+    assert failure == (
+        "Stored credentials changed since this command started; retry the command with the "
+        "current login."
+    )
+    assert client.auth_token == "old-access"
+    assert client._replay_scope == original_scope
 
 
 @pytest.mark.asyncio
@@ -155,6 +347,7 @@ async def test_refresh_rotates_and_writes_tokens_under_lock(
         expires_in: int | None = None,
         lock: bool = True,
         credential_scope: str | None = None,
+        pending_replay_scope: str | None = None,
     ) -> None:
         writes.append(
             {
@@ -164,11 +357,11 @@ async def test_refresh_rotates_and_writes_tokens_under_lock(
                 "expires_in": expires_in,
                 "lock": lock,
                 "credential_scope": credential_scope,
+                "pending_replay_scope": pending_replay_scope,
             }
         )
 
     monkeypatch.setattr(client_auth_module, "set_tokens", fake_set_tokens)
-
     class FakeResponse:
         status_code = 200
         text = ""
@@ -203,6 +396,9 @@ async def test_refresh_rotates_and_writes_tokens_under_lock(
     assert refreshed is True
     assert failure is None
     assert client.auth_token == "new-access"
+    assert client._replay_scope == client_transport_module._auth_replay_scope(
+        None, "old-access"
+    )
     assert writes == [
         {
             "api_url": "http://example.test/api",
@@ -211,5 +407,8 @@ async def test_refresh_rotates_and_writes_tokens_under_lock(
             "expires_in": 3600,
             "lock": False,
             "credential_scope": None,
+            "pending_replay_scope": client_transport_module._auth_replay_scope(
+                None, "old-access"
+            ),
         }
     ]

--- a/apps/cli/tests/test_pending_cli.py
+++ b/apps/cli/tests/test_pending_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -262,6 +263,52 @@ def test_pending_writes_claim_binds_and_retries_legacy_entries(
     assert replayed == [item["id"]]
     assert replay_options == [True]
     assert pending_writes.list_pending_writes() == []
+
+
+def test_pending_writes_claim_fails_when_replay_lock_is_busy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    item = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="http://testserver/api",
+        json_payload={"title": "Legacy"},
+        params=None,
+    )
+
+    class FakeClient:
+        def __init__(self, *, context_name: str | None = None) -> None:
+            self.context_name = context_name
+            self.base_url = "http://testserver/api"
+            self._replay_scope = TEST_REPLAY_SCOPE
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def get(self, path: str) -> dict[str, Any]:
+            assert path == "/auth/me"
+            return {
+                "user": {"email": "bliss@example.test"},
+                "organization": {"slug": "silkcircuit"},
+            }
+
+        async def _maybe_replay_pending_writes(self, *, ignore_backoff: bool = False) -> None:
+            raise AssertionError("claim replay ran without the replay lock")
+
+    monkeypatch.setattr(pending, "SibylClient", FakeClient)
+    monkeypatch.setattr(pending, "pending_replay_lock", lambda: nullcontext(False))
+    monkeypatch.setattr("sibyl_cli.config_store.resolve_context_name", lambda: "local")
+
+    result = CliRunner().invoke(pending.app, ["claim", "--yes"])
+
+    assert result.exit_code == 1
+    assert "claim did not run" in result.stdout
+    assert pending_writes.read_pending_write(str(item["id"]))["replay_scope"] is None
 
 
 @pytest.mark.parametrize(

--- a/apps/cli/tests/test_pending_cli.py
+++ b/apps/cli/tests/test_pending_cli.py
@@ -264,6 +264,64 @@ def test_pending_writes_claim_binds_and_retries_legacy_entries(
     assert pending_writes.list_pending_writes() == []
 
 
+@pytest.mark.parametrize(
+    "claim_error",
+    [
+        FileNotFoundError("Pending write disappeared"),
+        ValueError("Pending write already belongs to another credential"),
+    ],
+)
+def test_pending_writes_claim_reports_a_concurrent_queue_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    claim_error: Exception,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    item = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="http://testserver/api",
+        json_payload={"title": "Legacy"},
+        params=None,
+    )
+
+    class FakeClient:
+        def __init__(self, *, context_name: str | None = None) -> None:
+            self.context_name = context_name
+            self.base_url = "http://testserver/api"
+            self._replay_scope = TEST_REPLAY_SCOPE
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def get(self, path: str) -> dict[str, Any]:
+            assert path == "/auth/me"
+            return {
+                "user": {"email": "bliss@example.test"},
+                "organization": {"slug": "silkcircuit"},
+            }
+
+        async def _maybe_replay_pending_writes(self, *, ignore_backoff: bool = False) -> None:
+            raise AssertionError("an unclaimed write reached replay")
+
+    def fail_claim(_write_id: str, _replay_scope: str) -> dict[str, Any]:
+        raise claim_error
+
+    monkeypatch.setattr(pending, "SibylClient", FakeClient)
+    monkeypatch.setattr(pending, "claim_pending_write_replay_scope", fail_claim)
+    monkeypatch.setattr("sibyl_cli.config_store.resolve_context_name", lambda: "local")
+
+    result = CliRunner().invoke(pending.app, ["claim", "--yes"])
+
+    assert result.exit_code == 1
+    assert "Could not claim" in result.stdout
+    assert "Traceback" not in result.stdout
+    assert pending_writes.resolve_pending_write_path(str(item["id"])).exists()
+
+
 def test_pending_writes_flush_refuses_an_unclaimed_legacy_entry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/cli/tests/test_pending_cli.py
+++ b/apps/cli/tests/test_pending_cli.py
@@ -10,6 +10,8 @@ from typer.testing import CliRunner
 from sibyl_cli import pending, pending_writes
 from sibyl_cli.client import SibylClientError
 
+TEST_REPLAY_SCOPE = "token-sha256:test"
+
 
 def _create_pending(path: str = "/memory/raw") -> dict[str, Any]:
     return pending_writes.create_pending_write(
@@ -22,6 +24,7 @@ def _create_pending(path: str = "/memory/raw") -> dict[str, Any]:
             "memory_scope": "private",
         },
         params=None,
+        replay_scope=TEST_REPLAY_SCOPE,
     )
 
 
@@ -95,6 +98,7 @@ def test_pending_writes_flush_replays_valid_entries_but_keeps_corrupt_ones(
         def __init__(self, *, base_url: str, context_name: str | None = None) -> None:
             self.base_url = base_url
             self.context_name = context_name
+            self._replay_scope = TEST_REPLAY_SCOPE
 
         async def __aenter__(self) -> FakeClient:
             return self
@@ -202,6 +206,102 @@ def test_pending_writes_discard_read_like_removes_only_read_replays(
     assert pending_writes.read_pending_metrics()["discarded"] == 1
 
 
+def test_pending_writes_claim_binds_and_retries_legacy_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    item = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="http://testserver/api",
+        json_payload={"title": "Legacy", "raw_content": "Sensitive body"},
+        params=None,
+    )
+    pending_writes.increment_attempts(str(item["id"]))
+    replayed: list[str] = []
+    replay_options: list[bool] = []
+
+    class FakeClient:
+        def __init__(self, *, context_name: str | None = None) -> None:
+            self.context_name = context_name
+            self.base_url = "http://testserver/api"
+            self._replay_scope = TEST_REPLAY_SCOPE
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def get(self, path: str) -> dict[str, Any]:
+            assert path == "/auth/me"
+            return {
+                "user": {"email": "bliss@example.test"},
+                "organization": {"slug": "silkcircuit"},
+            }
+
+        async def _maybe_replay_pending_writes(self, *, ignore_backoff: bool = False) -> None:
+            replay_options.append(ignore_backoff)
+            for queued in pending_writes.list_pending_writes():
+                if queued.get("replay_scope") == self._replay_scope:
+                    replayed.append(str(queued["id"]))
+                    pending_writes.delete_pending_write(str(queued["id"]))
+
+    monkeypatch.setattr(pending, "SibylClient", FakeClient)
+    monkeypatch.setattr(
+        "sibyl_cli.config_store.resolve_context_name",
+        lambda: "local",
+    )
+
+    result = CliRunner().invoke(pending.app, ["claim", "--yes"])
+
+    assert result.exit_code == 0
+    assert "bliss@example.test" in result.stdout
+    assert "silkcircuit" in result.stdout
+    assert replayed == [item["id"]]
+    assert replay_options == [True]
+    assert pending_writes.list_pending_writes() == []
+
+
+def test_pending_writes_flush_refuses_an_unclaimed_legacy_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="http://testserver/api",
+        json_payload={"title": "Legacy"},
+        params=None,
+    )
+
+    class FakeClient:
+        _replay_scope = TEST_REPLAY_SCOPE
+
+        def __init__(self, *, base_url: str, context_name: str | None = None) -> None:
+            self.base_url = base_url
+            self.context_name = context_name
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def _request(self, *_args: object, **_kwargs: object) -> dict[str, Any]:
+            raise AssertionError("unclaimed write reached the server")
+
+    monkeypatch.setattr(pending, "SibylClient", FakeClient)
+
+    result = CliRunner().invoke(pending.app, ["flush"])
+
+    assert result.exit_code == 1
+    assert "run sibyl pending-writes claim first" in result.stdout
+    assert pending_writes.pending_write_count() == 1
+
+
 def test_pending_writes_flush_replays_and_deletes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -214,6 +314,7 @@ def test_pending_writes_flush_replays_and_deletes(
         def __init__(self, *, base_url: str, context_name: str | None = None) -> None:
             self.base_url = base_url
             self.context_name = context_name
+            self._replay_scope = TEST_REPLAY_SCOPE
 
         async def __aenter__(self) -> FakeClient:
             return self
@@ -252,6 +353,7 @@ def test_pending_writes_flush_skips_read_like_replays(
         def __init__(self, *, base_url: str, context_name: str | None = None) -> None:
             self.base_url = base_url
             self.context_name = context_name
+            self._replay_scope = TEST_REPLAY_SCOPE
 
         async def __aenter__(self) -> FakeClient:
             return self
@@ -290,6 +392,7 @@ def test_pending_writes_flush_reuses_client_per_base_url(
         def __init__(self, *, base_url: str, context_name: str | None = None) -> None:
             self.base_url = base_url
             self.context_name = context_name
+            self._replay_scope = TEST_REPLAY_SCOPE
             instances.append(self)
 
         async def __aenter__(self) -> FakeClient:
@@ -325,6 +428,7 @@ def test_pending_writes_flush_stops_after_auth_refresh_failure(
         def __init__(self, *, base_url: str, context_name: str | None = None) -> None:
             self.base_url = base_url
             self.context_name = context_name
+            self._replay_scope = TEST_REPLAY_SCOPE
 
         async def __aenter__(self) -> FakeClient:
             return self
@@ -364,6 +468,7 @@ def test_pending_writes_flush_failure_summary_names_both_classes(
         def __init__(self, *, base_url: str, context_name: str | None = None) -> None:
             self.base_url = base_url
             self.context_name = context_name
+            self._replay_scope = TEST_REPLAY_SCOPE
 
         async def __aenter__(self) -> FakeClient:
             return self

--- a/uv.lock
+++ b/uv.lock
@@ -3670,6 +3670,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -3690,6 +3691,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff" },
+    { name = "ty", specifier = ">=0.0.69" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🦋 Why

Pending writes were bound to a context name, not the credential that created
them. A later login in the same context could therefore replay another
principal's queued work. Older queue entries have no trustworthy owner at all.

## 🔮 What changed

- Give every stored login a durable pending-write lineage.
- Preserve that lineage only across server-confirmed refreshes and exact-org
  local relogin.
- Refuse fresh or replaced credentials before they can consume another
  lineage.
- Add `sibyl pending-writes claim` for ambiguous legacy entries. The command
  displays the authenticated user and organization, then retries approved
  writes immediately with their original idempotency keys.
- Refuse manual or automatic replay when ownership does not match.
- Remove the duplicate OAuth token persistence boundary.

## 🧪 Verification

- `moon run cli:lint`
- `moon run cli:typecheck`
- `moon run cli:test` with 626 passing tests
- Independent adversarial verification across user turnover, expired-token
  turnover, refresh races, local org switching, OAuth persistence, claim
  cooldown, manual flush, and idempotency

## 🎯 Review guide

The central invariant is simple: a queued write can only leave the machine
under the credential lineage that created or explicitly claimed it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `pending-writes claim` to assign eligible pending writes to the active authenticated context and replay them immediately.
  - Added support for safely tracking credential ownership across pending writes and organization contexts.

- **Bug Fixes**
  - Improved token refresh and silent re-login behavior when switching organizations.
  - Prevented unclaimed legacy pending writes from being replayed accidentally.
  - Improved handling of credential changes while preserving valid pending-write associations.

- **Tests**
  - Added coverage for claiming, replaying, refreshing, and safely rejecting improperly scoped pending writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->