### PR TITLE
fix(auth): setup mode no longer unlocks local surfaces on SSO-only instances

### DIFF
--- a/apps/api/src/sibyl/api/routes/auth.py
+++ b/apps/api/src/sibyl/api/routes/auth.py
@@ -423,13 +423,18 @@ async def _require_signup_allowed(
     if invite_token is not None:
         await _validate_invitation_for_email(token=invite_token, email=body.email)
         return invite_token
-    if config_module.settings.public_signups_enabled or await is_setup_mode():
+    if config_module.settings.public_signups_enabled or (
+        await is_setup_mode() and not config_module.settings.sso_only_instance
+    ):
         return None
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=SIGNUP_DISABLED_DETAIL)
 
 
 async def _require_local_auth_allowed(request: Request) -> None:
-    if await is_setup_mode():
+    # Setup mode unlocks local auth only when this instance actually
+    # owns identity; an SSO-only deployment completes setup through the
+    # first provider login instead (#456).
+    if await is_setup_mode() and not config_module.settings.sso_only_instance:
         return
     if config_module.settings.break_glass_enabled:
         _require_break_glass_allowed(request)

--- a/apps/api/src/sibyl/api/routes/setup.py
+++ b/apps/api/src/sibyl/api/routes/setup.py
@@ -32,6 +32,12 @@ class SetupStatus(BaseModel):
     """Current setup state of the Sibyl instance."""
 
     needs_setup: bool = Field(description="True until setup has initialized an owner/admin org")
+    sso_first_run: bool = Field(
+        default=False,
+        description="True when identity is SSO-only and no owner/admin exists "
+        "yet: the first provider login completes setup, so clients should "
+        "route to the provider instead of the local setup wizard",
+    )
     has_users: bool = Field(description="True if at least one user exists")
     has_orgs: bool = Field(description="True if at least one org exists")
     setup_complete: bool = Field(
@@ -167,6 +173,7 @@ async def get_setup_status(
 
     return SetupStatus(
         needs_setup=not setup_status.setup_complete,
+        sso_first_run=(not setup_status.setup_complete) and settings.sso_only_instance,
         has_users=setup_status.has_users,
         has_orgs=setup_status.has_orgs,
         setup_complete=setup_status.setup_complete,

--- a/apps/api/src/sibyl/config.py
+++ b/apps/api/src/sibyl/config.py
@@ -198,6 +198,18 @@ class Settings(BaseSettings):
         default=False,
         description="Treat local auth as an active break-glass access path",
     )
+
+    @property
+    def sso_only_instance(self) -> bool:
+        """Identity is delegated entirely to OIDC.
+
+        On such an instance the first SSO login IS the setup, so setup
+        mode must never unlock local signup, local login, or
+        unauthenticated configuration: that window is claimable by
+        whoever reaches the URL first (#456).
+        """
+        return bool(self.oidc.providers) and not self.local_auth_enabled
+
     break_glass_allowed_ips: list[str] = Field(
         default_factory=list,
         description="Optional CIDR ranges allowed to use break-glass local auth",

--- a/apps/api/src/sibyl/persistence/surreal/setup.py
+++ b/apps/api/src/sibyl/persistence/surreal/setup.py
@@ -9,10 +9,10 @@ from uuid import UUID
 from fastapi import HTTPException, status
 from starlette.requests import Request
 
+from sibyl import config as config_module
 from sibyl.auth.dependencies import build_auth_context
 from sibyl.auth.http import select_access_token
 from sibyl.auth.jwt import JwtError, verify_access_token
-from sibyl.config import settings
 from sibyl.persistence.setup_common import SetupStatus
 from sibyl.persistence.surreal.auth import (
     SurrealOrganizationRepository,
@@ -107,7 +107,7 @@ def _verify_token_claims(token: str) -> dict[str, object]:
 
 async def require_setup_mode_or_auth(request: Request) -> None:
     """Allow setup mode access, otherwise require a valid access token."""
-    if await is_setup_mode() and not settings.sso_only_instance:
+    if await is_setup_mode() and not config_module.settings.sso_only_instance:
         return
 
     token = _require_request_token(request)
@@ -116,7 +116,7 @@ async def require_setup_mode_or_auth(request: Request) -> None:
 
 async def require_setup_mode_or_admin(request: Request) -> AuthUser | None:
     """Allow setup mode access, otherwise require an authenticated global admin."""
-    if await is_setup_mode() and not settings.sso_only_instance:
+    if await is_setup_mode() and not config_module.settings.sso_only_instance:
         return None
 
     token = _require_request_token(request)
@@ -141,7 +141,7 @@ async def require_setup_mode_or_admin(request: Request) -> AuthUser | None:
 
 async def require_settings_admin(request: Request) -> None:
     """Allow setup-mode bootstrap access, otherwise require an org admin."""
-    if await is_setup_mode() and not settings.sso_only_instance:
+    if await is_setup_mode() and not config_module.settings.sso_only_instance:
         return
 
     ctx = await build_auth_context(request, None)

--- a/apps/api/src/sibyl/persistence/surreal/setup.py
+++ b/apps/api/src/sibyl/persistence/surreal/setup.py
@@ -12,6 +12,7 @@ from starlette.requests import Request
 from sibyl.auth.dependencies import build_auth_context
 from sibyl.auth.http import select_access_token
 from sibyl.auth.jwt import JwtError, verify_access_token
+from sibyl.config import settings
 from sibyl.persistence.setup_common import SetupStatus
 from sibyl.persistence.surreal.auth import (
     SurrealOrganizationRepository,
@@ -106,7 +107,7 @@ def _verify_token_claims(token: str) -> dict[str, object]:
 
 async def require_setup_mode_or_auth(request: Request) -> None:
     """Allow setup mode access, otherwise require a valid access token."""
-    if await is_setup_mode():
+    if await is_setup_mode() and not settings.sso_only_instance:
         return
 
     token = _require_request_token(request)
@@ -115,7 +116,7 @@ async def require_setup_mode_or_auth(request: Request) -> None:
 
 async def require_setup_mode_or_admin(request: Request) -> AuthUser | None:
     """Allow setup mode access, otherwise require an authenticated global admin."""
-    if await is_setup_mode():
+    if await is_setup_mode() and not settings.sso_only_instance:
         return None
 
     token = _require_request_token(request)
@@ -140,7 +141,7 @@ async def require_setup_mode_or_admin(request: Request) -> AuthUser | None:
 
 async def require_settings_admin(request: Request) -> None:
     """Allow setup-mode bootstrap access, otherwise require an org admin."""
-    if await is_setup_mode():
+    if await is_setup_mode() and not settings.sso_only_instance:
         return
 
     ctx = await build_auth_context(request, None)

--- a/apps/api/tests/test_sso_only_setup_gates.py
+++ b/apps/api/tests/test_sso_only_setup_gates.py
@@ -1,0 +1,117 @@
+"""Setup mode must not unlock local surfaces on SSO-only instances (#456).
+
+On a fresh OIDC-only deployment, the window between first boot and the
+first owner login was claimable: setup mode bypassed localAuthEnabled=false
+for signup and login, and served configuration endpoints unauthenticated.
+These tests pin the closed behavior: with providers configured and local
+auth disabled, setup mode changes nothing about what is reachable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from sibyl import config as config_module
+from sibyl.api.routes import auth as auth_routes
+from sibyl.config import OIDCProviderSettings
+from sibyl.persistence.surreal import setup as surreal_setup
+
+
+def _entra_provider() -> OIDCProviderSettings:
+    return OIDCProviderSettings(
+        name="entra",
+        issuer="https://login.microsoftonline.com/tenant/v2.0",
+        client_id="client-id",
+        client_secret_env="SIBYL_OIDC_ENTRA_CLIENT_SECRET",
+        organization_slug="gradial",
+    )
+
+
+@pytest.fixture
+def sso_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config_module.settings.oidc, "providers", [_entra_provider()])
+    monkeypatch.setattr(config_module.settings, "local_auth_enabled", False)
+    monkeypatch.setattr(config_module.settings, "break_glass_enabled", False)
+
+
+@pytest.fixture
+def local_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config_module.settings.oidc, "providers", [])
+    monkeypatch.setattr(config_module.settings, "local_auth_enabled", False)
+    monkeypatch.setattr(config_module.settings, "break_glass_enabled", False)
+
+
+def test_sso_only_instance_predicate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config_module.settings.oidc, "providers", [_entra_provider()])
+    monkeypatch.setattr(config_module.settings, "local_auth_enabled", False)
+    assert config_module.settings.sso_only_instance is True
+
+    monkeypatch.setattr(config_module.settings, "local_auth_enabled", True)
+    assert config_module.settings.sso_only_instance is False
+
+    monkeypatch.setattr(config_module.settings.oidc, "providers", [])
+    monkeypatch.setattr(config_module.settings, "local_auth_enabled", False)
+    assert config_module.settings.sso_only_instance is False
+
+
+@pytest.mark.asyncio
+async def test_local_auth_stays_closed_in_setup_mode_when_sso_only(
+    monkeypatch: pytest.MonkeyPatch,
+    sso_only: None,
+) -> None:
+    monkeypatch.setattr(auth_routes, "is_setup_mode", AsyncMock(return_value=True))
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_routes._require_local_auth_allowed(object())
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_local_auth_opens_in_setup_mode_without_sso(
+    monkeypatch: pytest.MonkeyPatch,
+    local_identity: None,
+) -> None:
+    monkeypatch.setattr(auth_routes, "is_setup_mode", AsyncMock(return_value=True))
+
+    assert await auth_routes._require_local_auth_allowed(object()) is None
+
+
+@pytest.mark.asyncio
+async def test_signup_stays_closed_in_setup_mode_when_sso_only(
+    monkeypatch: pytest.MonkeyPatch,
+    sso_only: None,
+) -> None:
+    monkeypatch.setattr(auth_routes, "is_setup_mode", AsyncMock(return_value=True))
+    monkeypatch.setattr(config_module.settings, "public_signups_enabled", False)
+    body = auth_routes.LocalSignupRequest(
+        email="claim@attacker.test", password="password-123456", name="First Claimer"
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_routes._require_signup_allowed(body=body)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_setup_gates_require_token_in_setup_mode_when_sso_only(
+    monkeypatch: pytest.MonkeyPatch,
+    sso_only: None,
+) -> None:
+    monkeypatch.setattr(surreal_setup, "is_setup_mode", AsyncMock(return_value=True))
+
+    class _BareRequest:
+        headers: dict[str, str] = {}
+        cookies: dict[str, str] = {}
+
+    with pytest.raises(HTTPException) as exc:
+        await surreal_setup.require_setup_mode_or_auth(_BareRequest())
+    assert exc.value.status_code == 401
+
+    with pytest.raises(HTTPException) as exc:
+        await surreal_setup.require_setup_mode_or_admin(_BareRequest())
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## 💡 What this is

Closes #456. A fresh OIDC-only deployment had a claimable window: until the first owner or admin membership existed, setup mode bypassed `localAuthEnabled=false` for local signup and login and served the setup configuration endpoints unauthenticated. The instance's own configuration said identity belongs to the provider, and the code overrode that exactly when it mattered most. The window now closes structurally: `settings.sso_only_instance` (providers configured + local auth off) gates every setup-mode bypass, and the first SSO login is the setup, which the JIT provisioning path already implements by creating the owner from the provider's role claim.

## 🎯 The invariant

On an SSO-only instance, setup mode changes nothing about what is reachable: local login 403s, signup 403s, and the setup/config endpoints demand real credentials, before and after the first owner exists. Break-glass remains the sanctioned recovery path since it demands an explicit expiry and IP allowlist.

## 🛠️ How it works

One predicate in `config.py` (`sso_only_instance`), consulted at all five bypass sites: `_require_local_auth_allowed` and `_require_signup_allowed` in the auth routes, and `require_setup_mode_or_auth` / `require_setup_mode_or_admin` / `require_settings_admin` in the setup persistence gates. `/setup/status` adds `sso_first_run` so web clients can send users to the provider login instead of the local wizard while the instance awaits its first owner (frontend adoption is a follow-up; the API field ships first).

## 🧪 Validation

- New contract suite (`test_sso_only_setup_gates.py`): predicate truth table, 403 for local login and signup during SSO-only setup mode, permissive behavior preserved when no provider is configured, 401 from both setup gates. Neighboring auth and setup suites unchanged. 58 passed across the three files; `ruff` clean.
- The live deployment that motivated this (Entra-only, IP-gated) had its window closed by the first owner login; this makes the closed state the default for every future SSO-only install.
- ⚠️ Cross-model review is quota-blocked until Sep 8; this ran the self-verified rung. Given the auth-sensitive surface, flagging explicitly: a second pair of eyes on the five gate sites before the next release cut is worth it even after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)