### PR TITLE
fix(memory): require retained sources before reflection promotion

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Sequence
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -975,6 +976,16 @@ async def _resolve_reflection_promotion_plan(
         organization_id=organization_id,
         raw_source_ids=raw_source_ids,
     )
+    required_source_ids = set(raw_source_ids)
+    loaded_source_ids = {source.id for source in source_memories}
+    if candidate_memory.source_id in required_source_ids and re.fullmatch(
+        r"reflection:input:[0-9a-f]{16}", candidate_memory.source_id
+    ):
+        # Explicit unretained input anchors carry no stored source or revision.
+        # Present rows still participate in the authorization/lifecycle checks below.
+        required_source_ids.remove(candidate_memory.source_id)
+        loaded_source_ids.discard(candidate_memory.source_id)
+    sources_complete = required_source_ids == loaded_source_ids
     raw_source_ids = raw_source_ids or [candidate_memory.id]
     input_memories = [candidate_memory, *source_memories]
 
@@ -998,7 +1009,7 @@ async def _resolve_reflection_promotion_plan(
     if source_scope_denial is not None:
         return source_scope_denial
 
-    if any(not raw_memory_recallable(memory) for memory in input_memories):
+    if not sources_complete or any(not raw_memory_recallable(memory) for memory in input_memories):
         return _promotion_denied(
             candidate_id=candidate_memory.id,
             reason="source_not_recallable",

--- a/packages/python/sibyl-core/tests/test_memory.py
+++ b/packages/python/sibyl-core/tests/test_memory.py
@@ -166,6 +166,120 @@ async def test_preview_review_candidate_returns_missing_without_write(
     save.assert_not_awaited()
 
 
+@pytest.mark.parametrize(
+    ("source_state", "missing", "reason"),
+    [
+        ("available", True, "source_not_recallable"),
+        ("revoked", False, "source_not_recallable"),
+        ("other_owner", True, "principal_mismatch"),
+    ],
+)
+async def test_preview_review_source_completeness_preserves_lifecycle_and_owner_denials(
+    monkeypatch: pytest.MonkeyPatch, source_state: str, missing: bool, reason: str
+) -> None:
+    source_ids = ["source-1", "missing"] if missing else ["source-1"]
+    candidate = _raw_review_candidate(
+        metadata={**_raw_review_candidate().metadata, "raw_source_ids": source_ids}
+    )
+    source = _raw_import_memory(
+        id="source-1",
+        principal_id="other-user" if source_state == "other_owner" else "user-1",
+        metadata={"lifecycle_state": "revoked"} if source_state == "revoked" else {},
+    )
+    monkeypatch.setattr(
+        reflection_module, "get_raw_memory", AsyncMock(side_effect=[candidate, source, None])
+    )
+    reserve = AsyncMock()
+    monkeypatch.setattr(reflection_module, "_reserve_promotion", reserve)
+
+    result = await preview_reflection_candidate_promotion(
+        candidate_id=candidate.id,
+        organization_id="org-1",
+        principal_id="user-1",
+        promote_to_scope="project",
+        promote_to_scope_key="project_123",
+        accessible_projects={"project_123"},
+    )
+
+    assert not result.allowed
+    assert result.reason == reason
+    assert result.raw_source_ids == source_ids
+    reserve.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("source_id", "declared"),
+    [
+        ("reflection:input:0123456789abcde", ["reflection:input:0123456789abcde"]),
+        ("reflection:input:0123456789abcdef0", ["reflection:input:0123456789abcdef0"]),
+        ("reflection:input:0123456789abcdeg", ["reflection:input:0123456789abcdeg"]),
+        ("reflection:input:0123456789ABCDEF", ["reflection:input:0123456789ABCDEF"]),
+        ("reflection:input:0123456789abcdef\n", ["reflection:input:0123456789abcdef\n"]),
+        ("retained-source", ["reflection:input:0123456789abcdef"]),
+        (
+            "reflection:input:0123456789abcdef",
+            ["reflection:input:0123456789abcdef", "reflection:input:fedcba9876543210"],
+        ),
+        (
+            "reflection:input:0123456789abcdef",
+            ["reflection:input:0123456789abcdef", "missing-retained-source"],
+        ),
+    ],
+)
+async def test_review_input_anchor_does_not_exempt_other_or_malformed_sources(
+    monkeypatch: pytest.MonkeyPatch, source_id: str, declared: list[str]
+) -> None:
+    candidate = _raw_review_candidate(
+        source_id=source_id,
+        metadata={**_raw_review_candidate().metadata, "raw_source_ids": declared},
+    )
+    monkeypatch.setattr(
+        reflection_module,
+        "get_raw_memory",
+        AsyncMock(
+            side_effect=lambda **kwargs: candidate if kwargs["memory_id"] == candidate.id else None
+        ),
+    )
+    result = await preview_reflection_candidate_promotion(
+        candidate_id=candidate.id,
+        organization_id="org-1",
+        principal_id="user-1",
+        promote_to_scope="private",
+    )
+    assert not result.allowed
+    assert result.reason == "source_not_recallable"
+
+
+@pytest.mark.parametrize(
+    ("source_state", "reason"),
+    [("revoked", "source_not_recallable"), ("other_owner", "principal_mismatch")],
+)
+async def test_present_input_anchor_rows_still_require_lifecycle_and_ownership(
+    monkeypatch: pytest.MonkeyPatch, source_state: str, reason: str
+) -> None:
+    anchor = "reflection:input:0123456789abcdef"
+    candidate = _raw_review_candidate(
+        source_id=anchor,
+        metadata={**_raw_review_candidate().metadata, "raw_source_ids": [anchor]},
+    )
+    source = _raw_import_memory(
+        id=anchor,
+        principal_id="other-user" if source_state == "other_owner" else "user-1",
+        metadata={"lifecycle_state": "revoked"} if source_state == "revoked" else {},
+    )
+    monkeypatch.setattr(
+        reflection_module, "get_raw_memory", AsyncMock(side_effect=[candidate, source])
+    )
+    result = await preview_reflection_candidate_promotion(
+        candidate_id=candidate.id,
+        organization_id="org-1",
+        principal_id="user-1",
+        promote_to_scope="private",
+    )
+    assert not result.allowed
+    assert result.reason == reason
+
+
 @pytest.mark.asyncio
 async def test_preview_raw_memory_promotion_uses_write_policy_gate(
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/python/sibyl-core/tests/test_reflection_identity.py
+++ b/packages/python/sibyl-core/tests/test_reflection_identity.py
@@ -497,6 +497,156 @@ async def test_legacy_evidence_is_not_remapped(runtime: GraphRuntime) -> None:
     assert await runtime.entity_manager.get(legacy.id) == before
 
 
+@pytest.mark.parametrize("declared", ["one_missing", "all_missing", "foreign_organization"])
+async def test_review_promotion_requires_every_declared_source_before_reservation(
+    runtime: GraphRuntime,
+    content_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+    declared: str,
+) -> None:
+    from sibyl_core.services import memory_reflection
+
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="complete-source",
+        title="Present evidence",
+        raw_content="The first source exists and is recallable.",
+        embedding_provider=None,
+    )
+    missing_id = "missing-capture"
+    if declared == "foreign_organization":
+        foreign = await remember_raw_memory(
+            organization_id="other-organization",
+            principal_id="user_a",
+            source_id="foreign-source",
+            title="Foreign evidence",
+            raw_content="This source exists only in another organization.",
+            embedding_provider=None,
+        )
+        missing_id = foreign.id
+    source_ids = [missing_id] if declared == "all_missing" else [source.id, missing_id]
+    review = await remember_reflection_candidate_review(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        candidate=candidate(),
+        raw_source_ids=source_ids,
+    )
+    reserve = AsyncMock(wraps=memory_reflection._reserve_promotion)
+    persist = AsyncMock(wraps=memory_reflection.persist_reflection_candidate)
+    links = AsyncMock(wraps=runtime.relationship_manager.create_bulk)
+    monkeypatch.setattr(memory_reflection, "_reserve_promotion", reserve)
+    monkeypatch.setattr(memory_reflection, "persist_reflection_candidate", persist)
+    monkeypatch.setattr(runtime.relationship_manager, "create_bulk", links)
+
+    result = await promote_reflection_candidate_review(
+        candidate_id=review.id,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        promote_to_scope="project",
+        promote_to_scope_key="project_a",
+        accessible_projects={"project_a"},
+    )
+
+    assert not result.success
+    assert result.reason == "source_not_recallable"
+    assert result.promoted_id is None
+    assert result.raw_source_ids == source_ids
+    reserve.assert_not_awaited()
+    persist.assert_not_awaited()
+    links.assert_not_awaited()
+    assert (
+        await get_raw_memory(organization_id=runtime.client.group_id, memory_id=review.id) == review
+    )
+    assert (
+        await runtime.client.execute_query(
+            "SELECT VALUE uuid FROM entity WHERE entity_type != 'project';"
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize("declared", ["empty", "duplicate"])
+async def test_review_source_completeness_preserves_self_fallback_and_duplicates(
+    runtime: GraphRuntime, content_store: None, declared: str
+) -> None:
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="complete-source",
+        title="Present evidence",
+        raw_content="The declared evidence is complete.",
+        embedding_provider=None,
+    )
+    review = await remember_reflection_candidate_review(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        candidate=candidate(),
+        raw_source_ids=[] if declared == "empty" else [source.id, source.id],
+    )
+    result = await promote_reflection_candidate_review(
+        candidate_id=review.id,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        promote_to_scope="project",
+        promote_to_scope_key="project_a",
+        accessible_projects={"project_a"},
+    )
+    assert result.success
+    assert result.raw_source_ids == [review.id if declared == "empty" else source.id]
+
+
+@pytest.mark.parametrize("scope", ["private", "project"])
+async def test_unretained_reflection_input_can_be_reviewed_promoted_and_replayed(
+    runtime: GraphRuntime, content_store: None, scope: str
+) -> None:
+    from sibyl_core.services.reflection import ephemeral_reflection_source_id
+
+    content = "We decided to preserve explicit input provenance without retaining the source."
+    project = "project_a" if scope == "project" else None
+    pack = await reflect_memory(
+        content,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        project=project,
+        accessible_projects={"project_a"},
+        memory_scope=scope,
+        scope_key=project,
+        persist=True,
+        persist_source=False,
+        persist_review=True,
+    )
+    assert pack.source_id is None
+    assert pack.persisted_count == 1
+    anchor = ephemeral_reflection_source_id(content)
+    review_id = pack.candidates[0].persisted_id
+    review = await get_raw_memory(organization_id=runtime.client.group_id, memory_id=review_id)
+    assert review.source_id == anchor
+    assert review.metadata["raw_source_ids"] == [anchor]
+    assert await get_raw_memory(organization_id=runtime.client.group_id, memory_id=anchor) is None
+    kwargs = {
+        "candidate_id": review_id,
+        "organization_id": runtime.client.group_id,
+        "principal_id": "user_a",
+        "promote_to_scope": scope,
+        "promote_to_scope_key": project,
+        "accessible_projects": {"project_a"},
+    }
+    result = await promote_reflection_candidate_review(**kwargs)
+    assert result.success
+    assert result.raw_source_ids == [anchor]
+    entity = await runtime.entity_manager.get(str(result.promoted_id))
+    assert entity.metadata["raw_source_ids"] == [anchor]
+    assert entity.source_file == anchor
+    assert entity.metadata["reflection_identity"]["source_ids"] == [anchor]
+    assert entity.metadata["reflection_identity"]["primary_source_id"] == anchor
+    replay = await promote_reflection_candidate_review(**kwargs)
+    assert replay.success
+    assert replay.promoted_id == result.promoted_id
+    assert replay.raw_source_ids == [anchor]
+    assert await runtime.entity_manager.get(str(result.promoted_id)) == entity
+
+
 async def test_source_conflict_cannot_publish_orphan_candidates(runtime: GraphRuntime) -> None:
     from sibyl_core.services.memory_reflection import persist_reflection_source
 


### PR DESCRIPTION
Reflection promotion could accept a candidate whose declared source no longer existed. The source loader skipped missing rows, so later authorization and revision checks only saw the sources that remained.

The existing promotion plan now requires every declared retained source before publication. Missing inputs use the existing `source_not_recallable` denial after owner and scope checks, before reservation, graph writes, or relationships. An empty source list still uses the candidate itself; duplicate IDs remain valid.

Reviewing input without storing the original remains supported. The canonical `reflection:input:` alias is exempt only when it matches the candidate's structured source ID and exact generated format. Other declared IDs remain mandatory. A loaded alias row still receives the normal authorization and lifecycle checks. The alias stays in identity and provenance, without claiming a stored source or revision.

## 🧪 Validation

Embedded regression cases reject partial, wholly missing, and foreign-organization source sets without publication side effects. Actual private/project reflection, review, promotion and replay preserve the supported unretained-input workflow. Malformed aliases, secondary aliases, missing retained sources, and present but revoked or foreign-owner alias rows are covered.

Full remote suites pass: 2,924 core tests and 2,334 API tests, plus lint and type checks. Source hashes and import origins match the reviewed worktree. Independent static review found no blocker; parent execution spot-checks cover the refined admission paths.

The change protects declared inputs at promotion. It does not extend correction propagation through older review-derived or shared copies.
