### PR TITLE
fix(memory): isolate reflection evidence and promotion lineage

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entities.py
@@ -20,6 +20,7 @@ from sibyl_core.services.graph_entity_store import (
     _CONTENT_MIRRORS_DESCRIPTION_TYPES,
     _entity_update_patch,
     _heal_metadata_snapshots_for_write,
+    _insert_entity_if_absent,
     _persisted_entity_embedding_text,
     _replace_entities_bulk,
     _replace_entity,
@@ -32,6 +33,15 @@ from sibyl_core.services.graph_records import _entity_from_row, entity_from_surr
 class EntityManager(_EntityWorkItemManager):
     supports_bounded_entity_list = True
     supports_lightweight_entity_list = True
+
+    async def create_direct_if_absent(self, entity: Entity) -> tuple[Entity, bool]:
+        """Insert once, returning the stored row and whether this call created it."""
+        row, created = await _insert_entity_if_absent(
+            self._client,
+            entity,
+            group_id=self._group_id,
+        )
+        return _entity_from_row(row), created
 
     async def create_direct(self, entity: Entity, *, generate_embedding: bool = False) -> str:
         if generate_embedding:
@@ -179,6 +189,7 @@ class EntityManager(_EntityWorkItemManager):
         updates: dict[str, Any],
         *,
         expected_revision: int | None = None,
+        replace_metadata_keys: Sequence[str] = (),
     ) -> Entity | None:
         if not updates:
             return await self.get(entity_id)
@@ -209,6 +220,14 @@ class EntityManager(_EntityWorkItemManager):
                     RETURN AFTER
                 );
                 UPDATE $updated SET
+                    attributes = IF $metadata_replacements = {} THEN
+                        attributes
+                    ELSE
+                        object::from_entries(array::concat(
+                            object::entries(attributes ?? {}),
+                            object::entries($metadata_replacements)
+                        ))
+                    END,
                     summary = IF description != NONE AND description != '' THEN
                         string::slice(description, 0, 500)
                     ELSE
@@ -230,6 +249,11 @@ class EntityManager(_EntityWorkItemManager):
             expected_revision=expected_revision,
             mirror_content=mirror_content,
             content_mirror_types=list(_CONTENT_MIRRORS_DESCRIPTION_TYPES),
+            metadata_replacements={
+                key: patch_attributes[key]
+                for key in replace_metadata_keys
+                if isinstance(patch_attributes, Mapping) and key in patch_attributes
+            },
         )
         if not rows and expected_revision is not None:
             try:

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
@@ -194,6 +194,38 @@ async def _replace_entity(
     return stored
 
 
+async def _insert_entity_if_absent(
+    client: SurrealGraphClient,
+    entity: Entity,
+    *,
+    group_id: str,
+) -> tuple[SurrealRecord, bool]:
+    """Arbitrate creation by physical record ID without rewriting a retry."""
+    _enforce_entity_content_limit([entity])
+    record = _entity_record(entity, group_id=group_id)
+    record["id"] = entity.id
+    query = "INSERT IGNORE INTO entity $rows;"
+    try:
+        result = await client.execute_query(query, rows=[record])
+    except Exception as exc:
+        if not _is_legacy_updated_at_string_schema_error(exc):
+            raise
+        result = await client.execute_query(
+            query, rows=_records_with_legacy_updated_at_strings([record])
+        )
+    rows = normalize_records(result)
+    if rows:
+        return rows[0], True
+    stored = await _select_one(
+        client,
+        "SELECT * FROM entity WHERE uuid = $uuid LIMIT 1;",
+        uuid=entity.id,
+    )
+    if stored is None:
+        raise RuntimeError(f"failed to insert or find entity {entity.id}")
+    return stored, False
+
+
 async def _replace_entities_bulk(
     client: SurrealGraphClient,
     entities: Sequence[Entity],

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_identity.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_identity.py
@@ -1,0 +1,67 @@
+"""Versioned identities for immutable reflection evidence and assertions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from sibyl_core.models.entities import Entity
+
+IDENTITY_KEY = "reflection_identity"
+
+
+def reflection_identity(entity: Entity) -> dict[str, object]:
+    """Bind full evidence to its authoritative ownership and provenance.
+
+    Title whitespace follows graph read normalization; content is byte-exact. Extraction
+    UUIDs, timestamps and lifecycle decisions are deliberately not identities.
+    Legacy title-derived IDs remain readable and are never rewritten here.
+    """
+    metadata = entity.metadata
+    source_ids = {
+        str(value)
+        for key in ("raw_source_ids", "source_ids")
+        for value in metadata.get(key, [])
+        if value
+    }
+    if entity.source_file:
+        source_ids.add(entity.source_file)
+    identity = {
+        "version": 2,
+        "purpose": "source" if metadata.get("reflection_source") is True else "candidate",
+        "kind": entity.entity_type.value,
+        "title": entity.name.strip(),
+        "content_sha256": hashlib.sha256(entity.content.encode("utf-8")).hexdigest(),
+        "organization_id": entity.organization_id,
+        "principal_id": metadata.get("principal_id"),
+        "created_by": entity.created_by,
+        "memory_scope": metadata.get("memory_scope"),
+        "scope_key": metadata.get("scope_key"),
+        "project_id": metadata.get("project_id"),
+        "domain": metadata.get("category") or None,
+        "primary_source_id": entity.source_file,
+        "source_ids": sorted(source_ids),
+        "review_capture_id": metadata.get("review_capture_id"),
+        "imported_capture_id": metadata.get("imported_capture_id"),
+    }
+    # Surreal NONE removes object keys. Canonical absence must therefore be
+    # identical before serialization and after reading the stored evidence.
+    return {key: value for key, value in identity.items() if value is not None}
+
+
+def reflection_entity_id(entity: Entity) -> str:
+    payload = json.dumps(reflection_identity(entity), sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"{entity.entity_type.value}_v2_{digest}"
+
+
+def verify_reflection_identity(expected: Entity, stored: Entity) -> None:
+    """Do not trust a stored fingerprint without checking its actual fields."""
+    identity = reflection_identity(expected)
+    if (
+        expected.id != stored.id
+        or expected.content != stored.content
+        or stored.metadata.get(IDENTITY_KEY) != identity
+        or reflection_identity(stored) != identity
+    ):
+        raise ValueError("reflection identity conflict; existing evidence was not modified")

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_promotion.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_promotion.py
@@ -13,6 +13,11 @@ from sibyl_core.models.entities import Entity, EntityType, Relationship, Relatio
 from sibyl_core.models.reflection import ReflectionCandidate
 from sibyl_core.models.relations import declared_relation_targets
 from sibyl_core.services.memory_contract import ReflectionPromotionResult
+from sibyl_core.services.memory_identity import (
+    IDENTITY_KEY,
+    reflection_entity_id,
+    reflection_identity,
+)
 from sibyl_core.services.memory_lifecycle import _relationship
 from sibyl_core.services.memory_policy import (
     _candidate_source_ids,
@@ -25,7 +30,6 @@ from sibyl_core.services.surreal_content import (
     MemoryScope,
     RawMemory,
 )
-from sibyl_core.tools.helpers import _generate_id
 
 _SCOPE_RANK: dict[MemoryScope, int] = {
     MemoryScope.PRIVATE: 0,
@@ -265,8 +269,7 @@ def _entity_from_candidate(
     policy_metadata: Mapping[str, Any],
 ) -> Entity:
     entity_type = _entity_type(candidate.kind)
-    entity_id = _generate_id(entity_type.value, candidate.title, domain or "general")
-    source_ids = _candidate_source_ids(candidate, source_id)
+    source_ids = sorted(_candidate_source_ids(candidate, source_id))
     primary_source_id = source_id or (source_ids[0] if source_ids else None)
     native_write_path = _metadata_str(candidate.metadata, "native_write_path")
     if not native_write_path:
@@ -305,11 +308,13 @@ def _entity_from_candidate(
         metadata.pop("category", None)
     if project:
         metadata["project_id"] = project
+    else:
+        metadata.pop("project_id", None)
     if primary_source_id:
         metadata["reflection_source_id"] = primary_source_id
 
-    return Entity(
-        id=entity_id,
+    entity = Entity(
+        id="reflection_pending",
         entity_type=entity_type,
         name=candidate.title,
         description=candidate.content[:500],
@@ -319,6 +324,9 @@ def _entity_from_candidate(
         metadata=metadata,
         source_file=primary_source_id,
     )
+    entity.id = reflection_entity_id(entity)
+    entity.metadata[IDENTITY_KEY] = reflection_identity(entity)
+    return entity
 
 
 async def _linkable_related_targets(

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import structlog
 
+from sibyl_core.errors import EntityNotFoundError, RevisionConflictError
+from sibyl_core.memory_pipeline.lifecycle import graph_lifecycle_stamp, graph_metadata_recallable
 from sibyl_core.models.entities import EntityType, Relationship
 from sibyl_core.models.reflection import ReflectionCandidate
 from sibyl_core.services.graph import get_surreal_graph_runtime
@@ -21,7 +23,11 @@ from sibyl_core.services.memory_contract import (
     _ReflectionPromotionPlan,
     _RelationshipWriteReceipt,
 )
-from sibyl_core.services.memory_lifecycle import _apply_candidate_temporal_invalidations
+from sibyl_core.services.memory_identity import verify_reflection_identity
+from sibyl_core.services.memory_lifecycle import (
+    _apply_candidate_temporal_invalidations,
+    _candidate_temporal_invalidation_targets,
+)
 from sibyl_core.services.memory_policy import (
     _authorize_reflection_write,
     _authorized_superseded_entity_ids,
@@ -139,6 +145,7 @@ async def persist_reflection_candidate(
     memory_scope: MemoryScope | str | None = None,
     scope_key: str | None = None,
     link_source_entity: bool = True,
+    source_memories: Sequence[RawMemory] = (),
 ) -> ReflectionWriteResult:
     scope = _resolve_memory_scope(memory_scope, project)
     resolved_scope_key = _resolve_scope_key(scope, scope_key, project)
@@ -205,7 +212,7 @@ async def persist_reflection_candidate(
         principal_id=principal_id,
         accessible_projects=accessible_projects,
     )
-    created_id = await runtime.entity_manager.create_direct(entity)
+    created_id = entity.id
     native_write_path = _metadata_str(candidate.metadata, "native_write_path")
     if not native_write_path:
         native_write_path = "reflection_promotion"
@@ -218,6 +225,42 @@ async def persist_reflection_candidate(
         raw_source_ids=source_ids,
         native_write_path=native_write_path,
     )
+    publication_request = {
+        "relationships": sorted(relationship.id for relationship in relationships),
+        "invalidation_targets": sorted(
+            [target.source_id, target.reason]
+            for target in _candidate_temporal_invalidation_targets(candidate)
+        ),
+        "invalidation_cutoff": {
+            key: str(candidate.metadata[key])
+            for key in ("valid_at", "valid_from", "occurred_at")
+            if candidate.metadata.get(key) is not None
+        },
+    }
+    entity.metadata["reflection_publication"] = {
+        "state": "pending",
+        "request": publication_request,
+    }
+    if not await _verify_promotion_sources(runtime, source_memories):
+        return _retired_reflection_result(entity.id)
+    stored, created = await runtime.entity_manager.create_direct_if_absent(entity)
+    verify_reflection_identity(entity, stored)
+    if not await _verify_promotion_sources(runtime, source_memories, entity_id=stored.id):
+        return _retired_reflection_result(stored.id)
+    if not graph_metadata_recallable(stored.metadata):
+        return _retired_reflection_result(stored.id)
+    prior_publication = stored.metadata.get("reflection_publication", {})
+    if (
+        not created
+        and prior_publication.get("state") == "complete"
+        and prior_publication.get("request") == publication_request
+    ):
+        return _reflection_publication_result(
+            stored.id,
+            candidate.title,
+            prior_publication["receipt"],
+            "replayed",
+        )
     relationship_receipt = await _write_promotion_relationships(
         runtime.relationship_manager,
         relationships,
@@ -234,27 +277,121 @@ async def persist_reflection_candidate(
         authorized_entity_ids=superseded_ids,
     )
 
+    receipt = {
+        **policy_metadata,
+        "native_write_mode": WriteMode.ENABLED.value,
+        "native_write_path": native_write_path,
+        "native_relationship_count": relationship_receipt.created,
+        "native_relationship_requested_count": relationship_receipt.requested,
+        "native_relationship_failed_count": relationship_receipt.failed,
+        "promotion_state": relationship_receipt.state,
+        "promotion_errors": list(relationship_receipt.errors),
+        "raw_source_ids": source_ids,
+        "source_ids": source_ids,
+        **invalidation_metadata,
+    }
+    publication = {
+        "state": relationship_receipt.state,
+        "request": publication_request,
+        "receipt": _public_publication_receipt(receipt),
+    }
+    try:
+        updated = await runtime.entity_manager.update(
+            stored.id,
+            {"metadata": {"reflection_publication": publication}},
+            expected_revision=stored.revision,
+            replace_metadata_keys=("reflection_publication",),
+        )
+    except RevisionConflictError:
+        try:
+            current = await runtime.entity_manager.get(stored.id)
+        except (KeyError, EntityNotFoundError) as exc:
+            raise RuntimeError("reflection evidence disappeared during publication") from exc
+        if current is None:
+            raise RuntimeError("reflection evidence disappeared during publication") from None
+        verify_reflection_identity(entity, current)
+        if not graph_metadata_recallable(current.metadata):
+            return _retired_reflection_result(current.id)
+        current_publication = current.metadata.get("reflection_publication", {})
+        if (
+            current_publication.get("state") == "complete"
+            and current_publication.get("request") == publication_request
+        ):
+            return _reflection_publication_result(
+                current.id,
+                candidate.title,
+                current_publication["receipt"],
+                "replayed",
+            )
+        raise
+    if updated is None:
+        raise RuntimeError("reflection evidence disappeared during publication")
+    return _reflection_publication_result(
+        stored.id,
+        candidate.title,
+        receipt,
+        "created" if created else "resumed",
+    )
+
+
+def _retired_reflection_result(entity_id: str) -> ReflectionWriteResult:
+    return ReflectionWriteResult(
+        response=AddResponse(
+            success=False,
+            id=entity_id,
+            message="Existing reflection evidence is retired; use an explicit lifecycle action",
+            timestamp=datetime.now(UTC),
+        ),
+        metadata={"promotion_state": "denied", "publication_outcome": "retired"},
+    )
+
+
+def _reflection_publication_result(
+    entity_id: str,
+    title: str,
+    receipt: dict[str, Any],
+    outcome: str,
+) -> ReflectionWriteResult:
     return ReflectionWriteResult(
         response=AddResponse(
             success=True,
-            id=created_id,
-            message=f"Promoted natively: {candidate.title}",
+            id=entity_id,
+            message=f"Promoted natively: {title}",
             timestamp=datetime.now(UTC),
         ),
         metadata={
-            **policy_metadata,
-            "native_write_mode": WriteMode.ENABLED.value,
-            "native_write_path": native_write_path,
-            "native_relationship_count": relationship_receipt.created,
-            "native_relationship_requested_count": relationship_receipt.requested,
-            "native_relationship_failed_count": relationship_receipt.failed,
-            "promotion_state": relationship_receipt.state,
-            "promotion_errors": list(relationship_receipt.errors),
-            "raw_source_ids": source_ids,
-            "source_ids": source_ids,
-            **invalidation_metadata,
+            "scope_key": None,
+            "invalidation_details_available": True,
+            **receipt,
+            "publication_outcome": outcome,
         },
     )
+
+
+def _public_publication_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    """A target-scoped row must not reveal the writer's private invalidation results."""
+    public_keys = (
+        "memory_scope",
+        "scope_key",
+        "policy_allowed",
+        "policy_reasons",
+        "policy_actions",
+        "native_write_mode",
+        "native_write_path",
+        "native_relationship_count",
+        "native_relationship_requested_count",
+        "native_relationship_failed_count",
+        "promotion_state",
+        "raw_source_ids",
+        "source_ids",
+    )
+    return {
+        **{key: receipt[key] for key in public_keys if key in receipt},
+        "promotion_errors": ["Relationship publication incomplete"]
+        if receipt.get("promotion_errors")
+        else [],
+        "invalidation_details_available": False,
+    }
 
 
 async def _write_promotion_relationships(
@@ -501,6 +638,40 @@ async def _apply_promotion_plan(
     lifecycle_source_id: str,
     lifecycle_reason: str,
 ) -> ReflectionPromotionResult:
+    policy_decisions = _authorize_reflection_write(
+        principal_id=principal_id,
+        memory_scope=plan.target_scope,
+        scope_key=plan.target_scope_key,
+        accessible_projects=accessible_projects,
+        accessible_teams=accessible_teams,
+        accessible_delegations=accessible_delegations,
+    )
+    policy_metadata = _policy_metadata(policy_decisions)
+    if any(not decision.allowed for decision in policy_decisions):
+        return _promotion_denied(
+            candidate_id=plan.candidate_memory.id,
+            reason=_policy_denial_reason(policy_metadata),
+            review_state=plan.candidate_memory.review_state,
+            memory_scope=plan.target_scope,
+            scope_key=plan.target_scope_key,
+            raw_source_ids=plan.raw_source_ids,
+            metadata=policy_metadata,
+        )
+    prospective = _entity_from_candidate(
+        plan.promotion_candidate,
+        organization_id=organization_id,
+        principal_id=principal_id,
+        domain=domain or _metadata_str(plan.candidate_memory.metadata, "domain"),
+        project=plan.target_project,
+        source_id=native_source_id,
+        memory_scope=plan.target_scope,
+        scope_key=_resolve_scope_key(plan.target_scope, plan.target_scope_key, plan.target_project),
+        policy_metadata=policy_metadata,
+    )
+    reservation = await _reserve_promotion(plan, prospective.id)
+    if isinstance(reservation, ReflectionPromotionResult):
+        return reservation
+    plan = reservation
     result = await persist_reflection_candidate(
         candidate=plan.promotion_candidate,
         organization_id=organization_id,
@@ -515,14 +686,125 @@ async def _apply_promotion_plan(
         memory_scope=plan.target_scope,
         scope_key=plan.target_scope_key,
         link_source_entity=False,
+        source_memories=plan.input_memories,
     )
-    if not result.response.success:
+    if not result.response.success or result.metadata.get("promotion_state") == "partial":
         return _promotion_write_denied(plan=plan, result=result)
+    runtime = await get_surreal_graph_runtime(organization_id)
+    if not await _verify_promotion_sources(
+        runtime, plan.input_memories, entity_id=result.response.id
+    ):
+        return _promotion_write_denied(plan=plan, result=_retired_reflection_result(prospective.id))
     return await _mark_promotion_plan_promoted(
         plan=plan,
         result=result,
         lifecycle_source_id=lifecycle_source_id,
         lifecycle_reason=lifecycle_reason,
+    )
+
+
+def _promotion_source_signature(memory: RawMemory) -> tuple[object, ...]:
+    return (
+        memory.organization_id,
+        memory.principal_id,
+        memory.memory_scope,
+        memory.scope_key,
+        memory.source_id,
+        memory.title,
+        memory.raw_content,
+        memory.entity_type,
+        memory.metadata.get("domain"),
+        memory.metadata.get("category"),
+        tuple(sorted(source_id for source_id in _raw_source_ids(memory) if source_id != memory.id)),
+    )
+
+
+async def _verify_promotion_sources(
+    runtime: Any,
+    memories: Sequence[RawMemory],
+    *,
+    entity_id: str | None = None,
+) -> bool:
+    """Close correction's read-before-insert gap without restoring retired rows."""
+    for expected in memories:
+        current = await get_raw_memory(
+            organization_id=expected.organization_id, memory_id=expected.id
+        )
+        stamp: dict[str, object] = {}
+        if current is None:
+            stamp = {"excluded_from_recall": True, "lifecycle_state": "deleted"}
+        elif not raw_memory_recallable(current):
+            stamp = graph_lifecycle_stamp(current)
+        elif _promotion_source_signature(current) != _promotion_source_signature(expected):
+            stamp = {"excluded_from_recall": True, "lifecycle_state": "contested"}
+        if stamp:
+            if entity_id is not None:
+                await runtime.entity_manager.update(entity_id, {"metadata": stamp})
+            return False
+    return True
+
+
+async def _reserve_promotion(
+    plan: _ReflectionPromotionPlan,
+    entity_id: str,
+) -> _ReflectionPromotionPlan | ReflectionPromotionResult:
+    """Reserve correction's existing pointer before publishing any graph row."""
+    memory = plan.candidate_memory
+    recorded_id = _metadata_str(memory.metadata, "promoted_entity_id")
+    if recorded_id or memory.review_state == _PROMOTED_REVIEW_STATE:
+        if recorded_id != entity_id:
+            return _promotion_denied(
+                candidate_id=memory.id,
+                reason="candidate_already_promoted",
+                review_state=memory.review_state,
+                memory_scope=plan.target_scope,
+                scope_key=plan.target_scope_key,
+                raw_source_ids=plan.raw_source_ids,
+            )
+        return plan
+    try:
+        reserved = await save_raw_memory(
+            replace(
+                memory,
+                metadata={
+                    **memory.metadata,
+                    "promoted_entity_id": entity_id,
+                    "promotion_state": "pending",
+                },
+            ),
+            expected_revision=memory.revision,
+        )
+    except RevisionConflictError:
+        current = await get_raw_memory(organization_id=memory.organization_id, memory_id=memory.id)
+        if current is None or not raw_memory_recallable(current):
+            return _promotion_denied(
+                candidate_id=memory.id,
+                reason="source_not_recallable",
+                review_state=current.review_state if current else "missing",
+                memory_scope=plan.target_scope,
+                scope_key=plan.target_scope_key,
+                raw_source_ids=plan.raw_source_ids,
+            )
+        if _metadata_str(
+            current.metadata, "promoted_entity_id"
+        ) != entity_id or _promotion_source_signature(current) != _promotion_source_signature(
+            memory
+        ):
+            return _promotion_denied(
+                candidate_id=memory.id,
+                reason="candidate_already_promoted",
+                review_state=current.review_state,
+                memory_scope=plan.target_scope,
+                scope_key=plan.target_scope_key,
+                raw_source_ids=plan.raw_source_ids,
+            )
+        reserved = current
+    return replace(
+        plan,
+        candidate_memory=reserved,
+        input_memories=[
+            reserved if source.id == memory.id else source for source in plan.input_memories
+        ],
     )
 
 
@@ -534,8 +816,10 @@ def _promotion_write_denied(
     return ReflectionPromotionResult(
         success=False,
         candidate_id=plan.candidate_memory.id,
-        promoted_id=None,
-        reason=_policy_denial_reason(result.metadata),
+        promoted_id=result.response.id,
+        reason="promotion_incomplete"
+        if result.metadata.get("promotion_state") == "partial"
+        else result.metadata.get("publication_outcome") or _policy_denial_reason(result.metadata),
         review_state=plan.candidate_memory.review_state,
         memory_scope=plan.target_scope,
         scope_key=plan.target_scope_key,
@@ -551,19 +835,52 @@ async def _mark_promotion_plan_promoted(
     lifecycle_source_id: str,
     lifecycle_reason: str,
 ) -> ReflectionPromotionResult:
-    metadata = _promoted_candidate_metadata(
-        plan=plan,
-        result=result,
-        lifecycle_source_id=lifecycle_source_id,
-        lifecycle_reason=lifecycle_reason,
-    )
-    await save_raw_memory(
-        replace(
-            plan.candidate_memory,
-            review_state=_PROMOTED_REVIEW_STATE,
-            metadata=metadata,
+    if (
+        result.metadata.get("publication_outcome") == "replayed"
+        and plan.candidate_memory.review_state == _PROMOTED_REVIEW_STATE
+        and plan.candidate_memory.metadata.get("promoted_entity_id") == result.response.id
+    ):
+        metadata = {**plan.candidate_memory.metadata, **result.metadata}
+    else:
+        metadata = _promoted_candidate_metadata(
+            plan=plan,
+            result=result,
+            lifecycle_source_id=lifecycle_source_id,
+            lifecycle_reason=lifecycle_reason,
         )
-    )
+        try:
+            await save_raw_memory(
+                replace(
+                    plan.candidate_memory,
+                    review_state=_PROMOTED_REVIEW_STATE,
+                    metadata=metadata,
+                ),
+                expected_revision=plan.candidate_memory.revision,
+            )
+        except RevisionConflictError:
+            current = await get_raw_memory(
+                organization_id=plan.candidate_memory.organization_id,
+                memory_id=plan.candidate_memory.id,
+            )
+            if (
+                current is not None
+                and raw_memory_recallable(current)
+                and current.review_state == _PROMOTED_REVIEW_STATE
+                and current.metadata.get("promoted_entity_id") == result.response.id
+                and _promotion_source_signature(current)
+                == _promotion_source_signature(plan.candidate_memory)
+            ):
+                metadata = {**current.metadata, **result.metadata}
+            else:
+                runtime = await get_surreal_graph_runtime(plan.candidate_memory.organization_id)
+                if not await _verify_promotion_sources(
+                    runtime, plan.input_memories, entity_id=result.response.id
+                ):
+                    return _promotion_write_denied(
+                        plan=plan,
+                        result=_retired_reflection_result(str(result.response.id)),
+                    )
+                raise
     return ReflectionPromotionResult(
         success=True,
         candidate_id=plan.candidate_memory.id,
@@ -643,15 +960,6 @@ async def _resolve_reflection_promotion_plan(
             raw_source_ids=[],
         )
 
-    if candidate_memory.review_state == _PROMOTED_REVIEW_STATE:
-        return _promotion_denied(
-            candidate_id=candidate_memory.id,
-            reason="candidate_already_promoted",
-            review_state=candidate_memory.review_state,
-            memory_scope=candidate_memory.memory_scope,
-            scope_key=candidate_memory.scope_key,
-            raw_source_ids=_raw_source_ids(candidate_memory),
-        )
     if candidate_memory.review_state == "archived":
         return _promotion_denied(
             candidate_id=candidate_memory.id,
@@ -689,6 +997,16 @@ async def _resolve_reflection_promotion_plan(
     )
     if source_scope_denial is not None:
         return source_scope_denial
+
+    if any(not raw_memory_recallable(memory) for memory in input_memories):
+        return _promotion_denied(
+            candidate_id=candidate_memory.id,
+            reason="source_not_recallable",
+            review_state=candidate_memory.review_state,
+            memory_scope=candidate_memory.memory_scope,
+            scope_key=candidate_memory.scope_key,
+            raw_source_ids=raw_source_ids,
+        )
 
     target_scope = _coerce_promotion_scope(promote_to_scope)
     if target_scope is None:
@@ -787,15 +1105,6 @@ async def _resolve_raw_memory_promotion_plan(
         )
 
     raw_source_ids = [memory.id]
-    if memory.review_state == _PROMOTED_REVIEW_STATE or memory.metadata.get("promoted_entity_id"):
-        return _promotion_denied(
-            candidate_id=memory.id,
-            reason="candidate_already_promoted",
-            review_state=memory.review_state,
-            memory_scope=memory.memory_scope,
-            scope_key=memory.scope_key,
-            raw_source_ids=raw_source_ids,
-        )
     if not raw_memory_recallable(memory):
         return _promotion_denied(
             candidate_id=memory.id,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_sharing.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_sharing.py
@@ -619,7 +619,7 @@ async def _apply_share_plan(
         scope_key=plan.target_scope_key,
         link_source_entity=False,
     )
-    if not result.response.success:
+    if not result.response.success or result.metadata.get("promotion_state") == "partial":
         return _promotion_write_denied(plan=plan, result=result)
 
     metadata = {

--- a/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
@@ -171,6 +171,37 @@ async def reflect_memory(
             )
         if source.success:
             source_id = source.id
+        else:
+            # A requested source is an evidence prerequisite. Never publish a
+            # candidate after its source was denied or retired.
+            return ReflectionPack(
+                source_title=source_title,
+                source_id=source.id,
+                intent=intent,
+                domain=domain,
+                project=project,
+                candidates=[
+                    ground_reflection_candidate(
+                        replace(
+                            candidate,
+                            metadata={
+                                **candidate.metadata,
+                                **persist_policy_metadata,
+                                "promotion_state": "denied",
+                                "promotion_errors": [source.message],
+                            },
+                        ),
+                        raw_source_ids=[],
+                        suggested_memory_scope=resolved_suggested_scope.value,
+                        suggested_scope_key=resolved_suggested_scope_key,
+                        extraction_prompt_metadata=extraction_prompt_metadata,
+                        source_id=None,
+                    )
+                    for candidate in candidates
+                ],
+                total_candidates=len(candidates),
+                persisted_count=0,
+            )
 
     source_anchor_id = source_id
     if persist and source_anchor_id is None and not persist_source:

--- a/packages/python/sibyl-core/tests/fixtures/reflection_native_contract.json
+++ b/packages/python/sibyl-core/tests/fixtures/reflection_native_contract.json
@@ -6,7 +6,7 @@
       "description": "We decided to preserve source evidence before publishing decisions.",
       "embedding": null,
       "entity_type": "session",
-      "id": "session_9c6ad27491fa",
+      "id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
       "metadata": {
         "capture_mode": "reflect",
         "capture_surface": "reflection",
@@ -20,18 +20,18 @@
           "action": "promote",
           "created_at": "2026-09-04T12:00:00+00:00",
           "derived_ids": [
-            "session_9c6ad27491fa"
+            "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
           ],
           "duplicate_of_source_id": null,
           "flags": [],
           "metadata": {
-            "promoted_entity_id": "session_9c6ad27491fa"
+            "promoted_entity_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
           },
           "prior_state": null,
           "reason": "preserves raw reflection source material",
           "replacement_source_id": null,
           "reversible": true,
-          "source_id": "session_9c6ad27491fa",
+          "source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
           "state": "active"
         },
         "memory_scope": "project",
@@ -59,7 +59,7 @@
             "kind": "promotion",
             "lifecycle_state": "active",
             "metadata": {
-              "promoted_entity_id": "session_9c6ad27491fa"
+              "promoted_entity_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
             },
             "policy_reasons": [
               "same_scope_reflect_allowed",
@@ -67,13 +67,61 @@
             ],
             "reason": "preserves raw reflection source material",
             "related_source_ids": [
-              "session_9c6ad27491fa"
+              "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
             ],
             "reversible": true,
             "source_ids": [],
-            "target_source_id": "session_9c6ad27491fa"
+            "target_source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
           }
         ],
+        "reflection_identity": {
+          "content_sha256": "eaa25e41b0f392837f10c4a37512205fd867b9dd72b8f829d5c787b9c4a83d0c",
+          "created_by": "user_123",
+          "domain": "sibyl",
+          "kind": "session",
+          "memory_scope": "project",
+          "organization_id": "org_123",
+          "principal_id": "user_123",
+          "project_id": "project_123",
+          "purpose": "source",
+          "scope_key": "project_123",
+          "source_ids": [],
+          "title": "Evidence review",
+          "version": 2
+        },
+        "reflection_publication": {
+          "receipt": {
+            "invalidation_details_available": false,
+            "memory_scope": "project",
+            "native_relationship_count": 1,
+            "native_relationship_failed_count": 0,
+            "native_relationship_requested_count": 1,
+            "native_write_mode": "enabled",
+            "native_write_path": "reflection_promotion",
+            "policy_actions": [
+              "reflect",
+              "write"
+            ],
+            "policy_allowed": true,
+            "policy_reasons": [
+              "same_scope_reflect_allowed",
+              "same_scope_write_allowed"
+            ],
+            "promotion_errors": [],
+            "promotion_state": "complete",
+            "raw_source_ids": [],
+            "scope_key": "project_123",
+            "source_ids": []
+          },
+          "request": {
+            "invalidation_cutoff": {},
+            "invalidation_targets": [],
+            "relationships": [
+              "rel_session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a_belongs_to_project_123"
+            ]
+          },
+          "state": "complete"
+        },
         "reflection_reason": "preserves raw reflection source material",
         "reflection_source": true,
         "remember_kind": "session",
@@ -96,7 +144,7 @@
       "description": "We decided to preserve source evidence before publishing decisions.",
       "embedding": null,
       "entity_type": "decision",
-      "id": "decision_cfeb13f7083a",
+      "id": "decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f",
       "metadata": {
         "capture_mode": "reflect",
         "capture_surface": "reflection",
@@ -120,18 +168,18 @@
           "action": "promote",
           "created_at": "2026-09-04T12:00:00+00:00",
           "derived_ids": [
-            "decision_cfeb13f7083a"
+            "decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f"
           ],
           "duplicate_of_source_id": null,
           "flags": [],
           "metadata": {
-            "promoted_entity_id": "decision_cfeb13f7083a"
+            "promoted_entity_id": "decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f"
           },
           "prior_state": "pending",
           "reason": "captures a choice or direction future agents should preserve",
           "replacement_source_id": null,
           "reversible": true,
-          "source_id": "session_9c6ad27491fa",
+          "source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
           "state": "active"
         },
         "memory_scope": "project",
@@ -151,7 +199,7 @@
         "principal_id": "user_123",
         "project_id": "project_123",
         "raw_source_ids": [
-          "session_9c6ad27491fa"
+          "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
         ],
         "reflection_findings": [
           {
@@ -162,7 +210,7 @@
             "kind": "promotion",
             "lifecycle_state": "active",
             "metadata": {
-              "promoted_entity_id": "decision_cfeb13f7083a"
+              "promoted_entity_id": "decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f"
             },
             "policy_reasons": [
               "same_scope_reflect_allowed",
@@ -170,19 +218,75 @@
             ],
             "reason": "captures a choice or direction future agents should preserve",
             "related_source_ids": [
-              "decision_cfeb13f7083a"
+              "decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f"
             ],
             "reversible": true,
             "source_ids": [
-              "session_9c6ad27491fa"
+              "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
             ],
-            "target_source_id": "session_9c6ad27491fa"
+            "target_source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
           }
         ],
+        "reflection_identity": {
+          "content_sha256": "eaa25e41b0f392837f10c4a37512205fd867b9dd72b8f829d5c787b9c4a83d0c",
+          "created_by": "user_123",
+          "domain": "sibyl",
+          "kind": "decision",
+          "memory_scope": "project",
+          "organization_id": "org_123",
+          "primary_source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
+          "principal_id": "user_123",
+          "project_id": "project_123",
+          "purpose": "candidate",
+          "scope_key": "project_123",
+          "source_ids": [
+            "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
+          ],
+          "title": "Decision: We decided to preserve source evidence before publishing decisions.",
+          "version": 2
+        },
         "reflection_index": 0,
         "reflection_intent": "build",
+        "reflection_publication": {
+          "receipt": {
+            "invalidation_details_available": false,
+            "memory_scope": "project",
+            "native_relationship_count": 2,
+            "native_relationship_failed_count": 0,
+            "native_relationship_requested_count": 2,
+            "native_write_mode": "enabled",
+            "native_write_path": "reflection_promotion",
+            "policy_actions": [
+              "reflect",
+              "write"
+            ],
+            "policy_allowed": true,
+            "policy_reasons": [
+              "same_scope_reflect_allowed",
+              "same_scope_write_allowed"
+            ],
+            "promotion_errors": [],
+            "promotion_state": "complete",
+            "raw_source_ids": [
+              "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
+            ],
+            "scope_key": "project_123",
+            "source_ids": [
+              "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
+            ]
+          },
+          "request": {
+            "invalidation_cutoff": {},
+            "invalidation_targets": [],
+            "relationships": [
+              "rel_decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f_belongs_to_project_123",
+              "rel_decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f_derived_from_session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
+            ]
+          },
+          "state": "complete"
+        },
         "reflection_reason": "captures a choice or direction future agents should preserve",
-        "reflection_source_id": "session_9c6ad27491fa",
+        "reflection_source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
         "reflection_source_title": "Evidence review",
         "relationship_records": [
           {
@@ -193,7 +297,7 @@
             "relationship_type": "BELONGS_TO",
             "source_id": "candidate:0",
             "source_ids": [
-              "session_9c6ad27491fa"
+              "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
             ],
             "target_id": "project_123"
           }
@@ -202,7 +306,7 @@
         "review_state": "pending",
         "scope_key": "project_123",
         "source_ids": [
-          "session_9c6ad27491fa"
+          "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
         ],
         "suggested_memory_scope": "project",
         "suggested_scope_key": null,
@@ -216,10 +320,10 @@
       "name": "Decision: We decided to preserve source evidence before publishing decisions.",
       "organization_id": "org_123",
       "revision": 1,
-      "source_file": "session_9c6ad27491fa"
+      "source_file": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
     }
   ],
-  "markdown": "# Sibyl Reflection: Evidence review\nIntent: build\nSource: `session_9c6ad27491fa`\nDomain: sibyl\nProject: project_123\n\n## Decision: Decision: We decided to preserve source evidence before publishing decisions. `decision_cfeb13f7083a`\n- Confidence: 0.86\n- Why: captures a choice or direction future agents should preserve\n- Memory: We decided to preserve source evidence before publishing decisions.\n\n_Hint: Review candidates, persist the durable ones, and keep raw session source as provenance._",
+  "markdown": "# Sibyl Reflection: Evidence review\nIntent: build\nSource: `session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a`\nDomain: sibyl\nProject: project_123\n\n## Decision: Decision: We decided to preserve source evidence before publishing decisions. `decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f`\n- Confidence: 0.86\n- Why: captures a choice or direction future agents should preserve\n- Memory: We decided to preserve source evidence before publishing decisions.\n\n_Hint: Review candidates, persist the durable ones, and keep raw session source as provenance._",
   "pack": {
     "candidates": [
       {
@@ -245,6 +349,7 @@
           "invalidated_entity_ids": [],
           "invalidated_source_count": 0,
           "invalidated_source_ids": [],
+          "invalidation_details_available": true,
           "invalidation_skipped_source_count": 0,
           "invalidation_skipped_source_ids": [],
           "memory_scope": "project",
@@ -267,13 +372,14 @@
           "project_id": "project_123",
           "promotion_errors": [],
           "promotion_state": "complete",
+          "publication_outcome": "created",
           "raw_source_ids": [
-            "session_9c6ad27491fa"
+            "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
           ],
           "reflection_index": 0,
           "reflection_intent": "build",
           "reflection_reason": "captures a choice or direction future agents should preserve",
-          "reflection_source_id": "session_9c6ad27491fa",
+          "reflection_source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
           "reflection_source_title": "Evidence review",
           "relationship_records": [
             {
@@ -284,7 +390,7 @@
               "relationship_type": "BELONGS_TO",
               "source_id": "candidate:0",
               "source_ids": [
-                "session_9c6ad27491fa"
+                "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
               ],
               "target_id": "project_123"
             }
@@ -293,14 +399,14 @@
           "review_state": "pending",
           "scope_key": "project_123",
           "source_ids": [
-            "session_9c6ad27491fa"
+            "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
           ],
           "suggested_memory_scope": "project",
           "suggested_scope_key": null
         },
-        "persisted_id": "decision_cfeb13f7083a",
+        "persisted_id": "decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f",
         "raw_source_ids": [
-          "session_9c6ad27491fa"
+          "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
         ],
         "reason": "captures a choice or direction future agents should preserve",
         "reflection_findings": [],
@@ -313,7 +419,7 @@
             "relationship_type": "BELONGS_TO",
             "source_id": "candidate:0",
             "source_ids": [
-              "session_9c6ad27491fa"
+              "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
             ],
             "target_id": "project_123"
           }
@@ -334,44 +440,44 @@
     "intent": "build",
     "persisted_count": 1,
     "project": "project_123",
-    "source_id": "session_9c6ad27491fa",
+    "source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
     "source_title": "Evidence review",
     "total_candidates": 1,
     "usage_hint": "Review candidates, persist the durable ones, and keep raw session source as provenance."
   },
   "relationships": [
     {
-      "id": "rel_session_9c6ad27491fa_belongs_to_project_123",
+      "id": "rel_session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a_belongs_to_project_123",
       "metadata": {
         "created_at": "2026-09-04T12:00:00+00:00",
         "native_write_path": "reflection_promotion"
       },
       "relationship_type": "BELONGS_TO",
-      "source_id": "session_9c6ad27491fa",
+      "source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
       "target_id": "project_123",
       "weight": 1.0
     },
     {
-      "id": "rel_decision_cfeb13f7083a_belongs_to_project_123",
+      "id": "rel_decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f_belongs_to_project_123",
       "metadata": {
         "created_at": "2026-09-04T12:00:00+00:00",
         "native_write_path": "reflection_promotion"
       },
       "relationship_type": "BELONGS_TO",
-      "source_id": "decision_cfeb13f7083a",
+      "source_id": "decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f",
       "target_id": "project_123",
       "weight": 1.0
     },
     {
-      "id": "rel_decision_cfeb13f7083a_derived_from_session_9c6ad27491fa",
+      "id": "rel_decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f_derived_from_session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
       "metadata": {
         "created_at": "2026-09-04T12:00:00+00:00",
         "native_write_path": "reflection_promotion",
-        "source_id": "session_9c6ad27491fa"
+        "source_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a"
       },
       "relationship_type": "DERIVED_FROM",
-      "source_id": "decision_cfeb13f7083a",
-      "target_id": "session_9c6ad27491fa",
+      "source_id": "decision_v2_4de9394e566cd6c22aed2b2a269bdc27f91e086fe9acd61b0bb188762dd5817f",
+      "target_id": "session_v2_0498b6e4b78075fa5232986a42e053790d07a04c8a8a3b26da4b95a31163543a",
       "weight": 1.0
     }
   ]

--- a/packages/python/sibyl-core/tests/test_memory.py
+++ b/packages/python/sibyl-core/tests/test_memory.py
@@ -1264,6 +1264,7 @@ async def test_promote_review_candidate_persists_native_record_and_marks_promote
     )
     source = _raw_review_candidate(id="source-1")
     saved: list[RawMemory] = []
+    memories = {candidate.id: candidate, source.id: source}
 
     async def fake_persist(**kwargs):
         assert kwargs["memory_scope"] is MemoryScope.PROJECT
@@ -1288,17 +1289,22 @@ async def test_promote_review_candidate_persists_native_record_and_marks_promote
             },
         )
 
-    async def fake_save(memory: RawMemory) -> RawMemory:
+    async def fake_save(memory: RawMemory, *, expected_revision=None) -> RawMemory:
         saved.append(memory)
+        memories[memory.id] = memory
         return memory
 
     monkeypatch.setattr(
         reflection_module,
         "get_raw_memory",
-        AsyncMock(side_effect=[candidate, source]),
+        AsyncMock(side_effect=lambda **kwargs: memories.get(kwargs["memory_id"])),
     )
     monkeypatch.setattr(reflection_module, "persist_reflection_candidate", fake_persist)
     monkeypatch.setattr(reflection_module, "save_raw_memory", fake_save)
+
+    monkeypatch.setattr(
+        reflection_module, "get_surreal_graph_runtime", AsyncMock(return_value=SimpleNamespace())
+    )
 
     result = await promote_reflection_candidate_review(
         candidate_id="candidate-1",
@@ -1313,14 +1319,14 @@ async def test_promote_review_candidate_persists_native_record_and_marks_promote
     assert result.success
     assert result.promoted_id == "decision_123"
     assert result.reason == "promoted"
-    assert saved[0].review_state == "promoted"
-    assert saved[0].metadata["promoted_entity_id"] == "decision_123"
+    assert saved[-1].review_state == "promoted"
+    assert saved[-1].metadata["promoted_entity_id"] == "decision_123"
     lifecycle = memory_lifecycle_from_metadata(
-        saved[0].metadata,
+        saved[-1].metadata,
         source_id="candidate-1",
-        review_state=saved[0].review_state,
+        review_state=saved[-1].review_state,
     )
-    findings = reflection_findings_from_metadata(saved[0].metadata)
+    findings = reflection_findings_from_metadata(saved[-1].metadata)
     assert lifecycle.state == "active"
     assert lifecycle.source_id == "candidate-1"
     assert lifecycle.derived_ids == ["decision_123"]
@@ -1355,7 +1361,10 @@ async def test_persist_reflection_candidate_reports_partial_relationship_writes(
         )
 
     entity_manager = SimpleNamespace(
-        create_direct=AsyncMock(return_value="decision_partial"),
+        create_direct_if_absent=AsyncMock(side_effect=lambda entity: (entity, True)),
+        update=AsyncMock(
+            return_value=Entity(id="receipt", entity_type=EntityType.DECISION, name="Receipt")
+        ),
         get=AsyncMock(side_effect=get_related),
     )
 
@@ -1419,8 +1428,9 @@ async def test_promote_review_candidate_bounds_contradicted_source_for_as_of_rea
         def __init__(self) -> None:
             self.updated: list[tuple[str, dict[str, object]]] = []
 
-        async def create_direct(self, _entity):
-            return "decision_new"
+        async def create_direct_if_absent(self, entity):
+            self.created_entity = entity
+            return entity, True
 
         async def get(self, entity_id: str):
             if entity_id == "decision_old":
@@ -1430,7 +1440,18 @@ async def test_promote_review_candidate_bounds_contradicted_source_for_as_of_rea
                 )
             return None
 
-        async def update(self, entity_id: str, updates: dict[str, object]):
+        async def update(
+            self,
+            entity_id: str,
+            updates: dict[str, object],
+            *,
+            expected_revision=None,
+            replace_metadata_keys=(),
+        ):
+            if expected_revision is not None:
+                assert entity_id == self.created_entity.id
+                self.created_entity.metadata.update(updates["metadata"])
+                return self.created_entity
             self.updated.append((entity_id, updates))
             return SimpleNamespace(id=entity_id, metadata=updates.get("metadata", {}))
 
@@ -1446,7 +1467,7 @@ async def test_promote_review_candidate_bounds_contradicted_source_for_as_of_rea
         assert organization_id == "org-1"
         return memories.get(memory_id)
 
-    async def fake_save_raw_memory(memory: RawMemory) -> RawMemory:
+    async def fake_save_raw_memory(memory: RawMemory, *, expected_revision=None) -> RawMemory:
         memories[memory.id] = memory
         saved.append(memory)
         return memory
@@ -1477,7 +1498,7 @@ async def test_promote_review_candidate_bounds_contradicted_source_for_as_of_rea
     invalidated = next(memory for memory in saved if memory.id == "source-old")
     assert invalidated.metadata["invalid_at"] == cutoff
     assert invalidated.metadata["valid_to"] == cutoff
-    assert invalidated.metadata["invalidated_by_entity_id"] == "decision_new"
+    assert invalidated.metadata["invalidated_by_entity_id"] == result.promoted_id
     assert raw_memory_matches_as_of(
         invalidated,
         datetime(2026, 1, 15, tzinfo=UTC),
@@ -1519,13 +1540,25 @@ async def test_promote_review_candidate_skips_other_private_principal_invalidati
         def __init__(self) -> None:
             self.updated: list[tuple[str, dict[str, object]]] = []
 
-        async def create_direct(self, _entity):
-            return "decision_new"
+        async def create_direct_if_absent(self, entity):
+            self.created_entity = entity
+            return entity, True
 
         async def get(self, entity_id: str):
             return None
 
-        async def update(self, entity_id: str, updates: dict[str, object]):
+        async def update(
+            self,
+            entity_id: str,
+            updates: dict[str, object],
+            *,
+            expected_revision=None,
+            replace_metadata_keys=(),
+        ):
+            if expected_revision is not None:
+                assert entity_id == self.created_entity.id
+                self.created_entity.metadata.update(updates["metadata"])
+                return self.created_entity
             self.updated.append((entity_id, updates))
             return SimpleNamespace(id=entity_id, metadata=updates.get("metadata", {}))
 
@@ -1541,7 +1574,7 @@ async def test_promote_review_candidate_skips_other_private_principal_invalidati
         assert organization_id == "org-1"
         return memories.get(memory_id)
 
-    async def fake_save_raw_memory(memory: RawMemory) -> RawMemory:
+    async def fake_save_raw_memory(memory: RawMemory, *, expected_revision=None) -> RawMemory:
         memories[memory.id] = memory
         saved.append(memory)
         return memory
@@ -1593,9 +1626,10 @@ async def test_promote_review_candidate_skips_foreign_private_superseded_entity(
             self.created_metadata: dict[str, object] | None = None
             self.updated: list[tuple[str, dict[str, object]]] = []
 
-        async def create_direct(self, entity):
+        async def create_direct_if_absent(self, entity):
             self.created_metadata = entity.metadata
-            return "decision_new"
+            self.created_entity = entity
+            return entity, True
 
         async def get(self, entity_id: str):
             if entity_id == "decision_foreign":
@@ -1605,7 +1639,18 @@ async def test_promote_review_candidate_skips_foreign_private_superseded_entity(
                 )
             return None
 
-        async def update(self, entity_id: str, updates: dict[str, object]):
+        async def update(
+            self,
+            entity_id: str,
+            updates: dict[str, object],
+            *,
+            expected_revision=None,
+            replace_metadata_keys=(),
+        ):
+            if expected_revision is not None:
+                assert entity_id == self.created_entity.id
+                self.created_entity.metadata.update(updates["metadata"])
+                return self.created_entity
             self.updated.append((entity_id, updates))
             return SimpleNamespace(id=entity_id, metadata=updates.get("metadata", {}))
 
@@ -1623,7 +1668,7 @@ async def test_promote_review_candidate_skips_foreign_private_superseded_entity(
 
     monkeypatch.setattr(reflection_module, "get_raw_memory", fake_get_raw_memory)
     monkeypatch.setattr(
-        reflection_module, "save_raw_memory", AsyncMock(side_effect=lambda memory: memory)
+        reflection_module, "save_raw_memory", AsyncMock(side_effect=lambda memory, **kwargs: memory)
     )
     monkeypatch.setattr(
         reflection_module, "get_surreal_graph_runtime", AsyncMock(return_value=runtime)
@@ -1650,6 +1695,7 @@ async def test_promote_raw_memory_persists_native_record_and_marks_promoted(
 ) -> None:
     memory = _raw_import_memory()
     saved: list[RawMemory] = []
+    memories = {memory.id: memory}
 
     async def fake_persist(**kwargs):
         assert kwargs["memory_scope"] is MemoryScope.PROJECT
@@ -1675,13 +1721,22 @@ async def test_promote_raw_memory_persists_native_record_and_marks_promoted(
             },
         )
 
-    async def fake_save(memory: RawMemory) -> RawMemory:
+    async def fake_save(memory: RawMemory, *, expected_revision=None) -> RawMemory:
         saved.append(memory)
+        memories[memory.id] = memory
         return memory
 
-    monkeypatch.setattr(reflection_module, "get_raw_memory", AsyncMock(return_value=memory))
+    monkeypatch.setattr(
+        reflection_module,
+        "get_raw_memory",
+        AsyncMock(side_effect=lambda **kwargs: memories.get(kwargs["memory_id"])),
+    )
     monkeypatch.setattr(reflection_module, "persist_reflection_candidate", fake_persist)
     monkeypatch.setattr(reflection_module, "save_raw_memory", fake_save)
+
+    monkeypatch.setattr(
+        reflection_module, "get_surreal_graph_runtime", AsyncMock(return_value=SimpleNamespace())
+    )
 
     result = await promote_raw_memory(
         raw_memory_id="raw-1",
@@ -1696,15 +1751,15 @@ async def test_promote_raw_memory_persists_native_record_and_marks_promoted(
     assert result.success
     assert result.promoted_id == "episode_123"
     assert result.reason == "promoted"
-    assert saved[0].review_state == "promoted"
-    assert saved[0].metadata["promoted_entity_id"] == "episode_123"
-    assert saved[0].metadata["native_write_path"] == "raw_memory_promotion"
+    assert saved[-1].review_state == "promoted"
+    assert saved[-1].metadata["promoted_entity_id"] == "episode_123"
+    assert saved[-1].metadata["native_write_path"] == "raw_memory_promotion"
     lifecycle = memory_lifecycle_from_metadata(
-        saved[0].metadata,
+        saved[-1].metadata,
         source_id="raw-1",
-        review_state=saved[0].review_state,
+        review_state=saved[-1].review_state,
     )
-    findings = reflection_findings_from_metadata(saved[0].metadata)
+    findings = reflection_findings_from_metadata(saved[-1].metadata)
     assert lifecycle.state == "active"
     assert lifecycle.source_id == "raw-1"
     assert lifecycle.derived_ids == ["episode_123"]

--- a/packages/python/sibyl-core/tests/test_memory_policy.py
+++ b/packages/python/sibyl-core/tests/test_memory_policy.py
@@ -575,6 +575,7 @@ def test_search_scope_policy_denies_bands_it_cannot_verify() -> None:
 # file, with why it is not a second copy of the read rule. Authorization goes
 # through memory_metadata_read_allowed; these do something else with the value.
 _SCOPE_READERS_THAT_DO_NOT_AUTHORIZE = {
+    "services/memory_identity.py::reflection_identity": "binds evidence identity to its authorized scope",
     "audit/filters.py::audit_event_matches_resource": "filters an audit log by a recorded value",
     "migrate/scope_backfill.py::_recovered": "write stamp: applies a capture's authoritative scope",
     "migrate/scope_backfill.py::_reverse_in_org": "write stamp: names the clear the upsert requires",

--- a/packages/python/sibyl-core/tests/test_reflect.py
+++ b/packages/python/sibyl-core/tests/test_reflect.py
@@ -27,9 +27,14 @@ def native_reflection_runtime(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespac
     entities: list[Entity] = []
     relationships = []
 
-    async def create_direct(entity):
+    async def create_direct_if_absent(entity):
         entities.append(entity)
-        return entity.id
+        return entity, True
+
+    async def update(entity_id, updates, **kwargs):
+        entity = next(entity for entity in entities if entity.id == entity_id)
+        entity.metadata.update(updates["metadata"])
+        return entity
 
     async def create_bulk(items):
         relationships.extend(items)
@@ -37,7 +42,8 @@ def native_reflection_runtime(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespac
 
     runtime = SimpleNamespace(
         entity_manager=SimpleNamespace(
-            create_direct=AsyncMock(side_effect=create_direct),
+            create_direct_if_absent=AsyncMock(side_effect=create_direct_if_absent),
+            update=AsyncMock(side_effect=update),
             get=AsyncMock(return_value=None),
         ),
         relationship_manager=SimpleNamespace(create_bulk=AsyncMock(side_effect=create_bulk)),
@@ -235,7 +241,7 @@ async def test_reflect_memory_persist_denies_unverified_project(
         persist_review=False,
     )
 
-    native_reflection_runtime.entity_manager.create_direct.assert_not_awaited()
+    native_reflection_runtime.entity_manager.create_direct_if_absent.assert_not_awaited()
     native_reflection_runtime.relationship_manager.create_bulk.assert_not_awaited()
     assert pack.source_id is None
     assert pack.persisted_count == 0
@@ -328,7 +334,7 @@ async def test_reflect_memory_can_persist_review_queue(
     assert calls[1][1]["suggested_scope_key"] is None
     assert calls[1][1]["extraction_prompt_metadata"]["extractor"] == ("sibyl_reflection_extractor")
 
-    native_reflection_runtime.entity_manager.create_direct.assert_not_awaited()
+    native_reflection_runtime.entity_manager.create_direct_if_absent.assert_not_awaited()
     native_reflection_runtime.relationship_manager.create_bulk.assert_not_awaited()
 
 
@@ -374,7 +380,7 @@ async def test_reflect_memory_review_persistence_denies_unverified_project(
     source_review.assert_not_awaited()
     candidate_review.assert_not_awaited()
 
-    native_reflection_runtime.entity_manager.create_direct.assert_not_awaited()
+    native_reflection_runtime.entity_manager.create_direct_if_absent.assert_not_awaited()
     native_reflection_runtime.relationship_manager.create_bulk.assert_not_awaited()
 
 
@@ -386,9 +392,14 @@ async def test_reflect_memory_native_write_uses_policy_and_direct_graph(
     created_relationships = []
 
     class FakeEntityManager:
-        async def create_direct(self, entity):
+        async def create_direct_if_absent(self, entity):
             created_entities.append(entity)
-            return entity.id
+            return entity, True
+
+        async def update(self, entity_id, updates, **kwargs):
+            entity = next(entity for entity in created_entities if entity.id == entity_id)
+            entity.metadata.update(updates["metadata"])
+            return entity
 
         # Promotion links only targets it can resolve and the writer can see,
         # so the declared link has to exist for the RELATED_TO edge to appear.

--- a/packages/python/sibyl-core/tests/test_reflection_identity.py
+++ b/packages/python/sibyl-core/tests/test_reflection_identity.py
@@ -1,0 +1,955 @@
+"""Reflection evidence isolation against an actual isolated embedded database."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl_core.auth.memory_policy import memory_metadata_read_allowed
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services.graph_client import SurrealGraphClient, prepare_graph_schema
+from sibyl_core.services.graph_common import normalize_graph_records
+from sibyl_core.services.graph_entities import EntityManager
+from sibyl_core.services.graph_relationships import RelationshipManager
+from sibyl_core.services.graph_runtime import GraphRuntime
+from sibyl_core.services.memory_correction import apply_memory_correction
+from sibyl_core.services.memory_reflection import (
+    persist_reflection_candidate,
+    promote_raw_memory,
+    promote_reflection_candidate_review,
+)
+from sibyl_core.services.memory_sharing import share_memory
+from sibyl_core.services.surreal_content import (
+    get_raw_memory,
+    remember_raw_memory,
+    remember_reflection_candidate_review,
+)
+from sibyl_core.tools.reflect import reflect_memory
+from sibyl_core.tools.search import graph_entity_to_search_result
+
+
+@pytest.fixture
+async def runtime(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[GraphRuntime]:
+    client = SurrealGraphClient(group_id=f"identity-{uuid4().hex}", url="memory://")
+    try:
+        await prepare_graph_schema(client)
+        runtime = GraphRuntime(
+            client=client,
+            entity_manager=EntityManager(client, group_id=client.group_id),
+            relationship_manager=RelationshipManager(client, group_id=client.group_id),
+        )
+        for project in ("project_a", "project_b"):
+            await runtime.entity_manager.create_direct(
+                Entity(id=project, entity_type=EntityType.PROJECT, name=project)
+            )
+        monkeypatch.setattr(
+            "sibyl_core.services.memory_reflection.get_surreal_graph_runtime",
+            AsyncMock(return_value=runtime),
+        )
+        monkeypatch.setattr(
+            "sibyl_core.tools.reflect._load_reflection_decision_memories",
+            AsyncMock(return_value=[]),
+        )
+        yield runtime
+    finally:
+        await client.close()
+
+
+@pytest.fixture
+async def content_store(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[None]:
+    client = SurrealContentClient(url="memory://")
+    try:
+        await bootstrap_content_schema(client, reset=True)
+
+        @asynccontextmanager
+        async def session():
+            yield client
+
+        monkeypatch.setattr("sibyl_core.services.content_client.surreal_content_client", session)
+        yield
+    finally:
+        await client.close()
+
+
+@pytest.mark.parametrize(
+    ("first_project", "second_project", "second_principal"),
+    [
+        (None, None, "user_a"),
+        (None, None, "user_b"),
+        (None, "project_b", "user_b"),
+        ("project_a", "project_b", "user_b"),
+    ],
+)
+async def test_sources_keep_original_content_scope_and_edges(
+    runtime: GraphRuntime,
+    first_project: str | None,
+    second_project: str | None,
+    second_principal: str,
+) -> None:
+    first_text = "We decided to preserve the original source evidence forever."
+    second_text = "We decided to publish an unrelated purple terminal theme."
+    first = await reflect_memory(
+        first_text,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        project=first_project,
+        accessible_projects={first_project} if first_project else set(),
+        persist=True,
+    )
+    source_before = await runtime.entity_manager.get(str(first.source_id))
+    second = await reflect_memory(
+        second_text,
+        organization_id=runtime.client.group_id,
+        principal_id=second_principal,
+        project=second_project,
+        accessible_projects={second_project} if second_project else set(),
+        persist=True,
+    )
+    assert first.persisted_count == second.persisted_count == 1
+    assert first.source_id != second.source_id
+    assert await runtime.entity_manager.get(str(first.source_id)) == source_before
+    assert (await runtime.entity_manager.get(str(second.source_id))).content == second_text
+    edges = await runtime.client.execute_query(
+        "SELECT * FROM relates_to WHERE source_id = $source AND target_id = $target;",
+        source=first.candidates[0].persisted_id,
+        target=first.source_id,
+    )
+    assert len(edges) == 1
+
+
+@pytest.mark.parametrize("project", [None, "project_b"])
+async def test_candidate_identity_isolates_content_and_owner(
+    runtime: GraphRuntime,
+    project: str | None,
+) -> None:
+    candidate = ReflectionCandidate(
+        kind="decision",
+        title="Retention policy",
+        content="Keep all records.",
+        reason="test",
+        confidence=1.0,
+    )
+    first = await persist_reflection_candidate(
+        candidate=candidate,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+    )
+    original = await runtime.entity_manager.get(str(first.response.id))
+    second = await persist_reflection_candidate(
+        candidate=replace(candidate, content="Delete old records."),
+        organization_id=runtime.client.group_id,
+        principal_id="user_b",
+        project=project,
+        accessible_projects={project} if project else set(),
+    )
+    assert first.response.success and second.response.success
+    assert first.response.id != second.response.id
+    assert await runtime.entity_manager.get(str(first.response.id)) == original
+
+
+def candidate() -> ReflectionCandidate:
+    return ReflectionCandidate(
+        kind="decision",
+        title="Retention policy",
+        content="Keep all records.",
+        reason="test",
+        confidence=1.0,
+    )
+
+
+@pytest.mark.parametrize("changed", ["content", "principal", "project", "source", "domain"])
+async def test_each_identity_boundary_is_independent(runtime: GraphRuntime, changed: str) -> None:
+    original_candidate = replace(candidate(), content="a" * 150 + "first")
+    args = dict(
+        candidate=original_candidate, organization_id=runtime.client.group_id, principal_id="user_a"
+    )
+    first = await persist_reflection_candidate(**args)
+    if changed == "content":
+        args["candidate"] = replace(original_candidate, content="a" * 150 + "second")
+    elif changed == "principal":
+        args["principal_id"] = "user_b"
+    elif changed == "project":
+        args.update(project="project_b", accessible_projects={"project_b"})
+    elif changed == "source":
+        args["candidate"] = replace(original_candidate, raw_source_ids=["raw_source_b"])
+    else:
+        args["domain"] = "new-domain"
+    second = await persist_reflection_candidate(**args)
+    assert first.response.success and second.response.success
+    assert first.response.id != second.response.id
+
+
+async def test_exact_retry_replays_receipt_without_rewriting_evidence(
+    runtime: GraphRuntime,
+) -> None:
+    args = dict(
+        candidate=candidate(), organization_id=runtime.client.group_id, principal_id="user_a"
+    )
+    first = await persist_reflection_candidate(**args)
+    before = await runtime.entity_manager.get(str(first.response.id))
+    second = await persist_reflection_candidate(**args)
+    assert second.response.success and second.response.id == first.response.id
+    assert first.metadata["publication_outcome"] == "created"
+    assert second.metadata["publication_outcome"] == "replayed"
+    assert first.metadata["invalidation_details_available"] is True
+    assert second.metadata["invalidation_details_available"] is False
+    assert second.metadata["promotion_state"] == first.metadata["promotion_state"]
+    assert "invalidated_source_ids" not in second.metadata
+    assert await runtime.entity_manager.get(str(first.response.id)) == before
+
+
+async def test_source_order_and_extraction_ids_do_not_change_identity(
+    runtime: GraphRuntime,
+) -> None:
+    original = replace(candidate(), raw_source_ids=["source_b", "source_a"])
+    args = dict(organization_id=runtime.client.group_id, principal_id="user_a")
+    first = await persist_reflection_candidate(candidate=original, **args)
+    second = await persist_reflection_candidate(
+        candidate=replace(
+            original,
+            raw_source_ids=["source_a", "source_b"],
+            metadata={"extraction_id": "unrelated-run"},
+        ),
+        **args,
+    )
+    assert first.response.id == second.response.id
+    assert second.metadata["publication_outcome"] == "replayed"
+
+
+@pytest.mark.parametrize("state", ["archived", "superseded", "deleted"])
+async def test_retired_candidate_retry_preserves_lifecycle(
+    runtime: GraphRuntime, state: str
+) -> None:
+    args = dict(
+        candidate=candidate(), organization_id=runtime.client.group_id, principal_id="user_a"
+    )
+    first = await persist_reflection_candidate(**args)
+    await runtime.entity_manager.update(
+        str(first.response.id), {"metadata": {"lifecycle_state": state}}
+    )
+    before = await runtime.entity_manager.get(str(first.response.id))
+    result = await persist_reflection_candidate(**args)
+    assert not result.response.success
+    assert result.response.id == first.response.id
+    assert result.metadata["publication_outcome"] == "retired"
+    assert await runtime.entity_manager.get(str(first.response.id)) == before
+
+
+async def test_retired_source_prevents_new_candidate_publication(runtime: GraphRuntime) -> None:
+    from sibyl_core.services.memory_reflection import persist_reflection_source
+
+    content = "We decided to preserve evidence before publishing decisions."
+    result = await persist_reflection_source(
+        title="Session reflection",
+        content=content,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+    )
+    await runtime.entity_manager.update(
+        str(result.response.id), {"metadata": {"lifecycle_state": "deleted"}}
+    )
+    before = await runtime.entity_manager.get(str(result.response.id))
+    pack = await reflect_memory(
+        content, organization_id=runtime.client.group_id, principal_id="user_a", persist=True
+    )
+    assert pack.persisted_count == 0
+    assert pack.candidates[0].metadata["promotion_state"] == "denied"
+    assert await runtime.entity_manager.get(str(result.response.id)) == before
+    assert (
+        await runtime.client.execute_query(
+            "SELECT VALUE uuid FROM entity WHERE entity_type = 'decision';"
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"content": "Corrupted evidence"},
+        {"metadata": {"principal_id": "user_b"}},
+        {
+            "metadata": {
+                "memory_scope": "project",
+                "project_id": "project_b",
+                "scope_key": "project_b",
+            }
+        },
+        {"metadata": {"raw_source_ids": ["forged"]}},
+    ],
+)
+async def test_conflict_checks_actual_row_fields(runtime: GraphRuntime, updates: dict) -> None:
+    args = dict(
+        candidate=candidate(), organization_id=runtime.client.group_id, principal_id="user_a"
+    )
+    first = await persist_reflection_candidate(**args)
+    await runtime.entity_manager.update(str(first.response.id), updates)
+    before = await runtime.entity_manager.get(str(first.response.id))
+    with pytest.raises(ValueError, match="reflection identity conflict"):
+        await persist_reflection_candidate(**args)
+    assert await runtime.entity_manager.get(str(first.response.id)) == before
+
+
+async def test_concurrent_same_identity_is_inserted_once(runtime: GraphRuntime) -> None:
+    # Embedded connections serialize engine access. Concurrent callers still
+    # exercise the insert-versus-existing and publication revision races.
+    args = dict(
+        candidate=candidate(), organization_id=runtime.client.group_id, principal_id="user_a"
+    )
+    results = await asyncio.gather(*(persist_reflection_candidate(**args) for _ in range(6)))
+    assert all(result.response.success for result in results)
+    assert len({result.response.id for result in results}) == 1
+    rows = await runtime.client.execute_query(
+        "SELECT * FROM entity WHERE entity_type = 'decision';"
+    )
+    assert len(rows) == 1
+    assert rows[0]["attributes"]["reflection_publication"]["state"] == "complete"
+
+
+async def test_interrupted_publication_resumes_missing_edges(
+    runtime: GraphRuntime, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class Interrupted(BaseException):
+        pass
+
+    async def interrupt(_relationships):
+        raise Interrupted()
+
+    args = dict(
+        candidate=candidate(),
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        project="project_a",
+        accessible_projects={"project_a"},
+    )
+    real_create = runtime.relationship_manager.create_bulk
+    monkeypatch.setattr(runtime.relationship_manager, "create_bulk", interrupt)
+    with pytest.raises(Interrupted):
+        await persist_reflection_candidate(**args)
+    rows = await runtime.client.execute_query(
+        "SELECT * FROM entity WHERE entity_type = 'decision';"
+    )
+    assert len(rows) == 1
+    assert rows[0]["attributes"]["reflection_publication"]["state"] == "pending"
+    monkeypatch.setattr(runtime.relationship_manager, "create_bulk", real_create)
+    result = await persist_reflection_candidate(**args)
+    assert result.response.success and result.response.id == rows[0]["uuid"]
+    assert result.metadata["publication_outcome"] == "resumed"
+    assert result.metadata["promotion_state"] == "complete"
+    edges = await runtime.client.execute_query(
+        "SELECT * FROM relates_to WHERE source_id = $source;", source=result.response.id
+    )
+    assert len(edges) == 1
+
+
+@pytest.mark.parametrize("mode", ["review", "raw", "share"])
+async def test_public_promotion_and_share_replay_preserve_raw_lifecycle(
+    runtime: GraphRuntime,
+    content_store: None,
+    mode: str,
+) -> None:
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="session-one",
+        title="Retention policy",
+        raw_content="Keep all records.",
+        embedding_provider=None,
+    )
+    if mode == "review":
+        raw = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[raw.id],
+        )
+
+    async def publish(project="project_a"):
+        common = dict(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            accessible_projects={project},
+        )
+        if mode == "share":
+            result = await share_memory(
+                source_ids=[raw.id], target_scope="project", target_scope_key=project, **common
+            )
+            assert len(result.promotions) == 1
+            return result.promotions[0]
+        common.update(promote_to_scope="project", promote_to_scope_key=project)
+        if mode == "review":
+            return await promote_reflection_candidate_review(candidate_id=raw.id, **common)
+        return await promote_raw_memory(raw_memory_id=raw.id, **common)
+
+    first = await publish()
+    assert first.success
+    original = await runtime.entity_manager.get(str(first.promoted_id))
+    raw_before = await get_raw_memory(organization_id=runtime.client.group_id, memory_id=raw.id)
+    second = await publish()
+    assert second.success and second.promoted_id == first.promoted_id
+    assert second.metadata["publication_outcome"] == "replayed"
+    assert await runtime.entity_manager.get(str(first.promoted_id)) == original
+    assert (
+        await get_raw_memory(organization_id=runtime.client.group_id, memory_id=raw.id)
+        == raw_before
+    )
+    another_scope = await publish("project_b")
+    if mode == "share":
+        assert another_scope.success and another_scope.promoted_id != first.promoted_id
+    else:
+        assert not another_scope.success
+        assert another_scope.reason == "candidate_already_promoted"
+    assert await runtime.entity_manager.get(str(first.promoted_id)) == original
+
+
+@pytest.mark.parametrize("mode", ["review", "raw", "share"])
+async def test_partial_promotion_is_retryable_before_raw_review_transition(
+    runtime: GraphRuntime,
+    content_store: None,
+    mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="session-one",
+        title="Retention policy",
+        raw_content="Keep all records.",
+        embedding_provider=None,
+    )
+    if mode == "review":
+        raw = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[raw.id],
+        )
+
+    async def publish():
+        common = dict(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            accessible_projects={"project_a"},
+        )
+        if mode == "share":
+            result = await share_memory(
+                source_ids=[raw.id], target_scope="project", target_scope_key="project_a", **common
+            )
+            return result.promotions[0]
+        common.update(promote_to_scope="project", promote_to_scope_key="project_a")
+        if mode == "review":
+            return await promote_reflection_candidate_review(candidate_id=raw.id, **common)
+        return await promote_raw_memory(raw_memory_id=raw.id, **common)
+
+    raw_before = await get_raw_memory(organization_id=runtime.client.group_id, memory_id=raw.id)
+    real_create = runtime.relationship_manager.create_bulk
+    monkeypatch.setattr(
+        runtime.relationship_manager,
+        "create_bulk",
+        AsyncMock(side_effect=lambda items: (0, len(items))),
+    )
+    first = await publish()
+    assert not first.success and first.reason == "promotion_incomplete"
+    assert first.promoted_id
+    pending = await get_raw_memory(organization_id=runtime.client.group_id, memory_id=raw.id)
+    if mode == "share":
+        assert pending == raw_before
+    else:
+        assert pending.review_state == raw_before.review_state
+        assert pending.raw_content == raw_before.raw_content
+        assert pending.principal_id == raw_before.principal_id
+        assert pending.metadata["promoted_entity_id"] == first.promoted_id
+        assert pending.metadata["promotion_state"] == "pending"
+    monkeypatch.setattr(runtime.relationship_manager, "create_bulk", real_create)
+    second = await publish()
+    assert second.success and second.promoted_id == first.promoted_id
+    assert second.metadata["publication_outcome"] == "resumed"
+
+
+async def test_legacy_evidence_is_not_remapped(runtime: GraphRuntime) -> None:
+    legacy = Entity(
+        id="session_bb302e9ccf16",
+        entity_type=EntityType.SESSION,
+        name="Session reflection",
+        content="Legacy archive source",
+        organization_id=runtime.client.group_id,
+    )
+    await runtime.entity_manager.create_direct(legacy)
+    before = await runtime.entity_manager.get(legacy.id)
+    result = await reflect_memory(
+        "We decided to keep a new source separate from historical evidence.",
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        persist=True,
+    )
+    assert result.source_id.startswith("session_v2_")
+    assert await runtime.entity_manager.get(legacy.id) == before
+
+
+async def test_source_conflict_cannot_publish_orphan_candidates(runtime: GraphRuntime) -> None:
+    from sibyl_core.services.memory_reflection import persist_reflection_source
+
+    content = "We decided to preserve evidence before publishing decisions."
+    source = await persist_reflection_source(
+        title="Session reflection",
+        content=content,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+    )
+    await runtime.entity_manager.update(str(source.response.id), {"content": "Changed externally"})
+    with pytest.raises(ValueError, match="reflection identity conflict"):
+        await reflect_memory(
+            content, organization_id=runtime.client.group_id, principal_id="user_a", persist=True
+        )
+    assert (
+        await runtime.client.execute_query(
+            "SELECT VALUE uuid FROM entity WHERE entity_type = 'decision';"
+        )
+        == []
+    )
+
+
+async def test_revocation_during_publication_is_not_reactivated(
+    runtime: GraphRuntime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_create = runtime.relationship_manager.create_bulk
+
+    async def revoke(relationships):
+        entity_id = relationships[0].source_id
+        await runtime.entity_manager.update(entity_id, {"metadata": {"lifecycle_state": "deleted"}})
+        return await real_create(relationships)
+
+    monkeypatch.setattr(runtime.relationship_manager, "create_bulk", revoke)
+    result = await persist_reflection_candidate(
+        candidate=candidate(),
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        project="project_a",
+        accessible_projects={"project_a"},
+    )
+    assert not result.response.success
+    assert result.metadata["publication_outcome"] == "retired"
+    stored = await runtime.entity_manager.get(str(result.response.id))
+    assert stored.metadata["lifecycle_state"] == "deleted"
+    assert stored.metadata["reflection_publication"]["state"] == "pending"
+
+
+@pytest.mark.parametrize("mode", ["raw", "review"])
+async def test_second_promotion_does_not_strand_first_copy(
+    runtime, content_store, monkeypatch, mode
+):
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="session-one",
+        title="Retention policy",
+        raw_content="Keep all records.",
+        embedding_provider=None,
+    )
+    if mode == "review":
+        raw = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[raw.id],
+        )
+    common = dict(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        accessible_projects={"project_a", "project_b"},
+        promote_to_scope="project",
+    )
+
+    async def publish(project):
+        if mode == "review":
+            return await promote_reflection_candidate_review(
+                candidate_id=raw.id, promote_to_scope_key=project, **common
+            )
+        return await promote_raw_memory(
+            raw_memory_id=raw.id, promote_to_scope_key=project, **common
+        )
+
+    first = await publish("project_a")
+    second = await publish("project_b")
+    assert first.success and not second.success
+    assert second.reason == "candidate_already_promoted"
+    correction = await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        source_id=raw.id,
+        principal_id="user_a",
+        action="delete",
+        accessible_projects={"project_a", "project_b"},
+    )
+    assert correction.applied
+    first_row = await runtime.entity_manager.get(first.promoted_id)
+    assert not graph_metadata_recallable(first_row.metadata), {
+        "mode": mode,
+        "first_copy_state": first_row.metadata.get("lifecycle_state"),
+        "source_promoted_id": (
+            await get_raw_memory(organization_id=runtime.client.group_id, memory_id=raw.id)
+        ).metadata.get("promoted_entity_id"),
+    }
+
+
+@pytest.mark.parametrize("mode", ["raw", "review"])
+async def test_partial_promotion_source_deletion_retires_inserted_row(
+    runtime, content_store, monkeypatch, mode
+):
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="session-partial",
+        title="Partial publication evidence",
+        raw_content="Keep the underlying evidence authoritative.",
+        embedding_provider=None,
+    )
+    if mode == "review":
+        raw = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[raw.id],
+        )
+    monkeypatch.setattr(
+        runtime.relationship_manager,
+        "create_bulk",
+        AsyncMock(side_effect=lambda items: (0, len(items))),
+    )
+    common = dict(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        accessible_projects={"project_a"},
+        promote_to_scope="project",
+        promote_to_scope_key="project_a",
+    )
+    if mode == "review":
+        result = await promote_reflection_candidate_review(candidate_id=raw.id, **common)
+    else:
+        result = await promote_raw_memory(raw_memory_id=raw.id, **common)
+    assert not result.success and result.reason == "promotion_incomplete"
+    before = await runtime.entity_manager.get(result.promoted_id)
+    assert before.metadata["reflection_publication"]["state"] == "partial"
+    correction = await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        source_id=raw.id,
+        principal_id="user_a",
+        action="delete",
+        accessible_projects={"project_a"},
+    )
+    assert correction.applied
+    row = await runtime.entity_manager.get(result.promoted_id)
+    source = await get_raw_memory(organization_id=runtime.client.group_id, memory_id=raw.id)
+    assert not graph_metadata_recallable(row.metadata), {
+        "mode": mode,
+        "graph_state": row.metadata.get("lifecycle_state"),
+        "publication_state": row.metadata["reflection_publication"]["state"],
+        "source_promoted_id": source.metadata.get("promoted_entity_id"),
+        "source_state": source.metadata.get("lifecycle_state"),
+    }
+
+
+async def test_restored_v2_uuid_at_random_record_id_replays(runtime):
+    args = dict(
+        candidate=candidate(), organization_id=runtime.client.group_id, principal_id="user_a"
+    )
+    first = await persist_reflection_candidate(**args)
+    saved = await runtime.entity_manager.get(first.response.id)
+    await runtime.entity_manager.delete(first.response.id)
+    assert await runtime.entity_manager.create_direct_bulk([saved]) == [saved.id]
+    rows = normalize_graph_records(
+        await runtime.client.execute_query(
+            "SELECT * FROM entity WHERE uuid = $uuid;", uuid=saved.id
+        )
+    )
+    assert len(rows) == 1
+    restored_record_id = str(rows[0]["record_id"])
+    assert restored_record_id != f"entity:{saved.id}"
+    restored = await runtime.entity_manager.get(saved.id)
+    replay = await persist_reflection_candidate(**args)
+    assert replay.response.success and replay.response.id == saved.id
+    assert replay.metadata["publication_outcome"] == "replayed"
+    assert await runtime.entity_manager.get(saved.id) == restored
+    rows_after = normalize_graph_records(
+        await runtime.client.execute_query(
+            "SELECT * FROM entity WHERE uuid = $uuid;", uuid=saved.id
+        )
+    )
+    assert len(rows_after) == 1
+    assert str(rows_after[0]["record_id"]) == restored_record_id
+
+
+async def test_project_receipt_does_not_reveal_private_invalidation_uuid(runtime, content_store):
+    private_source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="private-session-alias",
+        title="Private source",
+        raw_content="Private evidence invisible to another project member.",
+        embedding_provider=None,
+    )
+    proposal = replace(
+        candidate(),
+        metadata={"contradiction_source_ids": ["private-session-alias"]},
+    )
+    result = await persist_reflection_candidate(
+        candidate=proposal,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        project="project_a",
+        accessible_projects={"project_a"},
+    )
+    assert result.response.success
+    row = await runtime.entity_manager.get(result.response.id)
+    reader_args = dict(
+        principal_id="user_b", private_scope_granted=True, accessible_projects={"project_a"}
+    )
+    assert memory_metadata_read_allowed(row.metadata, **reader_args)
+    assert not memory_metadata_read_allowed(
+        {"memory_scope": "private", "principal_id": "user_a", "scope_key": "user_a"},
+        **reader_args,
+    )
+    visible_result = graph_entity_to_search_result(
+        row,
+        organization_id=runtime.client.group_id,
+        principal_id="user_b",
+        score=1.0,
+        policy_reason="project_scope_read_allowed",
+    )
+    assert result.metadata["invalidated_source_ids"] == [private_source.id]
+    assert result.metadata["invalidation_details_available"] is True
+    receipt = row.metadata["reflection_publication"]["receipt"]
+    assert receipt["invalidation_details_available"] is False
+    assert "invalidated_source_ids" not in receipt
+    assert "invalidation_errors" not in receipt
+    assert private_source.id not in json.dumps(visible_result.metadata, default=str)
+    assert private_source.id not in json.dumps(row.model_dump(), default=str)
+    replay = await persist_reflection_candidate(
+        candidate=proposal,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        project="project_a",
+        accessible_projects={"project_a"},
+    )
+    assert replay.response.success
+    assert replay.metadata["publication_outcome"] == "replayed"
+    assert replay.metadata["invalidation_details_available"] is False
+    assert private_source.id not in json.dumps(replay.metadata, default=str)
+
+
+@pytest.mark.parametrize("mode", ["raw", "review"])
+@pytest.mark.parametrize("boundary", ["before_insert", "final_save", "input_before_insert"])
+async def test_source_correction_during_promotion_cannot_publish_live_evidence(
+    runtime,
+    content_store,
+    monkeypatch,
+    mode,
+    boundary,
+):
+    from sibyl_core.services import memory_reflection as reflection
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="corrected-during-publication",
+        title="Original evidence",
+        raw_content="The source remains authoritative.",
+        embedding_provider=None,
+    )
+    raw = source
+    if mode == "review":
+        raw = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[source.id],
+        )
+    correction_id = source.id if boundary == "input_before_insert" else raw.id
+
+    async def correct():
+        result = await apply_memory_correction(
+            organization_id=runtime.client.group_id,
+            source_id=correction_id,
+            principal_id="user_a",
+            action="delete",
+            accessible_projects={"project_a"},
+        )
+        assert result.applied
+
+    if boundary == "final_save":
+        save = reflection.save_raw_memory
+
+        async def correcting_save(memory, **kwargs):
+            if memory.review_state == "promoted":
+                await correct()
+            return await save(memory, **kwargs)
+
+        monkeypatch.setattr(reflection, "save_raw_memory", correcting_save)
+    else:
+        insert = runtime.entity_manager.create_direct_if_absent
+
+        async def correcting_insert(entity):
+            await correct()
+            return await insert(entity)
+
+        monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", correcting_insert)
+    common = dict(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        accessible_projects={"project_a"},
+        promote_to_scope="project",
+        promote_to_scope_key="project_a",
+    )
+    if mode == "review":
+        result = await promote_reflection_candidate_review(candidate_id=raw.id, **common)
+    else:
+        result = await promote_raw_memory(raw_memory_id=raw.id, **common)
+    assert not result.success and result.reason == "retired"
+    row = await runtime.entity_manager.get(result.promoted_id)
+    assert not graph_metadata_recallable(row.metadata)
+    corrected = await get_raw_memory(
+        organization_id=runtime.client.group_id, memory_id=correction_id
+    )
+    assert corrected.metadata["lifecycle_state"] == "deleted"
+    retry = await (
+        promote_reflection_candidate_review(candidate_id=raw.id, **common)
+        if mode == "review"
+        else promote_raw_memory(raw_memory_id=raw.id, **common)
+    )
+    assert not retry.success
+    assert not graph_metadata_recallable((await runtime.entity_manager.get(row.id)).metadata)
+
+
+@pytest.mark.parametrize("mode", ["raw", "review"])
+@pytest.mark.parametrize("different_targets", [False, True])
+async def test_concurrent_source_promotion_reserves_one_identity(
+    runtime,
+    content_store,
+    mode,
+    different_targets,
+):
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="concurrent-promotion",
+        title="Stable source",
+        raw_content="One source has one authoritative promotion target.",
+        embedding_provider=None,
+    )
+    if mode == "review":
+        raw = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[raw.id],
+        )
+
+    async def publish(project):
+        common = dict(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            accessible_projects={"project_a", "project_b"},
+            promote_to_scope="project",
+            promote_to_scope_key=project,
+        )
+        if mode == "review":
+            return await promote_reflection_candidate_review(candidate_id=raw.id, **common)
+        return await promote_raw_memory(raw_memory_id=raw.id, **common)
+
+    results = await asyncio.gather(
+        publish("project_a"), publish("project_b" if different_targets else "project_a")
+    )
+    successful = [result for result in results if result.success]
+    assert len(successful) == (1 if different_targets else 2)
+    if different_targets:
+        denied = next(result for result in results if not result.success)
+        assert denied.reason == "candidate_already_promoted"
+    assert len({result.promoted_id for result in successful}) == 1
+    saved = await get_raw_memory(organization_id=runtime.client.group_id, memory_id=raw.id)
+    assert saved.review_state == "promoted"
+    assert saved.metadata["promoted_entity_id"] == successful[0].promoted_id
+    rows = await runtime.client.execute_query(
+        "SELECT VALUE uuid FROM entity WHERE entity_type != 'project';"
+    )
+    assert rows == [successful[0].promoted_id]
+
+
+@pytest.mark.parametrize("mode", ["raw", "review"])
+async def test_same_scope_changed_domain_cannot_retarget_promotion(runtime, content_store, mode):
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="domain-sensitive",
+        title="Stable source",
+        raw_content="Preserve target identity.",
+        embedding_provider=None,
+    )
+    if mode == "review":
+        raw = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[raw.id],
+        )
+    common = dict(
+        organization_id=runtime.client.group_id, principal_id="user_a", promote_to_scope="private"
+    )
+    publish = promote_reflection_candidate_review if mode == "review" else promote_raw_memory
+    common["candidate_id" if mode == "review" else "raw_memory_id"] = raw.id
+    first = await publish(domain="original", **common)
+    second = await publish(domain="changed", **common)
+    assert first.success
+    assert not second.success and second.reason == "candidate_already_promoted"
+
+
+async def test_publication_request_replaces_removed_nested_keys(runtime):
+    original = replace(candidate(), metadata={"valid_at": "2026-01-01T00:00:00+00:00"})
+    args = dict(organization_id=runtime.client.group_id, principal_id="user_a")
+    first = await persist_reflection_candidate(candidate=original, **args)
+    second = await persist_reflection_candidate(candidate=candidate(), **args)
+    assert second.response.success and second.response.id == first.response.id
+    row = await runtime.entity_manager.get(first.response.id)
+    assert row.metadata["reflection_publication"]["request"]["invalidation_cutoff"] == {}
+    replay = await persist_reflection_candidate(candidate=candidate(), **args)
+    assert replay.metadata["publication_outcome"] == "replayed"
+
+
+async def test_disappearance_after_publication_revision_conflict_is_controlled(
+    runtime, monkeypatch
+):
+    from sibyl_core.errors import RevisionConflictError
+
+    async def disappear(entity_id, updates, **kwargs):
+        await runtime.entity_manager.delete(entity_id)
+        raise RevisionConflictError(entity_id, expected_revision=1, actual_revision=2)
+
+    monkeypatch.setattr(runtime.entity_manager, "update", disappear)
+    with pytest.raises(RuntimeError, match="reflection evidence disappeared during publication"):
+        await persist_reflection_candidate(
+            candidate=candidate(),
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+        )


### PR DESCRIPTION
Reflecting another session with the default title could overwrite an earlier session's content and ownership. Same-titled candidates could collide too. The existing provenance edges then pointed at different evidence. This change gives native reflection sources and candidates versioned identities derived from their complete canonical content, ownership, destination scope, and source provenance.

Native publication inserts evidence once and verifies an existing row before replaying it. A retry preserves retired evidence and can resume an interrupted relationship write. Raw and reviewed promotion reserve their target through the existing source revision check before publishing, so correction can find the row even when publication is partial. A different target requires the separate sharing workflow. Legacy rows and IDs remain unchanged; re-reflection can create a new versioned row beside legacy evidence. Previously overwritten content requires original sources or backups for recovery.

Persisted publication receipts omit private invalidation details from project-visible metadata. The initial authorized writer can receive those details; replay does not disclose historical private outcomes to other readers. Replayed evidence retains its original non-identity metadata rather than treating another reflection as an update.

## 🧪 Validation

- Passed the full core suite: 2,820 tests, with 14 skips and one expected failure.
- Passed 52 focused embedded identity and correction tests, plus 19 API reflection tests. An independent reviewer also passed 494 broader core tests and 26 API reflection tests.
- Passed core lint, type checks, independent adversarial review, and the corrected cross-model security review. Parent spot checks reran all 52 identity cases.
- Verified the same 12 changed files on Linux with SurrealDB 3.2.3 over WebSocket. Sixteen overlapping callers across eight sockets produced one physical row and one relationship, with no errors. Distinct owner, project, and content cases stayed separate; completed replay remained unchanged and retired evidence was denied.

The WebSocket proof covers concurrent insertion and replay. Raw/review correction races and restored records were tested with embedded SurrealDB.

## 🧭 Remaining boundary

Upstream raw-input corrections can still miss a graph row derived through a review, and shared copies need lifetime correction propagation. Independent probes reproduce that gap on the base revision too. This change preserves the promoted capture's own target and revision boundary; it does not implement transitive correction across every upstream source.
