### PR TITLE
fix(api): take the capture fold backfill out of schema bootstrap

### DIFF
--- a/apps/api/tests/test_content_raw_capture_listing.py
+++ b/apps/api/tests/test_content_raw_capture_listing.py
@@ -12,7 +12,7 @@ from sibyl.persistence.content_common import RawCaptureRecord
 from sibyl.persistence.surreal import content as surreal_content
 from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
 from sibyl_core.backends.surreal.content_schema import (
-    CONTENT_RAW_CAPTURE_PROJECTION_FOLD_MIGRATION,
+    CONTENT_RAW_CAPTURE_PROJECTION_FOLD_BACKFILL,
 )
 
 
@@ -183,7 +183,7 @@ async def test_fold_composes_with_type_and_review_filters(content_client) -> Non
 
 
 @pytest.mark.asyncio
-async def test_projection_fold_migration_ignores_foreign_projections(content_client) -> None:
+async def test_projection_fold_backfill_ignores_foreign_projections(content_client) -> None:
     """A projection may not hide a raw row in another org or another principal."""
     org = uuid4()
     victim = _capture(org, title="mine", principal_id="owner")
@@ -203,7 +203,7 @@ async def test_projection_fold_migration_ignores_foreign_projections(content_cli
     )
     await _save(victim, foreign_org_projection, other_principal_projection)
 
-    await content_client.execute_query(CONTENT_RAW_CAPTURE_PROJECTION_FOLD_MIGRATION)
+    await content_client.execute_query(CONTENT_RAW_CAPTURE_PROJECTION_FOLD_BACKFILL)
 
     stored = await surreal_content.get_raw_capture(None, organization_id=org, capture_id=victim.id)
     assert stored is not None
@@ -213,7 +213,7 @@ async def test_projection_fold_migration_ignores_foreign_projections(content_cli
 
 
 @pytest.mark.asyncio
-async def test_projection_fold_migration_stamps_legacy_pairs(content_client) -> None:
+async def test_projection_fold_backfill_stamps_legacy_pairs(content_client) -> None:
     org = uuid4()
     raw = _capture(org)
     projected = _capture(
@@ -229,7 +229,7 @@ async def test_projection_fold_migration_stamps_legacy_pairs(content_client) -> 
     before, _ = await _list(org)
     assert {capture.id for capture in before} == {raw.id, projected.id, lone.id}
 
-    await content_client.execute_query(CONTENT_RAW_CAPTURE_PROJECTION_FOLD_MIGRATION)
+    await content_client.execute_query(CONTENT_RAW_CAPTURE_PROJECTION_FOLD_BACKFILL)
 
     after, _ = await _list(org)
     assert {capture.id for capture in after} == {projected.id, lone.id}

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -62,7 +62,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 26
+CONTENT_SCHEMA_CURRENT_VERSION = 25
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -587,10 +587,18 @@ CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS = "\n".join(
 )
 
 
+# Maintenance backfill, deliberately NOT in the migration list.
+#
 # Projected captures carry metadata.raw_memory_id; the raw rows they project
-# did not know about them, so listings showed both. Stamp every raw row that
-# already has a projection so the review queue can hide it with a plain
-# column predicate.
+# do not know about them, so a raw row written before the projection stamp
+# existed still lists alongside its projection. This statement stamps those
+# pairs so the review queue can hide them.
+#
+# It runs one UPDATE per projection row (22ms each against a live 3.x server,
+# so about 48s for 2,200 pairs) and holds the connection for the duration,
+# which is why schema bootstrap must never run it: an API start would block
+# on it and wedge the database for every other client. Run it deliberately
+# against a quiet instance instead.
 #
 # The stamp matches organization and principal, never the uuid alone:
 # raw_memory_id arrives in a client request body, so a capture in another
@@ -600,10 +608,8 @@ CONTENT_SCHEMAFULL_REPAIR_DEFINITIONS = "\n".join(
 # The rows go through LET and a coalesce rather than FOR over the SELECT
 # directly: SurrealDB 3.x rejects `FOR $x IN (SELECT ...)` with "Cannot
 # execute statement using value: NONE" whether or not the table has rows,
-# while the SDK-embedded engine the unit tests run on accepts it. Passed as
-# one statement on purpose, since the block carries its own semicolons and
-# must not go through split_statements.
-CONTENT_RAW_CAPTURE_PROJECTION_FOLD_MIGRATION = """
+# while the SDK-embedded engine accepts it.
+CONTENT_RAW_CAPTURE_PROJECTION_FOLD_BACKFILL = """
 LET $projections = (
     SELECT uuid, organization_id, principal_id, metadata.raw_memory_id AS raw_memory_id
     FROM raw_captures
@@ -776,11 +782,6 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             statements=tuple(
                 split_statements(CONTENT_SOURCE_IMPORT_REVISION_MIGRATION_DEFINITIONS)
             ),
-        ),
-        SchemaMigration(
-            version=26,
-            name="content_raw_capture_projection_fold",
-            statements=(CONTENT_RAW_CAPTURE_PROJECTION_FOLD_MIGRATION,),
         ),
     )
 


### PR DESCRIPTION
# 🚨 Schema bootstrap must not do O(n) writes

> Hotfix for PR #466. The API will not start against a populated database until this lands.

## 💡 What this is

Content schema migration 26 backfilled the capture-queue fold by stamping every existing raw memory that already had a projection. It does that one UPDATE per pair. On a real database that is 2,202 updates at roughly 22ms each, run inside schema bootstrap while holding the connection, so an API start blocks for the best part of a minute and SurrealDB stops answering everyone else. The observed symptom is startup stopping dead at:

```
api | Bootstrapping Surreal content schema target_version=26
```

## 🤔 Why the migration was the wrong home for it

A schema migration runs on every API start against every database, and it is the one code path that must stay O(1) in row count. A data backfill proportional to table size does not belong there no matter how it is written. My live rehearsal measured the statement inside `BEGIN`/`CANCEL TRANSACTION`, which reports cancelled statuses for every statement and so measured nothing, and the embedded test engine has 3 rows rather than 4,756. Both hid the cost.

## 🛠️ What changes

- The statement leaves `_content_schema_migrations` and `CONTENT_SCHEMA_CURRENT_VERSION` returns to 25.
- The SQL survives as `CONTENT_RAW_CAPTURE_PROJECTION_FOLD_BACKFILL` with its measured cost in the comment, to be run deliberately against a quiet instance.
- Tests that exercised it keep doing so, under the new name.

## 🎯 What still works

`archive_raw_capture` stamps the raw row as it archives a projection, so the queue stops accumulating duplicates from here. Pairs written before that shipped list twice until someone runs the backfill, which is exactly the state the queue was in before any of this work started. No data written by the fold is lost: nothing was stamped on the wedged instance (`already stamped: 0`).

## 🧪 Validation

- `pytest tests/test_content_raw_capture_listing.py` → 7 passed, including both backfill tests against the embedded engine.
- `moon run core:test -k schema` → 134 passed.
- `SIBYL_LIVE_SURREAL_TESTS=1 pytest tests/test_surreal_live_runtime.py` against the live 3.x server → 9 passed.
- Measured against the live database before the fix: 2,202 projection rows to iterate, 22ms per no-op UPDATE of the migration's exact shape, content `schema_version` still 25 and 0 rows stamped, so the migration never completed once.

## 📌 Follow-up

Run the backfill once against a quiet instance, or give it a `sibyld` maintenance subcommand so it is batched, resumable, and cancellable. Until then the fold applies to new writes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9cAKv7RejZPXK4vkLmhs