### PR TITLE
docs(memory): explain capture deduplication during upgrades

### DIFF
--- a/docs/guide/memory-workspace.md
+++ b/docs/guide/memory-workspace.md
@@ -41,6 +41,16 @@ This is the human half of the reflection workflow. The
 [dream-cycle](./memory-loop.md#the-reflection-dream-cycle) handles automatic review; the captures
 surface handles the judgment calls.
 
+Starting with 1.3.2, a newly projected memory appears once in the capture queue. Sibyl keeps the
+verbatim raw memory and its projection, but hides the raw row after recording their relationship.
+
+Existing raw memory and projection pairs can still appear twice after an upgrade. Startup does not
+backfill those pairs: the operation scales with stored captures and can delay readiness and other
+database clients. Operators can schedule the optional `CONTENT_RAW_CAPTURE_PROJECTION_FOLD_BACKFILL`
+operation from `sibyl_core.backends.surreal.content_schema` during a quiet maintenance window. The
+backfill marks matching pairs for the same organization and principal without deleting either
+record.
+
 ## Imports
 
 The imports surface tracks [source import](./sources.md#source-import) jobs. Source import ingests


### PR DESCRIPTION
## 💡 Capture queue behavior after an upgrade

The memory workspace guide now explains that 1.3.2 folds newly projected captures into one visible entry while preserving both stored records. Historical pairs can remain visible twice until an operator runs the optional backfill.

The guide names the backfill operation, its organization/principal matching, and why it stays out of startup. The change affects documentation only.

## 🧪 Validation

- `moon run docs:lint docs:build` passed.
- The prose scan reported no hard failures or candidates.
- The documented behavior was checked against the capture backfill SQL and the startup migration list.
