### PR TITLE
refactor(memory): retire the compatibility reflection writer

### DIFF
--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -299,14 +299,19 @@ stored encrypted in the database (using `SIBYL_SETTINGS_KEY`).
 
 ## Native Memory Configuration
 
-| Variable                                         | Default   | Description                                                |
-| ------------------------------------------------ | --------- | ---------------------------------------------------------- |
-| `SIBYL_NATIVE_WRITE`                             | `enabled` | Set `disabled` to skip persisting reflection candidates    |
-| `SIBYL_AUTO_EXTRACT_ENTITIES`                    | `false`   | Queue LLM entity extraction for prose-bearing memories     |
-| `SIBYL_OPERATIONAL_NOTE_DISTILLATION_MAX_TOKENS` | `2048`    | Max output tokens per note distillation call (256-8192)    |
-| `SIBYL_RAW_CAPTURE_CHANGEFEED_POLL_ENABLED`      | `true`    | Poll the raw-captures changefeed for incremental promotion |
-| `SIBYL_RAW_CAPTURE_LIVE_QUERY_ENABLED`           | `false`   | Use SurrealDB live queries for realtime promotion hints    |
-| `SIBYL_RAW_CAPTURE_LIVE_QUERY_RETRY_SECONDS`     | `5.0`     | Delay before reconnecting the raw-capture live query       |
+Reflection persistence always uses the native writer. Sibyl 1.4 removes the `SIBYL_NATIVE_WRITE`
+switch; remove it from deployment configuration. The old `disabled` value selected a compatibility
+writer and did not disable persistence. Use `persist=false` on reflection requests to preview
+candidates without writing, or `persist_review=true` with `persist=true` to store candidates for
+review before promotion.
+
+| Variable                                         | Default | Description                                                |
+| ------------------------------------------------ | ------- | ---------------------------------------------------------- |
+| `SIBYL_AUTO_EXTRACT_ENTITIES`                    | `false` | Queue LLM entity extraction for prose-bearing memories     |
+| `SIBYL_OPERATIONAL_NOTE_DISTILLATION_MAX_TOKENS` | `2048`  | Max output tokens per note distillation call (256-8192)    |
+| `SIBYL_RAW_CAPTURE_CHANGEFEED_POLL_ENABLED`      | `true`  | Poll the raw-captures changefeed for incremental promotion |
+| `SIBYL_RAW_CAPTURE_LIVE_QUERY_ENABLED`           | `false` | Use SurrealDB live queries for realtime promotion hints    |
+| `SIBYL_RAW_CAPTURE_LIVE_QUERY_RETRY_SECONDS`     | `5.0`   | Delay before reconnecting the raw-capture live query       |
 
 ## Runtime Telemetry
 

--- a/packages/python/sibyl-core/moon.yml
+++ b/packages/python/sibyl-core/moon.yml
@@ -75,14 +75,15 @@ tasks:
   reflection-quality-test:
     command:
       uv run pytest tests/test_reflection_models.py tests/test_reflection_extractor.py
-      tests/test_reflect.py tests/test_native_memory.py tests/test_memory_autonomy.py
+      tests/test_reflect.py tests/test_memory.py tests/test_memory_autonomy.py
       tests/test_context_pack.py -v
     inputs:
     - '@group(sources)'
     - tests/test_reflection_models.py
     - tests/test_reflection_extractor.py
     - tests/test_reflect.py
-    - tests/test_native_memory.py
+    - tests/fixtures/reflection_native_contract.json
+    - tests/test_memory.py
     - tests/test_memory_autonomy.py
     - tests/test_context_pack.py
   write-path-integrity-test:
@@ -178,6 +179,7 @@ fileGroups:
   - src/**/*.py
   tests:
   - tests/**/*.py
+  - tests/fixtures/reflection_native_contract.json
   configs:
   - pyproject.toml
   - /pyproject.toml

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory.py
@@ -22,15 +22,12 @@ from sibyl_core.services.memory_policy import (
     declared_suppression_allowed as declared_suppression_allowed,
 )
 from sibyl_core.services.memory_reflection import (
-    coerce_write_mode,
     persist_reflection_candidate,
     persist_reflection_source,
     preview_raw_memory_promotion,
     preview_reflection_candidate_promotion,
     promote_raw_memory,
     promote_reflection_candidate_review,
-    reflection_write_enabled,
-    write_mode_from_env,
 )
 from sibyl_core.services.memory_sharing import (
     preview_memory_access,
@@ -49,7 +46,6 @@ __all__ = [
     "ReflectionWriteResult",
     "WriteMode",
     "apply_memory_correction",
-    "coerce_write_mode",
     "persist_reflection_candidate",
     "persist_reflection_source",
     "preview_memory_access",
@@ -59,7 +55,5 @@ __all__ = [
     "preview_reflection_candidate_promotion",
     "promote_raw_memory",
     "promote_reflection_candidate_review",
-    "reflection_write_enabled",
     "share_memory",
-    "write_mode_from_env",
 ]

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import os
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
@@ -83,28 +82,6 @@ async def _load_raw_sources(
         if source is not None:
             memories.append(source)
     return memories
-
-
-def coerce_write_mode(value: str | WriteMode | None) -> WriteMode:
-    if isinstance(value, WriteMode):
-        return value
-    if value is None or not value.strip():
-        return WriteMode.ENABLED
-    normalized = value.strip().lower()
-    if normalized in {"enabled", "enable", "true", "1", "yes", "on"}:
-        return WriteMode.ENABLED
-    if normalized in {"disabled", "disable", "false", "0", "no", "off"}:
-        return WriteMode.DISABLED
-    return WriteMode.DISABLED
-
-
-def write_mode_from_env(environ: Mapping[str, str] | None = None) -> WriteMode:
-    source = os.environ if environ is None else environ
-    return coerce_write_mode(source.get("SIBYL_NATIVE_WRITE"))
-
-
-def reflection_write_enabled(environ: Mapping[str, str] | None = None) -> bool:
-    return write_mode_from_env(environ) is WriteMode.ENABLED
 
 
 async def persist_reflection_source(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
@@ -30,10 +29,8 @@ from sibyl_core.services.surreal_content import (
     list_raw_memories_for_scope,
     raw_memory_recallable,
 )
-from sibyl_core.tools.add import add as default_add
 from sibyl_core.tools.responses import AddResponse
 
-AddFn = Callable[..., Awaitable[AddResponse]]
 log = structlog.get_logger()
 
 
@@ -64,7 +61,6 @@ async def reflect_memory(
     persist_review: bool = False,
     existing_source_id: str | None = None,
     limit: int = 12,
-    add_fn: AddFn = default_add,
     extractor: ReflectionExtractor | None = None,
 ) -> ReflectionPack:
     """Reflect raw notes into reviewable, optionally persisted memory candidates."""
@@ -145,7 +141,6 @@ async def reflect_memory(
             )
 
     source_id: str | None = existing_source_id
-    use_native_write = persist and _reflection_write_enabled()
     if persist and persist_source and source_id is None:
         if persist_review:
             source = await _persist_reflection_source_review(
@@ -161,7 +156,7 @@ async def reflect_memory(
                 extraction_prompt_metadata=extraction_prompt_metadata,
                 policy_metadata=persist_policy_metadata,
             )
-        elif use_native_write:
+        else:
             source = await _persist_reflection_source(
                 title=source_title,
                 content=content,
@@ -173,37 +168,6 @@ async def reflect_memory(
                 accessible_projects=accessible_projects,
                 memory_scope=memory_scope,
                 scope_key=scope_key,
-            )
-        else:
-            source_metadata: dict[str, Any] = {
-                "organization_id": organization_id,
-                "capture_mode": "reflect",
-                "capture_surface": "reflection",
-                "remember_kind": "session",
-                "reflection_intent": intent,
-                "reflection_source": True,
-                **persist_policy_metadata,
-            }
-            if domain:
-                source_metadata["domain"] = domain
-            if project:
-                source_metadata["project_id"] = project
-            source = await add_fn(
-                title=source_title,
-                content=content,
-                entity_type="session",
-                category=domain,
-                tags=_tags_for("session", domain),
-                related_to=related_to,
-                metadata=source_metadata,
-                # Keep reflection source checkpoints as episodic memories so they
-                # are tenant-scoped writes and avoid deterministic direct-entity
-                # UUID collisions across organizations/projects.
-                sync=False,
-                check_conflicts=False,
-                memory_scope=resolved_scope.value,
-                scope_key=resolved_scope_key,
-                principal_id=principal_id,
             )
         if source.success:
             source_id = source.id
@@ -243,9 +207,6 @@ async def reflect_memory(
             persisted.append(candidate)
             continue
 
-        candidate_related_to = list(related_to or [])
-        if source_id:
-            candidate_related_to.append(source_id)
         metadata = {
             **candidate.metadata,
             "organization_id": organization_id,
@@ -283,47 +244,25 @@ async def reflect_memory(
                 )
             )
             continue
-        if use_native_write:
-            candidate_result = await _persist_reflection_candidate(
-                candidate=replace(candidate, metadata=metadata),
-                organization_id=str(organization_id),
-                principal_id=principal_id,
-                domain=domain,
-                project=project,
-                source_id=source_id,
-                related_to=related_to,
-                accessible_projects=accessible_projects,
-                memory_scope=memory_scope,
-                scope_key=scope_key,
-            )
-            persisted.append(
-                replace(
-                    candidate,
-                    metadata={**metadata, **candidate_result.metadata},
-                    persisted_id=candidate_result.response.id
-                    if candidate_result.response.success
-                    else None,
-                )
-            )
-            continue
-
-        result = await add_fn(
-            title=candidate.title,
-            content=candidate.content,
-            entity_type=candidate.kind,
-            category=domain,
-            tags=candidate.tags,
-            related_to=candidate_related_to or None,
-            metadata=metadata,
-            sync=True,
-            check_conflicts=True,
-            memory_scope=resolved_scope.value,
-            scope_key=resolved_scope_key,
+        candidate_result = await _persist_reflection_candidate(
+            candidate=replace(candidate, metadata=metadata),
+            organization_id=str(organization_id),
             principal_id=principal_id,
+            domain=domain,
+            project=project,
+            source_id=source_id,
+            related_to=related_to,
+            accessible_projects=accessible_projects,
+            memory_scope=memory_scope,
+            scope_key=scope_key,
         )
         persisted.append(
             replace(
-                candidate, metadata=metadata, persisted_id=result.id if result.success else None
+                candidate,
+                metadata={**metadata, **candidate_result.metadata},
+                persisted_id=candidate_result.response.id
+                if candidate_result.response.success
+                else None,
             )
         )
 
@@ -387,12 +326,6 @@ __all__ = [
     "reflection_pack_to_dict",
     "reflection_pack_to_markdown",
 ]
-
-
-def _reflection_write_enabled() -> bool:
-    from sibyl_core.services.memory import reflection_write_enabled
-
-    return reflection_write_enabled()
 
 
 def _resolve_reflection_scope(

--- a/packages/python/sibyl-core/tests/fixtures/reflection_native_contract.json
+++ b/packages/python/sibyl-core/tests/fixtures/reflection_native_contract.json
@@ -1,0 +1,378 @@
+{
+  "entities": [
+    {
+      "content": "We decided to preserve source evidence before publishing decisions.",
+      "created_by": "user_123",
+      "description": "We decided to preserve source evidence before publishing decisions.",
+      "embedding": null,
+      "entity_type": "session",
+      "id": "session_9c6ad27491fa",
+      "metadata": {
+        "capture_mode": "reflect",
+        "capture_surface": "reflection",
+        "category": "sibyl",
+        "confidence": 1.0,
+        "lifecycle_action": "promote",
+        "lifecycle_flags": [],
+        "lifecycle_reason": "preserves raw reflection source material",
+        "lifecycle_state": "active",
+        "memory_lifecycle": {
+          "action": "promote",
+          "created_at": "2026-09-04T12:00:00+00:00",
+          "derived_ids": [
+            "session_9c6ad27491fa"
+          ],
+          "duplicate_of_source_id": null,
+          "flags": [],
+          "metadata": {
+            "promoted_entity_id": "session_9c6ad27491fa"
+          },
+          "prior_state": null,
+          "reason": "preserves raw reflection source material",
+          "replacement_source_id": null,
+          "reversible": true,
+          "source_id": "session_9c6ad27491fa",
+          "state": "active"
+        },
+        "memory_scope": "project",
+        "native_write_mode": "enabled",
+        "native_write_path": "reflection_promotion",
+        "organization_id": "org_123",
+        "policy_actions": [
+          "reflect",
+          "write"
+        ],
+        "policy_allowed": true,
+        "policy_reasons": [
+          "same_scope_reflect_allowed",
+          "same_scope_write_allowed"
+        ],
+        "principal_id": "user_123",
+        "project_id": "project_123",
+        "raw_source_ids": [],
+        "reflection_findings": [
+          {
+            "action": "promote",
+            "confidence": 1.0,
+            "created_at": "2026-09-04T12:00:00+00:00",
+            "id": "finding_00000000000000000000000000000001",
+            "kind": "promotion",
+            "lifecycle_state": "active",
+            "metadata": {
+              "promoted_entity_id": "session_9c6ad27491fa"
+            },
+            "policy_reasons": [
+              "same_scope_reflect_allowed",
+              "same_scope_write_allowed"
+            ],
+            "reason": "preserves raw reflection source material",
+            "related_source_ids": [
+              "session_9c6ad27491fa"
+            ],
+            "reversible": true,
+            "source_ids": [],
+            "target_source_id": "session_9c6ad27491fa"
+          }
+        ],
+        "reflection_reason": "preserves raw reflection source material",
+        "reflection_source": true,
+        "remember_kind": "session",
+        "scope_key": "project_123",
+        "source_ids": [],
+        "tags": [
+          "reflection",
+          "session"
+        ]
+      },
+      "modified_by": null,
+      "name": "Evidence review",
+      "organization_id": "org_123",
+      "revision": 1,
+      "source_file": null
+    },
+    {
+      "content": "We decided to preserve source evidence before publishing decisions.",
+      "created_by": "user_123",
+      "description": "We decided to preserve source evidence before publishing decisions.",
+      "embedding": null,
+      "entity_type": "decision",
+      "id": "decision_cfeb13f7083a",
+      "metadata": {
+        "capture_mode": "reflect",
+        "capture_surface": "reflection",
+        "category": "sibyl",
+        "confidence": 0.86,
+        "domain": "sibyl",
+        "extraction_prompt_metadata": {
+          "domain": "sibyl",
+          "extractor": "sibyl_reflection_extractor",
+          "extractor_version": "v0.12",
+          "intent": "build",
+          "limit": 12,
+          "project": "project_123"
+        },
+        "extractor_kind": "heuristic",
+        "lifecycle_action": "promote",
+        "lifecycle_flags": [],
+        "lifecycle_reason": "captures a choice or direction future agents should preserve",
+        "lifecycle_state": "active",
+        "memory_lifecycle": {
+          "action": "promote",
+          "created_at": "2026-09-04T12:00:00+00:00",
+          "derived_ids": [
+            "decision_cfeb13f7083a"
+          ],
+          "duplicate_of_source_id": null,
+          "flags": [],
+          "metadata": {
+            "promoted_entity_id": "decision_cfeb13f7083a"
+          },
+          "prior_state": "pending",
+          "reason": "captures a choice or direction future agents should preserve",
+          "replacement_source_id": null,
+          "reversible": true,
+          "source_id": "session_9c6ad27491fa",
+          "state": "active"
+        },
+        "memory_scope": "project",
+        "native_write_mode": "enabled",
+        "native_write_path": "reflection_promotion",
+        "normalized_text_hash": "4d6b9e78cf84109cc734b511e3482f84aa25ce32d2828ae5cafaff520078d048",
+        "organization_id": "org_123",
+        "policy_actions": [
+          "reflect",
+          "write"
+        ],
+        "policy_allowed": true,
+        "policy_reasons": [
+          "same_scope_reflect_allowed",
+          "same_scope_write_allowed"
+        ],
+        "principal_id": "user_123",
+        "project_id": "project_123",
+        "raw_source_ids": [
+          "session_9c6ad27491fa"
+        ],
+        "reflection_findings": [
+          {
+            "action": "promote",
+            "confidence": 1.0,
+            "created_at": "2026-09-04T12:00:00+00:00",
+            "id": "finding_00000000000000000000000000000002",
+            "kind": "promotion",
+            "lifecycle_state": "active",
+            "metadata": {
+              "promoted_entity_id": "decision_cfeb13f7083a"
+            },
+            "policy_reasons": [
+              "same_scope_reflect_allowed",
+              "same_scope_write_allowed"
+            ],
+            "reason": "captures a choice or direction future agents should preserve",
+            "related_source_ids": [
+              "decision_cfeb13f7083a"
+            ],
+            "reversible": true,
+            "source_ids": [
+              "session_9c6ad27491fa"
+            ],
+            "target_source_id": "session_9c6ad27491fa"
+          }
+        ],
+        "reflection_index": 0,
+        "reflection_intent": "build",
+        "reflection_reason": "captures a choice or direction future agents should preserve",
+        "reflection_source_id": "session_9c6ad27491fa",
+        "reflection_source_title": "Evidence review",
+        "relationship_records": [
+          {
+            "confidence": 1.0,
+            "created_at": "2026-09-04T12:00:00+00:00",
+            "metadata": {},
+            "reason": "candidate was reflected in a project-scoped session",
+            "relationship_type": "BELONGS_TO",
+            "source_id": "candidate:0",
+            "source_ids": [
+              "session_9c6ad27491fa"
+            ],
+            "target_id": "project_123"
+          }
+        ],
+        "remember_kind": "decision",
+        "review_state": "pending",
+        "scope_key": "project_123",
+        "source_ids": [
+          "session_9c6ad27491fa"
+        ],
+        "suggested_memory_scope": "project",
+        "suggested_scope_key": null,
+        "tags": [
+          "reflection",
+          "decision",
+          "sibyl"
+        ]
+      },
+      "modified_by": null,
+      "name": "Decision: We decided to preserve source evidence before publishing decisions.",
+      "organization_id": "org_123",
+      "revision": 1,
+      "source_file": "session_9c6ad27491fa"
+    }
+  ],
+  "markdown": "# Sibyl Reflection: Evidence review\nIntent: build\nSource: `session_9c6ad27491fa`\nDomain: sibyl\nProject: project_123\n\n## Decision: Decision: We decided to preserve source evidence before publishing decisions. `decision_cfeb13f7083a`\n- Confidence: 0.86\n- Why: captures a choice or direction future agents should preserve\n- Memory: We decided to preserve source evidence before publishing decisions.\n\n_Hint: Review candidates, persist the durable ones, and keep raw session source as provenance._",
+  "pack": {
+    "candidates": [
+      {
+        "claim_records": [],
+        "confidence": 0.86,
+        "content": "We decided to preserve source evidence before publishing decisions.",
+        "kind": "decision",
+        "metadata": {
+          "capture_mode": "reflect",
+          "capture_surface": "reflection",
+          "confidence": 0.86,
+          "domain": "sibyl",
+          "extraction_prompt_metadata": {
+            "domain": "sibyl",
+            "extractor": "sibyl_reflection_extractor",
+            "extractor_version": "v0.12",
+            "intent": "build",
+            "limit": 12,
+            "project": "project_123"
+          },
+          "extractor_kind": "heuristic",
+          "invalidated_entity_count": 0,
+          "invalidated_entity_ids": [],
+          "invalidated_source_count": 0,
+          "invalidated_source_ids": [],
+          "invalidation_skipped_source_count": 0,
+          "invalidation_skipped_source_ids": [],
+          "memory_scope": "project",
+          "native_relationship_count": 2,
+          "native_relationship_failed_count": 0,
+          "native_relationship_requested_count": 2,
+          "native_write_mode": "enabled",
+          "native_write_path": "reflection_promotion",
+          "normalized_text_hash": "4d6b9e78cf84109cc734b511e3482f84aa25ce32d2828ae5cafaff520078d048",
+          "organization_id": "org_123",
+          "policy_actions": [
+            "reflect",
+            "write"
+          ],
+          "policy_allowed": true,
+          "policy_reasons": [
+            "same_scope_reflect_allowed",
+            "same_scope_write_allowed"
+          ],
+          "project_id": "project_123",
+          "promotion_errors": [],
+          "promotion_state": "complete",
+          "raw_source_ids": [
+            "session_9c6ad27491fa"
+          ],
+          "reflection_index": 0,
+          "reflection_intent": "build",
+          "reflection_reason": "captures a choice or direction future agents should preserve",
+          "reflection_source_id": "session_9c6ad27491fa",
+          "reflection_source_title": "Evidence review",
+          "relationship_records": [
+            {
+              "confidence": 1.0,
+              "created_at": "2026-09-04T12:00:00+00:00",
+              "metadata": {},
+              "reason": "candidate was reflected in a project-scoped session",
+              "relationship_type": "BELONGS_TO",
+              "source_id": "candidate:0",
+              "source_ids": [
+                "session_9c6ad27491fa"
+              ],
+              "target_id": "project_123"
+            }
+          ],
+          "remember_kind": "decision",
+          "review_state": "pending",
+          "scope_key": "project_123",
+          "source_ids": [
+            "session_9c6ad27491fa"
+          ],
+          "suggested_memory_scope": "project",
+          "suggested_scope_key": null
+        },
+        "persisted_id": "decision_cfeb13f7083a",
+        "raw_source_ids": [
+          "session_9c6ad27491fa"
+        ],
+        "reason": "captures a choice or direction future agents should preserve",
+        "reflection_findings": [],
+        "relationship_records": [
+          {
+            "confidence": 1.0,
+            "created_at": "2026-09-04T12:00:00+00:00",
+            "metadata": {},
+            "reason": "candidate was reflected in a project-scoped session",
+            "relationship_type": "BELONGS_TO",
+            "source_id": "candidate:0",
+            "source_ids": [
+              "session_9c6ad27491fa"
+            ],
+            "target_id": "project_123"
+          }
+        ],
+        "review_state": "pending",
+        "sensitivity_flags": [],
+        "suggested_memory_scope": "project",
+        "suggested_scope_key": null,
+        "tags": [
+          "reflection",
+          "decision",
+          "sibyl"
+        ],
+        "title": "Decision: We decided to preserve source evidence before publishing decisions."
+      }
+    ],
+    "domain": "sibyl",
+    "intent": "build",
+    "persisted_count": 1,
+    "project": "project_123",
+    "source_id": "session_9c6ad27491fa",
+    "source_title": "Evidence review",
+    "total_candidates": 1,
+    "usage_hint": "Review candidates, persist the durable ones, and keep raw session source as provenance."
+  },
+  "relationships": [
+    {
+      "id": "rel_session_9c6ad27491fa_belongs_to_project_123",
+      "metadata": {
+        "created_at": "2026-09-04T12:00:00+00:00",
+        "native_write_path": "reflection_promotion"
+      },
+      "relationship_type": "BELONGS_TO",
+      "source_id": "session_9c6ad27491fa",
+      "target_id": "project_123",
+      "weight": 1.0
+    },
+    {
+      "id": "rel_decision_cfeb13f7083a_belongs_to_project_123",
+      "metadata": {
+        "created_at": "2026-09-04T12:00:00+00:00",
+        "native_write_path": "reflection_promotion"
+      },
+      "relationship_type": "BELONGS_TO",
+      "source_id": "decision_cfeb13f7083a",
+      "target_id": "project_123",
+      "weight": 1.0
+    },
+    {
+      "id": "rel_decision_cfeb13f7083a_derived_from_session_9c6ad27491fa",
+      "metadata": {
+        "created_at": "2026-09-04T12:00:00+00:00",
+        "native_write_path": "reflection_promotion",
+        "source_id": "session_9c6ad27491fa"
+      },
+      "relationship_type": "DERIVED_FROM",
+      "source_id": "decision_cfeb13f7083a",
+      "target_id": "session_9c6ad27491fa",
+      "weight": 1.0
+    }
+  ]
+}

--- a/packages/python/sibyl-core/tests/test_memory.py
+++ b/packages/python/sibyl-core/tests/test_memory.py
@@ -19,9 +19,7 @@ from sibyl_core.services import memory_sharing as sharing_module
 from sibyl_core.services.content_models import raw_memory_matches_as_of
 from sibyl_core.services.memory import (
     ReflectionWriteResult,
-    WriteMode,
     apply_memory_correction,
-    coerce_write_mode,
     preview_memory_access,
     preview_memory_correction,
     preview_memory_share,
@@ -29,9 +27,7 @@ from sibyl_core.services.memory import (
     preview_reflection_candidate_promotion,
     promote_raw_memory,
     promote_reflection_candidate_review,
-    reflection_write_enabled,
     share_memory,
-    write_mode_from_env,
 )
 from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 from sibyl_core.tools.responses import AddResponse
@@ -93,26 +89,6 @@ def _raw_import_memory(**overrides: object) -> RawMemory:
     }
     values.update(overrides)
     return RawMemory(**values)
-
-
-def test_native_write_mode_defaults_enabled() -> None:
-    assert coerce_write_mode(None) is WriteMode.ENABLED
-    assert coerce_write_mode("") is WriteMode.ENABLED
-    assert write_mode_from_env({}) is WriteMode.ENABLED
-    assert reflection_write_enabled({}) is True
-
-
-def test_native_write_mode_accepts_enabled_values() -> None:
-    assert coerce_write_mode("enabled") is WriteMode.ENABLED
-    assert coerce_write_mode("true") is WriteMode.ENABLED
-    assert write_mode_from_env({"SIBYL_NATIVE_WRITE": "1"}) is WriteMode.ENABLED
-
-
-def test_native_write_mode_accepts_disabled_values() -> None:
-    assert coerce_write_mode("disabled") is WriteMode.DISABLED
-    assert coerce_write_mode("false") is WriteMode.DISABLED
-    assert write_mode_from_env({"SIBYL_NATIVE_WRITE": "0"}) is WriteMode.DISABLED
-    assert reflection_write_enabled({"SIBYL_NATIVE_WRITE": "off"}) is False
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/tests/test_reflect.py
+++ b/packages/python/sibyl-core/tests/test_reflect.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
+from itertools import count
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import pytest
 
+from sibyl_core.models import reflection as reflection_models
 from sibyl_core.models.entities import Entity, EntityType
 from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 from sibyl_core.tools.reflect import (
@@ -13,7 +19,160 @@ from sibyl_core.tools.reflect import (
     reflection_pack_to_dict,
     reflection_pack_to_markdown,
 )
-from sibyl_core.tools.responses import AddResponse
+
+
+@pytest.fixture
+def native_reflection_runtime(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Keep the native orchestration real while recording its storage boundary."""
+    entities: list[Entity] = []
+    relationships = []
+
+    async def create_direct(entity):
+        entities.append(entity)
+        return entity.id
+
+    async def create_bulk(items):
+        relationships.extend(items)
+        return len(items), 0
+
+    runtime = SimpleNamespace(
+        entity_manager=SimpleNamespace(
+            create_direct=AsyncMock(side_effect=create_direct),
+            get=AsyncMock(return_value=None),
+        ),
+        relationship_manager=SimpleNamespace(create_bulk=AsyncMock(side_effect=create_bulk)),
+        entities=entities,
+        relationships=relationships,
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_reflection.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    monkeypatch.setattr(
+        "sibyl_core.tools.reflect._load_reflection_decision_memories", AsyncMock(return_value=[])
+    )
+    return runtime
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retired_mode", [None, "enabled", "disabled", "typo"])
+async def test_native_reflection_frozen_contract(
+    native_reflection_runtime: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    retired_mode: str | None,
+) -> None:
+    class FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 9, 4, 12, tzinfo=UTC)
+
+    ids = count(1)
+    monkeypatch.setattr(reflection_models, "datetime", FrozenDatetime)
+    monkeypatch.setattr("sibyl_core.services.memory_lifecycle.datetime", FrozenDatetime)
+    monkeypatch.setattr(reflection_models, "uuid4", lambda: UUID(int=next(ids)))
+    if retired_mode is None:
+        monkeypatch.delenv("SIBYL_NATIVE_WRITE", raising=False)
+    else:
+        monkeypatch.setenv("SIBYL_NATIVE_WRITE", retired_mode)
+    pack = await reflect_memory(
+        "We decided to preserve source evidence before publishing decisions.",
+        source_title="Evidence review",
+        intent="build",
+        domain="sibyl",
+        project="project_123",
+        organization_id="org_123",
+        principal_id="user_123",
+        accessible_projects={"project_123"},
+        persist=True,
+    )
+    assert pack.persisted_count == 1
+    assert len(native_reflection_runtime.entities) == 2
+    actual = {
+        "pack": reflection_pack_to_dict(pack),
+        "markdown": reflection_pack_to_markdown(pack),
+        "entities": [
+            entity.model_dump(mode="json", exclude={"created_at", "updated_at"})
+            for entity in native_reflection_runtime.entities
+        ],
+        "relationships": [
+            relationship.model_dump(mode="json", exclude={"created_at"})
+            for relationship in native_reflection_runtime.relationships
+        ],
+    }
+    fixture = Path(__file__).parent / "fixtures" / "reflection_native_contract.json"
+    assert actual == json.loads(fixture.read_text())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", ["private", "project"])
+@pytest.mark.parametrize("existing_source_id", [None, "raw-existing-source"])
+@pytest.mark.parametrize("persist_source", [False, True])
+async def test_native_reflection_keeps_scope_and_provenance(
+    native_reflection_runtime: SimpleNamespace,
+    scope: str,
+    existing_source_id: str | None,
+    persist_source: bool,
+) -> None:
+    from sibyl_core.services.reflection import ephemeral_reflection_source_id
+
+    content = "We decided to preserve source evidence before publishing decisions."
+    project = "project_123" if scope == "project" else None
+    pack = await reflect_memory(
+        content,
+        organization_id="org_123",
+        principal_id="user_123",
+        project=project,
+        accessible_projects={"project_123"},
+        memory_scope=scope,
+        scope_key=project,
+        persist=True,
+        persist_source=persist_source,
+        existing_source_id=existing_source_id,
+    )
+    source_created = persist_source and existing_source_id is None
+    assert len(native_reflection_runtime.entities) == (2 if source_created else 1)
+    entity = native_reflection_runtime.entities[-1]
+    assert entity.metadata["memory_scope"] == scope
+    assert entity.metadata.get("scope_key") == project
+    assert entity.metadata["principal_id"] == "user_123"
+    assert entity.organization_id == "org_123"
+    if source_created:
+        source = native_reflection_runtime.entities[0]
+        assert source.entity_type is EntityType.SESSION
+        assert source.content == content
+        assert source.metadata["reflection_source"] is True
+        assert source.metadata["memory_scope"] == scope
+        assert source.metadata.get("scope_key") == project
+        assert source.metadata["principal_id"] == "user_123"
+        assert pack.source_id == source.id
+    else:
+        assert pack.source_id == existing_source_id
+    source_ids = [pack.source_id or ephemeral_reflection_source_id(content)]
+    assert pack.candidates[0].raw_source_ids == source_ids
+    assert entity.metadata["raw_source_ids"] == source_ids
+    assert pack.persisted_count == 1
+
+
+@pytest.mark.asyncio
+async def test_native_reflection_returns_partial_relationship_receipt(
+    native_reflection_runtime: SimpleNamespace,
+) -> None:
+    native_reflection_runtime.relationship_manager.create_bulk.side_effect = None
+    native_reflection_runtime.relationship_manager.create_bulk.return_value = (0, 1)
+    pack = await reflect_memory(
+        "We decided to preserve source evidence before publishing decisions.",
+        organization_id="org_123",
+        principal_id="user_123",
+        project="project_123",
+        accessible_projects={"project_123"},
+        persist=True,
+        persist_source=False,
+    )
+    assert pack.persisted_count == 1
+    metadata = reflection_pack_to_dict(pack)["candidates"][0]["metadata"]
+    assert metadata["native_relationship_failed_count"] == 1
+    assert metadata["promotion_state"] == "partial"
+    assert metadata["promotion_errors"] == ["1 promotion relationships failed"]
 
 
 @pytest.mark.asyncio
@@ -57,116 +216,13 @@ async def test_reflect_memory_dedupes_repeated_candidates_by_kind_and_content() 
 
 
 @pytest.mark.asyncio
-async def test_reflect_memory_can_use_compatibility_write_when_native_disabled(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_reflect_memory_persist_denies_unverified_project(
+    native_reflection_runtime: SimpleNamespace,
 ) -> None:
-    calls: list[dict[str, Any]] = []
-
-    async def fake_add(**kwargs: Any) -> AddResponse:
-        calls.append(kwargs)
-        return AddResponse(
-            success=True,
-            id=f"{kwargs['entity_type']}_{len(calls)}",
-            message="ok",
-            timestamp=datetime.now(UTC),
-        )
-
-    monkeypatch.setenv("SIBYL_NATIVE_WRITE", "disabled")
 
     pack = await reflect_memory(
-        "Confirmed the local Sibyl project is linked. We will migrate it to Cloud later.",
-        source_title="Dogfood setup",
-        intent="build",
-        domain="sibyl",
-        project="project_123",
-        related_to=["project_123"],
-        organization_id="org_123",
-        principal_id="user_123",
-        accessible_projects={"project_123"},
-        memory_scope="project",
-        scope_key="project_123",
-        persist=True,
-        add_fn=fake_add,
-    )
-
-    assert pack.persisted_count == len(pack.candidates)
-    assert pack.source_id == "session_1"
-    assert calls[0]["entity_type"] == "session"
-    assert calls[0]["content"].startswith("Confirmed the local Sibyl project")
-    assert calls[0]["metadata"]["reflection_source"] is True
-    assert calls[1]["metadata"]["organization_id"] == "org_123"
-    assert calls[1]["metadata"]["capture_mode"] == "reflect"
-    assert calls[1]["metadata"]["project_id"] == "project_123"
-    assert calls[1]["metadata"]["reflection_source_id"] == "session_1"
-    assert calls[1]["metadata"]["policy_reasons"] == [
-        "same_scope_reflect_allowed",
-        "same_scope_write_allowed",
-    ]
-    assert calls[1]["related_to"] == ["project_123", "session_1"]
-    assert calls[1]["sync"] is True
-
-
-@pytest.mark.asyncio
-async def test_reflect_memory_hands_add_the_authorized_scope_it_stamps_with(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The compatibility write path has to satisfy add()'s stamp contract.
-
-    Reflection always injects memory_scope and scope_key into the bag it hands
-    over, and add() rebuilds the owner triple from its arguments rather than
-    that bag. A caller that declares a scope in metadata without restating it
-    as an authorized argument is refused, so stubbing add_fn without enforcing
-    that precondition hides a crash on this path.
-    """
-    calls: list[dict[str, Any]] = []
-
-    async def contract_checked_add(**kwargs: Any) -> AddResponse:
-        metadata = kwargs.get("metadata") or {}
-        if metadata.get("memory_scope") is not None and kwargs.get("memory_scope") is None:
-            raise ValueError(
-                "add() received metadata declaring memory_scope without the "
-                "authorized memory_scope that names its audience"
-            )
-        calls.append(kwargs)
-        return AddResponse(
-            success=True,
-            id=f"{kwargs['entity_type']}_{len(calls)}",
-            message="ok",
-            timestamp=datetime.now(UTC),
-        )
-
-    monkeypatch.setenv("SIBYL_NATIVE_WRITE", "disabled")
-
-    pack = await reflect_memory(
-        "Confirmed the local Sibyl project is linked.",
-        source_title="Dogfood setup",
-        intent="build",
-        domain="sibyl",
-        project="project_123",
-        organization_id="org_123",
-        principal_id="user_123",
-        accessible_projects={"project_123"},
-        memory_scope="project",
-        scope_key="project_123",
-        persist=True,
-        add_fn=contract_checked_add,
-    )
-
-    assert pack.persisted_count == len(pack.candidates)
-    assert calls, "every add_fn call was refused by add()'s stamp contract"
-    for call in calls:
-        assert call["memory_scope"] == "project"
-        assert call["scope_key"] == "project_123"
-        assert call["principal_id"] == "user_123"
-
-
-@pytest.mark.asyncio
-async def test_reflect_memory_persist_denies_unverified_project_without_native_write() -> None:
-    add_fn = AsyncMock(side_effect=AssertionError("compatibility add path should not run"))
-
-    pack = await reflect_memory(
-        "We decided unauthorized reflect writes need policy before fallback persistence.",
-        source_title="Fallback reflection denial",
+        "We decided unauthorized reflection writes must fail before persistence.",
+        source_title="Reflection denial",
         intent="build",
         domain="sibyl",
         project="project_123",
@@ -177,12 +233,12 @@ async def test_reflect_memory_persist_denies_unverified_project_without_native_w
         scope_key="project_123",
         persist=True,
         persist_review=False,
-        add_fn=add_fn,
     )
 
+    native_reflection_runtime.entity_manager.create_direct.assert_not_awaited()
+    native_reflection_runtime.relationship_manager.create_bulk.assert_not_awaited()
     assert pack.source_id is None
     assert pack.persisted_count == 0
-    assert add_fn.await_count == 0
     assert pack.candidates[0].metadata["policy_allowed"] is False
     assert pack.candidates[0].metadata["policy_reasons"] == [
         "unverified_membership",
@@ -193,18 +249,13 @@ async def test_reflect_memory_persist_denies_unverified_project_without_native_w
 @pytest.mark.asyncio
 async def test_reflect_memory_can_persist_review_queue(
     monkeypatch: pytest.MonkeyPatch,
+    native_reflection_runtime: SimpleNamespace,
 ) -> None:
     calls: list[tuple[str, dict[str, Any]]] = []
-    add_fn = AsyncMock(side_effect=AssertionError("graph add path should not run"))
 
-    async def fake_source_review(**kwargs: Any) -> AddResponse:
+    async def fake_remember_source(**kwargs: Any) -> SimpleNamespace:
         calls.append(("source", kwargs))
-        return AddResponse(
-            success=True,
-            id="raw-source-1",
-            message="stored",
-            timestamp=datetime.now(UTC),
-        )
+        return SimpleNamespace(id="raw-source-1", title=kwargs["title"])
 
     async def fake_candidate_review(**kwargs: Any) -> RawMemory:
         calls.append(("candidate", kwargs))
@@ -227,8 +278,8 @@ async def test_reflect_memory_can_persist_review_queue(
         )
 
     monkeypatch.setattr(
-        "sibyl_core.tools.reflect._persist_reflection_source_review",
-        fake_source_review,
+        "sibyl_core.services.surreal_content.remember_raw_memory",
+        fake_remember_source,
     )
     monkeypatch.setattr(
         "sibyl_core.tools.reflect._persist_reflection_candidate_review",
@@ -249,7 +300,6 @@ async def test_reflect_memory_can_persist_review_queue(
         suggested_memory_scope="team",
         persist=True,
         persist_review=True,
-        add_fn=add_fn,
     )
 
     assert [kind for kind, _ in calls] == ["source", "candidate"]
@@ -266,22 +316,27 @@ async def test_reflect_memory_can_persist_review_queue(
         "same_scope_reflect_allowed",
         "same_scope_write_allowed",
     ]
-    assert calls[0][1]["policy_metadata"]["policy_reasons"] == [
+    assert calls[0][1]["metadata"]["policy_reasons"] == [
         "same_scope_reflect_allowed",
         "same_scope_write_allowed",
     ]
+    assert calls[0][1]["tags"] == ["reflection", "session", "sibyl"]
+    assert calls[0][1]["memory_scope"] is MemoryScope.PROJECT
+    assert calls[0][1]["scope_key"] == "project_123"
     assert calls[1][1]["memory_scope"] is MemoryScope.PROJECT
     assert calls[1][1]["suggested_memory_scope"] is MemoryScope.TEAM
     assert calls[1][1]["suggested_scope_key"] is None
     assert calls[1][1]["extraction_prompt_metadata"]["extractor"] == ("sibyl_reflection_extractor")
-    assert add_fn.await_count == 0
+
+    native_reflection_runtime.entity_manager.create_direct.assert_not_awaited()
+    native_reflection_runtime.relationship_manager.create_bulk.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_reflect_memory_review_persistence_denies_unverified_project(
     monkeypatch: pytest.MonkeyPatch,
+    native_reflection_runtime: SimpleNamespace,
 ) -> None:
-    add_fn = AsyncMock(side_effect=AssertionError("graph add path should not run"))
     source_review = AsyncMock(side_effect=AssertionError("source review should not persist"))
     candidate_review = AsyncMock(side_effect=AssertionError("candidate review should not persist"))
 
@@ -307,7 +362,6 @@ async def test_reflect_memory_review_persistence_denies_unverified_project(
         scope_key="project_123",
         persist=True,
         persist_review=True,
-        add_fn=add_fn,
     )
 
     assert pack.source_id is None
@@ -319,7 +373,9 @@ async def test_reflect_memory_review_persistence_denies_unverified_project(
     ]
     source_review.assert_not_awaited()
     candidate_review.assert_not_awaited()
-    assert add_fn.await_count == 0
+
+    native_reflection_runtime.entity_manager.create_direct.assert_not_awaited()
+    native_reflection_runtime.relationship_manager.create_bulk.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -328,7 +384,6 @@ async def test_reflect_memory_native_write_uses_policy_and_direct_graph(
 ) -> None:
     created_entities = []
     created_relationships = []
-    add_fn = AsyncMock(side_effect=AssertionError("compatibility add path should not run"))
 
     class FakeEntityManager:
         async def create_direct(self, entity):
@@ -362,7 +417,6 @@ async def test_reflect_memory_native_write_uses_policy_and_direct_graph(
             },
         )()
 
-    monkeypatch.setenv("SIBYL_NATIVE_WRITE", "enabled")
     monkeypatch.setattr(
         "sibyl_core.services.memory_reflection.get_surreal_graph_runtime",
         fake_get_graph_runtime,
@@ -379,12 +433,10 @@ async def test_reflect_memory_native_write_uses_policy_and_direct_graph(
         principal_id="user_123",
         accessible_projects={"project_123"},
         persist=True,
-        add_fn=add_fn,
     )
 
     assert pack.source_id is not None
     assert pack.persisted_count == len(pack.candidates)
-    assert add_fn.await_count == 0
     assert len(created_entities) == 2
     assert {entity.entity_type.value for entity in created_entities} == {"session", "decision"}
     assert created_entities[1].metadata["policy_allowed"] is True
@@ -404,7 +456,6 @@ async def test_reflect_memory_native_write_uses_policy_and_direct_graph(
 async def test_reflect_memory_native_write_denies_unverified_project(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    add_fn = AsyncMock(side_effect=AssertionError("compatibility add path should not run"))
     create_direct = AsyncMock()
 
     async def fake_get_graph_runtime(_organization_id: str):
@@ -421,7 +472,6 @@ async def test_reflect_memory_native_write_denies_unverified_project(
             },
         )()
 
-    monkeypatch.setenv("SIBYL_NATIVE_WRITE", "enabled")
     monkeypatch.setattr(
         "sibyl_core.services.memory_reflection.get_surreal_graph_runtime",
         fake_get_graph_runtime,
@@ -437,12 +487,10 @@ async def test_reflect_memory_native_write_denies_unverified_project(
         principal_id="user_123",
         accessible_projects={"project_other"},
         persist=True,
-        add_fn=add_fn,
     )
 
     assert pack.source_id is None
     assert pack.persisted_count == 0
-    assert add_fn.await_count == 0
     create_direct.assert_not_awaited()
     assert pack.candidates[0].metadata["policy_allowed"] is False
     assert pack.candidates[0].metadata["policy_reasons"] == [

--- a/packages/python/sibyl-core/tests/test_reflection_extractor.py
+++ b/packages/python/sibyl-core/tests/test_reflection_extractor.py
@@ -73,7 +73,9 @@ async def test_reflect_memory_persists_claim_receipts_with_source_grounding(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[tuple[str, dict[str, Any]]] = []
-    add_fn = AsyncMock(side_effect=AssertionError("graph add path should not run"))
+    native_write = AsyncMock(side_effect=AssertionError("native graph write should not run"))
+    monkeypatch.setattr("sibyl_core.tools.reflect._persist_reflection_source", native_write)
+    monkeypatch.setattr("sibyl_core.tools.reflect._persist_reflection_candidate", native_write)
 
     async def fake_source_review(**kwargs: Any) -> AddResponse:
         calls.append(("source", kwargs))
@@ -130,7 +132,6 @@ async def test_reflect_memory_persists_claim_receipts_with_source_grounding(
         scope_key="project_123",
         persist=True,
         persist_review=True,
-        add_fn=add_fn,
     )
 
     candidate_call = calls[1][1]


### PR DESCRIPTION
Reflection had two persistence implementations selected by an environment switch, although the native writer was already the default. This change removes the compatibility writer and routes persisted reflection through the existing native path. Review-queue storage remains separate because it deliberately holds candidates for promotion.

The default native contract was frozen before deletion: deterministic fixtures record returned JSON and Markdown, persisted source/candidate metadata, and relationships. The fixture remains byte-identical afterward. Scope checks, source reuse, temporal lifecycle behavior, and partial-write receipts remain covered; production code shrinks by 96 lines.

## 🛠️ Migration

Remove `SIBYL_NATIVE_WRITE` from deployment configuration. The old `disabled` value selected another writer; it never disabled persistence. Use `persist=false` for a preview, or `persist_review=true` together with `persist=true` to store candidates for review. The unused internal `add_fn` injection and switch-helper exports are retired with the compatibility path.

## 🧪 Validation

- Passed 274 focused core tests covering reflection and memory lifecycle behavior.
- Passed 26 API reflection tests across REST, background jobs, and review/promotion routes.
- Preserved the exact pre-deletion fixture digest across all four retired switch values.
- Passed the repaired reflection quality target (165 tests), core lint/type checks, and documentation formatting.

The change removes one persistence branch. It does not add consolidation behavior or claim improved task performance.

