### PR TITLE
fix(web): refresh alpine packages in the runner image

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -52,6 +52,10 @@ RUN pnpm exec next build --webpack
 # Stage 3: Runtime
 FROM node:24-alpine AS runner
 
+# The node:24-alpine snapshot lags Alpine security releases, so pull the
+# current package set at build time; the CVE gate scans this final stage.
+RUN apk upgrade --no-cache
+
 WORKDIR /app/apps/web
 
 # Create non-root user with a high service UID to avoid host user collisions.


### PR DESCRIPTION
## 💡 What this is

The web image CVE gate fails on every open PR right now: the `node:24-alpine` snapshot ships openssl `3.5.7-r0`, and CVE-2026-14456 (OpenSSL QUIC DoS, HIGH) is fixed in Alpine's `3.5.8-r0`. The runner stage never upgraded base packages, so the image shipped whatever the node snapshot froze. One `apk upgrade --no-cache` in the final stage pulls the current Alpine security set at build time, which fixes this CVE and absorbs the next base-image lag the same way.

## 🧪 Validation

The CVE gate on this PR is the receipt: it rebuilds the image and scans the final stage, so a green `Scan web (amd64)` proves the upgrade landed. The api image is unaffected (its scan passes on the same run; different base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)