### PR TITLE
fix(ci): track shared Python sources in quality task inputs

### DIFF
--- a/.moon/tasks/python.yml
+++ b/.moon/tasks/python.yml
@@ -1,0 +1,8 @@
+inheritedBy:
+  language: python
+
+implicitInputs:
+  - project://^?filter=src/**/*
+  - project://^?filter=pyproject.toml
+  - /pyproject.toml
+  - /uv.lock

--- a/apps/api/moon.yml
+++ b/apps/api/moon.yml
@@ -2,6 +2,8 @@
 $schema: https://moonrepo.dev/schemas/project.json
 
 language: python
+dependsOn:
+  - core
 layer: application
 toolchains:
   default: system

--- a/apps/cli/moon.yml
+++ b/apps/cli/moon.yml
@@ -2,6 +2,8 @@ $schema: https://moonrepo.dev/schemas/project.json
 toolchains:
   default: system
 language: python
+dependsOn:
+  - core
 env:
   PYTEST_ADDOPTS: "${PYTEST_ADDOPTS} -p sibyl_core.pytest_isolation"
 tasks:


### PR DESCRIPTION
API and CLI quality checks could report cached success after their shared Python library changed. Both projects now declare their dependency on `core`, and Python tasks inherit dependency source and package metadata inputs plus the workspace configuration and lockfile. Focused test tasks receive the same inputs without maintaining duplicate lists.

### 🧪 Validation

A controlled edit to a core source file reproduced unchanged API and CLI typecheck hashes with cached results before the fix. After the fix, both hashes changed and both checks ran successfully. An unchanged repeat reused the cache.

Resolved API and CLI test inputs include the core source tree. Core, E2E, and hook tasks resolve correctly with no project dependencies; their typecheck or lint spot checks passed. Web lint does not inherit the Python inputs. Independent static review passed, followed by the requested command checks.

The change adds no task execution dependencies. Live E2E tasks still need their own service source dependencies declared; that pre-existing gap is separate from the API and CLI cache fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved project build coordination for the API and CLI applications.
  - Updated Python task configuration so relevant source and project files trigger task reruns automatically.
  - Added shared core-project dependency tracking to improve build ordering and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->