### PR TITLE
fix(context): preserve complete procedures in memory packs

### DIFF
--- a/apps/api/tests/test_server_accessible_projects.py
+++ b/apps/api/tests/test_server_accessible_projects.py
@@ -211,7 +211,7 @@ async def test_compile_mcp_context_pack_audits_render_receipt() -> None:
     assert result["markdown"].startswith("# Sibyl Context Pack")
     from sibyl_core.tools.context import validate_context_render_payload
 
-    assert result["render_receipt"]["schema_version"] == "sibyl-context-render-v1"
+    assert result["render_receipt"]["schema_version"] == "sibyl-context-render-v2"
     assert validate_context_render_payload(result) == []
     resolve_scope.assert_awaited_once_with(ctx, "project-a")
     compile_context.assert_awaited_once()

--- a/benchmarks/agent_tasks/manifest.py
+++ b/benchmarks/agent_tasks/manifest.py
@@ -237,8 +237,11 @@ def validate_native_render_binding(arm: Arm, inputs: dict[str, bytes]) -> None:
     if not isinstance(payload, dict):
         raise ManifestError("native render payload must be a full JSON object")
     receipt = payload.get("render_receipt")
-    if not isinstance(receipt, dict) or receipt.get("schema_version") != "sibyl-context-render-v1":
-        raise ManifestError("native render claim requires a sibyl-context-render-v1 receipt")
+    if not isinstance(receipt, dict) or receipt.get("schema_version") not in (
+        "sibyl-context-render-v1",
+        "sibyl-context-render-v2",
+    ):
+        raise ManifestError("native render claim requires a supported native render receipt")
     markdown = payload.get("markdown")
     if not isinstance(markdown, str):
         raise ManifestError("native render payload requires Markdown text")

--- a/benchmarks/agent_tasks/runner.py
+++ b/benchmarks/agent_tasks/runner.py
@@ -252,11 +252,16 @@ def _checked_snapshot(output: Path, workspace: Path) -> str:
     return identity(inventory)
 
 
-def _receipt(manifest: Manifest, task: Task, arm: Arm) -> dict[str, Any]:
+def _receipt(manifest: Manifest, task: Task, arm: Arm, inputs: dict[str, bytes]) -> dict[str, Any]:
     native_payload = arm.native_render_payload
+    render_schema = (
+        strict_json(inputs[native_payload.path])["render_receipt"]["schema_version"]
+        if native_payload
+        else None
+    )
     provenance_status = "none" if arm.memory_pack.sha256 == digest(b"") else "unattributed"
     if native_payload is not None:
-        provenance_status = "native_render_v1"
+        provenance_status = render_schema.replace("sibyl-context-", "native_").replace("-", "_")
     return {
         "schema_version": "sibyl-agent-task-receipt-v1",
         "purpose": "trusted_development",
@@ -281,7 +286,7 @@ def _receipt(manifest: Manifest, task: Task, arm: Arm) -> dict[str, Any]:
         "memory_provenance": {
             "status": provenance_status,
             "native_payload_sha256": native_payload.sha256 if native_payload else None,
-            "render_schema_version": "sibyl-context-render-v1" if native_payload else None,
+            "render_schema_version": render_schema,
         },
         "runtime": runtime_identity(),
         "runner_source_sha256": {
@@ -449,7 +454,7 @@ def run_task(manifest_path: Path, *, task_id: str, arm_id: str, output: Path) ->
     if output.is_relative_to(manifest_path.parent.resolve()):
         raise ManifestError("attempt output must be outside the frozen input directory")
     output.mkdir(parents=False, exist_ok=False)
-    receipt = _receipt(manifest, task, arm)
+    receipt = _receipt(manifest, task, arm, inputs)
     _write_json(output / "receipt.json", receipt)
     try:
         _perform_attempt(manifest, task, arm, inputs, output, receipt)

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context_rendering.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context_rendering.py
@@ -164,6 +164,7 @@ class _RenderedItem:
     lines: list[str]
     related: list[ContextRelatedItem]
     content_state: str
+    content_prefix: str | None = None
 
 
 def _render_item(
@@ -172,6 +173,7 @@ def _render_item(
     pack_project: str | None,
     max_content_chars: int,
     include_related: bool,
+    atomic_procedures: bool,
 ) -> _RenderedItem:
     status = _compact_metadata_value(item.metadata.get("status"))
     if item.type and status:
@@ -188,9 +190,20 @@ def _render_item(
     )
     quality_label = f" _{quality}_" if quality else ""
     lines = [f"- **{item.name}**{type_label} `{item.id}`{quality_label}"]
-    content, content_state = _render_content(item, max_content_chars)
-    if content is not None:
-        lines.append(f"  - Memory: {content}")
+    content_prefix = None
+    if atomic_procedures and item.type == "procedure" and item.content.strip():
+        # A procedure's conditions and indentation are part of its meaning.
+        # A longer fence keeps embedded Markdown fences inside this one block.
+        fence = "`" * max(
+            3, 1 + max((len(m[0]) for m in re.finditer(r"`+", item.content)), default=0)
+        )
+        content_prefix = f"  - Memory:\n\n{fence}markdown\n"
+        lines.append(f"{content_prefix}{item.content}\n{fence}")
+        content_state = "emitted"
+    else:
+        content, content_state = _render_content(item, max_content_chars)
+        if content is not None:
+            lines.append(f"  - Memory: {content}")
     related = (
         [
             candidate
@@ -205,7 +218,7 @@ def _render_item(
             f"{candidate.relationship} {candidate.name} ({candidate.type})" for candidate in related
         )
         lines.append(f"  - Related: {labels}")
-    return _RenderedItem(lines, related, content_state)
+    return _RenderedItem(lines, related, content_state, content_prefix)
 
 
 def _text_digest(text: str) -> str:
@@ -287,7 +300,9 @@ def _item_render_spans(
             start_byte=start,
             end_byte=start + len(block.encode()),
             input_sha256=_text_digest(snapshot),
-            transform="markdown_item_v1",
+            transform="markdown_item_v2"
+            if rendered_item.content_prefix is not None
+            else "markdown_item_v1",
         )
     ]
     name_start = start + len(b"- **")
@@ -303,7 +318,21 @@ def _item_render_spans(
             input_end_byte=len(item.name.encode()),
         )
     )
-    if len(lines) > 1 and lines[1].startswith("  - Memory: "):
+    if rendered_item.content_prefix is not None:
+        body_start = start + len((lines[0] + "\n" + rendered_item.content_prefix).encode())
+        spans.append(
+            ContextRenderSpan(
+                **common,
+                field="content",
+                start_byte=body_start,
+                end_byte=body_start + len(item.content.encode()),
+                input_sha256=_text_digest(item.content),
+                transform="identity",
+                input_start_byte=0,
+                input_end_byte=len(item.content.encode()),
+            )
+        )
+    elif len(lines) > 1 and lines[1].startswith("  - Memory: "):
         rendered = lines[1].removeprefix("  - Memory: ")
         visible = rendered[:-3] if rendered_item.content_state == "truncated" else rendered
         source_end = _compact_source_end(item.content, visible)
@@ -363,6 +392,7 @@ def render_context_pack(
     include_related: bool = True,
     token_budget: int | None = None,
     request_id: str | None = None,
+    schema_version: str = "sibyl-context-render-v2",
 ) -> RenderedContextPack:
     """Render a context pack as compact Markdown for agent injection.
 
@@ -371,11 +401,17 @@ def render_context_pack(
     depth both scale toward it: more of the pack's items render, and each is
     allowed more of its content, up to the hard ceilings. The per-block guard
     below is what keeps the result inside the budget, and it always emits at
-    least one item so a tight budget degrades to a minimal brief rather than an
-    empty pack. Without a budget the count defaults bind exactly as they always
-    have, because there is nothing to size against.
+    least one ordinary item. Procedures render verbatim and indivisibly in v2;
+    an over-budget procedure is omitted even when it is the first item. Without
+    a budget, count and per-item content limits still apply; oversized procedures
+    are omitted. Within an explicit budget, a high-ranked procedure may consume
+    the remaining pack allowance. Fences are standalone Markdown blocks so their
+    source bytes, including indentation, remain unchanged.
     """
 
+    if schema_version not in ("sibyl-context-render-v1", "sibyl-context-render-v2"):
+        raise ValueError("unsupported render receipt schema version")
+    atomic_procedures = schema_version == "sibyl-context-render-v2"
     options = ContextRenderOptions(
         max_items, items_per_section, max_content_chars, include_related, token_budget
     )
@@ -429,6 +465,8 @@ def render_context_pack(
     remaining = max_items
     emitted_items = 0
     trimmed = False
+    omitted_procedure = False
+    omitted_content = False
     for section in _sections_for_markdown(pack.sections, intent=pack.intent):
         if remaining <= 0 or trimmed:
             break
@@ -448,10 +486,32 @@ def render_context_pack(
                 pack_project=pack.project,
                 max_content_chars=max_content_chars,
                 include_related=include_related,
+                atomic_procedures=atomic_procedures,
             )
             item_lines = rendered_item.lines
             block = [*section_lines, *item_lines] if not section_emitted else item_lines
             block_chars = sum(len(line) + 1 for line in block)
+            index = section_offset + position
+            if (
+                rendered_item.content_prefix is not None
+                and char_budget is None
+                and len(item.content) > max_content_chars
+            ):
+                dispositions[index] = ContextRenderDisposition(
+                    index, item.id, "omitted", "content_limit", "not_emitted"
+                )
+                omitted_content = True
+                continue
+            if (
+                char_budget is not None
+                and rendered_item.content_prefix is not None
+                and used + block_chars > char_budget
+            ):
+                dispositions[index] = ContextRenderDisposition(
+                    index, item.id, "omitted", "budget", "not_emitted"
+                )
+                omitted_procedure = True
+                continue
             if char_budget is not None and emitted_items > 0 and used + block_chars > char_budget:
                 trimmed = True
                 break
@@ -482,8 +542,12 @@ def render_context_pack(
             emitted_items += 1
             remaining -= 1
 
-    if trimmed:
+    if trimmed or omitted_procedure:
         lines.extend(["", f"_Trimmed to ~{token_budget} tokens; raise --budget for more._"])
+    elif omitted_content:
+        lines.extend(
+            ["", "_Procedures omitted by content limit; set --budget for complete bodies._"]
+        )
     elif pack.usage_hint:
         lines.extend(["", f"_Hint: {pack.usage_hint}_"])
 
@@ -498,7 +562,7 @@ def render_context_pack(
     return RenderedContextPack(
         markdown=markdown,
         receipt=ContextRenderReceipt(
-            schema_version="sibyl-context-render-v1",
+            schema_version=schema_version,
             markdown_sha256=_text_digest(markdown),
             markdown_bytes=len(markdown.encode()),
             selected_items=len(pack.items),
@@ -519,7 +583,7 @@ def context_pack_to_markdown(
     include_related: bool = True,
     token_budget: int | None = None,
 ) -> str:
-    """Return the unchanged Markdown representation of a context pack."""
+    """Return Markdown with complete procedure bodies when they fit the budget."""
     return render_context_pack(
         pack,
         max_items=max_items,
@@ -542,7 +606,8 @@ def validate_context_render_payload(payload: Mapping[str, Any]) -> list[str]:
         return []
     if not isinstance(receipt, dict):
         return ["render_receipt must be an object"]
-    if receipt.get("schema_version") != "sibyl-context-render-v1":
+    schema_version = receipt.get("schema_version")
+    if schema_version not in ("sibyl-context-render-v1", "sibyl-context-render-v2"):
         return ["unsupported render_receipt schema_version"]
     try:
         pack = TypeAdapter(ContextPack).validate_json(
@@ -559,6 +624,7 @@ def validate_context_render_payload(payload: Mapping[str, Any]) -> list[str]:
         pack,
         **asdict(parsed.options),
         request_id=parsed.request_id,
+        schema_version=parsed.schema_version,
     )
     failures = []
     if payload.get("markdown") != expected.markdown:

--- a/packages/python/sibyl-core/tests/test_context_render_receipts.py
+++ b/packages/python/sibyl-core/tests/test_context_render_receipts.py
@@ -452,3 +452,125 @@ def test_raw_observed_revision_is_not_an_authored_storage_field():
     record = raw_memory_record(memory)
     assert "observed_revision" not in record
     assert raw_memory_from_record(record).observed_revision == 2
+
+
+def procedure_pack(content: str) -> ContextPack:
+    pack = receipt_pack()
+    sections = [
+        ContextSection(
+            ContextFacet.PRIOR_ART,
+            "Procedures",
+            [replace(pack.items[0], type="procedure", content=content)],
+        )
+    ]
+    return replace(pack, sections=sections, total_items=1)
+
+
+@pytest.mark.parametrize("budget", [4000, 8000])
+def test_procedure_preserves_complete_conditions_and_code(budget):
+    from dataclasses import asdict
+
+    from sibyl_core.tools.context_rendering import validate_context_render_payload
+
+    content = (
+        "  ## Preconditions\nVersion = 3\n\n```python\nif ready:\n    apply()\n```\n"
+        + "Evidence αβ 💜\n" * 110
+        + "\n## Abstain when\nNever apply to version 2.\n"
+    )
+    pack = procedure_pack(content)
+    result = render_context_pack(pack, token_budget=budget, max_content_chars=80)
+    assert content in result.markdown
+    assert "````markdown\n" in result.markdown
+    assert result.receipt.schema_version == "sibyl-context-render-v2"
+    span = next(s for s in result.receipt.spans if s.field == "content")
+    assert span.transform == "identity"
+    assert span.source_revision == 7
+    assert result.markdown.encode()[span.start_byte : span.end_byte] == content.encode()
+    assert span.input_start_byte == 0
+    assert span.input_end_byte == len(content.encode())
+    assert result.receipt.dispositions[0].state == "emitted"
+    assert (
+        validate_context_render_payload(
+            {**asdict(pack), "markdown": result.markdown, "render_receipt": asdict(result.receipt)}
+        )
+        == []
+    )
+
+
+def test_oversized_first_procedure_is_omitted_and_next_note_can_fit():
+    pack = procedure_pack("Preconditions\n" + "x" * 3000 + "\nDo not apply blindly.")
+    note = replace(receipt_pack().items[1], content="A short useful note.")
+    pack.sections[0].items.append(note)
+    pack = replace(pack, total_items=2)
+    result = render_context_pack(pack, token_budget=150)
+    assert "Preconditions" not in result.markdown
+    assert "A short useful note." in result.markdown
+    assert result.receipt.dispositions[0].state == "omitted"
+    assert result.receipt.dispositions[0].reason == "budget"
+    assert result.receipt.dispositions[1].state == "emitted"
+    assert not any(s.item_index == 0 for s in result.receipt.spans)
+
+
+def test_oversized_only_procedure_never_emits_a_partial_instruction():
+    result = render_context_pack(procedure_pack("Step 1\n" * 1000), token_budget=100)
+    assert "Step 1" not in result.markdown
+    assert not result.receipt.spans
+    assert result.receipt.dispositions[0].content_state == "not_emitted"
+
+
+def test_v1_procedure_receipts_replay_the_original_compact_renderer():
+    from dataclasses import asdict
+
+    from sibyl_core.tools.context_rendering import validate_context_render_payload
+
+    pack = procedure_pack("  αβ\n  original  steps\t" * 100)
+    result = render_context_pack(
+        pack, max_content_chars=80, schema_version="sibyl-context-render-v1"
+    )
+    assert result.receipt.schema_version == "sibyl-context-render-v1"
+    assert result.receipt.dispositions[0].state == "trimmed"
+    span = next(s for s in result.receipt.spans if s.field == "content")
+    assert span.transform == "collapse_whitespace"
+    assert "```markdown" not in result.markdown
+    payload = {
+        **asdict(pack),
+        "markdown": result.markdown,
+        "render_receipt": asdict(result.receipt),
+    }
+    assert validate_context_render_payload(payload) == []
+    payload["render_receipt"]["schema_version"] = "sibyl-context-render-v2"
+    assert validate_context_render_payload(payload)
+
+
+def test_procedure_fence_cannot_be_closed_by_source_backticks():
+    content = "```\n``````\n## Do not apply\n`````\n"
+    result = render_context_pack(procedure_pack(content))
+    assert f"```````markdown\n{content}\n```````" in result.markdown
+
+
+def test_unknown_render_version_is_rejected():
+    with pytest.raises(ValueError, match="unsupported"):
+        render_context_pack(receipt_pack(), schema_version="sibyl-context-render-v9")
+
+
+@pytest.mark.parametrize("limit", [80, 280, 1200])
+def test_unbudgeted_procedure_honors_content_limit_without_partial_body(limit):
+    result = render_context_pack(procedure_pack("x" * (limit + 1)), max_content_chars=limit)
+    assert not result.receipt.spans
+    assert result.receipt.dispositions[0].state == "omitted"
+    assert result.receipt.dispositions[0].reason == "content_limit"
+    assert "set --budget for complete bodies" in result.markdown
+
+
+def test_ranked_procedure_may_consume_explicit_pack_budget():
+    content = "step with condition\n" * 740
+    pack = procedure_pack(content)
+    notes = [replace(receipt_pack().items[i], content="Large note " * 100) for i in (1, 2)]
+    pack.sections[0].items.extend(notes)
+    pack = replace(pack, total_items=3)
+    result = render_context_pack(pack, token_budget=4000)
+    assert content in result.markdown
+    assert result.receipt.dispositions[0].state == "emitted"
+    assert all(
+        d.state == "omitted" and d.reason == "budget" for d in result.receipt.dispositions[1:]
+    )

--- a/tools/tests/test_agent_task_runner.py
+++ b/tools/tests/test_agent_task_runner.py
@@ -535,13 +535,19 @@ def test_empty_control_and_memory_arm_share_frozen_comparison(experiment):
     assert not (output.with_name("control") / "inputs/memory.txt").exists()
 
 
-def native_payload(source_revision=7):
+def native_payload(source_revision=7, *, schema_version="sibyl-context-render-v2", procedure=False):
     """Small Unicode rendering with actual core receipt generation."""
     item = ContextItem(
         id="source-record",
-        type="note",
+        type="procedure" if procedure else "note",
         name="Café 💜",
-        content="A verified observation. " * 30,
+        content=(
+            "## Preconditions\n```python\nif ready:\n    apply()\n```\n"
+            + "Step with check 💜\n" * 90
+            + "## Abstain when\nUnsupported version.\n"
+        )
+        if procedure
+        else "A verified observation. " * 30,
         score=1.0,
         facet=ContextFacet.DECISIONS,
         reason="source",
@@ -556,7 +562,12 @@ def native_payload(source_revision=7):
         sections=[ContextSection(ContextFacet.DECISIONS, "Decisions", [item])],
         total_items=1,
     )
-    rendered = render_context_pack(pack, max_content_chars=80)
+    rendered = render_context_pack(
+        pack,
+        max_content_chars=80,
+        schema_version=schema_version,
+        token_budget=4000 if procedure else None,
+    )
     return {
         **asdict(pack),
         "markdown": rendered.markdown,
@@ -586,9 +597,13 @@ def bind_native_payload(experiment, payload, *, memory=None):
 
 
 @pytest.mark.parametrize("split", ["learning", "development"])
-def test_native_binding_automatically_retains_input_outside_controller_workspace(experiment, split):
+@pytest.mark.parametrize("version", ["v1", "v2"])
+@pytest.mark.parametrize("procedure", [False, True])
+def test_native_binding_automatically_retains_input_outside_controller_workspace(
+    experiment, split, version, procedure
+):
     experiment[0]["tasks"][0]["split"] = split
-    payload = native_payload()
+    payload = native_payload(schema_version=f"sibyl-context-render-{version}", procedure=procedure)
     arm = bind_native_payload(experiment, payload)
     receipt = execute(experiment)
     output = experiment[2]
@@ -599,9 +614,9 @@ def test_native_binding_automatically_retains_input_outside_controller_workspace
         receipt["pack_id"] == request["memory_pack_sha256"] == digest(payload["markdown"].encode())
     )
     assert receipt["memory_provenance"] == {
-        "status": "native_render_v1",
+        "status": f"native_render_{version}",
         "native_payload_sha256": arm["native_render_payload"]["sha256"],
-        "render_schema_version": "sibyl-context-render-v1",
+        "render_schema_version": f"sibyl-context-render-{version}",
     }
     assert receipt["memory_provenance"]["native_payload_sha256"] != request["memory_pack_sha256"]
     assert "native_render_payload" not in request


### PR DESCRIPTION
Long procedures currently lose their later conditions and failure warnings when context rendering collapses whitespace and truncates each body. The v2 renderer emits each procedure as a complete fenced Markdown block, preserving code indentation and exact source bytes. A procedure that exceeds the caller's allowance is omitted with a receipt disposition and a notice to increase the budget.

## 🛠️ Delivery and compatibility

An explicit token budget permits a complete procedure to use the remaining pack allowance. Without a token budget, the existing per-item content limit still applies. Oversized procedures do not block smaller later memories. Ordinary memory rendering keeps its existing bytes.

New receipts use `sibyl-context-render-v2`; the validator still replays retained v1 receipts with the original renderer behavior. Procedure content spans bind the entire UTF-8 body with an identity transform. The task runner accepts both receipt versions and records the validated, declared version in its provenance. Those checks establish artifact consistency, not source authorization, model consumption, or learning benefit.

## 🧪 Validation

- Three motivating cases fail against the previous renderer. The revised context checks pass 164 cases, including intact conditions, Unicode, embedded fences, unbudgeted omission, and explicit budget allocation.
- The task runner passes 107 cases, including both receipt versions with actual multiline procedures across learning and development tasks.
- The isolated Linux run passes 3,000 core tests and 2,334 API tests, plus core, API, and benchmark lint/type checks. The suites retain 25 skips and one existing retrieval-ranking expected failure.

No database migration is required. Existing v1 artifacts remain replayable, while new API/MCP output carries v2 receipts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Context rendering now supports schema version 2 by default.
  - Procedure content is preserved verbatim, including preconditions and code blocks, without partial truncation.
  - Render receipts now accurately report the schema version used.

- **Compatibility**
  - Existing version 1 context render receipts remain supported alongside version 2.
  - Native render validation accepts both supported schema versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->