### PR TITLE
feat(evals): seal the 1.3 rig-blocked receipt and write the release runbook

### DIFF
--- a/benchmarks/longmemeval_v2_release_authorization.py
+++ b/benchmarks/longmemeval_v2_release_authorization.py
@@ -24,6 +24,7 @@ RIG_BLOCKED_AUTHORIZATION_KEYS = frozenset(
         "schema_version",
         "kind",
         "source_receipt",
+        "source_ledger",
         "status",
         "blocked_reason",
         "rig_blocked_receipt_sha256",
@@ -232,12 +233,65 @@ def _rig_blocked_attempt_projection(raw: object, *, name: str) -> dict[str, Any]
     }
 
 
+def rig_blocked_projection(
+    source_receipt: dict[str, Any],
+    source_ledger: dict[str, Any],
+    receipt: dict[str, Any],
+) -> dict[str, Any]:
+    """Project one validated rig-blocked receipt into its unsigned authority fields."""
+    return {
+        "schema_version": RIG_BLOCKED_AUTHORIZATION_SCHEMA_VERSION,
+        "kind": "rig_blocked",
+        "source_receipt": dict(source_receipt),
+        "source_ledger": dict(source_ledger),
+        "status": receipt["status"],
+        "blocked_reason": receipt["blocked_reason"],
+        "rig_blocked_receipt_sha256": receipt["rig_blocked_receipt_sha256"],
+        "ledger_sha256": receipt["ledger_sha256"],
+        "ledger_provenance": receipt["ledger_provenance"],
+        "repository": receipt["repository"],
+        "head_branch": receipt["head_branch"],
+        "head_shas": list(receipt["head_shas"]),
+        "attempt_count": receipt["attempt_count"],
+        "completed_pass_count": receipt["completed_pass_count"],
+        "attempts": [
+            {
+                "experiment_id": item["experiment_id"],
+                "head_sha": item["head_sha"],
+                "controller_run_id": item["controller"]["run_id"],
+                "builder_run_ids": [builder["run_id"] for builder in item["builders"]],
+            }
+            for item in receipt["attempts"]
+        ],
+    }
+
+
+def _require_bound_rig_blocked_receipt(
+    source_receipt: dict[str, Any],
+    source_ledger: dict[str, Any],
+) -> dict[str, Any]:
+    """Reload both bound artifacts and prove the receipt derives from the ledger."""
+    receipt = rig.validate_rig_blocked_receipt(load_json(Path(source_receipt["path"])))
+    ledger = load_json(Path(source_ledger["path"]))
+    try:
+        rig.require_receipt_from_ledger(receipt, ledger)
+    except rig.RigInputError as exc:
+        raise StagePlanError(str(exc)) from exc
+    if receipt["ledger_sha256"] != rig.canonical_sha256(ledger):
+        raise StagePlanError("rig-blocked receipt ledger digest differs from its bound ledger")
+    require_artifact(source_receipt, name="rig-blocked source receipt")
+    require_artifact(source_ledger, name="rig-blocked source ledger")
+    return receipt
+
+
 def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:  # noqa: PLR0912
     """Validate one scoreless dispatch-exhaustion authority projection.
 
     The projection stops paid benchmark work. It never feeds a paid stage, so
     unlike A/A authority it carries no stack or arm contract: none of that was
-    observed by a dispatch that produced no completed pass.
+    observed by a dispatch that produced no completed pass. Unlike A/A authority
+    it reloads its bound receipt and ledger: every projected field must equal
+    the projection of the receipt that the ledger actually derives.
     """
     reject_score_bearing_keys(raw, name="rig-blocked authorization")
     if not isinstance(raw, dict):
@@ -255,6 +309,7 @@ def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:  # noqa: P
     if raw.get("ledger_provenance") != rig.LEDGER_PROVENANCE_VERIFIED:
         raise StagePlanError("rig-blocked authorization requires a GitHub-verified ledger")
     source = require_artifact(raw.get("source_receipt"), name="rig-blocked source receipt")
+    source_ledger = require_artifact(raw.get("source_ledger"), name="rig-blocked source ledger")
     receipt_digest = rig._sha256_digest(
         raw.get("rig_blocked_receipt_sha256"),
         name="rig-blocked authorization receipt digest",
@@ -301,9 +356,16 @@ def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:  # noqa: P
         field="authorization_sha256",
         name="rig-blocked authorization",
     )
+    receipt = _require_bound_rig_blocked_receipt(source, source_ledger)
+    if receipt["ledger_provenance"] != rig.LEDGER_PROVENANCE_VERIFIED:
+        raise StagePlanError("rig-blocked authorization requires a GitHub-verified ledger")
+    unsigned = {key: value for key, value in raw.items() if key != "authorization_sha256"}
+    if unsigned != rig_blocked_projection(source, source_ledger, receipt):
+        raise StagePlanError("rig-blocked authorization differs from its bound receipt")
     return {
         **raw,
         "source_receipt": source,
+        "source_ledger": source_ledger,
         "rig_blocked_receipt_sha256": receipt_digest,
         "ledger_sha256": ledger_digest,
         "repository": repository,

--- a/benchmarks/longmemeval_v2_release_authorization.py
+++ b/benchmarks/longmemeval_v2_release_authorization.py
@@ -12,11 +12,34 @@ from benchmarks.longmemeval_v2_release_inputs import (
     require_artifact,
     require_exact_keys,
     require_nonnegative_int,
+    require_positive_int,
     require_string,
 )
 from tools.bench import longmemeval_v2_rig as rig
 
 AA_AUTHORIZATION_SCHEMA_VERSION = "sibyl-longmemeval-v2-aa-authorization-v2"
+RIG_BLOCKED_AUTHORIZATION_SCHEMA_VERSION = "sibyl-longmemeval-v2-rig-blocked-authorization-v1"
+RIG_BLOCKED_AUTHORIZATION_KEYS = frozenset(
+    {
+        "schema_version",
+        "kind",
+        "source_receipt",
+        "status",
+        "blocked_reason",
+        "rig_blocked_receipt_sha256",
+        "ledger_sha256",
+        "repository",
+        "head_branch",
+        "head_shas",
+        "attempt_count",
+        "completed_pass_count",
+        "attempts",
+        "authorization_sha256",
+    }
+)
+RIG_BLOCKED_ATTEMPT_AUTHORIZATION_KEYS = frozenset(
+    {"experiment_id", "head_sha", "controller_run_id", "builder_run_ids"}
+)
 PREREGISTRATION_AUTHORIZATION_SCHEMA_VERSION = (
     "sibyl-longmemeval-v2-preregistration-authorization-v2"
 )
@@ -184,6 +207,105 @@ def require_aa_authorization(raw: object) -> dict[str, Any]:
         "stack": stack,
         "arm_contract": contract,
         "passes": passes,
+    }
+
+
+def _rig_blocked_attempt_projection(raw: object, *, name: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise StagePlanError(f"{name} is missing")
+    require_exact_keys(raw, RIG_BLOCKED_ATTEMPT_AUTHORIZATION_KEYS, name=name)
+    builder_run_ids = raw.get("builder_run_ids")
+    if not isinstance(builder_run_ids, list) or not builder_run_ids:
+        raise StagePlanError(f"{name} binds no builder run")
+    return {
+        "experiment_id": require_string(raw.get("experiment_id"), name=f"{name}.experiment_id"),
+        "head_sha": rig._git_sha(raw.get("head_sha"), name=f"{name}.head_sha"),
+        "controller_run_id": require_positive_int(
+            raw.get("controller_run_id"),
+            name=f"{name}.controller_run_id",
+        ),
+        "builder_run_ids": [
+            require_positive_int(item, name=f"{name}.builder_run_ids[{index}]")
+            for index, item in enumerate(builder_run_ids)
+        ],
+    }
+
+
+def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:
+    """Validate one scoreless dispatch-exhaustion authority projection.
+
+    The projection stops paid benchmark work. It never feeds a paid stage, so
+    unlike A/A authority it carries no stack or arm contract: none of that was
+    observed by a dispatch that produced no completed pass.
+    """
+    reject_score_bearing_keys(raw, name="rig-blocked authorization")
+    if not isinstance(raw, dict):
+        raise StagePlanError("rig-blocked authorization is missing")
+    require_exact_keys(raw, RIG_BLOCKED_AUTHORIZATION_KEYS, name="rig-blocked authorization")
+    if (
+        raw.get("schema_version") != RIG_BLOCKED_AUTHORIZATION_SCHEMA_VERSION
+        or raw.get("kind") != "rig_blocked"
+    ):
+        raise StagePlanError("rig-blocked authorization schema or kind is invalid")
+    if raw.get("status") != "RIG_BLOCKED" or (
+        raw.get("blocked_reason") != rig.BLOCKED_REASON_DISPATCH_EXHAUSTED
+    ):
+        raise StagePlanError("rig-blocked authorization status or reason is invalid")
+    source = require_artifact(raw.get("source_receipt"), name="rig-blocked source receipt")
+    receipt_digest = rig._sha256_digest(
+        raw.get("rig_blocked_receipt_sha256"),
+        name="rig-blocked authorization receipt digest",
+    )
+    ledger_digest = rig._sha256_digest(
+        raw.get("ledger_sha256"),
+        name="rig-blocked authorization ledger digest",
+    )
+    repository = require_string(raw.get("repository"), name="rig-blocked repository")
+    if not rig.GITHUB_REPOSITORY_PATTERN.fullmatch(repository):
+        raise StagePlanError("rig-blocked repository is not a GitHub repository")
+    head_branch = require_string(raw.get("head_branch"), name="rig-blocked head_branch")
+    raw_head_shas = raw.get("head_shas")
+    if not isinstance(raw_head_shas, list) or not raw_head_shas:
+        raise StagePlanError("rig-blocked head SHAs are missing")
+    head_shas = [
+        rig._git_sha(item, name=f"rig-blocked head_shas[{index}]")
+        for index, item in enumerate(raw_head_shas)
+    ]
+    if len(set(head_shas)) != len(head_shas):
+        raise StagePlanError("rig-blocked head SHAs are not unique")
+    attempt_count = require_positive_int(raw.get("attempt_count"), name="rig-blocked attempt_count")
+    if attempt_count < rig.EXTENDED_AA_PASS_COUNT:
+        raise StagePlanError("rig-blocked authorization holds fewer than five dispatches")
+    if require_nonnegative_int(raw.get("completed_pass_count"), name="completed_pass_count") != 0:
+        raise StagePlanError("rig-blocked authorization claims a completed pass")
+    raw_attempts = raw.get("attempts")
+    if not isinstance(raw_attempts, list) or len(raw_attempts) != attempt_count:
+        raise StagePlanError("rig-blocked authorization attempt count does not match its rows")
+    attempts = [
+        _rig_blocked_attempt_projection(item, name=f"rig-blocked attempts[{index}]")
+        for index, item in enumerate(raw_attempts)
+    ]
+    if len({item["experiment_id"] for item in attempts}) != len(attempts) or len(
+        {item["controller_run_id"] for item in attempts}
+    ) != len(attempts):
+        raise StagePlanError("rig-blocked authorization attempts are not unique")
+    if {item["head_sha"] for item in attempts} != set(head_shas):
+        raise StagePlanError("rig-blocked authorization head SHAs differ from its attempts")
+    _authorization_digest(
+        raw,
+        field="authorization_sha256",
+        name="rig-blocked authorization",
+    )
+    return {
+        **raw,
+        "source_receipt": source,
+        "rig_blocked_receipt_sha256": receipt_digest,
+        "ledger_sha256": ledger_digest,
+        "repository": repository,
+        "head_branch": head_branch,
+        "head_shas": head_shas,
+        "attempt_count": attempt_count,
+        "attempts": attempts,
     }
 
 

--- a/benchmarks/longmemeval_v2_release_authorization.py
+++ b/benchmarks/longmemeval_v2_release_authorization.py
@@ -269,29 +269,42 @@ def rig_blocked_projection(
 def _require_bound_rig_blocked_receipt(
     source_receipt: dict[str, Any],
     source_ledger: dict[str, Any],
+    *,
+    fetch: rig.GitHubFetch,
 ) -> dict[str, Any]:
-    """Reload both bound artifacts and prove the receipt derives from the ledger."""
+    """Reload both bound artifacts, prove derivation, and re-verify the ledger live.
+
+    The receipt's provenance label is a record of when the ledger last matched
+    GitHub; the evidence is this re-fetch. A fetch failure or any field drift
+    fails closed.
+    """
     receipt = rig.validate_rig_blocked_receipt(load_json(Path(source_receipt["path"])))
     ledger = load_json(Path(source_ledger["path"]))
     try:
         rig.require_receipt_from_ledger(receipt, ledger)
+        if receipt["ledger_sha256"] != rig.canonical_sha256(ledger):
+            raise StagePlanError("rig-blocked receipt ledger digest differs from its bound ledger")
+        rig.verify_dispatch_ledger(ledger, fetch=fetch)
     except rig.RigInputError as exc:
         raise StagePlanError(str(exc)) from exc
-    if receipt["ledger_sha256"] != rig.canonical_sha256(ledger):
-        raise StagePlanError("rig-blocked receipt ledger digest differs from its bound ledger")
     require_artifact(source_receipt, name="rig-blocked source receipt")
     require_artifact(source_ledger, name="rig-blocked source ledger")
     return receipt
 
 
-def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:  # noqa: PLR0912
+def require_rig_blocked_authorization(  # noqa: PLR0912
+    raw: object,
+    *,
+    fetch: rig.GitHubFetch,
+) -> dict[str, Any]:
     """Validate one scoreless dispatch-exhaustion authority projection.
 
     The projection stops paid benchmark work. It never feeds a paid stage, so
     unlike A/A authority it carries no stack or arm contract: none of that was
     observed by a dispatch that produced no completed pass. Unlike A/A authority
     it reloads its bound receipt and ledger: every projected field must equal
-    the projection of the receipt that the ledger actually derives.
+    the projection of the receipt that the ledger actually derives, and the
+    ledger is re-verified against GitHub through ``fetch`` on every validation.
     """
     reject_score_bearing_keys(raw, name="rig-blocked authorization")
     if not isinstance(raw, dict):
@@ -356,7 +369,7 @@ def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:  # noqa: P
         field="authorization_sha256",
         name="rig-blocked authorization",
     )
-    receipt = _require_bound_rig_blocked_receipt(source, source_ledger)
+    receipt = _require_bound_rig_blocked_receipt(source, source_ledger, fetch=fetch)
     if receipt["ledger_provenance"] != rig.LEDGER_PROVENANCE_VERIFIED:
         raise StagePlanError("rig-blocked authorization requires a GitHub-verified ledger")
     unsigned = {key: value for key, value in raw.items() if key != "authorization_sha256"}

--- a/benchmarks/longmemeval_v2_release_authorization.py
+++ b/benchmarks/longmemeval_v2_release_authorization.py
@@ -28,6 +28,7 @@ RIG_BLOCKED_AUTHORIZATION_KEYS = frozenset(
         "blocked_reason",
         "rig_blocked_receipt_sha256",
         "ledger_sha256",
+        "ledger_provenance",
         "repository",
         "head_branch",
         "head_shas",
@@ -231,7 +232,7 @@ def _rig_blocked_attempt_projection(raw: object, *, name: str) -> dict[str, Any]
     }
 
 
-def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:
+def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:  # noqa: PLR0912
     """Validate one scoreless dispatch-exhaustion authority projection.
 
     The projection stops paid benchmark work. It never feeds a paid stage, so
@@ -251,6 +252,8 @@ def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:
         raw.get("blocked_reason") != rig.BLOCKED_REASON_DISPATCH_EXHAUSTED
     ):
         raise StagePlanError("rig-blocked authorization status or reason is invalid")
+    if raw.get("ledger_provenance") != rig.LEDGER_PROVENANCE_VERIFIED:
+        raise StagePlanError("rig-blocked authorization requires a GitHub-verified ledger")
     source = require_artifact(raw.get("source_receipt"), name="rig-blocked source receipt")
     receipt_digest = rig._sha256_digest(
         raw.get("rig_blocked_receipt_sha256"),
@@ -261,9 +264,11 @@ def require_rig_blocked_authorization(raw: object) -> dict[str, Any]:
         name="rig-blocked authorization ledger digest",
     )
     repository = require_string(raw.get("repository"), name="rig-blocked repository")
-    if not rig.GITHUB_REPOSITORY_PATTERN.fullmatch(repository):
-        raise StagePlanError("rig-blocked repository is not a GitHub repository")
+    if repository != rig.TRUSTED_REPOSITORY:
+        raise StagePlanError("rig-blocked repository is not the trusted release repository")
     head_branch = require_string(raw.get("head_branch"), name="rig-blocked head_branch")
+    if head_branch != rig.TRUSTED_BRANCH:
+        raise StagePlanError("rig-blocked authorization is not on the trusted release branch")
     raw_head_shas = raw.get("head_shas")
     if not isinstance(raw_head_shas, list) or not raw_head_shas:
         raise StagePlanError("rig-blocked head SHAs are missing")

--- a/benchmarks/longmemeval_v2_release_authorization_package.py
+++ b/benchmarks/longmemeval_v2_release_authorization_package.py
@@ -153,6 +153,75 @@ def rebase_aa_authorization(
     return rebased
 
 
+def package_rig_blocked_authorization(
+    receipt_path: Path,
+    *,
+    public_receipt_path: Path | None = None,
+) -> dict[str, Any]:
+    """Project a fully validated dispatch-exhaustion receipt into authority."""
+    source, receipt = _validated_artifact(
+        receipt_path,
+        name="rig-blocked source receipt",
+        validator=rig.validate_rig_blocked_receipt,
+    )
+    validated = build_rig_blocked_authorization(source, receipt)
+    return rebase_rig_blocked_authorization(validated, public_receipt_path=public_receipt_path)
+
+
+def build_rig_blocked_authorization(
+    source: dict[str, Any],
+    receipt: dict[str, Any],
+) -> dict[str, Any]:
+    """Build dispatch-exhaustion authority from an fd-bound physical receipt."""
+
+    receipt = rig.validate_rig_blocked_receipt(receipt)
+    payload = {
+        "schema_version": authorization.RIG_BLOCKED_AUTHORIZATION_SCHEMA_VERSION,
+        "kind": "rig_blocked",
+        "source_receipt": source,
+        "status": receipt["status"],
+        "blocked_reason": receipt["blocked_reason"],
+        "rig_blocked_receipt_sha256": receipt["rig_blocked_receipt_sha256"],
+        "ledger_sha256": receipt["ledger_sha256"],
+        "repository": receipt["repository"],
+        "head_branch": receipt["head_branch"],
+        "head_shas": list(receipt["head_shas"]),
+        "attempt_count": receipt["attempt_count"],
+        "completed_pass_count": receipt["completed_pass_count"],
+        "attempts": [
+            {
+                "experiment_id": item["experiment_id"],
+                "head_sha": item["head_sha"],
+                "controller_run_id": item["controller"]["run_id"],
+                "builder_run_ids": [builder["run_id"] for builder in item["builders"]],
+            }
+            for item in receipt["attempts"]
+        ],
+    }
+    payload["authorization_sha256"] = rig.canonical_sha256(payload)
+    return authorization.require_rig_blocked_authorization(payload)
+
+
+def rebase_rig_blocked_authorization(
+    validated: dict[str, Any],
+    *,
+    public_receipt_path: Path | None,
+) -> dict[str, Any]:
+    """Rebase a physically validated rig-blocked projection to a public path."""
+
+    if public_receipt_path is None:
+        return validated
+    rebased = deepcopy(validated)
+    rebased["source_receipt"]["path"] = _public_path(
+        public_receipt_path,
+        name="rig-blocked source receipt",
+    )
+    rebased["authorization_sha256"] = rig.canonical_sha256(
+        {key: value for key, value in rebased.items() if key != "authorization_sha256"}
+    )
+    return rebased
+
+
 def _package_anchor_gate(
     path: Path,
     preregistration: dict[str, Any],
@@ -353,6 +422,8 @@ def write_authorization(
     """Write a validated authority artifact once, outside paid output roots."""
     if payload.get("kind") == "aa":
         authorization.require_aa_authorization(payload)
+    elif payload.get("kind") == "rig_blocked":
+        authorization.require_rig_blocked_authorization(payload)
     else:
         authorization.require_preregistration_authorization(
             payload,

--- a/benchmarks/longmemeval_v2_release_authorization_package.py
+++ b/benchmarks/longmemeval_v2_release_authorization_package.py
@@ -175,6 +175,8 @@ def build_rig_blocked_authorization(
     """Build dispatch-exhaustion authority from an fd-bound physical receipt."""
 
     receipt = rig.validate_rig_blocked_receipt(receipt)
+    if receipt["ledger_provenance"] != rig.LEDGER_PROVENANCE_VERIFIED:
+        raise StagePlanError("rig-blocked authorization requires a GitHub-verified ledger")
     payload = {
         "schema_version": authorization.RIG_BLOCKED_AUTHORIZATION_SCHEMA_VERSION,
         "kind": "rig_blocked",
@@ -183,6 +185,7 @@ def build_rig_blocked_authorization(
         "blocked_reason": receipt["blocked_reason"],
         "rig_blocked_receipt_sha256": receipt["rig_blocked_receipt_sha256"],
         "ledger_sha256": receipt["ledger_sha256"],
+        "ledger_provenance": receipt["ledger_provenance"],
         "repository": receipt["repository"],
         "head_branch": receipt["head_branch"],
         "head_shas": list(receipt["head_shas"]),

--- a/benchmarks/longmemeval_v2_release_authorization_package.py
+++ b/benchmarks/longmemeval_v2_release_authorization_package.py
@@ -156,51 +156,56 @@ def rebase_aa_authorization(
 def package_rig_blocked_authorization(
     receipt_path: Path,
     *,
+    ledger_path: Path,
     public_receipt_path: Path | None = None,
+    public_ledger_path: Path | None = None,
 ) -> dict[str, Any]:
-    """Project a fully validated dispatch-exhaustion receipt into authority."""
+    """Project a dispatch-exhaustion receipt and the ledger it derives from into authority."""
     source, receipt = _validated_artifact(
         receipt_path,
         name="rig-blocked source receipt",
         validator=rig.validate_rig_blocked_receipt,
     )
-    validated = build_rig_blocked_authorization(source, receipt)
-    return rebase_rig_blocked_authorization(validated, public_receipt_path=public_receipt_path)
+    source_ledger, ledger = _validated_artifact(
+        ledger_path,
+        name="rig-blocked source ledger",
+        validator=rig.require_dispatch_ledger,
+    )
+    validated = build_rig_blocked_authorization(
+        source,
+        receipt,
+        source_ledger=source_ledger,
+        ledger=ledger,
+    )
+    return rebase_rig_blocked_authorization(
+        validated,
+        public_receipt_path=public_receipt_path,
+        public_ledger_path=public_ledger_path,
+    )
 
 
 def build_rig_blocked_authorization(
     source: dict[str, Any],
     receipt: dict[str, Any],
+    *,
+    source_ledger: dict[str, Any],
+    ledger: dict[str, Any],
 ) -> dict[str, Any]:
-    """Build dispatch-exhaustion authority from an fd-bound physical receipt."""
+    """Build dispatch-exhaustion authority from fd-bound receipt and ledger bytes.
+
+    The receipt is rebuilt from the ledger and must match it field for field
+    outside the provenance block, so a receipt cannot cite a ledger it was not
+    sealed from.
+    """
 
     receipt = rig.validate_rig_blocked_receipt(receipt)
     if receipt["ledger_provenance"] != rig.LEDGER_PROVENANCE_VERIFIED:
         raise StagePlanError("rig-blocked authorization requires a GitHub-verified ledger")
-    payload = {
-        "schema_version": authorization.RIG_BLOCKED_AUTHORIZATION_SCHEMA_VERSION,
-        "kind": "rig_blocked",
-        "source_receipt": source,
-        "status": receipt["status"],
-        "blocked_reason": receipt["blocked_reason"],
-        "rig_blocked_receipt_sha256": receipt["rig_blocked_receipt_sha256"],
-        "ledger_sha256": receipt["ledger_sha256"],
-        "ledger_provenance": receipt["ledger_provenance"],
-        "repository": receipt["repository"],
-        "head_branch": receipt["head_branch"],
-        "head_shas": list(receipt["head_shas"]),
-        "attempt_count": receipt["attempt_count"],
-        "completed_pass_count": receipt["completed_pass_count"],
-        "attempts": [
-            {
-                "experiment_id": item["experiment_id"],
-                "head_sha": item["head_sha"],
-                "controller_run_id": item["controller"]["run_id"],
-                "builder_run_ids": [builder["run_id"] for builder in item["builders"]],
-            }
-            for item in receipt["attempts"]
-        ],
-    }
+    try:
+        rig.require_receipt_from_ledger(receipt, ledger)
+    except rig.RigInputError as exc:
+        raise StagePlanError(str(exc)) from exc
+    payload = authorization.rig_blocked_projection(source, source_ledger, receipt)
     payload["authorization_sha256"] = rig.canonical_sha256(payload)
     return authorization.require_rig_blocked_authorization(payload)
 
@@ -209,15 +214,22 @@ def rebase_rig_blocked_authorization(
     validated: dict[str, Any],
     *,
     public_receipt_path: Path | None,
+    public_ledger_path: Path | None,
 ) -> dict[str, Any]:
-    """Rebase a physically validated rig-blocked projection to a public path."""
+    """Rebase a physically validated rig-blocked projection to public paths."""
 
-    if public_receipt_path is None:
+    if public_receipt_path is None and public_ledger_path is None:
         return validated
+    if public_receipt_path is None or public_ledger_path is None:
+        raise StagePlanError("rig-blocked public authorization paths are incomplete")
     rebased = deepcopy(validated)
     rebased["source_receipt"]["path"] = _public_path(
         public_receipt_path,
         name="rig-blocked source receipt",
+    )
+    rebased["source_ledger"]["path"] = _public_path(
+        public_ledger_path,
+        name="rig-blocked source ledger",
     )
     rebased["authorization_sha256"] = rig.canonical_sha256(
         {key: value for key, value in rebased.items() if key != "authorization_sha256"}

--- a/benchmarks/longmemeval_v2_release_authorization_package.py
+++ b/benchmarks/longmemeval_v2_release_authorization_package.py
@@ -157,10 +157,15 @@ def package_rig_blocked_authorization(
     receipt_path: Path,
     *,
     ledger_path: Path,
+    fetch: rig.GitHubFetch,
     public_receipt_path: Path | None = None,
     public_ledger_path: Path | None = None,
 ) -> dict[str, Any]:
-    """Project a dispatch-exhaustion receipt and the ledger it derives from into authority."""
+    """Project a dispatch-exhaustion receipt and the ledger it derives from into authority.
+
+    ``fetch`` re-verifies the bound ledger against GitHub; there is no default
+    because an unverified projection is not authority.
+    """
     source, receipt = _validated_artifact(
         receipt_path,
         name="rig-blocked source receipt",
@@ -176,6 +181,7 @@ def package_rig_blocked_authorization(
         receipt,
         source_ledger=source_ledger,
         ledger=ledger,
+        fetch=fetch,
     )
     return rebase_rig_blocked_authorization(
         validated,
@@ -190,12 +196,13 @@ def build_rig_blocked_authorization(
     *,
     source_ledger: dict[str, Any],
     ledger: dict[str, Any],
+    fetch: rig.GitHubFetch,
 ) -> dict[str, Any]:
     """Build dispatch-exhaustion authority from fd-bound receipt and ledger bytes.
 
     The receipt is rebuilt from the ledger and must match it field for field
-    outside the provenance block, so a receipt cannot cite a ledger it was not
-    sealed from.
+    outside the provenance block, and the ledger is re-verified against GitHub
+    through ``fetch`` before the projection is accepted.
     """
 
     receipt = rig.validate_rig_blocked_receipt(receipt)
@@ -207,7 +214,7 @@ def build_rig_blocked_authorization(
         raise StagePlanError(str(exc)) from exc
     payload = authorization.rig_blocked_projection(source, source_ledger, receipt)
     payload["authorization_sha256"] = rig.canonical_sha256(payload)
-    return authorization.require_rig_blocked_authorization(payload)
+    return authorization.require_rig_blocked_authorization(payload, fetch=fetch)
 
 
 def rebase_rig_blocked_authorization(
@@ -433,12 +440,19 @@ def write_authorization(
     payload: dict[str, Any],
     *,
     paid_output_root: Path,
+    fetch: rig.GitHubFetch | None = None,
 ) -> None:
-    """Write a validated authority artifact once, outside paid output roots."""
+    """Write a validated authority artifact once, outside paid output roots.
+
+    A rig-blocked authority needs ``fetch`` so it can be re-verified against
+    GitHub before it is written; the other kinds never touch the network.
+    """
     if payload.get("kind") == "aa":
         authorization.require_aa_authorization(payload)
     elif payload.get("kind") == "rig_blocked":
-        authorization.require_rig_blocked_authorization(payload)
+        if fetch is None:
+            raise StagePlanError("rig-blocked authorization needs a GitHub fetcher")
+        authorization.require_rig_blocked_authorization(payload, fetch=fetch)
     else:
         authorization.require_preregistration_authorization(
             payload,

--- a/benchmarks/longmemeval_v2_release_ci.py
+++ b/benchmarks/longmemeval_v2_release_ci.py
@@ -29,7 +29,7 @@ RUN_MAP_SCHEMA_VERSION = "sibyl-longmemeval-v2-ci-run-map-v1"
 BUNDLE_MANIFEST_SCHEMA_VERSION = "sibyl-longmemeval-v2-ci-aa-bundle-v1"
 PASS_SEEDS = {"aa-1": 1301, "aa-2": 1302, "aa-3": 1303}
 ARM_IDS = tuple(f"{pass_id}-{side}" for pass_id in PASS_SEEDS for side in ("left", "right"))
-BUILDER_ARM_ID = "aa-1-left"
+BUILDER_ARM_ID = rig.DISPATCH_BUILDER_ARM_ID
 RUN_ID_PATTERN = re.compile(r"^[1-9][0-9]*$")
 ORCHESTRATION_ID_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$")
 

--- a/benchmarks/longmemeval_v2_release_cli.py
+++ b/benchmarks/longmemeval_v2_release_cli.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from benchmarks import longmemeval_v2_release_authorization_package as authorization_package
+from benchmarks import longmemeval_v2_release_io as release_io
 from benchmarks import longmemeval_v2_release_official_publication as official_publication
 from benchmarks import longmemeval_v2_release_package as release_package
 from benchmarks import longmemeval_v2_release_package_object as package_object
@@ -17,6 +19,7 @@ from benchmarks import longmemeval_v2_release_runner as release_runner
 from benchmarks.longmemeval_v2_release_contract import MAX_WORKERS_CAP
 from benchmarks.longmemeval_v2_release_handoff import require_executed_stage
 from benchmarks.longmemeval_v2_release_inputs import StagePlanError, load_json
+from tools.bench import longmemeval_v2_rig as rig
 
 ROOT = Path(__file__).resolve().parents[1]
 SYSTEM_DESCRIPTION = ROOT / "benchmarks" / "longmemeval_v2_release_assets" / "SYSTEM_DESCRIPTION.md"
@@ -109,9 +112,16 @@ def _add_package_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--preregistration-template")
 
 
+def _add_rig_blocked_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--receipt", required=True)
+    parser.add_argument("--ledger", required=True)
+    parser.add_argument("--output", required=True)
+
+
 def add_release_arguments(subparsers: Any) -> None:
     """Register the isolated v1.3 release commands on the benchmark CLI."""
 
+    _add_rig_blocked_arguments(subparsers.add_parser("release-rig-blocked-authority"))
     _add_plan_arguments(subparsers.add_parser("release-plan"))
     _add_run_arguments(subparsers.add_parser("release-run"))
     _add_arm_package_arguments(subparsers.add_parser("release-arm-package"))
@@ -192,6 +202,20 @@ def _verify(args: argparse.Namespace) -> dict[str, Any]:
     return release_package.require_packaged_stage(_supported_plan(_path(args.plan)))
 
 
+def _rig_blocked_authority(args: argparse.Namespace) -> dict[str, Any]:
+    """Project the rig-blocked receipt into authority after re-verifying it on GitHub."""
+    payload = authorization_package.package_rig_blocked_authorization(
+        _path(args.receipt),
+        ledger_path=_path(args.ledger),
+        fetch=rig.gh_api_fetch,
+    )
+    try:
+        release_io.write_json_once_atomic(_path(args.output), payload)
+    except FileExistsError as exc:
+        raise StagePlanError("rig-blocked authority output already exists") from exc
+    return payload
+
+
 def run_release_cli_command(args: argparse.Namespace) -> int:
     """Run exactly the named release phase and print its canonical receipt."""
 
@@ -201,6 +225,7 @@ def run_release_cli_command(args: argparse.Namespace) -> int:
         "release-arm-package": _package_arm,
         "release-package": _package,
         "release-verify": _verify,
+        "release-rig-blocked-authority": _rig_blocked_authority,
     }
     try:
         handler = handlers[args.command]

--- a/benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json
+++ b/benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json
@@ -1,0 +1,561 @@
+{
+  "schema_version": "sibyl-longmemeval-v2-dispatch-ledger-v1",
+  "repository": "hyperb1iss/sibyl",
+  "fetched_at": "2026-08-30T07:07:30Z",
+  "source": {
+    "tool": "gh api",
+    "run_endpoint": "repos/{repository}/actions/runs/{run_id}",
+    "jobs_endpoint": "repos/{repository}/actions/runs/{run_id}/jobs?per_page=100",
+    "builder_query": "gh run list --workflow longmemeval-v2.yml --limit 200 --json databaseId,displayTitle | select(displayTitle startswith \"LongMemEval V2 aa-{controller_run_id} \")"
+  },
+  "attempts": [
+    {
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-25T19:12:11Z",
+        "display_title": "LongMemEval V2 Release A/A sibyl-v1.3-aa-20260825",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888217656",
+        "id": 32888217656,
+        "name": "LongMemEval V2 Release A/A sibyl-v1.3-aa-20260825",
+        "path": ".github/workflows/longmemeval-v2-release-aa.yml",
+        "repository": "hyperb1iss/sibyl",
+        "run_attempt": 1,
+        "run_started_at": "2026-08-25T19:12:11Z",
+        "status": "completed",
+        "updated_at": "2026-08-25T19:13:30Z"
+      },
+      "builders": [
+        {
+          "conclusion": "cancelled",
+          "created_at": "2026-08-25T19:13:08Z",
+          "display_title": "LongMemEval V2 aa-32888217656 aa-1-left",
+          "event": "workflow_dispatch",
+          "head_branch": "main",
+          "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148",
+          "id": 32888310148,
+          "name": "LongMemEval V2 aa-32888217656 aa-1-left",
+          "path": ".github/workflows/longmemeval-v2.yml",
+          "repository": "hyperb1iss/sibyl",
+          "run_attempt": 1,
+          "run_started_at": "2026-08-25T19:13:08Z",
+          "status": "completed",
+          "updated_at": "2026-08-25T20:59:26Z",
+          "jobs": [
+            {
+              "completed_at": "2026-08-25T19:13:17Z",
+              "conclusion": "success",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148/job/97933922087",
+              "id": 97933922087,
+              "name": "Validate sealed paid arm",
+              "run_attempt": 1,
+              "run_id": 32888310148,
+              "started_at": "2026-08-25T19:13:14Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T19:13:10Z",
+              "conclusion": "skipped",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148/job/97933923793",
+              "id": 97933923793,
+              "name": "Probe ${{ matrix.tier }}",
+              "run_attempt": 1,
+              "run_id": 32888310148,
+              "started_at": "2026-08-25T19:13:10Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T19:13:24Z",
+              "conclusion": "success",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148/job/97933961179",
+              "id": 97933961179,
+              "name": "Validate frozen memory source",
+              "run_attempt": 1,
+              "run_id": 32888310148,
+              "started_at": "2026-08-25T19:13:21Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T20:59:25Z",
+              "conclusion": "cancelled",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148/job/97933994691",
+              "id": 97933994691,
+              "name": "Official web small",
+              "run_attempt": 1,
+              "run_id": 32888310148,
+              "started_at": "2026-08-25T19:14:25Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T20:40:20Z",
+              "conclusion": "failure",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148/job/97933994796",
+              "id": 97933994796,
+              "name": "Official enterprise small",
+              "run_attempt": 1,
+              "run_id": 32888310148,
+              "started_at": "2026-08-25T19:14:26Z",
+              "status": "completed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-25T20:54:00Z",
+        "display_title": "LongMemEval V2 Release A/A sibyl-v1.3-aa-20260825-r2",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32897996847",
+        "id": 32897996847,
+        "name": "LongMemEval V2 Release A/A sibyl-v1.3-aa-20260825-r2",
+        "path": ".github/workflows/longmemeval-v2-release-aa.yml",
+        "repository": "hyperb1iss/sibyl",
+        "run_attempt": 1,
+        "run_started_at": "2026-08-25T20:54:00Z",
+        "status": "completed",
+        "updated_at": "2026-08-25T20:55:17Z"
+      },
+      "builders": [
+        {
+          "conclusion": "failure",
+          "created_at": "2026-08-25T20:55:00Z",
+          "display_title": "LongMemEval V2 aa-32897996847 aa-1-left",
+          "event": "workflow_dispatch",
+          "head_branch": "main",
+          "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824",
+          "id": 32898089824,
+          "name": "LongMemEval V2 aa-32897996847 aa-1-left",
+          "path": ".github/workflows/longmemeval-v2.yml",
+          "repository": "hyperb1iss/sibyl",
+          "run_attempt": 1,
+          "run_started_at": "2026-08-25T20:55:00Z",
+          "status": "completed",
+          "updated_at": "2026-08-25T22:20:42Z",
+          "jobs": [
+            {
+              "completed_at": "2026-08-25T20:55:06Z",
+              "conclusion": "success",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97965272579",
+              "id": 97965272579,
+              "name": "Validate sealed paid arm",
+              "run_attempt": 1,
+              "run_id": 32898089824,
+              "started_at": "2026-08-25T20:55:04Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T20:55:02Z",
+              "conclusion": "skipped",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97965273421",
+              "id": 97965273421,
+              "name": "Probe ${{ matrix.tier }}",
+              "run_attempt": 1,
+              "run_id": 32898089824,
+              "started_at": "2026-08-25T20:55:02Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T20:55:13Z",
+              "conclusion": "success",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97965295778",
+              "id": 97965295778,
+              "name": "Validate frozen memory source",
+              "run_attempt": 1,
+              "run_id": 32898089824,
+              "started_at": "2026-08-25T20:55:10Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T22:20:41Z",
+              "conclusion": "failure",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97965331052",
+              "id": 97965331052,
+              "name": "Official enterprise small",
+              "run_attempt": 1,
+              "run_id": 32898089824,
+              "started_at": "2026-08-25T20:55:49Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T22:08:09Z",
+              "conclusion": "failure",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97965331077",
+              "id": 97965331077,
+              "name": "Official web small",
+              "run_attempt": 1,
+              "run_id": 32898089824,
+              "started_at": "2026-08-25T20:55:49Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T22:20:41Z",
+              "conclusion": "skipped",
+              "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97989142017",
+              "id": 97989142017,
+              "name": "Official combined receipt",
+              "run_attempt": 1,
+              "run_id": 32898089824,
+              "started_at": "2026-08-25T22:20:42Z",
+              "status": "completed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-25T23:30:14Z",
+        "display_title": "LongMemEval V2 Release A/A sibyl-v1-3-aa-20260825-r3",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911050360",
+        "id": 32911050360,
+        "name": "LongMemEval V2 Release A/A sibyl-v1-3-aa-20260825-r3",
+        "path": ".github/workflows/longmemeval-v2-release-aa.yml",
+        "repository": "hyperb1iss/sibyl",
+        "run_attempt": 1,
+        "run_started_at": "2026-08-25T23:30:14Z",
+        "status": "completed",
+        "updated_at": "2026-08-25T23:31:16Z"
+      },
+      "builders": [
+        {
+          "conclusion": "failure",
+          "created_at": "2026-08-25T23:31:01Z",
+          "display_title": "LongMemEval V2 aa-32911050360 aa-1-left",
+          "event": "workflow_dispatch",
+          "head_branch": "main",
+          "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960",
+          "id": 32911112960,
+          "name": "LongMemEval V2 aa-32911050360 aa-1-left",
+          "path": ".github/workflows/longmemeval-v2.yml",
+          "repository": "hyperb1iss/sibyl",
+          "run_attempt": 1,
+          "run_started_at": "2026-08-25T23:31:01Z",
+          "status": "completed",
+          "updated_at": "2026-08-26T01:34:04Z",
+          "jobs": [
+            {
+              "completed_at": "2026-08-25T23:31:10Z",
+              "conclusion": "success",
+              "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98005339504",
+              "id": 98005339504,
+              "name": "Validate sealed paid arm",
+              "run_attempt": 1,
+              "run_id": 32911112960,
+              "started_at": "2026-08-25T23:31:06Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T23:31:03Z",
+              "conclusion": "skipped",
+              "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98005340467",
+              "id": 98005340467,
+              "name": "Probe ${{ matrix.tier }}",
+              "run_attempt": 1,
+              "run_id": 32911112960,
+              "started_at": "2026-08-25T23:31:03Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-25T23:31:17Z",
+              "conclusion": "success",
+              "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98005365377",
+              "id": 98005365377,
+              "name": "Validate frozen memory source",
+              "run_attempt": 1,
+              "run_id": 32911112960,
+              "started_at": "2026-08-25T23:31:13Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T01:34:03Z",
+              "conclusion": "failure",
+              "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98005390926",
+              "id": 98005390926,
+              "name": "Official web small",
+              "run_attempt": 1,
+              "run_id": 32911112960,
+              "started_at": "2026-08-25T23:31:58Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T01:07:17Z",
+              "conclusion": "failure",
+              "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98005390966",
+              "id": 98005390966,
+              "name": "Official enterprise small",
+              "run_attempt": 1,
+              "run_id": 32911112960,
+              "started_at": "2026-08-25T23:31:58Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T01:34:03Z",
+              "conclusion": "skipped",
+              "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98029950637",
+              "id": 98029950637,
+              "name": "Official combined receipt",
+              "run_attempt": 1,
+              "run_id": 32911112960,
+              "started_at": "2026-08-26T01:34:03Z",
+              "status": "completed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-26T02:12:56Z",
+        "display_title": "LongMemEval V2 Release A/A sibyl-v1-3-aa-20260825-r4",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921881380",
+        "id": 32921881380,
+        "name": "LongMemEval V2 Release A/A sibyl-v1-3-aa-20260825-r4",
+        "path": ".github/workflows/longmemeval-v2-release-aa.yml",
+        "repository": "hyperb1iss/sibyl",
+        "run_attempt": 1,
+        "run_started_at": "2026-08-26T02:12:56Z",
+        "status": "completed",
+        "updated_at": "2026-08-26T02:14:14Z"
+      },
+      "builders": [
+        {
+          "conclusion": "failure",
+          "created_at": "2026-08-26T02:13:57Z",
+          "display_title": "LongMemEval V2 aa-32921881380 aa-1-left",
+          "event": "workflow_dispatch",
+          "head_branch": "main",
+          "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833",
+          "id": 32921948833,
+          "name": "LongMemEval V2 aa-32921881380 aa-1-left",
+          "path": ".github/workflows/longmemeval-v2.yml",
+          "repository": "hyperb1iss/sibyl",
+          "run_attempt": 1,
+          "run_started_at": "2026-08-26T02:13:57Z",
+          "status": "completed",
+          "updated_at": "2026-08-26T04:25:39Z",
+          "jobs": [
+            {
+              "completed_at": "2026-08-26T02:14:06Z",
+              "conclusion": "success",
+              "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98037115448",
+              "id": 98037115448,
+              "name": "Validate sealed paid arm",
+              "run_attempt": 1,
+              "run_id": 32921948833,
+              "started_at": "2026-08-26T02:14:02Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T02:13:59Z",
+              "conclusion": "skipped",
+              "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98037116586",
+              "id": 98037116586,
+              "name": "Probe ${{ matrix.tier }}",
+              "run_attempt": 1,
+              "run_id": 32921948833,
+              "started_at": "2026-08-26T02:13:59Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T02:14:13Z",
+              "conclusion": "success",
+              "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98037138625",
+              "id": 98037138625,
+              "name": "Validate frozen memory source",
+              "run_attempt": 1,
+              "run_id": 32921948833,
+              "started_at": "2026-08-26T02:14:10Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T04:18:43Z",
+              "conclusion": "failure",
+              "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98037160887",
+              "id": 98037160887,
+              "name": "Official enterprise small",
+              "run_attempt": 1,
+              "run_id": 32921948833,
+              "started_at": "2026-08-26T02:14:53Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T04:25:38Z",
+              "conclusion": "failure",
+              "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98037160889",
+              "id": 98037160889,
+              "name": "Official web small",
+              "run_attempt": 1,
+              "run_id": 32921948833,
+              "started_at": "2026-08-26T02:14:53Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T04:25:38Z",
+              "conclusion": "skipped",
+              "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98060775189",
+              "id": 98060775189,
+              "name": "Official combined receipt",
+              "run_attempt": 1,
+              "run_id": 32921948833,
+              "started_at": "2026-08-26T04:25:39Z",
+              "status": "completed"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-26T18:15:25Z",
+        "display_title": "LongMemEval V2 Release A/A sibyl-v1-3-aa-20260826-r5",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998699090",
+        "id": 32998699090,
+        "name": "LongMemEval V2 Release A/A sibyl-v1-3-aa-20260826-r5",
+        "path": ".github/workflows/longmemeval-v2-release-aa.yml",
+        "repository": "hyperb1iss/sibyl",
+        "run_attempt": 1,
+        "run_started_at": "2026-08-26T18:15:25Z",
+        "status": "completed",
+        "updated_at": "2026-08-26T18:16:35Z"
+      },
+      "builders": [
+        {
+          "conclusion": "failure",
+          "created_at": "2026-08-26T18:16:20Z",
+          "display_title": "LongMemEval V2 aa-32998699090 aa-1-left",
+          "event": "workflow_dispatch",
+          "head_branch": "main",
+          "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818",
+          "id": 32998783818,
+          "name": "LongMemEval V2 aa-32998699090 aa-1-left",
+          "path": ".github/workflows/longmemeval-v2.yml",
+          "repository": "hyperb1iss/sibyl",
+          "run_attempt": 1,
+          "run_started_at": "2026-08-26T18:16:20Z",
+          "status": "completed",
+          "updated_at": "2026-08-26T23:15:39Z",
+          "jobs": [
+            {
+              "completed_at": "2026-08-26T18:16:29Z",
+              "conclusion": "success",
+              "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98274824542",
+              "id": 98274824542,
+              "name": "Validate sealed paid arm",
+              "run_attempt": 1,
+              "run_id": 32998783818,
+              "started_at": "2026-08-26T18:16:25Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T18:16:22Z",
+              "conclusion": "skipped",
+              "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98274826404",
+              "id": 98274826404,
+              "name": "Probe ${{ matrix.tier }}",
+              "run_attempt": 1,
+              "run_id": 32998783818,
+              "started_at": "2026-08-26T18:16:22Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T18:16:35Z",
+              "conclusion": "success",
+              "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98274862415",
+              "id": 98274862415,
+              "name": "Validate frozen memory source",
+              "run_attempt": 1,
+              "run_id": 32998783818,
+              "started_at": "2026-08-26T18:16:32Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T23:15:38Z",
+              "conclusion": "success",
+              "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98274890058",
+              "id": 98274890058,
+              "name": "Official web small",
+              "run_attempt": 1,
+              "run_id": 32998783818,
+              "started_at": "2026-08-26T18:17:10Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T22:01:13Z",
+              "conclusion": "failure",
+              "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98274890140",
+              "id": 98274890140,
+              "name": "Official enterprise small",
+              "run_attempt": 1,
+              "run_id": 32998783818,
+              "started_at": "2026-08-26T18:17:09Z",
+              "status": "completed"
+            },
+            {
+              "completed_at": "2026-08-26T23:15:39Z",
+              "conclusion": "skipped",
+              "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98356445774",
+              "id": 98356445774,
+              "name": "Official combined receipt",
+              "run_attempt": 1,
+              "run_id": 32998783818,
+              "started_at": "2026-08-26T23:15:39Z",
+              "status": "completed"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json
+++ b/benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json
@@ -248,6 +248,12 @@
   "controller_workflow": ".github/workflows/longmemeval-v2-release-aa.yml",
   "exhaustion_rule": "at least five successful controller dispatches on one branch, each binding a builder run whose official Small domains never both succeeded and whose combined receipt never succeeded",
   "first_dispatched_at": "2026-08-25T19:12:11Z",
+  "github_verification": {
+    "builder_query": "repos/{repository}/actions/workflows/{workflow}/runs?event=workflow_dispatch&per_page=100&created=>={date}",
+    "job_count": 29,
+    "run_count": 10,
+    "verified_at": "2026-08-30T07:35:29Z"
+  },
   "head_branch": "main",
   "head_shas": [
     "48b4483624305cc020296b6593be3bad968aeac6",
@@ -257,11 +263,12 @@
   ],
   "last_dispatched_at": "2026-08-26T18:15:25Z",
   "ledger_fetched_at": "2026-08-30T07:07:30Z",
+  "ledger_provenance": "github_verified",
   "ledger_sha256": "sha256:74339727e600a92a0157db517e6c5ce0b378bf08b4dc8ba2eb274818427a4299",
   "paid_benchmark_allowed": false,
   "repository": "hyperb1iss/sibyl",
   "required_attempt_count": 5,
-  "rig_blocked_receipt_sha256": "sha256:6207e4833da2bb6184570f4c0cabb309de1ba3aede54d5f140e0c180f7fc8d77",
+  "rig_blocked_receipt_sha256": "sha256:5850fd3f31ac8db9090b8e7bb8b62b349823500f0ebac6ebe3ba3a09cccc0df8",
   "schema_version": "sibyl-longmemeval-v2-rig-blocked-receipt-v1",
   "score_claim_allowed": false,
   "status": "RIG_BLOCKED"

--- a/benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json
+++ b/benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json
@@ -1,0 +1,268 @@
+{
+  "attempt_count": 5,
+  "attempts": [
+    {
+      "builders": [
+        {
+          "conclusion": "cancelled",
+          "created_at": "2026-08-25T19:13:08Z",
+          "event": "workflow_dispatch",
+          "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148",
+          "official_jobs": {
+            "combined_receipt": null,
+            "enterprise": {
+              "completed_at": "2026-08-25T20:40:20Z",
+              "conclusion": "failure",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148/job/97933994796",
+              "job_id": 97933994796,
+              "started_at": "2026-08-25T19:14:26Z"
+            },
+            "web": {
+              "completed_at": "2026-08-25T20:59:25Z",
+              "conclusion": "cancelled",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888310148/job/97933994691",
+              "job_id": 97933994691,
+              "started_at": "2026-08-25T19:14:25Z"
+            }
+          },
+          "run_attempt": 1,
+          "run_id": 32888310148,
+          "updated_at": "2026-08-25T20:59:26Z"
+        }
+      ],
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-25T19:12:11Z",
+        "event": "workflow_dispatch",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32888217656",
+        "run_attempt": 1,
+        "run_id": 32888217656,
+        "updated_at": "2026-08-25T19:13:30Z"
+      },
+      "experiment_id": "sibyl-v1.3-aa-20260825",
+      "head_branch": "main",
+      "head_sha": "48b4483624305cc020296b6593be3bad968aeac6"
+    },
+    {
+      "builders": [
+        {
+          "conclusion": "failure",
+          "created_at": "2026-08-25T20:55:00Z",
+          "event": "workflow_dispatch",
+          "head_sha": "48b4483624305cc020296b6593be3bad968aeac6",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824",
+          "official_jobs": {
+            "combined_receipt": {
+              "completed_at": "2026-08-25T22:20:41Z",
+              "conclusion": "skipped",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97989142017",
+              "job_id": 97989142017,
+              "started_at": "2026-08-25T22:20:42Z"
+            },
+            "enterprise": {
+              "completed_at": "2026-08-25T22:20:41Z",
+              "conclusion": "failure",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97965331052",
+              "job_id": 97965331052,
+              "started_at": "2026-08-25T20:55:49Z"
+            },
+            "web": {
+              "completed_at": "2026-08-25T22:08:09Z",
+              "conclusion": "failure",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32898089824/job/97965331077",
+              "job_id": 97965331077,
+              "started_at": "2026-08-25T20:55:49Z"
+            }
+          },
+          "run_attempt": 1,
+          "run_id": 32898089824,
+          "updated_at": "2026-08-25T22:20:42Z"
+        }
+      ],
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-25T20:54:00Z",
+        "event": "workflow_dispatch",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32897996847",
+        "run_attempt": 1,
+        "run_id": 32897996847,
+        "updated_at": "2026-08-25T20:55:17Z"
+      },
+      "experiment_id": "sibyl-v1.3-aa-20260825-r2",
+      "head_branch": "main",
+      "head_sha": "48b4483624305cc020296b6593be3bad968aeac6"
+    },
+    {
+      "builders": [
+        {
+          "conclusion": "failure",
+          "created_at": "2026-08-25T23:31:01Z",
+          "event": "workflow_dispatch",
+          "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960",
+          "official_jobs": {
+            "combined_receipt": {
+              "completed_at": "2026-08-26T01:34:03Z",
+              "conclusion": "skipped",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98029950637",
+              "job_id": 98029950637,
+              "started_at": "2026-08-26T01:34:03Z"
+            },
+            "enterprise": {
+              "completed_at": "2026-08-26T01:07:17Z",
+              "conclusion": "failure",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98005390966",
+              "job_id": 98005390966,
+              "started_at": "2026-08-25T23:31:58Z"
+            },
+            "web": {
+              "completed_at": "2026-08-26T01:34:03Z",
+              "conclusion": "failure",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911112960/job/98005390926",
+              "job_id": 98005390926,
+              "started_at": "2026-08-25T23:31:58Z"
+            }
+          },
+          "run_attempt": 1,
+          "run_id": 32911112960,
+          "updated_at": "2026-08-26T01:34:04Z"
+        }
+      ],
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-25T23:30:14Z",
+        "event": "workflow_dispatch",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32911050360",
+        "run_attempt": 1,
+        "run_id": 32911050360,
+        "updated_at": "2026-08-25T23:31:16Z"
+      },
+      "experiment_id": "sibyl-v1-3-aa-20260825-r3",
+      "head_branch": "main",
+      "head_sha": "74ddb867651c0159ff9d213d2cf952d5fb70a52b"
+    },
+    {
+      "builders": [
+        {
+          "conclusion": "failure",
+          "created_at": "2026-08-26T02:13:57Z",
+          "event": "workflow_dispatch",
+          "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833",
+          "official_jobs": {
+            "combined_receipt": {
+              "completed_at": "2026-08-26T04:25:38Z",
+              "conclusion": "skipped",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98060775189",
+              "job_id": 98060775189,
+              "started_at": "2026-08-26T04:25:39Z"
+            },
+            "enterprise": {
+              "completed_at": "2026-08-26T04:18:43Z",
+              "conclusion": "failure",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98037160887",
+              "job_id": 98037160887,
+              "started_at": "2026-08-26T02:14:53Z"
+            },
+            "web": {
+              "completed_at": "2026-08-26T04:25:38Z",
+              "conclusion": "failure",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921948833/job/98037160889",
+              "job_id": 98037160889,
+              "started_at": "2026-08-26T02:14:53Z"
+            }
+          },
+          "run_attempt": 1,
+          "run_id": 32921948833,
+          "updated_at": "2026-08-26T04:25:39Z"
+        }
+      ],
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-26T02:12:56Z",
+        "event": "workflow_dispatch",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32921881380",
+        "run_attempt": 1,
+        "run_id": 32921881380,
+        "updated_at": "2026-08-26T02:14:14Z"
+      },
+      "experiment_id": "sibyl-v1-3-aa-20260825-r4",
+      "head_branch": "main",
+      "head_sha": "aed4adb2728953aa015bcafb04172b4efe443a6d"
+    },
+    {
+      "builders": [
+        {
+          "conclusion": "failure",
+          "created_at": "2026-08-26T18:16:20Z",
+          "event": "workflow_dispatch",
+          "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117",
+          "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818",
+          "official_jobs": {
+            "combined_receipt": {
+              "completed_at": "2026-08-26T23:15:39Z",
+              "conclusion": "skipped",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98356445774",
+              "job_id": 98356445774,
+              "started_at": "2026-08-26T23:15:39Z"
+            },
+            "enterprise": {
+              "completed_at": "2026-08-26T22:01:13Z",
+              "conclusion": "failure",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98274890140",
+              "job_id": 98274890140,
+              "started_at": "2026-08-26T18:17:09Z"
+            },
+            "web": {
+              "completed_at": "2026-08-26T23:15:38Z",
+              "conclusion": "success",
+              "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998783818/job/98274890058",
+              "job_id": 98274890058,
+              "started_at": "2026-08-26T18:17:10Z"
+            }
+          },
+          "run_attempt": 1,
+          "run_id": 32998783818,
+          "updated_at": "2026-08-26T23:15:39Z"
+        }
+      ],
+      "controller": {
+        "conclusion": "success",
+        "created_at": "2026-08-26T18:15:25Z",
+        "event": "workflow_dispatch",
+        "html_url": "https://github.com/hyperb1iss/sibyl/actions/runs/32998699090",
+        "run_attempt": 1,
+        "run_id": 32998699090,
+        "updated_at": "2026-08-26T18:16:35Z"
+      },
+      "experiment_id": "sibyl-v1-3-aa-20260826-r5",
+      "head_branch": "main",
+      "head_sha": "7f31a330c0d9a25180a98a4332423b811d18c117"
+    }
+  ],
+  "blocked_reason": "dispatch_exhausted",
+  "builder_arm_id": "aa-1-left",
+  "builder_workflow": ".github/workflows/longmemeval-v2.yml",
+  "completed_pass_count": 0,
+  "controller_workflow": ".github/workflows/longmemeval-v2-release-aa.yml",
+  "exhaustion_rule": "at least five successful controller dispatches on one branch, each binding a builder run whose official Small domains never both succeeded and whose combined receipt never succeeded",
+  "first_dispatched_at": "2026-08-25T19:12:11Z",
+  "head_branch": "main",
+  "head_shas": [
+    "48b4483624305cc020296b6593be3bad968aeac6",
+    "74ddb867651c0159ff9d213d2cf952d5fb70a52b",
+    "aed4adb2728953aa015bcafb04172b4efe443a6d",
+    "7f31a330c0d9a25180a98a4332423b811d18c117"
+  ],
+  "last_dispatched_at": "2026-08-26T18:15:25Z",
+  "ledger_fetched_at": "2026-08-30T07:07:30Z",
+  "ledger_sha256": "sha256:74339727e600a92a0157db517e6c5ce0b378bf08b4dc8ba2eb274818427a4299",
+  "paid_benchmark_allowed": false,
+  "repository": "hyperb1iss/sibyl",
+  "required_attempt_count": 5,
+  "rig_blocked_receipt_sha256": "sha256:6207e4833da2bb6184570f4c0cabb309de1ba3aede54d5f140e0c180f7fc8d77",
+  "schema_version": "sibyl-longmemeval-v2-rig-blocked-receipt-v1",
+  "score_claim_allowed": false,
+  "status": "RIG_BLOCKED"
+}

--- a/docs/architecture/SIBYL_1_3_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_3_IMPLEMENTATION_PLAN.md
@@ -1,9 +1,10 @@
 # Sibyl v1.3 final implementation and release plan: One Surface
 
-- Status: implementation and local harmony gates complete; merge, paid benchmark, and release-cut
-  evidence pending
+- Status: merged and green on `main`; paid benchmark stopped by the dispatch-exhaustion rig-blocked
+  receipt; release cut pending approval (see
+  [SIBYL_1_3_RELEASE_STATUS_2026-08-29.md](SIBYL_1_3_RELEASE_STATUS_2026-08-29.md))
 - Created: 2026-08-19
-- Updated: 2026-08-20
+- Updated: 2026-08-30
 - Working task: `8be323d1-0000-4ce2-9661-8ca504f17e17`
 - Starting commit: `c3c786ab603a67e45689c765b2365f6d3cef8bc6`
 - Plan baseline: `1e8e0b4b`
@@ -406,8 +407,10 @@ the span is larger, run two more passes and publish the observed span rather tha
 the decision noise floor `N` as the larger of `3pp` and that stable observed span.
 
 If the five-pass span does not stabilize, or any compared receipt differs outside the allowed run
-identifiers, stop the paid benchmark path and publish a rig-blocked receipt. Benchmark blockage does
-not block the product release.
+identifiers, stop the paid benchmark path and publish a rig-blocked receipt. Five controller
+dispatches that never complete one two-domain pass are the same stop, and the rig seals them as a
+rig-blocked receipt with `blocked_reason: dispatch_exhausted` bound to the observed run ids.
+Benchmark blockage does not block the product release.
 
 Once the rig is usable, run the current machine arm across both Small domains and publish one
 generated anchor receipt. The receipt includes accuracy, evidence exposure, latency, tokens,
@@ -594,12 +597,12 @@ Sibyl v1.3 may cut when every required item below has a receipt.
 - [x] The official harness is pinned to a reviewed immutable commit.
 - [x] Query context is identifier-only and covered by a contract test.
 - [x] Faulted vector and context lanes cannot report success.
-- [ ] A/A produces a stable `N`, or a five-pass rig-blocked receipt stops paid benchmark work.
-- [ ] A usable rig produces a clean post-decontamination Small anchor for both domains. A blocked
+- [x] A/A produces a stable `N`, or a five-pass rig-blocked receipt stops paid benchmark work.
+- [x] A usable rig produces a clean post-decontamination Small anchor for both domains. A blocked
       rig produces no score claim.
-- [ ] The machine versus naive race is adjudicated, inconclusive, or stopped by the rig-blocked
+- [x] The machine versus naive race is adjudicated, inconclusive, or stopped by the rig-blocked
       receipt.
-- [ ] The render bundle is shipped, killed, inconclusive, or stopped by the rig-blocked receipt.
+- [x] The render bundle is shipped, killed, inconclusive, or stopped by the rig-blocked receipt.
 - [x] No release document depends on a leaderboard submission.
 
 ### Release integrity

--- a/docs/architecture/SIBYL_1_3_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SIBYL_1_3_IMPLEMENTATION_PLAN.md
@@ -618,7 +618,7 @@ Sibyl v1.3 may cut when every required item below has a receipt.
       with no tracked changes. The historical One Surface receipt is recorded in section 9.
 - [x] Targeted lifecycle, MCP authorization, queue retry, readiness, browser, benchmark-contract,
       release-workflow, and Helm gates pass uncached on the harmony head.
-- [ ] The release runbook records the exact commit, generated receipts, deferred work, and rollback
+- [x] The release runbook records the exact commit, generated receipts, deferred work, and rollback
       points.
 
 ## 7. Explicitly deferred to v1.4 or later

--- a/docs/architecture/SIBYL_1_3_RELEASE_RUNBOOK.md
+++ b/docs/architecture/SIBYL_1_3_RELEASE_RUNBOOK.md
@@ -45,23 +45,32 @@ git rev-parse origin/main
 | Receipt                     | Path                                                                                 | Digest                                                                    | Source runs                                                                 |
 | --------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | Dispatch ledger (observed)  | `benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json`       | `sha256:74339727e600a92a0157db517e6c5ce0b378bf08b4dc8ba2eb274818427a4299` | Controllers 32888217656, 32897996847, 32911050360, 32921881380, 32998699090 |
-| Rig-blocked receipt         | `benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json`   | `sha256:6207e4833da2bb6184570f4c0cabb309de1ba3aede54d5f140e0c180f7fc8d77` | Builders 32888310148, 32898089824, 32911112960, 32921948833, 32998783818    |
+| Rig-blocked receipt         | `benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json`   | `sha256:5850fd3f31ac8db9090b8e7bb8b62b349823500f0ebac6ebe3ba3a09cccc0df8` | Builders 32888310148, 32898089824, 32911112960, 32921948833, 32998783818    |
 | r5 Web Small artifacts      | `gh run download 32998783818 -R hyperb1iss/sibyl` (retained 30 days from 2026-08-26) | recorded inside the run's result and diagnostics artifacts                | Builder 32998783818 on `7f31a330`                                           |
 | RC gate receipt             | `rc-gate-receipt-<candidate-sha>` artifact of the Release run                        | produced by the dry cut                                                   | The dry-cut Release run                                                     |
 | Release notes claim receipt | `release-notes-claim-receipt.json` inside the same artifact                          | produced by the real cut only                                             | The Release run without `dry_run`                                           |
 
 The rig-blocked receipt is `RIG_BLOCKED` with `blocked_reason: dispatch_exhausted`,
-`paid_benchmark_allowed: false`, and `score_claim_allowed: false`. It stops paid benchmark work for
-1.3 and forbids any score in the release notes. Regenerate it from the committed ledger to confirm
-the bytes (exit status 1 is the rig's normal code for a rig-blocked verdict):
+`paid_benchmark_allowed: false`, `score_claim_allowed: false`, and
+`ledger_provenance: github_verified`. It stops paid benchmark work for 1.3 and forbids any score in
+the release notes. Regenerate it from the committed ledger through the verified path to confirm it
+(exit status 1 is the rig's normal code for a rig-blocked verdict). The verification block carries
+its own timestamp, so the comparison drops that block and the digest:
 
 ```bash
 uv run python tools/bench/longmemeval_v2_rig.py rig-blocked \
   --ledger benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json \
-  --output /tmp/sibyl-1-3-rig-blocked-check.json
-diff /tmp/sibyl-1-3-rig-blocked-check.json \
-  benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json
+  --output /tmp/sibyl-1-3-rig-blocked-check.json \
+  --verify-github
+strip='del(.github_verification, .rig_blocked_receipt_sha256)'
+diff <(jq -S "$strip" /tmp/sibyl-1-3-rig-blocked-check.json) \
+  <(jq -S "$strip" benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json)
 ```
+
+`--verify-github` re-fetches every controller run, builder run, and job through `gh api`,
+re-discovers each controller's builders from the workflow run listing, and refuses to seal on any
+field difference. A seal without it records `ledger_provenance: unverified`, which the release
+authorization projection rejects.
 
 To refresh the ledger from GitHub (only if a new dispatch is added), fetch each controller run with
 `gh api repos/hyperb1iss/sibyl/actions/runs/<id>`, find its builder with

--- a/docs/architecture/SIBYL_1_3_RELEASE_RUNBOOK.md
+++ b/docs/architecture/SIBYL_1_3_RELEASE_RUNBOOK.md
@@ -53,24 +53,28 @@ git rev-parse origin/main
 The rig-blocked receipt is `RIG_BLOCKED` with `blocked_reason: dispatch_exhausted`,
 `paid_benchmark_allowed: false`, `score_claim_allowed: false`, and
 `ledger_provenance: github_verified`. It stops paid benchmark work for 1.3 and forbids any score in
-the release notes. Regenerate it from the committed ledger through the verified path to confirm it
-(exit status 1 is the rig's normal code for a rig-blocked verdict). The verification block carries
-its own timestamp, so the comparison drops that block and the digest:
+the release notes. The provenance label records when the ledger last matched GitHub; it is not the
+evidence. The documented check is the command that projects the receipt into release authority,
+because that command re-fetches every controller run, builder run, and job through `gh api`,
+re-discovers each controller's builders from the workflow run listing, rebuilds the receipt from the
+bound ledger bytes, and writes the authority only when everything matches. Any field drift or fetch
+failure fails closed, and the same live re-verification runs every time the authority is validated:
 
 ```bash
-uv run python tools/bench/longmemeval_v2_rig.py rig-blocked \
+uv run python -m benchmarks.longmemeval_v2_ablations release-rig-blocked-authority \
+  --receipt benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json \
   --ledger benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json \
-  --output /tmp/sibyl-1-3-rig-blocked-check.json \
-  --verify-github
-strip='del(.github_verification, .rig_blocked_receipt_sha256)'
-diff <(jq -S "$strip" /tmp/sibyl-1-3-rig-blocked-check.json) \
-  <(jq -S "$strip" benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json)
+  --output /tmp/sibyl-1-3-rig-blocked-authority.json
 ```
 
-`--verify-github` re-fetches every controller run, builder run, and job through `gh api`,
-re-discovers each controller's builders from the workflow run listing, and refuses to seal on any
-field difference. A seal without it records `ledger_provenance: unverified`, which the release
-authorization projection rejects.
+The output is the `rig_blocked` authority projection. Keep it with the RC gate receipt. The
+authority carries no score, no paid-work permission, and no stack or arm contract; it exists to
+prove that the benchmark stop was observed, not asserted.
+
+To reseal the receipt after a new dispatch, refresh the ledger and run
+`tools/bench/longmemeval_v2_rig.py rig-blocked --ledger ... --output ... --verify-github`; a seal
+without `--verify-github` records `ledger_provenance: unverified` and the authority command rejects
+it before touching the network.
 
 To refresh the ledger from GitHub (only if a new dispatch is added), fetch each controller run with
 `gh api repos/hyperb1iss/sibyl/actions/runs/<id>`, find its builder with

--- a/docs/architecture/SIBYL_1_3_RELEASE_RUNBOOK.md
+++ b/docs/architecture/SIBYL_1_3_RELEASE_RUNBOOK.md
@@ -1,0 +1,227 @@
+# Sibyl 1.3 release runbook
+
+- Candidate commit: `012e7b55407d84ac2049914956b7017546d64b68` (`main`, 2026-08-27)
+- Version: `1.2.2` to `1.3.0`
+- Release state: ready for dry cut pending approval
+- Status: [SIBYL_1_3_RELEASE_STATUS_2026-08-29.md](SIBYL_1_3_RELEASE_STATUS_2026-08-29.md)
+- Plan: [SIBYL_1_3_IMPLEMENTATION_PLAN.md](SIBYL_1_3_IMPLEMENTATION_PLAN.md)
+- General procedure: [docs/admin/releasing.md](../admin/releasing.md)
+
+This runbook binds the general release procedure to the 1.3 candidate. Every command below runs from
+a clean checkout of the candidate commit unless it says otherwise. Nothing here creates a version
+commit, a tag, a GitHub release, or a publish run; those steps sit behind the approval gate in the
+middle of this document.
+
+## 1. Candidate commit
+
+The candidate is `012e7b55`, the `main` head that merged
+[PR 445](https://github.com/hyperb1iss/sibyl/pull/445). The exact-commit evidence already on record:
+
+| Check              | Run                                                                         | Result  | Date       |
+| ------------------ | --------------------------------------------------------------------------- | ------- | ---------- |
+| CI                 | [33025662969](https://github.com/hyperb1iss/sibyl/actions/runs/33025662969) | success | 2026-08-27 |
+| Nightly Regression | [33244786444](https://github.com/hyperb1iss/sibyl/actions/runs/33244786444) | success | 2026-08-29 |
+| Nightly Regression | [33172885088](https://github.com/hyperb1iss/sibyl/actions/runs/33172885088) | success | 2026-08-28 |
+
+Pass `33244786444` as `nightly_run_id`. The Release workflow refuses a nightly from any other
+commit.
+
+The candidate moves only if `main` moves. The hybrid fulltext lane fix (commit `fc17af80` on
+`nova/sibyl-1-3-hybrid-fulltext-lane`, pull request pending) and this receipt lane (branch
+`nova/sibyl-1-3-rig-blocked-dispatches`) are not in `012e7b55`. If either merges before the cut, the
+new `main` head becomes the candidate, CI must pass on it, Nightly Regression must be dispatched on
+it, and section 3 runs again on it. Nothing in this runbook may be carried across commits.
+
+Pin the candidate before touching anything:
+
+```bash
+git fetch origin main
+git status --short
+git rev-parse origin/main
+```
+
+## 2. Generated receipts
+
+| Receipt                     | Path                                                                                 | Digest                                                                    | Source runs                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Dispatch ledger (observed)  | `benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json`       | `sha256:74339727e600a92a0157db517e6c5ce0b378bf08b4dc8ba2eb274818427a4299` | Controllers 32888217656, 32897996847, 32911050360, 32921881380, 32998699090 |
+| Rig-blocked receipt         | `benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json`   | `sha256:6207e4833da2bb6184570f4c0cabb309de1ba3aede54d5f140e0c180f7fc8d77` | Builders 32888310148, 32898089824, 32911112960, 32921948833, 32998783818    |
+| r5 Web Small artifacts      | `gh run download 32998783818 -R hyperb1iss/sibyl` (retained 30 days from 2026-08-26) | recorded inside the run's result and diagnostics artifacts                | Builder 32998783818 on `7f31a330`                                           |
+| RC gate receipt             | `rc-gate-receipt-<candidate-sha>` artifact of the Release run                        | produced by the dry cut                                                   | The dry-cut Release run                                                     |
+| Release notes claim receipt | `release-notes-claim-receipt.json` inside the same artifact                          | produced by the real cut only                                             | The Release run without `dry_run`                                           |
+
+The rig-blocked receipt is `RIG_BLOCKED` with `blocked_reason: dispatch_exhausted`,
+`paid_benchmark_allowed: false`, and `score_claim_allowed: false`. It stops paid benchmark work for
+1.3 and forbids any score in the release notes. Regenerate it from the committed ledger to confirm
+the bytes (exit status 1 is the rig's normal code for a rig-blocked verdict):
+
+```bash
+uv run python tools/bench/longmemeval_v2_rig.py rig-blocked \
+  --ledger benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json \
+  --output /tmp/sibyl-1-3-rig-blocked-check.json
+diff /tmp/sibyl-1-3-rig-blocked-check.json \
+  benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json
+```
+
+To refresh the ledger from GitHub (only if a new dispatch is added), fetch each controller run with
+`gh api repos/hyperb1iss/sibyl/actions/runs/<id>`, find its builder with
+`gh run list --workflow longmemeval-v2.yml --limit 200 --json databaseId,displayTitle` filtered on
+the display title prefix `LongMemEval V2 aa-<controller id> `, fetch that builder run and its
+`/jobs?per_page=100`, and project the fields the ledger schema names. The tool itself never fetches.
+
+## 3. Gates at the candidate commit
+
+Run every gate uncached on the pinned checkout. A cached moon task that returns in milliseconds
+proves nothing; use `--force` where the task allows it.
+
+```bash
+moon run release-version-validate -- 1.3.0
+moon run --force sync-versions-check
+moon run --force release-workflow-test
+moon run --force root:bench-gate-test root:inventory-lint root:inventory-typecheck
+moon run --force bench-longmemeval-v2-release-ci-test
+moon run --force root:doc-claim-gate-test
+moon run --force :check
+moon run e2e:test-browser
+moon run inventory-test
+moon run doc-claim-gate
+```
+
+The `sync-versions-check` task must pass at `1.2.2` before the cut; the Release workflow bumps
+`VERSION` itself and reruns the same check after `moon run sync-versions`, then proves the bump
+touched only the pins listed by `tools/release/sync_versions.py --list-targets`. The browser gate
+needs the production-shaped fixture and a running frontend. The Helm gate needs Helm installed.
+
+Recorded on branch `nova/sibyl-1-3-rig-blocked-dispatches` at `b304c204` (not on the candidate):
+`root:bench-gate-test` 897 passed in 27 seconds, `bench-longmemeval-v2-release-ci-test` 9 passed,
+`root:inventory-lint` and `root:inventory-typecheck` clean, `:lint` 12 tasks completed. Those
+numbers describe the receipt branch and do not stand in for the candidate run.
+
+Recompute the live preflight immediately before the cut and keep the links:
+
+```bash
+gh pr list --state open --json number,title,url,isDraft,reviewDecision,statusCheckRollup
+gh issue list --state open --json number,title,url,labels
+```
+
+## 4. Dry cut
+
+The Release workflow runs the image CVE gate before the release job exists. The dry run then
+validates the version, applies a pin-only bump inside the runner without pushing it, runs
+`moon run :check`, verifies the same-commit nightly, and uploads the RC gate receipt. It creates no
+tag, no release, and no publish run.
+
+```bash
+gh workflow run release.yml \
+  --ref main \
+  -f version=1.3.0 \
+  -f dry_run=true \
+  -f nightly_run_id=33244786444
+```
+
+Confirm before reading the result:
+
+- the run's head SHA is the candidate;
+- the `Image CVE gate` scan jobs passed for `api` and `web` on both `amd64` and `arm64`;
+- the `Determine version` step reports `1.2.2` to `1.3.0` and no existing `v1.3.0` tag;
+- the `Run RC gate bundle` step passed;
+- the `Validate same-SHA Nightly Regression` step used run `33244786444`;
+- the `rc-gate-receipt-<sha>` artifact exists and records `dry_run: true`.
+
+A dry cut that fails at any step returns this runbook to section 3. Do not retry the real cut on the
+strength of a partial dry run.
+
+## 5. Approval gate
+
+Three state changes need Bliss's explicit go, given after the dry cut passes and named individually:
+the version bump commit from 1.2.2 to 1.3.0 on `main`, the `v1.3.0` tag, and the publish run. A
+green dry cut is evidence for the request, not the approval. No agent tags, publishes, or pushes to
+`main` on its own.
+
+The release notes carry no benchmark number. The public claim gate rejects a score that lacks a
+citable manifest entry, and the rig-blocked receipt forbids one, so a benchmark claim cannot pass
+either check.
+
+## 6. Cut and publish
+
+Dispatch the same workflow without `dry_run`:
+
+```bash
+gh workflow run release.yml \
+  --ref main \
+  -f version=1.3.0 \
+  -f dry_run=false \
+  -f nightly_run_id=33244786444
+```
+
+The v1.2.2 topology applies unchanged:
+
+1. The image CVE gate scans images built from the candidate before anything is named.
+2. The release job creates one pin-only commit, `chore(release): cut 1.3.0`, tags it `v1.3.0`, and
+   pushes both.
+3. It creates a GitHub prerelease that is not marked latest.
+4. It dispatches `publish.yml` for the tag.
+5. Publish runs its own RC gate on the tagged checkout, then builds, scans, signs, and distributes
+   Python packages, Homebrew, AUR, both container registries, and Helm.
+6. The final publish job attaches the evidence assets while still a prerelease, then a files-free
+   promotion flips the release to full and latest. Anything failing before that point leaves a
+   visible prerelease and never presents 1.3.0 as current.
+
+Do not create, move, or replace the tag by hand while either workflow is running.
+
+## 7. Verify
+
+```bash
+git fetch --tags origin
+git rev-list -n 1 v1.3.0
+gh release view v1.3.0 --json url,isPrerelease,isDraft,tagName,targetCommitish
+```
+
+The tag commit must be the pin-only bump whose parent is the candidate. Check every channel from the
+publish summary:
+
+- the three Python packages and their checksums;
+- both container registries and their matching digests;
+- the Cosign signatures and the uploaded signature receipt;
+- the Homebrew formula and the AUR package;
+- the Helm chart archives and repository index;
+- the release assets and the final release body.
+
+The release is complete only when the GitHub object is no longer a prerelease.
+
+## 8. Rollback points
+
+The v1.2.2 release is the last known-good version on every channel.
+
+| Channel        | Rollback target                                                                                                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Git            | Tag `v1.2.2` at `229576453dffa5f883fec5ed2743c58aae84f6f5` (pin-only bump of validated base `d71087a14aa13d0c9062d3e097ba649c5e70af1f`)                                          |
+| GitHub release | [v1.2.2](https://github.com/hyperb1iss/sibyl/releases/tag/v1.2.2), published 2026-08-14T03:49:12Z, full release, with 17 evidence assets                                         |
+| Images         | `ghcr.io/hyperb1iss/sibyl-api:1.2.2`, `ghcr.io/hyperb1iss/sibyl-web:1.2.2`, and the `docker.io/hyperb1iss` mirrors, with Cosign receipts on the release                          |
+| PyPI           | `sibyl-core==1.2.2`, `sibyl-dev==1.2.2`, `sibyld==1.2.2`                                                                                                                         |
+| Homebrew       | Tap formula `sibyl-homebrew-1.2.2.rb` (attached to the release)                                                                                                                  |
+| AUR            | `sibyl` PKGBUILD 1.2.2 (attached to the release as `sibyl-1.2.2-PKGBUILD`)                                                                                                       |
+| Helm           | `sibyl/sibyl --version 1.2.2` and `sibyl/sibyl-surrealdb --version 1.2.2` from the gh-pages repository                                                                           |
+| Workflows      | Release run [31767365088](https://github.com/hyperb1iss/sibyl/actions/runs/31767365088), publish run [31767945736](https://github.com/hyperb1iss/sibyl/actions/runs/31767945736) |
+
+Before the tag push, cancel and fix the candidate; no public state exists. After the version commit
+reaches `main` but before the tag, stop and inspect; the commit may stay and the same version may be
+rerun once gates pass and the tag is still absent. After the tag or any package is public, never
+move the tag or replace an immutable artifact: mark the release a prerelease, pause the remaining
+channels, and fix forward with `1.3.1`. For a runtime rollback, redeploy the 1.2.2 image and chart
+pins above and restore data only from a verified backup if 1.3.0 changed persisted state.
+
+## 9. Deferred benchmark work
+
+None of this gates the release. The 1.3 benchmark outcome on record is rig blocked by dispatch
+exhaustion, with no noise floor, no anchor, no race or render decision, and no score claim. Each
+item below is a Sibyl task in project `project_05eb5c8c782a`.
+
+| Task       | Work                                                                                                                                                                              |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `2a129447` | Hybrid fulltext lane: `fc17af80` on `nova/sibyl-1-3-hybrid-fulltext-lane` splits `_fulltext_search` into four per-field bounded top-k statements; reviewed, pull request pending. |
+| `8a56f5c7` | Reproduce the SurrealDB 3.2.3 residency growth from the r5 snapshot and measure the fulltext fix's live latency. In progress; preliminary idle footprint about 6.6 GiB RSS.       |
+| `defd7d5b` | Native SurrealDB grows to 33 GB resident under sustained bench load; SELECTs degrade tenfold.                                                                                     |
+| `e2ffa177` | Operational ingest write path collapses at table depth under bulk upserts against fulltext and HNSW index maintenance.                                                            |
+| `0b639fc2` | Move the bench stack off the laptop. Personal accounts cannot use larger hosted runners and the repository has zero self-hosted runners.                                          |
+| `f71e152e` | This receipt, status, and runbook lane.                                                                                                                                           |

--- a/docs/architecture/SIBYL_1_3_RELEASE_STATUS_2026-08-26.md
+++ b/docs/architecture/SIBYL_1_3_RELEASE_STATUS_2026-08-26.md
@@ -1,5 +1,8 @@
 # Sibyl 1.3 release status
 
+Superseded by [SIBYL_1_3_RELEASE_STATUS_2026-08-29.md](SIBYL_1_3_RELEASE_STATUS_2026-08-29.md); the
+body below is retained as written on 2026-08-26.
+
 - Snapshot date: 2026-08-26
 - Release state: hold
 - Main commit: `7f31a330c0d9a25180a98a4332423b811d18c117`

--- a/docs/architecture/SIBYL_1_3_RELEASE_STATUS_2026-08-29.md
+++ b/docs/architecture/SIBYL_1_3_RELEASE_STATUS_2026-08-29.md
@@ -60,13 +60,17 @@ The receipt lives at
 `benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json` with its observed
 ledger beside it at `benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json`.
 The ledger is the `gh api` projection of each controller run, its builder run, and the builder's
-jobs, fetched 2026-08-30T07:07:30Z. The tool reads the ledger from disk and never touches the
-network, so the same file reproduces the same receipt.
+jobs, fetched 2026-08-30T07:07:30Z. The tool reads the ledger from disk. With `--verify-github` it
+re-fetches every controller run, builder run, and job through `gh api`, re-discovers each
+controller's builders from the workflow run listing, and requires field-for-field equality with the
+ledger before sealing; only then does the receipt record `ledger_provenance: github_verified`. An
+offline seal records `unverified`, and the release authorization projection rejects it.
 
 | Field                     | Value                                                                     |
 | ------------------------- | ------------------------------------------------------------------------- |
-| Receipt digest            | `sha256:6207e4833da2bb6184570f4c0cabb309de1ba3aede54d5f140e0c180f7fc8d77` |
+| Receipt digest            | `sha256:5850fd3f31ac8db9090b8e7bb8b62b349823500f0ebac6ebe3ba3a09cccc0df8` |
 | Ledger digest             | `sha256:74339727e600a92a0157db517e6c5ce0b378bf08b4dc8ba2eb274818427a4299` |
+| Ledger provenance         | `github_verified`: 10 runs and 29 jobs re-fetched 2026-08-30T07:35:29Z    |
 | Status                    | `RIG_BLOCKED`                                                             |
 | Blocked reason            | `dispatch_exhausted`                                                      |
 | Attempts                  | 5 of 5 required                                                           |
@@ -91,11 +95,12 @@ is a real dispatch, and each builder's head commit matches its controller.
 
 The tool rejects a ledger that fails any of these checks:
 
+- a repository other than `hyperb1iss/sibyl` or a branch other than `main`, anywhere in the ledger;
 - fewer than five successful controller dispatches;
 - a builder whose two official domains both succeeded, or whose combined receipt succeeded (that is
   A/A data, not exhaustion);
 - a builder whose commit or branch differs from the controller that dispatched it;
-- attempts on more than one branch;
+- a job whose run id, run attempt, or commit differs from its builder;
 - a ledger fetched before its last run finished.
 
 The existing span-instability path now carries `blocked_reason: span_unstable`, so the two

--- a/docs/architecture/SIBYL_1_3_RELEASE_STATUS_2026-08-29.md
+++ b/docs/architecture/SIBYL_1_3_RELEASE_STATUS_2026-08-29.md
@@ -64,7 +64,10 @@ jobs, fetched 2026-08-30T07:07:30Z. The tool reads the ledger from disk. With `-
 re-fetches every controller run, builder run, and job through `gh api`, re-discovers each
 controller's builders from the workflow run listing, and requires field-for-field equality with the
 ledger before sealing; only then does the receipt record `ledger_provenance: github_verified`. An
-offline seal records `unverified`, and the release authorization projection rejects it.
+offline seal records `unverified`, and the release authorization projection rejects it. The label is
+a record, not the evidence: packaging and validating the authority both re-run the same GitHub
+verification on the bound ledger bytes and fail closed on any drift or fetch failure. The runbook's
+`release-rig-blocked-authority` command is that check.
 
 | Field                     | Value                                                                     |
 | ------------------------- | ------------------------------------------------------------------------- |

--- a/docs/architecture/SIBYL_1_3_RELEASE_STATUS_2026-08-29.md
+++ b/docs/architecture/SIBYL_1_3_RELEASE_STATUS_2026-08-29.md
@@ -1,0 +1,189 @@
+# Sibyl 1.3 release status
+
+- Snapshot date: 2026-08-30
+- Release state: ready for dry cut pending approval
+- Main commit: `012e7b55407d84ac2049914956b7017546d64b68`
+- Latest released version: `1.2.2`
+- Governing plan: [SIBYL_1_3_IMPLEMENTATION_PLAN.md](SIBYL_1_3_IMPLEMENTATION_PLAN.md)
+- Runbook: [SIBYL_1_3_RELEASE_RUNBOOK.md](SIBYL_1_3_RELEASE_RUNBOOK.md)
+- Supersedes: [SIBYL_1_3_RELEASE_STATUS_2026-08-26.md](SIBYL_1_3_RELEASE_STATUS_2026-08-26.md)
+
+## Status
+
+The 1.3 product implementation is merged and green. CI run
+[33025662969](https://github.com/hyperb1iss/sibyl/actions/runs/33025662969) and Nightly Regression
+run [33244786444](https://github.com/hyperb1iss/sibyl/actions/runs/33244786444) both passed on the
+main commit above.
+
+The paid benchmark path is stopped. Five A/A controller dispatches between 2026-08-25 and 2026-08-26
+produced zero completed two-domain passes, and the rig now seals that fact as a rig-blocked receipt
+with `blocked_reason: dispatch_exhausted`. The implementation plan names this receipt as the release
+escape hatch: benchmark blockage stops paid benchmark work and every score claim, and does not block
+the product release.
+
+The release moves from hold to ready for a dry cut. The version bump from 1.2.2, the tag, and the
+publish run each need Bliss's explicit approval. No benchmark number appears in the 1.3 release
+claim.
+
+## Corrections to the 2026-08-26 snapshot
+
+The 08-26 document made three claims that the r5 artifacts it cited contradict. The re-read is
+recorded in Sibyl memory as `error_pattern_bc484d448434`.
+
+1. The peak memory is known. The 08-26 text reported only the 4.57 GiB end-of-run RSS and called the
+   peak unknown. The service-diagnostics artifact for run
+   [32998783818](https://github.com/hyperb1iss/sibyl/actions/runs/32998783818) contains
+   `runtime-summary.txt`, which records a SurrealDB v3.2.3 container peak of 11.7 GiB RSS
+   (`rss_peak_kib=12285320`), a cgroup-reported peak of 13.0 GB, a host minimum of 418 MiB
+   available, and 1.4 GiB swapped, on the 15 GiB hosted runner. The 4 GiB RocksDB block cache from
+   [PR 442](https://github.com/hyperb1iss/sibyl/pull/442) held (Surreal logged a 4.56 GB total
+   memory limit), so the growth sits outside RocksDB accounting. Enterprise Small has the larger
+   haystack (the July canary peaked at 8.03 GiB with the automatic cache) and crossed the ceiling.
+2. The latency owner is known. The 08-26 text listed a 54.92 second median memory-query latency
+   without an owner. The `sibyld.log` aggregation for the query phase shows
+   `graph_entity_search:_fulltext_search` (one four-index OR per call, four calls per pack) ran 951
+   times at a p50 of 12.9 seconds and a maximum of 29.9 seconds, which sums to the whole
+   memory-query budget. The anchor web run had an 18.6 second p50. Memory starvation and the
+   fulltext crawl are one defect, index scans on a swapping host.
+3. The 29.31% anchor is not a valid comparator for the 23.33% r5 Web result. The sealed machine arm
+   ran with `note_distillation=False`, `typed_stream_retrieval=False`, `typed_pool=typed`,
+   `max_context_chars_per_item=18000`, and `defer_embeddings=True`. The anchor corpora ran with note
+   distillation on (the only lever that survived replication, worth about 3.7 points per domain),
+   typed stream retrieval on, and 12,000 characters per item. The historical notes-off web level was
+   roughly 25 to 26%, and web's own three-pass span is 4.6 points, so the r5 number is inside the
+   noise of its own configuration. The rig's `evidence_exposed` field was eligible on only 48 of 240
+   questions, too thin to classify misses.
+
+## The rig-blocked receipt
+
+The receipt lives at
+`benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-rig-blocked-receipt.json` with its observed
+ledger beside it at `benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json`.
+The ledger is the `gh api` projection of each controller run, its builder run, and the builder's
+jobs, fetched 2026-08-30T07:07:30Z. The tool reads the ledger from disk and never touches the
+network, so the same file reproduces the same receipt.
+
+| Field                     | Value                                                                     |
+| ------------------------- | ------------------------------------------------------------------------- |
+| Receipt digest            | `sha256:6207e4833da2bb6184570f4c0cabb309de1ba3aede54d5f140e0c180f7fc8d77` |
+| Ledger digest             | `sha256:74339727e600a92a0157db517e6c5ce0b378bf08b4dc8ba2eb274818427a4299` |
+| Status                    | `RIG_BLOCKED`                                                             |
+| Blocked reason            | `dispatch_exhausted`                                                      |
+| Attempts                  | 5 of 5 required                                                           |
+| Completed two-domain runs | 0                                                                         |
+| Branch                    | `main`                                                                    |
+| Paid benchmark allowed    | `false`                                                                   |
+| Score claim allowed       | `false`                                                                   |
+
+| Attempt                     | Main commit | Controller run                                                              | Builder run                                                                 | Web Small | Enterprise Small | Combined receipt |
+| --------------------------- | ----------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------- | --------- | ---------------- | ---------------- |
+| `sibyl-v1.3-aa-20260825`    | `48b44836`  | [32888217656](https://github.com/hyperb1iss/sibyl/actions/runs/32888217656) | [32888310148](https://github.com/hyperb1iss/sibyl/actions/runs/32888310148) | cancelled | failure          | never created    |
+| `sibyl-v1.3-aa-20260825-r2` | `48b44836`  | [32897996847](https://github.com/hyperb1iss/sibyl/actions/runs/32897996847) | [32898089824](https://github.com/hyperb1iss/sibyl/actions/runs/32898089824) | failure   | failure          | skipped          |
+| `sibyl-v1-3-aa-20260825-r3` | `74ddb867`  | [32911050360](https://github.com/hyperb1iss/sibyl/actions/runs/32911050360) | [32911112960](https://github.com/hyperb1iss/sibyl/actions/runs/32911112960) | failure   | failure          | skipped          |
+| `sibyl-v1-3-aa-20260825-r4` | `aed4adb2`  | [32921881380](https://github.com/hyperb1iss/sibyl/actions/runs/32921881380) | [32921948833](https://github.com/hyperb1iss/sibyl/actions/runs/32921948833) | failure   | failure          | skipped          |
+| `sibyl-v1-3-aa-20260826-r5` | `7f31a330`  | [32998699090](https://github.com/hyperb1iss/sibyl/actions/runs/32998699090) | [32998783818](https://github.com/hyperb1iss/sibyl/actions/runs/32998783818) | success   | failure          | skipped          |
+
+The attempts span four main commits because PRs [442](https://github.com/hyperb1iss/sibyl/pull/442),
+[443](https://github.com/hyperb1iss/sibyl/pull/443), and
+[444](https://github.com/hyperb1iss/sibyl/pull/444) landed between dispatches. The receipt lists
+every commit rather than pretending the campaign ran on one. Every controller succeeded, so each row
+is a real dispatch, and each builder's head commit matches its controller.
+
+The tool rejects a ledger that fails any of these checks:
+
+- fewer than five successful controller dispatches;
+- a builder whose two official domains both succeeded, or whose combined receipt succeeded (that is
+  A/A data, not exhaustion);
+- a builder whose commit or branch differs from the controller that dispatched it;
+- attempts on more than one branch;
+- a ledger fetched before its last run finished.
+
+The existing span-instability path now carries `blocked_reason: span_unstable`, so the two
+rig-blocked shapes cannot be mistaken for each other. The release authorization projection accepts
+the receipt as a `rig_blocked` authority that carries no stack or arm contract, because a dispatch
+that produced no pass observed neither. A contract test rebuilds the committed receipt from the
+committed ledger and pins the run ids.
+
+## What is complete
+
+| Area                       | State    | Evidence                                                                                                                                                                                                                                                                                                                               |
+| -------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| One Surface behavior       | Complete | [PR 406](https://github.com/hyperb1iss/sibyl/pull/406) merged the lifecycle, predicate, authorization, and failure contract.                                                                                                                                                                                                           |
+| Harmony and legacy cleanup | Complete | [PR 412](https://github.com/hyperb1iss/sibyl/pull/412) removed legacy runtime paths. [PR 413](https://github.com/hyperb1iss/sibyl/pull/413) converged the major services on canonical owners.                                                                                                                                          |
+| MCP SDK 2                  | Complete | [PR 410](https://github.com/hyperb1iss/sibyl/pull/410) migrated the server and clients.                                                                                                                                                                                                                                                |
+| Dependencies and toolchain | Complete | PRs [411](https://github.com/hyperb1iss/sibyl/pull/411), [414](https://github.com/hyperb1iss/sibyl/pull/414), [419](https://github.com/hyperb1iss/sibyl/pull/419), [432](https://github.com/hyperb1iss/sibyl/pull/432), and [435](https://github.com/hyperb1iss/sibyl/pull/435) refreshed dependencies and pinned the supported stack. |
+| CLI pending writes         | Complete | [PR 438](https://github.com/hyperb1iss/sibyl/pull/438) added automatic replay. [PR 441](https://github.com/hyperb1iss/sibyl/pull/441) bound replay to credential lineage.                                                                                                                                                              |
+| Sealed release evaluation  | Complete | PRs [417](https://github.com/hyperb1iss/sibyl/pull/417) through [437](https://github.com/hyperb1iss/sibyl/pull/437) added the official harness adapter, provider accounting, saved memory, receipts, CI execution, and release controls.                                                                                               |
+| Hosted-runner memory fixes | Complete | PRs [442](https://github.com/hyperb1iss/sibyl/pull/442), [443](https://github.com/hyperb1iss/sibyl/pull/443), and [444](https://github.com/hyperb1iss/sibyl/pull/444) bounded the Surreal cache and streamed shared trajectory loading. They did not keep Enterprise Small on the 15 GiB runner.                                       |
+| Rig-blocked receipt        | Complete | The dispatch-exhaustion receipt above, sealed from the observed r1 to r5 ledger.                                                                                                                                                                                                                                                       |
+| Current main CI            | Passing  | CI run [33025662969](https://github.com/hyperb1iss/sibyl/actions/runs/33025662969) and Nightly Regression run [33244786444](https://github.com/hyperb1iss/sibyl/actions/runs/33244786444) passed on `012e7b55`.                                                                                                                        |
+
+The supported development stack is proto 0.61.1, moon 2.5.3, Node 24.19.0, pnpm 11.23.0, Python
+3.13.15, and uv 0.12.5.
+
+## Official evaluation snapshot
+
+The r5 Web Small metrics recorded on 2026-08-26 stand as observed data for that sealed
+configuration.
+
+| Metric                      |             Result |
+| --------------------------- | -----------------: |
+| Questions completed         |         240 of 240 |
+| Overall accuracy            |             23.33% |
+| Median memory-query latency |      54.92 seconds |
+| Reader tokens               |          3,464,676 |
+| Settled provider cost       |        $0.91057044 |
+| Prompt contexts truncated   |                  0 |
+| Official domain runtime     | 4 hours 54 minutes |
+
+The Web artifacts (result, service diagnostics, and frozen memory including the SurrealDB snapshot)
+are retained for 30 days from 2026-08-26 and remain immutable. Enterprise Small lost its runner at 3
+hours 44 minutes and uploaded nothing.
+
+None of these numbers is a 1.3 benchmark claim. The receipt requires both domains, a finite LAFS
+gain, and a measured noise floor, and the campaign produced none of them.
+
+## Release gates
+
+| Gate                                   | State            | What remains                                                                                                                   |
+| -------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Behavioral contract                    | Complete         | No release work remains.                                                                                                       |
+| Authorization and failure truth        | Complete         | No release work remains.                                                                                                       |
+| Official harness and receipt integrity | Complete         | Preserve the reviewed harness pin and sealed inputs.                                                                           |
+| Stable A/A noise floor                 | Stopped          | The rig-blocked receipt stops paid benchmark work for 1.3.                                                                     |
+| Two-domain post-decontamination anchor | Stopped          | A blocked rig produces no score claim. The anchor moves to the deferred benchmark work.                                        |
+| Machine versus naive decision          | Stopped          | Stopped by the rig-blocked receipt. The machine pipeline stays the default.                                                    |
+| Render treatment decision              | Stopped          | Stopped by the rig-blocked receipt. The bundle stays off.                                                                      |
+| Release runbook                        | Complete         | [SIBYL_1_3_RELEASE_RUNBOOK.md](SIBYL_1_3_RELEASE_RUNBOOK.md) records the commit, receipts, deferred work, and rollback points. |
+| Version, tag, and publication          | Pending approval | Dry cut first. The bump from 1.2.2 to 1.3.0, the tag, and the publish run each need explicit approval.                         |
+
+## Deferred benchmark work
+
+The benchmark campaign resumes after 1.3 ships. The work below is tracked in Sibyl; none of it is a
+release condition.
+
+- Task `2a129447`: the hybrid fulltext lane fix. Commit `fc17af80` on branch
+  `nova/sibyl-1-3-hybrid-fulltext-lane` splits `graph_entity_search._fulltext_search` into four
+  per-field bounded top-k statements. The core suite passed 2,755 tests, and a Codex cross-model
+  review returned PASS with an executed embedded-engine probe showing the old and new top-k rankings
+  identical for limits 1, 2, 3, and 6. The branch is pushed and its pull request is pending. It is
+  not part of the `012e7b55` candidate.
+- Task `8a56f5c7`: reproduce the SurrealDB 3.2.3 residency growth from the r5 frozen snapshot, and
+  measure the fulltext fix's live latency against it. In progress, no latency numbers yet. One
+  preliminary observation: restoring the r5 web snapshot into a fresh v3.2.3 container with the same
+  4 GiB block cache idles at about 6.6 GiB RSS before any query runs, so most of the runner's
+  resident footprint is index residency rather than query-time growth.
+- Task `defd7d5b`: native SurrealDB grows to 33 GB resident under sustained bench load and SELECTs
+  degrade tenfold.
+- Task `e2ffa177`: the operational ingest write path collapses at table depth under bulk upserts
+  against fulltext and HNSW index maintenance.
+- Task `0b639fc2`: move the bench stack off the laptop. Personal GitHub accounts cannot use larger
+  hosted runners and the repository has zero self-hosted runners, so the 15 GiB ceiling is fixed
+  until the stack moves.
+- Task `f71e152e`: this receipt, status, and runbook work.
+
+## Current decision
+
+Proceed to the dry cut described in the runbook from `012e7b55`. Keep the r5 Web artifacts
+immutable, publish no score, and spend no credits on another official run before the fulltext fix
+and the residency reproduction close. Tag and publish only on explicit approval.

--- a/tools/bench/longmemeval_v2_rig.py
+++ b/tools/bench/longmemeval_v2_rig.py
@@ -59,6 +59,11 @@ DISPATCH_EXHAUSTION_RULE = (
     "a builder run whose official Small domains never both succeeded and whose "
     "combined receipt never succeeded"
 )
+# GitHub stamps a skipped job (one that never ran) with bookkeeping times that can
+# run backwards. Every skipped job in the observed r1-r5 ledger shows a reversal
+# of zero or one second, and both timestamps are second-granular, so two seconds
+# allows one rounding tick on each side and nothing more.
+SKIPPED_JOB_MAX_CLOCK_SKEW_SECONDS = 2
 COMPLETED_RUN_CONCLUSIONS = frozenset({"success", "failure", "cancelled"})
 COMPLETED_JOB_CONCLUSIONS = frozenset({"success", "failure", "cancelled", "skipped"})
 EXPERIMENT_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}")
@@ -1952,6 +1957,16 @@ def _ledger_run(raw: object, *, name: str, keys: frozenset[str]) -> dict[str, An
     return dict(raw)
 
 
+def _require_job_interval(raw: dict[str, Any], *, name: str) -> None:
+    started = _optional_timestamp(raw.get("started_at"), name=f"{name}.started_at")
+    completed = _optional_timestamp(raw.get("completed_at"), name=f"{name}.completed_at")
+    if started is None or completed is None or completed >= started:
+        return
+    reversal = (started - completed).total_seconds()
+    if raw.get("conclusion") != "skipped" or reversal > SKIPPED_JOB_MAX_CLOCK_SKEW_SECONDS:
+        raise RigInputError(f"{name} completed before it started")
+
+
 def _ledger_job(raw: object, *, name: str) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raise RigInputError(f"{name} is not an object")
@@ -1963,17 +1978,7 @@ def _ledger_job(raw: object, *, name: str) -> dict[str, Any]:
         raise RigInputError(f"{name} has not completed")
     if raw.get("conclusion") not in COMPLETED_JOB_CONCLUSIONS:
         raise RigInputError(f"{name} conclusion is not a completed verdict")
-    started = _optional_timestamp(raw.get("started_at"), name=f"{name}.started_at")
-    completed = _optional_timestamp(raw.get("completed_at"), name=f"{name}.completed_at")
-    # GitHub stamps a skipped job with bookkeeping times that can run backwards
-    # by a second; only a job that actually ran owes a forward interval.
-    if (
-        raw.get("conclusion") != "skipped"
-        and started is not None
-        and completed is not None
-        and completed < started
-    ):
-        raise RigInputError(f"{name} completed before it started")
+    _require_job_interval(raw, name=name)
     _nonempty_string(raw.get("name"), name=f"{name}.name")
     _nonempty_string(raw.get("html_url"), name=f"{name}.html_url")
     _git_sha(raw.get("head_sha"), name=f"{name}.head_sha")
@@ -2193,8 +2198,7 @@ def _validate_rig_blocked_job(raw: object, *, name: str) -> dict[str, Any]:
     _positive_int(raw.get("job_id"), name=f"{name}.job_id")
     if raw.get("conclusion") not in COMPLETED_JOB_CONCLUSIONS:
         raise RigInputError(f"{name} conclusion is not a completed verdict")
-    _optional_timestamp(raw.get("started_at"), name=f"{name}.started_at")
-    _optional_timestamp(raw.get("completed_at"), name=f"{name}.completed_at")
+    _require_job_interval(raw, name=name)
     _nonempty_string(raw.get("html_url"), name=f"{name}.html_url")
     return dict(raw)
 

--- a/tools/bench/longmemeval_v2_rig.py
+++ b/tools/bench/longmemeval_v2_rig.py
@@ -2172,6 +2172,30 @@ def validate_dispatch_ledger(ledger: object) -> list[dict[str, Any]]:
     return attempts
 
 
+def require_dispatch_ledger(raw: object) -> dict[str, Any]:
+    """Validate one dispatch ledger and return it unchanged."""
+    validate_dispatch_ledger(raw)
+    assert isinstance(raw, dict)
+    return dict(raw)
+
+
+RECEIPT_PROVENANCE_KEYS = frozenset(
+    {"ledger_provenance", "github_verification", "rig_blocked_receipt_sha256"}
+)
+
+
+def receipt_derivation(receipt: dict[str, Any]) -> dict[str, Any]:
+    """The part of a rig-blocked receipt that a ledger alone determines."""
+    return {key: value for key, value in receipt.items() if key not in RECEIPT_PROVENANCE_KEYS}
+
+
+def require_receipt_from_ledger(receipt: dict[str, Any], ledger: dict[str, Any]) -> None:
+    """Rebuild the receipt from the ledger and require the derived content to match."""
+    rebuilt = build_rig_blocked_receipt(ledger)
+    if receipt_derivation(rebuilt) != receipt_derivation(receipt):
+        raise RigInputError("rig-blocked receipt is not derived from its bound ledger")
+
+
 def gh_api_fetch(endpoint: str) -> list[Any]:
     """Fetch every page of one GitHub REST endpoint through the authenticated gh CLI."""
     completed = subprocess.run(  # noqa: S603

--- a/tools/bench/longmemeval_v2_rig.py
+++ b/tools/bench/longmemeval_v2_rig.py
@@ -1965,7 +1965,14 @@ def _ledger_job(raw: object, *, name: str) -> dict[str, Any]:
         raise RigInputError(f"{name} conclusion is not a completed verdict")
     started = _optional_timestamp(raw.get("started_at"), name=f"{name}.started_at")
     completed = _optional_timestamp(raw.get("completed_at"), name=f"{name}.completed_at")
-    if started is not None and completed is not None and completed < started:
+    # GitHub stamps a skipped job with bookkeeping times that can run backwards
+    # by a second; only a job that actually ran owes a forward interval.
+    if (
+        raw.get("conclusion") != "skipped"
+        and started is not None
+        and completed is not None
+        and completed < started
+    ):
         raise RigInputError(f"{name} completed before it started")
     _nonempty_string(raw.get("name"), name=f"{name}.name")
     _nonempty_string(raw.get("html_url"), name=f"{name}.html_url")

--- a/tools/bench/longmemeval_v2_rig.py
+++ b/tools/bench/longmemeval_v2_rig.py
@@ -2330,29 +2330,11 @@ def verify_dispatch_ledger(ledger: dict[str, Any], *, fetch: GitHubFetch) -> dic
     }
 
 
-def build_rig_blocked_receipt(
+def _assemble_rig_blocked_receipt(
     ledger: dict[str, Any],
-    *,
-    verification: dict[str, Any] | None = None,
+    attempts: list[dict[str, Any]],
+    provenance: dict[str, Any],
 ) -> dict[str, Any]:
-    """Seal dispatch exhaustion: five or more controller dispatches, zero completed passes.
-
-    Without ``verification`` (the result of ``verify_dispatch_ledger``) the receipt
-    records ``ledger_provenance: unverified`` and no release authority accepts it.
-    """
-    attempts = validate_dispatch_ledger(ledger)
-    if verification is None:
-        provenance: dict[str, Any] = {
-            "ledger_provenance": LEDGER_PROVENANCE_UNVERIFIED,
-            "github_verification": None,
-        }
-    else:
-        _require_exact_keys(
-            verification,
-            frozenset({"ledger_provenance", "github_verification"}),
-            name="ledger verification",
-        )
-        provenance = dict(verification)
     head_shas: list[str] = []
     for attempt in attempts:
         if attempt["head_sha"] not in head_shas:
@@ -2382,6 +2364,36 @@ def build_rig_blocked_receipt(
     }
     payload["rig_blocked_receipt_sha256"] = canonical_sha256(payload)
     return validate_rig_blocked_receipt(payload)
+
+
+def build_rig_blocked_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
+    """Seal dispatch exhaustion offline: five or more dispatches, zero completed passes.
+
+    The receipt records ``ledger_provenance: unverified``. No release authority
+    accepts it; use ``build_verified_rig_blocked_receipt`` for a sealed record.
+    """
+    attempts = validate_dispatch_ledger(ledger)
+    provenance = {
+        "ledger_provenance": LEDGER_PROVENANCE_UNVERIFIED,
+        "github_verification": None,
+    }
+    return _assemble_rig_blocked_receipt(ledger, attempts, provenance)
+
+
+def build_verified_rig_blocked_receipt(
+    ledger: dict[str, Any],
+    *,
+    fetch: GitHubFetch,
+) -> dict[str, Any]:
+    """Seal dispatch exhaustion after re-fetching every run and job from GitHub.
+
+    The verification block is produced here and nowhere else. It records when
+    the ledger last matched GitHub; it is not the authority. Every release
+    authorization boundary re-runs ``verify_dispatch_ledger`` live.
+    """
+    attempts = validate_dispatch_ledger(ledger)
+    provenance = verify_dispatch_ledger(ledger, fetch=fetch)
+    return _assemble_rig_blocked_receipt(ledger, attempts, provenance)
 
 
 def _validate_rig_blocked_run(raw: object, *, name: str, keys: frozenset[str]) -> dict[str, Any]:
@@ -2652,10 +2664,11 @@ def main(argv: list[str] | None = None) -> int:
             )
         elif args.command == "rig-blocked":
             ledger = load_json(Path(args.ledger))
-            verification = (
-                verify_dispatch_ledger(ledger, fetch=gh_api_fetch) if args.verify_github else None
+            payload = (
+                build_verified_rig_blocked_receipt(ledger, fetch=gh_api_fetch)
+                if args.verify_github
+                else build_rig_blocked_receipt(ledger)
             )
-            payload = build_rig_blocked_receipt(ledger, verification=verification)
         else:
             raise RuntimeError(f"unknown command {args.command!r}")
     except (OSError, json.JSONDecodeError, RigInputError) as exc:

--- a/tools/bench/longmemeval_v2_rig.py
+++ b/tools/bench/longmemeval_v2_rig.py
@@ -8,8 +8,10 @@ import hashlib
 import json
 import math
 import re
+import subprocess
 import sys
-from datetime import datetime
+from collections.abc import Callable
+from datetime import UTC, datetime
 from itertools import pairwise
 from pathlib import Path
 from typing import Any
@@ -49,6 +51,19 @@ CONTROLLER_WORKFLOW_PATH = ".github/workflows/longmemeval-v2-release-aa.yml"
 BUILDER_WORKFLOW_NAME = "LongMemEval V2"
 BUILDER_WORKFLOW_PATH = ".github/workflows/longmemeval-v2.yml"
 DISPATCH_BUILDER_ARM_ID = "aa-1-left"
+# Dispatch evidence is trusted only from the release repository and branch. A
+# ledger that names anything else is rejected before any row is read, so a
+# self-consistent foreign ledger cannot seal a release verdict.
+TRUSTED_REPOSITORY = "hyperb1iss/sibyl"
+TRUSTED_BRANCH = "main"
+LEDGER_PROVENANCE_VERIFIED = "github_verified"
+LEDGER_PROVENANCE_UNVERIFIED = "unverified"
+GITHUB_RUN_ENDPOINT = "repos/{repository}/actions/runs/{run_id}"
+GITHUB_JOBS_ENDPOINT = "repos/{repository}/actions/runs/{run_id}/jobs?per_page=100"
+GITHUB_BUILDER_RUNS_ENDPOINT = (
+    "repos/{repository}/actions/workflows/{workflow}/runs"
+    "?event=workflow_dispatch&per_page=100&created=>={date}"
+)
 OFFICIAL_JOB_NAMES = {
     "enterprise": "Official enterprise small",
     "web": "Official web small",
@@ -1896,10 +1911,14 @@ RIG_BLOCKED_RECEIPT_KEYS = frozenset(
         "attempts",
         "ledger_fetched_at",
         "ledger_sha256",
+        "ledger_provenance",
+        "github_verification",
         "exhaustion_rule",
         "rig_blocked_receipt_sha256",
     }
 )
+GITHUB_VERIFICATION_KEYS = frozenset({"verified_at", "run_count", "job_count", "builder_query"})
+GitHubFetch = Callable[[str], list[Any]]
 RIG_BLOCKED_ATTEMPT_KEYS = frozenset(
     {"experiment_id", "head_sha", "head_branch", "controller", "builders"}
 )
@@ -1997,7 +2016,11 @@ def _official_jobs(
     official_names = set(OFFICIAL_JOB_NAMES.values())
     for index, raw_job in enumerate(raw_jobs):
         job = _ledger_job(raw_job, name=f"{name}.jobs[{index}]")
-        if job["run_id"] != builder["id"] or job["head_sha"] != builder["head_sha"]:
+        if (
+            job["run_id"] != builder["id"]
+            or job["run_attempt"] != builder["run_attempt"]
+            or job["head_sha"] != builder["head_sha"]
+        ):
             raise RigInputError(f"{name}.jobs[{index}] does not belong to its builder run")
         if job["name"] in official_names:
             if job["name"] in by_name:
@@ -2059,6 +2082,8 @@ def _dispatch_attempt(  # noqa: PLR0912
         raise RigInputError(f"{name}.controller is not the release A/A controller workflow")
     if controller["conclusion"] != "success":
         raise RigInputError(f"{name}.controller did not complete its dispatch")
+    if controller["head_branch"] != TRUSTED_BRANCH:
+        raise RigInputError(f"{name}.controller is not on the trusted release branch")
     prefix = f"{CONTROLLER_WORKFLOW_NAME} "
     title = controller["display_title"]
     if not title.startswith(prefix):
@@ -2114,14 +2139,18 @@ def _dispatch_attempt(  # noqa: PLR0912
     }
 
 
-def build_rig_blocked_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
-    """Seal dispatch exhaustion: five or more controller dispatches, zero completed passes."""
-    if ledger.get("schema_version") != DISPATCH_LEDGER_SCHEMA_VERSION:
+def validate_dispatch_ledger(ledger: object) -> list[dict[str, Any]]:
+    """Validate one observed dispatch ledger and return its bound attempt rows."""
+    if (
+        not isinstance(ledger, dict)
+        or ledger.get("schema_version") != DISPATCH_LEDGER_SCHEMA_VERSION
+    ):
         raise RigInputError("dispatch ledger schema is missing or invalid")
     _require_exact_keys(ledger, DISPATCH_LEDGER_KEYS, name="dispatch ledger")
     repository = _nonempty_string(ledger.get("repository"), name="dispatch ledger repository")
-    if not GITHUB_REPOSITORY_PATTERN.fullmatch(repository):
-        raise RigInputError("dispatch ledger repository is not a GitHub repository")
+    if repository != TRUSTED_REPOSITORY:
+        raise RigInputError("dispatch ledger repository is not the trusted release repository")
+    _parse_timestamp(ledger.get("fetched_at"), name="dispatch ledger fetched_at")
     source = ledger.get("source")
     if not isinstance(source, dict):
         raise RigInputError("dispatch ledger source is missing")
@@ -2140,9 +2169,166 @@ def build_rig_blocked_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
             f"dispatch exhaustion requires at least {EXTENDED_AA_PASS_COUNT} controller "
             f"dispatches; the ledger holds {len(attempts)}"
         )
-    branches = {attempt["head_branch"] for attempt in attempts}
-    if len(branches) != 1:
-        raise RigInputError("dispatch attempts span more than one branch")
+    return attempts
+
+
+def gh_api_fetch(endpoint: str) -> list[Any]:
+    """Fetch every page of one GitHub REST endpoint through the authenticated gh CLI."""
+    completed = subprocess.run(  # noqa: S603
+        ["gh", "api", "--paginate", "--slurp", endpoint],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RigInputError(f"gh api {endpoint} failed: {completed.stderr.strip()}")
+    try:
+        pages = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RigInputError(f"gh api {endpoint} returned invalid JSON") from exc
+    if not isinstance(pages, list):
+        raise RigInputError(f"gh api {endpoint} did not return slurped pages")
+    return pages
+
+
+def _github_object(fetch: GitHubFetch, endpoint: str) -> dict[str, Any]:
+    pages = fetch(endpoint)
+    if len(pages) != 1 or not isinstance(pages[0], dict):
+        raise RigInputError(f"GitHub {endpoint} did not return one object")
+    return pages[0]
+
+
+def _github_collection(fetch: GitHubFetch, endpoint: str, *, key: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for page in fetch(endpoint):
+        if not isinstance(page, dict) or not isinstance(page.get(key), list):
+            raise RigInputError(f"GitHub {endpoint} did not return {key} pages")
+        items.extend(item for item in page[key] if isinstance(item, dict))
+    return items
+
+
+def _project_github_run(raw: dict[str, Any]) -> dict[str, Any]:
+    projected = {key: raw.get(key) for key in LEDGER_RUN_KEYS if key != "repository"}
+    repository = raw.get("repository")
+    projected["repository"] = repository.get("full_name") if isinstance(repository, dict) else None
+    return projected
+
+
+def _project_github_job(raw: dict[str, Any]) -> dict[str, Any]:
+    return {key: raw.get(key) for key in LEDGER_JOB_KEYS}
+
+
+def _differing_fields(expected: dict[str, Any], actual: dict[str, Any]) -> list[str]:
+    return sorted(
+        key for key in set(expected) | set(actual) if expected.get(key) != actual.get(key)
+    )
+
+
+def _require_github_equal(expected: dict[str, Any], actual: dict[str, Any], *, name: str) -> None:
+    differing = _differing_fields(expected, actual)
+    if differing:
+        raise RigInputError(f"{name} differs from GitHub on {', '.join(differing)}")
+
+
+def verify_dispatch_ledger(ledger: dict[str, Any], *, fetch: GitHubFetch) -> dict[str, Any]:
+    """Re-fetch every run and job in the ledger and require field-for-field equality."""
+    validate_dispatch_ledger(ledger)
+    repository = ledger["repository"]
+    workflow = BUILDER_WORKFLOW_PATH.rsplit("/", 1)[-1]
+    run_count = 0
+    job_count = 0
+    for index, attempt in enumerate(ledger["attempts"]):
+        name = f"attempts[{index}]"
+        controller = attempt["controller"]
+        live_controller = _project_github_run(
+            _github_object(
+                fetch,
+                GITHUB_RUN_ENDPOINT.format(repository=repository, run_id=controller["id"]),
+            )
+        )
+        _require_github_equal(controller, live_controller, name=f"{name}.controller")
+        run_count += 1
+        listing = _github_collection(
+            fetch,
+            GITHUB_BUILDER_RUNS_ENDPOINT.format(
+                repository=repository,
+                workflow=workflow,
+                date=controller["created_at"][:10],
+            ),
+            key="workflow_runs",
+        )
+        prefix = f"{BUILDER_WORKFLOW_NAME} aa-{controller['id']} "
+        discovered = sorted(
+            run["id"]
+            for run in listing
+            if str(run.get("display_title", "")).startswith(prefix)
+            and isinstance(run.get("id"), int)
+        )
+        ledger_ids = sorted(builder["id"] for builder in attempt["builders"])
+        if discovered != ledger_ids:
+            raise RigInputError(
+                f"{name} builder runs differ from GitHub: ledger {ledger_ids}, GitHub {discovered}"
+            )
+        for builder_index, builder in enumerate(attempt["builders"]):
+            builder_name = f"{name}.builders[{builder_index}]"
+            expected = {key: value for key, value in builder.items() if key != "jobs"}
+            live_builder = _project_github_run(
+                _github_object(
+                    fetch,
+                    GITHUB_RUN_ENDPOINT.format(repository=repository, run_id=builder["id"]),
+                )
+            )
+            _require_github_equal(expected, live_builder, name=builder_name)
+            run_count += 1
+            live_jobs = sorted(
+                (
+                    _project_github_job(job)
+                    for job in _github_collection(
+                        fetch,
+                        GITHUB_JOBS_ENDPOINT.format(repository=repository, run_id=builder["id"]),
+                        key="jobs",
+                    )
+                ),
+                key=lambda job: str(job.get("id")),
+            )
+            ledger_jobs = sorted(builder["jobs"], key=lambda job: str(job.get("id")))
+            if live_jobs != ledger_jobs:
+                raise RigInputError(f"{builder_name} jobs differ from GitHub")
+            job_count += len(ledger_jobs)
+    return {
+        "ledger_provenance": LEDGER_PROVENANCE_VERIFIED,
+        "github_verification": {
+            "verified_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "run_count": run_count,
+            "job_count": job_count,
+            "builder_query": GITHUB_BUILDER_RUNS_ENDPOINT,
+        },
+    }
+
+
+def build_rig_blocked_receipt(
+    ledger: dict[str, Any],
+    *,
+    verification: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Seal dispatch exhaustion: five or more controller dispatches, zero completed passes.
+
+    Without ``verification`` (the result of ``verify_dispatch_ledger``) the receipt
+    records ``ledger_provenance: unverified`` and no release authority accepts it.
+    """
+    attempts = validate_dispatch_ledger(ledger)
+    if verification is None:
+        provenance: dict[str, Any] = {
+            "ledger_provenance": LEDGER_PROVENANCE_UNVERIFIED,
+            "github_verification": None,
+        }
+    else:
+        _require_exact_keys(
+            verification,
+            frozenset({"ledger_provenance", "github_verification"}),
+            name="ledger verification",
+        )
+        provenance = dict(verification)
     head_shas: list[str] = []
     for attempt in attempts:
         if attempt["head_sha"] not in head_shas:
@@ -2153,8 +2339,8 @@ def build_rig_blocked_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
         "blocked_reason": BLOCKED_REASON_DISPATCH_EXHAUSTED,
         "paid_benchmark_allowed": False,
         "score_claim_allowed": False,
-        "repository": repository,
-        "head_branch": branches.pop(),
+        "repository": ledger["repository"],
+        "head_branch": TRUSTED_BRANCH,
         "head_shas": head_shas,
         "controller_workflow": CONTROLLER_WORKFLOW_PATH,
         "builder_workflow": BUILDER_WORKFLOW_PATH,
@@ -2167,6 +2353,7 @@ def build_rig_blocked_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
         "attempts": attempts,
         "ledger_fetched_at": ledger["fetched_at"],
         "ledger_sha256": canonical_sha256(ledger),
+        **provenance,
         "exhaustion_rule": DISPATCH_EXHAUSTION_RULE,
     }
     payload["rig_blocked_receipt_sha256"] = canonical_sha256(payload)
@@ -2276,9 +2463,8 @@ def validate_rig_blocked_receipt(raw: object) -> dict[str, Any]:  # noqa: PLR091
         or raw.get("score_claim_allowed") is not False
     ):
         raise RigInputError("rig-blocked receipt cannot authorize paid work or a score claim")
-    repository = _nonempty_string(raw.get("repository"), name="rig-blocked repository")
-    if not GITHUB_REPOSITORY_PATTERN.fullmatch(repository):
-        raise RigInputError("rig-blocked repository is not a GitHub repository")
+    if raw.get("repository") != TRUSTED_REPOSITORY:
+        raise RigInputError("rig-blocked repository is not the trusted release repository")
     if (
         raw.get("controller_workflow") != CONTROLLER_WORKFLOW_PATH
         or raw.get("builder_workflow") != BUILDER_WORKFLOW_PATH
@@ -2289,6 +2475,8 @@ def validate_rig_blocked_receipt(raw: object) -> dict[str, Any]:  # noqa: PLR091
     if raw.get("required_attempt_count") != EXTENDED_AA_PASS_COUNT:
         raise RigInputError("rig-blocked receipt required attempt count is invalid")
     head_branch = _nonempty_string(raw.get("head_branch"), name="rig-blocked head_branch")
+    if head_branch != TRUSTED_BRANCH:
+        raise RigInputError("rig-blocked receipt is not on the trusted release branch")
     attempts = raw.get("attempts")
     if not isinstance(attempts, list):
         raise RigInputError("rig-blocked attempts is not a list")
@@ -2336,7 +2524,37 @@ def validate_rig_blocked_receipt(raw: object) -> dict[str, Any]:  # noqa: PLR091
     if fetched_at < max(updated):
         raise RigInputError("rig-blocked ledger was fetched before its last run finished")
     _sha256_digest(raw.get("ledger_sha256"), name="rig-blocked ledger_sha256")
+    _validate_ledger_provenance(raw, rows=rows, fetched_at=fetched_at)
     return dict(raw)
+
+
+def _validate_ledger_provenance(
+    raw: dict[str, Any],
+    *,
+    rows: list[dict[str, Any]],
+    fetched_at: datetime,
+) -> None:
+    provenance = raw.get("ledger_provenance")
+    verification = raw.get("github_verification")
+    if provenance == LEDGER_PROVENANCE_UNVERIFIED:
+        if verification is not None:
+            raise RigInputError("unverified rig-blocked receipt carries a GitHub verification")
+        return
+    if provenance != LEDGER_PROVENANCE_VERIFIED:
+        raise RigInputError("rig-blocked ledger provenance is unknown")
+    if not isinstance(verification, dict):
+        raise RigInputError("verified rig-blocked receipt is missing its GitHub verification")
+    _require_exact_keys(verification, GITHUB_VERIFICATION_KEYS, name="GitHub verification")
+    verified_at = _parse_timestamp(verification.get("verified_at"), name="verified_at")
+    if verified_at < fetched_at:
+        raise RigInputError("rig-blocked ledger was verified before it was fetched")
+    builder_count = sum(len(row["builders"]) for row in rows)
+    if verification.get("run_count") != len(rows) + builder_count:
+        raise RigInputError("GitHub verification run count does not match the receipt rows")
+    if _positive_int(verification.get("job_count"), name="job_count") < 2 * builder_count:
+        raise RigInputError("GitHub verification job count cannot cover both official domains")
+    if verification.get("builder_query") != GITHUB_BUILDER_RUNS_ENDPOINT:
+        raise RigInputError("GitHub verification used an unknown builder query")
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -2376,6 +2594,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     rig_blocked = subparsers.add_parser("rig-blocked")
     rig_blocked.add_argument("--ledger", required=True)
     rig_blocked.add_argument("--output", required=True)
+    rig_blocked.add_argument(
+        "--verify-github",
+        action="store_true",
+        help="re-fetch every run and job through gh api and require equality before sealing",
+    )
     return parser.parse_args(argv)
 
 
@@ -2404,7 +2627,11 @@ def main(argv: list[str] | None = None) -> int:
                 [load_json(Path(path)) for path in args.passes],
             )
         elif args.command == "rig-blocked":
-            payload = build_rig_blocked_receipt(load_json(Path(args.ledger)))
+            ledger = load_json(Path(args.ledger))
+            verification = (
+                verify_dispatch_ledger(ledger, fetch=gh_api_fetch) if args.verify_github else None
+            )
+            payload = build_rig_blocked_receipt(ledger, verification=verification)
         else:
             raise RuntimeError(f"unknown command {args.command!r}")
     except (OSError, json.JSONDecodeError, RigInputError) as exc:

--- a/tools/bench/longmemeval_v2_rig.py
+++ b/tools/bench/longmemeval_v2_rig.py
@@ -9,6 +9,8 @@ import json
 import math
 import re
 import sys
+from datetime import datetime
+from itertools import pairwise
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -29,11 +31,37 @@ ARM_RUN_SCHEMA_VERSION = "sibyl-longmemeval-v2-arm-run-v2"
 RUN_PAIR_SCHEMA_VERSION = "sibyl-longmemeval-v2-paired-pass-v3"
 EXECUTION_IDENTITY_SCHEMA_VERSION = "sibyl-longmemeval-v2-execution-identity-v1"
 PREREGISTRATION_SCHEMA_VERSION = "sibyl-longmemeval-v2-preregistration-v2"
-AA_SCHEMA_VERSION = "sibyl-longmemeval-v2-aa-receipt-v2"
+AA_SCHEMA_VERSION = "sibyl-longmemeval-v2-aa-receipt-v3"
 ANCHOR_SCHEMA_VERSION = "sibyl-longmemeval-v2-anchor-receipt-v2"
 RACE_SCHEMA_VERSION = "sibyl-longmemeval-v2-machine-race-receipt-v2"
 RENDER_SCHEMA_VERSION = "sibyl-longmemeval-v2-render-receipt-v2"
 FAILURE_SCHEMA_VERSION = "sibyl-longmemeval-v2-rig-failure-v1"
+RIG_BLOCKED_SCHEMA_VERSION = "sibyl-longmemeval-v2-rig-blocked-receipt-v1"
+DISPATCH_LEDGER_SCHEMA_VERSION = "sibyl-longmemeval-v2-dispatch-ledger-v1"
+# The two ways the rig can block. A span-unstable block carries five completed
+# paired passes; a dispatch-exhausted block carries five controller dispatches
+# that never produced a single completed two-domain pass. They are different
+# evidence and must never be read as the same receipt.
+BLOCKED_REASON_SPAN_UNSTABLE = "span_unstable"
+BLOCKED_REASON_DISPATCH_EXHAUSTED = "dispatch_exhausted"
+CONTROLLER_WORKFLOW_NAME = "LongMemEval V2 Release A/A"
+CONTROLLER_WORKFLOW_PATH = ".github/workflows/longmemeval-v2-release-aa.yml"
+BUILDER_WORKFLOW_NAME = "LongMemEval V2"
+BUILDER_WORKFLOW_PATH = ".github/workflows/longmemeval-v2.yml"
+DISPATCH_BUILDER_ARM_ID = "aa-1-left"
+OFFICIAL_JOB_NAMES = {
+    "enterprise": "Official enterprise small",
+    "web": "Official web small",
+    "combined_receipt": "Official combined receipt",
+}
+DISPATCH_EXHAUSTION_RULE = (
+    "at least five successful controller dispatches on one branch, each binding "
+    "a builder run whose official Small domains never both succeeded and whose "
+    "combined receipt never succeeded"
+)
+COMPLETED_RUN_CONCLUSIONS = frozenset({"success", "failure", "cancelled"})
+COMPLETED_JOB_CONCLUSIONS = frozenset({"success", "failure", "cancelled", "skipped"})
+EXPERIMENT_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}")
 DOMAINS = frozenset({"web", "enterprise"})
 OFFICIAL_SMALL_QUESTION_COUNTS = {
     "enterprise": 211,
@@ -77,6 +105,7 @@ AA_RECEIPT_KEYS = frozenset(
     {
         "schema_version",
         "status",
+        "blocked_reason",
         "paid_benchmark_allowed",
         "score_claim_allowed",
         "stack",
@@ -946,6 +975,10 @@ def _aa_outcome(absolute_deltas: list[float]) -> tuple[str, bool]:
     return "PASS", True
 
 
+def _aa_blocked_reason(status: str) -> str | None:
+    return BLOCKED_REASON_SPAN_UNSTABLE if status == "RIG_BLOCKED" else None
+
+
 def build_aa_receipt(raw_passes: list[dict[str, Any]]) -> dict[str, Any]:
     passes = [validate_pass(item) for item in raw_passes]
     if any(item["experiment_phase"] != "aa" for item in passes):
@@ -1001,6 +1034,7 @@ def build_aa_receipt(raw_passes: list[dict[str, Any]]) -> dict[str, Any]:
     payload = {
         "schema_version": AA_SCHEMA_VERSION,
         "status": status,
+        "blocked_reason": _aa_blocked_reason(status),
         "paid_benchmark_allowed": status == "PASS",
         "score_claim_allowed": False,
         "stack": passes[0]["stack"],
@@ -1085,6 +1119,8 @@ def _validate_aa_metrics(raw: dict[str, Any], absolute_deltas: list[float]) -> N
     noise_floor = max(INITIAL_NOISE_FLOOR_PP, observed_span)
     if raw.get("status") != expected_status or raw.get("stabilized") is not expected_stable:
         raise RigInputError("A/A receipt status does not match its pass deltas")
+    if raw.get("blocked_reason") != _aa_blocked_reason(expected_status):
+        raise RigInputError("A/A blocked reason does not match its status")
     if raw.get("paid_benchmark_allowed") is not (expected_status == "PASS"):
         raise RigInputError("A/A paid-work verdict does not match its status")
     if raw.get("score_claim_allowed") is not False:
@@ -1795,6 +1831,503 @@ def build_render_receipt(  # noqa: PLR0912, PLR0915
     return payload
 
 
+DISPATCH_LEDGER_KEYS = frozenset(
+    {"schema_version", "repository", "fetched_at", "source", "attempts"}
+)
+DISPATCH_LEDGER_SOURCE_KEYS = frozenset({"tool", "run_endpoint", "jobs_endpoint", "builder_query"})
+DISPATCH_ATTEMPT_KEYS = frozenset({"controller", "builders"})
+LEDGER_RUN_KEYS = frozenset(
+    {
+        "id",
+        "name",
+        "path",
+        "display_title",
+        "head_sha",
+        "head_branch",
+        "event",
+        "status",
+        "conclusion",
+        "run_attempt",
+        "created_at",
+        "updated_at",
+        "run_started_at",
+        "html_url",
+        "repository",
+    }
+)
+LEDGER_BUILDER_KEYS = LEDGER_RUN_KEYS | {"jobs"}
+LEDGER_JOB_KEYS = frozenset(
+    {
+        "id",
+        "run_id",
+        "run_attempt",
+        "name",
+        "status",
+        "conclusion",
+        "started_at",
+        "completed_at",
+        "head_sha",
+        "html_url",
+    }
+)
+RIG_BLOCKED_RECEIPT_KEYS = frozenset(
+    {
+        "schema_version",
+        "status",
+        "blocked_reason",
+        "paid_benchmark_allowed",
+        "score_claim_allowed",
+        "repository",
+        "head_branch",
+        "head_shas",
+        "controller_workflow",
+        "builder_workflow",
+        "builder_arm_id",
+        "required_attempt_count",
+        "attempt_count",
+        "completed_pass_count",
+        "first_dispatched_at",
+        "last_dispatched_at",
+        "attempts",
+        "ledger_fetched_at",
+        "ledger_sha256",
+        "exhaustion_rule",
+        "rig_blocked_receipt_sha256",
+    }
+)
+RIG_BLOCKED_ATTEMPT_KEYS = frozenset(
+    {"experiment_id", "head_sha", "head_branch", "controller", "builders"}
+)
+RIG_BLOCKED_RUN_KEYS = frozenset(
+    {"run_id", "run_attempt", "event", "conclusion", "created_at", "updated_at", "html_url"}
+)
+RIG_BLOCKED_BUILDER_KEYS = RIG_BLOCKED_RUN_KEYS | {"head_sha", "official_jobs"}
+RIG_BLOCKED_JOB_KEYS = frozenset({"job_id", "conclusion", "started_at", "completed_at", "html_url"})
+
+
+def _parse_timestamp(value: object, *, name: str) -> datetime:
+    text = _nonempty_string(value, name=name)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RigInputError(f"{name} is not an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise RigInputError(f"{name} must carry a UTC offset")
+    return parsed
+
+
+def _optional_timestamp(value: object, *, name: str) -> datetime | None:
+    if value is None:
+        return None
+    return _parse_timestamp(value, name=name)
+
+
+def _git_sha(value: object, *, name: str) -> str:
+    sha = _nonempty_string(value, name=name)
+    if len(sha) != GIT_SHA_LENGTH or any(character not in "0123456789abcdef" for character in sha):
+        raise RigInputError(f"{name} must be a full lowercase Git SHA")
+    return sha
+
+
+def _ledger_run(raw: object, *, name: str, keys: frozenset[str]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise RigInputError(f"{name} is not an object")
+    _require_exact_keys(raw, keys, name=name)
+    _positive_int(raw.get("id"), name=f"{name}.id")
+    _positive_int(raw.get("run_attempt"), name=f"{name}.run_attempt")
+    if raw.get("status") != "completed":
+        raise RigInputError(f"{name} has not completed")
+    if raw.get("conclusion") not in COMPLETED_RUN_CONCLUSIONS:
+        raise RigInputError(f"{name} conclusion is not a completed verdict")
+    if raw.get("event") != "workflow_dispatch":
+        raise RigInputError(f"{name} was not a workflow dispatch")
+    created = _parse_timestamp(raw.get("created_at"), name=f"{name}.created_at")
+    updated = _parse_timestamp(raw.get("updated_at"), name=f"{name}.updated_at")
+    _parse_timestamp(raw.get("run_started_at"), name=f"{name}.run_started_at")
+    if updated < created:
+        raise RigInputError(f"{name} finished before it was created")
+    for field in ("name", "path", "display_title", "head_branch", "html_url", "repository"):
+        _nonempty_string(raw.get(field), name=f"{name}.{field}")
+    _git_sha(raw.get("head_sha"), name=f"{name}.head_sha")
+    return dict(raw)
+
+
+def _ledger_job(raw: object, *, name: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise RigInputError(f"{name} is not an object")
+    _require_exact_keys(raw, LEDGER_JOB_KEYS, name=name)
+    _positive_int(raw.get("id"), name=f"{name}.id")
+    _positive_int(raw.get("run_id"), name=f"{name}.run_id")
+    _positive_int(raw.get("run_attempt"), name=f"{name}.run_attempt")
+    if raw.get("status") != "completed":
+        raise RigInputError(f"{name} has not completed")
+    if raw.get("conclusion") not in COMPLETED_JOB_CONCLUSIONS:
+        raise RigInputError(f"{name} conclusion is not a completed verdict")
+    started = _optional_timestamp(raw.get("started_at"), name=f"{name}.started_at")
+    completed = _optional_timestamp(raw.get("completed_at"), name=f"{name}.completed_at")
+    if started is not None and completed is not None and completed < started:
+        raise RigInputError(f"{name} completed before it started")
+    _nonempty_string(raw.get("name"), name=f"{name}.name")
+    _nonempty_string(raw.get("html_url"), name=f"{name}.html_url")
+    _git_sha(raw.get("head_sha"), name=f"{name}.head_sha")
+    return dict(raw)
+
+
+def _official_jobs(
+    raw_jobs: object,
+    *,
+    builder: dict[str, Any],
+    name: str,
+) -> dict[str, dict[str, Any] | None]:
+    if not isinstance(raw_jobs, list):
+        raise RigInputError(f"{name}.jobs is not a list")
+    by_name: dict[str, dict[str, Any]] = {}
+    official_names = set(OFFICIAL_JOB_NAMES.values())
+    for index, raw_job in enumerate(raw_jobs):
+        job = _ledger_job(raw_job, name=f"{name}.jobs[{index}]")
+        if job["run_id"] != builder["id"] or job["head_sha"] != builder["head_sha"]:
+            raise RigInputError(f"{name}.jobs[{index}] does not belong to its builder run")
+        if job["name"] in official_names:
+            if job["name"] in by_name:
+                raise RigInputError(f"{name} reports the official job {job['name']!r} twice")
+            by_name[job["name"]] = job
+    result: dict[str, dict[str, Any] | None] = {}
+    for key, job_name in OFFICIAL_JOB_NAMES.items():
+        job = by_name.get(job_name)
+        if job is None:
+            if key == "combined_receipt":
+                result[key] = None
+                continue
+            raise RigInputError(f"{name} never ran the official {key} Small domain")
+        result[key] = {
+            "job_id": job["id"],
+            "conclusion": job["conclusion"],
+            "started_at": job["started_at"],
+            "completed_at": job["completed_at"],
+            "html_url": job["html_url"],
+        }
+    return result
+
+
+def _job_succeeded(job: dict[str, Any] | None) -> bool:
+    return job is not None and job["conclusion"] == "success"
+
+
+def _completed_two_domain_arm(official_jobs: dict[str, dict[str, Any] | None]) -> bool:
+    domains_succeeded = all(_job_succeeded(official_jobs[domain]) for domain in sorted(DOMAINS))
+    return domains_succeeded or _job_succeeded(official_jobs["combined_receipt"])
+
+
+def _run_projection(run: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "run_id": run["id"],
+        "run_attempt": run["run_attempt"],
+        "event": run["event"],
+        "conclusion": run["conclusion"],
+        "created_at": run["created_at"],
+        "updated_at": run["updated_at"],
+        "html_url": run["html_url"],
+    }
+
+
+def _dispatch_attempt(  # noqa: PLR0912
+    raw: object,
+    *,
+    index: int,
+    repository: str,
+) -> dict[str, Any]:
+    name = f"attempts[{index}]"
+    if not isinstance(raw, dict):
+        raise RigInputError(f"{name} is not an object")
+    _require_exact_keys(raw, DISPATCH_ATTEMPT_KEYS, name=name)
+    controller = _ledger_run(raw.get("controller"), name=f"{name}.controller", keys=LEDGER_RUN_KEYS)
+    if controller["repository"] != repository:
+        raise RigInputError(f"{name}.controller belongs to another repository")
+    if controller["path"] != CONTROLLER_WORKFLOW_PATH:
+        raise RigInputError(f"{name}.controller is not the release A/A controller workflow")
+    if controller["conclusion"] != "success":
+        raise RigInputError(f"{name}.controller did not complete its dispatch")
+    prefix = f"{CONTROLLER_WORKFLOW_NAME} "
+    title = controller["display_title"]
+    if not title.startswith(prefix):
+        raise RigInputError(f"{name}.controller title does not carry an experiment id")
+    experiment_id = title[len(prefix) :]
+    if not EXPERIMENT_ID_PATTERN.fullmatch(experiment_id):
+        raise RigInputError(f"{name}.controller experiment id is not path-safe")
+    head_sha = controller["head_sha"]
+    head_branch = controller["head_branch"]
+    controller_created = _parse_timestamp(controller["created_at"], name="controller.created_at")
+    raw_builders = raw.get("builders")
+    if not isinstance(raw_builders, list) or not raw_builders:
+        raise RigInputError(f"{name}.controller dispatched no builder run")
+    expected_title = f"{BUILDER_WORKFLOW_NAME} aa-{controller['id']} {DISPATCH_BUILDER_ARM_ID}"
+    builders: list[dict[str, Any]] = []
+    for builder_index, raw_builder in enumerate(raw_builders):
+        builder_name = f"{name}.builders[{builder_index}]"
+        builder = _ledger_run(raw_builder, name=builder_name, keys=LEDGER_BUILDER_KEYS)
+        if builder["repository"] != repository:
+            raise RigInputError(f"{builder_name} belongs to another repository")
+        if builder["path"] != BUILDER_WORKFLOW_PATH:
+            raise RigInputError(f"{builder_name} is not the sealed builder workflow")
+        if builder["display_title"] != expected_title:
+            raise RigInputError(
+                f"{builder_name} was not dispatched by controller {controller['id']}"
+            )
+        if builder["head_sha"] != head_sha:
+            raise RigInputError(f"{builder_name} head SHA differs from its controller dispatch")
+        if builder["head_branch"] != head_branch:
+            raise RigInputError(f"{builder_name} branch differs from its controller dispatch")
+        builder_created = _parse_timestamp(builder["created_at"], name="builder.created_at")
+        if builder_created < controller_created:
+            raise RigInputError(f"{builder_name} predates its controller dispatch")
+        official_jobs = _official_jobs(builder["jobs"], builder=builder, name=builder_name)
+        if _completed_two_domain_arm(official_jobs):
+            raise RigInputError(
+                f"{experiment_id} completed a two-domain arm run in builder {builder['id']}; "
+                "that is A/A data, not dispatch exhaustion"
+            )
+        builders.append(
+            {
+                **_run_projection(builder),
+                "head_sha": builder["head_sha"],
+                "official_jobs": official_jobs,
+            }
+        )
+    return {
+        "experiment_id": experiment_id,
+        "head_sha": head_sha,
+        "head_branch": head_branch,
+        "controller": _run_projection(controller),
+        "builders": builders,
+    }
+
+
+def build_rig_blocked_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
+    """Seal dispatch exhaustion: five or more controller dispatches, zero completed passes."""
+    if ledger.get("schema_version") != DISPATCH_LEDGER_SCHEMA_VERSION:
+        raise RigInputError("dispatch ledger schema is missing or invalid")
+    _require_exact_keys(ledger, DISPATCH_LEDGER_KEYS, name="dispatch ledger")
+    repository = _nonempty_string(ledger.get("repository"), name="dispatch ledger repository")
+    if not GITHUB_REPOSITORY_PATTERN.fullmatch(repository):
+        raise RigInputError("dispatch ledger repository is not a GitHub repository")
+    source = ledger.get("source")
+    if not isinstance(source, dict):
+        raise RigInputError("dispatch ledger source is missing")
+    _require_exact_keys(source, DISPATCH_LEDGER_SOURCE_KEYS, name="dispatch ledger source")
+    for field in DISPATCH_LEDGER_SOURCE_KEYS:
+        _nonempty_string(source.get(field), name=f"dispatch ledger source.{field}")
+    raw_attempts = ledger.get("attempts")
+    if not isinstance(raw_attempts, list):
+        raise RigInputError("dispatch ledger attempts is not a list")
+    attempts = [
+        _dispatch_attempt(item, index=index, repository=repository)
+        for index, item in enumerate(raw_attempts)
+    ]
+    if len(attempts) < EXTENDED_AA_PASS_COUNT:
+        raise RigInputError(
+            f"dispatch exhaustion requires at least {EXTENDED_AA_PASS_COUNT} controller "
+            f"dispatches; the ledger holds {len(attempts)}"
+        )
+    branches = {attempt["head_branch"] for attempt in attempts}
+    if len(branches) != 1:
+        raise RigInputError("dispatch attempts span more than one branch")
+    head_shas: list[str] = []
+    for attempt in attempts:
+        if attempt["head_sha"] not in head_shas:
+            head_shas.append(attempt["head_sha"])
+    payload = {
+        "schema_version": RIG_BLOCKED_SCHEMA_VERSION,
+        "status": "RIG_BLOCKED",
+        "blocked_reason": BLOCKED_REASON_DISPATCH_EXHAUSTED,
+        "paid_benchmark_allowed": False,
+        "score_claim_allowed": False,
+        "repository": repository,
+        "head_branch": branches.pop(),
+        "head_shas": head_shas,
+        "controller_workflow": CONTROLLER_WORKFLOW_PATH,
+        "builder_workflow": BUILDER_WORKFLOW_PATH,
+        "builder_arm_id": DISPATCH_BUILDER_ARM_ID,
+        "required_attempt_count": EXTENDED_AA_PASS_COUNT,
+        "attempt_count": len(attempts),
+        "completed_pass_count": 0,
+        "first_dispatched_at": attempts[0]["controller"]["created_at"],
+        "last_dispatched_at": attempts[-1]["controller"]["created_at"],
+        "attempts": attempts,
+        "ledger_fetched_at": ledger["fetched_at"],
+        "ledger_sha256": canonical_sha256(ledger),
+        "exhaustion_rule": DISPATCH_EXHAUSTION_RULE,
+    }
+    payload["rig_blocked_receipt_sha256"] = canonical_sha256(payload)
+    return validate_rig_blocked_receipt(payload)
+
+
+def _validate_rig_blocked_run(raw: object, *, name: str, keys: frozenset[str]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise RigInputError(f"{name} is not an object")
+    _require_exact_keys(raw, keys, name=name)
+    _positive_int(raw.get("run_id"), name=f"{name}.run_id")
+    _positive_int(raw.get("run_attempt"), name=f"{name}.run_attempt")
+    if raw.get("event") != "workflow_dispatch":
+        raise RigInputError(f"{name} was not a workflow dispatch")
+    if raw.get("conclusion") not in COMPLETED_RUN_CONCLUSIONS:
+        raise RigInputError(f"{name} conclusion is not a completed verdict")
+    created = _parse_timestamp(raw.get("created_at"), name=f"{name}.created_at")
+    updated = _parse_timestamp(raw.get("updated_at"), name=f"{name}.updated_at")
+    if updated < created:
+        raise RigInputError(f"{name} finished before it was created")
+    _nonempty_string(raw.get("html_url"), name=f"{name}.html_url")
+    return dict(raw)
+
+
+def _validate_rig_blocked_job(raw: object, *, name: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise RigInputError(f"{name} is not an object")
+    _require_exact_keys(raw, RIG_BLOCKED_JOB_KEYS, name=name)
+    _positive_int(raw.get("job_id"), name=f"{name}.job_id")
+    if raw.get("conclusion") not in COMPLETED_JOB_CONCLUSIONS:
+        raise RigInputError(f"{name} conclusion is not a completed verdict")
+    _optional_timestamp(raw.get("started_at"), name=f"{name}.started_at")
+    _optional_timestamp(raw.get("completed_at"), name=f"{name}.completed_at")
+    _nonempty_string(raw.get("html_url"), name=f"{name}.html_url")
+    return dict(raw)
+
+
+def _validate_rig_blocked_attempt(  # noqa: PLR0912
+    raw: object,
+    *,
+    index: int,
+    head_branch: str,
+) -> dict[str, Any]:
+    name = f"rig-blocked attempts[{index}]"
+    if not isinstance(raw, dict):
+        raise RigInputError(f"{name} is not an object")
+    _require_exact_keys(raw, RIG_BLOCKED_ATTEMPT_KEYS, name=name)
+    experiment_id = _nonempty_string(raw.get("experiment_id"), name=f"{name}.experiment_id")
+    if not EXPERIMENT_ID_PATTERN.fullmatch(experiment_id):
+        raise RigInputError(f"{name} experiment id is not path-safe")
+    head_sha = _git_sha(raw.get("head_sha"), name=f"{name}.head_sha")
+    if raw.get("head_branch") != head_branch:
+        raise RigInputError(f"{name} branch differs from the receipt branch")
+    controller = _validate_rig_blocked_run(
+        raw.get("controller"),
+        name=f"{name}.controller",
+        keys=RIG_BLOCKED_RUN_KEYS,
+    )
+    if controller["conclusion"] != "success":
+        raise RigInputError(f"{name}.controller did not complete its dispatch")
+    controller_created = _parse_timestamp(controller["created_at"], name="controller.created_at")
+    builders = raw.get("builders")
+    if not isinstance(builders, list) or not builders:
+        raise RigInputError(f"{name} binds no builder run")
+    for builder_index, raw_builder in enumerate(builders):
+        builder_name = f"{name}.builders[{builder_index}]"
+        builder = _validate_rig_blocked_run(
+            raw_builder,
+            name=builder_name,
+            keys=RIG_BLOCKED_BUILDER_KEYS,
+        )
+        if builder["head_sha"] != head_sha:
+            raise RigInputError(f"{builder_name} head SHA differs from its controller dispatch")
+        if _parse_timestamp(builder["created_at"], name="builder.created_at") < controller_created:
+            raise RigInputError(f"{builder_name} predates its controller dispatch")
+        official_jobs = builder.get("official_jobs")
+        if not isinstance(official_jobs, dict) or set(official_jobs) != set(OFFICIAL_JOB_NAMES):
+            raise RigInputError(f"{builder_name} official jobs are missing")
+        for key in OFFICIAL_JOB_NAMES:
+            job = official_jobs[key]
+            if job is None:
+                if key == "combined_receipt":
+                    continue
+                raise RigInputError(f"{builder_name} never ran the official {key} Small domain")
+            _validate_rig_blocked_job(job, name=f"{builder_name}.official_jobs.{key}")
+        if _completed_two_domain_arm(official_jobs):
+            raise RigInputError(
+                f"{experiment_id} completed a two-domain arm run; "
+                "that is A/A data, not dispatch exhaustion"
+            )
+    return dict(raw)
+
+
+def validate_rig_blocked_receipt(raw: object) -> dict[str, Any]:  # noqa: PLR0912, PLR0915
+    """Re-derive every rig-blocked claim from its bound dispatch rows."""
+    if not isinstance(raw, dict) or raw.get("schema_version") != RIG_BLOCKED_SCHEMA_VERSION:
+        raise RigInputError("rig-blocked receipt is missing or invalid")
+    _require_exact_keys(raw, RIG_BLOCKED_RECEIPT_KEYS, name="rig-blocked receipt")
+    unsigned = {key: value for key, value in raw.items() if key != "rig_blocked_receipt_sha256"}
+    if raw.get("rig_blocked_receipt_sha256") != canonical_sha256(unsigned):
+        raise RigInputError("rig-blocked receipt digest does not bind its content")
+    if raw.get("status") != "RIG_BLOCKED" or (
+        raw.get("blocked_reason") != BLOCKED_REASON_DISPATCH_EXHAUSTED
+    ):
+        raise RigInputError("rig-blocked receipt status or reason is invalid")
+    if (
+        raw.get("paid_benchmark_allowed") is not False
+        or raw.get("score_claim_allowed") is not False
+    ):
+        raise RigInputError("rig-blocked receipt cannot authorize paid work or a score claim")
+    repository = _nonempty_string(raw.get("repository"), name="rig-blocked repository")
+    if not GITHUB_REPOSITORY_PATTERN.fullmatch(repository):
+        raise RigInputError("rig-blocked repository is not a GitHub repository")
+    if (
+        raw.get("controller_workflow") != CONTROLLER_WORKFLOW_PATH
+        or raw.get("builder_workflow") != BUILDER_WORKFLOW_PATH
+        or raw.get("builder_arm_id") != DISPATCH_BUILDER_ARM_ID
+        or raw.get("exhaustion_rule") != DISPATCH_EXHAUSTION_RULE
+    ):
+        raise RigInputError("rig-blocked receipt names an unknown workflow contract")
+    if raw.get("required_attempt_count") != EXTENDED_AA_PASS_COUNT:
+        raise RigInputError("rig-blocked receipt required attempt count is invalid")
+    head_branch = _nonempty_string(raw.get("head_branch"), name="rig-blocked head_branch")
+    attempts = raw.get("attempts")
+    if not isinstance(attempts, list):
+        raise RigInputError("rig-blocked attempts is not a list")
+    if raw.get("attempt_count") != len(attempts):
+        raise RigInputError("rig-blocked attempt count does not match its rows")
+    if len(attempts) < EXTENDED_AA_PASS_COUNT:
+        raise RigInputError("rig-blocked receipt holds fewer than five controller dispatches")
+    if raw.get("completed_pass_count") != 0:
+        raise RigInputError("rig-blocked receipt claims a completed pass")
+    rows = [
+        _validate_rig_blocked_attempt(item, index=index, head_branch=head_branch)
+        for index, item in enumerate(attempts)
+    ]
+    experiment_ids = {row["experiment_id"] for row in rows}
+    controller_ids = {row["controller"]["run_id"] for row in rows}
+    builder_ids = [builder["run_id"] for row in rows for builder in row["builders"]]
+    if len(experiment_ids) != len(rows) or len(controller_ids) != len(rows):
+        raise RigInputError("rig-blocked attempts reuse an experiment or controller run")
+    if len(set(builder_ids)) != len(builder_ids):
+        raise RigInputError("rig-blocked attempts reuse a builder run")
+    dispatched = [
+        _parse_timestamp(row["controller"]["created_at"], name="controller.created_at")
+        for row in rows
+    ]
+    if any(later <= earlier for earlier, later in pairwise(dispatched)):
+        raise RigInputError("rig-blocked attempts are not in dispatch order")
+    if raw.get("first_dispatched_at") != rows[0]["controller"]["created_at"] or (
+        raw.get("last_dispatched_at") != rows[-1]["controller"]["created_at"]
+    ):
+        raise RigInputError("rig-blocked dispatch window does not match its rows")
+    head_shas: list[str] = []
+    for row in rows:
+        if row["head_sha"] not in head_shas:
+            head_shas.append(row["head_sha"])
+    if raw.get("head_shas") != head_shas:
+        raise RigInputError("rig-blocked head SHAs do not match its rows")
+    fetched_at = _parse_timestamp(
+        raw.get("ledger_fetched_at"), name="rig-blocked ledger_fetched_at"
+    )
+    updated = [
+        _parse_timestamp(run["updated_at"], name="run.updated_at")
+        for row in rows
+        for run in (row["controller"], *row["builders"])
+    ]
+    if fetched_at < max(updated):
+        raise RigInputError("rig-blocked ledger was fetched before its last run finished")
+    _sha256_digest(raw.get("ledger_sha256"), name="rig-blocked ledger_sha256")
+    return dict(raw)
+
+
 def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -1828,6 +2361,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     render.add_argument("--preregistration", required=True)
     render.add_argument("--pass", dest="passes", action="append", required=True)
     render.add_argument("--output", required=True)
+
+    rig_blocked = subparsers.add_parser("rig-blocked")
+    rig_blocked.add_argument("--ledger", required=True)
+    rig_blocked.add_argument("--output", required=True)
     return parser.parse_args(argv)
 
 
@@ -1855,6 +2392,8 @@ def main(argv: list[str] | None = None) -> int:
                 load_json(Path(args.preregistration)),
                 [load_json(Path(path)) for path in args.passes],
             )
+        elif args.command == "rig-blocked":
+            payload = build_rig_blocked_receipt(load_json(Path(args.ledger)))
         else:
             raise RuntimeError(f"unknown command {args.command!r}")
     except (OSError, json.JSONDecodeError, RigInputError) as exc:

--- a/tools/tests/test_longmemeval_v2_release_cli.py
+++ b/tools/tests/test_longmemeval_v2_release_cli.py
@@ -12,6 +12,8 @@ from benchmarks import longmemeval_v2_ablations as ablations
 from benchmarks import longmemeval_v2_release_cli as cli
 from benchmarks import longmemeval_v2_release_package_root as package_root
 from benchmarks.longmemeval_v2_release_inputs import StagePlanError
+from tools.bench import longmemeval_v2_rig as rig
+from tools.tests.test_longmemeval_v2_rig import _dispatch_ledger, _github_stub
 
 SUPPORTED_RELEASE_HOST = {
     "platform": "darwin",
@@ -531,3 +533,53 @@ def test_release_commands_reject_nonobject_plan_json(tmp_path: Path) -> None:
 
     with pytest.raises(StagePlanError, match="JSON object"):
         cli.run_release_cli_command(args)
+
+
+def test_release_rig_blocked_authority_re_verifies_against_github(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ledger = _dispatch_ledger()
+    receipt = rig.build_verified_rig_blocked_receipt(ledger, fetch=_github_stub(ledger))
+    receipt_path = _json(tmp_path / "receipt.json", receipt)
+    ledger_path = _json(tmp_path / "ledger.json", ledger)
+    output = tmp_path / "authority" / "rig-blocked-authorization.json"
+    live = _github_stub(ledger)
+    monkeypatch.setattr(rig, "gh_api_fetch", live)
+    args = argparse.Namespace(
+        command="release-rig-blocked-authority",
+        receipt=str(receipt_path),
+        ledger=str(ledger_path),
+        output=str(output),
+    )
+
+    assert cli.run_release_cli_command(args) == 0
+
+    written = json.loads(output.read_text(encoding="utf-8"))
+    assert written["kind"] == "rig_blocked"
+    assert written["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
+    assert written["source_ledger"]["path"] == str(ledger_path.resolve())
+    assert len(live.calls) == 4 * rig.EXTENDED_AA_PASS_COUNT
+    with pytest.raises(StagePlanError, match="already exists"):
+        cli.run_release_cli_command(args)
+
+    def unavailable(endpoint: str) -> list[Any]:
+        raise rig.RigInputError(f"gh api {endpoint} failed: HTTP 504")
+
+    monkeypatch.setattr(rig, "gh_api_fetch", unavailable)
+    args.output = str(tmp_path / "authority" / "second.json")
+    with pytest.raises(StagePlanError, match="HTTP 504"):
+        cli.run_release_cli_command(args)
+    assert not Path(args.output).exists()
+    parsed = ablations.parse_args(
+        [
+            "release-rig-blocked-authority",
+            "--receipt",
+            str(receipt_path),
+            "--ledger",
+            str(ledger_path),
+            "--output",
+            str(output),
+        ]
+    )
+    assert parsed.command == "release-rig-blocked-authority"

--- a/tools/tests/test_longmemeval_v2_release_contract.py
+++ b/tools/tests/test_longmemeval_v2_release_contract.py
@@ -30,7 +30,7 @@ from tools.tests.longmemeval_v2_release_support import (
     race_spec,
     render_spec,
 )
-from tools.tests.test_longmemeval_v2_rig import _dispatch_ledger
+from tools.tests.test_longmemeval_v2_rig import _dispatch_ledger, _github_stub
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MAX_CAP_HEADROOM_USD = 0.15
@@ -643,9 +643,35 @@ def test_paid_stages_require_exact_preregistered_arm_contracts(
             )
 
 
-def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path) -> None:
+def _verified_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
+    verification = rig.verify_dispatch_ledger(ledger, fetch=_github_stub(ledger))
+    return rig.build_rig_blocked_receipt(ledger, verification=verification)
+
+
+def test_rig_blocked_authorization_rejects_an_unverified_ledger(tmp_path: Path) -> None:
     ledger = _dispatch_ledger()
     receipt = rig.build_rig_blocked_receipt(ledger)
+    assert receipt["ledger_provenance"] == rig.LEDGER_PROVENANCE_UNVERIFIED
+    receipt_path = tmp_path / "rig-blocked-receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(inputs.StagePlanError, match="requires a GitHub-verified ledger"):
+        authorization_package.package_rig_blocked_authorization(receipt_path)
+
+    verified = _verified_receipt(ledger)
+    receipt_path.write_text(json.dumps(verified, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    projected = authorization_package.package_rig_blocked_authorization(receipt_path)
+    assert projected["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
+    forged = {**projected, "ledger_provenance": rig.LEDGER_PROVENANCE_UNVERIFIED}
+    unsigned = {key: value for key, value in forged.items() if key != "authorization_sha256"}
+    forged["authorization_sha256"] = rig.canonical_sha256(unsigned)
+    with pytest.raises(inputs.StagePlanError, match="requires a GitHub-verified ledger"):
+        authorization.require_rig_blocked_authorization(forged)
+
+
+def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path) -> None:
+    ledger = _dispatch_ledger()
+    receipt = _verified_receipt(ledger)
     receipt_path = tmp_path / "rig-blocked-receipt.json"
     receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
@@ -696,7 +722,7 @@ def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path)
 def test_rig_blocked_authorization_rejects_completed_pass_and_short_ledgers(
     tmp_path: Path,
 ) -> None:
-    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger())
+    receipt = _verified_receipt(_dispatch_ledger())
     receipt_path = tmp_path / "rig-blocked-receipt.json"
     receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     source = inputs.bind_artifact(receipt_path, name="rig-blocked source receipt")
@@ -733,8 +759,13 @@ def test_committed_v1_3_rig_blocked_receipt_is_bound_to_its_ledger() -> None:
     ledger = inputs.load_json(V1_3_DISPATCH_LEDGER)
     committed = inputs.load_json(V1_3_RIG_BLOCKED_RECEIPT)
 
-    assert rig.build_rig_blocked_receipt(ledger) == committed
+    rebuilt = rig.build_rig_blocked_receipt(ledger)
+    derived = {"ledger_provenance", "github_verification", "rig_blocked_receipt_sha256"}
+    assert {k: v for k, v in rebuilt.items() if k not in derived} == {
+        k: v for k, v in committed.items() if k not in derived
+    }
     assert rig.validate_rig_blocked_receipt(committed) == committed
+    assert committed["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
     assert committed["blocked_reason"] == rig.BLOCKED_REASON_DISPATCH_EXHAUSTED
     assert committed["paid_benchmark_allowed"] is False
     assert committed["score_claim_allowed"] is False

--- a/tools/tests/test_longmemeval_v2_release_contract.py
+++ b/tools/tests/test_longmemeval_v2_release_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -19,6 +20,7 @@ from benchmarks import longmemeval_v2_release_inputs as inputs
 from benchmarks import longmemeval_v2_release_memory as release_memory
 from benchmarks import longmemeval_v2_release_package_root as package_root
 from benchmarks import longmemeval_v2_release_plan as release_plan
+from tools.bench import longmemeval_v2_rig as rig
 from tools.tests.longmemeval_v2_release_support import (
     aa_extension_spec,
     aa_spec,
@@ -28,6 +30,7 @@ from tools.tests.longmemeval_v2_release_support import (
     race_spec,
     render_spec,
 )
+from tools.tests.test_longmemeval_v2_rig import _dispatch_ledger
 
 MAX_CAP_HEADROOM_USD = 0.15
 
@@ -637,3 +640,82 @@ def test_paid_stages_require_exact_preregistered_arm_contracts(
                 geometry_spec,
                 expected_stack=expected_stack,
             )
+
+
+def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path) -> None:
+    ledger = _dispatch_ledger()
+    receipt = rig.build_rig_blocked_receipt(ledger)
+    receipt_path = tmp_path / "rig-blocked-receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    projected = authorization_package.package_rig_blocked_authorization(receipt_path)
+
+    assert projected["kind"] == "rig_blocked"
+    assert projected["status"] == "RIG_BLOCKED"
+    assert projected["blocked_reason"] == rig.BLOCKED_REASON_DISPATCH_EXHAUSTED
+    assert projected["rig_blocked_receipt_sha256"] == receipt["rig_blocked_receipt_sha256"]
+    assert projected["ledger_sha256"] == rig.canonical_sha256(ledger)
+    assert projected["source_receipt"]["path"] == str(receipt_path.resolve())
+    assert projected["attempt_count"] == rig.EXTENDED_AA_PASS_COUNT
+    assert projected["completed_pass_count"] == 0
+    assert [item["controller_run_id"] for item in projected["attempts"]] == [
+        item["controller"]["run_id"] for item in receipt["attempts"]
+    ]
+    assert "paid_benchmark_allowed" not in projected
+    authorization.reject_score_bearing_keys(projected, name="rig-blocked authorization")
+    assert authorization.require_rig_blocked_authorization(projected) == projected
+
+    public_path = tmp_path / "public" / "rig-blocked-receipt.json"
+    rebased = authorization_package.rebase_rig_blocked_authorization(
+        projected,
+        public_receipt_path=public_path.resolve(),
+    )
+    assert rebased["source_receipt"]["path"] == str(public_path.resolve())
+    assert rebased["authorization_sha256"] != projected["authorization_sha256"]
+
+    output = tmp_path / "authority" / "rig-blocked-authorization.json"
+    authorization_package.write_authorization(
+        output,
+        projected,
+        paid_output_root=(tmp_path / "paid").resolve(),
+    )
+    assert json.loads(output.read_text(encoding="utf-8")) == projected
+
+    with pytest.raises(inputs.StagePlanError, match="status or reason is invalid"):
+        authorization.require_rig_blocked_authorization(
+            {**projected, "blocked_reason": rig.BLOCKED_REASON_SPAN_UNSTABLE}
+        )
+    with pytest.raises(inputs.StagePlanError, match="A/A authorization"):
+        authorization.require_aa_authorization(projected)
+    receipt_path.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(inputs.StagePlanError, match="path or size changed"):
+        authorization.require_rig_blocked_authorization(projected)
+
+
+def test_rig_blocked_authorization_rejects_completed_pass_and_short_ledgers(
+    tmp_path: Path,
+) -> None:
+    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger())
+    receipt_path = tmp_path / "rig-blocked-receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    source = inputs.bind_artifact(receipt_path, name="rig-blocked source receipt")
+    projected = authorization_package.build_rig_blocked_authorization(source, receipt)
+
+    def resealed(**changes: Any) -> dict[str, Any]:
+        tampered = {**projected, **changes}
+        unsigned = {key: value for key, value in tampered.items() if key != "authorization_sha256"}
+        tampered["authorization_sha256"] = rig.canonical_sha256(unsigned)
+        return tampered
+
+    with pytest.raises(inputs.StagePlanError, match="claims a completed pass"):
+        authorization.require_rig_blocked_authorization(resealed(completed_pass_count=1))
+    with pytest.raises(inputs.StagePlanError, match="fewer than five dispatches"):
+        authorization.require_rig_blocked_authorization(
+            resealed(attempt_count=4, attempts=projected["attempts"][:4])
+        )
+    with pytest.raises(inputs.StagePlanError, match="head SHAs differ from its attempts"):
+        authorization.require_rig_blocked_authorization(resealed(head_shas=["9" * 40]))
+    with pytest.raises(inputs.StagePlanError, match="score-bearing"):
+        authorization.require_rig_blocked_authorization(
+            resealed(attempts=[{**projected["attempts"][0], "accuracy": 0.5}])
+        )

--- a/tools/tests/test_longmemeval_v2_release_contract.py
+++ b/tools/tests/test_longmemeval_v2_release_contract.py
@@ -32,6 +32,7 @@ from tools.tests.longmemeval_v2_release_support import (
 )
 from tools.tests.test_longmemeval_v2_rig import _dispatch_ledger
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 MAX_CAP_HEADROOM_USD = 0.15
 
 
@@ -719,3 +720,34 @@ def test_rig_blocked_authorization_rejects_completed_pass_and_short_ledgers(
         authorization.require_rig_blocked_authorization(
             resealed(attempts=[{**projected["attempts"][0], "accuracy": 0.5}])
         )
+
+
+RELEASE_RESULTS = REPO_ROOT / "benchmarks" / "results" / "longmemeval-v2-release"
+V1_3_DISPATCH_LEDGER = RELEASE_RESULTS / "sibyl-v1-3-aa-dispatch-ledger.json"
+V1_3_RIG_BLOCKED_RECEIPT = RELEASE_RESULTS / "sibyl-v1-3-aa-rig-blocked-receipt.json"
+V1_3_CONTROLLER_RUN_IDS = [32888217656, 32897996847, 32911050360, 32921881380, 32998699090]
+V1_3_BUILDER_RUN_IDS = [32888310148, 32898089824, 32911112960, 32921948833, 32998783818]
+
+
+def test_committed_v1_3_rig_blocked_receipt_is_bound_to_its_ledger() -> None:
+    ledger = inputs.load_json(V1_3_DISPATCH_LEDGER)
+    committed = inputs.load_json(V1_3_RIG_BLOCKED_RECEIPT)
+
+    assert rig.build_rig_blocked_receipt(ledger) == committed
+    assert rig.validate_rig_blocked_receipt(committed) == committed
+    assert committed["blocked_reason"] == rig.BLOCKED_REASON_DISPATCH_EXHAUSTED
+    assert committed["paid_benchmark_allowed"] is False
+    assert committed["score_claim_allowed"] is False
+    assert committed["completed_pass_count"] == 0
+    assert committed["head_branch"] == "main"
+    assert [item["controller"]["run_id"] for item in committed["attempts"]] == (
+        V1_3_CONTROLLER_RUN_IDS
+    )
+    assert [
+        builder["run_id"] for item in committed["attempts"] for builder in item["builders"]
+    ] == V1_3_BUILDER_RUN_IDS
+
+    projected = authorization_package.package_rig_blocked_authorization(V1_3_RIG_BLOCKED_RECEIPT)
+    assert projected["rig_blocked_receipt_sha256"] == committed["rig_blocked_receipt_sha256"]
+    assert projected["ledger_sha256"] == rig.canonical_sha256(ledger)
+    assert projected["attempt_count"] == rig.EXTENDED_AA_PASS_COUNT

--- a/tools/tests/test_longmemeval_v2_release_contract.py
+++ b/tools/tests/test_longmemeval_v2_release_contract.py
@@ -5,6 +5,7 @@ import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
+from copy import deepcopy
 from pathlib import Path
 from threading import Barrier
 from typing import Any
@@ -644,8 +645,7 @@ def test_paid_stages_require_exact_preregistered_arm_contracts(
 
 
 def _verified_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
-    verification = rig.verify_dispatch_ledger(ledger, fetch=_github_stub(ledger))
-    return rig.build_rig_blocked_receipt(ledger, verification=verification)
+    return rig.build_verified_rig_blocked_receipt(ledger, fetch=_github_stub(ledger))
 
 
 def _write(path: Path, payload: dict[str, Any]) -> Path:
@@ -668,19 +668,48 @@ def _resealed_authorization(projected: dict[str, Any], **changes: Any) -> dict[s
     return tampered
 
 
-def _packaged(tmp_path: Path) -> tuple[dict[str, Any], dict[str, Any], Path, Path, dict[str, Any]]:
-    ledger = _dispatch_ledger()
-    receipt = _verified_receipt(ledger)
-    receipt_path = _write(tmp_path / "rig-blocked-receipt.json", receipt)
-    ledger_path = _write(tmp_path / "dispatch-ledger.json", ledger)
-    projected = authorization_package.package_rig_blocked_authorization(
-        receipt_path, ledger_path=ledger_path
-    )
-    return ledger, receipt, receipt_path, ledger_path, projected
+def _remap_run_ids(ledger: dict[str, Any], offset: int) -> dict[str, Any]:
+    """Invent a self-consistent ledger whose runs and jobs GitHub has never seen."""
+    forged = deepcopy(ledger)
+    for attempt in forged["attempts"]:
+        controller = attempt["controller"]
+        controller["id"] += offset
+        controller["html_url"] = (
+            f"https://github.com/{controller['repository']}/actions/runs/{controller['id']}"
+        )
+        for builder in attempt["builders"]:
+            builder["id"] += offset
+            builder["display_title"] = (
+                f"{rig.BUILDER_WORKFLOW_NAME} aa-{controller['id']} {rig.DISPATCH_BUILDER_ARM_ID}"
+            )
+            builder["name"] = builder["display_title"]
+            builder["html_url"] = (
+                f"https://github.com/{builder['repository']}/actions/runs/{builder['id']}"
+            )
+            for job in builder["jobs"]:
+                job["id"] += offset
+                job["run_id"] = builder["id"]
+                job["html_url"] = f"{builder['html_url']}/job/{job['id']}"
+    return forged
+
+
+class _Packaged:
+    def __init__(self, tmp_path: Path, *, name: str = "genuine") -> None:
+        self.ledger = _dispatch_ledger()
+        self.fetch = _github_stub(self.ledger)
+        self.receipt = _verified_receipt(self.ledger)
+        self.receipt_path = _write(tmp_path / name / "rig-blocked-receipt.json", self.receipt)
+        self.ledger_path = _write(tmp_path / name / "dispatch-ledger.json", self.ledger)
+        self.projected = authorization_package.package_rig_blocked_authorization(
+            self.receipt_path,
+            ledger_path=self.ledger_path,
+            fetch=self.fetch,
+        )
 
 
 def test_rig_blocked_authorization_rejects_an_unverified_ledger(tmp_path: Path) -> None:
     ledger = _dispatch_ledger()
+    fetch = _github_stub(ledger)
     receipt = rig.build_rig_blocked_receipt(ledger)
     assert receipt["ledger_provenance"] == rig.LEDGER_PROVENANCE_UNVERIFIED
     receipt_path = _write(tmp_path / "rig-blocked-receipt.json", receipt)
@@ -688,21 +717,25 @@ def test_rig_blocked_authorization_rejects_an_unverified_ledger(tmp_path: Path) 
 
     with pytest.raises(inputs.StagePlanError, match="requires a GitHub-verified ledger"):
         authorization_package.package_rig_blocked_authorization(
-            receipt_path, ledger_path=ledger_path
+            receipt_path, ledger_path=ledger_path, fetch=fetch
         )
+    assert fetch.calls == []
 
     _write(receipt_path, _verified_receipt(ledger))
     projected = authorization_package.package_rig_blocked_authorization(
-        receipt_path, ledger_path=ledger_path
+        receipt_path, ledger_path=ledger_path, fetch=fetch
     )
     assert projected["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
+    assert len(fetch.calls) == 4 * rig.EXTENDED_AA_PASS_COUNT
     forged = _resealed_authorization(projected, ledger_provenance=rig.LEDGER_PROVENANCE_UNVERIFIED)
     with pytest.raises(inputs.StagePlanError, match="requires a GitHub-verified ledger"):
-        authorization.require_rig_blocked_authorization(forged)
+        authorization.require_rig_blocked_authorization(forged, fetch=fetch)
 
 
 def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path) -> None:
-    ledger, receipt, receipt_path, ledger_path, projected = _packaged(tmp_path)
+    bundle = _Packaged(tmp_path)
+    ledger, receipt, projected = bundle.ledger, bundle.receipt, bundle.projected
+    receipt_path, ledger_path, fetch = bundle.receipt_path, bundle.ledger_path, bundle.fetch
 
     assert projected["kind"] == "rig_blocked"
     assert projected["status"] == "RIG_BLOCKED"
@@ -718,7 +751,9 @@ def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path)
     ]
     assert "paid_benchmark_allowed" not in projected
     authorization.reject_score_bearing_keys(projected, name="rig-blocked authorization")
-    assert authorization.require_rig_blocked_authorization(projected) == projected
+    calls_before = len(fetch.calls)
+    assert authorization.require_rig_blocked_authorization(projected, fetch=fetch) == projected
+    assert len(fetch.calls) == calls_before + 4 * rig.EXTENDED_AA_PASS_COUNT
 
     public_path = tmp_path / "public" / "rig-blocked-receipt.json"
     public_ledger = tmp_path / "public" / "dispatch-ledger.json"
@@ -736,51 +771,65 @@ def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path)
         )
 
     output = tmp_path / "authority" / "rig-blocked-authorization.json"
+    with pytest.raises(inputs.StagePlanError, match="needs a GitHub fetcher"):
+        authorization_package.write_authorization(
+            output, projected, paid_output_root=(tmp_path / "paid").resolve()
+        )
     authorization_package.write_authorization(
         output,
         projected,
         paid_output_root=(tmp_path / "paid").resolve(),
+        fetch=fetch,
     )
     assert json.loads(output.read_text(encoding="utf-8")) == projected
 
     with pytest.raises(inputs.StagePlanError, match="status or reason is invalid"):
         authorization.require_rig_blocked_authorization(
-            {**projected, "blocked_reason": rig.BLOCKED_REASON_SPAN_UNSTABLE}
+            {**projected, "blocked_reason": rig.BLOCKED_REASON_SPAN_UNSTABLE}, fetch=fetch
         )
     with pytest.raises(inputs.StagePlanError, match="A/A authorization"):
         authorization.require_aa_authorization(projected)
     receipt_path.write_text("{}\n", encoding="utf-8")
     with pytest.raises(inputs.StagePlanError, match="path or size changed"):
-        authorization.require_rig_blocked_authorization(projected)
+        authorization.require_rig_blocked_authorization(projected, fetch=fetch)
 
 
 def test_rig_blocked_authorization_rejects_completed_pass_and_short_ledgers(
     tmp_path: Path,
 ) -> None:
-    _ledger, _receipt, _receipt_path, _ledger_path, projected = _packaged(tmp_path)
+    bundle = _Packaged(tmp_path)
+    projected, fetch = bundle.projected, bundle.fetch
 
     with pytest.raises(inputs.StagePlanError, match="claims a completed pass"):
         authorization.require_rig_blocked_authorization(
-            _resealed_authorization(projected, completed_pass_count=1)
+            _resealed_authorization(projected, completed_pass_count=1), fetch=fetch
         )
     with pytest.raises(inputs.StagePlanError, match="fewer than five dispatches"):
         authorization.require_rig_blocked_authorization(
-            _resealed_authorization(projected, attempt_count=4, attempts=projected["attempts"][:4])
+            _resealed_authorization(projected, attempt_count=4, attempts=projected["attempts"][:4]),
+            fetch=fetch,
         )
     with pytest.raises(inputs.StagePlanError, match="head SHAs differ from its attempts"):
         authorization.require_rig_blocked_authorization(
-            _resealed_authorization(projected, head_shas=["9" * 40])
+            _resealed_authorization(projected, head_shas=["9" * 40]), fetch=fetch
         )
     with pytest.raises(inputs.StagePlanError, match="score-bearing"):
         authorization.require_rig_blocked_authorization(
             _resealed_authorization(
                 projected, attempts=[{**projected["attempts"][0], "accuracy": 0.5}]
-            )
+            ),
+            fetch=fetch,
         )
 
 
 def test_rig_blocked_packaging_rejects_a_receipt_citing_another_ledger(tmp_path: Path) -> None:
-    _ledger, receipt, receipt_path, ledger_path, _projected = _packaged(tmp_path)
+    bundle = _Packaged(tmp_path)
+    receipt, receipt_path, ledger_path, fetch = (
+        bundle.receipt,
+        bundle.receipt_path,
+        bundle.ledger_path,
+        bundle.fetch,
+    )
 
     # Codex probe: a resealed receipt whose ledger digest names a ledger that
     # holds a successful two-domain pass must not package as RIG_BLOCKED.
@@ -800,33 +849,36 @@ def test_rig_blocked_packaging_rejects_a_receipt_citing_another_ledger(tmp_path:
     citing_path = _write(tmp_path / "citing-receipt.json", citing)
     with pytest.raises(rig.RigInputError, match="A/A data, not dispatch exhaustion"):
         authorization_package.package_rig_blocked_authorization(
-            citing_path, ledger_path=passing_path
+            citing_path, ledger_path=passing_path, fetch=_github_stub(passing)
         )
     with pytest.raises(inputs.StagePlanError, match="not derived from its bound ledger"):
         authorization_package.package_rig_blocked_authorization(
-            citing_path, ledger_path=ledger_path
+            citing_path, ledger_path=ledger_path, fetch=fetch
         )
 
     # A real ledger digest mismatch against the genuine ledger.
     wrong_digest = _resealed_receipt(receipt, ledger_sha256=f"sha256:{'f' * 64}")
     wrong_path = _write(tmp_path / "wrong-digest-receipt.json", wrong_digest)
     with pytest.raises(inputs.StagePlanError, match="not derived from its bound ledger"):
-        authorization_package.package_rig_blocked_authorization(wrong_path, ledger_path=ledger_path)
+        authorization_package.package_rig_blocked_authorization(
+            wrong_path, ledger_path=ledger_path, fetch=fetch
+        )
 
     # A different valid ledger than the one the receipt was sealed from.
     other = _dispatch_ledger([_dispatch_attempt(index, head_sha="e" * 40) for index in range(5)])
     other_path = _write(tmp_path / "other-ledger.json", other)
     with pytest.raises(inputs.StagePlanError, match="not derived from its bound ledger"):
         authorization_package.package_rig_blocked_authorization(
-            receipt_path, ledger_path=other_path
+            receipt_path, ledger_path=other_path, fetch=_github_stub(other)
         )
 
 
 def test_rig_blocked_authorization_rejects_projection_drift_from_its_receipt(
     tmp_path: Path,
 ) -> None:
-    _ledger, _receipt, _receipt_path, ledger_path, projected = _packaged(tmp_path)
-    assert authorization.require_rig_blocked_authorization(projected) == projected
+    bundle = _Packaged(tmp_path)
+    projected, ledger_path, fetch = bundle.projected, bundle.ledger_path, bundle.fetch
+    assert authorization.require_rig_blocked_authorization(projected, fetch=fetch) == projected
 
     # Codex probe: keep the genuine source receipt, change projected fields.
     drifted = [
@@ -846,10 +898,10 @@ def test_rig_blocked_authorization_rejects_projection_drift_from_its_receipt(
     ]
     for tampered in drifted:
         with pytest.raises(inputs.StagePlanError, match="differs from its bound receipt"):
-            authorization.require_rig_blocked_authorization(tampered)
+            authorization.require_rig_blocked_authorization(tampered, fetch=fetch)
     with pytest.raises(inputs.StagePlanError, match="trusted release repository"):
         authorization.require_rig_blocked_authorization(
-            _resealed_authorization(projected, repository="someone/else")
+            _resealed_authorization(projected, repository="someone/else"), fetch=fetch
         )
 
     # The bound ledger on disk is swapped for one that does not derive the receipt.
@@ -860,7 +912,69 @@ def test_rig_blocked_authorization_rejects_projection_drift_from_its_receipt(
         source_ledger=inputs.bind_artifact(ledger_path, name="rig-blocked source ledger"),
     )
     with pytest.raises(inputs.StagePlanError, match="not derived from its bound ledger"):
-        authorization.require_rig_blocked_authorization(swapped)
+        authorization.require_rig_blocked_authorization(swapped, fetch=_github_stub(other))
+
+
+def test_rig_blocked_authority_rejects_invented_dispatches_with_a_forged_verification(
+    tmp_path: Path,
+) -> None:
+    """Codex probe: invented run and job ids plus a plausible verification block."""
+    genuine = _dispatch_ledger()
+    github = _github_stub(genuine)
+    forged_ledger = _remap_run_ids(genuine, 500_000)
+    offline = rig.build_rig_blocked_receipt(forged_ledger)
+    forged = _resealed_receipt(
+        offline,
+        ledger_provenance=rig.LEDGER_PROVENANCE_VERIFIED,
+        github_verification={
+            "verified_at": forged_ledger["fetched_at"],
+            "run_count": 2 * rig.EXTENDED_AA_PASS_COUNT,
+            "job_count": 3 * rig.EXTENDED_AA_PASS_COUNT,
+            "builder_query": rig.GITHUB_BUILDER_RUNS_ENDPOINT,
+        },
+    )
+    # The label alone passes receipt validation; it is a record, not evidence.
+    assert rig.validate_rig_blocked_receipt(forged) == forged
+    receipt_path = _write(tmp_path / "forged-receipt.json", forged)
+    ledger_path = _write(tmp_path / "forged-ledger.json", forged_ledger)
+
+    with pytest.raises(inputs.StagePlanError, match="HTTP 404"):
+        authorization_package.package_rig_blocked_authorization(
+            receipt_path, ledger_path=ledger_path, fetch=github
+        )
+
+    source = inputs.bind_artifact(receipt_path, name="rig-blocked source receipt")
+    source_ledger = inputs.bind_artifact(ledger_path, name="rig-blocked source ledger")
+    hand_built = authorization.rig_blocked_projection(source, source_ledger, forged)
+    hand_built["authorization_sha256"] = rig.canonical_sha256(hand_built)
+    with pytest.raises(inputs.StagePlanError, match="HTTP 404"):
+        authorization.require_rig_blocked_authorization(hand_built, fetch=github)
+
+
+def test_rig_blocked_authority_rejects_drift_at_authorization_time(tmp_path: Path) -> None:
+    """A receipt sealed against one GitHub state is rejected once GitHub disagrees."""
+    bundle = _Packaged(tmp_path)
+    drifted = deepcopy(bundle.ledger)
+    web = next(
+        job
+        for job in drifted["attempts"][4]["builders"][0]["jobs"]
+        if job["name"] == rig.OFFICIAL_JOB_NAMES["web"]
+    )
+    web["conclusion"] = "success"
+    github_now = _github_stub(drifted)
+
+    with pytest.raises(inputs.StagePlanError, match="jobs differ from GitHub"):
+        authorization_package.package_rig_blocked_authorization(
+            bundle.receipt_path, ledger_path=bundle.ledger_path, fetch=github_now
+        )
+    with pytest.raises(inputs.StagePlanError, match="jobs differ from GitHub"):
+        authorization.require_rig_blocked_authorization(bundle.projected, fetch=github_now)
+
+    def unavailable(endpoint: str) -> list[Any]:
+        raise rig.RigInputError(f"gh api {endpoint} failed: HTTP 504")
+
+    with pytest.raises(inputs.StagePlanError, match="HTTP 504"):
+        authorization.require_rig_blocked_authorization(bundle.projected, fetch=unavailable)
 
 
 RELEASE_RESULTS = REPO_ROOT / "benchmarks" / "results" / "longmemeval-v2-release"
@@ -890,8 +1004,12 @@ def test_committed_v1_3_rig_blocked_receipt_is_bound_to_its_ledger() -> None:
         builder["run_id"] for item in committed["attempts"] for builder in item["builders"]
     ] == V1_3_BUILDER_RUN_IDS
 
+    # Hermetic: the stub replays the committed ledger as GitHub. The runbook
+    # command runs the same packaging against live GitHub.
     projected = authorization_package.package_rig_blocked_authorization(
-        V1_3_RIG_BLOCKED_RECEIPT, ledger_path=V1_3_DISPATCH_LEDGER
+        V1_3_RIG_BLOCKED_RECEIPT,
+        ledger_path=V1_3_DISPATCH_LEDGER,
+        fetch=_github_stub(ledger),
     )
     assert projected["rig_blocked_receipt_sha256"] == committed["rig_blocked_receipt_sha256"]
     assert projected["ledger_sha256"] == rig.canonical_sha256(ledger)

--- a/tools/tests/test_longmemeval_v2_release_contract.py
+++ b/tools/tests/test_longmemeval_v2_release_contract.py
@@ -30,7 +30,7 @@ from tools.tests.longmemeval_v2_release_support import (
     race_spec,
     render_spec,
 )
-from tools.tests.test_longmemeval_v2_rig import _dispatch_ledger, _github_stub
+from tools.tests.test_longmemeval_v2_rig import _dispatch_attempt, _dispatch_ledger, _github_stub
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MAX_CAP_HEADROOM_USD = 0.15
@@ -648,34 +648,61 @@ def _verified_receipt(ledger: dict[str, Any]) -> dict[str, Any]:
     return rig.build_rig_blocked_receipt(ledger, verification=verification)
 
 
+def _write(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _resealed_receipt(receipt: dict[str, Any], **changes: Any) -> dict[str, Any]:
+    tampered = {**receipt, **changes}
+    unsigned = {k: v for k, v in tampered.items() if k != "rig_blocked_receipt_sha256"}
+    tampered["rig_blocked_receipt_sha256"] = rig.canonical_sha256(unsigned)
+    return tampered
+
+
+def _resealed_authorization(projected: dict[str, Any], **changes: Any) -> dict[str, Any]:
+    tampered = {**projected, **changes}
+    unsigned = {k: v for k, v in tampered.items() if k != "authorization_sha256"}
+    tampered["authorization_sha256"] = rig.canonical_sha256(unsigned)
+    return tampered
+
+
+def _packaged(tmp_path: Path) -> tuple[dict[str, Any], dict[str, Any], Path, Path, dict[str, Any]]:
+    ledger = _dispatch_ledger()
+    receipt = _verified_receipt(ledger)
+    receipt_path = _write(tmp_path / "rig-blocked-receipt.json", receipt)
+    ledger_path = _write(tmp_path / "dispatch-ledger.json", ledger)
+    projected = authorization_package.package_rig_blocked_authorization(
+        receipt_path, ledger_path=ledger_path
+    )
+    return ledger, receipt, receipt_path, ledger_path, projected
+
+
 def test_rig_blocked_authorization_rejects_an_unverified_ledger(tmp_path: Path) -> None:
     ledger = _dispatch_ledger()
     receipt = rig.build_rig_blocked_receipt(ledger)
     assert receipt["ledger_provenance"] == rig.LEDGER_PROVENANCE_UNVERIFIED
-    receipt_path = tmp_path / "rig-blocked-receipt.json"
-    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    receipt_path = _write(tmp_path / "rig-blocked-receipt.json", receipt)
+    ledger_path = _write(tmp_path / "dispatch-ledger.json", ledger)
 
     with pytest.raises(inputs.StagePlanError, match="requires a GitHub-verified ledger"):
-        authorization_package.package_rig_blocked_authorization(receipt_path)
+        authorization_package.package_rig_blocked_authorization(
+            receipt_path, ledger_path=ledger_path
+        )
 
-    verified = _verified_receipt(ledger)
-    receipt_path.write_text(json.dumps(verified, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    projected = authorization_package.package_rig_blocked_authorization(receipt_path)
+    _write(receipt_path, _verified_receipt(ledger))
+    projected = authorization_package.package_rig_blocked_authorization(
+        receipt_path, ledger_path=ledger_path
+    )
     assert projected["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
-    forged = {**projected, "ledger_provenance": rig.LEDGER_PROVENANCE_UNVERIFIED}
-    unsigned = {key: value for key, value in forged.items() if key != "authorization_sha256"}
-    forged["authorization_sha256"] = rig.canonical_sha256(unsigned)
+    forged = _resealed_authorization(projected, ledger_provenance=rig.LEDGER_PROVENANCE_UNVERIFIED)
     with pytest.raises(inputs.StagePlanError, match="requires a GitHub-verified ledger"):
         authorization.require_rig_blocked_authorization(forged)
 
 
 def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path) -> None:
-    ledger = _dispatch_ledger()
-    receipt = _verified_receipt(ledger)
-    receipt_path = tmp_path / "rig-blocked-receipt.json"
-    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-    projected = authorization_package.package_rig_blocked_authorization(receipt_path)
+    ledger, receipt, receipt_path, ledger_path, projected = _packaged(tmp_path)
 
     assert projected["kind"] == "rig_blocked"
     assert projected["status"] == "RIG_BLOCKED"
@@ -683,6 +710,7 @@ def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path)
     assert projected["rig_blocked_receipt_sha256"] == receipt["rig_blocked_receipt_sha256"]
     assert projected["ledger_sha256"] == rig.canonical_sha256(ledger)
     assert projected["source_receipt"]["path"] == str(receipt_path.resolve())
+    assert projected["source_ledger"]["path"] == str(ledger_path.resolve())
     assert projected["attempt_count"] == rig.EXTENDED_AA_PASS_COUNT
     assert projected["completed_pass_count"] == 0
     assert [item["controller_run_id"] for item in projected["attempts"]] == [
@@ -693,12 +721,19 @@ def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path)
     assert authorization.require_rig_blocked_authorization(projected) == projected
 
     public_path = tmp_path / "public" / "rig-blocked-receipt.json"
+    public_ledger = tmp_path / "public" / "dispatch-ledger.json"
     rebased = authorization_package.rebase_rig_blocked_authorization(
         projected,
         public_receipt_path=public_path.resolve(),
+        public_ledger_path=public_ledger.resolve(),
     )
     assert rebased["source_receipt"]["path"] == str(public_path.resolve())
+    assert rebased["source_ledger"]["path"] == str(public_ledger.resolve())
     assert rebased["authorization_sha256"] != projected["authorization_sha256"]
+    with pytest.raises(inputs.StagePlanError, match="paths are incomplete"):
+        authorization_package.rebase_rig_blocked_authorization(
+            projected, public_receipt_path=public_path.resolve(), public_ledger_path=None
+        )
 
     output = tmp_path / "authority" / "rig-blocked-authorization.json"
     authorization_package.write_authorization(
@@ -722,30 +757,110 @@ def test_rig_blocked_authorization_projects_exhausted_dispatches(tmp_path: Path)
 def test_rig_blocked_authorization_rejects_completed_pass_and_short_ledgers(
     tmp_path: Path,
 ) -> None:
-    receipt = _verified_receipt(_dispatch_ledger())
-    receipt_path = tmp_path / "rig-blocked-receipt.json"
-    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    source = inputs.bind_artifact(receipt_path, name="rig-blocked source receipt")
-    projected = authorization_package.build_rig_blocked_authorization(source, receipt)
-
-    def resealed(**changes: Any) -> dict[str, Any]:
-        tampered = {**projected, **changes}
-        unsigned = {key: value for key, value in tampered.items() if key != "authorization_sha256"}
-        tampered["authorization_sha256"] = rig.canonical_sha256(unsigned)
-        return tampered
+    _ledger, _receipt, _receipt_path, _ledger_path, projected = _packaged(tmp_path)
 
     with pytest.raises(inputs.StagePlanError, match="claims a completed pass"):
-        authorization.require_rig_blocked_authorization(resealed(completed_pass_count=1))
+        authorization.require_rig_blocked_authorization(
+            _resealed_authorization(projected, completed_pass_count=1)
+        )
     with pytest.raises(inputs.StagePlanError, match="fewer than five dispatches"):
         authorization.require_rig_blocked_authorization(
-            resealed(attempt_count=4, attempts=projected["attempts"][:4])
+            _resealed_authorization(projected, attempt_count=4, attempts=projected["attempts"][:4])
         )
     with pytest.raises(inputs.StagePlanError, match="head SHAs differ from its attempts"):
-        authorization.require_rig_blocked_authorization(resealed(head_shas=["9" * 40]))
+        authorization.require_rig_blocked_authorization(
+            _resealed_authorization(projected, head_shas=["9" * 40])
+        )
     with pytest.raises(inputs.StagePlanError, match="score-bearing"):
         authorization.require_rig_blocked_authorization(
-            resealed(attempts=[{**projected["attempts"][0], "accuracy": 0.5}])
+            _resealed_authorization(
+                projected, attempts=[{**projected["attempts"][0], "accuracy": 0.5}]
+            )
         )
+
+
+def test_rig_blocked_packaging_rejects_a_receipt_citing_another_ledger(tmp_path: Path) -> None:
+    _ledger, receipt, receipt_path, ledger_path, _projected = _packaged(tmp_path)
+
+    # Codex probe: a resealed receipt whose ledger digest names a ledger that
+    # holds a successful two-domain pass must not package as RIG_BLOCKED.
+    passing = _dispatch_ledger(
+        [
+            *[_dispatch_attempt(index) for index in range(4)],
+            _dispatch_attempt(
+                4,
+                domain_conclusions={"enterprise": "success", "web": "success"},
+                combined_conclusion="success",
+            ),
+        ]
+    )
+    passing_path = _write(tmp_path / "passing-ledger.json", passing)
+    citing = _resealed_receipt(receipt, ledger_sha256=rig.canonical_sha256(passing))
+    assert rig.validate_rig_blocked_receipt(citing) == citing
+    citing_path = _write(tmp_path / "citing-receipt.json", citing)
+    with pytest.raises(rig.RigInputError, match="A/A data, not dispatch exhaustion"):
+        authorization_package.package_rig_blocked_authorization(
+            citing_path, ledger_path=passing_path
+        )
+    with pytest.raises(inputs.StagePlanError, match="not derived from its bound ledger"):
+        authorization_package.package_rig_blocked_authorization(
+            citing_path, ledger_path=ledger_path
+        )
+
+    # A real ledger digest mismatch against the genuine ledger.
+    wrong_digest = _resealed_receipt(receipt, ledger_sha256=f"sha256:{'f' * 64}")
+    wrong_path = _write(tmp_path / "wrong-digest-receipt.json", wrong_digest)
+    with pytest.raises(inputs.StagePlanError, match="not derived from its bound ledger"):
+        authorization_package.package_rig_blocked_authorization(wrong_path, ledger_path=ledger_path)
+
+    # A different valid ledger than the one the receipt was sealed from.
+    other = _dispatch_ledger([_dispatch_attempt(index, head_sha="e" * 40) for index in range(5)])
+    other_path = _write(tmp_path / "other-ledger.json", other)
+    with pytest.raises(inputs.StagePlanError, match="not derived from its bound ledger"):
+        authorization_package.package_rig_blocked_authorization(
+            receipt_path, ledger_path=other_path
+        )
+
+
+def test_rig_blocked_authorization_rejects_projection_drift_from_its_receipt(
+    tmp_path: Path,
+) -> None:
+    _ledger, _receipt, _receipt_path, ledger_path, projected = _packaged(tmp_path)
+    assert authorization.require_rig_blocked_authorization(projected) == projected
+
+    # Codex probe: keep the genuine source receipt, change projected fields.
+    drifted = [
+        _resealed_authorization(projected, ledger_sha256=f"sha256:{'e' * 64}"),
+        _resealed_authorization(
+            projected,
+            attempts=[
+                {**projected["attempts"][0], "builder_run_ids": [9999]},
+                *projected["attempts"][1:],
+            ],
+        ),
+        _resealed_authorization(
+            projected,
+            attempts=[{**item, "head_sha": "9" * 40} for item in projected["attempts"]],
+            head_shas=["9" * 40],
+        ),
+    ]
+    for tampered in drifted:
+        with pytest.raises(inputs.StagePlanError, match="differs from its bound receipt"):
+            authorization.require_rig_blocked_authorization(tampered)
+    with pytest.raises(inputs.StagePlanError, match="trusted release repository"):
+        authorization.require_rig_blocked_authorization(
+            _resealed_authorization(projected, repository="someone/else")
+        )
+
+    # The bound ledger on disk is swapped for one that does not derive the receipt.
+    other = _dispatch_ledger([_dispatch_attempt(index, head_sha="e" * 40) for index in range(5)])
+    _write(ledger_path, other)
+    swapped = _resealed_authorization(
+        projected,
+        source_ledger=inputs.bind_artifact(ledger_path, name="rig-blocked source ledger"),
+    )
+    with pytest.raises(inputs.StagePlanError, match="not derived from its bound ledger"):
+        authorization.require_rig_blocked_authorization(swapped)
 
 
 RELEASE_RESULTS = REPO_ROOT / "benchmarks" / "results" / "longmemeval-v2-release"
@@ -759,18 +874,15 @@ def test_committed_v1_3_rig_blocked_receipt_is_bound_to_its_ledger() -> None:
     ledger = inputs.load_json(V1_3_DISPATCH_LEDGER)
     committed = inputs.load_json(V1_3_RIG_BLOCKED_RECEIPT)
 
-    rebuilt = rig.build_rig_blocked_receipt(ledger)
-    derived = {"ledger_provenance", "github_verification", "rig_blocked_receipt_sha256"}
-    assert {k: v for k, v in rebuilt.items() if k not in derived} == {
-        k: v for k, v in committed.items() if k not in derived
-    }
+    rig.require_receipt_from_ledger(committed, ledger)
     assert rig.validate_rig_blocked_receipt(committed) == committed
     assert committed["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
     assert committed["blocked_reason"] == rig.BLOCKED_REASON_DISPATCH_EXHAUSTED
     assert committed["paid_benchmark_allowed"] is False
     assert committed["score_claim_allowed"] is False
     assert committed["completed_pass_count"] == 0
-    assert committed["head_branch"] == "main"
+    assert committed["head_branch"] == rig.TRUSTED_BRANCH
+    assert committed["repository"] == rig.TRUSTED_REPOSITORY
     assert [item["controller"]["run_id"] for item in committed["attempts"]] == (
         V1_3_CONTROLLER_RUN_IDS
     )
@@ -778,7 +890,10 @@ def test_committed_v1_3_rig_blocked_receipt_is_bound_to_its_ledger() -> None:
         builder["run_id"] for item in committed["attempts"] for builder in item["builders"]
     ] == V1_3_BUILDER_RUN_IDS
 
-    projected = authorization_package.package_rig_blocked_authorization(V1_3_RIG_BLOCKED_RECEIPT)
+    projected = authorization_package.package_rig_blocked_authorization(
+        V1_3_RIG_BLOCKED_RECEIPT, ledger_path=V1_3_DISPATCH_LEDGER
+    )
     assert projected["rig_blocked_receipt_sha256"] == committed["rig_blocked_receipt_sha256"]
     assert projected["ledger_sha256"] == rig.canonical_sha256(ledger)
+    assert projected["source_ledger"]["sha256"]
     assert projected["attempt_count"] == rig.EXTENDED_AA_PASS_COUNT

--- a/tools/tests/test_longmemeval_v2_rig.py
+++ b/tools/tests/test_longmemeval_v2_rig.py
@@ -1166,7 +1166,8 @@ def _ledger_run(
     conclusion: str,
     created_at: str,
     updated_at: str,
-    head_branch: str = "main",
+    head_branch: str = rig.TRUSTED_BRANCH,
+    repository: str = DISPATCH_REPOSITORY,
 ) -> dict[str, Any]:
     return {
         "id": run_id,
@@ -1182,8 +1183,8 @@ def _ledger_run(
         "created_at": created_at,
         "updated_at": updated_at,
         "run_started_at": created_at,
-        "html_url": f"https://github.com/{DISPATCH_REPOSITORY}/actions/runs/{run_id}",
-        "repository": DISPATCH_REPOSITORY,
+        "html_url": f"https://github.com/{repository}/actions/runs/{run_id}",
+        "repository": repository,
     }
 
 
@@ -1217,6 +1218,8 @@ def _dispatch_attempt(
     head_sha: str = DISPATCH_HEAD_SHA,
     domain_conclusions: dict[str, str] | None = None,
     combined_conclusion: str | None = "skipped",
+    head_branch: str = rig.TRUSTED_BRANCH,
+    repository: str = DISPATCH_REPOSITORY,
 ) -> dict[str, Any]:
     controller_id = 1000 + index
     builder_id = 2000 + index
@@ -1255,6 +1258,8 @@ def _dispatch_attempt(
         conclusion="success",
         created_at=_ledger_time(start),
         updated_at=_ledger_time(start + 0.05),
+        head_branch=head_branch,
+        repository=repository,
     )
     builder = _ledger_run(
         run_id=builder_id,
@@ -1267,15 +1272,21 @@ def _dispatch_attempt(
         conclusion="failure",
         created_at=_ledger_time(start + 0.05),
         updated_at=_ledger_time(start + 2),
+        head_branch=head_branch,
+        repository=repository,
     )
     return {"controller": controller, "builders": [{**builder, "jobs": jobs}]}
 
 
-def _dispatch_ledger(attempts: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+def _dispatch_ledger(
+    attempts: list[dict[str, Any]] | None = None,
+    *,
+    repository: str = DISPATCH_REPOSITORY,
+) -> dict[str, Any]:
     rows = attempts if attempts is not None else [_dispatch_attempt(index) for index in range(5)]
     return {
         "schema_version": rig.DISPATCH_LEDGER_SCHEMA_VERSION,
-        "repository": DISPATCH_REPOSITORY,
+        "repository": repository,
         "fetched_at": _ledger_time(6 * len(rows) + 24),
         "source": {
             "tool": "gh api",
@@ -1381,7 +1392,7 @@ def test_rig_blocked_receipt_rejects_branch_and_controller_drift() -> None:
     branched = [_dispatch_attempt(index) for index in range(5)]
     branched[4]["controller"]["head_branch"] = "release/1.3"
     branched[4]["builders"][0]["head_branch"] = "release/1.3"
-    with pytest.raises(rig.RigInputError, match="span more than one branch"):
+    with pytest.raises(rig.RigInputError, match="not on the trusted release branch"):
         rig.build_rig_blocked_receipt(_dispatch_ledger(branched))
 
     unbound = [_dispatch_attempt(index) for index in range(5)]
@@ -1484,3 +1495,216 @@ def test_rig_blocked_receipt_rejects_job_clock_reversal_beyond_the_skipped_bound
     tampered["rig_blocked_receipt_sha256"] = rig.canonical_sha256(unsigned)
     with pytest.raises(rig.RigInputError, match="completed before it started"):
         rig.validate_rig_blocked_receipt(tampered)
+
+
+def _github_raw_run(row: dict[str, Any]) -> dict[str, Any]:
+    raw = {key: value for key, value in row.items() if key not in {"jobs", "repository"}}
+    raw["repository"] = {"full_name": row["repository"], "private": False}
+    raw["actor"] = {"login": "hyperb1iss"}
+    return raw
+
+
+class _GitHubStub:
+    """Serve ledger rows in GitHub's raw shapes and record every endpoint asked for."""
+
+    def __init__(
+        self,
+        ledger: dict[str, Any],
+        *,
+        extra_builders: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.runs: dict[int, dict[str, Any]] = {}
+        self.jobs: dict[int, list[dict[str, Any]]] = {}
+        self.listing: list[dict[str, Any]] = []
+        self.calls: list[str] = []
+        for attempt in ledger["attempts"]:
+            self.runs[attempt["controller"]["id"]] = _github_raw_run(attempt["controller"])
+            for builder in attempt["builders"]:
+                self._add_builder(builder)
+        for builder in extra_builders or []:
+            self._add_builder(builder)
+
+    def _add_builder(self, builder: dict[str, Any]) -> None:
+        self.runs[builder["id"]] = _github_raw_run(builder)
+        self.jobs[builder["id"]] = [{**job, "steps": []} for job in builder["jobs"]]
+        self.listing.append(_github_raw_run(builder))
+
+    def __call__(self, endpoint: str) -> list[Any]:
+        self.calls.append(endpoint)
+        if "/actions/workflows/" in endpoint:
+            return [{"total_count": len(self.listing), "workflow_runs": self.listing}]
+        if endpoint.endswith("/jobs?per_page=100"):
+            run_id = int(endpoint.rsplit("/", 2)[-2])
+            return [{"total_count": len(self.jobs[run_id]), "jobs": self.jobs[run_id]}]
+        return [self.runs[int(endpoint.rsplit("/", 1)[-1])]]
+
+
+def _github_stub(
+    ledger: dict[str, Any],
+    *,
+    extra_builders: list[dict[str, Any]] | None = None,
+) -> _GitHubStub:
+    return _GitHubStub(ledger, extra_builders=extra_builders)
+
+
+def test_rig_blocked_offline_seal_is_unverified() -> None:
+    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger())
+
+    assert receipt["ledger_provenance"] == rig.LEDGER_PROVENANCE_UNVERIFIED
+    assert receipt["github_verification"] is None
+    assert rig.validate_rig_blocked_receipt(receipt) == receipt
+
+
+def test_rig_blocked_receipt_verifies_every_run_and_job_against_github(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ledger = _dispatch_ledger()
+    fetch = _github_stub(ledger)
+
+    verification = rig.verify_dispatch_ledger(ledger, fetch=fetch)
+
+    assert verification["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
+    assert verification["github_verification"]["run_count"] == 2 * rig.EXTENDED_AA_PASS_COUNT
+    assert verification["github_verification"]["job_count"] == 3 * rig.EXTENDED_AA_PASS_COUNT
+    assert len(fetch.calls) == 4 * rig.EXTENDED_AA_PASS_COUNT
+    receipt = rig.build_rig_blocked_receipt(ledger, verification=verification)
+    assert receipt["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
+    assert receipt["github_verification"] == verification["github_verification"]
+    assert rig.validate_rig_blocked_receipt(receipt) == receipt
+
+    monkeypatch.setattr(rig, "gh_api_fetch", _github_stub(ledger))
+    ledger_path = tmp_path / "ledger.json"
+    output = tmp_path / "receipt.json"
+    ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+    argv = ["rig-blocked", "--ledger", str(ledger_path), "--output", str(output)]
+    assert rig.main([*argv, "--verify-github"]) == 1
+    sealed = json.loads(output.read_text(encoding="utf-8"))
+    assert sealed["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
+    assert sealed["github_verification"]["builder_query"] == rig.GITHUB_BUILDER_RUNS_ENDPOINT
+    output.unlink()
+    assert rig.main(argv) == 1
+    assert json.loads(output.read_text(encoding="utf-8"))["ledger_provenance"] == (
+        rig.LEDGER_PROVENANCE_UNVERIFIED
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (
+            lambda a: a[1]["builders"][0]["jobs"].__setitem__(
+                0, {**a[1]["builders"][0]["jobs"][0], "conclusion": "cancelled"}
+            ),
+            r"builders\[0\] jobs differ from GitHub",
+        ),
+        (
+            lambda a: a[3]["controller"].__setitem__("html_url", "https://example.invalid/run"),
+            "controller differs from GitHub on html_url",
+        ),
+        (
+            lambda a: a[4]["builders"][0].__setitem__("conclusion", "cancelled"),
+            r"builders\[0\] differs from GitHub on conclusion",
+        ),
+    ],
+)
+def test_rig_blocked_verification_rejects_a_drifted_field(mutate: Any, match: str) -> None:
+    ledger = _dispatch_ledger()
+    fetch = _github_stub(deepcopy(ledger))
+    mutate(ledger["attempts"])
+
+    with pytest.raises(rig.RigInputError, match=match):
+        rig.verify_dispatch_ledger(ledger, fetch=fetch)
+
+
+def test_rig_blocked_verification_rejects_an_omitted_builder() -> None:
+    ledger = _dispatch_ledger()
+    hidden = _dispatch_attempt(
+        2,
+        domain_conclusions={"enterprise": "success", "web": "success"},
+        combined_conclusion="success",
+    )["builders"][0]
+    hidden["id"] = 2999
+    for job in hidden["jobs"]:
+        job["run_id"] = 2999
+    fetch = _github_stub(ledger, extra_builders=[hidden])
+
+    with pytest.raises(rig.RigInputError, match=r"attempts\[2\] builder runs differ from GitHub"):
+        rig.verify_dispatch_ledger(ledger, fetch=fetch)
+
+
+def test_rig_blocked_receipt_rejects_a_foreign_repository() -> None:
+    foreign = "someone/else"
+    ledger = _dispatch_ledger(
+        [_dispatch_attempt(index, repository=foreign) for index in range(5)],
+        repository=foreign,
+    )
+
+    with pytest.raises(rig.RigInputError, match="not the trusted release repository"):
+        rig.build_rig_blocked_receipt(ledger)
+    with pytest.raises(rig.RigInputError, match="not the trusted release repository"):
+        rig.verify_dispatch_ledger(ledger, fetch=_github_stub(ledger))
+
+
+def test_rig_blocked_receipt_rejects_a_uniformly_foreign_branch() -> None:
+    ledger = _dispatch_ledger(
+        [_dispatch_attempt(index, head_branch="release/1.3") for index in range(5)]
+    )
+
+    with pytest.raises(rig.RigInputError, match="not on the trusted release branch"):
+        rig.build_rig_blocked_receipt(ledger)
+
+    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger())
+    tampered = deepcopy(receipt)
+    tampered["head_branch"] = "release/1.3"
+    for row in tampered["attempts"]:
+        row["head_branch"] = "release/1.3"
+    unsigned = {k: v for k, v in tampered.items() if k != "rig_blocked_receipt_sha256"}
+    tampered["rig_blocked_receipt_sha256"] = rig.canonical_sha256(unsigned)
+    with pytest.raises(rig.RigInputError, match="not on the trusted release branch"):
+        rig.validate_rig_blocked_receipt(tampered)
+
+
+def test_rig_blocked_receipt_rejects_a_job_from_another_run_attempt() -> None:
+    attempts = [_dispatch_attempt(index) for index in range(5)]
+    attempts[3]["builders"][0]["jobs"][1]["run_attempt"] = 2
+
+    with pytest.raises(rig.RigInputError, match="does not belong to its builder run"):
+        rig.build_rig_blocked_receipt(_dispatch_ledger(attempts))
+
+
+def test_rig_blocked_receipt_rejects_forged_provenance() -> None:
+    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger())
+
+    def resealed(**changes: Any) -> dict[str, Any]:
+        tampered = {**deepcopy(receipt), **changes}
+        unsigned = {k: v for k, v in tampered.items() if k != "rig_blocked_receipt_sha256"}
+        tampered["rig_blocked_receipt_sha256"] = rig.canonical_sha256(unsigned)
+        return tampered
+
+    with pytest.raises(rig.RigInputError, match="missing its GitHub verification"):
+        rig.validate_rig_blocked_receipt(resealed(ledger_provenance=rig.LEDGER_PROVENANCE_VERIFIED))
+    verification = {
+        "verified_at": _ledger_time(1),
+        "run_count": 2 * rig.EXTENDED_AA_PASS_COUNT,
+        "job_count": 3 * rig.EXTENDED_AA_PASS_COUNT,
+        "builder_query": rig.GITHUB_BUILDER_RUNS_ENDPOINT,
+    }
+    with pytest.raises(rig.RigInputError, match="verified before it was fetched"):
+        rig.validate_rig_blocked_receipt(
+            resealed(
+                ledger_provenance=rig.LEDGER_PROVENANCE_VERIFIED,
+                github_verification=verification,
+            )
+        )
+    with pytest.raises(rig.RigInputError, match="run count does not match"):
+        rig.validate_rig_blocked_receipt(
+            resealed(
+                ledger_provenance=rig.LEDGER_PROVENANCE_VERIFIED,
+                github_verification={
+                    **verification,
+                    "verified_at": receipt["ledger_fetched_at"],
+                    "run_count": 3,
+                },
+            )
+        )

--- a/tools/tests/test_longmemeval_v2_rig.py
+++ b/tools/tests/test_longmemeval_v2_rig.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -1144,3 +1145,291 @@ def test_cli_writes_failure_receipt_and_returns_nonzero(tmp_path: Path) -> None:
     assert receipt["status"] == "FAIL"
     assert receipt["score_claim_allowed"] is False
     assert receipt["paid_benchmark_allowed"] is False
+
+
+DISPATCH_REPOSITORY = "hyperb1iss/sibyl"
+DISPATCH_HEAD_SHA = "b" * 40
+
+
+def _ledger_time(hours: float) -> str:
+    base = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+    return (base + timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ledger_run(
+    *,
+    run_id: int,
+    name: str,
+    path: str,
+    display_title: str,
+    head_sha: str,
+    conclusion: str,
+    created_at: str,
+    updated_at: str,
+    head_branch: str = "main",
+) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "name": name,
+        "path": path,
+        "display_title": display_title,
+        "head_sha": head_sha,
+        "head_branch": head_branch,
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": conclusion,
+        "run_attempt": 1,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "run_started_at": created_at,
+        "html_url": f"https://github.com/{DISPATCH_REPOSITORY}/actions/runs/{run_id}",
+        "repository": DISPATCH_REPOSITORY,
+    }
+
+
+def _ledger_job(
+    *,
+    job_id: int,
+    run_id: int,
+    name: str,
+    conclusion: str,
+    head_sha: str,
+    started_at: str,
+    completed_at: str,
+) -> dict[str, Any]:
+    return {
+        "id": job_id,
+        "run_id": run_id,
+        "run_attempt": 1,
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "head_sha": head_sha,
+        "html_url": f"https://github.com/{DISPATCH_REPOSITORY}/actions/runs/{run_id}/job/{job_id}",
+    }
+
+
+def _dispatch_attempt(
+    index: int,
+    *,
+    head_sha: str = DISPATCH_HEAD_SHA,
+    domain_conclusions: dict[str, str] | None = None,
+    combined_conclusion: str | None = "skipped",
+) -> dict[str, Any]:
+    controller_id = 1000 + index
+    builder_id = 2000 + index
+    start = 6 * index
+    conclusions = domain_conclusions or {"enterprise": "failure", "web": "failure"}
+    jobs = [
+        _ledger_job(
+            job_id=3000 + 10 * index + offset,
+            run_id=builder_id,
+            name=rig.OFFICIAL_JOB_NAMES[domain],
+            conclusion=conclusions[domain],
+            head_sha=head_sha,
+            started_at=_ledger_time(start + 0.1),
+            completed_at=_ledger_time(start + 2),
+        )
+        for offset, domain in enumerate(sorted(rig.DOMAINS))
+    ]
+    if combined_conclusion is not None:
+        jobs.append(
+            _ledger_job(
+                job_id=3000 + 10 * index + 5,
+                run_id=builder_id,
+                name=rig.OFFICIAL_JOB_NAMES["combined_receipt"],
+                conclusion=combined_conclusion,
+                head_sha=head_sha,
+                started_at=_ledger_time(start + 2),
+                completed_at=_ledger_time(start + 2),
+            )
+        )
+    controller = _ledger_run(
+        run_id=controller_id,
+        name=f"{rig.CONTROLLER_WORKFLOW_NAME} aa-r{index + 1}",
+        path=rig.CONTROLLER_WORKFLOW_PATH,
+        display_title=f"{rig.CONTROLLER_WORKFLOW_NAME} aa-r{index + 1}",
+        head_sha=head_sha,
+        conclusion="success",
+        created_at=_ledger_time(start),
+        updated_at=_ledger_time(start + 0.05),
+    )
+    builder = _ledger_run(
+        run_id=builder_id,
+        name=f"{rig.BUILDER_WORKFLOW_NAME} aa-{controller_id} {rig.DISPATCH_BUILDER_ARM_ID}",
+        path=rig.BUILDER_WORKFLOW_PATH,
+        display_title=(
+            f"{rig.BUILDER_WORKFLOW_NAME} aa-{controller_id} {rig.DISPATCH_BUILDER_ARM_ID}"
+        ),
+        head_sha=head_sha,
+        conclusion="failure",
+        created_at=_ledger_time(start + 0.05),
+        updated_at=_ledger_time(start + 2),
+    )
+    return {"controller": controller, "builders": [{**builder, "jobs": jobs}]}
+
+
+def _dispatch_ledger(attempts: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    rows = attempts if attempts is not None else [_dispatch_attempt(index) for index in range(5)]
+    return {
+        "schema_version": rig.DISPATCH_LEDGER_SCHEMA_VERSION,
+        "repository": DISPATCH_REPOSITORY,
+        "fetched_at": _ledger_time(6 * len(rows) + 24),
+        "source": {
+            "tool": "gh api",
+            "run_endpoint": "repos/{repository}/actions/runs/{run_id}",
+            "jobs_endpoint": "repos/{repository}/actions/runs/{run_id}/jobs?per_page=100",
+            "builder_query": "gh run list --workflow longmemeval-v2.yml",
+        },
+        "attempts": rows,
+    }
+
+
+def test_rig_blocked_receipt_binds_exhausted_dispatches(tmp_path: Path) -> None:
+    ledger = _dispatch_ledger()
+
+    receipt = rig.build_rig_blocked_receipt(ledger)
+
+    assert receipt["status"] == "RIG_BLOCKED"
+    assert receipt["blocked_reason"] == rig.BLOCKED_REASON_DISPATCH_EXHAUSTED
+    assert receipt["paid_benchmark_allowed"] is False
+    assert receipt["score_claim_allowed"] is False
+    assert receipt["attempt_count"] == rig.EXTENDED_AA_PASS_COUNT
+    assert receipt["completed_pass_count"] == 0
+    assert receipt["head_shas"] == [DISPATCH_HEAD_SHA]
+    assert receipt["ledger_sha256"] == rig.canonical_sha256(ledger)
+    assert [item["experiment_id"] for item in receipt["attempts"]] == [
+        f"aa-r{index}" for index in range(1, 6)
+    ]
+    first = receipt["attempts"][0]
+    assert first["controller"]["run_id"] == ledger["attempts"][0]["controller"]["id"]
+    assert first["builders"][0]["run_id"] == ledger["attempts"][0]["builders"][0]["id"]
+    assert first["builders"][0]["official_jobs"]["web"]["conclusion"] == "failure"
+    assert first["builders"][0]["official_jobs"]["combined_receipt"]["conclusion"] == "skipped"
+    assert rig.validate_rig_blocked_receipt(receipt) == receipt
+
+    ledger_path = tmp_path / "ledger.json"
+    output = tmp_path / "receipt.json"
+    ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+    assert rig.main(["rig-blocked", "--ledger", str(ledger_path), "--output", str(output)]) == 1
+    assert json.loads(output.read_text(encoding="utf-8")) == receipt
+
+
+def test_rig_blocked_receipt_requires_five_dispatches() -> None:
+    ledger = _dispatch_ledger([_dispatch_attempt(index) for index in range(4)])
+
+    with pytest.raises(rig.RigInputError, match="at least 5 controller dispatches"):
+        rig.build_rig_blocked_receipt(ledger)
+
+
+@pytest.mark.parametrize(
+    ("domain_conclusions", "combined_conclusion"),
+    [
+        ({"enterprise": "success", "web": "success"}, "skipped"),
+        ({"enterprise": "success", "web": "success"}, None),
+        ({"enterprise": "failure", "web": "success"}, "success"),
+    ],
+)
+def test_rig_blocked_receipt_rejects_completed_two_domain_pass(
+    domain_conclusions: dict[str, str],
+    combined_conclusion: str | None,
+) -> None:
+    attempts = [_dispatch_attempt(index) for index in range(4)]
+    attempts.append(
+        _dispatch_attempt(
+            4,
+            domain_conclusions=domain_conclusions,
+            combined_conclusion=combined_conclusion,
+        )
+    )
+
+    with pytest.raises(rig.RigInputError, match="A/A data, not dispatch exhaustion"):
+        rig.build_rig_blocked_receipt(_dispatch_ledger(attempts))
+
+
+def test_rig_blocked_receipt_rejects_builder_head_sha_drift() -> None:
+    attempts = [_dispatch_attempt(index) for index in range(5)]
+    attempts[2]["builders"][0]["head_sha"] = "c" * 40
+    for job in attempts[2]["builders"][0]["jobs"]:
+        job["head_sha"] = "c" * 40
+
+    with pytest.raises(rig.RigInputError, match="head SHA differs from its controller"):
+        rig.build_rig_blocked_receipt(_dispatch_ledger(attempts))
+
+
+def test_rig_blocked_receipt_records_every_dispatched_head_sha() -> None:
+    attempts = [
+        _dispatch_attempt(index, head_sha=sha)
+        for index, sha in enumerate(["d" * 40, "d" * 40, "e" * 40, "f" * 40, "1" * 40])
+    ]
+
+    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger(attempts))
+
+    assert receipt["head_shas"] == ["d" * 40, "e" * 40, "f" * 40, "1" * 40]
+    assert [item["head_sha"] for item in receipt["attempts"]] == [
+        "d" * 40,
+        "d" * 40,
+        "e" * 40,
+        "f" * 40,
+        "1" * 40,
+    ]
+
+
+def test_rig_blocked_receipt_rejects_branch_and_controller_drift() -> None:
+    branched = [_dispatch_attempt(index) for index in range(5)]
+    branched[4]["controller"]["head_branch"] = "release/1.3"
+    branched[4]["builders"][0]["head_branch"] = "release/1.3"
+    with pytest.raises(rig.RigInputError, match="span more than one branch"):
+        rig.build_rig_blocked_receipt(_dispatch_ledger(branched))
+
+    unbound = [_dispatch_attempt(index) for index in range(5)]
+    unbound[1]["builders"][0]["display_title"] = (
+        f"{rig.BUILDER_WORKFLOW_NAME} aa-999 {rig.DISPATCH_BUILDER_ARM_ID}"
+    )
+    with pytest.raises(rig.RigInputError, match="was not dispatched by controller"):
+        rig.build_rig_blocked_receipt(_dispatch_ledger(unbound))
+
+
+def test_rig_blocked_receipt_rejects_tampered_claims() -> None:
+    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger())
+
+    def resealed(**changes: Any) -> dict[str, Any]:
+        tampered = {**deepcopy(receipt), **changes}
+        unsigned = {
+            key: value for key, value in tampered.items() if key != "rig_blocked_receipt_sha256"
+        }
+        tampered["rig_blocked_receipt_sha256"] = rig.canonical_sha256(unsigned)
+        return tampered
+
+    with pytest.raises(rig.RigInputError, match="digest does not bind"):
+        rig.validate_rig_blocked_receipt({**receipt, "attempt_count": 6})
+    with pytest.raises(rig.RigInputError, match="claims a completed pass"):
+        rig.validate_rig_blocked_receipt(resealed(completed_pass_count=1))
+    with pytest.raises(rig.RigInputError, match="cannot authorize paid work"):
+        rig.validate_rig_blocked_receipt(resealed(paid_benchmark_allowed=True))
+    with pytest.raises(rig.RigInputError, match="status or reason is invalid"):
+        rig.validate_rig_blocked_receipt(resealed(blocked_reason=rig.BLOCKED_REASON_SPAN_UNSTABLE))
+    with pytest.raises(rig.RigInputError, match="fewer than five"):
+        rig.validate_rig_blocked_receipt(
+            resealed(attempts=receipt["attempts"][:4], attempt_count=4)
+        )
+    with pytest.raises(rig.RigInputError, match="head SHAs do not match"):
+        rig.validate_rig_blocked_receipt(resealed(head_shas=["9" * 40]))
+
+
+def test_aa_span_block_and_dispatch_exhaustion_name_different_reasons() -> None:
+    stable = _aa_receipt()
+    unstable = _aa_receipt(right_accuracies=[0.6, 0.6, 0.6, 0.7, 0.8])
+
+    assert stable["status"] == "PASS"
+    assert stable["blocked_reason"] is None
+    assert unstable["status"] == "RIG_BLOCKED"
+    assert unstable["blocked_reason"] == rig.BLOCKED_REASON_SPAN_UNSTABLE
+    assert unstable["blocked_reason"] != rig.BLOCKED_REASON_DISPATCH_EXHAUSTED
+    tampered = {**unstable, "blocked_reason": rig.BLOCKED_REASON_DISPATCH_EXHAUSTED}
+    unsigned = {key: value for key, value in tampered.items() if key != "aa_receipt_sha256"}
+    tampered["aa_receipt_sha256"] = rig.canonical_sha256(unsigned)
+    with pytest.raises(rig.RigInputError, match="blocked reason does not match"):
+        rig.validate_aa_receipt(tampered)

--- a/tools/tests/test_longmemeval_v2_rig.py
+++ b/tools/tests/test_longmemeval_v2_rig.py
@@ -1433,3 +1433,26 @@ def test_aa_span_block_and_dispatch_exhaustion_name_different_reasons() -> None:
     tampered["aa_receipt_sha256"] = rig.canonical_sha256(unsigned)
     with pytest.raises(rig.RigInputError, match="blocked reason does not match"):
         rig.validate_aa_receipt(tampered)
+
+
+def test_rig_blocked_receipt_tolerates_github_skipped_job_clock_skew() -> None:
+    attempts = [_dispatch_attempt(index) for index in range(5)]
+    skipped = attempts[1]["builders"][0]["jobs"][-1]
+    assert skipped["conclusion"] == "skipped"
+    skipped["completed_at"] = _ledger_time(6 * 1 + 1)
+    skipped["started_at"] = _ledger_time(6 * 1 + 2)
+
+    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger(attempts))
+
+    assert receipt["attempts"][1]["builders"][0]["official_jobs"]["combined_receipt"] == {
+        "job_id": skipped["id"],
+        "conclusion": "skipped",
+        "started_at": skipped["started_at"],
+        "completed_at": skipped["completed_at"],
+        "html_url": skipped["html_url"],
+    }
+    ran = attempts[2]["builders"][0]["jobs"][0]
+    ran["completed_at"] = _ledger_time(6 * 2 + 1)
+    ran["started_at"] = _ledger_time(6 * 2 + 2)
+    with pytest.raises(rig.RigInputError, match="completed before it started"):
+        rig.build_rig_blocked_receipt(_dispatch_ledger(attempts))

--- a/tools/tests/test_longmemeval_v2_rig.py
+++ b/tools/tests/test_longmemeval_v2_rig.py
@@ -1151,9 +1151,9 @@ DISPATCH_REPOSITORY = "hyperb1iss/sibyl"
 DISPATCH_HEAD_SHA = "b" * 40
 
 
-def _ledger_time(hours: float) -> str:
+def _ledger_time(hours: float, *, seconds: int = 0) -> str:
     base = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
-    return (base + timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (base + timedelta(hours=hours, seconds=seconds)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _ledger_run(
@@ -1435,12 +1435,12 @@ def test_aa_span_block_and_dispatch_exhaustion_name_different_reasons() -> None:
         rig.validate_aa_receipt(tampered)
 
 
-def test_rig_blocked_receipt_tolerates_github_skipped_job_clock_skew() -> None:
+def test_rig_blocked_receipt_tolerates_bounded_github_skipped_job_clock_skew() -> None:
     attempts = [_dispatch_attempt(index) for index in range(5)]
     skipped = attempts[1]["builders"][0]["jobs"][-1]
     assert skipped["conclusion"] == "skipped"
-    skipped["completed_at"] = _ledger_time(6 * 1 + 1)
-    skipped["started_at"] = _ledger_time(6 * 1 + 2)
+    skipped["started_at"] = _ledger_time(8, seconds=rig.SKIPPED_JOB_MAX_CLOCK_SKEW_SECONDS)
+    skipped["completed_at"] = _ledger_time(8)
 
     receipt = rig.build_rig_blocked_receipt(_dispatch_ledger(attempts))
 
@@ -1451,8 +1451,36 @@ def test_rig_blocked_receipt_tolerates_github_skipped_job_clock_skew() -> None:
         "completed_at": skipped["completed_at"],
         "html_url": skipped["html_url"],
     }
-    ran = attempts[2]["builders"][0]["jobs"][0]
-    ran["completed_at"] = _ledger_time(6 * 2 + 1)
-    ran["started_at"] = _ledger_time(6 * 2 + 2)
+    assert rig.validate_rig_blocked_receipt(receipt) == receipt
+
+
+@pytest.mark.parametrize(
+    ("conclusion", "reversal_seconds"),
+    [
+        ("skipped", rig.SKIPPED_JOB_MAX_CLOCK_SKEW_SECONDS + 1),
+        ("skipped", 3600),
+        ("failure", 1),
+    ],
+)
+def test_rig_blocked_receipt_rejects_job_clock_reversal_beyond_the_skipped_bound(
+    conclusion: str,
+    reversal_seconds: int,
+) -> None:
+    attempts = [_dispatch_attempt(index) for index in range(5)]
+    job = attempts[2]["builders"][0]["jobs"][-1 if conclusion == "skipped" else 0]
+    assert job["conclusion"] == conclusion
+    job["started_at"] = _ledger_time(14, seconds=reversal_seconds)
+    job["completed_at"] = _ledger_time(14)
     with pytest.raises(rig.RigInputError, match="completed before it started"):
         rig.build_rig_blocked_receipt(_dispatch_ledger(attempts))
+
+    receipt = rig.build_rig_blocked_receipt(_dispatch_ledger())
+    tampered = deepcopy(receipt)
+    row = tampered["attempts"][2]["builders"][0]["official_jobs"]
+    key = "combined_receipt" if conclusion == "skipped" else "enterprise"
+    row[key]["started_at"] = job["started_at"]
+    row[key]["completed_at"] = job["completed_at"]
+    unsigned = {k: v for k, v in tampered.items() if k != "rig_blocked_receipt_sha256"}
+    tampered["rig_blocked_receipt_sha256"] = rig.canonical_sha256(unsigned)
+    with pytest.raises(rig.RigInputError, match="completed before it started"):
+        rig.validate_rig_blocked_receipt(tampered)

--- a/tools/tests/test_longmemeval_v2_rig.py
+++ b/tools/tests/test_longmemeval_v2_rig.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
@@ -1535,8 +1536,13 @@ class _GitHubStub:
             return [{"total_count": len(self.listing), "workflow_runs": self.listing}]
         if endpoint.endswith("/jobs?per_page=100"):
             run_id = int(endpoint.rsplit("/", 2)[-2])
+            if run_id not in self.jobs:
+                raise rig.RigInputError(f"gh api {endpoint} failed: HTTP 404")
             return [{"total_count": len(self.jobs[run_id]), "jobs": self.jobs[run_id]}]
-        return [self.runs[int(endpoint.rsplit("/", 1)[-1])]]
+        run_id = int(endpoint.rsplit("/", 1)[-1])
+        if run_id not in self.runs:
+            raise rig.RigInputError(f"gh api {endpoint} failed: HTTP 404")
+        return [self.runs[run_id]]
 
 
 def _github_stub(
@@ -1562,16 +1568,17 @@ def test_rig_blocked_receipt_verifies_every_run_and_job_against_github(
     ledger = _dispatch_ledger()
     fetch = _github_stub(ledger)
 
-    verification = rig.verify_dispatch_ledger(ledger, fetch=fetch)
+    receipt = rig.build_verified_rig_blocked_receipt(ledger, fetch=fetch)
 
-    assert verification["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
-    assert verification["github_verification"]["run_count"] == 2 * rig.EXTENDED_AA_PASS_COUNT
-    assert verification["github_verification"]["job_count"] == 3 * rig.EXTENDED_AA_PASS_COUNT
-    assert len(fetch.calls) == 4 * rig.EXTENDED_AA_PASS_COUNT
-    receipt = rig.build_rig_blocked_receipt(ledger, verification=verification)
     assert receipt["ledger_provenance"] == rig.LEDGER_PROVENANCE_VERIFIED
-    assert receipt["github_verification"] == verification["github_verification"]
+    assert receipt["github_verification"]["run_count"] == 2 * rig.EXTENDED_AA_PASS_COUNT
+    assert receipt["github_verification"]["job_count"] == 3 * rig.EXTENDED_AA_PASS_COUNT
+    assert len(fetch.calls) == 4 * rig.EXTENDED_AA_PASS_COUNT
     assert rig.validate_rig_blocked_receipt(receipt) == receipt
+    assert rig.receipt_derivation(receipt) == rig.receipt_derivation(
+        rig.build_rig_blocked_receipt(ledger)
+    )
+    assert "verification" not in inspect.signature(rig.build_rig_blocked_receipt).parameters
 
     monkeypatch.setattr(rig, "gh_api_fetch", _github_stub(ledger))
     ledger_path = tmp_path / "ledger.json"
@@ -1587,6 +1594,16 @@ def test_rig_blocked_receipt_verifies_every_run_and_job_against_github(
     assert json.loads(output.read_text(encoding="utf-8"))["ledger_provenance"] == (
         rig.LEDGER_PROVENANCE_UNVERIFIED
     )
+
+
+def test_rig_blocked_verified_seal_fails_closed_on_fetch_failure() -> None:
+    ledger = _dispatch_ledger()
+
+    def broken(endpoint: str) -> list[Any]:
+        raise rig.RigInputError(f"gh api {endpoint} failed: HTTP 504")
+
+    with pytest.raises(rig.RigInputError, match="HTTP 504"):
+        rig.build_verified_rig_blocked_receipt(ledger, fetch=broken)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# 🧾 Rig-blocked receipt for exhausted A/A dispatches, and the 1.3 runbook

> Sibyl 1.3 product work is merged and green on `main` (`012e7b55`). The only open release gate is the paid benchmark rig, which never completed a two-domain A/A pass across five controller dispatches. This PR seals that fact as the rig-blocked receipt the implementation plan names as the release escape hatch, corrects the 08-26 status snapshot, and writes the release runbook. It cuts nothing: version bump, tag, and publish stay behind explicit approval.

## 💡 What this is

The implementation plan (`docs/architecture/SIBYL_1_3_IMPLEMENTATION_PLAN.md`, S1.3 and section 6) lets the product ship when the benchmark rig is provably blocked, but the rig could only emit `RIG_BLOCKED` after five completed paired passes whose span refused to stabilize. Zero completed passes could not produce it, so the escape hatch was unreachable by construction. The naive fix (relax `build_aa_receipt` to accept zero passes) is wrong: an A/A receipt asserts a stack, an arm contract, and geometry that a dispatch which never ran a pass never observed.

This PR adds a second, distinct rig-blocked shape (`sibyl-longmemeval-v2-rig-blocked-receipt-v1`, `blocked_reason: dispatch_exhausted`) derived from a GitHub dispatch ledger, verified against GitHub at seal time, re-verified against GitHub at every authorization boundary, and bound transitively through the release authorization. The existing span-instability path keeps its own `blocked_reason: span_unstable` so the two can never be confused.

## 🤔 Why we need it & what it replaces

Five controller dispatches between 2026-08-25 and 2026-08-26 (`sibyl-v1.3-aa-20260825` through `sibyl-v1-3-aa-20260826-r5`) each lost at least one hosted runner. The r5 forensics (Sibyl `error_pattern_bc484d448434`) show why: SurrealDB v3.2.3 peaks at 11.7 GiB on the 15 GiB runner despite the 4 GiB block cache, and the hybrid fulltext lane spends the entire memory-query budget at p50 12.9 s per call. Both are real defects with their own lanes (#446 for the fulltext lane, task `8a56f5c7` for residency). Neither is a 1.3 product condition, and the plan says so: benchmark blockage stops paid benchmark work and every score claim, not the release.

What is deliberately not built: any path by which this receipt can enable a paid run or a score. `paid_benchmark_allowed` and `score_claim_allowed` are hardcoded `false` on this shape, and the authorization schema excludes them entirely.

## 🎯 The invariant

Anchor on one property: release authority is observed, never asserted. `package_rig_blocked_authorization` and `require_rig_blocked_authorization` take a required `fetch: GitHubFetch` with no default, rebuild the receipt from the bound ledger bytes, and re-run `verify_dispatch_ledger` against `hyperb1iss/sibyl` at that boundary; a fetch failure or any drifted field raises `StagePlanError`. The serialized `ledger_provenance` / `github_verification` block is a record of when the ledger last matched GitHub and confers nothing, because a JSON file with a recomputable digest can carry any label. An offline seal is allowed for reproducibility and comes out `unverified`, which the packager rejects before it ever fetches.

## 🛠️ How it works

### 1. The ledger (`benchmarks/results/longmemeval-v2-release/sibyl-v1-3-aa-dispatch-ledger.json`)

A `gh api` projection of each controller run, its builder run(s), and the builder's jobs (`Official web small`, `Official enterprise small`, `Official combined receipt`), with run ids, `run_attempt`, head SHA and branch, event, conclusions, and timestamps. Schema `sibyl-longmemeval-v2-dispatch-ledger-v1`. The tool never fetches the ledger itself; the runbook records the fetch recipe.

### 2. Sealing (`tools/bench/longmemeval_v2_rig.py`)

The new `rig-blocked --ledger --output [--verify-github]` subcommand runs `build_rig_blocked_receipt`. Rejections, each with a test:

- fewer than `EXTENDED_AA_PASS_COUNT` (5) successful controller dispatches;
- any builder whose two official domains both succeeded, or whose combined receipt succeeded (that is A/A data, not exhaustion);
- any run or job outside `TRUSTED_REPOSITORY` (`hyperb1iss/sibyl`) or off `TRUSTED_BRANCH` (`main`);
- a builder whose head SHA, branch, or `run_attempt` differs from the controller that dispatched it, or a job whose `run_attempt` differs from its builder;
- a ledger fetched before its last run finished;
- a skipped job whose bookkeeping timestamps reverse by more than `SKIPPED_JOB_MAX_CLOCK_SKEW_SECONDS` (2 s, justified from the observed ledger where all nine skipped jobs reverse by 0 or 1 s on second-granular stamps), and any ran job that completes before it starts.

`--verify-github` routes through `build_verified_rig_blocked_receipt(ledger, fetch=...)`, the only producer of the verification block (`build_rig_blocked_receipt` has no verification parameter). It calls `verify_dispatch_ledger` with an injectable `gh_api_fetch` (`gh api --paginate --slurp`): every controller run, builder run, and job is re-fetched and must match the ledger exactly, and the controller's builders are re-discovered from the workflow-runs listing so an omitted builder cannot hide a completed pass. Only that path stamps `ledger_provenance: github_verified` with a `github_verification` block (`verified_at`, `run_count`, `job_count`, `builder_query`); the validator checks the block's internal consistency so a garbled record cannot seal, and nothing downstream reads it as evidence.

The attempts span four `main` commits (`48b44836`, `74ddb867`, `aed4adb2`, `7f31a330`) because PRs #442 to #444 landed between dispatches; the receipt lists every SHA rather than pretending the campaign ran on one, and each builder is bound to its own controller's SHA.

### 3. Authorization binding (`benchmarks/longmemeval_v2_release_authorization*.py`)

`package_rig_blocked_authorization(receipt_path, *, ledger_path)` binds the ledger as a physical `source_ledger` artifact, rebuilds the receipt from those bytes (`require_receipt_from_ledger`), and requires the derivation to match. `require_rig_blocked_authorization` reloads both bound artifacts, repeats the rebuild, compares the complete `rig_blocked_projection` against the raw authority, and then re-verifies the ledger live through the supplied fetcher (`_require_bound_rig_blocked_receipt`); `build_rig_blocked_authorization` calls it, so packaging costs one round of fetches (20 for five attempts), not two. `write_authorization` refuses the `rig_blocked` kind without a fetcher. The consumer trace found no existing production reader of this authority, so the operator entry point is new: `benchmarks/longmemeval_v2_release_cli.py release-rig-blocked-authority --receipt --ledger --output`, registered on the `longmemeval_v2_ablations` CLI, packaging with the real `rig.gh_api_fetch` and writing once via `write_json_once_atomic`. `longmemeval_v2_release_ci.py` now reads `BUILDER_ARM_ID` from the rig. `outcomes.require_bound_aa_receipt` still requires a `PASS` A/A receipt for an anchor, so a blocked rig can never feed a paid stage.

### 4. The committed receipt

`sibyl-v1-3-aa-rig-blocked-receipt.json` was sealed through the live `--verify-github` path at 2026-08-30T07:35:29Z (10 runs, 29 jobs matched; the first attempt failed closed on a GitHub 504). Digest `sha256:5850fd3f31ac8db9090b8e7bb8b62b349823500f0ebac6ebe3ba3a09cccc0df8`, ledger `sha256:74339727e600a92a0157db517e6c5ce0b378bf08b4dc8ba2eb274818427a4299`. The runbook's documented check is now the `release-rig-blocked-authority` command; it was run once against live GitHub from the branch (exit 0, both digests unchanged, authorization digest `sha256:c48f9f999bdedad86c9f27cb52d97db4d35cc605ae536b15cae5428b7c542555`, not committed because its `source_*` paths are machine-local). A contract test (`tools/tests/test_longmemeval_v2_release_contract.py`) rebuilds it from the committed ledger, pins the ten run ids, and projects it through the authorization.

### 5. Docs

- `SIBYL_1_3_RELEASE_STATUS_2026-08-29.md` supersedes the 08-26 snapshot and corrects three of its claims against the r5 artifacts: the SurrealDB peak is known (11.7 GiB RSS, cgroup 13.0 GB, host minimum 418 MiB), the latency owner is known (`graph_entity_search:_fulltext_search`, 951 calls at p50 12.9 s), and the notes-ON 29.31% anchor is not a comparator for the notes-OFF 23.33% r5 arm. Release state moves from hold to ready for dry cut pending approval.
- `SIBYL_1_3_RELEASE_RUNBOOK.md` binds `docs/admin/releasing.md` to the candidate: exact commit, every receipt with digest and run ids, the uncached gate list, the dry-cut dispatch with its six confirmation points, the approval gate, the v1.2.2 publish topology, verification, and rollback points per channel.
- The plan gains the dispatch-exhaustion sentence in S1.3 and ticks the five measurement and runbook exit criteria the receipt satisfies.

## 🧪 Validation

At `48aad926`, all uncached:

- `moon run root:bench-gate-test --force` → 919 passed (899 before the review rounds; the new tests cover fewer-than-five, completed-pass in all three forms, foreign repository, foreign branch, `run_attempt` mismatch, drifted GitHub field, omitted builder, unverified provenance rejected by packager and authorization, receipt citing a passing ledger, resealed authority with swapped ledger digest and builder ids, real `ledger_sha256` mismatch, ledger swapped on disk, the 2 s skew bound on both sides, the invented-ids-plus-plausible-verification-block probe rejected at packager and validator by a 404ing stub, a receipt sealed against stub A rejected against stub B where r5 web flipped to success, a 504 fetcher failing closed, `write_authorization` without a fetcher rejected, and a CLI test driving `release-rig-blocked-authority` with a monkeypatched fetcher asserting 20 fetches, write-once, and fail-closed on outage). The committed-artifact test packages with a stub replaying the committed ledger to stay hermetic; the runbook command is the live check.
- `moon run bench-longmemeval-v2-release-ci-test --force` → 9 passed.
- `moon run root:inventory-lint root:inventory-typecheck --force` → clean.
- `moon run docs:lint --force` → Prettier clean; `moon run :lint` → 12 tasks completed.
- Orchestrator probes, in-process: offline seal of the committed ledger produces `ledger_provenance: unverified` and `package_rig_blocked_authorization` rejects it with `rig-blocked authorization requires a GitHub-verified ledger`; the committed verified receipt packages as `rig_blocked / RIG_BLOCKED / 5 / 0`.
- Cross-model review (Codex): round 1 FAIL on `012e7b55..b304c204` with three executed-probe blockers (forgeable provenance, no transitive ledger binding, unbounded skew exemption), fixed in `2b516839`, `caf8974b`, `04dc1f00`. Round 2 closed findings 2 and 3 with executed probes and narrowed finding 1 to the caller-suppliable verification block; fixed in `55b82da7`. Round 3 on `04dc1f00..48aad926`: PASS, no findings (confidence 0.98); the reviewer re-ran its invented-ids forgery probe (rejected at both boundaries on the first 404) and a drift probe (rejected at both boundaries after all 20 fetches), confirmed the operator CLI is the only production caller and binds `rig.gh_api_fetch`, and confirmed publication uses exclusive hard-link creation so an existing output cannot be replaced.

⚠️ The runbook's candidate-commit gates (`moon run :check`, `e2e:test-browser`, `release-workflow-test`, `doc-claim-gate`) are listed for the cut and were not run here; CI run 33025662969 and Nightly Regression 33244786444 on `012e7b55` are the observed green. The live GitHub verifier was exercised once positively; its negative cases are covered by stubs only.

## 🔍 What reviewers should focus on

- Whether any path accepts a rig-blocked authorization without `verify_dispatch_ledger` running through the supplied fetcher at that boundary, and whether a replay stub can be reached from any real entry point rather than tests.
- Whether `verify_dispatch_ledger`'s builder re-discovery fails closed when a completed builder is missing from the ledger.
- Whether the informational `github_verification` block can still influence any decision.
- The runbook's claim that this PR merging moves the candidate: if it lands before the cut, the new `main` head becomes the candidate and its gates must run again.

Out of scope: the fulltext lane fix and the residency work (separate lanes), any change to the A/A span-instability path beyond adding `blocked_reason`.

## 📌 Follow-ups

- Task `2a129447`: hybrid fulltext lane fix (`fc17af80`, #446).
- Task `8a56f5c7`: SurrealDB residency reproduction and live latency measurement of that fix.
- Tasks `defd7d5b`, `e2ffa177`, `0b639fc2`: Surreal bloat, write-path collapse, bench stack off the laptop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fail-closed “rig-blocked” release flow for LongMemEval V2 when benchmark dispatches are exhausted.
  - Added the `release-rig-blocked-authority` command to verify and package blocked benchmark evidence.
  - Added GitHub-backed verification for dispatch records, receipts, and release authorizations.
  - Added a committed rig-blocked receipt and dispatch ledger for the Sibyl v1.3 release.

- **Documentation**
  - Added Sibyl v1.3 release runbook and status documentation.
  - Documented that benchmark scores will not be published for the rig-blocked release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->