### PR TITLE
fix(release): never cache the version-pin sync tasks

### DIFF
--- a/moon.yml
+++ b/moon.yml
@@ -291,8 +291,15 @@ tasks:
       - cli:test
       - web:test
 
+  # Never cache these two: sync-versions mutates the pin files without
+  # declaring them as outputs, so a cache replay applies nothing, and the
+  # 1.3.0 release run proved the trap: the dry cut cached a success at
+  # VERSION=1.3.0 and the real cut replayed it, leaving every pin at the
+  # old version for sync-versions-check to (correctly) reject.
   sync-versions:
     command: uv run python tools/release/sync_versions.py
+    options:
+      cache: false
     inputs:
       - VERSION
       - tools/release/sync_versions.py
@@ -300,6 +307,8 @@ tasks:
 
   sync-versions-check:
     command: uv run python tools/release/sync_versions.py --check
+    options:
+      cache: false
     inputs:
       - VERSION
       - tools/release/sync_versions.py


### PR DESCRIPTION
## 💡 What this is

The 1.3.0 real cut ([run 33686635368](https://github.com/hyperb1iss/sibyl/actions/runs/33686635368)) failed at `Apply version bump`: `root:sync-versions` came back `(cached, 68a3aaae)` in 65ms and rewrote nothing, then `sync-versions-check` correctly rejected all eleven pins still at 1.2.2. The dry cut is what seeded the cache: both runs bump `VERSION` to 1.3.0 in-runner, so the mutating task's input hash matched, and with no declared outputs the replay is a no-op. The gate held (no tag, no commit, no publish), and this makes the mutation actually happen next time: `options.cache: false` on both `sync-versions` and `sync-versions-check`.

## 🧪 Validation

Consecutive local runs of `moon run sync-versions-check` both execute with zero cache hits (previously the second run replayed). The real receipt is the next release run's `Apply version bump` step executing `sync-versions` uncached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)