### PR TITLE
fix(evals): release trajectory heap after ingestion

### DIFF
--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -252,9 +252,13 @@ def main(argv: list[str] | None = None) -> int:
     import evaluation.harness as official_harness  # noqa: PLC0415
     import evaluation.qa_eval_metrics as official_metrics  # noqa: PLC0415
 
-    install_shared_trajectory_release(
-        official_harness,
-        selected_haystack=selected_haystack,
+    trajectory_release = (
+        install_shared_trajectory_release(
+            official_harness,
+            selected_haystack=selected_haystack,
+        )
+        if not args.load_memory_dir
+        else None
     )
     install_provider_usage_tracking(
         official_harness,
@@ -276,6 +280,8 @@ def main(argv: list[str] | None = None) -> int:
             memory_config_path=memory_config_path,
         )
         official_harness.main()
+        if trajectory_release is not None:
+            trajectory_release.assert_complete()
     finally:
         sys.argv = old_argv
     if args.experiment_id:
@@ -341,40 +347,67 @@ class _ConsumeOnLastReadTrajectories(dict[str, dict[str, Any]]):
         return trajectory
 
 
-def install_shared_trajectory_release(
-    official_harness: Any,
-    *,
-    selected_haystack: dict[str, list[str]],
-) -> bool:
-    """Bound harness heap retention for one shared ordered haystack."""
+class _SharedTrajectoryRelease:
+    def __init__(
+        self,
+        original_load: Any,
+        *,
+        read_counts: Counter[str],
+    ) -> None:
+        self._original_load = original_load
+        self._read_counts = read_counts
+        self._loaded_maps: list[_ConsumeOnLastReadTrajectories] = []
 
-    ordered_haystacks = list(selected_haystack.values())
-    if not ordered_haystacks or any(
-        haystack != ordered_haystacks[0] for haystack in ordered_haystacks[1:]
-    ):
-        return False
-    read_counts = Counter(ordered_haystacks[0])
-    original_load = official_harness.load_trajectories
-
-    def load_selected_trajectories(path: str) -> _ConsumeOnLastReadTrajectories:
-        loaded = original_load(path)
-        missing = sorted(set(read_counts).difference(loaded))
+    def load(self, path: str) -> _ConsumeOnLastReadTrajectories:
+        loaded = self._original_load(path)
+        missing = sorted(set(self._read_counts).difference(loaded))
         if missing:
             raise RuntimeError(f"Shared haystack references missing trajectories: {missing}")
-        selected = {trajectory_id: loaded[trajectory_id] for trajectory_id in read_counts}
+        selected = {
+            trajectory_id: loaded[trajectory_id] for trajectory_id in self._read_counts
+        }
         loaded.clear()
         print(  # noqa: T201
             "Shared-haystack trajectory retention: consume-on-insert "
             f"({len(selected)} selected).",
             flush=True,
         )
-        return _ConsumeOnLastReadTrajectories(
+        trajectories = _ConsumeOnLastReadTrajectories(
             selected,
-            read_counts=read_counts.copy(),
+            read_counts=self._read_counts.copy(),
         )
+        self._loaded_maps.append(trajectories)
+        return trajectories
 
-    official_harness.load_trajectories = load_selected_trajectories
-    return True
+    def assert_complete(self) -> None:
+        if not self._loaded_maps:
+            raise RuntimeError("Official harness did not load the shared trajectories")
+        remaining = sum(len(trajectories) for trajectories in self._loaded_maps)
+        if remaining:
+            raise RuntimeError(
+                "Official harness left shared trajectory payloads unread: "
+                f"{remaining} remaining"
+            )
+
+
+def install_shared_trajectory_release(
+    official_harness: Any,
+    *,
+    selected_haystack: dict[str, list[str]],
+) -> _SharedTrajectoryRelease | None:
+    """Bound harness heap retention for one shared ordered haystack."""
+
+    ordered_haystacks = list(selected_haystack.values())
+    if not ordered_haystacks or any(
+        haystack != ordered_haystacks[0] for haystack in ordered_haystacks[1:]
+    ):
+        return None
+    release = _SharedTrajectoryRelease(
+        official_harness.load_trajectories,
+        read_counts=Counter(ordered_haystacks[0]),
+    )
+    official_harness.load_trajectories = release.load
+    return release
 
 
 def _redacted_command_args(command_args: Sequence[str]) -> list[str]:

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections import Counter
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
@@ -251,6 +252,10 @@ def main(argv: list[str] | None = None) -> int:
     import evaluation.harness as official_harness  # noqa: PLC0415
     import evaluation.qa_eval_metrics as official_metrics  # noqa: PLC0415
 
+    install_shared_trajectory_release(
+        official_harness,
+        selected_haystack=selected_haystack,
+    )
     install_provider_usage_tracking(
         official_harness,
         official_metrics,
@@ -311,6 +316,65 @@ def install_official_memory_adapter(official_repo: Path) -> type[Any]:
         raise RuntimeError("Sibyl memory adapter did not register with the official harness")
     globals()["SibylLiveApiMemory"] = memory_cls
     return memory_cls
+
+
+class _ConsumeOnLastReadTrajectories(dict[str, dict[str, Any]]):
+    """Release shared-haystack trajectory payloads after their final insert."""
+
+    def __init__(
+        self,
+        trajectories: dict[str, dict[str, Any]],
+        *,
+        read_counts: Counter[str],
+    ) -> None:
+        super().__init__(trajectories)
+        self._read_counts = read_counts
+
+    def __getitem__(self, trajectory_id: str) -> dict[str, Any]:
+        trajectory = super().__getitem__(trajectory_id)
+        remaining = self._read_counts[trajectory_id] - 1
+        if remaining <= 0:
+            self._read_counts.pop(trajectory_id, None)
+            super().__delitem__(trajectory_id)
+        else:
+            self._read_counts[trajectory_id] = remaining
+        return trajectory
+
+
+def install_shared_trajectory_release(
+    official_harness: Any,
+    *,
+    selected_haystack: dict[str, list[str]],
+) -> bool:
+    """Bound harness heap retention for one shared ordered haystack."""
+
+    ordered_haystacks = list(selected_haystack.values())
+    if not ordered_haystacks or any(
+        haystack != ordered_haystacks[0] for haystack in ordered_haystacks[1:]
+    ):
+        return False
+    read_counts = Counter(ordered_haystacks[0])
+    original_load = official_harness.load_trajectories
+
+    def load_selected_trajectories(path: str) -> _ConsumeOnLastReadTrajectories:
+        loaded = original_load(path)
+        missing = sorted(set(read_counts).difference(loaded))
+        if missing:
+            raise RuntimeError(f"Shared haystack references missing trajectories: {missing}")
+        selected = {trajectory_id: loaded[trajectory_id] for trajectory_id in read_counts}
+        loaded.clear()
+        print(  # noqa: T201
+            "Shared-haystack trajectory retention: consume-on-insert "
+            f"({len(selected)} selected).",
+            flush=True,
+        )
+        return _ConsumeOnLastReadTrajectories(
+            selected,
+            read_counts=read_counts.copy(),
+        )
+
+    official_harness.load_trajectories = load_selected_trajectories
+    return True
 
 
 def _redacted_command_args(command_args: Sequence[str]) -> list[str]:

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -562,6 +562,55 @@ print("real_registry_rebind=PASS")
     assert result.stdout.strip() == "real_registry_rebind=PASS"
 
 
+def test_official_runner_releases_shared_trajectories_after_final_insert(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_runner_module()
+    loaded = {
+        "kept-once": {"id": "kept-once", "payload": "once"},
+        "kept-twice": {"id": "kept-twice", "payload": "twice"},
+        "unselected": {"id": "unselected", "payload": "unused"},
+    }
+    harness = SimpleNamespace(load_trajectories=lambda _path: loaded)
+
+    assert module.install_shared_trajectory_release(
+        harness,
+        selected_haystack={
+            "question-a": ["kept-once", "kept-twice", "kept-twice"],
+            "question-b": ["kept-once", "kept-twice", "kept-twice"],
+        },
+    )
+    trajectories = harness.load_trajectories("trajectories.jsonl")
+
+    assert loaded == {}
+    assert set(trajectories) == {"kept-once", "kept-twice"}
+    assert trajectories["kept-once"]["payload"] == "once"
+    assert "kept-once" not in trajectories
+    assert trajectories["kept-twice"]["payload"] == "twice"
+    assert "kept-twice" in trajectories
+    assert trajectories["kept-twice"]["payload"] == "twice"
+    assert trajectories == {}
+    assert "consume-on-insert (2 selected)" in capsys.readouterr().out
+
+
+def test_official_runner_keeps_nonshared_trajectory_loading_unchanged() -> None:
+    module = _load_runner_module()
+
+    def original_load(_path: str) -> dict[str, dict[str, str]]:
+        return {"trajectory": {"id": "trajectory"}}
+
+    harness = SimpleNamespace(load_trajectories=original_load)
+
+    assert not module.install_shared_trajectory_release(
+        harness,
+        selected_haystack={
+            "question-a": ["trajectory-a"],
+            "question-b": ["trajectory-b"],
+        },
+    )
+    assert harness.load_trajectories is original_load
+
+
 def test_official_runner_refuses_existing_provider_usage_before_work(tmp_path: Path) -> None:
     module = _load_runner_module()
     output_dir = tmp_path / "output"

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -573,13 +573,14 @@ def test_official_runner_releases_shared_trajectories_after_final_insert(
     }
     harness = SimpleNamespace(load_trajectories=lambda _path: loaded)
 
-    assert module.install_shared_trajectory_release(
+    release = module.install_shared_trajectory_release(
         harness,
         selected_haystack={
             "question-a": ["kept-once", "kept-twice", "kept-twice"],
             "question-b": ["kept-once", "kept-twice", "kept-twice"],
         },
     )
+    assert release is not None
     trajectories = harness.load_trajectories("trajectories.jsonl")
 
     assert loaded == {}
@@ -590,6 +591,7 @@ def test_official_runner_releases_shared_trajectories_after_final_insert(
     assert "kept-twice" in trajectories
     assert trajectories["kept-twice"]["payload"] == "twice"
     assert trajectories == {}
+    release.assert_complete()
     assert "consume-on-insert (2 selected)" in capsys.readouterr().out
 
 
@@ -601,14 +603,41 @@ def test_official_runner_keeps_nonshared_trajectory_loading_unchanged() -> None:
 
     harness = SimpleNamespace(load_trajectories=original_load)
 
-    assert not module.install_shared_trajectory_release(
-        harness,
-        selected_haystack={
-            "question-a": ["trajectory-a"],
-            "question-b": ["trajectory-b"],
-        },
+    assert (
+        module.install_shared_trajectory_release(
+            harness,
+            selected_haystack={
+                "question-a": ["trajectory-a"],
+                "question-b": ["trajectory-b"],
+            },
+        )
+        is None
     )
     assert harness.load_trajectories is original_load
+
+
+def test_official_runner_rejects_shared_trajectory_loader_drift() -> None:
+    module = _load_runner_module()
+
+    def load_trajectories(_path: str) -> dict[str, dict[str, str]]:
+        return {"trajectory": {"id": "trajectory", "payload": "retained"}}
+
+    harness = SimpleNamespace(load_trajectories=load_trajectories)
+    release = module.install_shared_trajectory_release(
+        harness,
+        selected_haystack={"question": ["trajectory"]},
+    )
+    assert release is not None
+
+    with pytest.raises(RuntimeError, match="did not load"):
+        release.assert_complete()
+
+    trajectories = harness.load_trajectories("trajectories.jsonl")
+    with pytest.raises(RuntimeError, match="1 remaining"):
+        release.assert_complete()
+
+    assert trajectories["trajectory"]["payload"] == "retained"
+    release.assert_complete()
 
 
 def test_official_runner_refuses_existing_provider_usage_before_work(tmp_path: Path) -> None:


### PR DESCRIPTION
## 🔮 Why

The paid LongMemEval V2 A/A builder now completes all 100 ingestion trajectories with the bounded SurrealDB cache, but both GitHub-hosted domain runners still die as prompt construction begins.

The pinned official harness decodes the full trajectory corpus into a dictionary and keeps every payload alive after its synchronous Sibyl insert. Prompt construction therefore starts while the runner still carries the decoded source corpus, the 4 GiB RocksDB cache, and the live retrieval stack.

## 🛠️ What changed

The Sibyl adapter boundary now wraps the pinned harness trajectory loader for shared ordered haystacks.

- Unselected trajectory payloads are discarded immediately after the official loader validates the corpus.
- Selected payloads are removed after their final synchronous insert.
- Duplicate trajectory IDs remain available until their final occurrence.
- Nonshared and loaded-memory paths keep the original behavior.
- A post-run guard fails closed if a future harness pin stops consuming through the expected dictionary access path.

## 🎯 Invariants

The change does not alter ingestion concurrency, embedding backfills, retrieval geometry, prompt-builder concurrency, reader concurrency, provider accounting, or official checkout cleanliness. The official repository remains pinned and untouched. The wrapper is bound to the recorded Sibyl execution SHA.

## 🧪 Verification

- `moon run --force bench-gate-test -- tools/tests/test_longmemeval_v2_official.py -q`
  - 877 passed
- `moon run --force :lint`
  - 12 tasks passed
- `moon run --force :typecheck`
  - 7 tasks passed
- `moon run --force inventory-lint`
  - passed after the final hardening
- `moon run --force inventory-typecheck`
  - passed after the final hardening
- Independent exact-head review of `27636826`
  - PASS

The previous paid run reached 100 of 100 ingestion trajectories, then built only 1 of 211 enterprise prompts before the runner was canceled. The next paid run should begin prompt construction without retaining the decoded trajectory heap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing benchmark runs that share trajectory data.
  - Trajectory data is released after its final use, helping reduce unnecessary resource usage.
  - Missing or mismatched trajectory references now trigger immediate errors instead of silently continuing.
  - Existing memory-directory loading behavior remains unchanged.

- **Tests**
  - Added coverage for shared-data cleanup, standard loading behavior, and loader mismatch detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->