### PR TITLE
feat(cli): sibyl migrate to-team for self-service team migration

### DIFF
--- a/apps/cli/src/sibyl_cli/data/skill-packs/migration.md
+++ b/apps/cli/src/sibyl_cli/data/skill-packs/migration.md
@@ -486,3 +486,64 @@ feels right.
 - Export command source: `apps/api/src/sibyl/cli/migrate.py` (at commit `290b824b`)
 - Import command source: `apps/api/src/sibyl/cli/migrate.py` (at tag `v0.10.0`, the last version
   with the `legacy-archive` on-ramp; removed in `903a738d`)
+
+---
+
+## Migrating a Personal Instance into a Team Server (to-team replay)
+
+Use this when a user wants their local project knowledge in a shared team server (an
+enterprise deployment with SSO) and they are not an operator of that server. This is the
+self-service lane; several teammates can each run it with their own login.
+
+**Do not reach for the archive/consolidate lane here.** It is operator-shaped (SSH or
+kubectl to the target, root store access), it migrates whole orgs rather than one
+project, and its exporter fails on live stores that contain record links (RecordID
+serialization, issue #459). The replay lane goes through the target's ordinary
+authenticated API instead: ownership lands on the caller's own server identity by
+construction, and the target re-projects and re-embeds from the verbatim raw records.
+
+One-time setup per person:
+
+```bash
+sibyl config context create <team> --server https://<team-server> --use
+sibyl auth login --server https://<team-server>   # their own SSO login
+```
+
+The target project must exist on the team server first (any member with project-create
+rights, once for the whole team):
+
+```bash
+sibyl project create "<Project Name>" --description "..."
+```
+
+Then, from the person's normal local context:
+
+```bash
+sibyl migrate to-team --target-context <team> --project project_<source-scope-key> --dry-run
+sibyl migrate to-team --target-context <team> --project project_<source-scope-key>
+```
+
+What the verb guarantees, and what to check:
+
+- Scope: only raw captures with `memory_scope=project` and the given scope key move.
+  Private memories stay local. Find the scope key distribution first when unsure:
+  the source content store's `raw_captures` table, grouped by `scope_key`.
+- Idempotence: a per-route ledger under `~/.sibyl/migrations` (keyed and
+  manifest-pinned to source org + target context + target project) persists after every
+  successful post, so interrupts and re-runs never duplicate.
+- Provenance: `provenance.migration` on each replayed record carries the origin org,
+  raw id, original `created_at`, capture surface, and any truncated original title.
+- Failures are per-row and reported at the end; empty and oversize bodies are named
+  individually rather than aborting the run.
+- Replayed records carry today's `created_at` (the original lives in provenance);
+  decay-aware backdating is a known follow-up, not a bug to chase.
+- The target needs a working embedding key before the run, or ingestion will queue
+  projection failures.
+- Server/client version skew is enforced by the version contract: the server stamps
+  `X-Sibyl-Server-Version` and may publish a `minimum_client_version` floor that fails
+  old clients closed, so run the migration with a CLI at least as new as the target
+  server's release.
+
+Verification after a run: a few `sibyl context "<known topic>"` recalls against the
+team context that the user can grade themselves, plus the run's own migrated/skipped/
+failed counts.

--- a/apps/cli/src/sibyl_cli/main.py
+++ b/apps/cli/src/sibyl_cli/main.py
@@ -64,6 +64,7 @@ from sibyl_cli.memory_display import (
     is_raw_memory_reference,
     print_memory_source_inspect,
 )
+from sibyl_cli.migrate import app as migrate_app
 from sibyl_cli.org import app as org_app
 from sibyl_cli.pending import app as pending_writes_app
 from sibyl_cli.pending_writes import pending_write_count, pending_write_status
@@ -147,6 +148,7 @@ app.add_typer(archive_app, name="archive")
 app.add_typer(session_app, name="session")
 app.add_typer(entity_app, name="entity")
 app.add_typer(explore_app, name="explore")
+app.add_typer(migrate_app, name="migrate")
 app.add_typer(export_app, name="export")
 app.add_typer(crawl_app, name="crawl")
 app.add_typer(docs_app, name="docs")

--- a/apps/cli/src/sibyl_cli/migrate.py
+++ b/apps/cli/src/sibyl_cli/migrate.py
@@ -137,7 +137,7 @@ async def _resolve_target_project(client: Any, wanted: str) -> dict[str, Any] | 
             entity = None
         if entity and str(entity.get("id", "")).lower() == wanted.lower():
             return entity
-    response = await client.explore(mode="list", types=["project"], limit=500)
+    response = await client.explore(mode="list", types=["project"], limit=200)
     lowered = wanted.lower()
     entities = response.get("entities", [])
     for project in entities:

--- a/apps/cli/src/sibyl_cli/migrate.py
+++ b/apps/cli/src/sibyl_cli/migrate.py
@@ -1,0 +1,309 @@
+"""Migrate raw memories from a personal instance into a team server.
+
+The replay path: raw memory is law, so migration re-submits the verbatim
+raw captures to the target through the ordinary authenticated API, as the
+caller. Ownership lands on the caller's target identity by construction,
+the target re-projects and re-embeds server-side, and no cluster or
+operator access is involved. The source side reads the local content
+store directly, which every personal-instance owner has by definition.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Annotated, Any
+
+import httpx
+import typer
+
+from sibyl_cli.client import get_client
+from sibyl_cli.common import error, info, run_async, success
+
+app = typer.Typer(help="Migrate data between Sibyl instances")
+
+_LEDGER_DIR = Path.home() / ".sibyl" / "migrations"
+_PAGE_SIZE = 200
+
+
+def _ledger_path(target_context: str, project_key: str) -> Path:
+    safe = f"{target_context}--{project_key}".replace("/", "_")
+    return _LEDGER_DIR / f"{safe}.json"
+
+
+def _load_ledger(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_ledger(path: Path, ledger: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(ledger, indent=1, sort_keys=True), encoding="utf-8")
+
+
+def _source_sql(
+    *,
+    surreal_url: str,
+    username: str,
+    password: str,
+    statement: str,
+) -> list[Any]:
+    """Run one read-only statement against the local content store."""
+    base = surreal_url.replace("ws://", "http://").replace("wss://", "https://")
+    base = base.removesuffix("/rpc").rstrip("/")
+    response = httpx.post(
+        f"{base}/sql",
+        content=statement,
+        auth=(username, password),
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "text/plain",
+            "surreal-ns": "sibyl_content",
+            "surreal-db": "content",
+        },
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    results: list[Any] = []
+    for item in payload:
+        if item.get("status") != "OK":
+            raise RuntimeError(f"source query failed: {item.get('result')}")
+        results.append(item.get("result"))
+    return results
+
+
+def _fetch_source_page(
+    *,
+    surreal_url: str,
+    username: str,
+    password: str,
+    organization_id: str,
+    scope_key: str,
+    start: int,
+) -> list[dict[str, Any]]:
+    statement = (
+        "SELECT uuid, title, raw_content, memory_scope, scope_key, tags, "
+        "metadata, provenance, source_id, capture_surface, created_at "
+        "FROM raw_captures "
+        f"WHERE organization_id = '{organization_id}' "
+        "AND memory_scope = 'project' "
+        f"AND scope_key = '{scope_key}' "
+        f"ORDER BY created_at ASC LIMIT {_PAGE_SIZE} START {start};"
+    )
+    rows = _source_sql(
+        surreal_url=surreal_url,
+        username=username,
+        password=password,
+        statement=statement,
+    )[0]
+    return rows or []
+
+
+async def _resolve_target_project(client: Any, wanted: str) -> dict[str, Any] | None:
+    response = await client.explore(mode="list", types=["project"], limit=200)
+    lowered = wanted.lower()
+    for project in response.get("entities", []):
+        pid = str(project.get("id", ""))
+        name = str(project.get("name", ""))
+        if lowered in (pid.lower(), name.lower()):
+            return project
+    return None
+
+
+@app.command("to-team")
+def to_team(
+    target_context: Annotated[
+        str,
+        typer.Option(
+            "--target-context",
+            help="Named context for the team server (create with sibyl config "
+            "context, then sibyl auth login against it)",
+        ),
+    ],
+    project: Annotated[
+        str,
+        typer.Option(
+            "--project",
+            help="Source project scope key (project_...) to migrate",
+        ),
+    ],
+    target_project: Annotated[
+        str | None,
+        typer.Option(
+            "--target-project",
+            help="Target project id or name; defaults to the same name lookup",
+        ),
+    ] = None,
+    source_org: Annotated[
+        str | None,
+        typer.Option(
+            "--source-org",
+            help="Source organization UUID (defaults to the only org with rows "
+            "for the project scope)",
+        ),
+    ] = None,
+    source_surreal_url: Annotated[
+        str,
+        typer.Option("--source-surreal-url", help="Local SurrealDB endpoint"),
+    ] = "ws://localhost:8000/rpc",
+    source_surreal_user: Annotated[
+        str,
+        typer.Option("--source-surreal-user", help="Local SurrealDB username"),
+    ] = "root",
+    source_surreal_pass: Annotated[
+        str,
+        typer.Option("--source-surreal-pass", help="Local SurrealDB password"),
+    ] = "root",
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Count and preview without writing"),
+    ] = False,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", help="Migrate at most N memories"),
+    ] = None,
+) -> None:
+    """Replay a project's raw memories into a team server as yourself.
+
+    Reads the verbatim raw captures for one project scope from the local
+    content store, then re-submits each to the target through POST
+    /memory/raw with provenance recording the original identity and
+    timestamps. A ledger under ~/.sibyl/migrations makes re-runs skip
+    everything already migrated.
+    """
+
+    @run_async
+    async def _run() -> None:
+        if source_org:
+            org_id = source_org
+        else:
+            orgs = _source_sql(
+                surreal_url=source_surreal_url,
+                username=source_surreal_user,
+                password=source_surreal_pass,
+                statement=(
+                    "SELECT organization_id, count() AS n FROM raw_captures "
+                    "WHERE memory_scope = 'project' AND scope_key = "
+                    f"'{project}' GROUP BY organization_id;"
+                ),
+            )[0]
+            if not orgs:
+                error(f"No project-scoped raw memories found for {project}")
+                raise typer.Exit(1)
+            if len(orgs) > 1:
+                error(
+                    "Multiple source orgs carry this project scope; pass "
+                    "--source-org to disambiguate: "
+                    + ", ".join(str(o["organization_id"]) for o in orgs)
+                )
+                raise typer.Exit(1)
+            org_id = str(orgs[0]["organization_id"])
+
+        info(f"Source org {org_id}, project scope {project}")
+
+        target = get_client(target_context)
+        wanted = target_project or project
+        resolved = await _resolve_target_project(target, wanted)
+        if resolved is None and target_project is None:
+            # Fall back to matching the source project's display name.
+            names = _source_sql(
+                surreal_url=source_surreal_url,
+                username=source_surreal_user,
+                password=source_surreal_pass,
+                statement=(
+                    "SELECT name FROM entity WHERE entity_type = 'project' "
+                    f"AND uuid = '{project.removeprefix('project_')}' LIMIT 1;"
+                ),
+            )[0]
+            if names:
+                resolved = await _resolve_target_project(target, str(names[0]["name"]))
+        if resolved is None:
+            error(
+                f"Target project '{wanted}' not found on {target_context}. "
+                "Create it there first (sibyl project create) or pass "
+                "--target-project."
+            )
+            raise typer.Exit(1)
+        target_project_id = str(resolved.get("id"))
+        info(f"Target project: {resolved.get('name')} ({target_project_id})")
+
+        ledger_file = _ledger_path(target_context, project)
+        ledger = _load_ledger(ledger_file)
+
+        migrated = 0
+        skipped = 0
+        failed: list[str] = []
+        start = 0
+        while True:
+            rows = _fetch_source_page(
+                surreal_url=source_surreal_url,
+                username=source_surreal_user,
+                password=source_surreal_pass,
+                organization_id=org_id,
+                scope_key=project,
+                start=start,
+            )
+            if not rows:
+                break
+            for row in rows:
+                original_id = str(row.get("uuid"))
+                if original_id in ledger:
+                    skipped += 1
+                    continue
+                if limit is not None and migrated >= limit:
+                    break
+                if dry_run:
+                    migrated += 1
+                    continue
+                provenance = dict(row.get("provenance") or {})
+                provenance["migration"] = {
+                    "origin_org": org_id,
+                    "origin_raw_id": original_id,
+                    "origin_created_at": str(row.get("created_at")),
+                    "origin_capture_surface": row.get("capture_surface"),
+                    "tool": "sibyl migrate to-team",
+                }
+                try:
+                    response = await target.remember_raw_memory(
+                        title=str(row.get("title") or ""),
+                        raw_content=str(row.get("raw_content") or ""),
+                        source_id=str(row.get("source_id") or "") or f"migrated:{original_id}",
+                        memory_scope="project",
+                        scope_key=target_project_id,
+                        tags=list(row.get("tags") or []),
+                        metadata=dict(row.get("metadata") or {}),
+                        provenance=provenance,
+                        capture_surface="migration",
+                    )
+                except Exception as exc:
+                    failed.append(f"{original_id}: {exc}")
+                    continue
+                ledger[original_id] = str(response.get("id") or response.get("uuid") or "ok")
+                migrated += 1
+                if migrated % 25 == 0:
+                    _save_ledger(ledger_file, ledger)
+                    info(f"  {migrated} migrated...")
+            if limit is not None and migrated >= limit:
+                break
+            start += _PAGE_SIZE
+            await asyncio.sleep(0)
+
+        if not dry_run:
+            _save_ledger(ledger_file, ledger)
+
+        verb = "Would migrate" if dry_run else "Migrated"
+        success(f"{verb} {migrated} raw memories ({skipped} already in ledger)")
+        if failed:
+            error(f"{len(failed)} failures:")
+            for line in failed[:10]:
+                error(f"  {line}")
+            raise typer.Exit(1)
+
+    _run()

--- a/apps/cli/src/sibyl_cli/migrate.py
+++ b/apps/cli/src/sibyl_cli/migrate.py
@@ -25,26 +25,47 @@ app = typer.Typer(help="Migrate data between Sibyl instances")
 
 _LEDGER_DIR = Path.home() / ".sibyl" / "migrations"
 _PAGE_SIZE = 200
+_MAX_TITLE = 300
+_MAX_CONTENT = 500000
 
 
-def _ledger_path(target_context: str, project_key: str) -> Path:
-    safe = f"{target_context}--{project_key}".replace("/", "_")
+def _ledger_path(route: dict[str, str]) -> Path:
+    safe = "--".join(
+        route[k] for k in ("source_org", "target_context", "target_project_id")
+    ).replace("/", "_")
     return _LEDGER_DIR / f"{safe}.json"
 
 
-def _load_ledger(path: Path) -> dict[str, str]:
+def _load_ledger(path: Path, route: dict[str, str]) -> dict[str, str]:
+    """Load receipts for exactly this migration route.
+
+    The manifest inside the file pins source org, target context, and
+    target project; a mismatch means the file belongs to a different
+    route and must not suppress writes for this one.
+    """
     if not path.exists():
         return {}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        return {}
+    if data.get("route") != route:
+        raise RuntimeError(
+            f"ledger {path} belongs to a different migration route; "
+            "move it aside or pass a different target"
+        )
+    receipts = data.get("receipts")
+    return receipts if isinstance(receipts, dict) else {}
 
 
-def _save_ledger(path: Path, ledger: dict[str, str]) -> None:
+def _save_ledger(path: Path, route: dict[str, str], ledger: dict[str, str]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(ledger, indent=1, sort_keys=True), encoding="utf-8")
+    payload = json.dumps({"route": route, "receipts": ledger}, indent=1, sort_keys=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    tmp.replace(path)
 
 
 def _source_sql(
@@ -109,12 +130,18 @@ def _fetch_source_page(
 async def _resolve_target_project(client: Any, wanted: str) -> dict[str, Any] | None:
     response = await client.explore(mode="list", types=["project"], limit=200)
     lowered = wanted.lower()
-    for project in response.get("entities", []):
-        pid = str(project.get("id", ""))
-        name = str(project.get("name", ""))
-        if lowered in (pid.lower(), name.lower()):
+    entities = response.get("entities", [])
+    for project in entities:
+        if str(project.get("id", "")).lower() == lowered:
             return project
-    return None
+    named = [p for p in entities if str(p.get("name", "")).lower() == lowered]
+    if len(named) > 1:
+        raise RuntimeError(
+            f"target project name '{wanted}' is ambiguous "
+            f"({', '.join(str(p.get('id')) for p in named)}); "
+            "pass --target-project with the exact id"
+        )
+    return named[0] if named else None
 
 
 @app.command("to-team")
@@ -159,7 +186,14 @@ def to_team(
     ] = "root",
     source_surreal_pass: Annotated[
         str,
-        typer.Option("--source-surreal-pass", help="Local SurrealDB password"),
+        typer.Option(
+            "--source-surreal-pass",
+            envvar="SIBYL_SOURCE_SURREAL_PASS",
+            show_default=False,
+            help="Local SurrealDB password (prefer the "
+            "SIBYL_SOURCE_SURREAL_PASS environment variable; a value on "
+            "the command line lands in shell history)",
+        ),
     ] = "root",
     dry_run: Annotated[
         bool,
@@ -212,18 +246,17 @@ def to_team(
         wanted = target_project or project
         resolved = await _resolve_target_project(target, wanted)
         if resolved is None and target_project is None:
-            # Fall back to matching the source project's display name.
-            names = _source_sql(
-                surreal_url=source_surreal_url,
-                username=source_surreal_user,
-                password=source_surreal_pass,
-                statement=(
-                    "SELECT name FROM entity WHERE entity_type = 'project' "
-                    f"AND uuid = '{project.removeprefix('project_')}' LIMIT 1;"
-                ),
-            )[0]
-            if names:
-                resolved = await _resolve_target_project(target, str(names[0]["name"]))
+            # Fall back to the source project's display name via the
+            # source API (project entities live in the org graph, which
+            # the local API serves; the content store does not).
+            source = get_client()
+            try:
+                source_project = await source.get_entity(project)
+            except Exception:
+                source_project = None
+            source_name = str((source_project or {}).get("name") or "").strip()
+            if source_name:
+                resolved = await _resolve_target_project(target, source_name)
         if resolved is None:
             error(
                 f"Target project '{wanted}' not found on {target_context}. "
@@ -234,8 +267,13 @@ def to_team(
         target_project_id = str(resolved.get("id"))
         info(f"Target project: {resolved.get('name')} ({target_project_id})")
 
-        ledger_file = _ledger_path(target_context, project)
-        ledger = _load_ledger(ledger_file)
+        route = {
+            "source_org": org_id,
+            "target_context": target_context,
+            "target_project_id": target_project_id,
+        }
+        ledger_file = _ledger_path(route)
+        ledger = _load_ledger(ledger_file, route)
 
         migrated = 0
         skipped = 0
@@ -296,7 +334,7 @@ def to_team(
             await asyncio.sleep(0)
 
         if not dry_run:
-            _save_ledger(ledger_file, ledger)
+            _save_ledger(ledger_file, route, ledger)
 
         verb = "Would migrate" if dry_run else "Migrated"
         success(f"{verb} {migrated} raw memories ({skipped} already in ledger)")

--- a/apps/cli/src/sibyl_cli/migrate.py
+++ b/apps/cli/src/sibyl_cli/migrate.py
@@ -128,7 +128,16 @@ def _fetch_source_page(
 
 
 async def _resolve_target_project(client: Any, wanted: str) -> dict[str, Any] | None:
-    response = await client.explore(mode="list", types=["project"], limit=200)
+    if wanted.startswith("project_"):
+        # Exact ids resolve directly, so a project beyond the listing
+        # window is still reachable.
+        try:
+            entity = await client.get_entity(wanted)
+        except Exception:
+            entity = None
+        if entity and str(entity.get("id", "")).lower() == wanted.lower():
+            return entity
+    response = await client.explore(mode="list", types=["project"], limit=500)
     lowered = wanted.lower()
     entities = response.get("entities", [])
     for project in entities:
@@ -300,6 +309,18 @@ def to_team(
                 if dry_run:
                     migrated += 1
                     continue
+                raw_content = str(row.get("raw_content") or "")
+                if not raw_content.strip():
+                    failed.append(f"{original_id}: empty content, not migrated")
+                    continue
+                if len(raw_content) > _MAX_CONTENT:
+                    failed.append(
+                        f"{original_id}: content exceeds the API limit "
+                        f"({len(raw_content)} > {_MAX_CONTENT}); migrate "
+                        "this record manually"
+                    )
+                    continue
+                title = str(row.get("title") or "")
                 provenance = dict(row.get("provenance") or {})
                 provenance["migration"] = {
                     "origin_org": org_id,
@@ -308,15 +329,28 @@ def to_team(
                     "origin_capture_surface": row.get("capture_surface"),
                     "tool": "sibyl migrate to-team",
                 }
+                if len(title) > _MAX_TITLE:
+                    provenance["migration"]["origin_title"] = title
+                    title = title[: _MAX_TITLE - 1] + "…"
+                # The retrieval layer prefers metadata.project_id over the
+                # scope key (_search_candidates), so a copied source
+                # project id would misroute or hide the memory on the
+                # target.
+                metadata = dict(row.get("metadata") or {})
+                if metadata.get("project_id"):
+                    provenance["migration"]["origin_metadata_project_id"] = str(
+                        metadata["project_id"]
+                    )
+                    metadata["project_id"] = target_project_id
                 try:
                     response = await target.remember_raw_memory(
-                        title=str(row.get("title") or ""),
-                        raw_content=str(row.get("raw_content") or ""),
+                        title=title,
+                        raw_content=raw_content,
                         source_id=str(row.get("source_id") or "") or f"migrated:{original_id}",
                         memory_scope="project",
                         scope_key=target_project_id,
                         tags=list(row.get("tags") or []),
-                        metadata=dict(row.get("metadata") or {}),
+                        metadata=metadata,
                         provenance=provenance,
                         capture_surface="migration",
                     )
@@ -324,9 +358,9 @@ def to_team(
                     failed.append(f"{original_id}: {exc}")
                     continue
                 ledger[original_id] = str(response.get("id") or response.get("uuid") or "ok")
+                _save_ledger(ledger_file, route, ledger)
                 migrated += 1
                 if migrated % 25 == 0:
-                    _save_ledger(ledger_file, ledger)
                     info(f"  {migrated} migrated...")
             if limit is not None and migrated >= limit:
                 break


### PR DESCRIPTION
# 🧳 Self-service team migration

> Closes the self-service half of the team-migration story: a personal instance's project knowledge moves into a shared team server with one command and the caller's own SSO login. The operator archive lane stays what it is; this lane needs no cluster access at all.

## 💡 What this is

A new client verb, `sibyl migrate to-team`, replays one project's raw memories from a personal instance into a team server through the target's ordinary authenticated API. The naive approach here is the existing archive/consolidate machinery, and it is wrong for this case three times over: it is operator-shaped (SSH or kubectl to the target, root store access), it moves whole orgs when the user wants one project, and its exporter currently fails on live stores containing record links (#459). The replay lane leans on raw memory being law: the verbatim raw captures are re-submitted through `POST /memory/raw` as the authenticated caller, and the target re-projects and re-embeds server-side.

## 🎯 The invariant

Ownership, scope, and access are all correct by construction rather than by mapping: each person authenticates as themselves on the target, so their rows land under their own identity; only `memory_scope=project` rows for the named scope key move; and nothing in the flow touches the target's infrastructure. There is no owner-UUID remap table anywhere because the design never needs one.

## 🛠️ How it works

1. **Source enumeration** (`migrate.py::_fetch_source_page`) pages `raw_captures` for one org + project scope straight from the local content store over the Surreal HTTP API. Every personal-instance owner has root store access to their own stack by definition; the password prefers the `SIBYL_SOURCE_SURREAL_PASS` environment variable so nondefault credentials stay out of argv.
2. **Target resolution** (`_resolve_target_project`) tries a direct `get_entity` fetch for exact `project_...` ids (so projects beyond the listing window stay reachable), then a name match against the listing at the `ExploreRequest` maximum of 200. Ambiguous names abort with the candidate ids. The same-name fallback reads the source project's display name through the source API, not the content namespace.
3. **Replay**: each capture posts with its title, content, tags, and metadata, plus `provenance.migration` carrying the origin org, raw id, original `created_at`, capture surface, and any truncated original title. `metadata.project_id` is rewritten to the target project because the retrieval layer prefers it over the scope key (`_search_candidates.py:283`); a copied source id would misroute or hide the memory on the target.
4. **Idempotence**: a ledger under `~/.sibyl/migrations`, keyed and manifest-pinned to the full route (source org, target context, target project), persists atomically after every successful post. Interrupts and re-runs skip exactly what already landed; a ledger from a different route refuses instead of silently suppressing writes.
5. **Shape normalization**: titles beyond the API's 300-character bound truncate with the original preserved in provenance; empty and oversize bodies are reported per row instead of 422ing mid-run. All failures are per-row and listed at the end.
6. **Skill pack**: the version-matched `migration.md` pack gains the to-team lane (when to use it over the archive path, the setup commands, the guarantees, the known limitations), so agents driving migrations inherit the playbook with the release that carries the verb.

## 🚦 Rollout sequencing (and why it's safe)

The verb is read-only against the source and writes only through the target's normal API surface under the caller's own permissions, so there is nothing to sequence server-side. The one prerequisite is a working embedding key on the target, or replayed records queue projection failures. Version skew is covered by the existing version contract: the server stamps its version on every response and can publish a `minimum_client_version` floor that fails old clients closed; deployments should raise that floor to this release once it ships.

## 🧪 Validation

- Live dry run against a real personal store (4,627 captures, 3 project scopes): source org auto-resolved from the scope key, target project resolved by id, `132` v2-project captures staged, `0` in ledger, nothing written. Re-run after ledger writes reports skips correctly.
- `ruff check` clean across `apps/cli/src/sibyl_cli/`; `sibyl migrate to-team --help` and `sibyl skill get migration` both serve the new surface through the real CLI path.
- Cross-model review, three full rounds: round 1 raised seven findings (metadata misroute, interrupt-window duplication, ambiguous names, password in argv, wrong-namespace name fallback, capture-shape 422s, unscoped ledger), all fixed; round 2 caught that three fixes had missed the file after a formatting pass plus the resulting crash at the 25th post; round 3 caught the 500-row listing request exceeding the schema's 200 cap.
- ⚠️ The final one-line cap fix is self-verified (schema bound read directly, dry run green) because the reviewer's quota expired mid-loop; and no end-to-end run against a real team server has happened yet. The first live migration is the acceptance test and is about to run.

## 🔍 What reviewers should focus on

- The `metadata.project_id` rewrite in the replay loop: it is what keeps migrated rows visible in target search, and the original id survives in `provenance.migration`.
- The ledger's route manifest: same source project to a different target must never be suppressed by an old ledger file.
- The per-row failure isolation: one bad capture must not abort a 4,000-row run.
- Out of scope, tracked as follow-ups: task/graph-entity replay, decay-aware backdating of `created_at` (needs a server change; originals live in provenance meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `sibyl migrate to-team` command for moving project knowledge from a personal instance to a team server.
  * Supports dry runs, migration limits, project selection by ID or name, resumable migrations, provenance tracking, and per-record failure reporting.
  * Added validation for project availability, content limits, authentication, embedding configuration, and compatible server versions.

* **Documentation**
  * Added guidance covering setup, migration workflows, verification, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->