### PR TITLE
fix(evals): bound shared trajectory loading

### DIFF
--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -368,15 +368,24 @@ class _SharedTrajectoryRelease:
         selected: dict[str, dict[str, Any]] = {}
         seen_ids: set[str] = set()
         with trajectory_path.open(encoding="utf-8") as handle:
-            for index, line in enumerate(handle):
+            for line_number, line in enumerate(handle, start=1):
                 if not line.strip():
                     continue
-                trajectory = json.loads(line)
+                try:
+                    trajectory = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise RuntimeError(
+                        f"Invalid trajectory JSON at {trajectory_path}:{line_number}"
+                    ) from exc
                 if not isinstance(trajectory, dict):
-                    raise RuntimeError(f"Invalid trajectory at index {index}")
+                    raise RuntimeError(
+                        f"Invalid trajectory at {trajectory_path}:{line_number}"
+                    )
                 trajectory_id = trajectory.get("id")
                 if not isinstance(trajectory_id, str) or not trajectory_id:
-                    raise RuntimeError(f"Invalid trajectory id at index {index}")
+                    raise RuntimeError(
+                        f"Invalid trajectory id at {trajectory_path}:{line_number}"
+                    )
                 if trajectory_id in seen_ids:
                     raise RuntimeError(f"Duplicate trajectory id: {trajectory_id}")
                 seen_ids.add(trajectory_id)
@@ -421,6 +430,8 @@ def install_shared_trajectory_release(
         haystack != ordered_haystacks[0] for haystack in ordered_haystacks[1:]
     ):
         return None
+    if not callable(getattr(official_harness, "load_trajectories", None)):
+        raise RuntimeError("Official harness does not expose callable load_trajectories")
     release = _SharedTrajectoryRelease(
         read_counts=Counter(ordered_haystacks[0]),
     )

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -387,7 +387,10 @@ class _SharedTrajectoryRelease:
                         f"Invalid trajectory id at {trajectory_path}:{line_number}"
                     )
                 if trajectory_id in seen_ids:
-                    raise RuntimeError(f"Duplicate trajectory id: {trajectory_id}")
+                    raise RuntimeError(
+                        f"Duplicate trajectory id {trajectory_id!r} "
+                        f"at {trajectory_path}:{line_number}"
+                    )
                 seen_ids.add(trajectory_id)
                 if trajectory_id in self._read_counts:
                     selected[trajectory_id] = trajectory

--- a/benchmarks/longmemeval_v2_official.py
+++ b/benchmarks/longmemeval_v2_official.py
@@ -350,25 +350,44 @@ class _ConsumeOnLastReadTrajectories(dict[str, dict[str, Any]]):
 class _SharedTrajectoryRelease:
     def __init__(
         self,
-        original_load: Any,
-        *,
         read_counts: Counter[str],
     ) -> None:
-        self._original_load = original_load
         self._read_counts = read_counts
         self._loaded_maps: list[_ConsumeOnLastReadTrajectories] = []
 
     def load(self, path: str) -> _ConsumeOnLastReadTrajectories:
-        loaded = self._original_load(path)
-        missing = sorted(set(self._read_counts).difference(loaded))
+        trajectory_path = Path(path)
+        if not trajectory_path.exists():
+            raise RuntimeError(f"Missing JSON file: {trajectory_path}")
+        if trajectory_path.suffix != ".jsonl":
+            raise RuntimeError(
+                "Shared-haystack trajectory streaming requires a JSONL source: "
+                f"{trajectory_path}"
+            )
+
+        selected: dict[str, dict[str, Any]] = {}
+        seen_ids: set[str] = set()
+        with trajectory_path.open(encoding="utf-8") as handle:
+            for index, line in enumerate(handle):
+                if not line.strip():
+                    continue
+                trajectory = json.loads(line)
+                if not isinstance(trajectory, dict):
+                    raise RuntimeError(f"Invalid trajectory at index {index}")
+                trajectory_id = trajectory.get("id")
+                if not isinstance(trajectory_id, str) or not trajectory_id:
+                    raise RuntimeError(f"Invalid trajectory id at index {index}")
+                if trajectory_id in seen_ids:
+                    raise RuntimeError(f"Duplicate trajectory id: {trajectory_id}")
+                seen_ids.add(trajectory_id)
+                if trajectory_id in self._read_counts:
+                    selected[trajectory_id] = trajectory
+
+        missing = sorted(set(self._read_counts).difference(selected))
         if missing:
             raise RuntimeError(f"Shared haystack references missing trajectories: {missing}")
-        selected = {
-            trajectory_id: loaded[trajectory_id] for trajectory_id in self._read_counts
-        }
-        loaded.clear()
         print(  # noqa: T201
-            "Shared-haystack trajectory retention: consume-on-insert "
+            "Shared-haystack trajectory retention: streaming consume-on-insert "
             f"({len(selected)} selected).",
             flush=True,
         )
@@ -403,7 +422,6 @@ def install_shared_trajectory_release(
     ):
         return None
     release = _SharedTrajectoryRelease(
-        official_harness.load_trajectories,
         read_counts=Counter(ordered_haystacks[0]),
     )
     official_harness.load_trajectories = release.load

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import tracemalloc
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -611,6 +612,35 @@ def test_official_runner_releases_shared_trajectories_after_final_insert(
     assert "streaming consume-on-insert (2 selected)" in capsys.readouterr().out
 
 
+def test_official_runner_bounds_shared_trajectory_heap(tmp_path: Path) -> None:
+    module = _load_runner_module()
+    trajectory_path = tmp_path / "trajectories.jsonl"
+    payload = "x" * 65_536
+    rows = [{"id": f"unselected-{index}", "payload": payload} for index in range(64)]
+    rows.insert(32, {"id": "kept", "payload": payload})
+    trajectory_path.write_text(
+        "".join(f"{json.dumps(row)}\n" for row in rows),
+        encoding="utf-8",
+    )
+    harness = SimpleNamespace(load_trajectories=lambda _path: {})
+    release = module.install_shared_trajectory_release(
+        harness,
+        selected_haystack={"question": ["kept"]},
+    )
+    assert release is not None
+
+    tracemalloc.start()
+    try:
+        trajectories = harness.load_trajectories(str(trajectory_path))
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert trajectories["kept"]["payload"] == payload
+    assert peak < trajectory_path.stat().st_size // 4
+    release.assert_complete()
+
+
 @pytest.mark.parametrize(
     ("rows", "error"),
     [
@@ -656,6 +686,24 @@ def test_official_runner_rejects_missing_shared_trajectory(tmp_path: Path) -> No
         harness.load_trajectories(str(trajectory_path))
 
 
+def test_official_runner_reports_invalid_shared_trajectory_json(tmp_path: Path) -> None:
+    module = _load_runner_module()
+    trajectory_path = tmp_path / "trajectories.jsonl"
+    trajectory_path.write_text(
+        '{"id": "kept"}\n\nnot-json\n',
+        encoding="utf-8",
+    )
+    harness = SimpleNamespace(load_trajectories=lambda _path: {})
+    release = module.install_shared_trajectory_release(
+        harness,
+        selected_haystack={"question": ["kept"]},
+    )
+    assert release is not None
+
+    with pytest.raises(RuntimeError, match=rf"{trajectory_path}:3"):
+        harness.load_trajectories(str(trajectory_path))
+
+
 def test_official_runner_rejects_non_jsonl_shared_trajectories(tmp_path: Path) -> None:
     module = _load_runner_module()
     trajectory_path = tmp_path / "trajectories.json"
@@ -690,6 +738,16 @@ def test_official_runner_keeps_nonshared_trajectory_loading_unchanged() -> None:
         is None
     )
     assert harness.load_trajectories is original_load
+
+
+def test_official_runner_rejects_missing_shared_trajectory_loader() -> None:
+    module = _load_runner_module()
+
+    with pytest.raises(RuntimeError, match="does not expose callable load_trajectories"):
+        module.install_shared_trajectory_release(
+            SimpleNamespace(),
+            selected_haystack={"question": ["trajectory"]},
+        )
 
 
 def test_official_runner_rejects_shared_trajectory_loader_drift(tmp_path: Path) -> None:

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -667,8 +667,12 @@ def test_official_runner_validates_unselected_shared_trajectories(
     )
     assert release is not None
 
-    with pytest.raises(RuntimeError, match=error):
+    with pytest.raises(RuntimeError, match=error) as exc_info:
         harness.load_trajectories(str(trajectory_path))
+
+    if error == "Duplicate":
+        assert str(trajectory_path) in str(exc_info.value)
+        assert str(exc_info.value).endswith(":3")
 
 
 def test_official_runner_rejects_missing_shared_trajectory(tmp_path: Path) -> None:

--- a/tools/tests/test_longmemeval_v2_official.py
+++ b/tools/tests/test_longmemeval_v2_official.py
@@ -564,14 +564,30 @@ print("real_registry_rebind=PASS")
 
 def test_official_runner_releases_shared_trajectories_after_final_insert(
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     module = _load_runner_module()
-    loaded = {
-        "kept-once": {"id": "kept-once", "payload": "once"},
-        "kept-twice": {"id": "kept-twice", "payload": "twice"},
-        "unselected": {"id": "unselected", "payload": "unused"},
-    }
-    harness = SimpleNamespace(load_trajectories=lambda _path: loaded)
+    trajectory_path = tmp_path / "trajectories.jsonl"
+    trajectory_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"id": "kept-once", "payload": "once"}),
+                json.dumps({"id": "unselected", "payload": "unused"}),
+                json.dumps({"id": "kept-twice", "payload": "twice"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def original_load(_path: str) -> dict[str, dict[str, str]]:
+        raise AssertionError("shared trajectory loading must bypass the full-file loader")
+
+    def forbidden_read_text(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("shared trajectory loading must stream the JSONL source")
+
+    harness = SimpleNamespace(load_trajectories=original_load)
 
     release = module.install_shared_trajectory_release(
         harness,
@@ -581,9 +597,9 @@ def test_official_runner_releases_shared_trajectories_after_final_insert(
         },
     )
     assert release is not None
-    trajectories = harness.load_trajectories("trajectories.jsonl")
+    monkeypatch.setattr(Path, "read_text", forbidden_read_text)
+    trajectories = harness.load_trajectories(str(trajectory_path))
 
-    assert loaded == {}
     assert set(trajectories) == {"kept-once", "kept-twice"}
     assert trajectories["kept-once"]["payload"] == "once"
     assert "kept-once" not in trajectories
@@ -592,7 +608,67 @@ def test_official_runner_releases_shared_trajectories_after_final_insert(
     assert trajectories["kept-twice"]["payload"] == "twice"
     assert trajectories == {}
     release.assert_complete()
-    assert "consume-on-insert (2 selected)" in capsys.readouterr().out
+    assert "streaming consume-on-insert (2 selected)" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("rows", "error"),
+    [
+        ([{"id": "kept"}, {"id": "duplicate"}, {"id": "duplicate"}], "Duplicate"),
+        ([{"id": "kept"}, {"payload": "missing id"}], "Invalid trajectory id"),
+        ([{"id": "kept"}, ["not", "an", "object"]], "Invalid trajectory"),
+    ],
+)
+def test_official_runner_validates_unselected_shared_trajectories(
+    rows: list[object],
+    error: str,
+    tmp_path: Path,
+) -> None:
+    module = _load_runner_module()
+    trajectory_path = tmp_path / "trajectories.jsonl"
+    trajectory_path.write_text(
+        "".join(f"{json.dumps(row)}\n" for row in rows),
+        encoding="utf-8",
+    )
+    harness = SimpleNamespace(load_trajectories=lambda _path: {})
+    release = module.install_shared_trajectory_release(
+        harness,
+        selected_haystack={"question": ["kept"]},
+    )
+    assert release is not None
+
+    with pytest.raises(RuntimeError, match=error):
+        harness.load_trajectories(str(trajectory_path))
+
+
+def test_official_runner_rejects_missing_shared_trajectory(tmp_path: Path) -> None:
+    module = _load_runner_module()
+    trajectory_path = tmp_path / "trajectories.jsonl"
+    trajectory_path.write_text('{"id": "present"}\n', encoding="utf-8")
+    harness = SimpleNamespace(load_trajectories=lambda _path: {})
+    release = module.install_shared_trajectory_release(
+        harness,
+        selected_haystack={"question": ["missing"]},
+    )
+    assert release is not None
+
+    with pytest.raises(RuntimeError, match=r"missing trajectories.*missing"):
+        harness.load_trajectories(str(trajectory_path))
+
+
+def test_official_runner_rejects_non_jsonl_shared_trajectories(tmp_path: Path) -> None:
+    module = _load_runner_module()
+    trajectory_path = tmp_path / "trajectories.json"
+    trajectory_path.write_text("[]\n", encoding="utf-8")
+    harness = SimpleNamespace(load_trajectories=lambda _path: {})
+    release = module.install_shared_trajectory_release(
+        harness,
+        selected_haystack={"question": ["trajectory"]},
+    )
+    assert release is not None
+
+    with pytest.raises(RuntimeError, match="requires a JSONL source"):
+        harness.load_trajectories(str(trajectory_path))
 
 
 def test_official_runner_keeps_nonshared_trajectory_loading_unchanged() -> None:
@@ -616,13 +692,9 @@ def test_official_runner_keeps_nonshared_trajectory_loading_unchanged() -> None:
     assert harness.load_trajectories is original_load
 
 
-def test_official_runner_rejects_shared_trajectory_loader_drift() -> None:
+def test_official_runner_rejects_shared_trajectory_loader_drift(tmp_path: Path) -> None:
     module = _load_runner_module()
-
-    def load_trajectories(_path: str) -> dict[str, dict[str, str]]:
-        return {"trajectory": {"id": "trajectory", "payload": "retained"}}
-
-    harness = SimpleNamespace(load_trajectories=load_trajectories)
+    harness = SimpleNamespace(load_trajectories=lambda _path: {})
     release = module.install_shared_trajectory_release(
         harness,
         selected_haystack={"question": ["trajectory"]},
@@ -632,7 +704,12 @@ def test_official_runner_rejects_shared_trajectory_loader_drift() -> None:
     with pytest.raises(RuntimeError, match="did not load"):
         release.assert_complete()
 
-    trajectories = harness.load_trajectories("trajectories.jsonl")
+    trajectory_path = tmp_path / "trajectories.jsonl"
+    trajectory_path.write_text(
+        '{"id": "trajectory", "payload": "retained"}\n',
+        encoding="utf-8",
+    )
+    trajectories = harness.load_trajectories(str(trajectory_path))
     with pytest.raises(RuntimeError, match="1 remaining"):
         release.assert_complete()
 


### PR DESCRIPTION
# 🧹 Bounded trajectory loading for release evals

> The LongMemEval V2 release builder reads a 1.2 GB trajectory JSONL on a
> 16 GB hosted runner. The previous selection wrapper released payloads after
> insertion, but only after the official loader had decoded the whole corpus.

## 💡 What this is

Shared-haystack runs now stream the official trajectory JSONL and retain only
the selected payloads. The loader still parses every nonblank row, validates
IDs, rejects duplicates across the complete corpus, and reports missing
selected trajectories before provider work continues.

The returned mapping keeps the existing consume-on-final-insert behavior, so
selected payloads also leave memory as soon as the official harness finishes
with them.

## 🎯 The invariant

Anchor the review on one property: retained trajectory heap is bounded by the
selected payloads, the global ID set, and the largest input row. Corpus payload
size must never become retained Python heap again.

## 🛠️ How it works

1. The shared-haystack installer verifies that the pinned harness still exposes
   a callable `load_trajectories` hook.
2. The replacement loader scans `trajectories.jsonl` one line at a time with
   `Path.open()` and `json.loads()`.
3. Every ID enters a small `seen_ids` set for upstream-compatible duplicate
   rejection. Only IDs referenced by the selected haystack retain their row.
4. Malformed JSON and schema failures name the exact file and physical line.
5. The selected map deletes each payload after its final counted insert and
   fails closed if the harness leaves anything unread.

Nonshared haystacks retain the official loader unchanged. Loaded-memory arms
do not load trajectories in the pinned harness, so the interception is only
installed for the memory-building path that needs it.

## 🧪 Validation

- `moon run --force bench-gate-test -- tools/tests/test_longmemeval_v2_official.py -q`
  returned `885 passed`.
- `moon run --force :lint :typecheck` completed all 19 tasks.
- The heap regression builds a 4.26 MB corpus dominated by unselected payloads
  and requires traced peak allocation below one quarter of corpus bytes.
- The regression suite proves the official full-file loader and
  `Path.read_text()` are bypassed, while malformed unselected rows, global
  duplicates, missing selected IDs, non-JSONL drift, and incomplete
  consumption still fail closed.

## 🔍 What reviewers should focus on

- Whether full-corpus validation remains equivalent to the pinned official
  loader.
- Whether the heap assertion would catch any whole-file materialization path.
- Whether duplicate selected IDs still release only after their final insert.

The paid A/A release run remains outside this PR. A fresh experiment will run
from the merged main SHA, so no failed or partial artifact can be reused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading of shared trajectory data from JSONL files.
  - Added validation for missing files, invalid formats, malformed records, duplicate or empty IDs, and missing trajectories.
  - Reduced memory usage by retaining only trajectories required for a run.
  - Added clear errors when required loader support is unavailable.

- **Tests**
  - Expanded coverage for streaming behavior, malformed inputs, missing data, memory limits, and loader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->