### PR TITLE
fix(memory): verify retained sources when publishing shared memories

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
@@ -91,6 +91,24 @@ async def _load_raw_sources(
     return memories
 
 
+async def _load_promotion_inputs(
+    memory: RawMemory, *, organization_id: str
+) -> tuple[list[RawMemory], bool]:
+    """Resolve every declared retained capture for promotion and sharing."""
+    source_ids = _raw_source_ids(memory)
+    sources = await _load_raw_sources(organization_id=organization_id, raw_source_ids=source_ids)
+    required = set(source_ids)
+    loaded = {source.id for source in sources}
+    if memory.source_id in required and re.fullmatch(
+        r"reflection:input:[0-9a-f]{16}", memory.source_id
+    ):
+        # Unretained input anchors have no stored source or revision. Present
+        # rows still participate in authorization and lifecycle checks.
+        required.remove(memory.source_id)
+        loaded.discard(memory.source_id)
+    return [memory, *sources], required == loaded
+
+
 async def persist_reflection_source(
     *,
     title: str,
@@ -311,6 +329,8 @@ async def persist_reflection_candidate(
         if current is None:
             raise RuntimeError("reflection evidence disappeared during publication") from None
         verify_reflection_identity(entity, current)
+        if not await _verify_promotion_sources(runtime, source_memories, entity_id=current.id):
+            return _retired_reflection_result(current.id)
         if not graph_metadata_recallable(current.metadata):
             return _retired_reflection_result(current.id)
         current_publication = current.metadata.get("reflection_publication", {})
@@ -327,6 +347,8 @@ async def persist_reflection_candidate(
         raise
     if updated is None:
         raise RuntimeError("reflection evidence disappeared during publication")
+    if not await _verify_promotion_sources(runtime, source_memories, entity_id=stored.id):
+        return _retired_reflection_result(stored.id)
     return _reflection_publication_result(
         stored.id,
         candidate.title,
@@ -691,11 +713,6 @@ async def _apply_promotion_plan(
     )
     if not result.response.success or result.metadata.get("promotion_state") == "partial":
         return _promotion_write_denied(plan=plan, result=result)
-    runtime = await get_surreal_graph_runtime(organization_id)
-    if not await _verify_promotion_sources(
-        runtime, plan.input_memories, entity_id=result.response.id
-    ):
-        return _promotion_write_denied(plan=plan, result=_retired_reflection_result(prospective.id))
     return await _mark_promotion_plan_promoted(
         plan=plan,
         result=result,
@@ -971,23 +988,10 @@ async def _resolve_reflection_promotion_plan(
             raw_source_ids=_raw_source_ids(candidate_memory),
         )
 
-    raw_source_ids = _raw_source_ids(candidate_memory)
-    source_memories = await _load_raw_sources(
-        organization_id=organization_id,
-        raw_source_ids=raw_source_ids,
+    raw_source_ids = _raw_source_ids(candidate_memory) or [candidate_memory.id]
+    input_memories, sources_complete = await _load_promotion_inputs(
+        candidate_memory, organization_id=organization_id
     )
-    required_source_ids = set(raw_source_ids)
-    loaded_source_ids = {source.id for source in source_memories}
-    if candidate_memory.source_id in required_source_ids and re.fullmatch(
-        r"reflection:input:[0-9a-f]{16}", candidate_memory.source_id
-    ):
-        # Explicit unretained input anchors carry no stored source or revision.
-        # Present rows still participate in the authorization/lifecycle checks below.
-        required_source_ids.remove(candidate_memory.source_id)
-        loaded_source_ids.discard(candidate_memory.source_id)
-    sources_complete = required_source_ids == loaded_source_ids
-    raw_source_ids = raw_source_ids or [candidate_memory.id]
-    input_memories = [candidate_memory, *source_memories]
 
     ownership_denial = _principal_denial(
         input_memories,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_sharing.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_sharing.py
@@ -35,6 +35,7 @@ from sibyl_core.services.memory_promotion import (
     _source_scope_denial,
 )
 from sibyl_core.services.memory_reflection import (
+    _load_promotion_inputs,
     _promotion_write_denied,
     persist_reflection_candidate,
 )
@@ -532,26 +533,44 @@ async def _resolve_raw_memory_share_plan(
             raw_source_ids=raw_source_ids,
         )
 
-    input_memories = [memory]
-    ownership_denial = _principal_denial(
+    input_memories, sources_complete = await _load_promotion_inputs(
+        memory, organization_id=organization_id
+    )
+    source_denial = _principal_denial(
         input_memories,
         candidate_id=memory.id,
         principal_id=principal_id,
         raw_source_ids=raw_source_ids,
     )
-    if ownership_denial is not None:
-        return ownership_denial
-    source_scope_denial = _source_scope_denial(
-        input_memories,
-        candidate_id=memory.id,
-        principal_id=principal_id,
-        raw_source_ids=raw_source_ids,
-        accessible_projects=accessible_projects,
-        accessible_teams=accessible_teams,
-        accessible_delegations=accessible_delegations,
-    )
-    if source_scope_denial is not None:
-        return source_scope_denial
+    if source_denial is None:
+        source_denial = _source_scope_denial(
+            input_memories,
+            candidate_id=memory.id,
+            principal_id=principal_id,
+            raw_source_ids=raw_source_ids,
+            accessible_projects=accessible_projects,
+            accessible_teams=accessible_teams,
+            accessible_delegations=accessible_delegations,
+        )
+    if source_denial is not None:
+        return _promotion_denied(
+            candidate_id=memory.id,
+            reason="source_not_recallable",
+            review_state=memory.review_state,
+            memory_scope=memory.memory_scope,
+            scope_key=memory.scope_key,
+            raw_source_ids=raw_source_ids,
+        )
+
+    if not sources_complete or any(not raw_memory_recallable(source) for source in input_memories):
+        return _promotion_denied(
+            candidate_id=memory.id,
+            reason="source_not_recallable",
+            review_state=memory.review_state,
+            memory_scope=memory.memory_scope,
+            scope_key=memory.scope_key,
+            raw_source_ids=raw_source_ids,
+        )
 
     target_scope = _coerce_promotion_scope(promote_to_scope)
     if target_scope is None:
@@ -618,6 +637,7 @@ async def _apply_share_plan(
         memory_scope=plan.target_scope,
         scope_key=plan.target_scope_key,
         link_source_entity=False,
+        source_memories=plan.input_memories,
     )
     if not result.response.success or result.metadata.get("promotion_state") == "partial":
         return _promotion_write_denied(plan=plan, result=result)

--- a/packages/python/sibyl-core/tests/test_reflection_identity.py
+++ b/packages/python/sibyl-core/tests/test_reflection_identity.py
@@ -1103,3 +1103,135 @@ async def test_disappearance_after_publication_revision_conflict_is_controlled(
             organization_id=runtime.client.group_id,
             principal_id="user_a",
         )
+
+
+@pytest.mark.parametrize("boundary", ["insert", "relationships", "finalize"])
+@pytest.mark.parametrize("action", ["delete", "revise"])
+@pytest.mark.parametrize("mode", ["raw", "review"])
+async def test_source_change_during_share_cannot_publish_live_evidence(
+    runtime: GraphRuntime,
+    content_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+    action: str,
+    mode: str,
+    boundary: str,
+) -> None:
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="changed-during-share",
+        title="Original evidence",
+        raw_content="Keep the original policy.",
+        embedding_provider=None,
+    )
+    shared = source
+    if mode == "review":
+        shared = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[source.id],
+        )
+    manager, method = {
+        "insert": (runtime.entity_manager, "create_direct_if_absent"),
+        "relationships": (runtime.relationship_manager, "create_bulk"),
+        "finalize": (runtime.entity_manager, "update"),
+    }[boundary]
+    write = getattr(manager, method)
+    corrected = False
+
+    async def correcting_write(*args, **kwargs):
+        nonlocal corrected
+        if corrected:
+            return await write(*args, **kwargs)
+        corrected = True
+        correction = await apply_memory_correction(
+            organization_id=runtime.client.group_id,
+            source_id=source.id,
+            principal_id="user_a",
+            action=action,
+            revised_content="Use the revised policy." if action == "revise" else None,
+            accessible_projects={"project_a"},
+        )
+        assert correction.applied
+        return await write(*args, **kwargs)
+
+    monkeypatch.setattr(manager, method, correcting_write)
+    result = await share_memory(
+        source_ids=[shared.id],
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        accessible_projects={"project_a"},
+        target_scope="project",
+        target_scope_key="project_a",
+    )
+    assert len(result.promotions) == 1
+    publication = result.promotions[0]
+    assert not publication.success and publication.reason == "retired"
+    assert publication.promoted_id
+    row = await runtime.entity_manager.get(publication.promoted_id)
+    assert not graph_metadata_recallable(row.metadata)
+
+
+@pytest.mark.parametrize(
+    "support", ["present", "missing", "foreign_org", "foreign_owner", "foreign_project"]
+)
+async def test_sharing_review_requires_available_authorized_support(
+    runtime: GraphRuntime, content_store: None, support: str
+) -> None:
+    source = await remember_raw_memory(
+        organization_id="foreign-org" if support == "foreign_org" else runtime.client.group_id,
+        principal_id="user_b" if support == "foreign_owner" else "user_a",
+        source_id="share-support",
+        memory_scope="project" if support == "foreign_project" else "private",
+        scope_key="project_b"
+        if support == "foreign_project"
+        else "user_b"
+        if support == "foreign_owner"
+        else "user_a",
+        title="Supporting evidence",
+        raw_content="A private source must remain private.",
+        embedding_provider=None,
+    )
+    review = await remember_reflection_candidate_review(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        candidate=candidate(),
+        scope_key="user_a",
+        raw_source_ids=["missing-source" if support == "missing" else source.id],
+    )
+    result = await share_memory(
+        source_ids=[review.id],
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        accessible_projects={"project_a"},
+        target_scope="project",
+        target_scope_key="project_a",
+    )
+    assert len(result.promotions) == 1
+    publication = result.promotions[0]
+    assert publication.raw_source_ids == [review.id]
+    if support == "present":
+        assert publication.success
+        row = await runtime.entity_manager.get(publication.promoted_id)
+        assert graph_metadata_recallable(row.metadata)
+        assert row.metadata["raw_source_ids"] == [review.id]
+    else:
+        assert not publication.success
+        assert publication.promoted_id is None
+        assert publication.reason == "source_not_recallable"
+        assert publication.memory_scope == review.memory_scope
+        assert publication.scope_key == review.scope_key
+        assert source.id not in json.dumps(publication.metadata)
+        assert "project_b" not in json.dumps(publication.metadata)
+        assert "user_b" not in json.dumps(publication.metadata)
+        assert (
+            await runtime.client.execute_query(
+                "SELECT VALUE uuid FROM entity WHERE entity_type != 'project';"
+            )
+            == []
+        )


### PR DESCRIPTION
Sharing a raw or reviewed memory could publish live evidence after a supporting capture was deleted or revised during publication. Sharing now resolves every declared retained input through the same loader as review promotion, checks availability and access, and passes the inputs into the existing publisher.

The publisher verifies those inputs after its final metadata write and before returning a replay after a revision conflict. Promotion and sharing use that common check. Unavailable supporting inputs return one opaque denial with the selected capture's visible scope. The response does not distinguish a missing support from an inaccessible one or expose its owner or project identifier.

## 🧪 Validation

The embedded-database regressions cover deletion and revision during insertion, relationship creation, and publication finalization for both raw and reviewed sharing. Later publication windows and the private/project scope disclosures failed before their fixes. All **79 focused tests** pass, including valid sharing and missing, foreign-organization, foreign-owner, and foreign-project inputs.

The final code passes **3,017 core tests** (14 skipped, one known expected failure) and **2,334 API tests** (11 skipped) on the isolated devbox, with caching explicitly bypassed. Static checks and the parent verification of 17 publication/admission cases also pass. These tests exercise deterministic write interleavings; they are not a concurrent load test.

## 🎯 Boundary

The preview reports selected-source visibility and target policy. Applying the share revalidates retained supporting evidence. Stable share identity and stored source references retain their existing shape.

Correction of descendants that were already published remains separate work. This change closes the publication checks; it does not establish a cross-store transaction or recursive source invalidation.
