### PR TITLE
fix(cli): recover pending writes across authenticated logins

### DIFF
--- a/apps/api/src/sibyl/api/decorators.py
+++ b/apps/api/src/sibyl/api/decorators.py
@@ -20,6 +20,7 @@ from typing import ParamSpec, TypeVar
 import structlog
 from fastapi import HTTPException
 
+from sibyl.api.errors import entity_locked
 from sibyl.coordination.locks import LockAcquisitionError
 from sibyl_core.errors import EntityNotFoundError, InvalidTransitionError, RevisionConflictError
 
@@ -71,10 +72,7 @@ def handle_workflow_errors(
                 raise HTTPException(status_code=400, detail=str(e)) from e
 
             except LockAcquisitionError as e:
-                raise HTTPException(
-                    status_code=409,
-                    detail="Work item is locked by another process. Please retry.",
-                ) from e
+                raise entity_locked() from e
 
             except RevisionConflictError as e:
                 raise HTTPException(status_code=409, detail=e.details) from e

--- a/apps/api/src/sibyl/api/errors.py
+++ b/apps/api/src/sibyl/api/errors.py
@@ -152,6 +152,17 @@ def conflict(message: str | None = None) -> HTTPException:
     return HTTPException(status_code=409, detail=message or CONFLICT_ERROR)
 
 
+def entity_locked() -> HTTPException:
+    """Report transient write contention separately from semantic conflicts."""
+    return HTTPException(
+        status_code=409,
+        detail={
+            "error": "entity_locked",
+            "message": "The resource is being modified by another request. Retry the request.",
+        },
+    )
+
+
 def unauthorized(message: str | None = None) -> HTTPException:
     """Create a 401 exception for auth failures.
 

--- a/apps/api/src/sibyl/api/idempotency.py
+++ b/apps/api/src/sibyl/api/idempotency.py
@@ -289,7 +289,10 @@ def serialize_idempotent_request[**P, R](
         except LockAcquisitionError as exc:
             raise HTTPException(
                 status_code=409,
-                detail="An identical idempotent request is still in progress. Please retry.",
+                detail={
+                    "error": "idempotency_in_progress",
+                    "message": "An identical idempotent request is still in progress. Please retry.",
+                },
             ) from exc
 
     return wrapper

--- a/apps/api/src/sibyl/api/routes/auth.py
+++ b/apps/api/src/sibyl/api/routes/auth.py
@@ -45,6 +45,7 @@ from sibyl.persistence.auth_runtime import (
     deny_device_authorization,
     exchange_device_code,
     get_device_request_by_user_code,
+    get_server_instance_id,
     get_user_by_id,
     list_api_keys_for_user,
     log_audit_event,
@@ -1774,6 +1775,31 @@ async def revoke_api_key(
         request=request,
     )
     return {"success": True, "id": str(api_key_id)}
+
+
+@router.get("/replay-identity")
+async def replay_identity(ctx: AuthContext = Depends(get_auth_context)):
+    """Identify a durable write owner without exposing session credentials."""
+    if ctx.organization is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No organization context")
+
+    def optional_sorted(values: frozenset[str] | None) -> list[str] | None:
+        return sorted(values) if values is not None else None
+
+    return {
+        "version": 1,
+        "server_instance_id": await get_server_instance_id(),
+        "user_id": str(ctx.user.id),
+        "organization_id": str(ctx.organization.id),
+        "credential": {
+            "kind": "api_key" if ctx.api_key_id else "session",
+            "api_key_id": ctx.api_key_id,
+            "scopes": sorted(ctx.scopes),
+            "project_ids": optional_sorted(ctx.api_key_project_ids),
+            "memory_space_ids": optional_sorted(ctx.api_key_memory_space_ids),
+            "memory_scope_keys": optional_sorted(ctx.api_key_memory_scope_keys),
+        },
+    }
 
 
 @router.get("/me")

--- a/apps/api/src/sibyl/api/routes/entity_mutations.py
+++ b/apps/api/src/sibyl/api/routes/entity_mutations.py
@@ -7,7 +7,12 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from sibyl.api.decorators import handle_workflow_errors
-from sibyl.api.errors import constraint_violation, sanitize_error_text, unprocessable_entity
+from sibyl.api.errors import (
+    constraint_violation,
+    entity_locked,
+    sanitize_error_text,
+    unprocessable_entity,
+)
 from sibyl.api.event_types import WSEvent
 from sibyl.api.idempotency import (
     replay_idempotent_response,
@@ -448,10 +453,7 @@ async def update_entity(
         # Acquire distributed lock to prevent concurrent updates
         async with entity_lock(group_id, entity_id, blocking=True) as lock_token:
             if not lock_token:
-                raise HTTPException(
-                    status_code=409,
-                    detail="Entity is being updated by another process. Please retry.",
-                )
+                raise entity_locked()
 
             runtime = await policy.get_entity_graph_runtime(group_id)
 
@@ -622,10 +624,7 @@ async def update_entity(
             return response
 
     except LockAcquisitionError as e:
-        raise HTTPException(
-            status_code=409,
-            detail="Entity is locked by another process. Please retry.",
-        ) from e
+        raise entity_locked() from e
     except HTTPException:
         raise
     except Exception as e:
@@ -656,10 +655,7 @@ async def delete_entity(
         # Acquire distributed lock to prevent concurrent modifications
         async with entity_lock(group_id, entity_id, blocking=True) as lock_token:
             if not lock_token:
-                raise HTTPException(
-                    status_code=409,
-                    detail="Entity is being modified by another process. Please retry.",
-                )
+                raise entity_locked()
 
             runtime = await policy.get_entity_graph_runtime(group_id)
 
@@ -743,10 +739,7 @@ async def delete_entity(
             )
 
     except LockAcquisitionError as e:
-        raise HTTPException(
-            status_code=409,
-            detail="Entity is locked by another process. Please retry.",
-        ) from e
+        raise entity_locked() from e
     except HTTPException:
         raise
     except Exception as e:

--- a/apps/api/src/sibyl/api/routes/experience.py
+++ b/apps/api/src/sibyl/api/routes/experience.py
@@ -5,6 +5,7 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from sibyl.api.errors import entity_locked
 from sibyl.api.schemas import (
     OperationalExperienceCaptureRequest,
     OperationalExperienceCaptureResponse,
@@ -73,10 +74,7 @@ async def capture_operational_experience(
     try:
         async with entity_lock(group_id, manifest_id, blocking=True) as lock_token:
             if not lock_token:
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail="Operational experience is being modified; retry the request",
-                )
+                raise entity_locked()
             runtime = await get_experience_graph_runtime(group_id)
             try:
                 existing_manifest = await runtime.entity_manager.get(manifest_id)
@@ -186,10 +184,7 @@ async def capture_operational_experience(
                         error=str(exc),
                     )
     except LockAcquisitionError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Operational experience is locked; retry the request",
-        ) from exc
+        raise entity_locked() from exc
 
     return OperationalExperienceCaptureResponse(
         source_id=experience.source_id,

--- a/apps/api/src/sibyl/api/routes/tasks.py
+++ b/apps/api/src/sibyl/api/routes/tasks.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from sibyl.api.decorators import handle_workflow_errors
+from sibyl.api.errors import entity_locked
 from sibyl.api.event_types import WSEvent
 from sibyl.api.idempotency import (
     mutation_receipt,
@@ -884,10 +885,7 @@ async def update_task(
     try:
         async with entity_lock(group_id, task_id, blocking=True) as lock_token:
             if not lock_token:
-                raise HTTPException(
-                    status_code=409,
-                    detail="Task is being updated by another process. Please retry.",
-                )
+                raise entity_locked()
 
             runtime = await get_task_graph_runtime(group_id)
 
@@ -970,10 +968,7 @@ async def update_task(
             return response
 
     except LockAcquisitionError as e:
-        raise HTTPException(
-            status_code=409,
-            detail="Task is locked by another process. Please retry.",
-        ) from e
+        raise entity_locked() from e
     except HTTPException:
         raise
     except RevisionConflictError as e:

--- a/apps/api/src/sibyl/auth/dependencies.py
+++ b/apps/api/src/sibyl/auth/dependencies.py
@@ -17,6 +17,7 @@ from sibyl.persistence.auth_runtime import (
     InvalidAuthClaimsError,
     UserNotFoundError,
     authenticate_api_key,
+    get_server_instance_id,
     get_user_by_id,
     resolve_auth_context,
     validate_access_session,
@@ -208,6 +209,24 @@ def require_org_role(*allowed: OrganizationRole):
     return _check_role
 
 
+async def _validate_replay_server_instance(request: Request) -> None:
+    expected = request.headers.get("X-Sibyl-Server-Instance")
+    if expected is None or request.method.upper() in _SAFE_HTTP_METHODS:
+        return
+    if getattr(request.state, "replay_server_instance_validated", False):
+        return
+    if expected != await get_server_instance_id():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "replay_identity_mismatch",
+                "message": "The server data instance changed. The write was not applied.",
+                "remediation": "Verify the destination before recovering this pending write.",
+            },
+        )
+    request.state.replay_server_instance_validated = True
+
+
 async def build_auth_context(
     request: Request,
     session=None,
@@ -220,6 +239,7 @@ async def build_auth_context(
     if session is None:
         cached = getattr(request.state, "auth_context", None)
         if cached is not None:
+            await _validate_replay_server_instance(request)
             return cached
 
     claims = await resolve_claims(request)
@@ -238,6 +258,7 @@ async def build_auth_context(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
         ) from e
+    await _validate_replay_server_instance(request)
     organization = getattr(ctx, "organization", None)
     set_llm_budget_context(
         user_id=str(ctx.user.id),

--- a/apps/api/src/sibyl/auth/dependencies.py
+++ b/apps/api/src/sibyl/auth/dependencies.py
@@ -158,6 +158,7 @@ async def get_current_user(
     cached_ctx = getattr(request.state, "auth_context", None)
     cached_user = getattr(cached_ctx, "user", None)
     if getattr(cached_user, "id", None) == user_id:
+        await _validate_replay_server_instance(request)
         return cast("AuthUser", cached_user)
 
     if cached_ctx is not None:
@@ -175,6 +176,7 @@ async def get_current_user(
         ) from e
     if user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    await _validate_replay_server_instance(request)
     return user
 
 

--- a/apps/api/src/sibyl/persistence/auth_archive.py
+++ b/apps/api/src/sibyl/persistence/auth_archive.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import structlog
 
@@ -473,10 +473,16 @@ async def _export_surreal_auth_archive_payload(
     organization_id: str | UUID | None = None,
 ) -> dict[str, object]:
     client = build_surreal_auth_client()
+    server_instance_id = None
 
     try:
         if organization_id is None:
             tables = await _export_all_auth_tables(client)
+            identity_rows = _normalize_records(
+                await client.execute_query("SELECT instance_id FROM server_identity:singleton;")
+            )
+            if identity_rows:
+                server_instance_id = str(UUID(str(identity_rows[0].get("instance_id"))))
         else:
             tables = await _export_org_auth_tables(client, str(organization_id))
     finally:
@@ -487,6 +493,7 @@ async def _export_surreal_auth_archive_payload(
         "version": AUTH_ARCHIVE_VERSION,
         "created_at": datetime.now(UTC).isoformat(),
         "organization_id": str(organization_id) if organization_id is not None else None,
+        **({"server_instance_id": server_instance_id} if server_instance_id else {}),
         "tables": tables,
         "row_counts": row_counts,
         "total_rows": sum(row_counts.values()),
@@ -552,6 +559,11 @@ async def restore_auth_archive_payload(
     organization_id = str(payload_org_id).strip() if payload_org_id is not None else None
     if organization_id == "":
         organization_id = None
+    # Only a full replacement restores data lineage. Org restores and merges
+    # retain the destination identity because they retain other destination data.
+    source_instance_id = None
+    if clean and organization_id is None and payload.get("server_instance_id") is not None:
+        source_instance_id = str(UUID(str(payload["server_instance_id"])))
 
     client = build_surreal_auth_client()
     tables_restored = 0
@@ -562,6 +574,14 @@ async def restore_auth_archive_payload(
     try:
         await bootstrap_auth_schema(client, reset=False)
         if clean:
+            if organization_id is None:
+                # Invalidate the prior destination before any data is removed.
+                # A failed or legacy restore must not inherit its replay owner.
+                identity_result = await client.execute_query(
+                    "UPSERT server_identity:singleton SET instance_id = $instance_id;",
+                    instance_id=str(uuid4()),
+                )
+                _raise_on_error(identity_result, query="restore_auth_archive_payload:new_identity")
             await _clean_auth_archive_rows(client, organization_id)
 
         for table in AUTH_ARCHIVE_TABLES:
@@ -595,6 +615,12 @@ async def restore_auth_archive_payload(
                     errors.append(f"{table}:{uuid}: {exc}")
             if restored_table:
                 tables_restored += 1
+        if not errors and source_instance_id is not None:
+            identity_result = await client.execute_query(
+                "UPSERT server_identity:singleton SET instance_id = $instance_id;",
+                instance_id=source_instance_id,
+            )
+            _raise_on_error(identity_result, query="restore_auth_archive_payload:identity")
         if dropped_fields:
             log.warning(
                 "auth_archive_restore_dropped_undeclared_fields",

--- a/apps/api/src/sibyl/persistence/auth_runtime.py
+++ b/apps/api/src/sibyl/persistence/auth_runtime.py
@@ -30,6 +30,7 @@ from sibyl.persistence.surreal.auth_runtime import (
     get_memory_space,
     get_project_record_by_graph_id,
     get_project_record_by_id,
+    get_server_instance_id,
     get_team_record,
     get_user_by_id,
     has_owner_membership,
@@ -81,6 +82,7 @@ from sibyl.persistence.surreal.auth_runtime import (
 )
 
 __all__ = [
+    "get_server_instance_id",
     "AuthContextResolver",
     "InvalidAuthClaimsError",
     "OrganizationMembershipRepository",

--- a/apps/api/src/sibyl/persistence/surreal/auth_runtime/__init__.py
+++ b/apps/api/src/sibyl/persistence/surreal/auth_runtime/__init__.py
@@ -36,6 +36,7 @@ from sibyl.persistence.surreal.auth_runtime._common import (
     _SurrealRepository,  # noqa: F401
     _utcnow,  # noqa: F401
     config_module,  # noqa: F401
+    get_server_instance_id,
 )
 from sibyl.persistence.surreal.auth_runtime.api_keys import (
     authenticate_api_key,
@@ -130,6 +131,7 @@ from sibyl.persistence.surreal.auth_runtime.users import (
 )
 
 __all__ = [
+    "get_server_instance_id",
     "AuthContextResolver",
     "DeviceBrowserLogin",
     "IssuedAuthSession",

--- a/apps/api/src/sibyl/persistence/surreal/auth_runtime/_common.py
+++ b/apps/api/src/sibyl/persistence/surreal/auth_runtime/_common.py
@@ -476,6 +476,17 @@ async def _auth_client_scope() -> AsyncIterator[SurrealAuthClient]:
         yield client
 
 
+async def get_server_instance_id() -> str:
+    """Read the data-instance identity created by the auth schema migration."""
+    async with _auth_client_scope() as client:
+        rows = _normalize_records(
+            await client.execute_query("SELECT instance_id FROM server_identity:singleton;")
+        )
+    if not rows or not isinstance(rows[0].get("instance_id"), str):
+        raise RuntimeError("Server replay identity is missing; auth schema migration is required")
+    return str(UUID(str(rows[0]["instance_id"])))
+
+
 class _SurrealRepository:
     def __init__(self, client: QueryClient) -> None:
         self._client = client

--- a/apps/api/tests/test_api_idempotency.py
+++ b/apps/api/tests/test_api_idempotency.py
@@ -204,3 +204,32 @@ async def test_pending_takeover_rejects_a_different_payload() -> None:
 
     assert mismatch.value.status_code == 409
     assert "different request" in str(mismatch.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_busy_idempotency_lock_exposes_retryable_error_code() -> None:
+    from contextlib import asynccontextmanager
+
+    from sibyl.locks import LockAcquisitionError
+
+    @asynccontextmanager
+    async def busy_lock(**_kwargs):
+        raise LockAcquisitionError("request", "org")
+        yield
+
+    @serialize_idempotent_request
+    async def mutate(*, http_request, org, ctx):
+        pytest.fail("Busy lock must not execute the handler")
+
+    request = SimpleNamespace(
+        headers={"Idempotency-Key": "same-request"},
+        method="POST",
+        url=SimpleNamespace(path="/memory/raw"),
+    )
+    with (
+        patch("sibyl.api.idempotency.idempotency_lock", busy_lock),
+        pytest.raises(HTTPException) as caught,
+    ):
+        await mutate(http_request=request, org=SimpleNamespace(id=uuid4()), ctx=None)
+    assert caught.value.status_code == 409
+    assert caught.value.detail["error"] == "idempotency_in_progress"

--- a/apps/api/tests/test_auth_dependencies.py
+++ b/apps/api/tests/test_auth_dependencies.py
@@ -373,3 +373,29 @@ async def test_legacy_mutations_and_reads_do_not_require_server_identity(
     monkeypatch.setattr(dependencies, "get_server_instance_id", lookup)
     assert await dependencies.build_auth_context(request) is ctx
     lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cached", [False, True])
+@pytest.mark.parametrize("matches", [False, True])
+async def test_user_only_mutation_checks_server_instance(monkeypatch, cached, matches) -> None:
+    user_id = uuid4()
+    instance = str(uuid4())
+    request = _make_request(user_id=str(user_id), org_id="")
+    request.state.jwt_claims = {"sub": str(user_id)}
+    request.scope["method"] = "POST"
+    request.scope["headers"] = [(b"x-sibyl-server-instance", instance.encode())]
+    user = SimpleNamespace(id=user_id)
+    if cached:
+        request.state.auth_context = SimpleNamespace(user=user)
+    monkeypatch.setattr(dependencies, "get_user_by_id", AsyncMock(return_value=user))
+    lookup = AsyncMock(return_value=instance if matches else str(uuid4()))
+    monkeypatch.setattr(dependencies, "get_server_instance_id", lookup)
+    if matches:
+        assert await dependencies.get_current_user(request) is user
+    else:
+        with pytest.raises(dependencies.HTTPException) as exc:
+            await dependencies.get_current_user(request)
+        assert exc.value.status_code == 409
+        assert exc.value.detail["error"] == "replay_identity_mismatch"
+    lookup.assert_awaited_once()

--- a/apps/api/tests/test_auth_dependencies.py
+++ b/apps/api/tests/test_auth_dependencies.py
@@ -319,3 +319,57 @@ async def test_get_current_user_ignores_cached_auth_context_for_other_user(
         session=None,
     )
     get_user_by_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cached", [False, True])
+@pytest.mark.parametrize("method", ["POST", "PATCH", "DELETE"])
+async def test_mutation_rejects_replaced_server_before_returning_auth_context(
+    monkeypatch, cached, method
+) -> None:
+    request = _make_request(user_id=str(uuid4()), org_id=str(uuid4()))
+    request.scope["method"] = method
+    request.scope["headers"] = [(b"x-sibyl-server-instance", str(uuid4()).encode())]
+    ctx = SimpleNamespace(user=SimpleNamespace(id=uuid4()), organization=None)
+    monkeypatch.setattr(dependencies, "resolve_auth_context", AsyncMock(return_value=ctx))
+    monkeypatch.setattr(
+        dependencies, "get_server_instance_id", AsyncMock(return_value=str(uuid4()))
+    )
+    if cached:
+        request.state.auth_context = ctx
+    with pytest.raises(dependencies.HTTPException) as exc:
+        await dependencies.build_auth_context(request)
+    assert exc.value.status_code == 409
+    assert exc.value.detail["error"] == "replay_identity_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_mutation_validates_matching_server_once_per_request(monkeypatch) -> None:
+    instance = str(uuid4())
+    request = _make_request(user_id=str(uuid4()), org_id=str(uuid4()))
+    request.scope["method"] = "POST"
+    request.scope["headers"] = [(b"x-sibyl-server-instance", instance.encode())]
+    ctx = SimpleNamespace(user=SimpleNamespace(id=uuid4()), organization=None)
+    monkeypatch.setattr(dependencies, "resolve_auth_context", AsyncMock(return_value=ctx))
+    lookup = AsyncMock(return_value=instance)
+    monkeypatch.setattr(dependencies, "get_server_instance_id", lookup)
+    assert await dependencies.build_auth_context(request) is ctx
+    assert await dependencies.build_auth_context(request) is ctx
+    lookup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("method", "header"), [("POST", None), ("GET", "old-instance")])
+async def test_legacy_mutations_and_reads_do_not_require_server_identity(
+    monkeypatch, method, header
+) -> None:
+    request = _make_request(user_id=str(uuid4()), org_id=str(uuid4()))
+    request.scope["method"] = method
+    if header:
+        request.scope["headers"] = [(b"x-sibyl-server-instance", header.encode())]
+    ctx = SimpleNamespace(user=SimpleNamespace(id=uuid4()), organization=None)
+    request.state.auth_context = ctx
+    lookup = AsyncMock()
+    monkeypatch.setattr(dependencies, "get_server_instance_id", lookup)
+    assert await dependencies.build_auth_context(request) is ctx
+    lookup.assert_not_awaited()

--- a/apps/api/tests/test_decorators.py
+++ b/apps/api/tests/test_decorators.py
@@ -107,3 +107,18 @@ class TestHandleWorkflowErrors:
 
         assert start_task.__name__ == "start_task"
         assert start_task.__doc__ == "Start working on a task."
+
+
+@pytest.mark.asyncio
+async def test_workflow_lock_contention_has_retryable_error_code() -> None:
+    from sibyl.api.errors import http_exception_payload
+    from sibyl.coordination.locks import LockAcquisitionError
+
+    @handle_workflow_errors("update_task")
+    async def update(task_id: str):
+        raise LockAcquisitionError(task_id, "org-1")
+
+    with pytest.raises(HTTPException) as exc:
+        await update(task_id="task-1")
+    assert exc.value.status_code == 409
+    assert http_exception_payload(exc.value, "request-1")["error"] == "entity_locked"

--- a/apps/api/tests/test_routes_auth.py
+++ b/apps/api/tests/test_routes_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from inspect import signature
 from types import SimpleNamespace
@@ -1451,3 +1452,54 @@ async def test_refresh_tokens_returns_503_when_auth_storage_errors(
 
     assert response.status_code == 503
     assert json.loads(response.body)["detail"] == "Authentication storage temporarily unavailable"
+
+
+@pytest.mark.asyncio
+async def test_replay_identity_is_stable_across_sessions_and_roles(monkeypatch) -> None:
+    instance = str(uuid4())
+    monkeypatch.setattr(auth_routes, "get_server_instance_id", AsyncMock(return_value=instance))
+    ctx = _ctx()
+    first = await auth_routes.replay_identity(ctx=ctx)
+    second = await auth_routes.replay_identity(ctx=replace(ctx, org_role=OrganizationRole.OWNER))
+    assert first == second
+    assert first["server_instance_id"] == instance
+    assert first["user_id"] == str(ctx.user.id)
+    assert first["organization_id"] == str(ctx.organization.id)
+    assert first["credential"]["kind"] == "session"
+
+
+@pytest.mark.asyncio
+async def test_replay_identity_preserves_api_key_restrictions(monkeypatch) -> None:
+    monkeypatch.setattr(auth_routes, "get_server_instance_id", AsyncMock(return_value=str(uuid4())))
+    ctx = _ctx()
+    key_ctx = replace(
+        ctx,
+        api_key_id="key-1",
+        scopes=frozenset({"api:write", "api:read"}),
+        api_key_project_ids=frozenset({"project-b", "project-a"}),
+        api_key_memory_space_ids=frozenset(),
+        api_key_memory_scope_keys=frozenset({"scope-a"}),
+    )
+    key = await auth_routes.replay_identity(ctx=key_ctx)
+    session = await auth_routes.replay_identity(ctx=ctx)
+    assert key != session
+    assert key["credential"] == {
+        "kind": "api_key",
+        "api_key_id": "key-1",
+        "scopes": ["api:read", "api:write"],
+        "project_ids": ["project-a", "project-b"],
+        "memory_space_ids": [],
+        "memory_scope_keys": ["scope-a"],
+    }
+    assert await auth_routes.replay_identity(ctx=replace(key_ctx, api_key_id="key-2")) != key
+    assert await auth_routes.replay_identity(ctx=replace(key_ctx, api_key_project_ids=None)) != key
+
+
+@pytest.mark.asyncio
+async def test_replay_identity_requires_organization(monkeypatch) -> None:
+    lookup = AsyncMock()
+    monkeypatch.setattr(auth_routes, "get_server_instance_id", lookup)
+    with pytest.raises(HTTPException) as exc:
+        await auth_routes.replay_identity(ctx=_ctx(include_org=False))
+    assert exc.value.status_code == 403
+    lookup.assert_not_called()

--- a/apps/api/tests/test_routes_experience.py
+++ b/apps/api/tests/test_routes_experience.py
@@ -539,3 +539,28 @@ async def test_experience_router_rejects_viewer_role() -> None:
 
     assert exc_info.value.status_code == 403
     await dependency(OrganizationRole.MEMBER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raises", [False, True])
+async def test_experience_lock_contention_has_retryable_code(monkeypatch, raises) -> None:
+    from sibyl.api.errors import http_exception_payload
+    from sibyl.locks import LockAcquisitionError
+
+    @asynccontextmanager
+    async def unavailable(*_args, **_kwargs):
+        if raises:
+            raise LockAcquisitionError("manifest-1", "org-1")
+        yield None
+
+    monkeypatch.setattr(experience_routes, "entity_lock", unavailable)
+    monkeypatch.setattr(experience_routes, "verify_entity_project_access", AsyncMock())
+    runtime = AsyncMock()
+    monkeypatch.setattr(experience_routes, "get_experience_graph_runtime", runtime)
+    with pytest.raises(HTTPException) as exc:
+        await capture_operational_experience(
+            _request(), org=SimpleNamespace(id="org-1"), ctx=SimpleNamespace(user_id="user-1")
+        )
+    assert exc.value.status_code == 409
+    assert http_exception_payload(exc.value, "request-1")["error"] == "entity_locked"
+    runtime.assert_not_awaited()

--- a/apps/api/tests/test_routes_tasks.py
+++ b/apps/api/tests/test_routes_tasks.py
@@ -767,3 +767,36 @@ class TestNotesRoute:
         assert response.count == 0
         manager.get.assert_not_awaited()
         manager.get_notes_for_task.assert_awaited_once_with("task-123", limit=50)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raises", [False, True])
+async def test_task_update_lock_contention_has_retryable_code(raises) -> None:
+    from contextlib import asynccontextmanager
+
+    from fastapi import HTTPException
+
+    from sibyl.api.errors import http_exception_payload
+    from sibyl.locks import LockAcquisitionError
+
+    @asynccontextmanager
+    async def unavailable(*_args, **_kwargs):
+        if raises:
+            raise LockAcquisitionError("task-1", "org-1")
+        yield None
+
+    with (
+        patch("sibyl.api.routes.tasks._verify_task_access", AsyncMock()),
+        patch("sibyl.api.routes.tasks.entity_lock", unavailable),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await update_task(
+            task_id="task-1",
+            request=UpdateTaskRequest(title="Renamed"),
+            sync=True,
+            org=SimpleNamespace(id="org-1"),
+            user=SimpleNamespace(id="user-1"),
+            auth=SimpleNamespace(),
+        )
+    assert exc.value.status_code == 409
+    assert http_exception_payload(exc.value, "request-1")["error"] == "entity_locked"

--- a/apps/api/tests/test_surreal_auth_persistence.py
+++ b/apps/api/tests/test_surreal_auth_persistence.py
@@ -318,7 +318,8 @@ async def test_auth_archive_export_reads_from_surreal_backend(
 
 
 def test_auth_archive_tables_cover_auth_schema_tables() -> None:
-    assert set(auth_archive.AUTH_ARCHIVE_TABLES) == set(AUTH_TABLES)
+    # The singleton is archive metadata, not a UUID-keyed user/auth record.
+    assert set(auth_archive.AUTH_ARCHIVE_TABLES) | {"server_identity"} == set(AUTH_TABLES)
 
 
 @pytest.mark.asyncio
@@ -910,3 +911,136 @@ async def test_auth_archive_restore_accepts_full_user_rows(
     assert restored_membership.role is OrganizationRole.OWNER
     assert raw_user[0]["email_verified_at"] is not None
     assert raw_user[0]["last_login_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_auth_archive_clean_restore_rotates_legacy_identity_and_restores_lineage(
+    surreal_auth_client: SurrealAuthClient,
+) -> None:
+    original = _normalize_records(
+        await surreal_auth_client.execute_query(
+            "SELECT instance_id FROM server_identity:singleton;"
+        )
+    )[0]["instance_id"]
+    with (
+        patch.object(surreal_auth_client, "close", AsyncMock()),
+        patch(
+            "sibyl.persistence.auth_archive.build_surreal_auth_client",
+            return_value=surreal_auth_client,
+        ),
+    ):
+        archived = await auth_archive.export_auth_archive_payload()
+        assert archived["server_instance_id"] == original
+        legacy = {"version": "1.0", "organization_id": None, "tables": {}}
+        assert (await restore_auth_archive_payload(legacy, clean=True)).success
+        assert (
+            _normalize_records(
+                await surreal_auth_client.execute_query(
+                    "SELECT instance_id FROM server_identity:singleton;"
+                )
+            )[0]["instance_id"]
+            != original
+        )
+        replacement = str(uuid4())
+        await surreal_auth_client.execute_query(
+            "UPDATE server_identity:singleton SET instance_id = $instance_id;",
+            instance_id=replacement,
+        )
+        assert (await restore_auth_archive_payload(archived, clean=True)).success
+        assert (
+            _normalize_records(
+                await surreal_auth_client.execute_query(
+                    "SELECT instance_id FROM server_identity:singleton;"
+                )
+            )[0]["instance_id"]
+            == original
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("clean", "org"), [(False, None), (True, "org-a")])
+async def test_auth_archive_partial_restore_preserves_destination_identity(
+    surreal_auth_client: SurrealAuthClient,
+    clean: bool,
+    org: str | None,
+) -> None:
+    before = await surreal_auth_client.execute_query(
+        "SELECT instance_id FROM server_identity:singleton;"
+    )
+    payload = {
+        "version": "1.0",
+        "organization_id": org,
+        "tables": {},
+        "server_instance_id": str(uuid4()),
+    }
+    with (
+        patch.object(surreal_auth_client, "close", AsyncMock()),
+        patch(
+            "sibyl.persistence.auth_archive.build_surreal_auth_client",
+            return_value=surreal_auth_client,
+        ),
+    ):
+        assert (await restore_auth_archive_payload(payload, clean=clean)).success
+    assert (
+        await surreal_auth_client.execute_query(
+            "SELECT instance_id FROM server_identity:singleton;"
+        )
+        == before
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_archive_invalid_identity_rejected_before_cleanup() -> None:
+    payload = {"tables": {}, "server_instance_id": "invalid"}
+    with (
+        patch("sibyl.persistence.auth_archive.build_surreal_auth_client") as build,
+        pytest.raises(ValueError),
+    ):
+        await restore_auth_archive_payload(payload, clean=True)
+    build.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["cleanup", "import"])
+async def test_failed_full_restore_invalidates_old_identity_before_cleanup(
+    surreal_auth_client: SurrealAuthClient,
+    failure: str,
+) -> None:
+    before = await surreal_auth_client.execute_query(
+        "SELECT instance_id FROM server_identity:singleton;"
+    )
+    source_id = str(uuid4())
+    payload = {"tables": {"users": "invalid"}, "server_instance_id": source_id}
+    clean_rows = auth_archive._clean_auth_archive_rows
+    observed_identity = None
+
+    async def check_before_cleanup(client, organization_id):
+        nonlocal observed_identity
+        observed_identity = await client.execute_query(
+            "SELECT instance_id FROM server_identity:singleton;"
+        )
+        assert observed_identity != before
+        assert _normalize_records(observed_identity)[0]["instance_id"] != source_id
+        if failure == "cleanup":
+            raise RuntimeError("cleanup failed")
+        await clean_rows(client, organization_id)
+
+    with (
+        patch.object(surreal_auth_client, "close", AsyncMock()),
+        patch(
+            "sibyl.persistence.auth_archive.build_surreal_auth_client",
+            return_value=surreal_auth_client,
+        ),
+        patch.object(auth_archive, "_clean_auth_archive_rows", check_before_cleanup),
+    ):
+        if failure == "cleanup":
+            with pytest.raises(RuntimeError, match="cleanup failed"):
+                await restore_auth_archive_payload(payload, clean=True)
+        else:
+            result = await restore_auth_archive_payload(payload, clean=True)
+            assert not result.success
+        after = await surreal_auth_client.execute_query(
+            "SELECT instance_id FROM server_identity:singleton;"
+        )
+    assert observed_identity is not None
+    assert after == observed_identity

--- a/apps/api/tests/test_surreal_auth_runtime.py
+++ b/apps/api/tests/test_surreal_auth_runtime.py
@@ -3313,3 +3313,21 @@ def test_apply_password_change_rotates_credential_for_local_account() -> None:
 
     assert updated["password_hash"] != existing.hash_hex
     assert updated["password_salt"] != existing.salt_hex
+
+
+@pytest.mark.asyncio
+async def test_server_instance_id_reads_persisted_identity(monkeypatch) -> None:
+    instance = str(uuid4())
+    client = _RecordingAuthClient([{"instance_id": instance}])
+    monkeypatch.setattr(auth_common, "_auth_client_scope", lambda: _StaticAuthClientScope(client))
+    assert await auth_common.get_server_instance_id() == instance
+    assert client.calls[0][0].startswith("SELECT")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rows", [[], [{"instance_id": None}], [{"instance_id": "invalid"}]])
+async def test_server_instance_id_fails_closed_if_missing_or_invalid(monkeypatch, rows) -> None:
+    client = _RecordingAuthClient(rows)
+    monkeypatch.setattr(auth_common, "_auth_client_scope", lambda: _StaticAuthClientScope(client))
+    with pytest.raises((RuntimeError, ValueError)):
+        await auth_common.get_server_instance_id()

--- a/apps/api/tests/test_surreal_live_runtime.py
+++ b/apps/api/tests/test_surreal_live_runtime.py
@@ -6,11 +6,17 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
-from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
+from sibyl_core.backends.surreal import (
+    SurrealAuthClient,
+    SurrealContentClient,
+    bootstrap_auth_schema,
+    bootstrap_content_schema,
+)
+from sibyl_core.backends.surreal.auth_schema import AUTH_SCHEMA_NAME
 from sibyl_core.backends.surreal.content_schema import (
     CONTENT_SCHEMA_CURRENT_VERSION,
     CONTENT_SCHEMA_NAME,
@@ -956,3 +962,47 @@ async def test_live_surreal_server_executes_3x_ingestion_primitives(
                 await _drop_surreal_namespace(namespace)
         else:
             await _drop_surreal_namespace(namespace)
+
+
+@pytest.mark.asyncio
+async def test_live_auth_replay_identity_migration_preserves_data_lineage() -> None:
+    namespace = f"replay_identity_{uuid4().hex}"
+    client = SurrealAuthClient(
+        url=_live_surreal_url(),
+        username=_surreal_username(),
+        password=_surreal_password(),
+        namespace=namespace,
+        database="auth",
+    )
+    replacement = SurrealAuthClient(
+        url=_live_surreal_url(),
+        username=_surreal_username(),
+        password=_surreal_password(),
+        namespace=namespace,
+        database="replacement",
+    )
+    try:
+        await bootstrap_auth_schema(client)
+        assert await get_schema_version(client.execute_query, name=AUTH_SCHEMA_NAME) >= 7
+        first = normalize_records(
+            await client.execute_query("SELECT instance_id FROM server_identity:singleton;")
+        )
+        assert len(first) == 1
+        assert UUID(str(first[0]["instance_id"]))
+        await bootstrap_auth_schema(client)
+        assert (
+            normalize_records(
+                await client.execute_query("SELECT instance_id FROM server_identity:singleton;")
+            )
+            == first
+        )
+        await bootstrap_auth_schema(replacement)
+        other = normalize_records(
+            await replacement.execute_query("SELECT instance_id FROM server_identity:singleton;")
+        )
+        assert len(other) == 1
+        assert other != first
+    finally:
+        await client.close()
+        await replacement.close()
+        await _drop_surreal_namespace(namespace)

--- a/apps/cli/src/sibyl_cli/auth_store.py
+++ b/apps/cli/src/sibyl_cli/auth_store.py
@@ -348,7 +348,9 @@ def set_tokens(
         "access_token": access_token,
         PENDING_REPLAY_SCOPE_KEY: pending_replay_scope or f"credential:{uuid4().hex}",
     }
-    remove_keys: list[str] = []
+    # A refresh retains a verified owner; a fresh login must prove its owner
+    # again before reusing any cached identity.
+    remove_keys: list[str] = [] if pending_replay_scope else ["pending_replay_identity"]
     if refresh_token is not None and refresh_token:
         creds["refresh_token"] = refresh_token
     else:
@@ -374,6 +376,28 @@ def set_tokens(
         path=path,
         credential_scope=credential_scope,
     )
+
+
+def cache_pending_replay_identity(
+    api_url: str,
+    access_token: str,
+    identity: dict[str, Any],
+    *,
+    credential_scope: str | None = None,
+    path: Path | None = None,
+) -> bool:
+    """Cache a verified identity only if the authenticating token is still current."""
+    with auth_file_lock(path):
+        creds = read_server_credentials(api_url, path, credential_scope=credential_scope)
+        if creds.get("access_token") != access_token:
+            return False
+        write_server_credentials(
+            api_url,
+            {"pending_replay_identity": identity},
+            path,
+            credential_scope=credential_scope,
+        )
+        return True
 
 
 def clear_tokens(

--- a/apps/cli/src/sibyl_cli/client.py
+++ b/apps/cli/src/sibyl_cli/client.py
@@ -2,7 +2,7 @@
 
 import httpx
 
-from sibyl_cli.auth_store import normalize_api_url
+from sibyl_cli.auth_store import normalize_api_url, read_server_credentials
 from sibyl_cli.client_admin import ClientAdminMixin
 from sibyl_cli.client_auth import ClientAuthMixin
 from sibyl_cli.client_graph import ClientGraphMixin
@@ -17,7 +17,6 @@ from sibyl_cli.client_transport import (
     INIT_REMEDIATION,
     PENDING_WRITE_REMEDIATION,
     READ_LIKE_POST_PATHS,
-    UNAPPLIED_WRITE_STATUS_CODES,
     ClientTransportMixin,
     ErrorPayload,
     SibylClientError,
@@ -33,6 +32,7 @@ from sibyl_cli.client_transport import (
     resolve_api_base_url,
 )
 from sibyl_cli.client_work import ClientWorkMixin
+from sibyl_cli.pending_identity import normalize_replay_identity
 
 __all__ = [
     "BUFFERED_WRITE_METHODS",
@@ -42,7 +42,6 @@ __all__ = [
     "INIT_REMEDIATION",
     "PENDING_WRITE_REMEDIATION",
     "READ_LIKE_POST_PATHS",
-    "UNAPPLIED_WRITE_STATUS_CODES",
     "_FAILURE_WINDOWS",
     "ErrorPayload",
     "SibylClient",
@@ -109,6 +108,18 @@ class SibylClient(
             else _auth_replay_scope(None, self.auth_token)
         )
         self._client: httpx.AsyncClient | None = None
+        creds = (
+            read_server_credentials(self.base_url, credential_scope=self.credential_scope)
+            if self._uses_stored_auth
+            else {}
+        )
+        self._pending_identity = (
+            normalize_replay_identity(creds.get("pending_replay_identity"))
+            if creds.get("access_token") == self.auth_token
+            else None
+        )
+        self._identity_checked = False
+        self._identity_token: str | None = None
         # Load insecure setting from context
         self.insecure = self._get_insecure_from_context(context_name)
 

--- a/apps/cli/src/sibyl_cli/client_transport.py
+++ b/apps/cli/src/sibyl_cli/client_transport.py
@@ -5,6 +5,7 @@ import random
 import sys
 import time
 from collections import deque
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from hashlib import sha256
@@ -13,20 +14,26 @@ from typing import Any, Self, cast
 import httpx
 
 from sibyl_cli.auth_store import (
+    cache_pending_replay_identity,
     credential_scope,
     get_access_token,
     is_access_token_expired,
     normalize_api_url,
     read_server_credentials,
 )
+from sibyl_cli.pending_identity import normalize_replay_identity, pending_identity_matches
 from sibyl_cli.pending_writes import (
     PendingMetric,
+    bind_pending_write_identity,
     create_pending_write,
     delete_pending_write,
     increment_attempts,
     is_corrupt_pending_write,
     list_pending_writes,
     pending_replay_lock,
+    pending_write_resource,
+    read_pending_write,
+    record_pending_failure,
     record_pending_metric,
 )
 
@@ -41,7 +48,8 @@ AUTO_REPLAY_GRACE_SECONDS = 30.0
 AUTO_REPLAY_BACKOFF_BASE_SECONDS = 2.0
 AUTO_REPLAY_BACKOFF_MAX_SECONDS = 300.0
 PENDING_WRITE_REMEDIATION = (
-    "Run 'sibyl auth login'; buffered writes retry after the next successful API request."
+    "Sign in to the same server, user, and organization, then run 'sibyl pending-writes flush'. "
+    "Use 'sibyl pending-writes list' to inspect writes needing attention or legacy ownership."
 )
 INIT_REMEDIATION = "Run 'sibyl init' for local mode or 'sibyl init --remote <url>'."
 
@@ -363,19 +371,6 @@ def _requires_initialized_context(method: str, path: str) -> bool:
     return not path.startswith("/auth/")
 
 
-# Discarding a buffered write destroys the only copy of its payload: the server
-# stores a request hash, never the body. So the queue only drops a write when
-# the status proves the server rejected the payload itself and no retry could
-# ever land it. Everything else stays buffered, including 409 - a stranded
-# idempotency reservation reports 409 for a write that may already have applied,
-# and the client cannot tell the two apart.
-UNAPPLIED_WRITE_STATUS_CODES = {400, 422}
-
-
-def _should_keep_pending_write(status_code: int) -> bool:
-    return status_code not in UNAPPLIED_WRITE_STATUS_CODES
-
-
 def _resolve_pending_write(write_id: str | None, outcome: PendingMetric | None) -> None:
     """Drop a buffered write from the queue and record why it left.
 
@@ -481,36 +476,107 @@ class ClientTransportMixin:
             await self._client.aclose()
             self._client = None
 
+    async def _ensure_pending_identity(self) -> dict[str, Any] | None:
+        """Verify the destination before using a cached owner to send a mutation."""
+        if self._identity_checked and self._identity_token == self.auth_token:
+            return self._pending_identity
+        if not self.auth_token:
+            return None
+        try:
+            data = await self._request("GET", "/auth/replay-identity", _replay_pending=False)
+        except SibylClientError as exc:
+            if exc.status_code != 404:
+                raise
+            # Older servers only support replay within the original credential
+            # lineage. Never treat a cached durable owner as freshly verified.
+            self._pending_identity = None
+        else:
+            identity = normalize_replay_identity(data)
+            if identity is None:
+                raise SibylClientError(
+                    "Server returned an invalid pending-write identity; no mutation was sent.",
+                    error_code="replay_identity_invalid",
+                )
+            self._pending_identity = identity
+            if self._uses_stored_auth:
+                cache_pending_replay_identity(
+                    self.base_url,
+                    self.auth_token,
+                    identity,
+                    credential_scope=self.credential_scope,
+                )
+        self._identity_checked = True
+        self._identity_token = self.auth_token
+        return self._pending_identity
+
+    def _record_pending_failure(self, write_id: str | None, exc: SibylClientError) -> None:
+        if write_id is None:
+            return
+        status = exc.status_code
+        if exc.error_code == "pending_dependency":
+            category = "dependency"
+        elif status == 401 or exc.error_code == "token_refresh_failed":
+            category = "authentication"
+        elif status == 409:
+            category = "conflict"
+        elif status is not None and 400 <= status < 500 and status not in {408, 429}:
+            category = "rejected"
+        elif status is not None:
+            category = "server"
+        else:
+            category = "transport"
+        with suppress(FileNotFoundError):
+            record_pending_failure(
+                write_id, category=category, status_code=status, error_code=exc.error_code
+            )
+
     async def _maybe_replay_pending_writes(self, *, ignore_backoff: bool = False) -> None:
         """Replay a bounded batch after this client proves the API is healthy."""
         try:
-            if not list_pending_writes():
+            if not any(
+                item.get("base_url") == self.base_url
+                and not is_corrupt_pending_write(item)
+                and (
+                    item.get("replay_identity") is not None
+                    or (
+                        self._replay_scope is not None
+                        and item.get("replay_scope") == self._replay_scope
+                    )
+                )
+                for item in list_pending_writes()
+            ):
                 return
             with pending_replay_lock() as acquired:
                 if not acquired:
                     return
+                identity = await self._ensure_pending_identity()
                 matching = [
                     item
                     for item in list_pending_writes()
                     if not is_corrupt_pending_write(item)
                     and str(item.get("base_url")) == self.base_url
-                    and item.get("replay_scope") == self._replay_scope
-                    and self._replay_scope is not None
+                    and pending_identity_matches(item, identity, self._replay_scope)
                     and not (
                         str(item.get("method") or "").upper() == "POST"
                         and _is_read_like_post(str(item.get("path") or ""))
                     )
                 ]
                 matching.sort(key=lambda item: str(item.get("created_at") or ""))
-                batch: list[dict[str, Any]] = []
+                blocked: set[str] = set()
+                attempted = 0
                 for item in matching:
-                    if not ignore_backoff and not _ready_for_auto_replay(item):
-                        break
-                    batch.append(item)
-                    if len(batch) == AUTO_REPLAY_LIMIT:
-                        break
-                for item in batch:
+                    resource = pending_write_resource(item)
+                    if (
+                        "*" in blocked
+                        or resource in blocked
+                        or (resource == "*" and blocked)
+                        or item.get("status") == "attention"
+                        or (not ignore_backoff and not _ready_for_auto_replay(item))
+                    ):
+                        blocked.add(resource)
+                        continue
                     write_id = str(item["id"])
+                    attempted += 1
                     try:
                         current = increment_attempts(write_id)
                         await self._request(
@@ -524,9 +590,12 @@ class ClientTransportMixin:
                         )
                         record_pending_metric("replayed")
                     except SibylClientError as exc:
-                        if exc.status_code not in UNAPPLIED_WRITE_STATUS_CODES:
+                        blocked.add(resource)
+                        if exc.status_code == 401 or exc.error_code == "token_refresh_failed":
                             break
                     except (FileNotFoundError, OSError, ValueError):
+                        blocked.add(resource)
+                    if attempted == AUTO_REPLAY_LIMIT:
                         break
         except Exception:
             return
@@ -551,6 +620,7 @@ class ClientTransportMixin:
         _pending_write_id: str | None = None,
         _pending_write_created: bool = False,
         _idempotency_key: str | None = None,
+        _replay_pending: bool = True,
     ) -> dict[str, Any]:
         """Make an HTTP request to the API.
 
@@ -592,10 +662,49 @@ class ClientTransportMixin:
                 json_payload=json,
                 params=params,
                 replay_scope=self._replay_scope,
+                replay_identity=self._pending_identity,
             )
             pending_write_id = str(pending["id"])
             pending_write_created = True
             idempotency_key = str(pending["idempotency_key"])
+
+        if pending_write_id is not None:
+            try:
+                identity = await self._ensure_pending_identity()
+                pending = read_pending_write(pending_write_id)
+                if not pending_identity_matches(pending, identity, self._replay_scope):
+                    raise SibylClientError(
+                        "Buffered write belongs to a different or unverified identity; "
+                        "no mutation was sent.",
+                        status_code=403,
+                        error_code="replay_identity_mismatch",
+                    )
+                if identity is not None and pending.get("replay_identity") is None:
+                    bind_pending_write_identity(
+                        pending_write_id, identity, replay_scope=self._replay_scope
+                    )
+                resource = pending_write_resource(pending)
+                order = (str(pending.get("created_at", "")), pending_write_id)
+                for earlier in list_pending_writes():
+                    if (
+                        is_corrupt_pending_write(earlier)
+                        or earlier.get("base_url") != self.base_url
+                        or not pending_identity_matches(earlier, identity, self._replay_scope)
+                        or (str(earlier.get("created_at", "")), str(earlier["id"])) >= order
+                    ):
+                        continue
+                    predecessor = pending_write_resource(earlier)
+                    if resource == "*" or predecessor == "*" or resource == predecessor:
+                        raise SibylClientError(
+                            "An earlier related write is unresolved; this write remains "
+                            "buffered and no mutation was sent. Inspect pending-writes list.",
+                            status_code=409,
+                            error_code="pending_dependency",
+                        )
+            except SibylClientError as exc:
+                self._record_pending_failure(pending_write_id, exc)
+                exc.remediation = PENDING_WRITE_REMEDIATION
+                raise
 
         refresh_failure: str | None = None
 
@@ -610,20 +719,24 @@ class ClientTransportMixin:
         ):
             refreshed, refresh_failure = await self._refresh_token()
             if not refreshed:
-                raise SibylClientError(
+                exc = SibylClientError(
                     "Stored access token is expired and automatic token refresh failed.",
                     status_code=_refresh_failure_status_code(refresh_failure),
                     detail=refresh_failure,
                     error_code="token_refresh_failed",
                     remediation=_refresh_failure_remediation(pending_write_id=pending_write_id),
                 )
+                self._record_pending_failure(pending_write_id, exc)
+                raise exc
 
         client = await self._get_client()
         breaker_key = _failure_key(self.base_url)
         await _maybe_wait_for_circuit_breaker(breaker_key)
 
         try:
-            headers = {"Idempotency-Key": idempotency_key} if idempotency_key else None
+            headers = {"Idempotency-Key": idempotency_key} if idempotency_key else {}
+            if pending_write_id and self._pending_identity:
+                headers["X-Sibyl-Server-Instance"] = self._pending_identity["server_instance_id"]
             response = await client.request(
                 method=method,
                 url=path,
@@ -647,12 +760,11 @@ class ClientTransportMixin:
                         _pending_write_id=pending_write_id,
                         _pending_write_created=pending_write_created,
                         _idempotency_key=idempotency_key,
+                        _replay_pending=_replay_pending,
                     )
 
             # Handle error responses
             if response.status_code >= 400:
-                if not _should_keep_pending_write(response.status_code):
-                    _resolve_pending_write(pending_write_id, "dropped")
                 try:
                     payload = _parse_error_payload(response.json())
                 except Exception:
@@ -673,8 +785,9 @@ class ClientTransportMixin:
                     if not payload.remediation:
                         payload.remediation = "Access denied. Check org and project permissions."
 
-                _record_failure(breaker_key)
-                raise SibylClientError(
+                if not (path == "/auth/replay-identity" and response.status_code == 404):
+                    _record_failure(breaker_key)
+                exc = SibylClientError(
                     f"API error: {payload.error or detail}: {detail}",
                     status_code=response.status_code,
                     detail=detail,
@@ -683,6 +796,8 @@ class ClientTransportMixin:
                     remediation=payload.remediation,
                     details=payload.details,
                 )
+                self._record_pending_failure(pending_write_id, exc)
+                raise exc
 
             applied_outcome = "completed" if pending_write_created else None
 
@@ -690,29 +805,50 @@ class ClientTransportMixin:
             if response.status_code == 204:
                 _resolve_pending_write(pending_write_id, applied_outcome)
                 _record_success(breaker_key)
-                if pending_write_id is None or pending_write_created:
+                if _replay_pending and (pending_write_id is None or pending_write_created):
                     await self._maybe_replay_pending_writes()
                 return {}
 
-            data = response.json()
+            try:
+                data = response.json()
+            except ValueError as cause:
+                exc = SibylClientError(
+                    "Server response could not be decoded; the write outcome is unconfirmed.",
+                    status_code=502,
+                    error_code="response_unconfirmed",
+                )
+                self._record_pending_failure(pending_write_id, exc)
+                raise exc from cause
             _resolve_pending_write(pending_write_id, applied_outcome)
             _record_success(breaker_key)
-            if pending_write_id is None or pending_write_created:
+            if _replay_pending and (pending_write_id is None or pending_write_created):
                 await self._maybe_replay_pending_writes()
             return data
 
         except httpx.ConnectError as e:
             _record_failure(breaker_key)
-            raise SibylClientError(
+            exc = SibylClientError(
                 f"Cannot connect to Sibyl API at {self.base_url}. Is the server running?",
                 detail=str(e),
-            ) from e
+            )
+            self._record_pending_failure(pending_write_id, exc)
+            raise exc from e
         except httpx.TimeoutException as e:
             _record_failure(breaker_key)
-            raise SibylClientError(
+            exc = SibylClientError(
                 f"Request timed out after {self.timeout}s",
                 detail=str(e),
-            ) from e
+            )
+            self._record_pending_failure(pending_write_id, exc)
+            raise exc from e
+        except httpx.RequestError as e:
+            _record_failure(breaker_key)
+            exc = SibylClientError(
+                "Connection interrupted; the write outcome is unconfirmed.",
+                error_code="response_unconfirmed",
+            )
+            self._record_pending_failure(pending_write_id, exc)
+            raise exc from e
 
     async def get(
         self,

--- a/apps/cli/src/sibyl_cli/client_transport.py
+++ b/apps/cli/src/sibyl_cli/client_transport.py
@@ -517,7 +517,7 @@ class ClientTransportMixin:
             category = "dependency"
         elif status == 401 or exc.error_code == "token_refresh_failed":
             category = "authentication"
-        elif exc.error_code == "idempotency_in_progress":
+        elif status == 409 and exc.error_code in {"idempotency_in_progress", "entity_locked"}:
             category = "server"
         elif status == 409:
             category = "conflict"

--- a/apps/cli/src/sibyl_cli/client_transport.py
+++ b/apps/cli/src/sibyl_cli/client_transport.py
@@ -517,6 +517,8 @@ class ClientTransportMixin:
             category = "dependency"
         elif status == 401 or exc.error_code == "token_refresh_failed":
             category = "authentication"
+        elif exc.error_code == "idempotency_in_progress":
+            category = "server"
         elif status == 409:
             category = "conflict"
         elif status is not None and 400 <= status < 500 and status not in {408, 429}:
@@ -655,6 +657,11 @@ class ClientTransportMixin:
         pending_write_created = _pending_write_created
         idempotency_key = _idempotency_key
         if _buffer_pending and pending_write_id is None and _should_buffer_request(method, path):
+            identity_failure: SibylClientError | None = None
+            try:
+                await self._ensure_pending_identity()
+            except SibylClientError as exc:
+                identity_failure = exc
             pending = create_pending_write(
                 method=method,
                 path=path,
@@ -667,6 +674,10 @@ class ClientTransportMixin:
             pending_write_id = str(pending["id"])
             pending_write_created = True
             idempotency_key = str(pending["idempotency_key"])
+            if identity_failure is not None:
+                self._record_pending_failure(pending_write_id, identity_failure)
+                identity_failure.remediation = PENDING_WRITE_REMEDIATION
+                raise identity_failure
 
         if pending_write_id is not None:
             try:

--- a/apps/cli/src/sibyl_cli/common.py
+++ b/apps/cli/src/sibyl_cli/common.py
@@ -216,9 +216,9 @@ def hint(message: str) -> None:
 def pending_writes_summary(count: int) -> str:
     plural = "s" if count != 1 else ""
     return (
-        f"{count} write{plural} buffered locally and not saved on the server. "
-        "Sibyl retries replayable writes after the next successful API request; "
-        "run 'sibyl pending-writes list' if the count stops falling."
+        f"{count} write{plural} buffered locally without a confirmed server outcome. "
+        "Writes with a verified owner retry automatically; "
+        "run 'sibyl pending-writes list' for failures and ownership requiring attention."
     )
 
 

--- a/apps/cli/src/sibyl_cli/doctor.py
+++ b/apps/cli/src/sibyl_cli/doctor.py
@@ -509,10 +509,10 @@ def _check_pending_writes() -> DoctorCheck:
     return DoctorCheck(
         "pending-writes",
         "warn",
-        f"{count} write{plural} buffered locally and not saved on the server.",
+        f"{count} write{plural} buffered locally without a confirmed server outcome.",
         (
-            "Sibyl retries replayable writes after the next successful API request; "
-            f"inspect the queue at {pending_writes_dir()}."
+            "Verified retryable writes replay automatically. Use 'sibyl pending-writes list' "
+            f"for attention states and legacy ownership; local files: {pending_writes_dir()}."
         ),
     )
 

--- a/apps/cli/src/sibyl_cli/pending.py
+++ b/apps/cli/src/sibyl_cli/pending.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from contextlib import AsyncExitStack
 from typing import Annotated, Any
 
@@ -28,6 +29,7 @@ from sibyl_cli.common import (
     success,
     warn,
 )
+from sibyl_cli.pending_identity import normalize_replay_identity, pending_identity_matches
 from sibyl_cli.pending_writes import (
     claim_pending_write_replay_scope,
     delete_pending_write,
@@ -37,9 +39,11 @@ from sibyl_cli.pending_writes import (
     list_pending_writes,
     pending_replay_lock,
     pending_write_label,
+    pending_write_resource,
     pending_writes_dir,
     read_pending_write,
     record_pending_metric,
+    retry_pending_write,
 )
 
 app = typer.Typer(help="Inspect and replay locally buffered writes")
@@ -63,7 +67,24 @@ def _summary(item: dict[str, Any]) -> dict[str, Any]:
         "kind": kind,
         "attempts": item.get("attempts", 0),
         "base_url": item.get("base_url"),
+        "status": item.get("status", "pending"),
+        "ownership": "verified" if item.get("replay_identity") else "legacy",
+        "last_failure": item.get("last_failure"),
     }
+
+
+def _state_label(item: dict[str, Any]) -> str:
+    failure = item.get("last_failure")
+    reason = failure.get("category") if isinstance(failure, dict) else None
+    status_code = failure.get("status_code") if isinstance(failure, dict) else None
+    state = str(item.get("status", "pending"))
+    if item.get("ownership") == "legacy":
+        state += " / legacy ownership"
+    if reason:
+        state += f" / {reason}"
+    if status_code:
+        state += f" ({status_code})"
+    return state
 
 
 def _selected_writes(write_ids: list[str]) -> list[dict[str, Any]]:
@@ -120,10 +141,6 @@ def _context_name_for_base_url(
     return None
 
 
-def _should_abort_flush(exc: SibylClientError) -> bool:
-    return exc.error_code == "token_refresh_failed" or exc.status_code in {401, 429}
-
-
 def _legacy_claim_candidate(item: dict[str, Any]) -> bool:
     scope = item.get("replay_scope")
     return scope is None or str(scope).startswith("context:")
@@ -149,6 +166,7 @@ def list_writes(
     table.add_column("Kind")
     table.add_column("Title")
     table.add_column("Attempts", justify="right")
+    table.add_column("State / reason")
     for item in summaries:
         if item.get("status") == "corrupt":
             table.add_row(
@@ -158,6 +176,7 @@ def list_writes(
                 "repair",
                 str(item["error"]),
                 "-",
+                "corrupt",
             )
             continue
         table.add_row(
@@ -167,6 +186,7 @@ def list_writes(
             str(item["kind"]),
             str(item["title"]),
             str(item["attempts"]),
+            _state_label(item),
         )
     console.print(table)
 
@@ -229,9 +249,18 @@ def claim_writes(
         bool,
         typer.Option("--yes", "-y", help="Approve the displayed user and organization."),
     ] = False,
+    unverified: Annotated[
+        bool,
+        typer.Option(
+            "--unverified", help="Adopt explicitly named legacy writes from an older login."
+        ),
+    ] = False,
 ) -> None:
     """Claim ambiguous legacy writes, then retry them automatically."""
     mark_pending_writes_reported()
+    if unverified and not write_ids:
+        error("Use explicit write IDs when adopting writes with unknown historical ownership.")
+        raise typer.Exit(code=1)
     try:
         selected = _selected_writes(write_ids or [])
     except (FileNotFoundError, ValueError) as exc:
@@ -242,7 +271,8 @@ def claim_writes(
         for item in selected
         if not is_corrupt_pending_write(item)
         and not _is_buffered_read_like(item)
-        and _legacy_claim_candidate(item)
+        and item.get("replay_identity") is None
+        and (_legacy_claim_candidate(item) or unverified)
     ]
     if not candidates:
         success("No ambiguous legacy writes matched")
@@ -268,10 +298,14 @@ def claim_writes(
                 raise typer.Exit(code=1)
 
             try:
-                identity = await client.get("/auth/me")
+                replay_identity = await client._ensure_pending_identity()
+                identity = await client._request("GET", "/auth/me", _replay_pending=False)
             except SibylClientError as exc:
                 error(exc.detail or str(exc))
                 raise typer.Exit(code=1) from exc
+            if replay_identity is None:
+                error("Upgrade the server to verify write ownership before claiming legacy writes.")
+                raise typer.Exit(code=1)
             user = identity.get("user") if isinstance(identity.get("user"), dict) else {}
             organization = (
                 identity.get("organization")
@@ -289,6 +323,15 @@ def claim_writes(
                 f"Claim {len(matching)} legacy write"
                 f"{'s' if len(matching) != 1 else ''} for {user_label} in {org_label}."
             )
+            if unverified:
+                warn(
+                    "Original ownership cannot be verified. Proceed only if these writes belong "
+                    "to this account and organization."
+                )
+            for item in matching:
+                warn(
+                    f"{str(item['id'])[:12]} {item['method']} {item['path']} at {item['base_url']}"
+                )
             if not yes and not typer.confirm("Continue?"):
                 raise typer.Abort()
 
@@ -304,6 +347,8 @@ def claim_writes(
                         claim_pending_write_replay_scope(
                             write_id,
                             client._replay_scope,
+                            replay_identity=replay_identity,
+                            adopt_unverified=unverified,
                         )
                     except (FileNotFoundError, ValueError) as exc:
                         claim_failures.append((write_id, str(exc)))
@@ -342,6 +387,24 @@ def claim_writes(
                 raise typer.Exit(code=1)
 
     run_claim()
+
+
+@app.command("retry")
+def retry_writes(
+    write_ids: Annotated[list[str], typer.Argument(help="Exact write IDs or prefixes to retry")],
+) -> None:
+    """Re-enable selected writes after resolving their reported failure."""
+    with pending_replay_lock() as acquired:
+        if not acquired:
+            error("Another pending-write replay is already running.")
+            raise typer.Exit(code=1)
+        for write_id in write_ids:
+            try:
+                retry_pending_write(write_id)
+            except (FileNotFoundError, ValueError) as exc:
+                error(str(exc))
+                raise typer.Exit(code=1) from exc
+    flush_writes(write_ids)
 
 
 @app.command("flush")
@@ -389,50 +452,70 @@ def flush_writes(
 
     @run_async
     async def run_flush() -> None:
+        from sibyl_cli import config_store
+
         failures = len(corrupt)
-        replay_failures = 0
         replayed = 0
-        contended = 0
+        blocked: dict[str, set[str]] = {}
+        selected_ids = {str(item["id"]) for item in replayable}
+        all_writes = [item for item in list_pending_writes() if not is_corrupt_pending_write(item)]
         async with AsyncExitStack() as stack:
-            clients: dict[tuple[str, str | None, str | None], SibylClient] = {}
-            for item in replayable:
+            clients: dict[tuple[str, str | None], SibylClient] = {}
+            for item in sorted(
+                all_writes, key=lambda row: (str(row.get("created_at", "")), str(row["id"]))
+            ):
                 write_id = str(item["id"])
+                base_url = normalize_api_url(str(item["base_url"]))
+                replay_scope = item.get("replay_scope")
+                owner = normalize_replay_identity(item.get("replay_identity"))
+                lane = json.dumps([base_url, owner or replay_scope], sort_keys=True)
+                blocked_resources = blocked.setdefault(lane, set())
+                resource = pending_write_resource(item)
+                if write_id not in selected_ids:
+                    if not _is_buffered_read_like(item):
+                        blocked_resources.add(resource)
+                    continue
+                if (
+                    "*" in blocked_resources
+                    or resource in blocked_resources
+                    or (resource == "*" and blocked_resources)
+                    or item.get("status") == "attention"
+                ):
+                    blocked_resources.add(resource)
+                    failures += 1
+                    warn(f"Skipped {write_id[:12]}: needs attention or an earlier related write.")
+                    continue
+                names = [_context_name_for_base_url(base_url, replay_scope)]
+                if owner:
+                    names.extend(
+                        ctx.name
+                        for ctx in config_store.list_contexts()
+                        if normalize_api_url(f"{ctx.server_url}/api") == base_url
+                    )
+                selected_client = None
+                for context_name in dict.fromkeys(names):
+                    key = (base_url, context_name)
+                    client = clients.get(key)
+                    if client is None:
+                        client = await stack.enter_async_context(
+                            SibylClient(base_url=base_url, context_name=context_name)
+                        )
+                        clients[key] = client
+                    try:
+                        identity = await client._ensure_pending_identity()
+                    except SibylClientError:
+                        continue
+                    if pending_identity_matches(item, identity, client._replay_scope):
+                        selected_client = client
+                        break
+                if selected_client is None:
+                    failures += 1
+                    blocked_resources.add(resource)
+                    error(f"Skipped {write_id[:12]}: no verified matching owner is signed in.")
+                    continue
                 try:
                     current = increment_attempts(write_id)
-                except FileNotFoundError:
-                    continue
-                base_url = str(current["base_url"])
-                replay_scope = current.get("replay_scope")
-                context_name = _context_name_for_base_url(base_url, replay_scope)
-                client_key = (
-                    normalize_api_url(base_url),
-                    context_name,
-                    str(replay_scope) if replay_scope else None,
-                )
-                client = clients.get(client_key)
-                if client is None:
-                    client = await stack.enter_async_context(
-                        SibylClient(base_url=base_url, context_name=context_name)
-                    )
-                    clients[client_key] = client
-                if not replay_scope:
-                    failures += 1
-                    replay_failures += 1
-                    error(
-                        f"Failed {write_id[:12]}: legacy write has no credential owner; "
-                        "run sibyl pending-writes claim first"
-                    )
-                    continue
-                if client._replay_scope != replay_scope:
-                    failures += 1
-                    replay_failures += 1
-                    error(
-                        f"Failed {write_id[:12]}: no configured credential scope matches "
-                        "the buffered write"
-                    )
-                    continue
-                try:
-                    await client._request(
+                    await selected_client._request(
                         str(current["method"]),
                         str(current["path"]),
                         json=current.get("json"),
@@ -444,34 +527,18 @@ def flush_writes(
                     record_pending_metric("replayed")
                     replayed += 1
                     success(f"Flushed {write_id[:12]}")
+                except FileNotFoundError:
+                    continue
                 except SibylClientError as exc:
                     failures += 1
-                    replay_failures += 1
+                    blocked_resources.add(resource)
                     error(f"Failed {write_id[:12]}: {exc.detail or exc}")
-                    if exc.status_code == 409:
-                        contended += 1
-                    if _should_abort_flush(exc):
-                        error("Stopping flush; remaining writes are still buffered.")
-                        break
-        if failures:
-            warn(f"{replayed} replayed, {failures} failed; all failed entries stay buffered.")
-            if replay_failures:
+            if failures:
                 warn(
-                    f"{replay_failures} replay failure"
-                    f"{'s are' if replay_failures != 1 else ' is'} safe to flush again."
+                    f"{replayed} replayed, {failures} unresolved; payloads remain local. "
+                    "Inspect pending-writes list for ownership and failure reasons."
                 )
-            if corrupt:
-                warn(
-                    f"{len(corrupt)} corrupt queue entr"
-                    f"{'ies' if len(corrupt) != 1 else 'y'} cannot replay until repaired "
-                    "or explicitly discarded."
-                )
-            if contended:
-                warn(
-                    f"{contended} hit an identical request still executing on the "
-                    "server; those clear on their own, flush again shortly."
-                )
-            raise typer.Exit(code=1)
+                raise typer.Exit(code=1)
 
     with pending_replay_lock() as acquired:
         if not acquired:

--- a/apps/cli/src/sibyl_cli/pending_identity.py
+++ b/apps/cli/src/sibyl_cli/pending_identity.py
@@ -1,0 +1,53 @@
+"""Validated, session-independent ownership of buffered mutations."""
+
+from typing import Any
+from uuid import UUID
+
+
+def normalize_replay_identity(value: object) -> dict[str, Any] | None:
+    """Accept only the complete server-issued v1 identity contract."""
+    if not isinstance(value, dict) or type(value.get("version")) is not int:
+        return None
+    if value["version"] != 1:
+        return None
+    identity: dict[str, Any] = {"version": 1}
+    for key in ("server_instance_id", "user_id", "organization_id"):
+        try:
+            identity[key] = str(UUID(str(value[key])))
+        except (KeyError, ValueError, TypeError):
+            return None
+    credential = value.get("credential")
+    if not isinstance(credential, dict) or credential.get("kind") not in ("session", "api_key"):
+        return None
+    normalized: dict[str, Any] = {"kind": credential["kind"]}
+    key_id = credential.get("api_key_id")
+    if credential["kind"] == "api_key":
+        try:
+            key_id = str(UUID(str(key_id)))
+        except (ValueError, TypeError):
+            return None
+    elif key_id is not None:
+        return None
+    normalized["api_key_id"] = key_id
+    for key in ("scopes", "project_ids", "memory_space_ids", "memory_scope_keys"):
+        if key not in credential:
+            return None
+        entries = credential[key]
+        if entries is None and key != "scopes":
+            normalized[key] = None
+        elif isinstance(entries, list) and all(isinstance(item, str) for item in entries):
+            normalized[key] = sorted(set(entries))
+        else:
+            return None
+    identity["credential"] = normalized
+    return identity
+
+
+def pending_identity_matches(
+    item: dict[str, Any], identity: dict[str, Any] | None, replay_scope: str | None
+) -> bool:
+    """Never fall back to credential lineage when a durable owner is present."""
+    if item.get("replay_identity") is not None:
+        owner = normalize_replay_identity(item["replay_identity"])
+        return owner is not None and identity is not None and owner == identity
+    return replay_scope is not None and item.get("replay_scope") == replay_scope

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -428,7 +428,7 @@ def pending_write_resource(item: dict[str, Any]) -> str:
         return f"entity:{parts[1]}"
     if len(parts) >= 2 and parts[0] == "projects":
         return f"project:{parts[1]}"
-    return "*"
+    return f"path:{'/'.join(parts[:2])}"
 
 
 def bind_pending_write_identity(

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -15,6 +15,8 @@ from typing import Any, Literal, get_args
 from urllib.parse import urlsplit
 from uuid import UUID, uuid4
 
+from sibyl_cli.pending_identity import normalize_replay_identity
+
 # Every buffered write leaves the queue through exactly one of these outcomes,
 # so `attempted` should equal their sum plus whatever is still queued. A gap
 # means writes are vanishing without an accounted reason. Reads project onto
@@ -22,6 +24,29 @@ from uuid import UUID, uuid4
 PendingMetric = Literal["attempted", "completed", "replayed", "dropped", "discarded"]
 PENDING_METRIC_NAMES: tuple[PendingMetric, ...] = get_args(PendingMetric)
 CORRUPT_PENDING_WRITE_STATUS = "corrupt"
+PendingFailureCategory = Literal[
+    "authentication", "transport", "server", "rejected", "conflict", "dependency"
+]
+_SAFE_FAILURE_CODES = frozenset(
+    {
+        "authentication_error",
+        "unauthorized",
+        "forbidden",
+        "not_found",
+        "conflict",
+        "validation_error",
+        "constraint_violation",
+        "internal_error",
+        "token_refresh_failed",
+        "client_too_old",
+        "service_unavailable",
+        "idempotency_conflict",
+        "idempotency_in_progress",
+        "replay_identity_mismatch",
+        "pending_dependency",
+        "response_unconfirmed",
+    }
+)
 _REQUIRED_STRING_FIELDS = (
     "id",
     "idempotency_key",
@@ -214,6 +239,13 @@ def _read_pending_path(path: Path) -> dict[str, Any]:
     attempts = data.get("attempts", 0)
     if type(attempts) is not int or attempts < 0:
         return _corrupt_pending_write(path, "Missing or invalid required field: attempts")
+    if (
+        data.get("replay_identity") is not None
+        and normalize_replay_identity(data["replay_identity"]) is None
+    ):
+        return _corrupt_pending_write(path, "Missing or invalid required field: replay_identity")
+    if data.get("status", "pending") not in ("pending", "attention"):
+        return _corrupt_pending_write(path, "Missing or invalid required field: status")
     return data
 
 
@@ -242,6 +274,7 @@ def create_pending_write(
     json_payload: dict[str, Any] | None,
     params: dict[str, Any] | None,
     replay_scope: str | None = None,
+    replay_identity: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     write_id = uuid4().hex
     idempotency_key = str(uuid4())
@@ -256,7 +289,13 @@ def create_pending_write(
         "json": json_payload,
         "params": params,
         "attempts": 0,
+        "status": "pending",
     }
+    if replay_identity is not None:
+        normalized = normalize_replay_identity(replay_identity)
+        if normalized is None:
+            raise ValueError("Invalid pending write replay identity")
+        data["replay_identity"] = normalized
     _secure_write_json(_pending_path(write_id), data)
     record_pending_metric("attempted")
     return data
@@ -335,7 +374,97 @@ def increment_attempts(write_id: str) -> dict[str, Any]:
     return data
 
 
-def claim_pending_write_replay_scope(write_id: str, replay_scope: str) -> dict[str, Any]:
+def record_pending_failure(
+    write_id: str,
+    *,
+    category: PendingFailureCategory,
+    status_code: int | None = None,
+    error_code: str | None = None,
+) -> dict[str, Any]:
+    """Retain the operation with a diagnostic that cannot contain response secrets."""
+    if category not in get_args(PendingFailureCategory):
+        raise ValueError("Invalid pending write failure category")
+    if status_code is not None and (type(status_code) is not int or not 400 <= status_code <= 599):
+        raise ValueError("Invalid pending write failure status code")
+    path = resolve_pending_write_path(write_id)
+    data = _read_pending_path(path)
+    if is_corrupt_pending_write(data):
+        raise ValueError("Cannot record a failure for a corrupt pending write")
+    data["status"] = "attention" if category in {"rejected", "conflict"} else "pending"
+    data["last_failure"] = {
+        "category": category,
+        "status_code": status_code,
+        "error_code": error_code if error_code in _SAFE_FAILURE_CODES else None,
+        "at": datetime.now(UTC).isoformat(),
+    }
+    _secure_write_json(path, data)
+    return data
+
+
+def retry_pending_write(write_id: str) -> dict[str, Any]:
+    """Explicitly retry a retained operation without changing its identity or payload."""
+    path = resolve_pending_write_path(write_id)
+    data = _read_pending_path(path)
+    if is_corrupt_pending_write(data):
+        raise ValueError("Cannot retry a corrupt pending write")
+    data["status"] = "pending"
+    data.pop("last_attempt_at", None)
+    _secure_write_json(path, data)
+    return data
+
+
+def pending_write_resource(item: dict[str, Any]) -> str:
+    """Group ordered mutations of one resource, leaving independent creates unblocked."""
+    parts = [part for part in str(item.get("path", "")).split("/") if part]
+    method = str(item.get("method", "")).upper()
+    if method == "POST" and parts in (["memory", "raw"], ["tasks"], ["entities"]):
+        payload = item.get("json")
+        if parts in (["tasks"], ["entities"]) and isinstance(payload, dict) and payload.get("id"):
+            return f"entity:{payload['id']}"
+        return f"create:{item['id']}"
+    if len(parts) >= 2 and parts[1] in {"bulk", "batch", "import", "export"}:
+        return "*"
+    if len(parts) >= 2 and parts[0] in {"tasks", "entities"}:
+        return f"entity:{parts[1]}"
+    if len(parts) >= 2 and parts[0] == "projects":
+        return f"project:{parts[1]}"
+    return "*"
+
+
+def bind_pending_write_identity(
+    write_id: str,
+    replay_identity: dict[str, Any],
+    *,
+    replay_scope: str,
+) -> dict[str, Any]:
+    """Migrate only a write still owned by the caller's original credential lineage."""
+    normalized = normalize_replay_identity(replay_identity)
+    if not replay_scope or normalized is None:
+        raise ValueError("Invalid pending write replay identity or credential scope")
+    replay_identity = normalized
+    path = resolve_pending_write_path(write_id)
+    data = _read_pending_path(path)
+    if is_corrupt_pending_write(data):
+        raise ValueError("Cannot bind a corrupt pending write")
+    existing = data.get("replay_identity")
+    if existing is not None:
+        if existing != replay_identity:
+            raise ValueError("Pending write already belongs to another identity")
+        return data
+    if data.get("replay_scope") != replay_scope:
+        raise ValueError("Pending write belongs to another credential lineage")
+    data["replay_identity"] = replay_identity
+    _secure_write_json(path, data)
+    return data
+
+
+def claim_pending_write_replay_scope(
+    write_id: str,
+    replay_scope: str,
+    *,
+    replay_identity: dict[str, Any] | None = None,
+    adopt_unverified: bool = False,
+) -> dict[str, Any]:
     """Bind an ambiguous legacy write after explicit operator approval."""
     if not replay_scope:
         raise ValueError("Pending write replay scope cannot be empty")
@@ -343,12 +472,28 @@ def claim_pending_write_replay_scope(write_id: str, replay_scope: str) -> dict[s
     data = _read_pending_path(path)
     if is_corrupt_pending_write(data):
         raise ValueError(f"Cannot update corrupt pending write {data['filename']}: {data['error']}")
+    if data.get("replay_identity") is not None:
+        raise ValueError("A verified write owner cannot be reassigned")
+    identity = normalize_replay_identity(replay_identity)
+    if replay_identity is not None and identity is None:
+        raise ValueError("Invalid replay identity")
+    if adopt_unverified and identity is None:
+        raise ValueError("Adopting an unverified write requires a verified server identity")
     current_scope = data.get("replay_scope")
-    if current_scope == replay_scope:
+    if current_scope == replay_scope and identity is None:
         return data
-    if current_scope is not None and not str(current_scope).startswith("context:"):
+    if (
+        current_scope != replay_scope
+        and current_scope is not None
+        and not str(current_scope).startswith("context:")
+        and not adopt_unverified
+    ):
         raise ValueError("Pending write already belongs to another credential")
+    data["previous_replay_scope"] = current_scope
     data["replay_scope"] = replay_scope
+    if identity is not None:
+        data["replay_identity"] = identity
+        data["ownership_confirmed_at"] = datetime.now(UTC).isoformat()
     _secure_write_json(path, data)
     return data
 
@@ -382,6 +527,8 @@ def pending_write_status() -> dict[str, Any]:
     writes = list_pending_writes()
     return {
         "count": len(writes),
+        "pending": sum(item.get("status", "pending") == "pending" for item in writes),
+        "attention": sum(item.get("status") == "attention" for item in writes),
         "failures": [
             {"filename": item["filename"], "error": item["error"]}
             for item in writes

--- a/apps/cli/src/sibyl_cli/pending_writes.py
+++ b/apps/cli/src/sibyl_cli/pending_writes.py
@@ -42,6 +42,7 @@ _SAFE_FAILURE_CODES = frozenset(
         "service_unavailable",
         "idempotency_conflict",
         "idempotency_in_progress",
+        "entity_locked",
         "replay_identity_mismatch",
         "pending_dependency",
         "response_unconfirmed",

--- a/apps/cli/tests/test_client_errors.py
+++ b/apps/cli/tests/test_client_errors.py
@@ -18,9 +18,14 @@ from sibyl_cli.common import handle_client_error
 
 def _client_with_transport(transport: httpx.MockTransport) -> SibylClient:
     client = SibylClient(base_url="http://testserver/api", auth_token="token")
+    async def legacy_transport(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(404, json={"detail": "Not Found"})
+        return await transport.handle_async_request(request)
+
     client._client = httpx.AsyncClient(
         base_url=client.base_url,
-        transport=transport,
+        transport=httpx.MockTransport(legacy_transport),
         headers=client._default_headers(),
     )
     return client
@@ -264,7 +269,7 @@ async def test_failed_automatic_replay_does_not_fail_the_triggering_request(
 
 
 @pytest.mark.asyncio
-async def test_automatic_replay_stops_after_the_first_transient_failure(
+async def test_automatic_replay_attempts_independent_writes_after_transient_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -272,6 +277,7 @@ async def test_automatic_replay_stops_after_the_first_transient_failure(
     monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
     client_transport_module._FAILURE_WINDOWS.clear()
     posts = 0
+    monkeypatch.setattr(client_transport_module, "anyio_sleep", AsyncMock())
 
     def healthy_then_unavailable(request: httpx.Request) -> httpx.Response:
         nonlocal posts
@@ -299,10 +305,10 @@ async def test_automatic_replay_stops_after_the_first_transient_failure(
     await client.close()
     attempts = sorted(int(item["attempts"]) for item in pending_writes.list_pending_writes())
     assert result == {"status": "healthy"}
-    assert posts == 1
-    assert attempts == [0] * 7 + [1]
+    assert posts == 8
+    assert attempts == [1] * 8
     key = client_transport_module._failure_key(client.base_url)
-    assert len(client_transport_module._FAILURE_WINDOWS[key]) == 1
+    assert len(client_transport_module._FAILURE_WINDOWS[key]) == 8
     client_transport_module._FAILURE_WINDOWS.clear()
 
 
@@ -325,7 +331,7 @@ async def test_automatic_replay_does_not_pass_an_older_write_in_cooldown(
         method="POST",
         path="/entities",
         base_url=client.base_url,
-        json_payload={"name": "Create first"},
+        json_payload={"id": "entity_123", "name": "Create first"},
         params=None,
         replay_scope=client._replay_scope,
     )
@@ -589,7 +595,7 @@ async def test_mutating_request_keeps_pending_write_on_auth_failure(
 
 
 @pytest.mark.asyncio
-async def test_mutating_request_deletes_pending_write_on_validation_error(
+async def test_mutating_request_parks_pending_write_on_validation_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -606,13 +612,15 @@ async def test_mutating_request_deletes_pending_write_on_validation_error(
         await client.post("/entities", json={"name": "Invalid"})
 
     await client.close()
-    assert pending_writes.list_pending_writes() == []
-    assert pending_writes.read_pending_metrics()["dropped"] == 1
+    item = pending_writes.list_pending_writes()[0]
+    assert item["status"] == "attention"
+    assert item["last_failure"]["category"] == "rejected"
+    assert pending_writes.read_pending_metrics()["dropped"] == 0
 
 
 @pytest.mark.parametrize("status_code", [400, 422])
 @pytest.mark.asyncio
-async def test_mutating_request_drops_pending_write_when_payload_is_unusable(
+async def test_mutating_request_preserves_rejected_payload_for_inspection(
     status_code: int,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -631,8 +639,10 @@ async def test_mutating_request_drops_pending_write_when_payload_is_unusable(
         await client.post("/memory/raw", json={"title": "Doomed", "raw_content": "Body"})
 
     await client.close()
-    assert pending_writes.list_pending_writes() == []
-    assert pending_writes.read_pending_metrics()["dropped"] == 1
+    item = pending_writes.list_pending_writes()[0]
+    assert item["status"] == "attention"
+    assert item["last_failure"]["category"] == "rejected"
+    assert pending_writes.read_pending_metrics()["dropped"] == 0
 
 
 @pytest.mark.asyncio

--- a/apps/cli/tests/test_client_errors.py
+++ b/apps/cli/tests/test_client_errors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import httpx
@@ -18,6 +19,7 @@ from sibyl_cli.common import handle_client_error
 
 def _client_with_transport(transport: httpx.MockTransport) -> SibylClient:
     client = SibylClient(base_url="http://testserver/api", auth_token="token")
+
     async def legacy_transport(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/api/auth/replay-identity":
             return httpx.Response(404, json={"detail": "Not Found"})
@@ -275,6 +277,7 @@ async def test_automatic_replay_attempts_independent_writes_after_transient_fail
 ) -> None:
     monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
     monkeypatch.setattr(client_transport_module, "AUTO_REPLAY_GRACE_SECONDS", 0.0)
+    monkeypatch.setattr(client_transport_module, "time", SimpleNamespace(monotonic=lambda: 100.0))
     client_transport_module._FAILURE_WINDOWS.clear()
     posts = 0
     monkeypatch.setattr(client_transport_module, "anyio_sleep", AsyncMock())
@@ -310,6 +313,39 @@ async def test_automatic_replay_attempts_independent_writes_after_transient_fail
     key = client_transport_module._failure_key(client.base_url)
     assert len(client_transport_module._FAILURE_WINDOWS[key]) == 8
     client_transport_module._FAILURE_WINDOWS.clear()
+
+
+@pytest.mark.asyncio
+async def test_buffered_reflection_does_not_block_a_new_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    requests: list[httpx.Request] = []
+
+    def healthy(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"id": "new-task"})
+
+    client = _client_with_transport(httpx.MockTransport(healthy))
+    reflection = pending_writes.create_pending_write(
+        method="POST",
+        path="/context/reflect",
+        base_url=client.base_url,
+        json_payload={"content": "Preserve this reflection"},
+        params=None,
+        replay_scope=client._replay_scope,
+    )
+    pending_writes.record_pending_failure(reflection["id"], category="rejected", status_code=404)
+
+    result = await client.post("/tasks", json={"name": "Independent task"})
+    await client.close()
+
+    assert result == {"id": "new-task"}
+    assert [(request.method, request.url.path) for request in requests] == [("POST", "/api/tasks")]
+    remaining = pending_writes.list_pending_writes()
+    assert [item["id"] for item in remaining] == [reflection["id"]]
+    assert remaining[0]["status"] == "attention"
 
 
 @pytest.mark.asyncio

--- a/apps/cli/tests/test_pending_cli.py
+++ b/apps/cli/tests/test_pending_cli.py
@@ -5,13 +5,28 @@ from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
 from sibyl_cli import pending, pending_writes
-from sibyl_cli.client import SibylClientError
+from sibyl_cli.client import SibylClient, SibylClientError
 
 TEST_REPLAY_SCOPE = "token-sha256:test"
+TEST_IDENTITY = {
+    "version": 1,
+    "server_instance_id": "11111111-1111-1111-1111-111111111111",
+    "user_id": "22222222-2222-2222-2222-222222222222",
+    "organization_id": "33333333-3333-3333-3333-333333333333",
+    "credential": {
+        "kind": "session",
+        "api_key_id": None,
+        "scopes": [],
+        "project_ids": None,
+        "memory_space_ids": None,
+        "memory_scope_keys": None,
+    },
+}
 
 
 def _create_pending(path: str = "/memory/raw") -> dict[str, Any]:
@@ -101,6 +116,9 @@ def test_pending_writes_flush_replays_valid_entries_but_keeps_corrupt_ones(
             self.context_name = context_name
             self._replay_scope = TEST_REPLAY_SCOPE
 
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
+
         async def __aenter__(self) -> FakeClient:
             return self
 
@@ -124,7 +142,7 @@ def test_pending_writes_flush_replays_valid_entries_but_keeps_corrupt_ones(
     assert len(remaining) == 1
     assert remaining[0]["status"] == "corrupt"
     assert corrupt_path.exists()
-    assert "1 replayed, 1 failed" in result.stdout
+    assert "1 replayed, 1 unresolved" in result.stdout
 
 
 @pytest.mark.parametrize(("field", "value"), [("json", []), ("params", {"nested": {}})])
@@ -229,13 +247,16 @@ def test_pending_writes_claim_binds_and_retries_legacy_entries(
             self.base_url = "http://testserver/api"
             self._replay_scope = TEST_REPLAY_SCOPE
 
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
+
         async def __aenter__(self) -> FakeClient:
             return self
 
         async def __aexit__(self, *_args: object) -> None:
             return None
 
-        async def get(self, path: str) -> dict[str, Any]:
+        async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
             assert path == "/auth/me"
             return {
                 "user": {"email": "bliss@example.test"},
@@ -284,13 +305,16 @@ def test_pending_writes_claim_fails_when_replay_lock_is_busy(
             self.base_url = "http://testserver/api"
             self._replay_scope = TEST_REPLAY_SCOPE
 
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
+
         async def __aenter__(self) -> FakeClient:
             return self
 
         async def __aexit__(self, *_args: object) -> None:
             return None
 
-        async def get(self, path: str) -> dict[str, Any]:
+        async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
             assert path == "/auth/me"
             return {
                 "user": {"email": "bliss@example.test"},
@@ -338,13 +362,16 @@ def test_pending_writes_claim_reports_a_concurrent_queue_change(
             self.base_url = "http://testserver/api"
             self._replay_scope = TEST_REPLAY_SCOPE
 
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
+
         async def __aenter__(self) -> FakeClient:
             return self
 
         async def __aexit__(self, *_args: object) -> None:
             return None
 
-        async def get(self, path: str) -> dict[str, Any]:
+        async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
             assert path == "/auth/me"
             return {
                 "user": {"email": "bliss@example.test"},
@@ -354,7 +381,7 @@ def test_pending_writes_claim_reports_a_concurrent_queue_change(
         async def _maybe_replay_pending_writes(self, *, ignore_backoff: bool = False) -> None:
             raise AssertionError("an unclaimed write reached replay")
 
-    def fail_claim(_write_id: str, _replay_scope: str) -> dict[str, Any]:
+    def fail_claim(_write_id: str, _replay_scope: str, **kwargs: Any) -> dict[str, Any]:
         raise claim_error
 
     monkeypatch.setattr(pending, "SibylClient", FakeClient)
@@ -389,6 +416,9 @@ def test_pending_writes_flush_refuses_an_unclaimed_legacy_entry(
             self.base_url = base_url
             self.context_name = context_name
 
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
+
         async def __aenter__(self) -> FakeClient:
             return self
 
@@ -403,7 +433,7 @@ def test_pending_writes_flush_refuses_an_unclaimed_legacy_entry(
     result = CliRunner().invoke(pending.app, ["flush"])
 
     assert result.exit_code == 1
-    assert "run sibyl pending-writes claim first" in result.stdout
+    assert "no verified matching owner is signed in" in result.stdout
     assert pending_writes.pending_write_count() == 1
 
 
@@ -420,6 +450,9 @@ def test_pending_writes_flush_replays_and_deletes(
             self.base_url = base_url
             self.context_name = context_name
             self._replay_scope = TEST_REPLAY_SCOPE
+
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
 
         async def __aenter__(self) -> FakeClient:
             return self
@@ -459,6 +492,9 @@ def test_pending_writes_flush_skips_read_like_replays(
             self.base_url = base_url
             self.context_name = context_name
             self._replay_scope = TEST_REPLAY_SCOPE
+
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
 
         async def __aenter__(self) -> FakeClient:
             return self
@@ -500,6 +536,9 @@ def test_pending_writes_flush_reuses_client_per_base_url(
             self._replay_scope = TEST_REPLAY_SCOPE
             instances.append(self)
 
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
+
         async def __aenter__(self) -> FakeClient:
             return self
 
@@ -520,7 +559,7 @@ def test_pending_writes_flush_reuses_client_per_base_url(
     assert sorted(calls) == ["/memory/raw", "/tasks"]
 
 
-def test_pending_writes_flush_stops_after_auth_refresh_failure(
+def test_pending_writes_flush_retains_writes_after_auth_refresh_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -534,6 +573,9 @@ def test_pending_writes_flush_stops_after_auth_refresh_failure(
             self.base_url = base_url
             self.context_name = context_name
             self._replay_scope = TEST_REPLAY_SCOPE
+
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
 
         async def __aenter__(self) -> FakeClient:
             return self
@@ -555,10 +597,9 @@ def test_pending_writes_flush_stops_after_auth_refresh_failure(
     result = CliRunner().invoke(pending.app, ["flush"])
 
     assert result.exit_code == 1
-    assert len(calls) == 1
-    assert calls[0] in {"/memory/raw", "/tasks"}
+    assert sorted(calls) == ["/memory/raw", "/tasks"]
     assert len(pending_writes.list_pending_writes()) == 2
-    assert "Stopping flush" in result.stdout
+    assert "2 unresolved; payloads remain local" in result.stdout
 
 
 def test_pending_writes_flush_failure_summary_names_both_classes(
@@ -574,6 +615,9 @@ def test_pending_writes_flush_failure_summary_names_both_classes(
             self.base_url = base_url
             self.context_name = context_name
             self._replay_scope = TEST_REPLAY_SCOPE
+
+        async def _ensure_pending_identity(self) -> dict[str, Any]:
+            return TEST_IDENTITY
 
         async def __aenter__(self) -> FakeClient:
             return self
@@ -599,9 +643,9 @@ def test_pending_writes_flush_failure_summary_names_both_classes(
     remaining = pending_writes.list_pending_writes()
     assert len(remaining) == 1
     assert remaining[0]["path"] == "/tasks"
-    assert "1 replayed, 1 failed" in result.stdout
-    assert "safe to flush again" in result.stdout
-    assert "flush again shortly" in result.stdout
+    assert "1 replayed, 1 unresolved" in result.stdout
+    assert "safe to flush again" not in result.stdout
+    assert "payloads remain local" in result.stdout
 
 
 def test_pending_writes_discard_exits_nonzero_when_an_id_matches_nothing(
@@ -671,3 +715,163 @@ def test_pending_writes_discard_reports_what_it_removed_on_a_partial_match(
     assert result.exit_code == 1
     assert "Discarded 1 pending write" in result.stdout
     assert "No pending write matched 1" in result.stdout
+
+
+def _mock_authenticated_client(monkeypatch: pytest.MonkeyPatch, calls: list[httpx.Request]) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=TEST_IDENTITY)
+        if request.url.path == "/api/auth/me":
+            return httpx.Response(
+                200,
+                json={
+                    "user": {"email": "bliss@example.test"},
+                    "organization": {"slug": "silkcircuit"},
+                },
+            )
+        return httpx.Response(200, json={"mutation_receipt": {"applied": True}})
+
+    def factory(**kwargs: Any) -> SibylClient:
+        kwargs.pop("context_name", None)
+        client = SibylClient(
+            base_url=kwargs.get("base_url", "http://testserver/api"), auth_token="synthetic"
+        )
+        client._client = httpx.AsyncClient(
+            base_url=client.base_url,
+            transport=httpx.MockTransport(handler),
+            headers=client._default_headers(),
+        )
+        return client
+
+    monkeypatch.setattr(pending, "SibylClient", factory)
+    monkeypatch.setattr("sibyl_cli.config_store.resolve_context_name", lambda: None)
+
+
+def test_unverified_adoption_requires_explicit_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    item = _create_pending()
+    result = CliRunner().invoke(pending.app, ["claim", "--unverified", "--yes"])
+    assert result.exit_code == 1
+    assert "explicit write IDs" in result.stdout
+    assert pending_writes.read_pending_write(item["id"])["replay_scope"] == TEST_REPLAY_SCOPE
+
+
+def test_explicit_unverified_adoption_preserves_key_and_replays_only_selected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    selected = _create_pending()
+    untouched = _create_pending()
+    calls: list[httpx.Request] = []
+    _mock_authenticated_client(monkeypatch, calls)
+    result = CliRunner().invoke(pending.app, ["claim", selected["id"], "--unverified", "--yes"])
+    assert result.exit_code == 0, result.stdout
+    assert "Original ownership cannot be verified" in result.stdout
+    mutations = [request for request in calls if request.method == "POST"]
+    assert len(mutations) == 1
+    assert mutations[0].headers["Idempotency-Key"] == selected["idempotency_key"]
+    assert [item["id"] for item in pending_writes.list_pending_writes()] == [untouched["id"]]
+
+
+def test_unverified_adoption_never_reassigns_verified_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    foreign = {**TEST_IDENTITY, "user_id": "44444444-4444-4444-4444-444444444444"}
+    item = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="http://testserver/api",
+        json_payload={"raw_content": "keep"},
+        params=None,
+        replay_identity=foreign,
+    )
+    calls: list[httpx.Request] = []
+    _mock_authenticated_client(monkeypatch, calls)
+    CliRunner().invoke(pending.app, ["claim", item["id"], "--unverified", "--yes"])
+    assert not calls
+    assert pending_writes.read_pending_write(item["id"])["replay_identity"] == foreign
+
+
+def test_retry_reenables_attention_and_preserves_original_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    item = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="http://testserver/api",
+        json_payload={"raw_content": "keep"},
+        params=None,
+        replay_identity=TEST_IDENTITY,
+    )
+    pending_writes.record_pending_failure(item["id"], category="conflict", status_code=409)
+    calls: list[httpx.Request] = []
+    _mock_authenticated_client(monkeypatch, calls)
+    result = CliRunner().invoke(pending.app, ["retry", item["id"]])
+    assert result.exit_code == 0, result.stdout
+    mutations = [request for request in calls if request.method == "POST"]
+    assert len(mutations) == 1
+    assert mutations[0].headers["Idempotency-Key"] == item["idempotency_key"]
+    assert pending_writes.list_pending_writes() == []
+
+
+def test_selected_flush_cannot_bypass_earlier_related_attention(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    earlier = pending_writes.create_pending_write(
+        method="PATCH",
+        path="/tasks/123",
+        base_url="http://testserver/api",
+        json_payload={"name": "first"},
+        params=None,
+        replay_identity=TEST_IDENTITY,
+    )
+    later = pending_writes.create_pending_write(
+        method="POST",
+        path="/tasks/123/complete",
+        base_url="http://testserver/api",
+        json_payload={},
+        params=None,
+        replay_identity=TEST_IDENTITY,
+    )
+    pending_writes.record_pending_failure(earlier["id"], category="rejected", status_code=404)
+    calls: list[httpx.Request] = []
+    _mock_authenticated_client(monkeypatch, calls)
+    result = CliRunner().invoke(pending.app, ["flush", later["id"]])
+    assert result.exit_code == 1, result.stdout
+    assert all(request.method == "GET" for request in calls)
+    assert pending_writes.read_pending_write(later["id"])["attempts"] == 0
+
+
+def test_unverified_adoption_requires_server_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    item = _create_pending()
+    original = pending_writes.resolve_pending_write_path(item["id"]).read_bytes()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(404, json={"detail": "Not found"})
+        return httpx.Response(200, json={"user": {"email": "bliss@example.test"}})
+
+    def factory(**kwargs: Any) -> SibylClient:
+        client = SibylClient(base_url="http://testserver/api", auth_token="synthetic")
+        client._client = httpx.AsyncClient(
+            base_url=client.base_url, transport=httpx.MockTransport(handler)
+        )
+        return client
+
+    monkeypatch.setattr(pending, "SibylClient", factory)
+    monkeypatch.setattr("sibyl_cli.config_store.resolve_context_name", lambda: None)
+    result = CliRunner().invoke(pending.app, ["claim", item["id"], "--unverified", "--yes"])
+    assert result.exit_code == 1
+    assert "Upgrade the server" in result.stdout
+    assert pending_writes.resolve_pending_write_path(item["id"]).read_bytes() == original

--- a/apps/cli/tests/test_pending_identity_store.py
+++ b/apps/cli/tests/test_pending_identity_store.py
@@ -1,0 +1,41 @@
+from copy import deepcopy
+from pathlib import Path
+from uuid import uuid4
+
+from sibyl_cli import auth_store
+
+
+def test_verified_owner_cache_survives_refresh_but_not_new_login(tmp_path: Path) -> None:
+    path = tmp_path / "auth.json"
+    url = "http://server.test/api"
+    owner = {
+        "version": 1,
+        "server_instance_id": str(uuid4()),
+        "user_id": str(uuid4()),
+        "organization_id": str(uuid4()),
+        "credential": {
+            "kind": "session", "api_key_id": None, "scopes": [],
+            "project_ids": None, "memory_space_ids": None, "memory_scope_keys": None,
+        },
+    }
+    auth_store.set_tokens(url, "first", path=path)
+    scope = auth_store.get_pending_replay_scope(url, path)
+    assert auth_store.cache_pending_replay_identity(url, "first", owner, path=path)
+    auth_store.set_tokens(url, "refreshed", path=path, pending_replay_scope=scope)
+    assert auth_store.read_server_credentials(url, path)["pending_replay_identity"] == owner
+    auth_store.set_tokens(url, "new-login", path=path)
+    assert "pending_replay_identity" not in auth_store.read_server_credentials(url, path)
+    assert not auth_store.cache_pending_replay_identity(url, "refreshed", owner, path=path)
+    assert "pending_replay_identity" not in auth_store.read_server_credentials(url, path)
+
+
+def test_cached_ownership_cannot_leak_between_contexts(tmp_path: Path) -> None:
+    path = tmp_path / "auth.json"
+    url = "http://server.test/api"
+    auth_store.set_tokens(url, "a", path=path, credential_scope="org-a")
+    auth_store.set_tokens(url, "b", path=path, credential_scope="org-b")
+    before = deepcopy(auth_store.read_auth_data(path))
+    assert not auth_store.cache_pending_replay_identity(
+        url, "a", {"user_id": "not-the-current-token"}, path=path, credential_scope="org-b"
+    )
+    assert auth_store.read_auth_data(path) == before

--- a/apps/cli/tests/test_pending_recovery.py
+++ b/apps/cli/tests/test_pending_recovery.py
@@ -356,3 +356,73 @@ async def test_unconfirmed_response_retains_payload_and_diagnostic(
         "transport" if failure_kind == "protocol" else "server"
     )
     assert entry["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_transient_idempotency_lock_retries_original_request(identity: dict) -> None:
+    item = queued(identity)
+    writes = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=identity)
+        writes.append(request)
+        if len(writes) == 1:
+            return httpx.Response(409, json={"detail": {
+                "error": "idempotency_in_progress", "message": "Still running"
+            }})
+        return httpx.Response(200, json={"ok": True})
+
+    client = attach(SibylClient(base_url=BASE_URL, auth_token="synthetic"), handler)
+    await client._maybe_replay_pending_writes(ignore_backoff=True)
+    failed = pending_writes.read_pending_write(item["id"])
+    assert failed["status"] == "pending"
+    assert failed["last_failure"]["error_code"] == "idempotency_in_progress"
+    await client._maybe_replay_pending_writes(ignore_backoff=True)
+    await client.close()
+    assert len(writes) == 2
+    assert {request.headers["Idempotency-Key"] for request in writes} == {item["idempotency_key"]}
+    assert pending_writes.list_pending_writes() == []
+
+
+@pytest.mark.asyncio
+async def test_new_write_uses_fresh_identity_without_reassigning_older_write(identity: dict) -> None:
+    auth_store.set_tokens(BASE_URL, "synthetic", "refresh")
+    auth_store.cache_pending_replay_identity(BASE_URL, "synthetic", identity)
+    older = queued(identity)
+    current = deepcopy(identity)
+    current["server_instance_id"] = "44444444-4444-4444-4444-444444444444"
+    writes = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=current)
+        writes.append(request)
+        assert request.headers["X-Sibyl-Server-Instance"] == current["server_instance_id"]
+        return httpx.Response(200, json={"ok": True})
+
+    client = attach(SibylClient(base_url=BASE_URL), handler)
+    assert client._pending_identity == identity
+    await client.post("/memory/raw", json={"raw_content": "new draft"})
+    await client.close()
+    assert len(writes) == 1
+    assert pending_writes.read_pending_write(older["id"])["replay_identity"] == identity
+    assert len(pending_writes.list_pending_writes()) == 1
+
+
+@pytest.mark.asyncio
+async def test_offline_draft_keeps_last_verified_owner(identity: dict) -> None:
+    auth_store.set_tokens(BASE_URL, "synthetic", "refresh")
+    auth_store.cache_pending_replay_identity(BASE_URL, "synthetic", identity)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    client = attach(SibylClient(base_url=BASE_URL), handler)
+    with pytest.raises(SibylClientError):
+        await client.post("/memory/raw", json={"raw_content": "offline draft"})
+    await client.close()
+    item = pending_writes.list_pending_writes()[0]
+    assert item["replay_identity"] == identity
+    assert item["json"] == {"raw_content": "offline draft"}
+    assert item["last_failure"]["category"] == "transport"

--- a/apps/cli/tests/test_pending_recovery.py
+++ b/apps/cli/tests/test_pending_recovery.py
@@ -359,7 +359,8 @@ async def test_unconfirmed_response_retains_payload_and_diagnostic(
 
 
 @pytest.mark.asyncio
-async def test_transient_idempotency_lock_retries_original_request(identity: dict) -> None:
+@pytest.mark.parametrize("error_code", ["idempotency_in_progress", "entity_locked"])
+async def test_transient_lock_retries_original_request(identity: dict, error_code: str) -> None:
     item = queued(identity)
     writes = []
 
@@ -369,7 +370,7 @@ async def test_transient_idempotency_lock_retries_original_request(identity: dic
         writes.append(request)
         if len(writes) == 1:
             return httpx.Response(409, json={"detail": {
-                "error": "idempotency_in_progress", "message": "Still running"
+                "error": error_code, "message": "Still running"
             }})
         return httpx.Response(200, json={"ok": True})
 
@@ -377,7 +378,7 @@ async def test_transient_idempotency_lock_retries_original_request(identity: dic
     await client._maybe_replay_pending_writes(ignore_backoff=True)
     failed = pending_writes.read_pending_write(item["id"])
     assert failed["status"] == "pending"
-    assert failed["last_failure"]["error_code"] == "idempotency_in_progress"
+    assert failed["last_failure"]["error_code"] == error_code
     await client._maybe_replay_pending_writes(ignore_backoff=True)
     await client.close()
     assert len(writes) == 2

--- a/apps/cli/tests/test_pending_recovery.py
+++ b/apps/cli/tests/test_pending_recovery.py
@@ -1,0 +1,358 @@
+"""Exercise queue ownership and recovery through the actual HTTP client."""
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from sibyl_cli import auth_store, client_transport, pending_writes
+from sibyl_cli.client import SibylClient, SibylClientError
+from sibyl_cli.pending_identity import normalize_replay_identity
+
+BASE_URL = "https://testserver/api"
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    client_transport._FAILURE_WINDOWS.clear()
+
+
+@pytest.fixture
+def identity() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "server_instance_id": "11111111-1111-1111-1111-111111111111",
+        "user_id": "22222222-2222-2222-2222-222222222222",
+        "organization_id": "33333333-3333-3333-3333-333333333333",
+        "credential": {
+            "kind": "session",
+            "api_key_id": None,
+            "scopes": [],
+            "project_ids": None,
+            "memory_space_ids": None,
+            "memory_scope_keys": None,
+        },
+    }
+
+
+def attach(client: SibylClient, handler: Any) -> SibylClient:
+    client._client = httpx.AsyncClient(
+        base_url=client.base_url,
+        transport=httpx.MockTransport(handler),
+        headers=client._default_headers(),
+    )
+    return client
+
+
+def queued(
+    identity: dict[str, Any] | None,
+    *,
+    scope: str | None = None,
+    method: str = "POST",
+    path: str = "/memory/raw",
+) -> dict[str, Any]:
+    return pending_writes.create_pending_write(
+        method=method,
+        path=path,
+        base_url=BASE_URL,
+        json_payload={"raw_content": "original payload"},
+        params=None,
+        replay_identity=identity,
+        replay_scope=scope,
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_login_recovers_verified_owner_with_original_idempotency_key(
+    identity: dict,
+) -> None:
+    auth_store.set_tokens(BASE_URL, "first-login", "first-refresh")
+    first = SibylClient(base_url=BASE_URL)
+
+    async def interrupted(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=identity)
+        raise httpx.ReadTimeout("response lost", request=request)
+
+    attach(first, interrupted)
+    with pytest.raises(SibylClientError):
+        await first.post("/memory/raw", json={"raw_content": "original payload"})
+    await first.close()
+    original = pending_writes.list_pending_writes()[0]
+    assert original["replay_identity"] == identity
+    first_scope = original["replay_scope"]
+    auth_store.set_tokens(BASE_URL, "second-login", "second-refresh")
+    calls = []
+
+    def recovered(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=identity)
+        return httpx.Response(200, json={"mutation_receipt": {"applied": True, "replayed": True}})
+
+    second = attach(SibylClient(base_url=BASE_URL), recovered)
+    assert second._replay_scope != first_scope
+    await second._maybe_replay_pending_writes(ignore_backoff=True)
+    await second.close()
+    writes = [request for request in calls if request.method == "POST"]
+    assert len(writes) == 1
+    assert writes[0].headers["Idempotency-Key"] == original["idempotency_key"]
+    assert writes[0].headers["Authorization"] == "Bearer second-login"
+    assert pending_writes.list_pending_writes() == []
+    assert pending_writes.read_pending_metrics()["replayed"] == 1
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        "server_instance_id",
+        "user_id",
+        "organization_id",
+        "scopes",
+        "project_ids",
+        "memory_space_ids",
+        "memory_scope_keys",
+        "api_key_id",
+    ],
+)
+@pytest.mark.asyncio
+async def test_changed_owner_or_credential_restriction_never_sends(
+    identity: dict, changed: str
+) -> None:
+    original = queued(identity)
+    current = deepcopy(identity)
+    if changed in ("server_instance_id", "user_id", "organization_id"):
+        current[changed] = "44444444-4444-4444-4444-444444444444"
+    elif changed == "api_key_id":
+        current["credential"].update(
+            kind="api_key", api_key_id="44444444-4444-4444-4444-444444444444"
+        )
+    else:
+        current["credential"][changed] = ["limited"]
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        assert request.method == "GET"
+        return httpx.Response(200, json=current)
+
+    client = attach(SibylClient(base_url=BASE_URL, auth_token="different-login"), handler)
+    await client._maybe_replay_pending_writes(ignore_backoff=True)
+    await client.close()
+    assert len(calls) == 1
+    assert pending_writes.read_pending_write(original["id"])["attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_failed_identity_preflight_preserves_draft_without_sending_mutation() -> None:
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(
+            503, json={"error": "service_unavailable", "message": "private response"}
+        )
+
+    client = attach(SibylClient(base_url=BASE_URL, auth_token="synthetic"), handler)
+    with pytest.raises(SibylClientError):
+        await client.post("/memory/raw", json={"raw_content": "keep draft"})
+    await client.close()
+    assert [request.method for request in calls] == ["GET"]
+    item = pending_writes.list_pending_writes()[0]
+    assert item["json"] == {"raw_content": "keep draft"}
+    assert item["last_failure"]["status_code"] == 503
+    assert "private response" not in str(item)
+
+
+@pytest.mark.asyncio
+async def test_missing_task_parks_but_unrelated_capture_progresses(identity: dict) -> None:
+    missing = queued(identity, method="PATCH", path="/tasks/123")
+    later = queued(identity, path="/tasks/123/complete")
+    capture = queued(identity)
+    paths = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=identity)
+        if request.url.path == "/api/tasks/123":
+            return httpx.Response(404, json={"error": "not_found", "message": "Task missing"})
+        assert request.url.path == "/api/memory/raw"
+        assert request.headers["Idempotency-Key"] == capture["idempotency_key"]
+        return httpx.Response(200, json={"mutation_receipt": {"applied": True, "replayed": True}})
+
+    client = attach(SibylClient(base_url=BASE_URL, auth_token="synthetic"), handler)
+    await client._maybe_replay_pending_writes(ignore_backoff=True)
+    await client.close()
+    assert "/api/tasks/123/complete" not in paths
+    remaining = {item["id"]: item for item in pending_writes.list_pending_writes()}
+    assert set(remaining) == {missing["id"], later["id"]}
+    assert remaining[missing["id"]]["status"] == "attention"
+    assert remaining[missing["id"]]["last_failure"]["status_code"] == 404
+    assert remaining[later["id"]]["attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_old_server_fallback_replays_only_original_lineage(identity: dict) -> None:
+    client = SibylClient(base_url=BASE_URL, auth_token="synthetic")
+    same = queued(None, scope=client._replay_scope)
+    foreign = queued(None, scope="credential:another-login")
+    owned = queued(identity, scope=client._replay_scope)
+    paths = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(404, json={"detail": "Not found"})
+        assert request.headers["Idempotency-Key"] == same["idempotency_key"]
+        return httpx.Response(200, json={"ok": True})
+
+    attach(client, handler)
+    await client._maybe_replay_pending_writes(ignore_backoff=True)
+    await client.close()
+    assert len(paths) == 2
+    assert {item["id"] for item in pending_writes.list_pending_writes()} == {
+        foreign["id"],
+        owned["id"],
+    }
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing_org",
+        "invalid_uuid",
+        "bool_version",
+        "unknown_version",
+        "missing_restrictions",
+        "bad_scopes",
+        "session_key",
+        "unknown_kind",
+    ],
+)
+def test_identity_normalization_rejects_incomplete_contract(identity: dict, mutation: str) -> None:
+    candidate = deepcopy(identity)
+    if mutation == "missing_org":
+        candidate.pop("organization_id")
+    elif mutation == "invalid_uuid":
+        candidate["server_instance_id"] = "server"
+    elif mutation == "bool_version":
+        candidate["version"] = True
+    elif mutation == "unknown_version":
+        candidate["version"] = 2
+    elif mutation == "missing_restrictions":
+        candidate["credential"].pop("project_ids")
+    elif mutation == "bad_scopes":
+        candidate["credential"]["scopes"] = "read"
+    elif mutation == "session_key":
+        candidate["credential"]["api_key_id"] = identity["user_id"]
+    else:
+        candidate["credential"]["kind"] = "anonymous"
+    assert normalize_replay_identity(candidate) is None
+
+
+def test_identity_normalization_canonicalizes_set_restrictions(identity: dict) -> None:
+    identity["credential"]["scopes"] = ["write", "read", "read"]
+    normalized = normalize_replay_identity(identity)
+    assert normalized is not None
+    assert normalized["credential"]["scopes"] == ["read", "write"]
+    assert identity["credential"]["scopes"] == ["write", "read", "read"]
+
+
+@pytest.mark.parametrize("kind", [[], {}, 1, None])
+def test_identity_normalization_rejects_malformed_credential_kind(
+    identity: dict, kind: Any
+) -> None:
+    identity["credential"]["kind"] = kind
+    assert normalize_replay_identity(identity) is None
+
+
+@pytest.mark.asyncio
+async def test_attention_entry_blocks_its_resource_on_subsequent_replay(identity: dict) -> None:
+    first = queued(identity, method="PATCH", path="/tasks/123")
+    later = queued(identity, path="/tasks/123/complete")
+    capture = queued(identity)
+    pending_writes.record_pending_failure(first["id"], category="rejected", status_code=404)
+    sent = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=identity)
+        sent.append(request.url.path)
+        assert request.headers["Idempotency-Key"] == capture["idempotency_key"]
+        return httpx.Response(200, json={"ok": True})
+
+    client = attach(SibylClient(base_url=BASE_URL, auth_token="synthetic"), handler)
+    await client._maybe_replay_pending_writes(ignore_backoff=True)
+    await client.close()
+    assert sent == ["/api/memory/raw"]
+    assert pending_writes.read_pending_write(later["id"])["attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_unresolved_bulk_is_barrier_for_later_writes(identity: dict) -> None:
+    first = queued(identity, path="/entities/bulk")
+    later = queued(identity)
+    pending_writes.record_pending_failure(first["id"], category="conflict", status_code=409)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        return httpx.Response(200, json=identity)
+
+    client = attach(SibylClient(base_url=BASE_URL, auth_token="synthetic"), handler)
+    await client._maybe_replay_pending_writes(ignore_backoff=True)
+    await client.close()
+    assert pending_writes.read_pending_write(later["id"])["attempts"] == 0
+
+
+@pytest.mark.asyncio
+async def test_new_mutation_waits_for_older_related_attention(identity: dict) -> None:
+    prior = queued(identity, method="PATCH", path="/tasks/123")
+    pending_writes.record_pending_failure(prior["id"], category="rejected", status_code=404)
+    mutations = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=identity)
+        mutations.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    client = attach(SibylClient(base_url=BASE_URL, auth_token="synthetic"), handler)
+    with pytest.raises(SibylClientError) as failure:
+        await client.post("/tasks/123/complete", json={})
+    await client.close()
+    assert failure.value.error_code == "pending_dependency"
+    assert not mutations
+    remaining = pending_writes.list_pending_writes()
+    assert len(remaining) == 2
+    successor = next(item for item in remaining if item["id"] != prior["id"])
+    assert successor["last_failure"]["category"] == "dependency"
+    assert successor["status"] == "pending"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_kind", ["protocol", "invalid_json"])
+async def test_unconfirmed_response_retains_payload_and_diagnostic(
+    identity: dict, failure_kind: str
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/replay-identity":
+            return httpx.Response(200, json=identity)
+        if failure_kind == "protocol":
+            raise httpx.RemoteProtocolError("server disconnected", request=request)
+        return httpx.Response(200, content=b"invalid response")
+
+    client = attach(SibylClient(base_url=BASE_URL, auth_token="synthetic"), handler)
+    with pytest.raises(SibylClientError) as failure:
+        await client.post("/memory/raw", json={"raw_content": "keep me"})
+    await client.close()
+    assert failure.value.error_code == "response_unconfirmed"
+    entry = pending_writes.list_pending_writes()[0]
+    assert entry["json"] == {"raw_content": "keep me"}
+    assert entry["last_failure"]["category"] == (
+        "transport" if failure_kind == "protocol" else "server"
+    )
+    assert entry["status"] == "pending"

--- a/apps/cli/tests/test_pending_visibility.py
+++ b/apps/cli/tests/test_pending_visibility.py
@@ -58,7 +58,7 @@ def test_a_queued_write_warns_on_stderr_at_command_completion(
 
     captured = capsys.readouterr()
     assert "2 writes buffered locally" in captured.err
-    assert "retries replayable writes" in captured.err
+    assert "without a confirmed server outcome" in captured.err
     assert "buffered locally" not in captured.out
 
 
@@ -156,7 +156,7 @@ def test_doctor_checks_the_queue(sandbox_home: Path) -> None:
     assert check.status == "warn"
     assert "1 write buffered locally" in check.message
     assert check.detail is not None
-    assert "retries replayable writes" in check.detail
+    assert "Verified retryable writes replay automatically" in check.detail
 
 
 def test_doctor_passes_on_an_empty_queue(sandbox_home: Path) -> None:

--- a/apps/cli/tests/test_pending_writes.py
+++ b/apps/cli/tests/test_pending_writes.py
@@ -89,9 +89,7 @@ def test_corrupt_pending_write_remains_counted_as_a_structured_failure(
     assert "Invalid JSON" in writes[0]["error"]
     assert pending_writes.pending_write_count() == 1
     assert status["count"] == 1
-    assert status["failures"] == [
-        {"filename": f"{write_id}.json", "error": writes[0]["error"]}
-    ]
+    assert status["failures"] == [{"filename": f"{write_id}.json", "error": writes[0]["error"]}]
     assert path.exists()
 
 
@@ -238,3 +236,184 @@ def test_durable_writes_are_still_buffered() -> None:
     # Reads and auth never buffer.
     assert client_transport._should_buffer_request("GET", "/search") is False
     assert client_transport._should_buffer_request("POST", "/auth/login") is False
+
+
+@pytest.mark.parametrize(
+    ("category", "status_code", "expected_state"),
+    [
+        ("authentication", 401, "pending"),
+        ("transport", None, "pending"),
+        ("server", 503, "pending"),
+        ("rejected", 400, "attention"),
+        ("rejected", 403, "attention"),
+        ("rejected", 404, "attention"),
+        ("conflict", 409, "attention"),
+        ("rejected", 422, "attention"),
+    ],
+)
+def test_failure_preserves_operation_and_records_safe_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    category: pending_writes.PendingFailureCategory,
+    status_code: int | None,
+    expected_state: str,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    original = pending_writes.create_pending_write(
+        method="PATCH",
+        path="/tasks/123",
+        base_url="https://testserver/api",
+        json_payload={"name": "Keep this exact payload"},
+        params={"sync": True},
+        replay_scope="identity:test",
+    )
+    pending_writes.record_pending_failure(
+        original["id"],
+        category=category,
+        status_code=status_code,
+        error_code="Bearer secret-value-can-never-be-persisted",
+    )
+    updated = pending_writes.read_pending_write(original["id"])
+    assert updated["status"] == expected_state
+    assert updated["last_failure"]["category"] == category
+    assert updated["last_failure"]["status_code"] == status_code
+    assert updated["last_failure"]["error_code"] is None
+    assert updated["last_failure"]["at"]
+    for field in ("id", "idempotency_key", "created_at", "json", "params", "replay_scope"):
+        assert updated[field] == original[field]
+    assert (
+        "secret-value" not in pending_writes.resolve_pending_write_path(original["id"]).read_text()
+    )
+    assert pending_writes.pending_write_count() == 1
+    assert pending_writes.read_pending_metrics()["dropped"] == 0
+
+
+def test_explicit_retry_keeps_failure_evidence_and_idempotency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    item = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="https://testserver/api",
+        json_payload={"raw_content": "Preserve me"},
+        params=None,
+    )
+    pending_writes.increment_attempts(item["id"])
+    failed = pending_writes.record_pending_failure(
+        item["id"],
+        category="conflict",
+        status_code=409,
+        error_code="conflict",
+    )
+    assert pending_writes.pending_write_status()["attention"] == 1
+    retried = pending_writes.retry_pending_write(item["id"])
+    assert retried["status"] == "pending"
+    assert retried["last_failure"] == failed["last_failure"]
+    assert retried["last_failure"]["error_code"] == "conflict"
+    assert retried["attempts"] == 1
+    assert "last_attempt_at" not in retried
+    assert retried["idempotency_key"] == item["idempotency_key"]
+    assert retried["json"] == item["json"]
+    assert pending_writes.pending_write_status()["attention"] == 0
+    assert pending_writes.pending_write_status()["pending"] == 1
+
+
+def test_resource_ordering_spans_task_actions_and_entity_alias() -> None:
+    resource = pending_writes.pending_write_resource
+    assert (
+        resource({"method": "PATCH", "path": "/tasks/123"})
+        == resource({"method": "POST", "path": "/tasks/123/complete"})
+        == resource({"method": "DELETE", "path": "/entities/123"})
+    )
+    assert resource({"method": "PATCH", "path": "/tasks/123"}) != resource(
+        {"method": "PATCH", "path": "/tasks/456"}
+    )
+    assert resource({"method": "POST", "path": "/memory/raw", "id": "first"}) != resource(
+        {"method": "POST", "path": "/memory/raw", "id": "second"}
+    )
+
+
+def _replay_identity() -> dict:
+    return {
+        "version": 1,
+        "server_instance_id": "11111111-1111-1111-1111-111111111111",
+        "user_id": "22222222-2222-2222-2222-222222222222",
+        "organization_id": "33333333-3333-3333-3333-333333333333",
+        "credential": {
+            "kind": "session",
+            "api_key_id": None,
+            "scopes": [],
+            "project_ids": None,
+            "memory_space_ids": None,
+            "memory_scope_keys": None,
+        },
+    }
+
+
+def test_identity_migration_requires_original_credential_and_never_reassigns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    item = pending_writes.create_pending_write(
+        method="POST",
+        path="/memory/raw",
+        base_url="https://testserver/api",
+        json_payload={"raw_content": "Preserve me"},
+        params=None,
+        replay_scope="credential:original",
+    )
+    identity = _replay_identity()
+    with pytest.raises(ValueError, match="another credential lineage"):
+        pending_writes.bind_pending_write_identity(
+            item["id"], identity, replay_scope="credential:new"
+        )
+    assert "replay_identity" not in pending_writes.read_pending_write(item["id"])
+    bound = pending_writes.bind_pending_write_identity(
+        item["id"],
+        identity,
+        replay_scope="credential:original",
+    )
+    assert bound["replay_identity"] == identity
+    assert bound["idempotency_key"] == item["idempotency_key"]
+    assert (
+        pending_writes.bind_pending_write_identity(
+            item["id"],
+            identity,
+            replay_scope="credential:new",
+        )
+        == bound
+    )
+    other = {**identity, "user_id": "44444444-4444-4444-4444-444444444444"}
+    with pytest.raises(ValueError, match="another identity"):
+        pending_writes.bind_pending_write_identity(
+            item["id"], other, replay_scope="credential:original"
+        )
+
+
+def test_invalid_identity_is_never_written(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pending_writes.Path, "home", lambda: tmp_path)
+    with pytest.raises(ValueError, match="Invalid pending write replay identity"):
+        pending_writes.create_pending_write(
+            method="POST",
+            path="/memory/raw",
+            base_url="https://testserver/api",
+            json_payload={},
+            params=None,
+            replay_identity={"user_id": "someone"},
+        )
+    assert pending_writes.list_pending_writes() == []
+    assert pending_writes.read_pending_metrics()["attempted"] == 0
+
+
+def test_unknown_and_bulk_resources_are_ordering_barriers() -> None:
+    assert pending_writes.pending_write_resource({"path": "/entities/bulk"}) == "*"
+    assert pending_writes.pending_write_resource({"path": "/context/reflect"}) == "*"
+    assert (
+        pending_writes.pending_write_resource(
+            {"path": "/entities", "method": "POST", "json": {"id": "123"}}
+        )
+        == "entity:123"
+    )

--- a/apps/cli/tests/test_pending_writes.py
+++ b/apps/cli/tests/test_pending_writes.py
@@ -408,12 +408,29 @@ def test_invalid_identity_is_never_written(tmp_path: Path, monkeypatch: pytest.M
     assert pending_writes.read_pending_metrics()["attempted"] == 0
 
 
-def test_unknown_and_bulk_resources_are_ordering_barriers() -> None:
+def test_bulk_resources_are_ordering_barriers() -> None:
     assert pending_writes.pending_write_resource({"path": "/entities/bulk"}) == "*"
-    assert pending_writes.pending_write_resource({"path": "/context/reflect"}) == "*"
     assert (
         pending_writes.pending_write_resource(
             {"path": "/entities", "method": "POST", "json": {"id": "123"}}
         )
         == "entity:123"
     )
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/context/reflect", "/sources", "/memory/promote", "/teams", "/orgs", "/projects"],
+)
+def test_ordinary_resource_fallback_does_not_form_a_global_barrier(path: str) -> None:
+    resource = pending_writes.pending_write_resource({"method": "POST", "path": path})
+    assert resource == f"path:{path.lstrip('/')}"
+    assert resource != pending_writes.pending_write_resource(
+        {"method": "PATCH", "path": "/tasks/123"}
+    )
+
+
+def test_fallback_groups_actions_on_the_same_source() -> None:
+    resource = pending_writes.pending_write_resource
+    assert resource({"path": "/sources/123/sync"}) == resource({"path": "/sources/123"})
+    assert resource({"path": "/sources/123"}) != resource({"path": "/sources/456"})

--- a/docs/cli/pending-writes.md
+++ b/docs/cli/pending-writes.md
@@ -40,7 +40,8 @@ reason; the CLI cannot reconstruct one.
 Within a verified owner or original credential lineage, an unresolved write holds later operations
 on the same entity. Independent writes can continue. Bulk operations form an ordering barrier
 because they can touch multiple entities. Explicitly selecting a later write does not bypass its
-unresolved predecessor.
+unresolved predecessor. Outside task, entity, and project routes, ordering follows the first two URL
+path segments; different action paths do not share an ordering lane.
 
 ## Flush retryable writes
 
@@ -91,6 +92,9 @@ through its own context.
 sibyl pending-writes discard <write-id>...
 sibyl pending-writes discard --read-like
 ```
+
+Offline drafts retain their last verified owner. Replacing the database does not transfer those
+drafts to the new instance. Keep their payloads for inspection before deciding how to recover them.
 
 Discard permanently removes the named local copies without replay. Export or copy any payload you
 need before discarding it. The `--read-like` option removes requests buffered by older CLI versions

--- a/docs/cli/pending-writes.md
+++ b/docs/cli/pending-writes.md
@@ -37,9 +37,10 @@ reason; the CLI cannot reconstruct one.
   prove its lineage, but a new login cannot infer its historical owner.
 - **Corrupt:** the file must be repaired or explicitly discarded before it can be used.
 
-An unresolved write holds later operations on the same entity. Independent writes can continue. Bulk
-operations form an ordering barrier because they can touch multiple entities. Explicitly selecting a
-later write does not bypass its unresolved predecessor.
+Within a verified owner or original credential lineage, an unresolved write holds later operations
+on the same entity. Independent writes can continue. Bulk operations form an ordering barrier
+because they can touch multiple entities. Explicitly selecting a later write does not bypass its
+unresolved predecessor.
 
 ## Flush retryable writes
 

--- a/docs/cli/pending-writes.md
+++ b/docs/cli/pending-writes.md
@@ -1,116 +1,96 @@
 # pending-writes
 
-Inspect and replay locally buffered writes. When the CLI cannot reach the server, write operations
-are buffered to a secure local store with idempotency keys instead of being lost. `pending-writes`
-lists, replays, and discards that buffer.
+Inspect and recover writes whose server outcome is not confirmed. The CLI keeps the request and its
+original idempotency key in a local directory restricted to your user. A timeout can happen after
+the server applies a write, so a buffered entry does not prove that the server saved nothing.
 
-## Commands
+## Ownership and reauthentication
 
-| Command                                                   | Description                                        |
-| --------------------------------------------------------- | -------------------------------------------------- |
-| [`sibyl pending-writes list`](#pending-writes-list)       | List buffered writes (no sensitive payload bodies) |
-| [`sibyl pending-writes flush`](#pending-writes-flush)     | Replay buffered writes                             |
-| [`sibyl pending-writes discard`](#pending-writes-discard) | Discard buffered writes without replaying          |
+New writes record a server-confirmed identity: the database instance, user, organization, and
+credential restrictions. Signing in again as the same user in the same organization recovers that
+identity. Replacing a database at the same URL, switching accounts, or selecting a different
+organization does not authorize replay. API keys retain their own identity and restrictions.
 
-## How Buffering Works
+The CLI verifies the current identity before replay. Mutations also carry the expected database
+instance so the server can reject a changed destination. Cached identity is used to preserve an
+offline draft, never as sufficient proof to send it. An offline draft created before any identity
+was verified remains under legacy ownership until its owner can be established.
 
-A write that fails to reach the server (offline, server down, transient error) is appended to the
-local pending-writes buffer with an idempotency key. The key means a later `flush` can replay the
-write safely without creating a duplicate if part of it already landed. Inspect the buffer with
-`list`, replay it with `flush` once connectivity is back, or drop entries you no longer want with
-`discard`.
+Servers predating this contract support replay only under the original credential lineage. Upgrade
+the server to recover writes across new logins.
 
-## How You Find Out
-
-A non-empty buffer is reported in three places, so a queued write is never silent:
-
-- Every command prints a one-line warning to **stderr** as it finishes, carrying the queue depth and
-  the flush command. It goes to stderr, so `--json` output stays parseable.
-- `sibyl health` reports the queue depth alongside server health, and `sibyl health --json` carries
-  it under `pending_writes`.
-- `sibyl doctor` runs a `pending-writes` check that warns while anything is queued.
-
----
-
-## pending-writes list
-
-List buffered writes without printing sensitive payload bodies. Output shows write IDs, the target
-operation, and timestamps, but not the captured content itself.
-
-### Synopsis
-
-```bash
-sibyl pending-writes list [options]
-```
-
-### Options
-
-| Option   | Short | Description |
-| -------- | ----- | ----------- |
-| `--json` | `-j`  | Output JSON |
-
-### Example
+## Inspect the queue
 
 ```bash
 sibyl pending-writes list
+sibyl pending-writes list --json
 ```
 
----
+The list shows the target, operation, ownership status, attempts, and last failure category and HTTP
+status. Request bodies and response bodies are not printed. Older entries have no recorded failure
+reason; the CLI cannot reconstruct one.
 
-## pending-writes flush
+- **Pending:** authentication, transport, temporary server failures, or an unresolved predecessor
+  prevent confirmation. Matching retryable writes are attempted after a successful API request.
+- **Attention:** a rejection or unresolved conflict requires inspection. Automatic replay skips it.
+- **Legacy ownership:** the entry predates verified identities. The original credential can still
+  prove its lineage, but a new login cannot infer its historical owner.
+- **Corrupt:** the file must be repaired or explicitly discarded before it can be used.
 
-Replay buffered writes. With no arguments, flushes the entire buffer. Pass IDs or prefixes to replay
-a subset.
+An unresolved write holds later operations on the same entity. Independent writes can continue. Bulk
+operations form an ordering barrier because they can touch multiple entities. Explicitly selecting a
+later write does not bypass its unresolved predecessor.
 
-### Synopsis
-
-```bash
-sibyl pending-writes flush [write_ids]...
-```
-
-### Arguments
-
-| Argument    | Required | Description                                      |
-| ----------- | -------- | ------------------------------------------------ |
-| `write_ids` | No       | Pending write IDs or prefixes. Omit to flush all |
-
-### Examples
+## Flush retryable writes
 
 ```bash
-# Replay everything in the buffer
 sibyl pending-writes flush
-
-# Replay specific writes by prefix
-sibyl pending-writes flush a1b2 c3d4
+sibyl pending-writes flush <write-id>...
 ```
 
----
+Flush verifies ownership and reuses the original idempotency key. The server can return its stored
+receipt when an earlier attempt already completed. Only a confirmed successful response removes the
+local entry. Rejected and uncertain outcomes preserve the payload for inspection.
 
-## pending-writes discard
-
-Discard buffered writes without replaying them. Use this to drop entries you no longer want, for
-example after deciding a captured note is stale.
-
-### Synopsis
+After resolving an attention entry's cause, explicitly re-enable it:
 
 ```bash
-sibyl pending-writes discard <write_ids>...
+sibyl pending-writes retry <write-id>...
 ```
 
-### Arguments
+Retry preserves the original payload, key, and failure evidence. Ownership and ordering checks still
+apply. A permanent rejection stays in attention if the server rejects it again.
 
-| Argument    | Required | Description                   |
-| ----------- | -------- | ----------------------------- |
-| `write_ids` | Yes      | Pending write IDs or prefixes |
+## Recover legacy entries
 
-### Example
+For old entries with no credential owner, select the original server context and run:
 
 ```bash
-sibyl pending-writes discard a1b2c3
+sibyl -C <context> pending-writes claim <write-id>...
 ```
 
-## Related Commands
+For entries tied to an older login that is no longer available:
 
-- [`sibyl remember`](./remember.md) - Capture durable memory
-- [`sibyl capture`](./capture.md) - Quick capture
-- [`sibyl health`](./index.md) - Check server connectivity
+```bash
+sibyl -C <context> pending-writes claim --unverified <write-id>...
+```
+
+The command shows the authenticated user and organization plus each selected operation and server.
+Confirm only when those entries belong to that account and organization. The CLI cannot prove
+historical ownership that was never recorded. Explicit IDs are required with `--unverified`; `--yes`
+supplies confirmation for operator-controlled automation.
+
+Claim never transfers an entry that already has a verified owner. It preserves the old credential
+scope as recovery provenance and retries eligible claimed writes. Another server URL must be handled
+through its own context.
+
+## Discard unwanted entries
+
+```bash
+sibyl pending-writes discard <write-id>...
+sibyl pending-writes discard --read-like
+```
+
+Discard permanently removes the named local copies without replay. Export or copy any payload you
+need before discarding it. The `--read-like` option removes requests buffered by older CLI versions
+that incorrectly treated some searches as mutations.

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/auth_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/auth_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from sibyl_core.auth import OrganizationRole, ProjectRole, ProjectVisibility
 from sibyl_core.backends.surreal.schema_helpers import is_missing_table_error, split_statements
@@ -13,6 +14,7 @@ from sibyl_core.backends.surreal.schema_invariants import (
 from sibyl_core.backends.surreal.schema_version import (
     SCHEMA_VERSION_TABLE,
     SchemaMigration,
+    SurrealExecute,
     apply_schema_migrations,
     ensure_schema_version_table,
     get_schema_version,
@@ -45,9 +47,10 @@ EXTENDED_AUTH_TABLES = (
     "memory_spaces",
     "memory_space_members",
     "llm_usage_buckets",
+    "server_identity",
 )
 AUTH_TABLES = (*CORE_AUTH_TABLES, *EXTENDED_AUTH_TABLES)
-AUTH_SCHEMA_CURRENT_VERSION = 6
+AUTH_SCHEMA_CURRENT_VERSION = 7
 AUTH_SCHEMA_NAME = "auth"
 _AUTH_ORGANIZATION_ROLE_VALUES = tuple(role.value for role in OrganizationRole)
 _AUTH_PROJECT_ROLE_VALUES = tuple(role.value for role in ProjectRole)
@@ -644,6 +647,17 @@ AUTH_SCHEMAFULL_REPAIR_DEFINITIONS = "\n".join(
     f"ALTER TABLE IF EXISTS {table} SCHEMAFULL;" for table in AUTH_TABLES
 )
 
+AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS = """
+DEFINE TABLE IF NOT EXISTS server_identity SCHEMAFULL;
+ALTER TABLE IF EXISTS server_identity SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS instance_id ON server_identity TYPE string;
+ALTER TABLE IF EXISTS server_identity PERMISSIONS FOR select, create, update, delete NONE;
+INSERT IGNORE INTO server_identity {
+    id: server_identity:singleton,
+    instance_id: <string>rand::uuid()
+};
+"""
+
 AUTH_SCHEMA_MIGRATIONS = (
     SchemaMigration(
         version=1,
@@ -675,6 +689,11 @@ AUTH_SCHEMA_MIGRATIONS = (
         name="auth_schemafull_repair",
         statements=tuple(split_statements(AUTH_SCHEMAFULL_REPAIR_DEFINITIONS)),
     ),
+    SchemaMigration(
+        version=7,
+        name="auth_replay_identity",
+        statements=tuple(split_statements(AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS)),
+    ),
 )
 
 
@@ -685,14 +704,42 @@ def auth_schema_invariant_plan() -> SchemaInvariantPlan:
     )
 
 
+async def _execute_auth_schema_query(
+    execute_query: SurrealExecute, statement: str, **params: object
+) -> object:
+    """Accept a competing singleton initializer only after confirming its commit."""
+    from sibyl_core.backends.surreal.records import normalize_records
+
+    try:
+        return await execute_query(statement, **params)
+    except Exception as exc:
+        singleton_insert = split_statements(AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS)[-1]
+        conflict = str(exc).lower()
+        if statement != singleton_insert or not (
+            "transaction conflict" in conflict or "read or write conflict" in conflict
+        ):
+            raise
+        rows = normalize_records(
+            await execute_query("SELECT instance_id FROM server_identity:singleton;")
+        )
+        if not rows or not isinstance(rows[0].get("instance_id"), str):
+            raise
+        UUID(str(rows[0]["instance_id"]))
+        return rows
+
+
 async def bootstrap_auth_schema(client: SurrealAuthClient, *, reset: bool = False) -> None:
     if reset:
         for table in (*AUTH_TABLES, SCHEMA_VERSION_TABLE):
             await client.execute_query(f"REMOVE TABLE IF EXISTS {table};")
 
     await _assert_auth_migrations_safe(client)
+
+    async def execute_query(statement: str, **params: object) -> object:
+        return await _execute_auth_schema_query(client.execute_query, statement, **params)
+
     await apply_schema_migrations(
-        client.execute_query,
+        execute_query,
         AUTH_SCHEMA_MIGRATIONS,
         name=AUTH_SCHEMA_NAME,
         scope="auth_schema_migration",

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 import time
 from pathlib import Path
+from uuid import UUID
 
 import jwt
 import pytest
@@ -15,10 +17,12 @@ from sibyl_core.backends.surreal.auth_schema import (
     AUTH_INVITATION_TOKEN_MIGRATION_DEFINITIONS,
     AUTH_PERMISSION_MIGRATION_DEFINITIONS,
     AUTH_PROJECT_SLUG_MIGRATION_DEFINITIONS,
+    AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS,
     AUTH_SCHEMA_CURRENT_VERSION,
     AUTH_SCHEMA_DEFINITIONS,
     AUTH_SCHEMA_MIGRATIONS,
     AUTH_TABLES,
+    _execute_auth_schema_query,
     bootstrap_auth_schema,
 )
 from sibyl_core.backends.surreal.content_schema import (
@@ -188,7 +192,13 @@ def test_runtime_schemafull_tables_pair_define_with_alter() -> None:
     SCHEMALESS on a first application write, so without the ALTER such a table never
     becomes SCHEMAFULL and its FLEXIBLE fields fail forever.
     """
-    schema = "\n".join((AUTH_SCHEMA_DEFINITIONS, CONTENT_SCHEMA_DEFINITIONS))
+    schema = "\n".join(
+        (
+            AUTH_SCHEMA_DEFINITIONS,
+            AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS,
+            CONTENT_SCHEMA_DEFINITIONS,
+        )
+    )
     content_tables = tuple(
         table
         for table in CONTENT_TABLES
@@ -260,9 +270,7 @@ def test_auth_table_permissions_are_versioned() -> None:
 
     assert "auth_table_permissions" in [migration.name for migration in AUTH_SCHEMA_MIGRATIONS]
     for table in AUTH_TABLES:
-        assert f"ALTER TABLE IF EXISTS {table} PERMISSIONS" in (
-            AUTH_PERMISSION_MIGRATION_DEFINITIONS
-        )
+        assert f"ALTER TABLE IF EXISTS {table} PERMISSIONS" in migration_sql
     assert "WHERE organization_id = $token.org" in AUTH_PERMISSION_MIGRATION_DEFINITIONS
     assert "OR organization_id = $auth.organization_id" in (AUTH_PERMISSION_MIGRATION_DEFINITIONS)
     assert "WHERE uuid = $token.org" in AUTH_PERMISSION_MIGRATION_DEFINITIONS
@@ -1742,3 +1750,28 @@ async def test_schemafull_repair_restores_relation_metadata_on_auto_created_edge
     )
     assert "SCHEMAFULL" in after["tables"]["derived_from"]
     assert rows == [{"uuid": "e1"}]
+
+
+@pytest.mark.asyncio
+async def test_auth_replay_identity_survives_bootstrap_and_distinguishes_database() -> None:
+    db = AsyncSurreal("memory://")
+    try:
+        await db.use("identity_test", "first")
+        await db.query(AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS)
+        first = await db.query("SELECT instance_id FROM server_identity:singleton;")
+        assert UUID(first[0]["instance_id"])
+        await db.query(AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS)
+        assert await db.query("SELECT instance_id FROM server_identity:singleton;") == first
+        # Competing startup initializers must never replace an existing identity.
+        insert = split_statements(AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS)[-1]
+        await asyncio.gather(*(_execute_auth_schema_query(db.query, insert) for _ in range(8)))
+        assert await db.query("SELECT instance_id FROM server_identity:singleton;") == first
+        await db.use("identity_test", "replacement")
+        statements = split_statements(AUTH_REPLAY_IDENTITY_MIGRATION_DEFINITIONS)
+        for statement in statements[:-1]:
+            await db.query(statement)
+        await asyncio.gather(*(_execute_auth_schema_query(db.query, insert) for _ in range(8)))
+        replacement = await db.query("SELECT instance_id FROM server_identity:singleton;")
+        assert replacement != first
+    finally:
+        await db.close()


### PR DESCRIPTION
## 🛠️ Recover buffered writes across logins

A failed CLI write was saved under a random credential lineage, then the CLI recommended signing in again. A new login created a different lineage and stranded the saved request. The queue also retained almost every error without recording its cause, so a rejected task update could hold unrelated memories indefinitely.

Buffered writes now have a server-confirmed owner that survives reauthentication. A write can replay only against the same API URL, database instance, user, organization, and credential restrictions. Failed requests retain their payload and original idempotency key until a successful response confirms the outcome or an operator explicitly discards them.

## 🔗 Ownership and server replacement

The API exposes an authenticated `/auth/replay-identity` endpoint. Auth schema migration 7 creates a persistent database identity (one singleton, safe under concurrent initialization). The CLI keeps credential lineage for refresh coordination and stores the durable replay identity separately.

The transport verifies that identity before creating a new online draft and before sending a buffered mutation. If verification fails, the draft is retained with its last verified owner and failure diagnostic. Existing requests are never reassigned. The server also checks `X-Sibyl-Server-Instance` at the authenticated mutation boundary, rejecting a changed database before the handler executes. API-key identities include the key and its exact restrictions, so a session login cannot inherit writes from a differently scoped credential.

Full auth archives carry the data identity. A clean full restore invalidates the destination identity before cleanup. Successful modern restores adopt the source identity; legacy and failed restores retain the fresh replacement identity. Organization-scoped restores and merges retain the destination identity.

## 🧹 Failure handling and recovery

The queue records safe failure categories, HTTP status, and known error codes without copying response bodies. Authentication, transport failures, and known idempotency or entity lock contention remain pending. Rejections and unresolved conflicts move to attention. Neither path deletes the request.

Replay continues for unrelated operations while preserving order for the same entity. Bulk operations form an ordering barrier. The ordering check also applies to new commands and explicitly selected flushes within the same ownership lane. Ordinary fallback paths are scoped to their resource, so a pending reflection cannot block task creation.

The CLI list exposes state and failure reasons. The new `pending-writes retry` command re-enables selected attention entries after their cause is resolved. Explicit legacy adoption requires named IDs and confirmation of the displayed authenticated account and organization. An already verified owner cannot be reassigned.

## 🧪 Validation

- Final-head CI passed 702 CLI tests, 2,507 API tests, and 2,760 core tests. The eval regression gate passed 847 tests. CI also reported expected skips and one existing expected failure.
- Static checks, build, E2E, dependency audit, live SurrealDB ingestion, Darwin eval authority, and local embedding smoke all passed on the final commit.
- The migration test passed against a disposable live SurrealDB 3.2.3 server, including stable reinitialization and distinct replacement databases.
- Cross-model review and independent adversarial verification passed after corrections. Additional probes covered replacement-server preflights, user-only and cached-user guards, entity update/delete lock failures, and semantic conflicts remaining in attention.

## 📌 Upgrade behavior

Deploy the API and CLI together for recovery across logins. Older servers retain the original credential-lineage replay behavior. Historical queue entries without a verified owner require explicit adoption; the CLI does not infer an account from a matching localhost URL.

Existing live queue files were not replayed, reassigned, or discarded during validation. The documented recovery commands preserve their original requests and keys.
