### PR TITLE
fix(api): close the first-boot readiness window and 503 refresh storage failures

### DIFF
--- a/apps/api/src/sibyl/api/readiness.py
+++ b/apps/api/src/sibyl/api/readiness.py
@@ -88,7 +88,16 @@ def check_schema_bootstrap_ready() -> DependencyStatus | None:
 
     status = get_runtime_schema_bootstrap_status()
     if not status.attempted:
-        return None
+        # Bootstrap runs unconditionally in runtime startup, so an
+        # unattempted state means startup has not finished: the process
+        # is NOT ready. Returning None here opened a first-boot window
+        # where /health/ready answered 200 while the auth schema did not
+        # exist yet and signups 500ed (#461).
+        return DependencyStatus(
+            name="schemas",
+            ready=False,
+            detail="Surreal schema bootstrap has not started",
+        )
     if status.ready:
         return DependencyStatus(name="schemas", ready=True)
     detail = "; ".join(

--- a/apps/api/src/sibyl/api/routes/auth.py
+++ b/apps/api/src/sibyl/api/routes/auth.py
@@ -10,9 +10,11 @@ from urllib.parse import quote, urlencode, urlparse
 from uuid import UUID
 
 import httpx
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from pydantic import BaseModel, Field, field_validator
+from surrealdb.errors import SurrealError
 
 from sibyl import config as config_module
 from sibyl.api.rate_limit import limiter
@@ -58,6 +60,8 @@ from sibyl.persistence.auth_runtime import (
 )
 from sibyl.persistence.operations_runtime import is_setup_mode
 from sibyl_core.auth import AuthUser, GitHubUserIdentity
+
+log = structlog.get_logger()
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -1601,7 +1605,18 @@ async def refresh_tokens(request: Request):
             organization_id=org_id,
             request=request,
         )
-    except TimeoutError:
+    except (TimeoutError, ConnectionError, OSError) as e:
+        # A refresh that cannot reach or query auth storage is a
+        # temporary service condition, never an internal error: a 500
+        # here makes clients treat their session as broken and halts
+        # the CLI's pending-writes replay (#461).
+        log.warning("refresh_storage_unavailable", error=str(e))
+        return JSONResponse(
+            content={"detail": "Authentication storage temporarily unavailable"},
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    except SurrealError as e:
+        log.warning("refresh_storage_unavailable", error=str(e))
         return JSONResponse(
             content={"detail": "Authentication storage temporarily unavailable"},
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/apps/api/tests/test_readiness.py
+++ b/apps/api/tests/test_readiness.py
@@ -52,6 +52,8 @@ def test_readiness_returns_200_when_dependencies_ready() -> None:
         backend="local",
     )
 
+    schemas = DependencyStatus(name="schemas", ready=True)
+
     with (
         patch(
             "sibyl.api.readiness.check_surreal_ready",
@@ -60,6 +62,10 @@ def test_readiness_returns_200_when_dependencies_ready() -> None:
         patch(
             "sibyl.api.readiness.check_coordination_ready",
             AsyncMock(return_value=coordination),
+        ),
+        patch(
+            "sibyl.api.readiness.check_schema_bootstrap_ready",
+            return_value=schemas,
         ),
     ):
         response = client.get("/health/ready")
@@ -75,6 +81,7 @@ def test_readiness_returns_200_when_dependencies_ready() -> None:
             "latency_ms": 0.4,
             "backend": "local",
         },
+        {"name": "schemas", "ready": True},
     ]
 
 
@@ -295,3 +302,19 @@ async def test_coordination_readiness_rejects_dead_required_redis() -> None:
     assert status.backend == "redis"
     assert status.detail == "redis coordination broker unavailable"
     assert status.latency_ms is not None
+
+
+def test_schema_bootstrap_unattempted_reports_not_ready() -> None:
+    """Before startup marks the bootstrap attempted, readiness must say
+    NOT ready rather than dropping the dependency: the silent-drop
+    behavior opened a first-boot window where /health/ready answered 200
+    while the auth schema did not exist and signups 500ed (#461)."""
+    from sibyl.api.readiness import check_schema_bootstrap_ready
+    from sibyl.surreal_runtime_startup import reset_runtime_schema_bootstrap_status
+
+    reset_runtime_schema_bootstrap_status()
+    status = check_schema_bootstrap_ready()
+
+    assert status is not None
+    assert status.ready is False
+    assert "not started" in (status.detail or "")

--- a/apps/api/tests/test_routes_auth.py
+++ b/apps/api/tests/test_routes_auth.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException, Response
+from surrealdb.errors import SurrealError
 
 from sibyl.api.errors import http_exception_payload
 from sibyl.api.routes import auth as auth_routes
@@ -1417,3 +1418,36 @@ async def test_update_me_uses_runtime_helper(monkeypatch: pytest.MonkeyPatch) ->
 
     assert response["user"]["email"] == "updated@example.com"
     update_user.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "storage_error",
+    [
+        ConnectionError("socket closed mid-reload"),
+        OSError("connection reset"),
+        SurrealError("The table 'user_sessions' does not exist"),
+    ],
+)
+async def test_refresh_tokens_returns_503_when_auth_storage_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    storage_error: Exception,
+) -> None:
+    """Storage-layer failures during rotation are service conditions,
+    never internal errors: a 500 here halts the CLI's pending-writes
+    replay client-side (#461)."""
+    user_id = uuid4()
+    request = FakeRequest(json_data={"refresh_token": "refresh-token"})
+    rotate = AsyncMock(side_effect=storage_error)
+
+    monkeypatch.setattr(
+        auth_routes,
+        "verify_refresh_token",
+        lambda _: {"sub": str(user_id)},
+    )
+    monkeypatch.setattr(auth_routes, "rotate_refresh_exchange", rotate)
+
+    response = await _call_route(auth_routes.refresh_tokens, request=request)
+
+    assert response.status_code == 503
+    assert json.loads(response.body)["detail"] == "Authentication storage temporarily unavailable"


### PR DESCRIPTION
## 💡 What this is

Closes #461, both entry points. `/health/ready` answered 200 before the schema bootstrap finished because `check_schema_bootstrap_ready` returned `None` (dependency silently dropped) whenever the bootstrap had not yet been marked attempted; since the bootstrap runs unconditionally in runtime startup, unattempted always means startup is unfinished, and the dependency now reports not-ready instead of vanishing. Separately, the refresh endpoint mapped only `TimeoutError` to 503, so connection resets and Surreal errors during rotation escaped as 500 — which clients read as a dead session and which halts the CLI's pending-writes replay; `ConnectionError`, `OSError`, and `SurrealError` now map to the same 503 service condition.

## 🧪 Validation

- `pytest apps/api/tests/test_readiness.py apps/api/tests/test_routes_auth.py` → 58 passed: new unattempted-not-ready contract test, parametrized 503s for the three storage failure shapes, and the pre-existing all-ready test updated to include the schemas dependency it previously depended on being absent.
- The live failure this fixes was reproduced twice on a scratch stack before the fix (signup 500 with `The table 'users' does not exist` behind a 200 readiness; refresh 500 halting `pending-writes flush`), receipts in #461.
- ⚠️ The cross-model reviewer is quota-blocked until Sep 8; this ran the degradation ladder's self-verified rung with the contract tests standing as primary evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)