### PR TITLE
perf(search): skip retrieval when the stored type is absent

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_search.py
@@ -192,6 +192,26 @@ class _EntitySearchManager:
         search_query = build_fulltext_query(query)
         if not search_query:
             return []
+        if entity_types and len(entity_types) == 1:
+            try:
+                presence = await self._client.execute_query(
+                    """
+                    SELECT uuid FROM entity
+                    WHERE group_id = $group_id AND entity_type = $entity_type
+                    LIMIT 1;
+                    """,
+                    group_id=self._group_id,
+                    entity_type=entity_types[0].value,
+                    _query_label="entity.search.type_presence",
+                )
+            except Exception as exc:
+                log.warning("entity_type_presence_failed", error_type=type(exc).__name__)
+            else:
+                # Only the native client's successful empty row list proves absence.
+                # Normalization also drops malformed responses, so do not use it here.
+                # Keep this observation local: later searches must see newly inserted rows.
+                if isinstance(presence, list) and not presence:
+                    return []
         result_limit = max(int(limit), 1)
         anchor_search_query = _build_explicit_anchor_search_query(query)
 

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -1935,6 +1935,8 @@ class _PerFieldFulltextClient:
 
     async def execute_query(self, query: str, **params: object) -> list[dict[str, object]]:
         self.calls.append((query, params))
+        if params.get("_query_label") == "entity.search.type_presence":
+            return [{"uuid": "shared"}]
         if params.get("_query_label") != "entity.search.fulltext":
             return []
         field = next(
@@ -5039,6 +5041,230 @@ async def test_the_v17_migration_backfills_scope_from_attributes() -> None:
         assert rows[0]["memory_scope"] == "private"
     finally:
         await client.close()
+
+
+class _TypePresenceSearchClient(_PerFieldFulltextClient):
+    def __init__(self, presence: object) -> None:
+        super().__init__()
+        self.presence = presence
+
+    async def execute_query(self, query: str, **params: object) -> object:
+        if params.get("_query_label") == "entity.search.type_presence":
+            self.calls.append((query, params))
+            if isinstance(self.presence, Exception):
+                raise self.presence
+            return self.presence
+        return await super().execute_query(query, **params)
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_absent_type_skips_all_search_work() -> None:
+    client = _TypePresenceSearchClient([])
+    provider = AsyncMock()
+    provider.embed = AsyncMock(side_effect=AssertionError("absent type must not embed"))
+    manager = EntityManager(
+        cast("SurrealGraphClient", client), group_id=client.group_id, embedding_provider=provider
+    )
+
+    result = await manager.search(
+        query='On a `Report` record, what is under "Related Links"?',
+        entity_types=[EntityType.NOTE],
+    )
+
+    assert result == []
+    assert len(client.calls) == 1
+    query, params = client.calls[0]
+    assert "WHERE group_id = $group_id AND entity_type = $entity_type" in query
+    assert "LIMIT 1;" in query
+    assert params == {
+        "group_id": client.group_id,
+        "entity_type": "note",
+        "_query_label": "entity.search.type_presence",
+    }
+    assert provider.mock_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "presence",
+    [
+        [{"uuid": "shared"}],
+        None,
+        0,
+        False,
+        "",
+        {},
+        {"result": []},
+        {"status": "ERR", "result": []},
+        [{"status": "ERR", "result": []}],
+        [None],
+        RuntimeError("presence lookup unavailable"),
+    ],
+)
+async def test_native_entity_manager_uncertain_or_present_type_preserves_ranking(
+    presence: object,
+) -> None:
+    client = _TypePresenceSearchClient(presence)
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+    # A repeated type uses the original pipeline without the single-type probe.
+    expected = await manager.search(
+        query="surreal replay verification",
+        entity_types=[EntityType.TOPIC, EntityType.TOPIC],
+        limit=3,
+    )
+    baseline_calls = [
+        (query, {**params, "entity_types": ["topic"]}) for query, params in client.calls
+    ]
+    client.calls.clear()
+
+    actual = await manager.search(
+        query="surreal replay verification", entity_types=[EntityType.TOPIC], limit=3
+    )
+
+    assert actual == expected
+    assert [entity.id for entity, _score in actual] == ["shared", "summary-only", "name-only"]
+    assert client.calls[1:] == baseline_calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("types", [None, [], [EntityType.NOTE, EntityType.TOPIC]])
+async def test_native_entity_manager_untyped_and_mixed_skip_presence_probe(
+    types: list[EntityType] | None,
+) -> None:
+    client = _TypePresenceSearchClient(AssertionError("unexpected presence probe"))
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+
+    results = await manager.search(query="surreal replay verification", entity_types=types)
+
+    assert results
+    assert all(
+        params.get("_query_label") != "entity.search.type_presence" for _, params in client.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_absence_does_not_outlive_the_search() -> None:
+    client = _TypePresenceSearchClient([])
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+    assert await manager.search(query="surreal replay", entity_types=[EntityType.TOPIC]) == []
+    client.presence = [{"uuid": "shared"}]
+
+    results = await manager.search(query="surreal replay", entity_types=[EntityType.TOPIC])
+
+    assert results
+    assert (
+        sum(
+            params.get("_query_label") == "entity.search.type_presence"
+            for _, params in client.calls
+        )
+        == 2
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_empty_query_does_not_probe_type() -> None:
+    client = _TypePresenceSearchClient([])
+    manager = EntityManager(cast("SurrealGraphClient", client), group_id=client.group_id)
+    assert await manager.search(query="  ", entity_types=[EntityType.NOTE]) == []
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_presence_is_group_scoped_and_observed_per_call() -> None:
+    client = SurrealGraphClient(group_id="org-presence-race", url="memory://")
+    try:
+        await prepare_graph_schema(client)
+        manager = EntityManager(client, group_id=client.group_id)
+        other = EntityManager(client, group_id="other-group")
+        await other.create_direct(
+            Entity(
+                id="other_note",
+                entity_type=EntityType.NOTE,
+                name="presence race note",
+                organization_id="other-group",
+            )
+        )
+        observed_absence = asyncio.Event()
+        insert_finished = asyncio.Event()
+        original_execute = client.execute_query
+        presence_results: list[object] = []
+
+        async def execute_with_insert_barrier(query: str, **params: Any) -> object:
+            result = await original_execute(query, **params)
+            if params.get("_query_label") == "entity.search.type_presence":
+                presence_results.append(result)
+                if len(presence_results) == 1:
+                    observed_absence.set()
+                    await insert_finished.wait()
+            return result
+
+        client.execute_query = execute_with_insert_barrier  # type: ignore[method-assign]
+        first = asyncio.create_task(
+            manager.search(
+                query="presence race",
+                entity_types=[EntityType.NOTE],
+            )
+        )
+        try:
+            await asyncio.wait_for(observed_absence.wait(), timeout=5)
+            await manager.create_direct(
+                Entity(
+                    id="new_note",
+                    entity_type=EntityType.NOTE,
+                    name="presence race note",
+                    organization_id=client.group_id,
+                )
+            )
+            insert_finished.set()
+            # The first call observes the earlier indexed absence, not a shared cache.
+            assert await first == []
+            assert presence_results == [[]]
+            results = await manager.search(query="presence race", entity_types=[EntityType.NOTE])
+            assert [entity.id for entity, _score in results] == ["new_note"]
+            assert len(presence_results) == 2
+            assert presence_results[1]
+        finally:
+            insert_finished.set()
+            await first
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_native_entity_manager_present_type_preserves_vector_fusion() -> None:
+    client = _TypePresenceSearchClient([{"uuid": "shared"}])
+    original_execute = client.execute_query
+
+    async def with_vector_rows(query: str, **params: object) -> object:
+        if params.get("_query_label") == "entity.search.vector":
+            client.calls.append((query, params))
+            return [
+                client._row("vector-only", score=0.99, day=1),
+                client._row("shared", score=0.8, day=2),
+            ]
+        return await original_execute(query, **params)
+
+    client.execute_query = with_vector_rows  # type: ignore[method-assign]
+    manager = EntityManager(
+        cast("SurrealGraphClient", client),
+        group_id=client.group_id,
+        embedding_provider=_deterministic_provider(),
+    )
+    expected = await manager.search(
+        query="surreal replay",
+        entity_types=[EntityType.TOPIC, EntityType.TOPIC],
+        limit=3,
+    )
+    expected_calls = [
+        (query, {**params, "entity_types": ["topic"]}) for query, params in client.calls
+    ]
+    client.calls.clear()
+
+    actual = await manager.search(query="surreal replay", entity_types=[EntityType.TOPIC], limit=3)
+
+    assert actual == expected
+    assert "vector-only" in {entity.id for entity, _score in actual}
+    assert client.calls[1:] == expected_calls
 
 
 @pytest.mark.asyncio

--- a/packages/python/sibyl-core/tests/test_tools.py
+++ b/packages/python/sibyl-core/tests/test_tools.py
@@ -4993,3 +4993,118 @@ class TestExploreMemoryScope:
             )
 
         assert [entity.id for entity in response.entities] == ["task_root"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_enhanced", [False, True])
+@pytest.mark.parametrize("lifecycle_failure", [False, True])
+async def test_search_native_absent_type_preserves_legacy_fallback_gates(
+    use_enhanced: bool,
+    lifecycle_failure: bool,
+) -> None:
+    from sibyl_core.config import core_config
+    from sibyl_core.services.graph_entities import EntityManager
+
+    search_module = import_module("sibyl_core.tools.search")
+    rows = []
+    for uuid, extra in (
+        ("attribute_note", {}),
+        ("label_note", {}),
+        (
+            "private_note",
+            {"memory_scope": "private", "scope_key": "alice", "principal_id": "alice"},
+        ),
+        ("other_project", {"project_id": "other", "scope_key": "other"}),
+        ("deleted_note", {"lifecycle_state": "deleted"}),
+        ("superseded_note", {}),
+    ):
+        attributes = {
+            "entity_type": "note",
+            "category": "operational_distillation",
+            "memory_scope": "project",
+            "scope_key": "project_123",
+            "project_id": "project_123",
+            **extra,
+        }
+        if uuid == "label_note":
+            del attributes["entity_type"]
+        rows.append(
+            {
+                "uuid": uuid,
+                "record_id": f"entity:{uuid}",
+                "group_id": "org_123",
+                "name": f"Legacy recall {uuid}",
+                "content": "legacy recall evidence",
+                "entity_type": None,
+                "labels": ["Entity", "Note"],
+                "attributes": attributes,
+                "created_at": datetime(2026, 8, 1, tzinfo=UTC),
+                "score": 0.9,
+            }
+        )
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_query(query: str, **params: Any) -> list[dict[str, Any]]:
+        calls.append((query, params))
+        if params.get("_query_label") == "entity.search.type_presence":
+            return []
+        if "FROM relates_to" in query and params.get("predicate") == "SUPERSEDES":
+            if lifecycle_failure:
+                raise RuntimeError("supersession lookup failed")
+            if "superseded_note" in params.get("uuids", []):
+                return [
+                    {
+                        "uuid": "replacement_edge",
+                        "source_id": "replacement",
+                        "target_id": "superseded_note",
+                        "created_at": datetime(2026, 8, 2, tzinfo=UTC),
+                    }
+                ]
+            return []
+        if params.get("_query_label") == "entity.search.fulltext":
+            return [] if params.get("entity_types") else rows
+        return []
+
+    client = AsyncMock()
+    client.execute_query = AsyncMock(side_effect=execute_query)
+    manager = EntityManager(client, group_id="org_123")
+    original_search = manager.search
+    manager.search = AsyncMock(wraps=original_search)
+    runtime = SimpleNamespace(client=client, entity_manager=manager)
+    with (
+        patch.object(core_config, "rerank_enabled", False),
+        patch("sibyl_core.tools.search.get_graph_runtime", AsyncMock(return_value=runtime)),
+    ):
+        response = await search_module.search(
+            query="legacy recall",
+            types=["note"],
+            category="operational_distillation",
+            project="project_123",
+            organization_id="org_123",
+            principal_id="bob",
+            accessible_projects={"project_123"},
+            allowed_memory_scope_keys={memory_scope_policy_key("project", "project_123")},
+            include_documents=False,
+            include_raw_memory=False,
+            use_enhanced=use_enhanced,
+            boost_recent=False,
+            record_exposure=False,
+            limit=10,
+        )
+
+    assert {result.id for result in response.results} == (
+        set() if lifecycle_failure else {"attribute_note", "label_note"}
+    )
+    # This is the outer fallback's limit, distinct from the hybrid linking search.
+    assert any(
+        call.kwargs.get("entity_types") is None and call.kwargs["limit"] == 30
+        for call in manager.search.await_args_list
+    )
+    assert any(params.get("_query_label") == "entity.search.type_presence" for _, params in calls)
+    assert all(
+        not params.get("entity_types")
+        for _, params in calls
+        if params.get("_query_label") == "entity.search.fulltext"
+    )
+    if lifecycle_failure:
+        assert response.filters["search_source_failures"]


### PR DESCRIPTION
A typed search still ran fulltext, vector, anchor, and fallback-text retrieval when the requested stored type did not exist. In the isolated V2 corpus, all 451 fast queries waited on a reserved-note search that returned no candidates. This change proves absence with the existing type index before starting native retrieval.

Exactly one requested type gets a group-scoped presence query. A successful empty row list returns the same empty native result. A present type, failed probe, or unrecognized response uses the existing search. Untyped and mixed-type requests stay unchanged. The observation belongs to that call, so a later search sees newly inserted rows.

Hybrid linking, legacy untyped fallback, permissions, and lifecycle checks remain active. Historical rows with types encoded in attributes or labels can still be recovered by the broad fallback. The two broad searches cannot safely share their fused results because their candidate limits and ranking differ.

## 🧪 Validation

- Passed 547 graph and tool tests, core lint and type checks. Parent spot checks reran 21 focused cases.
- Passed a Linux WebSocket comparison against the exact baseline class. On an absent type, six native database calls and one embedding call became one indexed query and zero embedding calls. Untyped, empty-type-list, and mixed-type cases kept their call counts and identical ordered IDs, scores, and content hashes.
- Verified a note inserted after an empty search is found by the next search. A populated single-type search adds one presence query and retains the same result.
- Replayed one frozen-corpus question after explicit local-model prewarm and required a successful baseline vector lane. The empty native note search took 14.57 seconds before and 17.8 ms after (six calls to one); a populated session search retained all 72 ordered results and added one presence call. These are single native-stage observations, not full-request or percentile measurements.
- Covered malformed/error responses, group isolation, concurrent insertion, legacy decoding, private/project scope, deletion, supersession, and failed lifecycle lookups.

Independent adversarial and cross-model reviews passed. Parent checks also reran the independent cancellation and native error-response probes. The transport fixture measures native search only. The two broad fallbacks remain; this change does not remove the entire reserved-note lane or establish QA improvement. A populated type pays for one additional indexed query, so full-path latency and mixed-load qualification remain separate measurements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved searches restricted to a single entity type by checking whether matching entities are available before ranking results.
  - Searches now return promptly when no matching entities exist, while preserving existing behavior when availability cannot be confirmed.
  - Maintained fallback search results when native type checks or related lookups fail.
  - Preserved established behavior for untyped, mixed-type, repeated-type, and empty-query searches.
- **Tests**
  - Added coverage for presence checks, fallback behavior, concurrent updates, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->