### PR TITLE
perf(retrieval): split entity fulltext search into per-field top-k queries

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_search.py
@@ -41,6 +41,8 @@ from sibyl_core.services.graph_search import row_score as _row_score
 
 log = structlog.get_logger()
 
+_FULLTEXT_FIELDS = ("name", "summary", "description", "content")
+
 
 def _build_explicit_anchor_search_query(query: str) -> str:
     phrases = extract_explicit_anchor_phrases(query)
@@ -250,41 +252,65 @@ class _EntitySearchManager:
         entity_types: Sequence[EntityType] | None,
         limit: int,
     ) -> list[tuple[Entity, float]]:
-        match = build_match_disjunction(
-            ["name", "summary", "description", "content"],
-            build_fulltext_terms(search_query),
-        )
-        if match is None:
+        """BM25 candidates over every fulltext field, one bounded query per field.
+
+        A single four-field disjunction makes the engine score every matching
+        row across all four indexes before LIMIT applies. Splitting it into one
+        top-k statement per field, run concurrently, returns the same top-k:
+        the merged score is the max across fields, so a row outside a field's
+        top-k cannot enter the global top-k when that field already holds k
+        rows with equal or greater score. The merge re-applies the statement
+        order (score, created_at, uuid) descending before truncating.
+        """
+        terms = build_fulltext_terms(search_query)
+        if not terms:
             return []
         type_values = [entity_type.value for entity_type in entity_types or ()]
         type_clause = "AND entity_type IN $entity_types" if type_values else ""
-        rows = normalize_records(
-            await self._client.execute_query(
-                "SELECT "
-                + _ENTITY_SEARCH_FIELDS
-                + f""",
-                       {match.score_expr} AS score
-                FROM entity
-                WHERE group_id = $group_id
-                """
-                + type_clause
-                + f"""
-                  AND {match.where_clause}
-                ORDER BY score DESC, created_at DESC, uuid DESC
-                LIMIT $limit;
-                """,
-                group_id=self._group_id,
-                entity_types=type_values,
-                limit=limit,
-                _query_label="entity.search.fulltext",
-                **match.params,
+        matches = [
+            match
+            for match in (build_match_disjunction([field], terms) for field in _FULLTEXT_FIELDS)
+            if match is not None
+        ]
+        field_rows = await asyncio.gather(
+            *(
+                self._client.execute_query(
+                    "SELECT "
+                    + _ENTITY_SEARCH_FIELDS
+                    + f""",
+                           {match.score_expr} AS score
+                    FROM entity
+                    WHERE group_id = $group_id
+                    """
+                    + type_clause
+                    + f"""
+                      AND {match.where_clause}
+                    ORDER BY score DESC, created_at DESC, uuid DESC
+                    LIMIT $limit;
+                    """,
+                    group_id=self._group_id,
+                    entity_types=type_values,
+                    limit=limit,
+                    _query_label="entity.search.fulltext",
+                    **match.params,
+                )
+                for match in matches
             )
         )
-        fulltext_results: list[tuple[Entity, float]] = []
-        for row in rows:
-            entity = _entity_from_row(row)
-            fulltext_results.append((entity, _bounded_similarity_score(query, entity)))
-        return fulltext_results
+        best_by_uuid: dict[str, tuple[Entity, float]] = {}
+        for rows in field_rows:
+            for row in normalize_records(rows):
+                entity = _entity_from_row(row)
+                score = _row_score(row)
+                current = best_by_uuid.get(entity.id)
+                if current is None or score > current[1]:
+                    best_by_uuid[entity.id] = (entity, score)
+        ranked = sorted(
+            best_by_uuid.values(),
+            key=lambda item: (item[1], item[0].created_at, item[0].id),
+            reverse=True,
+        )[:limit]
+        return [(entity, _bounded_similarity_score(query, entity)) for entity, _score in ranked]
 
     async def _explicit_anchor_fulltext_search(
         self,

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import time
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -57,6 +57,7 @@ from sibyl_core.services.graph_common import (
 )
 from sibyl_core.services.graph_entities import EntityManager
 from sibyl_core.services.graph_relationships import RelationshipManager
+from sibyl_core.services.graph_search import bounded_similarity_score
 from sibyl_core.services.usage import (
     MemoryUsageItemKind,
     MemoryUsageStamp,
@@ -498,14 +499,14 @@ class _ExplicitAnchorSearchClient:
             ]
         if params.get("_query_label") == "entity.search.fulltext":
             return [
-                self._row("primary-one", "Primary result one."),
-                self._row("primary-two", "Primary result two."),
-                self._row("primary-three", "Primary result three."),
+                self._row("primary-one", "Primary result one.", day=3),
+                self._row("primary-two", "Primary result two.", day=2),
+                self._row("primary-three", "Primary result three.", day=1),
             ]
         return []
 
-    def _row(self, entity_id: str, content: str) -> dict[str, object]:
-        now = datetime.now(UTC)
+    def _row(self, entity_id: str, content: str, *, day: int = 1) -> dict[str, object]:
+        now = datetime(2026, 8, day, tzinfo=UTC)
         return {
             "record_id": f"entity:{entity_id}",
             "uuid": entity_id,
@@ -1908,6 +1909,199 @@ async def test_native_entity_manager_skips_anchor_probe_for_single_anchor() -> N
         params.get("_query_label") != "entity.search.fulltext_explicit_anchors"
         for _query, params in client.calls
     )
+
+
+class _PerFieldFulltextClient:
+    """Answers each single-field statement with that field's own top-k rows.
+
+    The scores are chosen so every merge property is observable: `shared`
+    scores low on name but highest on content, `summary-only` and `name-only`
+    tie on score and split on created_at, `tie-a` and `tie-b` tie on both and
+    split on uuid, and `content-only` sits inside content's top-k but outside
+    the global top-3.
+    """
+
+    group_id = "org-native"
+    rows_by_field: ClassVar[dict[str, list[tuple[str, float, int]]]] = {
+        "name": [("shared", 0.8, 1), ("name-only", 0.9, 2)],
+        "summary": [("summary-only", 0.9, 3)],
+        "description": [("tie-b", 0.7, 5), ("tie-a", 0.7, 5)],
+        "content": [("shared", 0.95, 1), ("content-only", 0.85, 4)],
+    }
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
+        self.calls.append((query, params))
+        if params.get("_query_label") != "entity.search.fulltext":
+            return []
+        field = next(
+            field
+            for field in graph_entity_search_module._FULLTEXT_FIELDS
+            if f"{field} @0@" in query
+        )
+        ranked = sorted(
+            self.rows_by_field[field],
+            key=lambda row: (row[1], row[2], row[0]),
+            reverse=True,
+        )
+        limit = cast("int", params["limit"])
+        return [self._row(uuid, score=score, day=day) for uuid, score, day in ranked[:limit]]
+
+    @classmethod
+    def single_statement_ranking(cls, limit: int) -> list[str]:
+        # The pre-split statement scored every row with math::max across the
+        # four field sums, then ORDER BY score DESC, created_at DESC, uuid DESC
+        # LIMIT $limit over the whole match set.
+        best: dict[str, tuple[float, int]] = {}
+        for rows in cls.rows_by_field.values():
+            for uuid, score, day in rows:
+                if uuid not in best or score > best[uuid][0]:
+                    best[uuid] = (score, day)
+        ordered = sorted(best, key=lambda uuid: (*best[uuid], uuid), reverse=True)
+        return ordered[:limit]
+
+    def _row(self, uuid: str, *, score: float, day: int) -> dict[str, object]:
+        return {
+            "record_id": f"entity:{uuid}",
+            "uuid": uuid,
+            "name": uuid,
+            "entity_type": "topic",
+            "summary": f"{uuid} surreal replay",
+            "content": f"{uuid} surreal replay verification",
+            "group_id": self.group_id,
+            "attributes": {},
+            "created_at": datetime(2026, 8, day, tzinfo=UTC),
+            "updated_at": datetime(2026, 8, day, tzinfo=UTC),
+            "score": score,
+        }
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_fulltext_issues_one_bounded_statement_per_field() -> None:
+    client = _PerFieldFulltextClient()
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+
+    await manager.search(
+        query="surreal replay verification",
+        entity_types=[EntityType.TOPIC],
+        limit=3,
+    )
+
+    fulltext_calls = [
+        (query, params)
+        for query, params in client.calls
+        if params.get("_query_label") == "entity.search.fulltext"
+    ]
+    fields = graph_entity_search_module._FULLTEXT_FIELDS
+    assert len(fulltext_calls) == len(fields) == 4
+    for field in fields:
+        [(query, params)] = [call for call in fulltext_calls if f"{field} @0@ $ft_term0" in call[0]]
+        assert f"{field} @1@ $ft_term1" in query
+        assert f"{field} @2@ $ft_term2" in query
+        assert all(other == field or f"{other} @" not in query for other in fields)
+        assert "math::max" not in query
+        assert "WHERE group_id = $group_id" in query
+        assert "AND entity_type IN $entity_types" in query
+        assert "ORDER BY score DESC, created_at DESC, uuid DESC" in query
+        assert "LIMIT $limit;" in query
+        assert "id AS record_id" in query
+        assert params["group_id"] == "org-native"
+        assert params["entity_types"] == ["topic"]
+        assert params["limit"] == 3
+        assert params["ft_term0"] == "surreal"
+        assert params["ft_term1"] == "replay"
+        assert params["ft_term2"] == "verification"
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_fulltext_merge_matches_single_statement_ranking() -> None:
+    client = _PerFieldFulltextClient()
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+    query = "surreal replay verification"
+
+    for limit in (1, 2, 3, 10):
+        results = await manager._fulltext_search(
+            query=query,
+            search_query=query,
+            entity_types=None,
+            limit=limit,
+        )
+        assert [entity.id for entity, _score in results] == client.single_statement_ranking(limit)
+        # BM25 only picks the candidates; the returned score is the bounded
+        # similarity re-score, exactly as before the split.
+        assert [score for _entity, score in results] == [
+            bounded_similarity_score(query, entity) for entity, _score in results
+        ]
+
+    results = await manager._fulltext_search(
+        query=query,
+        search_query=query,
+        entity_types=None,
+        limit=3,
+    )
+    # `shared` ranks first on its content score even though name ranked it
+    # below `name-only`: the merge keeps the max across fields.
+    assert [entity.id for entity, _score in results] == ["shared", "summary-only", "name-only"]
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_fulltext_ties_break_on_created_at_then_uuid() -> None:
+    client = _PerFieldFulltextClient()
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+    query = "surreal replay verification"
+
+    results = await manager._fulltext_search(
+        query=query,
+        search_query=query,
+        entity_types=None,
+        limit=10,
+    )
+
+    assert [entity.id for entity, _score in results] == [
+        "shared",
+        "summary-only",
+        "name-only",
+        "content-only",
+        "tie-b",
+        "tie-a",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_fulltext_truncates_after_merging() -> None:
+    client = _PerFieldFulltextClient()
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+
+    results = await manager.search(query="surreal replay verification", limit=3)
+
+    assert len(results) == 3
+    assert "content-only" not in {entity.id for entity, _score in results}
+    content_call = next(
+        params for query, params in client.calls if "content @0@ $ft_term0" in query
+    )
+    assert content_call["limit"] == 3
+    assert all(
+        params.get("_query_label") != "entity.search.fulltext_explicit_anchors"
+        for _query, params in client.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_fulltext_skips_query_without_terms() -> None:
+    client = _PerFieldFulltextClient()
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+
+    results = await manager._fulltext_search(
+        query="the of and",
+        search_query="the of and",
+        entity_types=None,
+        limit=3,
+    )
+
+    assert results == []
+    assert client.calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# ⚡ Per-field top-k for the hybrid fulltext lane

> The r5 release A/A web run (GitHub run 32998783818, commit `7f31a330`) spent its entire memory-query budget inside one lane. This PR ports the fix that #428 already applied to the context-pack `node_fulltext` lane onto the hybrid search lane that #428 did not touch. One file of source, one file of tests.

## 💡 What this is

`graph_entity_search._fulltext_search` issued a single statement that disjoined all four fulltext fields (`name`, `summary`, `description`, `content`) with `ORDER BY score DESC ... LIMIT $limit`, where `score` was `math::max` over the per-field BM25 sums. SurrealDB 3.2.3 must score every matching row across all four indexes before the `LIMIT` applies. On the 15 GiB hosted runner, with the index set larger than the 4 GiB block cache and swap in use, that took 13 to 30 seconds per call.

The lane now issues one bounded top-k statement per field, runs the four concurrently on the pooled per-org client, merges by max score per uuid, re-sorts on `(score, created_at, uuid)` descending, truncates to the limit, and post-scores with `_bounded_similarity_score` exactly as before. Empty terms return `[]` without querying.

## 🤔 Why we need it

The query-phase aggregation of `sibyld.log` from r5: `graph_entity_search:_fulltext_search` ran 951 times (4 per context pack, `retrieval_max_planned_queries=3`), p50 12,920 ms, max 29,895 ms, total 13,357 s against a 12,745 s memory-query total. Nothing else was close (`_vector_search` p50 352 ms). The anchor web run had an 18.6 s p50 per pack; r5 had 55.0 s. Each domain run on the rig is about five hours, and 3.5 of those hours are 240 serial packs at 53 s.

BM25 only decides which rows enter the top-k; the returned score is discarded and replaced by `_bounded_similarity_score`, so the ranking contract is purely about membership and order of the top-k.

## 🎯 The invariant

The union of the per-field top-k contains the global top-k. A row outside field F's top-k has k rows in F with score at least as high; those k rows carry a merged (max-across-fields) score at least as high, so the row cannot enter the global top-k. Re-sorting the union on the same `(score, created_at, uuid)` tuple the engine ordered by reproduces the single-statement result. The docstring on `_fulltext_search` states this argument.

## 🛠️ How it works

- `_FULLTEXT_FIELDS = ("name", "summary", "description", "content")` at module level.
- Each statement is `build_match_disjunction([field], terms)`: `SELECT <fields>, (sum of search::score per term) AS score FROM entity WHERE group_id = $group_id [AND entity_type IN $entity_types] AND (<field> @i@ $ft_termN OR ...) ORDER BY score DESC, created_at DESC, uuid DESC LIMIT $limit`, still labelled `entity.search.fulltext` and still carrying `group_id`, `entity_types`, `limit`, and the `$ft_termN` params. No `math::max` remains in any statement.
- The statement text stays inline inside `_fulltext_search` on purpose: the longmemeval preflight probe (`benchmarks/preflight/longmemeval_live_contract_probe.py`) reads that block for `build_match_disjunction` and `match.score_expr` to prove the API search path is BM25-driven.
- `_explicit_anchor_fulltext_search` (single field, `@AND@`) is a different lane and is unchanged.

## 🧪 Validation

At `fc17af80`, all uncached:

- `moon run core:lint core:typecheck --force` → both clean.
- `moon run core:test --force` → 2755 passed, 16 skipped, 1 xfailed (five new tests: four labelled single-field statements per search; merged result equals an in-test single-statement `math::max` oracle at limits 1, 2, 3, 10 on a fixture where a row scores highest on `content` and low on `name`; `created_at` then `uuid` tie-breaks; post-merge truncation; no-terms short circuit).
- The existing embedded-engine test (`test_graph.py`, `entity_manager.search(...)` on `memory://`) executes the new statements on the bundled SurrealDB engine, so the shape is valid SurrealQL rather than fake-client-shaped.
- Cross-model review (Codex, `codex review --commit fc17af80`): PASS, no actionable defects. Codex wrote and ran its own live embedded-Surreal probe (six rows spread across name/summary/content matches) and confirmed old and new top-k rankings identical for limits 1, 2, 3, and 6.
- Live reproduction against the r5 SurrealDB snapshot (task `8a56f5c7`): the frozen web snapshot from run 32998783818 restored into a v3.2.3 container with the CI env (`--memory 15g --cpus 4`, 4 GiB block cache confirmed in the Surreal log), the 240 r5 questions replayed serially through the same adapter path against a sibyld at `012e7b55`. Result: `_fulltext_search` is the dominant lane locally too, 960 calls at p50 5.7 s / p95 10.5 s, 51.7% of Surreal query time (47.2% on the runner, same rank order for the top four origins); pack latency p50 17.3 s / p95 31.4 s (runner: 55.0 / 74.6). The paired re-measure with this commit was staged (worktree venv on Python 3.13.15, patched import verified) and is blocked only by an OrbStack VM wedge that started after the baseline finished; it runs as soon as the VM is restarted and the paired per-question table lands here.

⚠️ The embedded engine is the SDK-bundled 2.0.0; the 3.2.3 planner's behaviour on a single-field multi-term disjunction is only proven by the pending live paired run, not by the unit suite. One observation from the baseline worth a look in this lane: the very first pack on a cold container returned HTTP 500 (`RuntimeError: No response returned.` after three `entity_vector_search_failed TimeoutError`s while the cold fulltext queries held Surreal); r5 logged two vector timeouts without a 500. Shorter fulltext calls should shrink that window, and the paired run will say whether it recurs.

## 🔍 What reviewers should focus on

- The one fixture change: `_ExplicitAnchorSearchClient._row` now takes `day=` with deterministic `created_at` values that agree with the order it claims the engine returned; the old `datetime.now(UTC)` per row put the wrong primary newest, and the merge's `created_at` re-sort exposed it. Assertions in the two explicit-anchor tests are unchanged.
- `_CoordinatedSearchClient` asserts a label set, so four same-label calls need no change; confirm that is the intended contract rather than an accidental pass.

Out of scope: the residency growth of SurrealDB on the runner (task `8a56f5c7`), the context-pack `node_fulltext` lane (#428), and any reordering of hybrid fusion.
