### PR TITLE
feat(evals): check task outcomes against frozen controller workspaces

### DIFF
--- a/benchmarks/agent_tasks/__init__.py
+++ b/benchmarks/agent_tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Trusted development task execution; not a sealed-agent security sandbox."""

--- a/benchmarks/agent_tasks/__main__.py
+++ b/benchmarks/agent_tasks/__main__.py
@@ -1,0 +1,26 @@
+"""Execute one manifest-selected trusted development task."""
+
+import argparse
+import json
+from pathlib import Path
+
+from benchmarks.agent_tasks.runner import run_task
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--arm", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        receipt = run_task(args.manifest, task_id=args.task, arm_id=args.arm, output=args.output)
+    except (OSError, ValueError) as exc:
+        parser.exit(2, f"{exc}\n")
+    print(json.dumps(receipt, sort_keys=True))  # noqa: T201
+    return 0 if receipt["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/agent_tasks/manifest.py
+++ b/benchmarks/agent_tasks/manifest.py
@@ -1,0 +1,248 @@
+"""Frozen inputs and declared split boundaries for trusted development tasks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import stat
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+SCHEMA_VERSION = "sibyl-agent-task-manifest-v1"
+DIGEST_PATTERN = r"^[0-9a-f]{64}$"
+IDENTIFIER_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$"
+FIXED_ENVIRONMENT = {"LANG": "C", "PYTHONHASHSEED": "0"}
+
+
+class ManifestError(ValueError):
+    """The experiment does not match its declared frozen inputs."""
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def identity(value: Any) -> str:
+    return digest(canonical_bytes(value))
+
+
+def relative_path(value: str) -> str:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or path.as_posix() != value
+        or any(part in {".", ".."} for part in path.parts)
+        or "\\" in value
+        or "\x00" in value
+    ):
+        raise ValueError("expected a canonical relative file path")
+    return value
+
+
+class FrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class Artifact(FrozenModel):
+    path: str
+    sha256: str = Field(pattern=DIGEST_PATTERN)
+
+    _path = field_validator("path")(relative_path)
+
+
+class WorkspaceFile(FrozenModel):
+    artifact: Artifact
+    destination: str
+    mode: Literal[420, 493] = 420  # Regular files and executable scripts only.
+
+    _destination = field_validator("destination")(relative_path)
+
+
+class Program(FrozenModel):
+    script: Artifact
+    args: list[str] = Field(default_factory=list)
+
+
+class Experience(FrozenModel):
+    id: str = Field(pattern=IDENTIFIER_PATTERN)
+    family_id: str = Field(pattern=IDENTIFIER_PATTERN)
+    split: Literal["learning", "development", "sealed"]
+    revision: str = Field(min_length=1)
+    artifact: Artifact
+
+
+class Task(FrozenModel):
+    id: str = Field(pattern=IDENTIFIER_PATTERN)
+    family_id: str = Field(pattern=IDENTIFIER_PATTERN)
+    split: Literal["development", "sealed"]
+    prompt: Artifact
+    workspace: list[WorkspaceFile]
+    checker: Program
+
+
+class Arm(FrozenModel):
+    id: str = Field(pattern=IDENTIFIER_PATTERN)
+    memory_pack: Artifact
+    learning_source_ids: list[str]
+
+
+class ControllerBudget(FrozenModel):
+    input_tokens: int = Field(ge=0)
+    output_tokens: int = Field(ge=0)
+    tool_calls: int = Field(ge=0)
+    cost_usd: float = Field(ge=0, allow_inf_nan=False)
+
+
+class Manifest(FrozenModel):
+    schema_version: Literal["sibyl-agent-task-manifest-v1"]
+    experiment_id: str = Field(pattern=IDENTIFIER_PATTERN)
+    purpose: Literal["trusted_development"]
+    runtime_sha256: str = Field(pattern=DIGEST_PATTERN)
+    dependency_lock: Artifact
+    seed: int = Field(ge=0)
+    controller: Program
+    controller_model: str = Field(min_length=1)
+    controller_tools: list[str]
+    controller_budget: ControllerBudget
+    controller_timeout_seconds: float = Field(gt=0, allow_inf_nan=False)
+    checker_timeout_seconds: float = Field(gt=0, allow_inf_nan=False)
+    experiences: list[Experience]
+    tasks: list[Task] = Field(min_length=1)
+    arms: list[Arm] = Field(min_length=1)
+
+
+def runtime_identity() -> dict[str, Any]:
+    """Bind the actual interpreter, OS and explicit subprocess environment."""
+    return {
+        "python": sys.version,
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "interpreter_sha256": digest(Path(sys.executable).resolve().read_bytes()),
+        "environment": FIXED_ENVIRONMENT,
+        "process_inspector_sha256": digest(Path("/bin/ps").read_bytes()),
+    }
+
+
+def read_artifact(root: Path, artifact: Artifact) -> bytes:
+    path = root
+    for part in PurePosixPath(artifact.path).parts:
+        path /= part
+        if path.is_symlink():
+            raise ManifestError(f"symlink input: {artifact.path}")
+    if not stat.S_ISREG(path.stat().st_mode):
+        raise ManifestError(f"non-file input: {artifact.path}")
+    content = path.read_bytes()
+    if digest(content) != artifact.sha256:
+        raise ManifestError(f"changed input: {artifact.path}")
+    return content
+
+
+def _unique(values: list[str], label: str) -> None:
+    if len(set(values)) != len(values):
+        raise ManifestError(f"duplicate {label}")
+
+
+def validate_partitions(manifest: Manifest) -> None:
+    _unique([item.id for item in manifest.tasks], "task ID")
+    _unique([item.id for item in manifest.arms], "arm ID")
+    _unique([item.id for item in manifest.experiences], "experience ID")
+    families: dict[str, str] = {}
+    contents: dict[str, str] = {}
+    for item in [*manifest.experiences, *manifest.tasks]:
+        for key, index in (
+            (item.family_id, families),
+            ((item.artifact if isinstance(item, Experience) else item.prompt).sha256, contents),
+        ):
+            if key in index and index[key] != item.split:
+                raise ManifestError("family or exact content overlaps experiment splits")
+            index[key] = item.split
+    experiences = {item.id: item for item in manifest.experiences}
+    nonlearning_hashes = {
+        item.artifact.sha256 for item in manifest.experiences if item.split != "learning"
+    }
+    for task in manifest.tasks:
+        nonlearning_hashes.update([task.prompt.sha256, task.checker.script.sha256])
+        nonlearning_hashes.update(item.artifact.sha256 for item in task.workspace)
+    for arm in manifest.arms:
+        if arm.memory_pack.sha256 != digest(b"") and arm.memory_pack.sha256 in nonlearning_hashes:
+            raise ManifestError("memory pack overlaps a declared nonlearning artifact")
+        _unique(arm.learning_source_ids, "pack source")
+        if any(
+            source_id not in experiences or experiences[source_id].split != "learning"
+            for source_id in arm.learning_source_ids
+        ):
+            raise ManifestError("memory packs may reference only declared learning sources")
+    for task in manifest.tasks:
+        destinations = [item.destination for item in task.workspace]
+        _unique(destinations, "workspace destination")
+        if any(
+            other.startswith(f"{path}/")
+            for path in destinations
+            for other in destinations
+            if path != other
+        ):
+            raise ManifestError("workspace file/directory collision")
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ManifestError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_constant(value: str) -> None:
+    raise ManifestError(f"non-JSON numeric constant: {value}")
+
+
+def strict_json(content: bytes) -> Any:
+    """Reject ambiguous duplicate keys and JavaScript-only numeric constants."""
+    return json.loads(content, object_pairs_hook=_strict_object, parse_constant=_reject_constant)
+
+
+def load_manifest(path: Path) -> tuple[Manifest, dict[str, bytes]]:
+    """Verify every binding before execution and retain the exact verified bytes."""
+    if path.is_symlink():
+        raise ManifestError("manifest must not be a symlink")
+    manifest = Manifest.model_validate(strict_json(path.read_bytes()))
+    if manifest.runtime_sha256 != identity(runtime_identity()):
+        raise ManifestError("runtime identity differs from the frozen manifest")
+    validate_partitions(manifest)
+    artifacts = [manifest.dependency_lock, manifest.controller.script]
+    artifacts.extend(item.artifact for item in manifest.experiences)
+    artifacts.extend(arm.memory_pack for arm in manifest.arms)
+    for task in manifest.tasks:
+        artifacts.extend([task.prompt, task.checker.script])
+        artifacts.extend(item.artifact for item in task.workspace)
+    content: dict[str, bytes] = {}
+    for artifact in artifacts:
+        value = read_artifact(path.parent.resolve(), artifact)
+        if artifact.path in content and content[artifact.path] != value:
+            raise ManifestError("conflicting input bindings")
+        content[artifact.path] = value
+    for artifact in [
+        *(task.prompt for task in manifest.tasks),
+        *(arm.memory_pack for arm in manifest.arms),
+    ]:
+        try:
+            content[artifact.path].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ManifestError(
+                f"prompt and memory pack inputs require UTF-8: {artifact.path}"
+            ) from exc
+    for program in [manifest.controller, *(task.checker for task in manifest.tasks)]:
+        if any("\x00" in arg for arg in program.args):
+            raise ManifestError("program argument contains a null character")
+    return manifest, content

--- a/benchmarks/agent_tasks/runner.py
+++ b/benchmarks/agent_tasks/runner.py
@@ -1,0 +1,443 @@
+"""Run one trusted development task and independently check its final snapshot.
+
+Separate same-UID processes prevent accidental workspace mixing, not adversarial
+access. Receipts explicitly make no sealed-isolation or learning-benefit claim.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import stat
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from benchmarks.agent_tasks.manifest import (
+    FIXED_ENVIRONMENT,
+    Arm,
+    ControllerBudget,
+    FrozenModel,
+    Manifest,
+    ManifestError,
+    Task,
+    canonical_bytes,
+    digest,
+    identity,
+    load_manifest,
+    runtime_identity,
+    strict_json,
+)
+from pydantic import Field
+
+PROCESS_TABLE_COLUMNS = 2
+
+
+class UnsafeSnapshotError(ValueError):
+    """A workspace cannot be copied completely and faithfully."""
+
+
+class ProtocolError(ValueError):
+    """A controller or checker returned an invalid protocol object."""
+
+    def __init__(self, role: str, message: str) -> None:
+        super().__init__(message)
+        self.status = f"{role}_protocol_invalid"
+
+
+class ControllerResult(FrozenModel):
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    cost_usd: float | None = Field(default=None, ge=0, allow_inf_nan=False)
+    tool_calls: int | None = Field(default=None, ge=0)
+    model: str | None = None
+    synthetic: bool
+
+
+class CheckerResult(FrozenModel):
+    passed: bool
+    detail: str
+
+
+def _write_json(path: Path, value: Any) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    with temporary.open("xb") as handle:
+        handle.write(canonical_bytes(value) + b"\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _put(path: Path, content: bytes, mode: int = 420) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("xb") as handle:
+        handle.write(content)
+    path.chmod(mode)
+
+
+def _snapshot_entries(directory: Path) -> Iterator[Path]:
+    # glob/rglob suppress subtree enumeration errors. A hidden unreadable file
+    # must not disappear symmetrically from both sides of a parity comparison.
+    with os.scandir(directory) as scan:
+        entries = sorted(scan, key=lambda entry: entry.name)
+    for entry in entries:
+        yield Path(entry.path)
+        if entry.is_dir(follow_symlinks=False):
+            yield from _snapshot_entries(Path(entry.path))
+
+
+def snapshot(root: Path) -> tuple[list[dict[str, Any]], dict[str, bytes]]:
+    """Read every regular file and directory, failing on unreadable subtrees."""
+    try:
+        return _read_snapshot(root)
+    except OSError as exc:
+        raise UnsafeSnapshotError(f"cannot read complete task snapshot: {exc}") from exc
+
+
+def _read_snapshot(root: Path) -> tuple[list[dict[str, Any]], dict[str, bytes]]:
+    if root.is_symlink() or not root.is_dir():
+        raise UnsafeSnapshotError("snapshot root is not a real directory")
+    entries: list[dict[str, Any]] = [
+        {"path": ".", "kind": "directory", "mode": stat.S_IMODE(root.stat().st_mode)}
+    ]
+    contents: dict[str, bytes] = {}
+    for path in _snapshot_entries(root):
+        mode = path.lstat().st_mode
+        relative = path.relative_to(root).as_posix()
+        if stat.S_ISDIR(mode):
+            entries.append({"path": relative, "kind": "directory", "mode": stat.S_IMODE(mode)})
+            continue
+        if not stat.S_ISREG(mode) or path.is_symlink():
+            raise UnsafeSnapshotError("task snapshot contains a symlink or special file")
+        content = path.read_bytes()
+        permissions = stat.S_IMODE(mode)
+        if permissions & (stat.S_ISUID | stat.S_ISGID | stat.S_ISVTX):
+            raise UnsafeSnapshotError("task snapshot contains special permissions")
+        entries.append(
+            {"path": relative, "kind": "file", "sha256": digest(content), "mode": permissions}
+        )
+        contents[relative] = content
+    return entries, contents
+
+
+def _kill_group(pid: int) -> None:
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+
+
+def _group_quiescent(group_id: int, timeout: float = 5.0) -> bool:
+    """Zombies cannot mutate files; any other owned-group member blocks snapshots."""
+    deadline = time.monotonic() + timeout
+    while True:
+        processes = subprocess.run(
+            ["/bin/ps", "-axo", "pgid=,stat="],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+            env=FIXED_ENVIRONMENT,
+        )
+        live = any(
+            fields[0] == str(group_id) and not fields[1].startswith("Z")
+            for line in processes.stdout.splitlines()
+            if len(fields := line.split()) == PROCESS_TABLE_COLUMNS
+        )
+        if not live:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.01)
+
+
+def _execute(
+    *,
+    program: Path,
+    program_sha256: str,
+    args: list[str],
+    request: dict[str, Any],
+    workspace: Path,
+    output: Path,
+    role: str,
+    timeout: float,
+) -> dict[str, Any]:
+    if digest(program.read_bytes()) != program_sha256:
+        raise ManifestError("staged program differs from the frozen manifest")
+    started = time.monotonic()
+    environment = {
+        **FIXED_ENVIRONMENT,
+        "PATH": str(Path(sys.executable).resolve().parent),
+        "HOME": str(output / f"{role}-home"),
+        "TMPDIR": str(output / f"{role}-tmp"),
+    }
+    Path(environment["HOME"]).mkdir()
+    Path(environment["TMPDIR"]).mkdir()
+    request_path = output / f"{role}-request.json"
+    _write_json(request_path, request)
+    timed_out = False
+    with (
+        request_path.open("rb") as stdin,
+        (output / f"{role}-stdout.txt").open("xb") as stdout,
+        (output / f"{role}-stderr.txt").open("xb") as stderr,
+    ):
+        process = subprocess.Popen(  # noqa: S603
+            [sys.executable, "-I", str(program), *args],
+            cwd=workspace,
+            env=environment,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=True,
+        )
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+        finally:
+            # The parent may exit before its children. Stop the owned group
+            # before taking the artifact snapshot on either success or failure.
+            _kill_group(process.pid)
+            process.wait()
+    return {
+        "process_group_quiescent": _group_quiescent(process.pid),
+        "returncode": process.returncode,
+        "timed_out": timed_out,
+        "elapsed_seconds": time.monotonic() - started,
+        "stdout_sha256": digest((output / f"{role}-stdout.txt").read_bytes()),
+        "stderr_sha256": digest((output / f"{role}-stderr.txt").read_bytes()),
+        "request_sha256": digest(request_path.read_bytes()),
+    }
+
+
+def _read_protocol[Model: FrozenModel](output: Path, role: str, schema: type[Model]) -> Model:
+    try:
+        return schema.model_validate(strict_json((output / f"{role}-stdout.txt").read_bytes()))
+    except (OSError, ValueError) as exc:
+        raise ProtocolError(role, str(exc)) from exc
+
+
+def _controller_usage(output: Path) -> dict[str, Any]:
+    result = _read_protocol(output, "controller", ControllerResult)
+    complete = all(
+        value is not None
+        for value in (result.input_tokens, result.output_tokens, result.tool_calls, result.cost_usd)
+    )
+    return {**result.model_dump(), "complete": complete, "provenance": "controller_reported"}
+
+
+def _checked_snapshot(output: Path, workspace: Path) -> str:
+    inventory, contents = snapshot(workspace)
+    _write_json(output / "final-snapshot.json", inventory)
+    destination = output / "checker-workspace"
+    destination.mkdir()
+    for item in inventory:
+        path = destination / item["path"]
+        if item["kind"] == "directory":
+            path.mkdir(parents=True, exist_ok=True)
+        else:
+            _put(path, contents[item["path"]], item["mode"])
+    # Set directory modes after writes so read-only directories remain copyable.
+    for item in reversed(inventory):
+        if item["kind"] == "directory":
+            (destination / item["path"]).chmod(item["mode"])
+    copied, _ = snapshot(destination)
+    if copied != inventory:
+        raise UnsafeSnapshotError("checker snapshot differs from controller final state")
+    return identity(inventory)
+
+
+def _receipt(manifest: Manifest, task: Task, arm: Arm) -> dict[str, Any]:
+    return {
+        "schema_version": "sibyl-agent-task-receipt-v1",
+        "purpose": "trusted_development",
+        "experiment_id": manifest.experiment_id,
+        "comparison_group": "manifest_sha256 and task_sha256",
+        "sealed_isolation": False,
+        "learning_benefit_established": False,
+        "process_isolation": "owned_process_group_only_no_detached_process_guarantee",
+        "run_id": uuid4().hex,
+        "attempt_id": uuid4().hex,
+        "request_id": uuid4().hex,
+        "manifest_sha256": identity(manifest.model_dump(mode="json")),
+        "task_id": task.id,
+        "task_sha256": identity(task.model_dump(mode="json")),
+        "arm_id": arm.id,
+        "arm_sha256": identity(arm.model_dump(mode="json")),
+        "pack_id": arm.memory_pack.sha256,
+        "memory_pack_sha256": arm.memory_pack.sha256,
+        "runtime": runtime_identity(),
+        "runner_source_sha256": {
+            name: digest(Path(__file__).with_name(name).read_bytes())
+            for name in ("manifest.py", "runner.py", "__main__.py", "__init__.py")
+        },
+        "seed": manifest.seed,
+        "controller_identity_provenance": "hash_bound_script_declared_model_tools",
+        "seed_enforcement": "controller_request_only",
+        "controller_model": manifest.controller_model,
+        "controller_tools": manifest.controller_tools,
+        "controller_budget": manifest.controller_budget.model_dump(),
+        "budget_enforcement": "wall_time_enforced_other_budgets_checked_from_controller_report",
+        "budget_status": "unknown",
+        "started_at": datetime.now(UTC).isoformat(),
+        "status": "running",
+        "success": False,
+        "usage": {
+            "input_tokens": None,
+            "output_tokens": None,
+            "tool_calls": None,
+            "cost_usd": None,
+            "complete": False,
+            "provenance": "unavailable",
+        },
+    }
+
+
+def _budget_status(usage: dict[str, Any], budget: ControllerBudget) -> str:
+    limits = budget.model_dump()
+    if any(usage[key] is not None and usage[key] > limit for key, limit in limits.items()):
+        return "exceeded"
+    return "within_reported_budget" if usage["complete"] else "unknown"
+
+
+def _process_failure(process: dict[str, Any], role: str) -> str | None:
+    if not process["process_group_quiescent"]:
+        return f"{role}_cleanup_failed"
+    if process["timed_out"]:
+        return f"{role}_timeout"
+    if process["returncode"] != 0:
+        return f"{role}_failed"
+    return None
+
+
+def _check_task(manifest: Manifest, task: Task, output: Path, receipt: dict[str, Any]) -> None:
+    receipt["usage"] = _controller_usage(output)
+    if receipt["usage"]["model"] not in (None, manifest.controller_model):
+        raise ProtocolError("controller", "controller reported a different model than the manifest")
+    receipt["budget_status"] = _budget_status(receipt["usage"], manifest.controller_budget)
+    checker = _execute(
+        program=output / "inputs" / task.checker.script.path,
+        program_sha256=task.checker.script.sha256,
+        args=task.checker.args,
+        request={
+            "attempt_id": receipt["attempt_id"],
+            "snapshot_sha256": receipt["checker_input_snapshot_sha256"],
+        },
+        workspace=output / "checker-workspace",
+        output=output,
+        role="checker",
+        timeout=manifest.checker_timeout_seconds,
+    )
+    receipt["checker"] = checker
+    if failure := _process_failure(checker, "checker"):
+        receipt["status"] = failure
+        return
+    result = _read_protocol(output, "checker", CheckerResult)
+    receipt["outcome"] = result.model_dump()
+    receipt["success"] = result.passed and receipt["budget_status"] != "exceeded"
+    receipt["status"] = "passed" if result.passed else "task_failed"
+    if receipt["budget_status"] == "exceeded":
+        receipt["status"] = "controller_budget_exceeded"
+
+
+def _perform_attempt(
+    manifest: Manifest,
+    task: Task,
+    arm: Arm,
+    inputs: dict[str, bytes],
+    output: Path,
+    receipt: dict[str, Any],
+) -> None:
+    _write_json(output / "manifest.json", manifest.model_dump(mode="json"))
+    for name, content in inputs.items():
+        _put(output / "inputs" / name, content, 292)
+    workspace = output / "controller-workspace"
+    workspace.mkdir()
+    for item in task.workspace:
+        _put(workspace / item.destination, inputs[item.artifact.path], item.mode)
+    initial, _ = snapshot(workspace)
+    _write_json(output / "initial-snapshot.json", initial)
+    request = {
+        **{
+            key: receipt[key]
+            for key in (
+                "run_id",
+                "attempt_id",
+                "request_id",
+                "task_id",
+                "task_sha256",
+                "pack_id",
+                "seed",
+                "controller_model",
+                "controller_tools",
+                "controller_budget",
+            )
+        },
+        "prompt": inputs[task.prompt.path].decode(),
+        "memory_pack": inputs[arm.memory_pack.path].decode(),
+        "memory_pack_sha256": arm.memory_pack.sha256,
+    }
+    controller = _execute(
+        program=output / "inputs" / manifest.controller.script.path,
+        program_sha256=manifest.controller.script.sha256,
+        args=manifest.controller.args,
+        request=request,
+        workspace=workspace,
+        output=output,
+        role="controller",
+        timeout=manifest.controller_timeout_seconds,
+    )
+    receipt["controller"] = controller
+    _write_json(output / "receipt.json", receipt)
+    if not controller["process_group_quiescent"]:
+        receipt["status"] = "controller_cleanup_failed"
+        return
+    final_hash = _checked_snapshot(output, workspace)
+    receipt["controller_final_snapshot_sha256"] = final_hash
+    receipt["checker_input_snapshot_sha256"] = final_hash
+    if failure := _process_failure(controller, "controller"):
+        receipt["status"] = failure
+        return
+    _check_task(manifest, task, output, receipt)
+
+
+def run_task(manifest_path: Path, *, task_id: str, arm_id: str, output: Path) -> dict[str, Any]:
+    """Validate first; create one exclusive attempt with durable partial receipts."""
+    if os.name != "posix":
+        raise ManifestError("the trusted development adapter requires POSIX process groups")
+    manifest, inputs = load_manifest(manifest_path)
+    task = next((task for task in manifest.tasks if task.id == task_id), None)
+    arm = next((arm for arm in manifest.arms if arm.id == arm_id), None)
+    if task is None or arm is None:
+        raise ManifestError("unknown task or arm")
+    if task.split != "development":
+        raise ManifestError(
+            "sealed execution requires an isolated agent runtime; this adapter is development-only"
+        )
+    output = output.absolute()
+    if output.is_symlink():
+        raise ManifestError("attempt output must not be a symlink")
+    output = output.parent.resolve() / output.name
+    if output.is_relative_to(manifest_path.parent.resolve()):
+        raise ManifestError("attempt output must be outside the frozen input directory")
+    output.mkdir(parents=False, exist_ok=False)
+    receipt = _receipt(manifest, task, arm)
+    _write_json(output / "receipt.json", receipt)
+    try:
+        _perform_attempt(manifest, task, arm, inputs, output, receipt)
+    except (ProtocolError, UnsafeSnapshotError) as exc:
+        receipt["status"] = exc.status if isinstance(exc, ProtocolError) else "unsafe_snapshot"
+        receipt["error"] = f"{type(exc).__name__}: {exc}"
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        receipt["status"] = "runner_error"
+        receipt["error"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        receipt["completed_at"] = datetime.now(UTC).isoformat()
+        receipt["receipt_sha256"] = identity(receipt)
+        _write_json(output / "receipt.json", receipt)
+    return receipt

--- a/moon.yml
+++ b/moon.yml
@@ -354,7 +354,7 @@ tasks:
 
   inventory-lint:
     script:
-      uv run ruff check tools benchmarks/provider_usage.py benchmarks/longmemeval_qa.py
+      uv run ruff check tools benchmarks/agent_tasks benchmarks/provider_usage.py benchmarks/longmemeval_qa.py
       benchmarks/local_execution_identity.py benchmarks/longmemeval_v2_official_source.py
       benchmarks/longmemeval_v2_release_authorization.py
       benchmarks/longmemeval_v2_release_authorization_package.py
@@ -407,7 +407,7 @@ tasks:
       benchmarks/longmemeval_v2_live_smoke.py
       benchmarks/longmemeval_v2_projection_audit.py
       benchmarks/longmemeval_v2_chunk_geometry benchmarks/usage_rerank
-      && uv run ruff format --check tools benchmarks/longmemeval_qa.py
+      && uv run ruff format --check tools benchmarks/agent_tasks benchmarks/longmemeval_qa.py
       benchmarks/local_execution_identity.py benchmarks/longmemeval_v2_official_source.py
       benchmarks/longmemeval_v2_release_authorization.py
       benchmarks/longmemeval_v2_release_authorization_package.py
@@ -461,6 +461,7 @@ tasks:
       benchmarks/longmemeval_v2_live_smoke.py benchmarks/longmemeval_v2_projection_audit.py
       benchmarks/usage_rerank
     inputs:
+      - benchmarks/agent_tasks/**/*.py
       - tools/**/*.py
       - benchmarks/provider_usage.py
       - benchmarks/longmemeval_qa.py
@@ -527,7 +528,7 @@ tasks:
 
   inventory-format:
     command:
-      uv run ruff format tools benchmarks/provider_usage.py benchmarks/longmemeval_qa.py
+      uv run ruff format tools benchmarks/agent_tasks benchmarks/provider_usage.py benchmarks/longmemeval_qa.py
       benchmarks/local_execution_identity.py benchmarks/longmemeval_v2_official_source.py
       benchmarks/longmemeval_v2_release_authorization.py
       benchmarks/longmemeval_v2_release_authorization_package.py
@@ -579,6 +580,7 @@ tasks:
       benchmarks/longmemeval_v2_live_smoke.py benchmarks/longmemeval_v2_projection_audit.py
       benchmarks/longmemeval_v2_chunk_geometry benchmarks/usage_rerank
     inputs:
+      - benchmarks/agent_tasks/**/*.py
       - tools/**/*.py
       - benchmarks/provider_usage.py
       - benchmarks/longmemeval_qa.py
@@ -644,7 +646,7 @@ tasks:
 
   inventory-typecheck:
     command:
-      uv run ty check tools benchmarks/longmemeval_qa.py benchmarks/local_execution_identity.py
+      uv run ty check tools benchmarks/agent_tasks benchmarks/longmemeval_qa.py benchmarks/local_execution_identity.py
       benchmarks/longmemeval_v2_official_source.py
       benchmarks/longmemeval_v2_release_authorization.py
       benchmarks/longmemeval_v2_release_authorization_package.py
@@ -698,6 +700,7 @@ tasks:
       benchmarks/usage_rerank/store.py
       benchmarks/usage_rerank/whatif.py
     inputs:
+      - benchmarks/agent_tasks/**/*.py
       - tools/**/*.py
       - benchmarks/git_provenance.py
       - benchmarks/longmemeval_qa.py
@@ -1032,9 +1035,23 @@ tasks:
     options:
       cache: false
 
+  agent-task-run:
+    command: uv run python -m benchmarks.agent_tasks
+    inputs:
+      - benchmarks/agent_tasks/**/*.py
+    options:
+      cache: false
+
+  agent-task-test:
+    command: uv run pytest tools/tests/test_agent_task_runner.py -v
+    inputs:
+      - benchmarks/agent_tasks/**/*.py
+      - tools/tests/test_agent_task_runner.py
+      - tools/tests/fixtures/agent_tasks/**/*.py
+
   bench-gate-test:
     command:
-      uv run pytest tools/tests/test_evidence_bundle.py
+      uv run pytest tools/tests/test_agent_task_runner.py tools/tests/test_evidence_bundle.py
       tools/tests/test_benchmark_git_provenance.py tools/tests/test_bench_gate.py
       tools/tests/test_compare_eval_reports.py tools/tests/test_context_pack_eval_script.py
       tools/tests/test_longmemeval_agentic_traversal.py
@@ -1069,6 +1086,7 @@ tasks:
       tools/tests/test_longmemeval_v2_release_cli.py -v
       tools/tests/test_longmemeval_v2_release_ci.py -v
     inputs:
+      - benchmarks/agent_tasks/**/*.py
       - tools/**/*.py
       - docker-compose.yml
       - .github/workflows/eval.yml

--- a/tools/tests/fixtures/agent_tasks/checker.py
+++ b/tools/tests/fixtures/agent_tasks/checker.py
@@ -1,0 +1,31 @@
+"""Independent fixture oracle, intentionally absent from controller input."""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+SHA256_HEX_LENGTH = 64
+
+request = json.load(sys.stdin)
+assert Path.cwd().name == "checker-workspace"
+assert len(request["snapshot_sha256"]) == SHA256_HEX_LENGTH
+mode = sys.argv[1] if len(sys.argv) > 1 else "check"
+if mode == "timeout":
+    time.sleep(30)
+if mode == "fail":
+    sys.stderr.write("intentional checker failure\n")
+    raise SystemExit(9)
+if mode == "malformed":
+    sys.stdout.write("not json")
+elif mode == "duplicate":
+    sys.stdout.write('{"passed":false,"passed":true,"detail":"conflicting verdict"}')
+elif mode == "deleted-private":
+    Path("private").chmod(0o700)
+    passed = not Path("private/retained.txt").exists()
+    sys.stdout.write(
+        json.dumps({"passed": passed, "detail": "private file must have been deleted"})
+    )
+else:
+    passed = Path("answer.txt").read_text() == "42"
+    sys.stdout.write(json.dumps({"passed": passed, "detail": "answer must be 42"}))

--- a/tools/tests/fixtures/agent_tasks/controller.py
+++ b/tools/tests/fixtures/agent_tasks/controller.py
@@ -1,0 +1,69 @@
+"""Deterministic process fixture; never calls a model or network service."""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+request = json.load(sys.stdin)
+mode = sys.argv[1] if len(sys.argv) > 1 else "success"
+assert "SIBYL_TEST_SECRET" not in os.environ
+assert "checker" not in request
+assert not Path("checker.py").exists()
+assert Path.cwd().name == "controller-workspace"
+if mode == "fail":
+    sys.stderr.write("intentional controller failure\n")
+    raise SystemExit(7)
+if mode == "timeout":
+    time.sleep(30)
+if mode in {"child", "orphan"}:
+    subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import time; from pathlib import Path; time.sleep(0.8); Path('late-child.txt').write_text('bad')",
+        ],
+    )
+    if mode == "child":
+        time.sleep(30)
+if mode == "directories":
+    Path("empty/subdir").mkdir(parents=True)
+    Path("empty").chmod(0o700)
+    Path(".").chmod(0o700)
+if mode == "unreadable":
+    Path("private").mkdir()
+    Path("private/retained.txt").write_text("must not disappear during snapshot")
+    Path("private").chmod(0)
+if mode == "tamper-checker":
+    checker = Path("../inputs/checker.py")
+    checker.chmod(0o600)
+    checker.write_text("raise SystemExit(0)")
+if mode == "symlink":
+    Path("unsafe").symlink_to("answer.txt")
+Path("answer.txt").write_text("wrong" if mode == "wrong" else request["memory_pack"])
+if mode == "malformed":
+    sys.stdout.write("not json")
+elif mode == "badusage":
+    sys.stdout.write('{"synthetic":true,"cost_usd":NaN}')
+elif mode == "duplicate":
+    sys.stdout.write(
+        '{"synthetic":true,"input_tokens":0,"output_tokens":0,"tool_calls":0,'
+        '"cost_usd":100,"cost_usd":0}'
+    )
+elif mode == "unknownusage":
+    sys.stdout.write('{"synthetic":true}')
+else:
+    sys.stdout.write(
+        json.dumps(
+            {
+                "synthetic": True,
+                "model": "deterministic-fixture",
+                "tool_calls": 1,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cost_usd": 0.0,
+            }
+        )
+    )

--- a/tools/tests/test_agent_task_runner.py
+++ b/tools/tests/test_agent_task_runner.py
@@ -1,0 +1,500 @@
+"""Actual process and snapshot checks for the trusted development task adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from benchmarks.agent_tasks.manifest import (
+    ManifestError,
+    digest,
+    identity,
+    runtime_identity,
+)
+from benchmarks.agent_tasks.runner import _group_quiescent, run_task
+
+CONTROLLER_FAILURE = 7
+
+FIXTURES = Path(__file__).parent / "fixtures" / "agent_tasks"
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    root = tmp_path / "frozen"
+    root.mkdir()
+
+    def artifact(name, content):
+        data = content.encode() if isinstance(content, str) else content
+        (root / name).write_bytes(data)
+        return {"path": name, "sha256": digest(data)}
+
+    manifest = {
+        "schema_version": "sibyl-agent-task-manifest-v1",
+        "purpose": "trusted_development",
+        "controller_model": "deterministic-fixture",
+        "controller_tools": ["write_file"],
+        "controller_budget": {
+            "input_tokens": 10,
+            "output_tokens": 10,
+            "tool_calls": 2,
+            "cost_usd": 0.0,
+        },
+        "experiment_id": "tiny-fixture",
+        "runtime_sha256": identity(runtime_identity()),
+        "seed": 3,
+        "dependency_lock": artifact("lock.json", "{}"),
+        "controller": {
+            "script": artifact("controller.py", (FIXTURES / "controller.py").read_bytes())
+        },
+        "controller_timeout_seconds": 3.0,
+        "checker_timeout_seconds": 3.0,
+        "experiences": [
+            {
+                "id": "source-one",
+                "family_id": "source-family",
+                "split": "learning",
+                "revision": "fixture-v1",
+                "artifact": artifact("experience.txt", "Observed evidence, not task answers."),
+            }
+        ],
+        "tasks": [
+            {
+                "id": "task-one",
+                "family_id": "task-family",
+                "split": "development",
+                "prompt": artifact("prompt.txt", "Use the supplied memory to update answer.txt."),
+                "workspace": [
+                    {"artifact": artifact("baseline.txt", "0"), "destination": "answer.txt"}
+                ],
+                "checker": {
+                    "script": artifact("checker.py", (FIXTURES / "checker.py").read_bytes())
+                },
+            }
+        ],
+        "arms": [
+            {
+                "id": "memory",
+                "memory_pack": artifact("memory.txt", "42"),
+                "learning_source_ids": ["source-one"],
+            }
+        ],
+    }
+    path = root / "manifest.json"
+
+    def freeze():
+        path.write_text(json.dumps(manifest))
+        return path
+
+    freeze()
+    return manifest, freeze, tmp_path / "attempt"
+
+
+def execute(experiment):
+    _, freeze, output = experiment
+    return run_task(freeze(), task_id="task-one", arm_id="memory", output=output)
+
+
+def test_controller_final_state_is_independently_checked(experiment, monkeypatch):
+    monkeypatch.setenv("SIBYL_TEST_SECRET", "must-not-reach-child")
+    receipt = execute(experiment)
+    _, freeze, output = experiment
+    assert receipt["success"]
+    assert receipt["status"] == "passed"
+    assert receipt["sealed_isolation"] is False
+    assert receipt["learning_benefit_established"] is False
+    assert (freeze().parent / "baseline.txt").read_text() == "0"
+    assert (output / "checker-workspace/answer.txt").read_text() == "42"
+    initial = json.loads((output / "initial-snapshot.json").read_text())
+    final = json.loads((output / "final-snapshot.json").read_text())
+    assert initial != final
+    assert (
+        receipt["checker_input_snapshot_sha256"]
+        == receipt["controller_final_snapshot_sha256"]
+        == identity(final)
+    )
+    assert receipt["usage"]["cost_usd"] == 0
+    assert receipt["usage"]["synthetic"] is True
+    assert receipt["usage"]["provenance"] == "controller_reported"
+    request = json.loads((output / "controller-request.json").read_text())
+    assert request["memory_pack"] == "42"
+    assert request["pack_id"] == receipt["pack_id"]
+    assert request["attempt_id"] == receipt["attempt_id"]
+    assert "checker" not in request
+    saved = json.loads((output / "receipt.json").read_text())
+    checksum = saved.pop("receipt_sha256")
+    assert checksum == identity(saved)
+
+
+@pytest.mark.parametrize(
+    ("role", "mode", "status"),
+    [
+        ("controller", "wrong", "task_failed"),
+        ("controller", "fail", "controller_failed"),
+        ("controller", "timeout", "controller_timeout"),
+        ("controller", "malformed", "controller_protocol_invalid"),
+        ("controller", "badusage", "controller_protocol_invalid"),
+        ("controller", "symlink", "unsafe_snapshot"),
+        ("checker", "fail", "checker_failed"),
+        ("checker", "timeout", "checker_timeout"),
+        ("checker", "malformed", "checker_protocol_invalid"),
+    ],
+)
+def test_failed_processes_keep_partial_receipts(experiment, role, mode, status):
+    manifest, _, output = experiment
+    program = manifest["controller"] if role == "controller" else manifest["tasks"][0]["checker"]
+    program["args"] = [mode]
+    if mode == "timeout":
+        manifest[f"{role}_timeout_seconds"] = 0.1
+    receipt = execute(experiment)
+    assert receipt["status"] == status
+    assert not receipt["success"]
+    assert (output / "receipt.json").exists()
+    assert (output / f"{role}-stdout.txt").exists()
+    assert (output / f"{role}-stderr.txt").exists()
+    if role == "controller" and mode == "fail":
+        assert receipt["controller"]["returncode"] == CONTROLLER_FAILURE
+        assert "checker" not in receipt
+
+
+def test_missing_usage_is_not_silently_zero(experiment):
+    experiment[0]["controller"]["args"] = ["unknownusage"]
+    receipt = execute(experiment)
+    assert receipt["success"]
+    assert receipt["usage"]["cost_usd"] is None
+    assert receipt["usage"]["input_tokens"] is None
+    assert receipt["usage"]["complete"] is False
+    assert receipt["budget_status"] == "unknown"
+
+
+def test_timeout_terminates_child_before_snapshot(experiment):
+    manifest, _, output = experiment
+    manifest["controller"]["args"] = ["child"]
+    manifest["controller_timeout_seconds"] = 0.2
+    receipt = execute(experiment)
+    assert receipt["status"] == "controller_timeout"
+    time.sleep(1.0)
+    assert not (output / "controller-workspace/late-child.txt").exists()
+    assert not (output / "checker-workspace/late-child.txt").exists()
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["baseline.txt", "controller.py", "checker.py", "memory.txt", "prompt.txt", "lock.json"],
+)
+def test_changed_frozen_inputs_fail_before_output(experiment, filename):
+    _, freeze, output = experiment
+    path = freeze()
+    (path.parent / filename).write_text("changed")
+    with pytest.raises(ManifestError, match="changed input"):
+        execute(experiment)
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    ("violation", "message"),
+    [
+        ("unknown", "Extra inputs are not permitted"),
+        ("family", "family or exact content overlaps"),
+        ("source", "only declared learning sources"),
+        ("sealed", "development-only"),
+        ("collision", "duplicate workspace destination"),
+        ("path", "canonical relative file path"),
+        ("runtime", "runtime identity differs"),
+    ],
+)
+def test_manifest_rejects_invalid_boundaries(experiment, violation, message):
+    manifest, _, output = experiment
+    if violation == "unknown":
+        manifest["unexpected"] = True
+    elif violation == "family":
+        manifest["tasks"][0]["family_id"] = "source-family"
+    elif violation == "source":
+        manifest["arms"][0]["learning_source_ids"] = ["undeclared"]
+    elif violation == "sealed":
+        manifest["tasks"][0]["split"] = "sealed"
+    elif violation == "collision":
+        manifest["tasks"][0]["workspace"] *= 2
+    elif violation == "path":
+        manifest["tasks"][0]["workspace"][0]["destination"] = "../escaped"
+    else:
+        manifest["runtime_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match=message):
+        execute(experiment)
+    assert not output.exists()
+
+
+def test_input_symlink_is_rejected(experiment):
+    _, freeze, output = experiment
+    path = freeze()
+    target = path.parent / "memory.txt"
+    target.unlink()
+    target.symlink_to("baseline.txt")
+    with pytest.raises(ManifestError, match="symlink"):
+        execute(experiment)
+    assert not output.exists()
+
+
+def test_output_collision_does_not_overwrite_receipt(experiment):
+    execute(experiment)
+    output = experiment[2]
+    before = (output / "receipt.json").read_bytes()
+    with pytest.raises(FileExistsError):
+        execute(experiment)
+    assert (output / "receipt.json").read_bytes() == before
+
+
+def test_cli_runs_the_actual_protocol(experiment):
+    _, freeze, output = experiment
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "benchmarks.agent_tasks",
+            "--manifest",
+            str(freeze()),
+            "--task",
+            "task-one",
+            "--arm",
+            "memory",
+            "--output",
+            str(output),
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["status"] == "passed"
+
+
+@pytest.mark.parametrize("limit", ["tool_calls", "input_tokens", "output_tokens", "cost_usd"])
+def test_reported_budget_excess_is_a_failure(experiment, limit):
+    manifest, _, output = experiment
+    manifest["controller_budget"][limit] = 0.0 if limit == "cost_usd" else 0
+    script = manifest["controller"]["script"]
+    path = experiment[1]().parent / script["path"]
+    content = path.read_text().replace('"' + limit + '": 0', '"' + limit + '": 1')
+    path.write_text(content)
+    script["sha256"] = digest(path.read_bytes())
+    receipt = execute(experiment)
+    assert receipt["status"] == "controller_budget_exceeded"
+    assert receipt["budget_status"] == "exceeded"
+    assert not receipt["success"]
+    assert receipt["outcome"]["passed"] is True
+    assert (output / "checker-stdout.txt").exists()
+
+
+def test_live_group_prevents_snapshot_publication(experiment, monkeypatch):
+    monkeypatch.setattr("benchmarks.agent_tasks.runner._group_quiescent", lambda group_id: False)
+    receipt = execute(experiment)
+    assert receipt["status"] == "controller_cleanup_failed"
+    assert "controller_final_snapshot_sha256" not in receipt
+    assert not (experiment[2] / "checker-workspace").exists()
+
+
+def test_successful_parent_cannot_leave_mutating_children(experiment):
+    experiment[0]["controller"]["args"] = ["orphan"]
+    receipt = execute(experiment)
+    assert receipt["success"]
+    assert receipt["controller"]["process_group_quiescent"] is True
+    time.sleep(1.0)
+    assert not (experiment[2] / "controller-workspace/late-child.txt").exists()
+
+
+def test_empty_directories_and_modes_reach_the_checker(experiment):
+    experiment[0]["controller"]["args"] = ["directories"]
+    receipt = execute(experiment)
+    assert receipt["success"]
+    checked = experiment[2] / "checker-workspace"
+    assert (checked / "empty/subdir").is_dir()
+    assert checked.stat().st_mode == (experiment[2] / "controller-workspace").stat().st_mode
+    assert (checked / "empty").stat().st_mode == (
+        experiment[2] / "controller-workspace/empty"
+    ).stat().st_mode
+
+
+def test_duplicate_json_keys_are_rejected(experiment):
+    path = experiment[1]()
+    path.write_text(path.read_text().replace('"seed": 3', '"seed": 3, "seed": 4'))
+    with pytest.raises(ManifestError, match="duplicate JSON key"):
+        run_task(path, task_id="task-one", arm_id="memory", output=experiment[2])
+
+
+def test_exact_content_cannot_cross_splits(experiment):
+    manifest, _, _ = experiment
+    manifest["experiences"][0]["artifact"] = manifest["tasks"][0]["prompt"]
+    with pytest.raises(ManifestError, match="exact content overlaps"):
+        execute(experiment)
+
+
+def test_output_parent_alias_cannot_write_into_frozen_inputs(experiment):
+    path = experiment[1]()
+    alias = experiment[2].parent / "input-alias"
+    alias.symlink_to(path.parent, target_is_directory=True)
+    with pytest.raises(ManifestError, match="outside the frozen input directory"):
+        run_task(path, task_id="task-one", arm_id="memory", output=alias / "attempt")
+    assert not (path.parent / "attempt").exists()
+
+
+@pytest.mark.parametrize("role", ["controller", "checker"])
+def test_duplicate_protocol_fields_cannot_publish_success(experiment, role):
+    manifest, _, output = experiment
+    program = manifest["controller"] if role == "controller" else manifest["tasks"][0]["checker"]
+    program["args"] = ["duplicate"]
+    receipt = execute(experiment)
+    assert receipt["status"] == f"{role}_protocol_invalid"
+    assert "duplicate JSON key" in receipt["error"]
+    assert receipt["success"] is False
+    assert (output / f"{role}-stdout.txt").read_text()
+    if role == "controller":
+        assert receipt["usage"]["cost_usd"] is None
+        assert "checker" not in receipt
+
+
+def test_unreadable_subtree_cannot_publish_lossy_success(experiment):
+    manifest, _, output = experiment
+    manifest["controller"]["args"] = ["unreadable"]
+    manifest["tasks"][0]["checker"]["args"] = ["deleted-private"]
+    receipt = execute(experiment)
+    private = output / "controller-workspace/private"
+    try:
+        assert receipt["success"] is False
+        if os.geteuid() != 0:
+            assert receipt["status"] == "unsafe_snapshot"
+            assert "cannot read complete task snapshot" in receipt["error"]
+            assert not (output / "checker-stdout.txt").exists()
+        else:
+            # Root can read mode000, so its faithful copy must fail the oracle.
+            assert receipt["status"] == "task_failed"
+    finally:
+        private.chmod(0o700)
+        checked = output / "checker-workspace/private"
+        if checked.exists():
+            checked.chmod(0o700)
+    assert (private / "retained.txt").read_text() == "must not disappear during snapshot"
+
+
+@pytest.mark.parametrize("artifact_kind", ["sealed_prompt", "checker", "workspace", "experience"])
+def test_pack_cannot_copy_known_nonlearning_bytes(experiment, artifact_kind):
+    manifest, freeze, output = experiment
+    task = manifest["tasks"][0]
+    if artifact_kind == "sealed_prompt":
+        artifact = manifest["arms"][0]["memory_pack"]
+        manifest["tasks"].append(
+            {
+                **task,
+                "id": "held-out",
+                "family_id": "held-out-family",
+                "split": "sealed",
+                "prompt": artifact,
+            }
+        )
+    elif artifact_kind == "checker":
+        artifact = task["checker"]["script"]
+    elif artifact_kind == "workspace":
+        artifact = task["workspace"][0]["artifact"]
+    else:
+        artifact = {"path": "held-out.txt", "sha256": digest(b"held-out evidence")}
+        (freeze().parent / artifact["path"]).write_bytes(b"held-out evidence")
+        manifest["experiences"].append(
+            {
+                "id": "held-out",
+                "family_id": "held-out-family",
+                "split": "sealed",
+                "revision": "v1",
+                "artifact": artifact,
+            }
+        )
+    manifest["arms"][0]["memory_pack"] = artifact
+    with pytest.raises(ManifestError, match="memory pack overlaps a declared nonlearning artifact"):
+        execute(experiment)
+    assert not output.exists()
+
+
+def test_live_process_group_blocks_until_killed():
+    process = subprocess.Popen(
+        [sys.executable, "-I", "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    try:
+        assert _group_quiescent(process.pid, timeout=0.1) is False
+    finally:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=5)
+    assert _group_quiescent(process.pid, timeout=1.0) is True
+
+
+def test_staged_checker_tamper_is_rejected_before_execution(experiment):
+    experiment[0]["controller"]["args"] = ["tamper-checker"]
+    receipt = execute(experiment)
+    assert receipt["status"] == "runner_error"
+    assert "staged program differs from the frozen manifest" in receipt["error"]
+    assert receipt["success"] is False
+    assert not (experiment[2] / "checker-stdout.txt").exists()
+
+
+def test_declared_nonlearning_source_reference_is_rejected(experiment):
+    experiment[0]["experiences"][0]["split"] = "development"
+    with pytest.raises(ManifestError, match="only declared learning sources"):
+        execute(experiment)
+    assert not experiment[2].exists()
+
+
+def test_nested_workspace_file_collision_is_rejected(experiment):
+    workspace = experiment[0]["tasks"][0]["workspace"]
+    workspace[0]["destination"] = "parent"
+    workspace.append({**workspace[0], "destination": "parent/child"})
+    with pytest.raises(ManifestError, match="workspace file/directory collision"):
+        execute(experiment)
+    assert not experiment[2].exists()
+
+
+@pytest.mark.parametrize("kind", ["prompt", "memory_pack"])
+def test_non_utf8_text_is_rejected_before_output(experiment, kind):
+    manifest, freeze, output = experiment
+    artifact = manifest["tasks"][0][kind] if kind == "prompt" else manifest["arms"][0][kind]
+    (freeze().parent / artifact["path"]).write_bytes(bytes([255]))
+    artifact["sha256"] = digest(bytes([255]))
+    with pytest.raises(ManifestError, match="prompt and memory pack inputs require UTF-8"):
+        execute(experiment)
+    assert not output.exists()
+
+
+def test_output_parent_alias_outside_inputs_is_supported(experiment):
+    _, freeze, output = experiment
+    alias = output.parent / "output-alias"
+    alias.symlink_to(output.parent, target_is_directory=True)
+    receipt = run_task(freeze(), task_id="task-one", arm_id="memory", output=alias / output.name)
+    assert receipt["success"] is True
+    assert (output / "receipt.json").exists()
+
+
+def test_empty_control_and_memory_arm_share_frozen_comparison(experiment):
+    manifest, freeze, output = experiment
+    root = freeze().parent
+    (root / "empty.txt").write_bytes(b"")
+    empty = {"path": "empty.txt", "sha256": digest(b"")}
+    # Empty baseline files cannot disqualify an empty no-memory control.
+    manifest["tasks"][0]["workspace"].append({"artifact": empty, "destination": "empty.txt"})
+    manifest["arms"].append({"id": "control", "memory_pack": empty, "learning_source_ids": []})
+    path = freeze()
+    memory = run_task(path, task_id="task-one", arm_id="memory", output=output)
+    control = run_task(
+        path, task_id="task-one", arm_id="control", output=output.with_name("control")
+    )
+    assert memory["status"] == "passed"
+    assert control["status"] == "task_failed"
+    assert control["success"] is False
+    for key in ("experiment_id", "manifest_sha256", "task_sha256", "controller_budget", "seed"):
+        assert memory[key] == control[key]
+    for key in ("arm_id", "pack_id", "attempt_id", "request_id"):
+        assert memory[key] != control[key]
+    assert control["pack_id"] == digest(b"")
+    assert (output.with_name("control") / "controller-request.json").exists()


### PR DESCRIPTION
Sibyl has retrieval and QA evals, but no task runner that connects a frozen memory pack to an independently checked task outcome. This adds a development adapter that runs a controller, snapshots its resulting workspace, and gives an exact copy to a separate checker.

A strict manifest binds the task, inputs, controller and checker scripts, memory pack, declared splits, runtime identity, and budgets. Each attempt gets an exclusive directory containing its input snapshots, subprocess output, final workspace inventory, and outcome receipt. The checker evaluates the controller's final state, including files, directories, and modes. Input changes, invalid protocol output, failed processes, unsafe snapshots, and known budget overruns remain failures with retained evidence.

The adapter is deliberately limited to trusted development tasks. It refuses sealed execution. Process groups isolate ordinary subprocess lifetimes; they do not provide an OS sandbox or protect hidden tests from an adversarial controller. Declared model/tools and controller-reported usage are labeled accordingly. Missing usage remains unknown, and no provider calls or learning-gain claims are introduced.

## 🧪 Validation

The 53 runner tests pass on macOS and Linux. Independent subprocess probes cover unreadable subtrees, duplicate protocol keys, known held-out content bindings, and non-finite JSON values. The checked workspace must match the controller snapshot before a checker can publish success. Root lint and type checks pass. Independent execution review and a separate cross-model source review found no remaining blocker within the trusted development boundary.
