### PR TITLE
fix(cli): survive RecordID payloads in archive export and refuse empty archives

### DIFF
--- a/apps/api/src/sibyl/cli/migrate.py
+++ b/apps/api/src/sibyl/cli/migrate.py
@@ -48,6 +48,21 @@ from sibyl_core.migrate.merge import (
     merge_archives,
 )
 
+
+def _archive_json_default(value: object) -> str:
+    """Canonical JSON fallback for archive payloads.
+
+    Live stores hand back values the stdlib encoder refuses: Surreal
+    record links arrive as RecordID objects whose str() form is already
+    the canonical table:id, and datetimes want ISO 8601. Anything else
+    falls back to str so an export of a real store never dies on a type
+    the SDK grows next release (#459).
+    """
+    if hasattr(value, "isoformat"):
+        return value.isoformat()  # type: ignore[union-attr]
+    return str(value)
+
+
 app = typer.Typer(
     name="migrate",
     help="Migration archives, verification, and rehearsal tooling",
@@ -679,7 +694,7 @@ def _load_graph_export(org_id: str) -> tuple[dict[str, object], bytes]:
             msg = result.message or "graph export failed"
             raise RuntimeError(msg)
         payload = asdict(result.backup_data)
-        encoded = json.dumps(payload, indent=2, default=str).encode("utf-8")
+        encoded = json.dumps(payload, indent=2, default=_archive_json_default).encode("utf-8")
         return payload, encoded
 
     return _export()
@@ -689,7 +704,9 @@ def _load_auth_export() -> tuple[dict[str, object], bytes]:
     @run_async
     async def _export() -> tuple[dict[str, object], bytes]:
         payload = await export_auth_archive_payload()
-        encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+        encoded = json.dumps(
+            payload, indent=2, sort_keys=True, default=_archive_json_default
+        ).encode("utf-8")
         return payload, encoded
 
     return _export()
@@ -699,7 +716,9 @@ def _load_content_export() -> tuple[dict[str, object], bytes]:
     @run_async
     async def _export() -> tuple[dict[str, object], bytes]:
         payload = await export_content_archive_payload()
-        encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+        encoded = json.dumps(
+            payload, indent=2, sort_keys=True, default=_archive_json_default
+        ).encode("utf-8")
         return payload, encoded
 
     return _export()
@@ -725,14 +744,18 @@ def _load_runtime_exports(
             payload = await export_auth_archive_payload()
             auth_export = (
                 payload,
-                json.dumps(payload, indent=2, sort_keys=True).encode("utf-8"),
+                json.dumps(payload, indent=2, sort_keys=True, default=_archive_json_default).encode(
+                    "utf-8"
+                ),
             )
 
         if include_content:
             payload = await export_content_archive_payload()
             content_export = (
                 payload,
-                json.dumps(payload, indent=2, sort_keys=True).encode("utf-8"),
+                json.dumps(payload, indent=2, sort_keys=True, default=_archive_json_default).encode(
+                    "utf-8"
+                ),
             )
 
         return auth_export, content_export
@@ -1569,6 +1592,15 @@ def export_archive(
             "--include-content/--skip-content", help="Include content/operations snapshot"
         ),
     ] = True,
+    allow_empty: Annotated[
+        bool,
+        typer.Option(
+            "--allow-empty",
+            help="Permit an archive whose included payloads contain zero rows "
+            "and zero entities (the default refuses, because an empty export "
+            "usually means the CLI is pointed at the wrong store)",
+        ),
+    ] = False,
 ) -> None:
     """Export a manifest-driven migration archive from the active store."""
     del include_database_dump
@@ -1649,6 +1681,20 @@ def export_archive(
         }
         archive_metadata["content_table_count"] = len(row_counts)
         archive_metadata["content_total_rows"] = int(content_payload.get("total_rows", 0))
+
+    exported_total = (
+        int(archive_metadata.get("graph_entity_count", 0))
+        + int(archive_metadata.get("auth_total_rows", 0))
+        + int(archive_metadata.get("content_total_rows", 0))
+    )
+    if exported_total == 0 and not allow_empty:
+        error(
+            "Export produced zero entities and zero rows across every included "
+            "payload. This almost always means the CLI resolved an empty or "
+            "wrong store (check SIBYL_SURREAL_URL and credentials match the "
+            "running server). Pass --allow-empty to export anyway."
+        )
+        raise typer.Exit(code=1)
 
     manifest = build_manifest(
         organization_id=org_id,

--- a/apps/api/src/sibyl/cli/migrate.py
+++ b/apps/api/src/sibyl/cli/migrate.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
@@ -58,8 +58,8 @@ def _archive_json_default(value: object) -> str:
     falls back to str so an export of a real store never dies on a type
     the SDK grows next release (#459).
     """
-    if hasattr(value, "isoformat"):
-        return value.isoformat()  # type: ignore[union-attr]
+    if isinstance(value, datetime | date):
+        return value.isoformat()
     return str(value)
 
 

--- a/apps/api/tests/test_migrate_cli_archive.py
+++ b/apps/api/tests/test_migrate_cli_archive.py
@@ -1,0 +1,31 @@
+"""Archive export serialization and emptiness guard (#459)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from surrealdb import RecordID
+
+from sibyl.cli.migrate import _archive_json_default
+
+
+def test_archive_default_renders_record_ids_canonically() -> None:
+    payload = {"link": RecordID("raw_captures", "abc123")}
+    encoded = json.dumps(payload, default=_archive_json_default)
+    assert json.loads(encoded) == {"link": "raw_captures:abc123"}
+
+
+def test_archive_default_renders_datetimes_iso() -> None:
+    moment = datetime(2026, 9, 3, 1, 2, 3, tzinfo=UTC)
+    encoded = json.dumps({"at": moment}, default=_archive_json_default)
+    assert json.loads(encoded) == {"at": "2026-09-03T01:02:03+00:00"}
+
+
+def test_archive_default_falls_back_to_str() -> None:
+    class Odd:
+        def __str__(self) -> str:
+            return "odd-value"
+
+    encoded = json.dumps({"v": Odd()}, default=_archive_json_default)
+    assert json.loads(encoded) == {"v": "odd-value"}


### PR DESCRIPTION
## 💡 What this is

Closes #459, both findings. Archive exports crashed on any live store containing Surreal record links because four dump sites used the bare stdlib JSON encoder; all five archive writers now share one canonical fallback (`_archive_json_default`: isoformat for datetimes, `str` otherwise, which renders `RecordID` as the `table:id` form the import side already parses). Separately, an export whose included payloads total zero entities and zero rows now exits 1 with guidance instead of writing a validated empty archive, with `--allow-empty` as the deliberate override — a zero export almost always means the CLI resolved the wrong store.

## 🧪 Validation

- Live receipt on the exact store that crashed: `sibyld migrate export --org-id <real org> --skip-auth` now writes a validated archive of **9,720 entities, 8,513 relationships, 72,372 content rows** (`migrate check` passes).
- Guard receipt: the same command against a nonexistent org exits 1 with the wrong-store guidance and writes no file.
- `pytest apps/api/tests/test_migrate_cli_archive.py` → 3 passed (RecordID canonical form, datetime ISO, arbitrary-object fallback); `ruff` clean.
- ⚠️ Review note: the cross-model reviewer is quota-blocked until Sep 8, so this ran the degradation ladder's self-verified rung with the live before/after receipts above standing in as the primary evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive exports now support an `--allow-empty` option for intentionally creating empty archives.

* **Bug Fixes**
  * Archive exports now reliably serialize record identifiers and date/time values.
  * Unsupported values are converted to readable text instead of causing export failures.
  * Empty archives are prevented by default, helping avoid accidentally generated archives with no data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->