### PR TITLE
fix(install): verify readiness and preserve running services

### DIFF
--- a/apps/cli/src/sibyl_cli/local.py
+++ b/apps/cli/src/sibyl_cli/local.py
@@ -102,7 +102,7 @@ COMPOSE_CONFIG = {
                     "CMD",
                     "python",
                     "-c",
-                    "import httpx; httpx.get('http://localhost:3334/api/health')",
+                    "import httpx; httpx.get('http://localhost:3334/api/health/ready', trust_env=False).raise_for_status()",
                 ],
                 "interval": "10s",
                 "timeout": "5s",
@@ -291,7 +291,9 @@ def wait_for_healthy(timeout: int = 120) -> bool:
     start = time.time()
     while time.time() - start < timeout:
         try:
-            response = httpx.get("http://localhost:3334/api/health", timeout=2)
+            response = httpx.get(
+                "http://localhost:3334/api/health/ready", timeout=2, trust_env=False
+            )
             if response.status_code == 200:
                 return True
         except Exception:
@@ -336,12 +338,15 @@ def start(
 
     # Check if already running
     if is_running():
-        warn("Sibyl is already running")
+        warn("Existing Sibyl API container found; leaving server images unchanged.")
         console.print()
         console.print(f"  [{NEON_CYAN}]Web UI:[/{NEON_CYAN}]    http://localhost:3337")
         console.print(f"  [{NEON_CYAN}]API:[/{NEON_CYAN}]       http://localhost:3334")
         console.print()
-        console.print("Run [bold]sibyl down[/bold] first if you want to restart.")
+        console.print(
+            "To apply updated server images, run "
+            "[bold]sibyl down && sibyl up --pull[/bold] when ready to restart."
+        )
         return
 
     # First run setup
@@ -363,7 +368,9 @@ def start(
     # Pull images if requested or first run
     if pull or not SIBYL_LOCAL_COMPOSE.exists():
         info("Pulling Docker images...")
-        run_compose(["pull", "--quiet"])
+        if run_compose(["pull", "--quiet"]).returncode != 0:
+            error("Failed to pull Docker images. Run 'sibyl up --pull' to retry.")
+            raise typer.Exit(1)
 
     # Start services
     info("Starting services...")
@@ -378,11 +385,12 @@ def start(
     if wait_for_healthy():
         success("Sibyl is running!")
     else:
-        warn("Services are starting (may take a moment)")
+        error("Sibyl did not become healthy. Run 'sibyl local logs' to inspect startup errors.")
+        raise typer.Exit(1)
 
     # Show info
     console.print()
-    console.print(f"[{SUCCESS_GREEN}][bold]🚀 Sibyl is ready![/bold][/{SUCCESS_GREEN}]")
+    console.print(f"[{SUCCESS_GREEN}][bold]Sibyl is ready![/bold][/{SUCCESS_GREEN}]")
     console.print()
     console.print(f"  [{NEON_CYAN}]Web UI:[/{NEON_CYAN}]    http://localhost:3337")
     console.print(f"  [{NEON_CYAN}]API:[/{NEON_CYAN}]       http://localhost:3334")

--- a/apps/cli/tests/test_local_surreal.py
+++ b/apps/cli/tests/test_local_surreal.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+import typer
 
 from sibyl_cli import local
 
@@ -64,3 +66,122 @@ def test_local_env_file_contains_surreal_credentials(
     assert len(password) >= 24, "token_urlsafe(24) yields ~32 chars of entropy"
     assert "SIBYL_POSTGRES_PASSWORD" not in env
     assert "SIBYL_FALKORDB_PASSWORD" not in env
+
+
+def _stub_local_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    running: bool = False,
+    healthy: bool = True,
+    pull_status: int = 0,
+) -> tuple[list[list[str]], list[str]]:
+    env_path = tmp_path / ".env"
+    env_path.touch()
+    monkeypatch.setattr(local, "SIBYL_LOCAL_ENV", env_path)
+    monkeypatch.setattr(local, "check_docker", lambda: True)
+    monkeypatch.setattr(local, "check_docker_compose", lambda: True)
+    monkeypatch.setattr(local, "is_running", lambda: running)
+    monkeypatch.setattr(local, "wait_for_healthy", lambda: healthy)
+    commands: list[list[str]] = []
+    browsers: list[str] = []
+    monkeypatch.setattr(local, "write_compose_file", lambda: commands.append(["write-config"]))
+    monkeypatch.setattr(local.webbrowser, "open", browsers.append)
+
+    def compose(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        return SimpleNamespace(returncode=pull_status if args[0] == "pull" else 0)
+
+    monkeypatch.setattr(local, "run_compose", compose)
+    return commands, browsers
+
+
+def test_local_start_preserves_running_instances(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    commands, browsers = _stub_local_start(tmp_path, monkeypatch, running=True)
+    local.start(no_browser=False, pull=True)
+    assert commands == []
+    assert browsers == []
+    output = capsys.readouterr().out
+    assert "leaving server images unchanged" in output
+    assert "sibyl down && sibyl up --pull" in output
+    assert "Sibyl is ready" not in output
+
+
+def test_local_start_stops_after_pull_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    commands, browsers = _stub_local_start(tmp_path, monkeypatch, pull_status=1)
+    with pytest.raises(typer.Exit) as exc:
+        local.start(no_browser=False, pull=True)
+    assert exc.value.exit_code == 1
+    assert commands == [["write-config"], ["pull", "--quiet"]]
+    assert browsers == []
+    assert "Sibyl is ready" not in capsys.readouterr().out
+
+
+def test_local_start_does_not_announce_or_open_unhealthy_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _, browsers = _stub_local_start(tmp_path, monkeypatch, healthy=False)
+    with pytest.raises(typer.Exit) as exc:
+        local.start(no_browser=False, pull=True)
+    assert exc.value.exit_code == 1
+    assert browsers == []
+    assert "Sibyl is ready" not in capsys.readouterr().out
+
+
+def test_local_start_opens_browser_after_successful_health_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    commands, browsers = _stub_local_start(tmp_path, monkeypatch)
+    local.start(no_browser=False, pull=True)
+    assert commands == [["write-config"], ["pull", "--quiet"], ["up", "-d"]]
+    assert browsers == ["http://localhost:3337"]
+    assert "Sibyl is ready" in capsys.readouterr().out
+
+
+def test_local_api_healthcheck_requires_success_status() -> None:
+    command = local.COMPOSE_CONFIG["services"]["api"]["healthcheck"]["test"]
+    assert command[-1].endswith(".raise_for_status()")
+
+
+@pytest.mark.parametrize("status", [200, 503])
+def test_local_wait_uses_dependency_readiness_without_proxy(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    import httpx
+
+    clock = iter([0, 0, 2])
+    monkeypatch.setattr(local.time, "time", lambda: next(clock))
+    monkeypatch.setattr(local.time, "sleep", lambda _seconds: None)
+    calls = []
+
+    def get(url: str, **kwargs: object) -> httpx.Response:
+        calls.append((url, kwargs))
+        return httpx.Response(status, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx, "get", get)
+    assert local.wait_for_healthy(timeout=1) is (status == 200)
+    assert calls == [("http://localhost:3334/api/health/ready", {"timeout": 2, "trust_env": False})]
+
+
+@pytest.mark.parametrize("status", [200, 503])
+def test_container_probe_executes_dependency_readiness_check(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    import httpx
+
+    def get(url: str, **kwargs: object) -> httpx.Response:
+        assert url == "http://localhost:3334/api/health/ready"
+        assert kwargs == {"trust_env": False}
+        return httpx.Response(status, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx, "get", get)
+    probe = local.COMPOSE_CONFIG["services"]["api"]["healthcheck"]["test"][-1]
+    if status == 503:
+        with pytest.raises(httpx.HTTPStatusError):
+            exec(probe)  # noqa: S102
+    else:
+        exec(probe)  # noqa: S102

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Sibyl Installer
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/hyperb1iss/sibyl/main/install.sh | sh
@@ -15,14 +15,24 @@ set -eu
 # ============================================================================
 # Colors (SilkCircuit palette)
 # ============================================================================
-PURPLE=$(printf '\033[38;2;225;53;255m')
-CYAN=$(printf '\033[38;2;128;255;234m')
-GREEN=$(printf '\033[38;2;80;250;123m')
-YELLOW=$(printf '\033[38;2;241;250;140m')
-RED=$(printf '\033[38;2;255;99;99m')
-DIM=$(printf '\033[2m')
-BOLD=$(printf '\033[1m')
-RESET=$(printf '\033[0m')
+init_output() {
+    PURPLE='' CYAN='' CORAL='' GREEN='' YELLOW='' RED=''
+    DIM='' BOLD='' RESET='' GRAD_2='' GRAD_3='' GRAD_4=''
+    if [ -t 1 ] && [ "${TERM:-}" != dumb ] && [ -z "${NO_COLOR:-}" ]; then
+        PURPLE=$(printf '\033[38;2;225;53;255m')
+        CYAN=$(printf '\033[38;2;128;255;234m')
+        CORAL=$(printf '\033[38;2;255;106;193m')
+        GREEN=$(printf '\033[38;2;80;250;123m')
+        YELLOW=$(printf '\033[38;2;241;250;140m')
+        RED=$(printf '\033[38;2;255;99;99m')
+        GRAD_2=$(printf '\033[38;2;201;88;247m')
+        GRAD_3=$(printf '\033[38;2;176;130;241m')
+        GRAD_4=$(printf '\033[38;2;152;172;238m')
+        DIM=$(printf '\033[2m')
+        BOLD=$(printf '\033[1m')
+        RESET=$(printf '\033[0m')
+    fi
+}
 
 # ============================================================================
 # Helpers
@@ -30,14 +40,14 @@ RESET=$(printf '\033[0m')
 info() { printf '%s\n' "${CYAN}▸${RESET} $1"; }
 success() { printf '%s\n' "${GREEN}✓${RESET} $1"; }
 warn() { printf '%s\n' "${YELLOW}!${RESET} $1"; }
-error() { printf '%s\n' "${RED}✗${RESET} $1"; exit 1; }
+error() { printf '%s\n' "${RED}✗${RESET} $1" >&2; exit 1; }
 
 usage() {
     cat << EOF
 Sibyl installer
 
 Usage:
-  install.sh [--server|--remote|--daemon] [--version VERSION] [--no-start] [--no-open]
+  install.sh [--server|--remote|--daemon] [--version VERSION] [--no-start] [--no-open] [--no-pull]
 
 Modes:
   --server   Install Sibyl, start the local API + web UI, and open the browser (default)
@@ -45,32 +55,35 @@ Modes:
   --daemon   Install sibyl + sibyld for the embedded daemon without the web UI
 
 Options:
+  --version   Install a specific package version (default: latest release)
   --no-start  Install only; print the command to start later
   --no-open   Do not open the browser after starting the web UI
   --no-pull   Do not pull Docker images before starting the local server
 
 Environment:
   SIBYL_INSTALL_MODE      server, remote, or daemon
-  SIBYL_INSTALL_VERSION   package version to install, such as 1.0.0rc1
+  SIBYL_INSTALL_VERSION   package version to install, such as 1.3.2
   SIBYL_INSTALL_START     0 to install without starting
   SIBYL_INSTALL_OPEN      0 to skip opening the browser
   SIBYL_INSTALL_PULL      0 to skip pulling Docker images
+  NO_COLOR                disable terminal colors
 EOF
 }
 
 banner() {
-    printf '%s' "${PURPLE}${BOLD}"
-    cat << 'EOF'
-   _____ _ __          __
-  / ___/(_) /_  __  __/ /
-  \__ \/ / __ \/ / / / /
- ___/ / / /_/ / /_/ / /
-/____/_/_.___/\__, /_/
-             /____/
-EOF
-    printf '%s\n' "${RESET}"
-    printf '%s\n' "${DIM}Collective Intelligence Runtime${RESET}"
     echo
+    if [ -n "$PURPLE" ]; then
+        printf '%s\n' "         ${CORAL}✦${RESET}"
+        printf '%s\n' "      ${PURPLE}╔═╗${GRAD_2}╦${GRAD_3}╔╗ ${GRAD_4}╦ ╦${CYAN}╦${RESET}"
+        printf '%s\n' "      ${PURPLE}╚═╗${GRAD_2}║${GRAD_3}╠╩╗${GRAD_4}╚╦╝${CYAN}║${RESET}"
+        printf '%s\n' "      ${PURPLE}╚═╝${GRAD_2}╩${GRAD_3}╚═╝ ${GRAD_4}╩ ${CYAN}╩═╝${RESET}"
+        printf '%s\n' "      ${DIM}${CYAN}collective intelligence runtime${RESET}"
+    else
+        printf '%s\n' 'SIBYL' 'collective intelligence runtime'
+    fi
+    echo
+    printf '%s\n' "${DIM}Install mode:${RESET} ${BOLD}${MODE}${RESET}"
+    printf '%s\n' "${DIM}Package version:${RESET} ${SIBYL_PYPI_VERSION:-latest release}"
 }
 
 # ============================================================================
@@ -86,11 +99,11 @@ check_os() {
 
 check_docker() {
     if ! command -v docker >/dev/null 2>&1; then
-        error "Docker is required but not installed.\n\n  Install from: https://docs.docker.com/get-docker/"
+        error "Docker is required. Install it from https://docs.docker.com/get-docker/"
     fi
 
     if ! docker info >/dev/null 2>&1; then
-        error "Docker daemon is not running.\n\n  Start Docker and try again."
+        error "Docker daemon is not running. Start Docker and try again."
     fi
 
     success "Docker is available"
@@ -131,7 +144,7 @@ package_spec() {
     if [ -n "${SIBYL_PYPI_VERSION:-}" ]; then
         printf '%s==%s' "$package" "$SIBYL_PYPI_VERSION"
     else
-        printf '%s' "$package"
+        printf '%s@latest' "$package"
     fi
 }
 
@@ -181,8 +194,10 @@ start_local_server() {
         return
     fi
 
-    check_docker
-
+    if [ "$(docker inspect --format '{{.State.Running}}' sibyl-api 2>/dev/null || true)" = true ]; then
+        warn "Existing server found; running server images will remain unchanged."
+        info "To upgrade server images, run 'sibyl down && sibyl up --pull' when ready to restart."
+    fi
     info "Starting Sibyl local server..."
     set -- up
     if [ "$PULL_IMAGES" = "1" ]; then
@@ -195,11 +210,61 @@ start_local_server() {
     if ! sibyl "$@"; then
         error "Failed to start Sibyl local server."
     fi
+    info "Checking the local API..."
+    if ! wait_for_api; then
+        error "The local API is not ready. Run 'sibyl local logs' to inspect startup errors."
+    fi
+}
+
+# Match the PID file contract used by `sibyl start`, without signalling processes.
+live_daemon_pid() {
+    daemon_pid=$(cat "$HOME/.sibyl/run/sibyld.pid" 2>/dev/null) || return 1
+    case "$daemon_pid" in ''|*[!0-9]*|0) return 1 ;; esac
+    kill -0 "$daemon_pid" 2>/dev/null || return 1
+    daemon_command=$(ps -p "$daemon_pid" -o args= 2>/dev/null) || return 1
+    case "$daemon_command" in
+        *sibyld*" serve --embedded "*"--port 3334 "*) printf '%s' "$daemon_pid" ;;
+        *) return 1 ;;
+    esac
+}
+
+wait_for_api() {
+    expected_pid="${1:-}"
+    readiness_deadline=$(( $(date +%s) + 120 ))
+    while [ "$(date +%s)" -lt "$readiness_deadline" ]; do
+        if [ -n "$expected_pid" ]; then
+            [ "$(live_daemon_pid)" = "$expected_pid" ] || return 1
+        fi
+        if curl -fsS --noproxy '*' --max-time 5 http://localhost:3334/api/health/ready >/dev/null 2>&1; then
+            if [ -n "$expected_pid" ]; then
+                # A failed child must not borrow readiness from another listener.
+                sleep 1
+                [ "$(live_daemon_pid)" = "$expected_pid" ] || return 1
+            fi
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
 }
 
 start_embedded_daemon() {
     if [ "$START_AFTER_INSTALL" != "1" ]; then
         return
+    fi
+
+    existing_pid=$(live_daemon_pid) || existing_pid=''
+    if [ -n "$existing_pid" ]; then
+        if ! wait_for_api "$existing_pid"; then
+            error "Existing daemon is not ready; it was left running. Run 'sibyl doctor' for details."
+        fi
+        warn "Existing daemon preserved; restart it to use the installed packages."
+        info "Run 'sibyl stop && sibyl start' when ready to restart with the installed version."
+        return
+    fi
+    # Even an unhealthy HTTP listener occupies the daemon's configured port.
+    if curl -sS --noproxy '*' --max-time 5 http://localhost:3334/api/health/ready >/dev/null 2>&1; then
+        error "Port 3334 already serves an API without a matching daemon PID. Existing services were left unchanged. Use --no-start for a package-only update."
     fi
 
     info "Initializing local embedded context..."
@@ -209,8 +274,11 @@ start_embedded_daemon() {
 
     info "Starting embedded daemon..."
     if ! sibyl start; then
-        warn "Embedded daemon did not start. It may already be running; run 'sibyl doctor'."
-        return
+        error "Embedded daemon did not start. Run 'sibyl doctor' for details."
+    fi
+    started_pid=$(live_daemon_pid) || started_pid=''
+    if [ -z "$started_pid" ] || ! wait_for_api "$started_pid"; then
+        error "Embedded daemon did not become ready. Run 'sibyl doctor' and inspect ~/.sibyl/run/sibyld.log."
     fi
 }
 
@@ -294,11 +362,25 @@ parse_args() {
 }
 
 main() {
-    banner
+    init_output
     parse_args "$@"
+    case "$MODE" in
+        server|remote|daemon) ;;
+        *) error "Unknown install mode: $MODE (use server, remote, or daemon)" ;;
+    esac
+    case "$START_AFTER_INSTALL:$OPEN_BROWSER:$PULL_IMAGES" in
+        [01]:[01]:[01]) ;;
+        *) error "SIBYL_INSTALL_START, SIBYL_INSTALL_OPEN, and SIBYL_INSTALL_PULL must be 0 or 1" ;;
+    esac
+    if { [ "$START_AFTER_INSTALL" = 1 ] && [ "$MODE" != remote ]; } || ! command -v uv >/dev/null 2>&1; then
+        command -v curl >/dev/null 2>&1 || error "curl is required for bootstrap and local readiness checks. Install curl and try again."
+    fi
     normalize_version
-
     check_os
+    banner
+    if [ "$MODE" = server ] && [ "$START_AFTER_INSTALL" = 1 ]; then
+        check_docker
+    fi
 
     echo
     install_uv
@@ -314,9 +396,6 @@ main() {
             start_embedded_daemon
             ;;
         remote)
-            ;;
-        *)
-            error "Unknown install mode: $MODE (use server, remote, or daemon)"
             ;;
     esac
 

--- a/moon.yml
+++ b/moon.yml
@@ -852,11 +852,13 @@ tasks:
   release-workflow-test:
     command:
       uv run pytest tools/tests/test_ci_changes.py tools/tests/test_release_workflow.py
-      tools/tests/test_workflow_cache_contract.py -v
+      tools/tests/test_workflow_cache_contract.py tools/tests/test_install_script.py -v
     inputs:
       - tools/tests/conftest.py
       - tools/tests/test_ci_changes.py
       - tools/tests/test_release_workflow.py
+      - tools/tests/test_install_script.py
+      - install.sh
       - tools/tests/test_workflow_cache_contract.py
       - tools/release/*.py
       - apps/e2e/moon.yml

--- a/tools/tests/test_install_script.py
+++ b/tools/tests/test_install_script.py
@@ -1,0 +1,304 @@
+"""Exercise the curl-pipe installer without installing tools or starting services."""
+
+from __future__ import annotations
+
+import os
+import pty
+import subprocess
+from pathlib import Path
+
+import pytest
+from tools.tests.conftest import REPO_ROOT
+
+STUB_SHELL = r"""
+uv() {
+    printf 'uv %s\n' "$*" >> "$INSTALLER_CALL_LOG"
+    if [ "$1" = --version ]; then printf 'uv fixture\n'; fi
+}
+sibyl() {
+    printf 'sibyl %s\n' "$*" >> "$INSTALLER_CALL_LOG"
+    if [ "$1" = start ]; then
+        if [ "${INSTALLER_FAIL_START:-0}" = 1 ]; then return 7; fi
+        INSTALLER_STARTED=1
+    fi
+}
+sibyld() { printf 'sibyld %s\n' "$*" >> "$INSTALLER_CALL_LOG"; }
+docker() {
+    printf 'docker %s\n' "$*" >> "$INSTALLER_CALL_LOG"
+    if [ "$1" = inspect ]; then printf '%s\n' "${INSTALLER_EXISTING_SERVER:-false}"; fi
+    return "${INSTALLER_DOCKER_STATUS:-0}"
+}
+curl() {
+    printf 'curl %s\n' "$*" >> "$INSTALLER_CALL_LOG"
+    case "$*" in
+        '-sS --noproxy * --max-time 5 http://localhost:3334/api/health/ready')
+            return "${INSTALLER_OCCUPIED_PORT_STATUS:-7}" ;;
+        '-fsS --noproxy * --max-time 5 http://localhost:3334/api/health/ready')
+            INSTALLER_PROBED=1
+            INSTALLER_PROBE_COUNT=$(( ${INSTALLER_PROBE_COUNT:-0} + 1 ))
+            if [ "$INSTALLER_PROBE_COUNT" -le "${INSTALLER_HEALTH_AFTER:-0}" ]; then return 7; fi
+            return "${INSTALLER_HEALTH_STATUS:-0}" ;;
+        *) printf 'Unexpected download\n' >&2; exit 99 ;;
+    esac
+}
+cat() {
+    if [ "$*" = "$HOME/.sibyl/run/sibyld.pid" ]; then
+        if [ "${INSTALLER_EXISTING_DAEMON:-0}" = 1 ] || [ "${INSTALLER_STARTED:-0}" = 1 ]; then
+            printf '%s\n' "${INSTALLER_PID:-12345}"
+        else
+            return 1
+        fi
+    else
+        command cat "$@"
+    fi
+}
+kill() {
+    [ "$1" = -0 ] || exit 99
+    if [ "${INSTALLER_DAEMON_DIES:-0}" = 1 ]; then return 1; fi
+    if [ "${INSTALLER_DIES_AFTER_PROBE:-0}:${INSTALLER_PROBED:-0}" = 1:1 ]; then return 1; fi
+}
+ps() { printf '%s\n' "${INSTALLER_PROCESS_COMMAND:-/fixture/bin/sibyld serve --embedded --host 127.0.0.1 --port 3334 --transport http}"; }
+sleep() { INSTALLER_ELAPSED=$(( ${INSTALLER_ELAPSED:-0} + $1 )); }
+date() { printf '%s\n' "${INSTALLER_ELAPSED:-0}"; }
+uname() { printf 'Linux\n'; }
+if [ "${INSTALLER_MISSING_CURL:-0}" = 1 ]; then
+    unset -f curl
+    PATH=/nonexistent
+fi
+installer_path=$1
+shift
+. "$installer_path"
+"""
+
+
+def _run_installer(
+    tmp_path: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+    terminal: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    call_log = tmp_path / "calls.log"
+    process_env = {
+        "PATH": "/usr/bin:/bin",
+        "TERM": "xterm-256color",
+        "INSTALLER_CALL_LOG": str(call_log),
+        **(env or {}),
+    }
+    # Tool functions shadow real executables even after the installer adds to PATH.
+    # Reuse the actual home path without touching it; every mutation is stubbed.
+    process_env["HOME"] = str(Path.home())
+    command = ["/bin/sh", "-c", STUB_SHELL, "installer-test", str(REPO_ROOT / "install.sh"), *args]
+    if terminal:
+        master, slave = pty.openpty()
+        try:
+            with (
+                (tmp_path / "stderr.txt").open("w+") as stderr,
+                subprocess.Popen(  # noqa: S603
+                    command, env=process_env, stdout=slave, stderr=stderr, text=True
+                ) as process,
+            ):
+                os.close(slave)
+                slave = -1
+                output = bytearray()
+                while True:
+                    try:
+                        chunk = os.read(master, 4096)
+                    except OSError:
+                        break
+                    if not chunk:
+                        break
+                    output.extend(chunk)
+                process.wait()
+                stderr.seek(0)
+                result = subprocess.CompletedProcess(
+                    command, process.returncode, output.decode(), stderr.read()
+                )
+        finally:
+            os.close(master)
+            if slave >= 0:
+                os.close(slave)
+    else:
+        result = subprocess.run(  # noqa: S603
+            command, env=process_env, capture_output=True, text=True, check=False
+        )
+    return result, call_log.read_text().splitlines() if call_log.exists() else []
+
+
+def test_default_installer_checks_docker_before_installing_and_starts_server(
+    tmp_path: Path,
+) -> None:
+    result, calls = _run_installer(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert calls == [
+        "docker info",
+        "uv --version",
+        "uv tool install sibyl-dev@latest --force",
+        "sibyl skill install --quiet",
+        "docker inspect --format {{.State.Running}} sibyl-api",
+        "sibyl up --pull",
+        "curl -fsS --noproxy * --max-time 5 http://localhost:3334/api/health/ready",
+    ]
+    assert "\x1b" not in result.stdout
+    assert "SIBYL" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("args", "env", "last_call"),
+    [
+        (["--remote"], {}, "sibyl skill install --quiet"),
+        (["--no-start"], {}, "sibyl skill install --quiet"),
+        (["--no-open"], {}, "sibyl up --pull --no-browser"),
+        (["--no-open", "--no-pull"], {}, "sibyl up --no-browser"),
+        (["--daemon"], {}, "sibyl start"),
+        ([], {"SIBYL_INSTALL_MODE": "remote"}, "sibyl skill install --quiet"),
+    ],
+)
+def test_installer_preserves_modes_and_start_flags(
+    tmp_path: Path, args: list[str], env: dict[str, str], last_call: str
+) -> None:
+    result, calls = _run_installer(tmp_path, *args, env=env)
+    assert result.returncode == 0, result.stderr
+    assert last_call in calls
+    if "--remote" in args or "--no-start" in args or env:
+        assert "docker info" not in calls
+    if "--daemon" in args:
+        assert "docker info" not in calls
+        assert "uv tool install sibyld@latest --force" in calls
+        assert "sibyl init --local --force" in calls
+
+
+def test_installer_preserves_pinned_prerelease_version(tmp_path: Path) -> None:
+    result, calls = _run_installer(tmp_path, "--daemon", "--no-start", "--version", "1.4.0-rc.1")
+    assert result.returncode == 0, result.stderr
+    assert "uv tool install sibyl-dev==1.4.0rc1 --force" in calls
+    assert "uv tool install sibyld==1.4.0rc1 --force" in calls
+
+
+@pytest.mark.parametrize(
+    "env",
+    [{"SIBYL_INSTALL_MODE": "bogus"}, {"SIBYL_INSTALL_START": "yes"}],
+)
+def test_invalid_configuration_fails_before_installing(tmp_path: Path, env: dict[str, str]) -> None:
+    result, calls = _run_installer(tmp_path, env=env)
+    assert result.returncode != 0
+    assert calls == []
+    assert "Installation complete" not in result.stdout
+
+
+def test_unavailable_docker_fails_before_installing(tmp_path: Path) -> None:
+    result, calls = _run_installer(tmp_path, env={"INSTALLER_DOCKER_STATUS": "1"})
+    assert result.returncode != 0
+    assert calls == ["docker info"]
+    assert "Docker daemon is not running" in result.stderr
+
+
+def test_daemon_failure_never_reports_completion(tmp_path: Path) -> None:
+    result, calls = _run_installer(tmp_path, "--daemon", env={"INSTALLER_FAIL_START": "1"})
+    assert result.returncode != 0
+    assert calls[-1] == "sibyl start"
+    assert "Embedded daemon did not start" in result.stderr
+    assert "Installation complete" not in result.stdout
+    assert "Embedded daemon: http" not in result.stdout
+
+
+def test_installer_checks_health_even_when_older_cli_reports_success(tmp_path: Path) -> None:
+    result, calls = _run_installer(tmp_path, env={"INSTALLER_HEALTH_STATUS": "22"})
+    assert result.returncode != 0
+    assert "sibyl up --pull" in calls
+    assert calls[-1] == "curl -fsS --noproxy * --max-time 5 http://localhost:3334/api/health/ready"
+    assert "local API is not ready" in result.stderr
+    assert "Installation complete" not in result.stdout
+
+
+@pytest.mark.parametrize("env", [{"NO_COLOR": "1"}, {"TERM": "dumb"}])
+def test_terminal_can_disable_ansi(tmp_path: Path, env: dict[str, str]) -> None:
+    result, _ = _run_installer(tmp_path, "--remote", env=env, terminal=True)
+    assert result.returncode == 0, result.stderr
+    assert "\x1b" not in result.stdout
+
+
+def test_terminal_shows_silkcircuit_gradient_wordmark(tmp_path: Path) -> None:
+    result, _ = _run_installer(tmp_path, "--remote", terminal=True)
+    assert result.returncode == 0, result.stderr
+    assert "╔═╗" in result.stdout
+    assert "\x1b[38;2;225;53;255m" in result.stdout
+    assert "\x1b[38;2;128;255;234m" in result.stdout
+
+
+def test_installer_help_has_no_side_effects(tmp_path: Path) -> None:
+    result, calls = _run_installer(tmp_path, "--help")
+    assert result.returncode == 0
+    assert calls == []
+    assert "--version" in result.stdout
+    assert "\x1b" not in result.stdout
+
+
+@pytest.mark.parametrize("args", [[], ["--daemon"]])
+def test_missing_curl_fails_before_any_install(tmp_path: Path, args: list[str]) -> None:
+    result, calls = _run_installer(tmp_path, *args, env={"INSTALLER_MISSING_CURL": "1"})
+    assert result.returncode != 0
+    assert calls == []
+    assert "curl is required" in result.stderr
+
+
+def test_server_rerun_explains_explicit_image_upgrade(tmp_path: Path) -> None:
+    result, _ = _run_installer(tmp_path, env={"INSTALLER_EXISTING_SERVER": "true"})
+    assert result.returncode == 0
+    assert "running server images will remain unchanged" in result.stdout
+    assert "sibyl down && sibyl up --pull" in result.stdout
+
+
+def test_healthy_daemon_rerun_preserves_process_and_context(tmp_path: Path) -> None:
+    result, calls = _run_installer(tmp_path, "--daemon", env={"INSTALLER_EXISTING_DAEMON": "1"})
+    assert result.returncode == 0, result.stderr
+    assert "sibyl start" not in calls
+    assert "sibyl init --local --force" not in calls
+    assert "Existing daemon preserved" in result.stdout
+    assert "sibyl stop && sibyl start" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"INSTALLER_DAEMON_DIES": "1"},
+        {"INSTALLER_DIES_AFTER_PROBE": "1"},
+        {"INSTALLER_HEALTH_STATUS": "22"},
+    ],
+)
+def test_daemon_zero_exit_requires_owned_process_and_readiness(
+    tmp_path: Path, env: dict[str, str]
+) -> None:
+    result, calls = _run_installer(tmp_path, "--daemon", env=env)
+    assert result.returncode != 0
+    assert "sibyl start" in calls
+    assert "did not become ready" in result.stderr
+    assert "Installation complete" not in result.stdout
+
+
+def test_daemon_does_not_borrow_readiness_from_other_api(tmp_path: Path) -> None:
+    result, calls = _run_installer(
+        tmp_path, "--daemon", env={"INSTALLER_OCCUPIED_PORT_STATUS": "0"}
+    )
+    assert result.returncode != 0
+    assert "sibyl start" not in calls
+    assert "Port 3334 already serves an API" in result.stderr
+
+
+def test_daemon_does_not_trust_reused_pid(tmp_path: Path) -> None:
+    result, _ = _run_installer(
+        tmp_path, "--daemon", env={"INSTALLER_PROCESS_COMMAND": "unrelated-service"}
+    )
+    assert result.returncode != 0
+    assert "Installation complete" not in result.stdout
+
+
+@pytest.mark.parametrize("args", [[], ["--daemon"]])
+def test_slow_startup_waits_for_dependency_readiness(tmp_path: Path, args: list[str]) -> None:
+    unready_probes = 30
+    result, calls = _run_installer(
+        tmp_path, *args, env={"INSTALLER_HEALTH_AFTER": str(unready_probes)}
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Installation complete" in result.stdout
+    probes = [call for call in calls if call.startswith("curl -fsS --noproxy")]
+    assert len(probes) == unready_probes + 1


### PR DESCRIPTION
The curl installer could report completion after an unhealthy startup, and daemon reruns could turn an already-running instance into a reported failure. The installer now checks dependency readiness, verifies the daemon process it started, and preserves running instances with explicit restart instructions.

The terminal banner uses the SilkCircuit gradient wordmark. Redirected output, `NO_COLOR`, and `TERM=dumb` stay free of ANSI escapes. Configuration and required tools are checked before installation; unpinned packages explicitly resolve `@latest`, while version pins remain intact.

For Docker installs, the CLI now fails on image pull errors or readiness timeouts. Container health also checks readiness. The script performs its own readiness check for compatibility with the currently published CLI, bypasses proxies for loopback probes, and explains when running server images remain unchanged.

For daemon installs, readiness must belong to a live process matching the expected PID and command. An existing healthy daemon keeps its process and context; an unrelated listener cannot supply startup success.

## 🧪 Validation

- Passed 29 installer checks, including real PTY color/plain output, delayed readiness, and startup/rerun failures.
- Passed all 711 CLI tests, including readiness failure and container preservation checks.
- Passed CLI and root inventory lint/type checks, POSIX shell syntax checks, and diff checks.
- Independent verification checked the daemon argument contract against the published 1.3.2 wheel and its PyPI digest.

Tests stub installation and service commands. No running user instance was restarted or reconfigured.

## 🛠️ Publication boundary

Script changes take effect when the public installer is updated and work with CLI 1.3.2. The CLI's internal pull and container health changes require the next package publication. Existing running services are preserved; the printed restart commands apply the newly installed code or images.
