### PR TITLE
fix(evals): bound Surreal cache on hosted runners

### DIFF
--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -519,6 +519,7 @@ jobs:
       SIBYL_SURREAL_USERNAME: sibyl_ci
       SIBYL_SURREAL_PASSWORD: sibyl_ci_password
       SIBYL_SURREAL_PATH: rocksdb:///data/sibyl-longmemeval-v2.db
+      SURREAL_ROCKSDB_BLOCK_CACHE_SIZE: "4294967296"
       SIBYL_REDIS_HOST: 127.0.0.1
       SIBYL_REDIS_PORT: "6381"
       SIBYL_GRAPH_EMBEDDING_PROVIDER: local

--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -821,9 +821,19 @@ jobs:
             echo "::error::SurrealDB RocksDB cache size was not applied exactly."
             exit 1
           fi
-          if docker compose --env-file /dev/null logs --no-color surrealdb |
-            grep -Fq 'Could not parse configuration value'; then
+          if ! surrealdb_logs="$(
+            docker compose --env-file /dev/null logs --no-color surrealdb
+          )"; then
+            echo "::error::SurrealDB logs are unavailable for configuration validation."
+            exit 1
+          fi
+          if grep -Fq 'Could not parse configuration value' <<< "$surrealdb_logs"; then
             echo "::error::SurrealDB rejected a runtime configuration value."
+            exit 1
+          fi
+          if ! grep -Fq "Block cache size: $expected_cache_size" \
+            <<< "$surrealdb_logs"; then
+            echo "::error::SurrealDB did not confirm the requested RocksDB cache size."
             exit 1
           fi
           mkdir -p "$telemetry"
@@ -1115,6 +1125,10 @@ jobs:
         run: |
           set -euo pipefail
           telemetry="$RUNNER_TEMP/surrealdb-runtime"
+          if [[ ! -s "$telemetry/container.id" ]]; then
+            echo "::notice::Skipping the runtime gate because telemetry did not start."
+            exit 0
+          fi
           surrealdb_id="$(cat "$telemetry/container.id")"
           tools/dev/surreal-runtime-monitor.sh gate \
             --container "$surrealdb_id" \

--- a/.github/workflows/longmemeval-v2.yml
+++ b/.github/workflows/longmemeval-v2.yml
@@ -810,6 +810,22 @@ jobs:
             echo "::error::SurrealDB container ID is unavailable."
             exit 1
           fi
+          expected_cache_size="${SURREAL_ROCKSDB_BLOCK_CACHE_SIZE:-}"
+          actual_cache_size="$(
+            docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' \
+              "$surrealdb_id" |
+              sed -n 's/^SURREAL_ROCKSDB_BLOCK_CACHE_SIZE=//p'
+          )"
+          if [[ ! "$expected_cache_size" =~ ^[1-9][0-9]*$ ]] ||
+            [[ "$actual_cache_size" != "$expected_cache_size" ]]; then
+            echo "::error::SurrealDB RocksDB cache size was not applied exactly."
+            exit 1
+          fi
+          if docker compose --env-file /dev/null logs --no-color surrealdb |
+            grep -Fq 'Could not parse configuration value'; then
+            echo "::error::SurrealDB rejected a runtime configuration value."
+            exit 1
+          fi
           mkdir -p "$telemetry"
           tools/dev/surreal-runtime-monitor.sh monitor \
             --container "$surrealdb_id" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       # `:U` is a podman extension that chowns the bind mount to the container UID
       # on first start (no-op under Docker Engine). Fixes rootless podman perm denied.
       - "${SURREAL_DATA_DIR:-./.moon/cache/surreal-dev}:/data:U"
+    environment:
+      - SURREAL_ROCKSDB_BLOCK_CACHE_SIZE
     restart: unless-stopped
 
   surrealdb-eval:

--- a/moon.yml
+++ b/moon.yml
@@ -1045,6 +1045,7 @@ tasks:
       tools/tests/test_longmemeval_v2_release_ci.py -v
     inputs:
       - tools/**/*.py
+      - docker-compose.yml
       - .github/workflows/eval.yml
       - .github/workflows/longmemeval-v2.yml
       - .github/workflows/longmemeval-v2-release-aa.yml

--- a/tools/tests/test_longmemeval_v2_probe.py
+++ b/tools/tests/test_longmemeval_v2_probe.py
@@ -284,6 +284,7 @@ def test_longmemeval_v2_workflow_packages_receipts_and_diagnostics() -> None:
     assert ".moon/cache/evals/longmemeval-v2-official/arm_run.json" in workflow
     assert "Upload service diagnostics" in workflow
     assert "SIBYL_SURREAL_PATH: rocksdb:///data/sibyl-longmemeval-v2.db" in workflow
+    assert 'SURREAL_ROCKSDB_BLOCK_CACHE_SIZE: "4294967296"' in workflow
     assert "sibyld.log" in workflow
     assert "sibyl-worker.log" in workflow
     assert "Capture service diagnostics" in workflow
@@ -409,6 +410,13 @@ def test_release_compose_service_pins_the_bounded_surreal_runtime() -> None:
     assert 'SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER: "4"' in eval_service
     assert '"127.0.0.1:8018:8000"' in eval_service
     assert "${SIBYL_RELEASE_ROOT:-./.moon/cache/surreal-eval}/surreal" in eval_service
+
+
+def test_default_compose_service_forwards_an_explicit_rocksdb_cache_size() -> None:
+    compose = (Path(__file__).parents[2] / "docker-compose.yml").read_text(encoding="utf-8")
+    default_service = compose.split("  surrealdb:", 1)[1].split("  surrealdb-eval:", 1)[0]
+
+    assert "- SURREAL_ROCKSDB_BLOCK_CACHE_SIZE" in default_service
 
 
 def _write_dataset(

--- a/tools/tests/test_longmemeval_v2_probe.py
+++ b/tools/tests/test_longmemeval_v2_probe.py
@@ -278,6 +278,11 @@ def test_longmemeval_v2_workflow_packages_receipts_and_diagnostics() -> None:
         for step in official_job["steps"]
         if step.get("name") == "Start SurrealDB runtime telemetry"
     )
+    runtime_gate_script = next(
+        step["run"]
+        for step in official_job["steps"]
+        if step.get("name") == "Gate SurrealDB runtime integrity"
+    )
 
     assert "build_submission_step_1_single_operating_point.py" in workflow
     assert "build_submission_step_2_build_package.py" in workflow
@@ -294,6 +299,9 @@ def test_longmemeval_v2_workflow_packages_receipts_and_diagnostics() -> None:
     assert 'actual_cache_size="$(' in telemetry_script
     assert '[[ "$actual_cache_size" != "$expected_cache_size" ]]' in telemetry_script
     assert "Could not parse configuration value" in telemetry_script
+    assert "Block cache size: $expected_cache_size" in telemetry_script
+    assert "logs are unavailable for configuration validation" in telemetry_script
+    assert '[[ ! -s "$telemetry/container.id" ]]' in runtime_gate_script
     assert "sibyld.log" in workflow
     assert "sibyl-worker.log" in workflow
     assert "Capture service diagnostics" in workflow

--- a/tools/tests/test_longmemeval_v2_probe.py
+++ b/tools/tests/test_longmemeval_v2_probe.py
@@ -269,9 +269,15 @@ def test_longmemeval_v2_workflow_seals_paid_arm_manifest() -> None:
 
 
 def test_longmemeval_v2_workflow_packages_receipts_and_diagnostics() -> None:
-    workflow = (
-        Path(__file__).parents[2] / ".github" / "workflows" / "longmemeval-v2.yml"
-    ).read_text(encoding="utf-8")
+    workflow_path = Path(__file__).parents[2] / ".github" / "workflows" / "longmemeval-v2.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    official_job = yaml.safe_load(workflow)["jobs"]["official-full"]
+    official_env = official_job["env"]
+    telemetry_script = next(
+        step["run"]
+        for step in official_job["steps"]
+        if step.get("name") == "Start SurrealDB runtime telemetry"
+    )
 
     assert "build_submission_step_1_single_operating_point.py" in workflow
     assert "build_submission_step_2_build_package.py" in workflow
@@ -284,7 +290,10 @@ def test_longmemeval_v2_workflow_packages_receipts_and_diagnostics() -> None:
     assert ".moon/cache/evals/longmemeval-v2-official/arm_run.json" in workflow
     assert "Upload service diagnostics" in workflow
     assert "SIBYL_SURREAL_PATH: rocksdb:///data/sibyl-longmemeval-v2.db" in workflow
-    assert 'SURREAL_ROCKSDB_BLOCK_CACHE_SIZE: "4294967296"' in workflow
+    assert official_env["SURREAL_ROCKSDB_BLOCK_CACHE_SIZE"] == "4294967296"
+    assert 'actual_cache_size="$(' in telemetry_script
+    assert '[[ "$actual_cache_size" != "$expected_cache_size" ]]' in telemetry_script
+    assert "Could not parse configuration value" in telemetry_script
     assert "sibyld.log" in workflow
     assert "sibyl-worker.log" in workflow
     assert "Capture service diagnostics" in workflow
@@ -413,10 +422,12 @@ def test_release_compose_service_pins_the_bounded_surreal_runtime() -> None:
 
 
 def test_default_compose_service_forwards_an_explicit_rocksdb_cache_size() -> None:
-    compose = (Path(__file__).parents[2] / "docker-compose.yml").read_text(encoding="utf-8")
-    default_service = compose.split("  surrealdb:", 1)[1].split("  surrealdb-eval:", 1)[0]
+    compose = yaml.safe_load(
+        (Path(__file__).parents[2] / "docker-compose.yml").read_text(encoding="utf-8")
+    )
+    environment = compose["services"]["surrealdb"]["environment"]
 
-    assert "- SURREAL_ROCKSDB_BLOCK_CACHE_SIZE" in default_service
+    assert environment == ["SURREAL_ROCKSDB_BLOCK_CACHE_SIZE"]
 
 
 def _write_dataset(


### PR DESCRIPTION
## Why

The v1.3 LongMemEval A/A build died on four GitHub-hosted runners at the same transition: after all 100 trajectories were ingested, prompt construction began retrieval, then the runner received a shutdown signal.

The repeated boundary matches the existing RocksDB memory-pressure signature. On the 15 GiB hosted runner, SurrealDB derived roughly 7.31 GiB of block cache before sibyld, the worker, prompt construction, and sentence-transformers were counted. None of the failed attempts reached OpenRouter inference.

## What changed

- Forward `SURREAL_ROCKSDB_BLOCK_CACHE_SIZE` through the shared SurrealDB Compose service without adding a local default.
- Set the official paid LongMemEval job to an exact 4 GiB RocksDB block cache.
- Fail before ingestion unless the expected value reaches the actual container and SurrealDB logs the exact applied cache size.
- Preserve the original failure when runtime telemetry never starts instead of stacking a misleading gate failure.
- Include `docker-compose.yml` in the Moon benchmark gate inputs.
- Parse the workflow and Compose models in tests so moving or hardcoding the value cannot preserve a false green.

All ingestion, query, reader, and worker concurrency stays unchanged. The patch right-sizes SurrealDB's cache allocation on the constrained hosted runner. It does not cap the workload.

## Blast radius

The base Compose service only forwards an explicitly supplied variable. Local development keeps SurrealDB's normal derived default when the variable is unset. Only the `official-full` paid evaluation job supplies 4 GiB.

No container memory limit was added. A container ceiling would only move the crash without evidence that the workload peak fits below it.

## Verification

- `moon run --force inventory-lint`
- `moon run --force bench-gate-test -- tools/tests/test_longmemeval_v2_probe.py -q`: 874 passed
- Compose render with the variable unset: container environment omits the setting
- Compose render with the variable set: container receives `4294967296`
- Independent Claude review on exact SHA `e3d5fd3e`: PASS
- Live isolated SurrealDB v3.2.3 probe confirmed `Block cache size: 4294967296`

The real GitHub-hosted A/A run remains the final proof that 4 GiB leaves enough headroom at the retrieval boundary. Runtime telemetry and diagnostics remain armed for that receipt.

## Reviewer focus

- Confirm the 4 GiB setting is scoped only to `official-full`.
- Confirm local Compose behavior remains unchanged when the variable is absent.
- Confirm configuration drift fails before paid ingestion and inference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for configuring SurrealDB’s RocksDB block-cache size through the deployment environment.
  * Startup checks now verify that the configured cache size is applied and confirmed in service logs.
  * Improved runtime validation to report when telemetry is unavailable without causing an unnecessary failure.

* **Reliability**
  * Enhanced deployment safeguards to detect invalid configuration and prevent running with an incorrectly configured database cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->