### PR TITLE
fix(cli): bind automation credentials to their API URL

### DIFF
--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -1,7 +1,5 @@
 """Public HTTP client contract for the Sibyl CLI."""
 
-import os
-
 import httpx
 
 from sibyl_cli.auth_store import normalize_api_url
@@ -25,6 +23,7 @@ from sibyl_cli.client_transport import (
     SibylClientError,
     _auth_credential_scope,
     _auth_replay_scope,
+    _environment_auth_token,
     _is_read_like_post,
     _is_refresh_revoked,
     _load_default_auth_token,
@@ -93,7 +92,7 @@ class SibylClient(
         )
         self.timeout = timeout
         self._uses_stored_auth = (
-            auth_token is None and not os.environ.get("SIBYL_AUTH_TOKEN", "").strip()
+            auth_token is None and _environment_auth_token(self.base_url) is None
         )
         self.auth_token = (
             auth_token
@@ -140,10 +139,15 @@ def get_client(context_name: str | None = None) -> SibylClient:
     global _clients
 
     # Resolve the effective context when one isn't explicitly provided.
-    if context_name is None and _paired_automation_api_url() is None:
+    if context_name is None:
         from sibyl_cli import config_store
+        from sibyl_cli.state import get_context_override
 
-        context_name = config_store.resolve_context_name()
+        context_name = (
+            get_context_override()
+            if _paired_automation_api_url()
+            else config_store.resolve_context_name()
+        )
 
     cache_key = context_name
 

--- a/apps/cli/src/sibyl_cli/client_transport.py
+++ b/apps/cli/src/sibyl_cli/client_transport.py
@@ -16,6 +16,7 @@ from sibyl_cli.auth_store import (
     credential_scope,
     get_access_token,
     is_access_token_expired,
+    normalize_api_url,
     read_server_credentials,
 )
 from sibyl_cli.pending_writes import (
@@ -128,6 +129,17 @@ def _auth_credential_scope(context_name: str | None = None) -> str | None:
     return credential_scope(ctx.name, ctx.org_slug)
 
 
+def _environment_auth_token(api_base_url: str) -> str | None:
+    """Keep a paired automation credential bound to its selected API URL."""
+    token = os.environ.get("SIBYL_AUTH_TOKEN", "").strip()
+    if not token:
+        return None
+    paired_url = _paired_automation_api_url()
+    if paired_url and normalize_api_url(paired_url) != normalize_api_url(api_base_url):
+        return None
+    return token
+
+
 def _load_default_auth_token(
     api_base_url: str,
     credential_scope_name: str | None = None,
@@ -135,11 +147,10 @@ def _load_default_auth_token(
     """Load auth token for the given API URL.
 
     Priority:
-    1. SIBYL_AUTH_TOKEN environment variable
+    1. SIBYL_AUTH_TOKEN when its paired URL matches (or no URL is provided)
     2. Stored access token for the specific server
     """
-    env_token = os.environ.get("SIBYL_AUTH_TOKEN", "").strip()
-    if env_token:
+    if env_token := _environment_auth_token(api_base_url):
         return env_token
 
     return get_access_token(api_base_url, credential_scope=credential_scope_name)
@@ -241,7 +252,7 @@ def _load_default_replay_scope(
     credential_scope_name: str | None,
     auth_token: str | None,
 ) -> str | None:
-    if os.environ.get("SIBYL_AUTH_TOKEN", "").strip():
+    if _environment_auth_token(api_base_url):
         return _auth_replay_scope(None, auth_token)
     stored_credentials = read_server_credentials(
         api_base_url,

--- a/apps/cli/tests/conftest.py
+++ b/apps/cli/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Keep CLI tests independent of the invoking shell's server credentials."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_cli_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for variable in ("SIBYL_API_URL", "SIBYL_AUTH_TOKEN", "SIBYL_CONTEXT"):
+        monkeypatch.delenv(variable, raising=False)

--- a/apps/cli/tests/test_auth_login.py
+++ b/apps/cli/tests/test_auth_login.py
@@ -466,6 +466,76 @@ def test_paired_automation_url_and_token_override_the_interactive_context(
         clear_client_cache()
 
 
+@pytest.mark.parametrize("selection", ["context", "base_url", "environment", "flag"])
+@pytest.mark.parametrize("stored", [True, False])
+def test_foreign_automation_credentials_do_not_follow_an_explicit_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+    stored: bool,
+) -> None:
+    from sibyl_cli import state
+
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(state, "_context_override", None)
+    monkeypatch.setattr(state, "_ignore_selection", False)
+    monkeypatch.delenv("SIBYL_CONTEXT", raising=False)
+    config_store.create_context("prod", "https://sibyl.example.com", org_slug="acme")
+    monkeypatch.setenv("SIBYL_API_URL", "http://localhost:3344/api")
+    monkeypatch.setenv("SIBYL_AUTH_TOKEN", "automation-token")
+    scope = None if selection == "base_url" else "context:prod:org:acme"
+    if stored:
+        auth_store.set_tokens(
+            "https://sibyl.example.com/api",
+            "prod-token",
+            refresh_token="prod-refresh",
+            expires_in=3600,
+            credential_scope=scope,
+            pending_replay_scope="credential:prod",
+        )
+
+    clear_client_cache()
+    try:
+        if selection == "context":
+            client = SibylClient(context_name="prod")
+        elif selection == "base_url":
+            client = SibylClient(base_url="https://sibyl.example.com/api")
+        else:
+            if selection == "environment":
+                monkeypatch.setenv("SIBYL_CONTEXT", "prod")
+            else:
+                monkeypatch.setattr(state, "_context_override", "prod")
+            client = get_client()
+        assert client.base_url == "https://sibyl.example.com/api"
+        assert client._default_headers().get("Authorization") == (
+            "Bearer prod-token" if stored else None
+        )
+        assert client._uses_stored_auth is True
+        assert client._replay_scope == ("credential:prod" if stored else None)
+    finally:
+        clear_client_cache()
+
+
+@pytest.mark.parametrize("paired_url", [None, "https://sibyl.example.com/api/"])
+def test_matching_or_unpaired_environment_token_remains_explicit_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    paired_url: str | None,
+) -> None:
+    monkeypatch.setattr(config_store.Path, "home", lambda: tmp_path)
+    config_store.create_context("prod", "https://sibyl.example.com", org_slug="acme")
+    monkeypatch.setenv("SIBYL_AUTH_TOKEN", "automation-token")
+    if paired_url:
+        monkeypatch.setenv("SIBYL_API_URL", paired_url)
+    else:
+        monkeypatch.delenv("SIBYL_API_URL", raising=False)
+
+    client = SibylClient(context_name="prod")
+
+    assert client._default_headers()["Authorization"] == "Bearer automation-token"
+    assert client._uses_stored_auth is False
+
+
 def test_auth_commands_follow_the_context_override_like_the_client(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/cli/tests/test_client_auth_refresh.py
+++ b/apps/cli/tests/test_client_auth_refresh.py
@@ -163,6 +163,7 @@ async def test_silent_local_relogin_refuses_an_unscoped_organization(
 async def test_environment_token_ignores_expired_stored_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delenv("SIBYL_API_URL", raising=False)
     monkeypatch.setenv("SIBYL_AUTH_TOKEN", "automation-token")
 
     def unexpected_stored_expiry_check(*_args: object, **_kwargs: object) -> bool:

--- a/apps/cli/tests/test_client_errors.py
+++ b/apps/cli/tests/test_client_errors.py
@@ -387,6 +387,7 @@ async def test_environment_token_scope_overrides_active_context_scope(
 ) -> None:
     monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
     monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+    monkeypatch.delenv("SIBYL_API_URL", raising=False)
     monkeypatch.setenv("SIBYL_AUTH_TOKEN", "automation-token")
     monkeypatch.setattr(
         client_module,

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -163,11 +163,11 @@ sibyl task list --csv > tasks.csv            # CSV export
 
 ## Environment Variables
 
-| Variable             | Description                       | Example                     |
-| -------------------- | --------------------------------- | --------------------------- |
-| `SIBYL_CONTEXT`      | Named context (server/org bundle) | `prod`                      |
-| `SIBYL_API_URL`      | Server URL (legacy)               | `http://localhost:3334/api` |
-| `SIBYL_ACCESS_TOKEN` | Auth token (rarely needed)        | `eyJhbG...`                 |
+| Variable           | Description                       | Example                     |
+| ------------------ | --------------------------------- | --------------------------- |
+| `SIBYL_CONTEXT`    | Named context (server/org bundle) | `prod`                      |
+| `SIBYL_API_URL`    | Server URL (legacy)               | `http://localhost:3334/api` |
+| `SIBYL_AUTH_TOKEN` | Auth token (rarely needed)        | `eyJhbG...`                 |
 
 `SIBYL_CONTEXT` names a context created with `sibyl config context create`, not a project ID. A name
 with no matching context is a hard error: the command stops instead of quietly running against the

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -174,15 +174,27 @@ with no matching context is a hard error: the command stops instead of quietly r
 active context, so a typo in a CI variable can never write to the wrong server. Scope a command to a
 project with `--project` instead.
 
-`SIBYL_API_URL` is a legacy fallback, not an override. Server selection resolves in this order, and
-`sibyl auth login` follows the same order as every other command so a login always writes its token
-under the server key the next command reads:
+API commands select their server in this order:
 
 1. An explicit server argument (`sibyl auth login https://...`, `--server`)
-2. The selected context (`--context` / `-C`, `SIBYL_CONTEXT`, directory pin, active context)
-3. `SIBYL_API_URL`
-4. `[server] url` in the legacy config file
-5. `http://localhost:3334/api`
+2. An explicit context (`--context` / `-C` or `SIBYL_CONTEXT`)
+3. A paired `SIBYL_API_URL` and `SIBYL_AUTH_TOKEN` automation environment
+4. The directory-pinned context, then the active context
+5. `SIBYL_API_URL` without a paired token
+6. `[server] url` in the legacy config file
+7. `http://localhost:3334/api`
+
+Authentication commands use the selected context (including a directory pin or the active context)
+unless an explicit server is supplied. Specify the server when logging into an automation target.
+
+A paired environment token is used only for its API URL. Selecting a different server uses that
+server's stored credentials; a missing login never falls back to the other server's token.
+A standalone `SIBYL_AUTH_TOKEN` without `SIBYL_API_URL` applies to the selected server.
+
+For parallel work, select each command's context with `sibyl -C <name> ...` rather than switching
+the shared active context. CLI processes coordinate token refresh through the credential file lock.
+Authenticate browser automation independently: copying the CLI's rotating refresh token into a
+browser cookie lets browser refresh invalidate the CLI's saved token.
 
 ## Configuration
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -188,8 +188,8 @@ Authentication commands use the selected context (including a directory pin or t
 unless an explicit server is supplied. Specify the server when logging into an automation target.
 
 A paired environment token is used only for its API URL. Selecting a different server uses that
-server's stored credentials; a missing login never falls back to the other server's token.
-A standalone `SIBYL_AUTH_TOKEN` without `SIBYL_API_URL` applies to the selected server.
+server's stored credentials; a missing login never falls back to the other server's token. A
+standalone `SIBYL_AUTH_TOKEN` without `SIBYL_API_URL` applies to the selected server.
 
 For parallel work, select each command's context with `sibyl -C <name> ...` rather than switching
 the shared active context. CLI processes coordinate token refresh through the credential file lock.

--- a/tools/showcase/seed.py
+++ b/tools/showcase/seed.py
@@ -19,6 +19,7 @@ import httpx
 
 from sibyl_cli import config_store
 from sibyl_cli.client import SibylClient, SibylClientError
+from sibyl_cli.client_transport import _environment_auth_token
 from tools.baselines.common import api_base_url, auth_headers, emit
 from tools.showcase.fixtures import (
     KNOWLEDGE,
@@ -136,8 +137,7 @@ def validate_fixture(terms: Iterable[str]) -> None:
 async def active_cli_token(base_url: str) -> str:
     """Load the active local CLI token without printing or persisting it elsewhere."""
     api_url = api_base_url(base_url)
-    env_token = os.getenv("SIBYL_AUTH_TOKEN", "").strip()
-    if env_token:
+    if env_token := _environment_auth_token(api_url):
         return env_token
 
     context = config_store.resolve_effective_context()

--- a/tools/tests/test_showcase.py
+++ b/tools/tests/test_showcase.py
@@ -30,6 +30,8 @@ from tools.showcase.seed import (
     validate_fixture,
 )
 
+from sibyl_cli import auth_store
+
 TEST_FORBIDDEN_TERMS = ("blocked alpha", "blocked beta", "blocked gamma")
 
 
@@ -287,8 +289,6 @@ async def test_showcase_never_borrows_a_foreign_environment_credential(
 async def test_showcase_uses_its_stored_login_when_environment_targets_another_server(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from sibyl_cli import auth_store
-
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("SIBYL_AUTH_TOKEN", "synthetic-foreign-token")
     monkeypatch.setenv("SIBYL_API_URL", "http://localhost:3334/api")

--- a/tools/tests/test_showcase.py
+++ b/tools/tests/test_showcase.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
+from tools.showcase import seed
 from tools.showcase.fixtures import (
     KNOWLEDGE,
     PROJECTS,
@@ -253,3 +255,50 @@ def test_idempotency_keys_are_deterministic_and_payload_bound() -> None:
 
     assert first == _idempotency_key("task", {"name": "One"})
     assert first != _idempotency_key("task", {"name": "Two"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("paired_url", [None, "http://localhost:3434/api/"])
+async def test_showcase_accepts_matching_or_unpaired_environment_credentials(
+    monkeypatch: pytest.MonkeyPatch, paired_url: str | None
+) -> None:
+    monkeypatch.setenv("SIBYL_AUTH_TOKEN", "synthetic-showcase-token")
+    if paired_url:
+        monkeypatch.setenv("SIBYL_API_URL", paired_url)
+    else:
+        monkeypatch.delenv("SIBYL_API_URL", raising=False)
+
+    assert await seed.active_cli_token("http://localhost:3434") == "synthetic-showcase-token"
+
+
+@pytest.mark.asyncio
+async def test_showcase_never_borrows_a_foreign_environment_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SIBYL_AUTH_TOKEN", "synthetic-foreign-token")
+    monkeypatch.setenv("SIBYL_API_URL", "http://localhost:3334/api")
+    monkeypatch.setattr(seed.config_store, "resolve_effective_context", lambda: None)
+
+    with pytest.raises(ShowcaseSafetyError, match="No active Sibyl CLI context"):
+        await seed.active_cli_token("http://localhost:3434")
+
+
+@pytest.mark.asyncio
+async def test_showcase_uses_its_stored_login_when_environment_targets_another_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sibyl_cli import auth_store
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("SIBYL_AUTH_TOKEN", "synthetic-foreign-token")
+    monkeypatch.setenv("SIBYL_API_URL", "http://localhost:3334/api")
+    context = seed.config_store.create_context("showcase", "http://localhost:3434")
+    monkeypatch.setattr(seed.config_store, "resolve_effective_context", lambda: context)
+    monkeypatch.setattr(seed.SibylClient, "list_orgs", AsyncMock(return_value=[]))
+    auth_store.set_tokens(
+        "http://localhost:3434/api",
+        "synthetic-stored-token",
+        credential_scope="context:showcase:org:default",
+    )
+
+    assert await seed.active_cli_token("http://localhost:3434") == "synthetic-stored-token"


### PR DESCRIPTION
## 🛡️ Keep automation credentials on their server

An explicit client context could select a different API server while retaining `SIBYL_AUTH_TOKEN` from a paired automation environment. A command-level context override could also be ignored whenever that environment pair was present. For example, selecting production while a local automation URL and token are set must use production's stored credentials, never the local token.

The client now accepts a paired environment token only when its normalized API URL matches the selected destination. Stored-token refresh and buffered-write ownership use the same decision. Explicit command context overrides take precedence over the automation pair; the pair still outranks an implicit active context. URL-only environment behavior and standalone environment tokens retain their existing semantics.

The showcase seed helper uses the same URL-bound credential check. The CLI guide documents server precedence, the authentication-command exception, and separate browser sessions for automation.

## 🎯 Review anchor

A token paired with one API URL must never appear in the Authorization header for another API URL. Review the shared `_environment_auth_token` check in `client_transport.py` and context selection in `client.py`. Missing target credentials produce an unauthenticated client, so the foreign token cannot become a fallback.

## 🧪 Validation

- The eight foreign-credential regression cases fail against the original source and pass with the fix. Cases cover explicit client contexts, direct base URLs, command context overrides, and `SIBYL_CONTEXT`, each with and without stored target credentials.
- The full CLI suite (`moon run cli:test --force`) passes all 639 tests in a clean environment and all 639 with a synthetic foreign API URL, auth token, and context exported. An autouse fixture isolates each test from the invoking shell.
- CLI lint and typecheck (`moon run cli:lint cli:typecheck`) pass.
- The showcase suite (`moon run root:showcase-test --force`) passes 31 tests, including paired-token rejection and fallback to the matching stored login.
- The two standalone-token CLI cases pass with an exported foreign `SIBYL_API_URL`.
- Tooling lint/typecheck (`moon run root:inventory-lint root:inventory-typecheck --force`) and documentation formatting (`moon run docs:lint --force`) pass.

Tests use isolated temporary configuration and synthetic credentials. The change affects CLI target selection and credential lookup in the CLI and showcase seed helper. Browser session rotation remains a separate authentication flow.



