### PR TITLE
fix(e2e): assert rendered readiness without network silence

### DIFF
--- a/apps/e2e/tests/browser/test_smoke.py
+++ b/apps/e2e/tests/browser/test_smoke.py
@@ -100,7 +100,7 @@ class TestFrontendBrowserContracts:
             "search seed",
         )
 
-        authenticated_page.goto("/search", wait_until="networkidle")
+        authenticated_page.goto("/search", wait_until="domcontentloaded")
         assert_path(authenticated_page, "/search")
         search_form = authenticated_page.get_by_role("main").locator("form").first
         search_form.get_by_label("Search", exact=True).fill(query)
@@ -133,7 +133,7 @@ class TestFrontendBrowserContracts:
         authenticated_page.get_by_role("button", name="Create Task", exact=True).click()
 
         expect(authenticated_page.get_by_text("Task created", exact=True)).to_be_visible()
-        authenticated_page.reload(wait_until="networkidle")
+        authenticated_page.reload(wait_until="domcontentloaded")
         assert_path(authenticated_page, "/tasks")
         task_heading = authenticated_page.get_by_role(
             "heading",


### PR DESCRIPTION
Browser smoke tests reached the search and task routes but timed out waiting for global network silence. Task creation had already passed its success assertion. These two navigation waits now use DOM readiness, matching the other smoke contracts, and leave the actual search result and persisted task assertions in place.

The change follows [Playwright's readiness guidance](https://playwright.dev/python/docs/api/class-page#page-goto). No timeout, retry, fixture, seeding, or application behavior changes. The failing job does not identify which request prevented network silence, so this fixes the test's readiness contract without claiming to diagnose that request.

## 🧪 Validation

A loopback Chromium probe passed five cases: both navigation and reload time out under network-idle waits with visible content and an unfinished background fetch; DOM readiness succeeds, and a missing-result assertion still fails. E2E lint and independent static review passed. Parent spot checks repeated the DOM-ready and missing-result cases and verified the reviewed file hash. Full application E2E remains a hosted merge gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated browser smoke tests to continue after the page reaches the DOM content loaded state, improving test flow reliability for search and task creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->