### PR TITLE
feat(evals): bind task memory packs to retained render receipts

### DIFF
--- a/benchmarks/agent_tasks/manifest.py
+++ b/benchmarks/agent_tasks/manifest.py
@@ -93,6 +93,9 @@ class Arm(FrozenModel):
     id: str = Field(pattern=IDENTIFIER_PATTERN)
     memory_pack: Artifact
     learning_source_ids: list[str]
+    native_render_payload: Artifact | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
 
 
 class ControllerBudget(FrozenModel):
@@ -212,6 +215,43 @@ def strict_json(content: bytes) -> Any:
     return json.loads(content, object_pairs_hook=_strict_object, parse_constant=_reject_constant)
 
 
+def validate_native_render_binding(arm: Arm, inputs: dict[str, bytes]) -> None:
+    """Verify retained render provenance and the exact bytes supplied as memory.
+
+    No source is fetched here. Renderer consistency does not establish learning
+    source authenticity, completeness, or subsequent model consumption.
+    """
+    if arm.native_render_payload is None:
+        return
+    try:
+        payload_bytes = inputs[arm.native_render_payload.path]
+        memory = inputs[arm.memory_pack.path]
+    except KeyError as exc:
+        raise ManifestError("native render binding is missing a retained artifact") from exc
+    if (
+        digest(payload_bytes) != arm.native_render_payload.sha256
+        or digest(memory) != arm.memory_pack.sha256
+    ):
+        raise ManifestError("native render binding contains changed artifact bytes")
+    payload = strict_json(payload_bytes)
+    if not isinstance(payload, dict):
+        raise ManifestError("native render payload must be a full JSON object")
+    receipt = payload.get("render_receipt")
+    if not isinstance(receipt, dict) or receipt.get("schema_version") != "sibyl-context-render-v1":
+        raise ManifestError("native render claim requires a sibyl-context-render-v1 receipt")
+    markdown = payload.get("markdown")
+    if not isinstance(markdown, str):
+        raise ManifestError("native render payload requires Markdown text")
+
+    # Unattributed and empty controls do not depend on the core renderer.
+    from sibyl_core.tools.context_rendering import validate_context_render_payload  # noqa: PLC0415
+
+    if failures := validate_context_render_payload(payload):
+        raise ManifestError(f"invalid native render payload: {'; '.join(failures)}")
+    if markdown.encode("utf-8") != memory or receipt.get("markdown_sha256") != digest(memory):
+        raise ManifestError("native rendered Markdown differs from the exact memory pack")
+
+
 def load_manifest(path: Path) -> tuple[Manifest, dict[str, bytes]]:
     """Verify every binding before execution and retain the exact verified bytes."""
     if path.is_symlink():
@@ -223,6 +263,9 @@ def load_manifest(path: Path) -> tuple[Manifest, dict[str, bytes]]:
     artifacts = [manifest.dependency_lock, manifest.controller.script]
     artifacts.extend(item.artifact for item in manifest.experiences)
     artifacts.extend(arm.memory_pack for arm in manifest.arms)
+    artifacts.extend(
+        arm.native_render_payload for arm in manifest.arms if arm.native_render_payload
+    )
     for task in manifest.tasks:
         artifacts.extend([task.prompt, task.checker.script])
         artifacts.extend(item.artifact for item in task.workspace)
@@ -245,4 +288,6 @@ def load_manifest(path: Path) -> tuple[Manifest, dict[str, bytes]]:
     for program in [manifest.controller, *(task.checker for task in manifest.tasks)]:
         if any("\x00" in arg for arg in program.args):
             raise ManifestError("program argument contains a null character")
+    for arm in manifest.arms:
+        validate_native_render_binding(arm, content)
     return manifest, content

--- a/benchmarks/agent_tasks/runner.py
+++ b/benchmarks/agent_tasks/runner.py
@@ -253,6 +253,10 @@ def _checked_snapshot(output: Path, workspace: Path) -> str:
 
 
 def _receipt(manifest: Manifest, task: Task, arm: Arm) -> dict[str, Any]:
+    native_payload = arm.native_render_payload
+    provenance_status = "none" if arm.memory_pack.sha256 == digest(b"") else "unattributed"
+    if native_payload is not None:
+        provenance_status = "native_render_v1"
     return {
         "schema_version": "sibyl-agent-task-receipt-v1",
         "purpose": "trusted_development",
@@ -271,6 +275,11 @@ def _receipt(manifest: Manifest, task: Task, arm: Arm) -> dict[str, Any]:
         "arm_sha256": identity(arm.model_dump(mode="json")),
         "pack_id": arm.memory_pack.sha256,
         "memory_pack_sha256": arm.memory_pack.sha256,
+        "memory_provenance": {
+            "status": provenance_status,
+            "native_payload_sha256": native_payload.sha256 if native_payload else None,
+            "render_schema_version": "sibyl-context-render-v1" if native_payload else None,
+        },
         "runtime": runtime_identity(),
         "runner_source_sha256": {
             name: digest(Path(__file__).with_name(name).read_bytes())

--- a/moon.yml
+++ b/moon.yml
@@ -1045,6 +1045,7 @@ tasks:
   agent-task-test:
     command: uv run pytest tools/tests/test_agent_task_runner.py -v
     inputs:
+      - packages/python/sibyl-core/src/**/*.py
       - benchmarks/agent_tasks/**/*.py
       - tools/tests/test_agent_task_runner.py
       - tools/tests/fixtures/agent_tasks/**/*.py
@@ -1086,6 +1087,7 @@ tasks:
       tools/tests/test_longmemeval_v2_release_cli.py -v
       tools/tests/test_longmemeval_v2_release_ci.py -v
     inputs:
+      - packages/python/sibyl-core/src/**/*.py
       - benchmarks/agent_tasks/**/*.py
       - tools/**/*.py
       - docker-compose.yml

--- a/tools/tests/test_agent_task_runner.py
+++ b/tools/tests/test_agent_task_runner.py
@@ -8,16 +8,30 @@ import signal
 import subprocess
 import sys
 import time
+import unicodedata
+from dataclasses import asdict
 from pathlib import Path
 
 import pytest
 from benchmarks.agent_tasks.manifest import (
+    Arm,
+    Manifest,
     ManifestError,
     digest,
     identity,
     runtime_identity,
+    validate_native_render_binding,
 )
 from benchmarks.agent_tasks.runner import _group_quiescent, run_task
+
+from sibyl_core.models.context import (
+    ContextFacet,
+    ContextIntent,
+    ContextItem,
+    ContextPack,
+    ContextSection,
+)
+from sibyl_core.tools.context_rendering import render_context_pack
 
 CONTROLLER_FAILURE = 7
 
@@ -498,3 +512,280 @@ def test_empty_control_and_memory_arm_share_frozen_comparison(experiment):
         assert memory[key] != control[key]
     assert control["pack_id"] == digest(b"")
     assert (output.with_name("control") / "controller-request.json").exists()
+
+
+def native_payload(source_revision=7):
+    """Small Unicode rendering with actual core receipt generation."""
+    item = ContextItem(
+        id="source-record",
+        type="note",
+        name="Café 💜",
+        content="A verified observation. " * 30,
+        score=1.0,
+        facet=ContextFacet.DECISIONS,
+        reason="source",
+        source_revision=source_revision,
+    )
+    pack = ContextPack(
+        goal="Use frozen evidence",
+        intent=ContextIntent.GENERAL,
+        query="observation",
+        domain=None,
+        project=None,
+        sections=[ContextSection(ContextFacet.DECISIONS, "Decisions", [item])],
+        total_items=1,
+    )
+    rendered = render_context_pack(pack, max_content_chars=80)
+    return {
+        **asdict(pack),
+        "markdown": rendered.markdown,
+        "render_receipt": asdict(rendered.receipt),
+    }
+
+
+def bind_native_payload(experiment, payload, *, memory=None):
+    """Freeze a sidecar and a hash-checking fixture oracle outside the workspace."""
+    manifest, freeze, _ = experiment
+    root = freeze().parent
+    packed = payload["markdown"].encode() if memory is None else memory
+    data = json.dumps(payload, default=str).encode()
+    (root / "native.json").write_bytes(data)
+    (root / "memory.txt").write_bytes(packed)
+    arm = manifest["arms"][0]
+    arm["memory_pack"]["sha256"] = digest(packed)
+    arm["native_render_payload"] = {"path": "native.json", "sha256": digest(data)}
+    checker = (
+        "import hashlib,json,sys\nfrom pathlib import Path\njson.load(sys.stdin)\n"
+        f"passed=hashlib.sha256(Path('answer.txt').read_bytes()).hexdigest()=={digest(packed)!r}\n"
+        "print(json.dumps({'passed':passed,'detail':'exact supplied bytes'}))\n"
+    ).encode()
+    (root / "checker.py").write_bytes(checker)
+    manifest["tasks"][0]["checker"]["script"]["sha256"] = digest(checker)
+    return arm
+
+
+def test_native_binding_automatically_retains_input_outside_controller_workspace(experiment):
+    payload = native_payload()
+    arm = bind_native_payload(experiment, payload)
+    receipt = execute(experiment)
+    output = experiment[2]
+    assert receipt["success"] is True
+    request = json.loads((output / "controller-request.json").read_text())
+    assert request["memory_pack"].encode() == payload["markdown"].encode()
+    assert (
+        receipt["pack_id"] == request["memory_pack_sha256"] == digest(payload["markdown"].encode())
+    )
+    assert receipt["memory_provenance"] == {
+        "status": "native_render_v1",
+        "native_payload_sha256": arm["native_render_payload"]["sha256"],
+        "render_schema_version": "sibyl-context-render-v1",
+    }
+    assert receipt["memory_provenance"]["native_payload_sha256"] != request["memory_pack_sha256"]
+    assert "native_render_payload" not in request
+    assert not (output / "controller-workspace/native.json").exists()
+    retained = {
+        name: (output / "inputs" / name).read_bytes() for name in ("native.json", "memory.txt")
+    }
+    validate_native_render_binding(Arm.model_validate(arm), retained)
+    retained["native.json"] += b"\n"
+    with pytest.raises(ManifestError, match="changed artifact bytes"):
+        validate_native_render_binding(Arm.model_validate(arm), retained)
+
+
+@pytest.mark.parametrize("missing", ["native.json", "memory.txt"])
+def test_native_binding_replay_rejects_missing_retained_artifact(experiment, missing):
+    arm = bind_native_payload(experiment, native_payload())
+    root = experiment[1]().parent
+    retained = {
+        name: (root / name).read_bytes()
+        for name in ("native.json", "memory.txt")
+        if name != missing
+    }
+    with pytest.raises(ManifestError, match="missing a retained artifact"):
+        validate_native_render_binding(Arm.model_validate(arm), retained)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing",
+        "null",
+        "version",
+        "receipt_only",
+        "list",
+        "string",
+        "number",
+        "no_markdown",
+        "item",
+        "revision",
+        "span",
+        "input_hash",
+        "disposition",
+        "options",
+    ],
+)
+def test_native_provenance_tamper_fails_before_process_or_output(experiment, monkeypatch, mutation):
+    payload = native_payload()
+    arm = bind_native_payload(experiment, payload)
+    if mutation == "missing":
+        del payload["render_receipt"]
+    elif mutation == "null":
+        payload["render_receipt"] = None
+    elif mutation == "version":
+        payload["render_receipt"]["schema_version"] = "sibyl-context-render-v9"
+    elif mutation == "receipt_only":
+        payload = {"render_receipt": payload["render_receipt"]}
+    elif mutation in {"list", "string", "number"}:
+        payload = {"list": [], "string": "x", "number": 5}[mutation]
+    elif mutation == "no_markdown":
+        del payload["markdown"]
+    elif mutation == "item":
+        payload["sections"][0]["items"][0]["content"] = "Different source"
+    elif mutation == "revision":
+        payload["sections"][0]["items"][0]["source_revision"] = 9
+    elif mutation == "span":
+        payload["render_receipt"]["spans"][0]["start_byte"] += 1
+    elif mutation == "input_hash":
+        payload["render_receipt"]["spans"][0]["input_sha256"] = "0" * 64
+    elif mutation == "disposition":
+        payload["render_receipt"]["dispositions"] = []
+    elif mutation == "options":
+        payload["render_receipt"]["options"]["max_content_chars"] = 1000
+    data = json.dumps(payload, default=str).encode()
+    (experiment[1]().parent / "native.json").write_bytes(data)
+    arm["native_render_payload"]["sha256"] = digest(data)
+
+    def forbidden_process(*args, **kwargs):
+        pytest.fail("preflight launched a controller")
+
+    monkeypatch.setattr(subprocess, "Popen", forbidden_process)
+    with pytest.raises(ManifestError, match="native render"):
+        execute(experiment)
+    assert not experiment[2].exists()
+
+
+@pytest.mark.parametrize("change", ["newline", "crlf", "space", "normalization", "empty"])
+def test_native_memory_join_is_exact_bytes(experiment, change):
+    payload = native_payload()
+    text = payload["markdown"]
+    changed = {
+        "newline": text + "\n",
+        "crlf": text.replace("\n", "\r\n"),
+        "space": text + " ",
+        "normalization": unicodedata.normalize("NFD", text),
+        "empty": "",
+    }[change]
+    assert changed != text
+    bind_native_payload(experiment, payload, memory=changed.encode())
+    with pytest.raises(ManifestError, match="differs from the exact memory pack"):
+        execute(experiment)
+    assert not experiment[2].exists()
+
+
+@pytest.mark.parametrize("explicit_null", [False, True])
+def test_legacy_manifest_and_arm_identity_remain_unchanged(experiment, explicit_null):
+    manifest, _, output = experiment
+    if explicit_null:
+        manifest["arms"][0]["native_render_payload"] = None
+    fixed = {**manifest, "runtime_sha256": "0" * 64}
+    parsed = Manifest.model_validate(fixed)
+    assert (
+        identity(parsed.model_dump(mode="json"))
+        == "0594a4ab474830ceeb267a2252127dd409b1bbd6248ac8d4a79062068b7cecea"
+    )
+    assert (
+        identity(parsed.arms[0].model_dump(mode="json"))
+        == "3b766c6d9ecb19c85a506e3defa112909c774d19e3b429300040674c9803754f"
+    )
+    receipt = execute(experiment)
+    assert receipt["memory_provenance"]["status"] == "unattributed"
+    assert (
+        "native_render_payload" not in json.loads((output / "manifest.json").read_text())["arms"][0]
+    )
+
+
+def test_empty_control_does_not_claim_native_provenance(experiment):
+    manifest, freeze, _ = experiment
+    (freeze().parent / "memory.txt").write_bytes(b"")
+    manifest["arms"][0]["memory_pack"]["sha256"] = digest(b"")
+    manifest["arms"][0]["learning_source_ids"] = []
+    receipt = execute(experiment)
+    assert receipt["memory_provenance"] == {
+        "status": "none",
+        "native_payload_sha256": None,
+        "render_schema_version": None,
+    }
+
+
+@pytest.mark.parametrize("claimed", [False, True])
+def test_manifest_preflight_imports_core_only_for_claims(experiment, claimed):
+    if claimed:
+        bind_native_payload(experiment, native_payload())
+    script = (
+        "import importlib.abc,sys\n"
+        "class RejectCore(importlib.abc.MetaPathFinder):\n"
+        " def find_spec(self,fullname,path=None,target=None):\n"
+        "  if fullname=='sibyl_core' or fullname.startswith('sibyl_core.'):\n"
+        "   raise RuntimeError('unexpected core import')\n"
+        "sys.meta_path.insert(0,RejectCore())\n"
+        "from pathlib import Path\n"
+        "from benchmarks.agent_tasks.manifest import load_manifest\n"
+        "load_manifest(Path(sys.argv[1]))\n"
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script, str(experiment[1]())],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if claimed:
+        assert result.returncode != 0
+        assert "unexpected core import" in result.stderr
+    else:
+        assert result.returncode == 0, result.stderr
+
+
+def test_native_claim_changes_arm_and_manifest_identity(experiment):
+    before = Manifest.model_validate(experiment[0])
+    bind_native_payload(experiment, native_payload())
+    after = Manifest.model_validate(experiment[0])
+    assert identity(before.model_dump(mode="json")) != identity(after.model_dump(mode="json"))
+    assert identity(before.arms[0].model_dump(mode="json")) != identity(
+        after.arms[0].model_dump(mode="json")
+    )
+    assert after.arms[0].model_dump(mode="json")["native_render_payload"] is not None
+
+
+def test_native_binding_keeps_unavailable_source_revisions(experiment):
+    payload = native_payload(source_revision=None)
+    bind_native_payload(experiment, payload)
+    receipt = execute(experiment)
+    assert receipt["success"] is True
+    retained = json.loads((experiment[2] / "inputs/native.json").read_text())
+    assert all(span["source_revision"] is None for span in retained["render_receipt"]["spans"])
+    assert all(
+        span["revision_status"] == "unavailable" for span in retained["render_receipt"]["spans"]
+    )
+
+
+@pytest.mark.parametrize("mutation", ["duplicate", "nan", "file_hash"])
+def test_native_sidecar_bytes_fail_preflight(experiment, monkeypatch, mutation):
+    payload = native_payload()
+    arm = bind_native_payload(experiment, payload)
+    data = json.dumps(payload, default=str).encode()
+    if mutation == "duplicate":
+        data = data[:-1] + b',"markdown":"duplicate"}'
+    elif mutation == "nan":
+        data = data[:-1] + b',"extra":NaN}'
+    (experiment[1]().parent / "native.json").write_bytes(data)
+    arm["native_render_payload"]["sha256"] = "0" * 64 if mutation == "file_hash" else digest(data)
+
+    def forbidden_process(*args, **kwargs):
+        pytest.fail("invalid sidecar launched a controller")
+
+    monkeypatch.setattr(subprocess, "Popen", forbidden_process)
+    with pytest.raises(
+        ManifestError, match=r"duplicate JSON key|non-JSON numeric constant|changed input"
+    ):
+        execute(experiment)
+    assert not experiment[2].exists()


### PR DESCRIPTION
A checked task outcome is useful only if we can identify the memory text supplied to its controller. This lets a development task arm bind its memory pack to a retained native context payload before execution.

An optional payload artifact is an explicit provenance claim. Preflight requires the v1 rendering receipt, replays its retained inputs, and compares its Markdown byte for byte with the memory pack. The payload file and memory text keep separate hashes. The existing attempt directory retains the payload outside the controller workspace; the controller receives the same text/hash protocol as before.

Unattributed packs and empty controls remain supported. Omitting the optional field preserves existing manifest and arm hashes. The binding proves rendering consistency and delivery to the controller protocol, not source authenticity, model consumption, or learning benefit. Sealed execution remains unsupported by this trusted development runner.

## 🧪 Validation

All 85 runner cases pass on the integrated branch, including rejection of malformed claims, changed source snapshots, byte mismatches, and changed artifact hashes before execution. Independent probes also pass, including original-module checks of the historical manifest hashes. An offline integration passes the actual retained 12,142-byte API Markdown through a subprocess and validates the restored payload without a service or model call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for native-rendered memory payloads, including integrity, format, schema, and exact content checks.
  * Added memory provenance details to execution receipts, including render schema and payload digest when available.
  * Native payloads now retain required input artifacts for reliable replay.

* **Bug Fixes**
  * Invalid, missing, tampered, or mismatched payloads are rejected before execution.

* **Tests**
  * Expanded coverage for native binding, provenance, replay integrity, legacy compatibility, and preflight validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->