### PR TITLE
feat(evals): add checked development coding tasks

### DIFF
--- a/benchmarks/agent_tasks/development/README.md
+++ b/benchmarks/agent_tasks/development/README.md
@@ -1,0 +1,43 @@
+# Development coding tasks
+
+Eight small Python repositories exercise four pairs of related contracts.
+Each repository contains a failing implementation, a written behavior contract,
+and public tests that run with Python's standard library. The runner's separate
+checker also tests cases that a partial fix can miss.
+
+| Family | First contract | Second contract |
+| --- | --- | --- |
+| Configuration presence | Preserve explicit falsey overrides | Treat a null patch value as deletion |
+| Pagination | Preserve zero and empty-string cursors | Advance offsets through filtered pages |
+| Time boundaries | Compare half-open windows as absolute instants | Include both entitlement dates |
+| Event ordering | Select the greatest version per key | Apply every delta in arrival order |
+
+The paired contracts require different fixes. For example, choosing the newest
+state event is correct for versioned snapshots but drops required increments
+from an ordered delta stream.
+
+The task definitions in `tasks.json` use the existing runner's `Task` schema.
+Paths and SHA-256 digests are relative to this directory. Copy the declared
+artifacts into a frozen experiment root and include these task definitions in
+its manifest. Use the [coding controller](../README.md) with explicit model,
+tool, token and cost budgets. Only each task's `workspace` entries belong in the
+candidate repository; the checker and validation reference edits remain outside.
+
+Run the corpus checks from the repository root:
+
+```sh
+moon run root:agent-task-test -- -k development_corpus
+```
+
+The checks run each initial repository through the existing runner, validate a
+complete repair, then confirm that a plausible partial repair passes public
+tests but fails the separate checker. Reference edits live only in the test
+harness and are applied to disposable validation copies. The harness uses a
+synthetic controller and makes no model calls.
+
+These tasks are exposed development material. They are not held-out evaluation
+or learning experiences. The checker executes candidate Python under the same
+user and does not provide sealed isolation. Passing corpus validation establishes
+that the tasks and checks discriminate these repairs; it establishes no model
+score or learning benefit. Freeze separate learning and held-out task families
+before making a consolidation comparison.

--- a/benchmarks/agent_tasks/development/checker.py
+++ b/benchmarks/agent_tasks/development/checker.py
@@ -1,0 +1,274 @@
+"""Independent behavioral checks for exposed, generated development tasks.
+
+Executed outside the candidate workspace with the existing CheckerResult JSON
+protocol. This trusted checker executes candidate Python; it is not a sealed
+sandbox or an oracle resistant to hostile same-user code.
+"""
+
+# ruff: noqa: PLR2004
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+from copy import deepcopy
+from datetime import UTC, date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+def require(condition: bool, label: str) -> None:
+    if not condition:
+        raise AssertionError(label)
+
+
+def rejects(callback, error: type[Exception]) -> None:
+    try:
+        callback()
+    except error:
+        return
+    raise AssertionError(f"expected {error.__name__}")
+
+
+def config_presence(app) -> None:
+    for value in (False, 0, "", [], {}, None, "explicit"):
+        defaults = {"chosen": "default", "retained": 5}
+        overrides = {"chosen": value, "unsupported": "ignore"}
+        before = deepcopy((defaults, overrides))
+        expected = "default" if value is None else value
+        require(
+            app.resolve_options(defaults, overrides) == {"chosen": expected, "retained": 5},
+            "explicit override semantics",
+        )
+        require((defaults, overrides) == before, "input mutation")
+    require(app.resolve_options({}, {"extra": 1}) == {}, "unsupported options")
+
+
+def patch_clear(app) -> None:
+    for value in (False, 0, "", [], {}, None, "new"):
+        current = {"chosen": "old", "retained": 5}
+        patch = {"chosen": value, "absent": None, "new": False}
+        before = deepcopy((current, patch))
+        expected = {"retained": 5, "new": False}
+        if value is not None:
+            expected["chosen"] = value
+        require(app.apply_patch(current, patch) == expected, "patch presence/deletion semantics")
+        require((current, patch) == before, "input mutation")
+    current = {"x": 1}
+    require(app.apply_patch(current, {}) is not current, "result must be a fresh mapping")
+
+
+def cursor_zero(app) -> None:
+    for tokens in ((0, ""), ("", 3), ("opaque", "last")):
+        cursors = (None, *tokens)
+        pages = {
+            cursors[0]: {"items": ["same"], "next_cursor": cursors[1]},
+            cursors[1]: {"items": [], "next_cursor": cursors[2]},
+            cursors[2]: {"items": ["same", "last"], "next_cursor": None},
+        }
+        before = deepcopy(pages)
+        calls = []
+
+        def fetch(cursor, *, calls=calls, pages=pages):
+            calls.append(cursor)
+            return pages[cursor]
+
+        require(app.collect_pages(fetch) == ["same", "same", "last"], "dropped export rows")
+        require(calls == list(cursors), "wrong cursor sequence")
+        require(pages == before, "page mutation")
+    require(
+        app.collect_pages(lambda cursor: {"items": [], "next_cursor": None}) == [], "empty export"
+    )
+
+
+def offset_filtered(app) -> None:
+    for total in (0, 1, 4, 7, 12):
+        for size in (1, 3, 5):
+            calls = []
+            expected = [value % 2 for value in range(total) if value % 3 == 2]
+
+            def fetch(offset, limit, *, calls=calls, total=total):
+                calls.append((offset, limit))
+                require(len(calls) <= total + 1, "pagination made no progress")
+                return {
+                    "items": [
+                        value % 2
+                        for value in range(offset, min(offset + limit, total))
+                        if value % 3 == 2
+                    ],
+                    "total": total,
+                }
+
+            require(app.collect_pages(fetch, size) == expected, "filtered rows lost")
+            require(
+                calls == [(offset, size) for offset in range(0, max(total, 1), size)],
+                "wrong offset advancement",
+            )
+    for size in (0, -1):
+        rejects(lambda size=size: app.collect_pages(lambda *_: None, size), ValueError)
+
+
+def window_overlap(app) -> None:
+    origin = datetime(2026, 2, 1, tzinfo=UTC)
+    hour = timedelta(hours=1)
+    for a, b, c, d, expected in (
+        (0, 1, 1, 2, False),
+        (1, 2, 0, 1, False),
+        (0, 3, 1, 2, True),
+        (0, 2, 1, 3, True),
+        (0, 1, 2, 3, False),
+        (0, 2, 0, 2, True),
+    ):
+        left = (origin + a * hour, origin + b * hour)
+        right = tuple(
+            (origin + value * hour).astimezone(timezone(timedelta(hours=5, minutes=30)))
+            for value in (c, d)
+        )
+        require(app.overlaps(left, right) is expected, "half-open absolute instant overlap")
+    good = (origin, origin + hour)
+    for bad in (
+        (origin, origin),
+        (origin + hour, origin),
+        (origin.replace(tzinfo=None), origin + hour),
+    ):
+        rejects(lambda bad=bad: app.overlaps(bad, good), ValueError)
+        rejects(lambda bad=bad: app.overlaps(good, bad), ValueError)
+
+
+def date_entitlement(app) -> None:
+    start = date(2026, 2, 27)
+    end = date(2026, 3, 2)
+    for delta in range(-2, 7):
+        require(
+            app.active_on(start, end, start + timedelta(days=delta)) is (0 <= delta <= 3),
+            "inclusive calendar boundaries",
+        )
+    require(app.active_on(start, start, start), "one-day entitlement")
+    rejects(lambda: app.active_on(end, start, start), ValueError)
+    for bad in (None, "2026-02-27", datetime(2026, 2, 27, tzinfo=UTC)):
+        for position in range(3):
+            args = [start, end, start]
+            args[position] = bad
+            rejects(lambda args=args: app.active_on(*args), TypeError)
+
+
+def versioned_events(app) -> None:
+    cases = [
+        (
+            [
+                {"key": "a", "version": 4, "deleted": True, "value": None},
+                {"key": "a", "version": 2, "deleted": False, "value": "old"},
+            ],
+            {},
+        ),
+        (
+            [
+                {"key": "a", "version": 3, "deleted": False, "value": False},
+                {"key": "a", "version": 1, "deleted": True, "value": None},
+            ],
+            {"a": False},
+        ),
+        (
+            [
+                {"key": "a", "version": 2, "deleted": True, "value": None},
+                {"key": "a", "version": 2, "deleted": False, "value": None},
+            ],
+            {"a": None},
+        ),
+        (
+            [
+                {"key": "a", "version": 2, "deleted": False, "value": 1},
+                {"key": "a", "version": 2, "deleted": True, "value": 99},
+            ],
+            {},
+        ),
+        ([], {}),
+    ]
+    for events, expected in cases:
+        before = deepcopy(events)
+        require(app.materialize(events) == expected, "version/tombstone selection")
+        require(events == before, "event mutation")
+    events = [
+        {"key": key, "version": version, "deleted": False, "value": version}
+        for version in (4, 1, 3, 2)
+        for key in ("a", "b")
+    ]
+    require(app.materialize(events) == {"a": 4, "b": 4}, "independent key versions")
+
+
+def ordered_deltas(app) -> None:
+    cases = [
+        (
+            {"a": 2},
+            [
+                {"op": "increment", "key": "a", "value": 3},
+                {"op": "increment", "key": "a", "value": 4},
+            ],
+            {"a": 9},
+        ),
+        (
+            {"a": 99},
+            [{"op": "remove", "key": "a"}, {"op": "increment", "key": "a", "value": 2}],
+            {"a": 2},
+        ),
+        (
+            {},
+            [{"op": "set", "key": "a", "value": 4}, {"op": "increment", "key": "a", "value": -1}],
+            {"a": 3},
+        ),
+        ({"a": 3}, [{"op": "increment", "key": "a", "value": 4}, {"op": "remove", "key": "a"}], {}),
+        (
+            {"z": 7},
+            [{"op": "set", "key": "a", "value": None}, {"op": "increment", "key": "b", "value": 0}],
+            {"z": 7, "a": None, "b": 0},
+        ),
+        ({"a": 1}, [], {"a": 1}),
+    ]
+    for initial, events, expected in cases:
+        before = deepcopy((initial, events))
+        result = app.replay(initial, events)
+        require(result == expected, "ordered delta replay")
+        require(result is not initial and (initial, events) == before, "input mutation")
+
+
+CHECKS = {
+    "config-presence": config_presence,
+    "patch-clear": patch_clear,
+    "cursor-zero": cursor_zero,
+    "offset-filtered": offset_filtered,
+    "window-overlap": window_overlap,
+    "date-entitlement": date_entitlement,
+    "versioned-events": versioned_events,
+    "ordered-deltas": ordered_deltas,
+}
+
+
+def load_candidate():
+    spec = importlib.util.spec_from_file_location("candidate", Path.cwd() / "app.py")
+    if spec is None or spec.loader is None:
+        raise ImportError("candidate module unavailable")
+    app = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(app)
+    return app
+
+
+def main() -> None:
+    request = json.load(sys.stdin)
+    if not request.get("attempt_id") or not request.get("snapshot_sha256"):
+        raise ValueError("checker request must identify the checked attempt and snapshot")
+    check = CHECKS[sys.argv[1]]
+    captured = io.StringIO()
+    try:
+        with redirect_stdout(captured):
+            check(load_candidate())
+    except Exception as exc:
+        result: dict[str, Any] = {"passed": False, "detail": f"{type(exc).__name__}: {exc}"}
+    else:
+        result = {"passed": True, "detail": f"{sys.argv[1]} behavioral contract passed"}
+    sys.stdout.write(json.dumps(result) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/agent_tasks/development/tasks.json
+++ b/benchmarks/agent_tasks/development/tasks.json
@@ -1,0 +1,330 @@
+[
+  {
+    "id": "dev-config-presence",
+    "family_id": "dev-configuration-presence",
+    "split": "development",
+    "prompt": {
+      "path": "tasks/config-presence/prompt.md",
+      "sha256": "3942988f09b7765d495dc8c422feb2896a9cbbbabaf415803925c8f30898c18c"
+    },
+    "workspace": [
+      {
+        "artifact": {
+          "path": "tasks/config-presence/workspace/README.md",
+          "sha256": "6b6fb89251014a9ce7dd1be875ea568c48d80fd89439bec9164ddb1a0eb344ae"
+        },
+        "destination": "README.md"
+      },
+      {
+        "artifact": {
+          "path": "tasks/config-presence/workspace/app.py",
+          "sha256": "e00c9d8c2077d7a479e11fff196087ad88b0544590c6c5ea90579a625375cf5d"
+        },
+        "destination": "app.py"
+      },
+      {
+        "artifact": {
+          "path": "tasks/config-presence/workspace/tests/test_public.py",
+          "sha256": "3296c93c29588ff8ff801417ba9cecf484184509fdeb840dde415fdbc1c58b2e"
+        },
+        "destination": "tests/test_public.py"
+      }
+    ],
+    "checker": {
+      "script": {
+        "path": "checker.py",
+        "sha256": "b3842ee6de30acf60e2a0c00a54dfcbd91aa29ffe2b2035b6341b052c6849e44"
+      },
+      "args": [
+        "config-presence"
+      ]
+    }
+  },
+  {
+    "id": "dev-patch-clear",
+    "family_id": "dev-configuration-presence",
+    "split": "development",
+    "prompt": {
+      "path": "tasks/patch-clear/prompt.md",
+      "sha256": "d392e05d22f887711f45bfab372d7742edd191296af963cb7e1ee4d946908c95"
+    },
+    "workspace": [
+      {
+        "artifact": {
+          "path": "tasks/patch-clear/workspace/README.md",
+          "sha256": "68b410ef8e5bac9dfd442b49d4fa0ffe2199eeef299ff4c4acd8e69b10e2d0b2"
+        },
+        "destination": "README.md"
+      },
+      {
+        "artifact": {
+          "path": "tasks/patch-clear/workspace/app.py",
+          "sha256": "6e6a1e89ffd1a61254e19a01b0a481f93896c1eaf85596483551b7197144ffe9"
+        },
+        "destination": "app.py"
+      },
+      {
+        "artifact": {
+          "path": "tasks/patch-clear/workspace/tests/test_public.py",
+          "sha256": "47d12dd4a4d056bbb48cd50abfc68e76d2cedc01516626e9336cb8dda9d13325"
+        },
+        "destination": "tests/test_public.py"
+      }
+    ],
+    "checker": {
+      "script": {
+        "path": "checker.py",
+        "sha256": "b3842ee6de30acf60e2a0c00a54dfcbd91aa29ffe2b2035b6341b052c6849e44"
+      },
+      "args": [
+        "patch-clear"
+      ]
+    }
+  },
+  {
+    "id": "dev-cursor-zero",
+    "family_id": "dev-pagination-termination",
+    "split": "development",
+    "prompt": {
+      "path": "tasks/cursor-zero/prompt.md",
+      "sha256": "d6a6b3f104f980314d9ec9a5a7ef9466dfae338c8b1d73e4b741c2f8c2cc646f"
+    },
+    "workspace": [
+      {
+        "artifact": {
+          "path": "tasks/cursor-zero/workspace/README.md",
+          "sha256": "4eb0d16c7807b3316d78a816a9c8dd665c0d71470034f8fc7d84ff31bf87e506"
+        },
+        "destination": "README.md"
+      },
+      {
+        "artifact": {
+          "path": "tasks/cursor-zero/workspace/app.py",
+          "sha256": "90f5ef25f3669b0196534fcb0824a3194b5437f85137fae462c32d7990b8d040"
+        },
+        "destination": "app.py"
+      },
+      {
+        "artifact": {
+          "path": "tasks/cursor-zero/workspace/tests/test_public.py",
+          "sha256": "1eb9683500f326f4d77a3bc034539b86087bb983a3ff920f7caa55ec74aa0d52"
+        },
+        "destination": "tests/test_public.py"
+      }
+    ],
+    "checker": {
+      "script": {
+        "path": "checker.py",
+        "sha256": "b3842ee6de30acf60e2a0c00a54dfcbd91aa29ffe2b2035b6341b052c6849e44"
+      },
+      "args": [
+        "cursor-zero"
+      ]
+    }
+  },
+  {
+    "id": "dev-offset-filtered",
+    "family_id": "dev-pagination-termination",
+    "split": "development",
+    "prompt": {
+      "path": "tasks/offset-filtered/prompt.md",
+      "sha256": "b89222903ad9451b4f2e5a9ef413890ce77ef7d48387d0f24a8526f8d328bab1"
+    },
+    "workspace": [
+      {
+        "artifact": {
+          "path": "tasks/offset-filtered/workspace/README.md",
+          "sha256": "223bfa4cdfba464cc81ab3980c55cf9011507adc09f0d3e58807f7e86f4b5d53"
+        },
+        "destination": "README.md"
+      },
+      {
+        "artifact": {
+          "path": "tasks/offset-filtered/workspace/app.py",
+          "sha256": "3074cd48b02f7e1b560726b3e43f28b26262eb412d31739356d9ef40bdd46873"
+        },
+        "destination": "app.py"
+      },
+      {
+        "artifact": {
+          "path": "tasks/offset-filtered/workspace/tests/test_public.py",
+          "sha256": "0d7e42c08f5536477b6948ceea0065314ecfbba1fb12c7e1a04265dc0a581fca"
+        },
+        "destination": "tests/test_public.py"
+      }
+    ],
+    "checker": {
+      "script": {
+        "path": "checker.py",
+        "sha256": "b3842ee6de30acf60e2a0c00a54dfcbd91aa29ffe2b2035b6341b052c6849e44"
+      },
+      "args": [
+        "offset-filtered"
+      ]
+    }
+  },
+  {
+    "id": "dev-window-overlap",
+    "family_id": "dev-interval-boundaries",
+    "split": "development",
+    "prompt": {
+      "path": "tasks/window-overlap/prompt.md",
+      "sha256": "b718e49844cd3b40fd93a18a1e3e71db747bab626ac3dae993813d48a41764a8"
+    },
+    "workspace": [
+      {
+        "artifact": {
+          "path": "tasks/window-overlap/workspace/README.md",
+          "sha256": "1aab1cc443f6335ab193bdfc1c654a3e9900fe05efeb529254dfbbed137318f8"
+        },
+        "destination": "README.md"
+      },
+      {
+        "artifact": {
+          "path": "tasks/window-overlap/workspace/app.py",
+          "sha256": "15b05a007ef830d142522401d4e1ccb11b0a93baaac8dd02409c14188e778f60"
+        },
+        "destination": "app.py"
+      },
+      {
+        "artifact": {
+          "path": "tasks/window-overlap/workspace/tests/test_public.py",
+          "sha256": "37acdb0901f701131d8550445cc5e623f94ee1bc17ccdc5b7b82d614e49676a8"
+        },
+        "destination": "tests/test_public.py"
+      }
+    ],
+    "checker": {
+      "script": {
+        "path": "checker.py",
+        "sha256": "b3842ee6de30acf60e2a0c00a54dfcbd91aa29ffe2b2035b6341b052c6849e44"
+      },
+      "args": [
+        "window-overlap"
+      ]
+    }
+  },
+  {
+    "id": "dev-date-entitlement",
+    "family_id": "dev-interval-boundaries",
+    "split": "development",
+    "prompt": {
+      "path": "tasks/date-entitlement/prompt.md",
+      "sha256": "b89a76767d8b68e16d3a4ddba06ea77139253c71042a77e92c77263144213855"
+    },
+    "workspace": [
+      {
+        "artifact": {
+          "path": "tasks/date-entitlement/workspace/README.md",
+          "sha256": "aad3e24a74bf30930f1ac3796af7b53389352c087097b6e6e57f9dc7d27e382c"
+        },
+        "destination": "README.md"
+      },
+      {
+        "artifact": {
+          "path": "tasks/date-entitlement/workspace/app.py",
+          "sha256": "60320f34fb52e55f370f4522717ef0c1a3321446f67d3e1cc395835cd67f2b3c"
+        },
+        "destination": "app.py"
+      },
+      {
+        "artifact": {
+          "path": "tasks/date-entitlement/workspace/tests/test_public.py",
+          "sha256": "e35a8d728b9c7e16498152a4caac6235762ba262d2ec91d09a22b20bb796549e"
+        },
+        "destination": "tests/test_public.py"
+      }
+    ],
+    "checker": {
+      "script": {
+        "path": "checker.py",
+        "sha256": "b3842ee6de30acf60e2a0c00a54dfcbd91aa29ffe2b2035b6341b052c6849e44"
+      },
+      "args": [
+        "date-entitlement"
+      ]
+    }
+  },
+  {
+    "id": "dev-versioned-events",
+    "family_id": "dev-state-folding",
+    "split": "development",
+    "prompt": {
+      "path": "tasks/versioned-events/prompt.md",
+      "sha256": "2e6329e30cf20149027032b89682f08c1315b7b55f117def82b1484c62c4d2cd"
+    },
+    "workspace": [
+      {
+        "artifact": {
+          "path": "tasks/versioned-events/workspace/README.md",
+          "sha256": "3c57f60dc42f45d93779bae6e6a634da52d63b4f52a1f6885d98c97dcfc8b7cd"
+        },
+        "destination": "README.md"
+      },
+      {
+        "artifact": {
+          "path": "tasks/versioned-events/workspace/app.py",
+          "sha256": "a95c00f58f53e1eca27bd74d8f806429a397bdc1c085739333b344b3f1faf35e"
+        },
+        "destination": "app.py"
+      },
+      {
+        "artifact": {
+          "path": "tasks/versioned-events/workspace/tests/test_public.py",
+          "sha256": "f4ef66fbc990e31ccf31a1be0460cd6708cc756652463aef1c5c66ded53fa33a"
+        },
+        "destination": "tests/test_public.py"
+      }
+    ],
+    "checker": {
+      "script": {
+        "path": "checker.py",
+        "sha256": "b3842ee6de30acf60e2a0c00a54dfcbd91aa29ffe2b2035b6341b052c6849e44"
+      },
+      "args": [
+        "versioned-events"
+      ]
+    }
+  },
+  {
+    "id": "dev-ordered-deltas",
+    "family_id": "dev-state-folding",
+    "split": "development",
+    "prompt": {
+      "path": "tasks/ordered-deltas/prompt.md",
+      "sha256": "24c62b96610eb91a3af9759130a9239d7a4c147bde28e3e71b1f70c15a6635a0"
+    },
+    "workspace": [
+      {
+        "artifact": {
+          "path": "tasks/ordered-deltas/workspace/README.md",
+          "sha256": "0ef74e99b6513c78626801d45f6b2a84fec9f29cc55d74be6aad479d7b9a4d93"
+        },
+        "destination": "README.md"
+      },
+      {
+        "artifact": {
+          "path": "tasks/ordered-deltas/workspace/app.py",
+          "sha256": "1005c04c17bae7cbf94ef2225f681170e6b0ba831bf89402f7fe3d526b2932d9"
+        },
+        "destination": "app.py"
+      },
+      {
+        "artifact": {
+          "path": "tasks/ordered-deltas/workspace/tests/test_public.py",
+          "sha256": "9a6d7f80658d18b764e6ea835502738130b67cde4526b2ca8265a17a9bfe711c"
+        },
+        "destination": "tests/test_public.py"
+      }
+    ],
+    "checker": {
+      "script": {
+        "path": "checker.py",
+        "sha256": "b3842ee6de30acf60e2a0c00a54dfcbd91aa29ffe2b2035b6341b052c6849e44"
+      },
+      "args": [
+        "ordered-deltas"
+      ]
+    }
+  }
+]

--- a/benchmarks/agent_tasks/development/tasks/config-presence/prompt.md
+++ b/benchmarks/agent_tasks/development/tasks/config-presence/prompt.md
@@ -1,0 +1,3 @@
+A deployment options resolver drops explicit false, zero, empty-string, and empty-list overrides. Fix resolve_options in app.py. Only keys present in defaults are supported. An absent override or None inherits the default; every other value is an explicit override. Return a fresh dictionary without changing either input. Keep unknown keys out.
+
+Edit app.py. Run `python -m unittest discover -s tests -v` from the repository root. Python 3.13 and the standard library are sufficient; no installation or network access is needed.

--- a/benchmarks/agent_tasks/development/tasks/config-presence/workspace/README.md
+++ b/benchmarks/agent_tasks/development/tasks/config-presence/workspace/README.md
@@ -1,0 +1,11 @@
+# Config Presence
+
+A deployment options resolver drops explicit false, zero, empty-string, and empty-list overrides. Fix resolve_options in app.py. Only keys present in defaults are supported. An absent override or None inherits the default; every other value is an explicit override. Return a fresh dictionary without changing either input. Keep unknown keys out.
+
+Run the local checks with:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The repository needs Python 3.13 and no external dependencies.

--- a/benchmarks/agent_tasks/development/tasks/config-presence/workspace/app.py
+++ b/benchmarks/agent_tasks/development/tasks/config-presence/workspace/app.py
@@ -1,0 +1,3 @@
+def resolve_options(defaults, overrides):
+    """Resolve a deployment's supported options."""
+    return {key: overrides.get(key) or value for key, value in defaults.items()}

--- a/benchmarks/agent_tasks/development/tasks/config-presence/workspace/tests/test_public.py
+++ b/benchmarks/agent_tasks/development/tasks/config-presence/workspace/tests/test_public.py
@@ -1,0 +1,11 @@
+import unittest
+
+import app
+
+
+class PublicContract(unittest.TestCase):
+    def test_explicit_zero(self):
+        assert app.resolve_options({"retries": 3}, {"retries": 0}) == {"retries": 0}
+
+    def test_none_inherits(self):
+        assert app.resolve_options({"retries": 3}, {"retries": None}) == {"retries": 3}

--- a/benchmarks/agent_tasks/development/tasks/cursor-zero/prompt.md
+++ b/benchmarks/agent_tasks/development/tasks/cursor-zero/prompt.md
@@ -1,0 +1,3 @@
+A cursor-based export stops before all pages are read. Fix collect_pages(fetch) in app.py. The first call is fetch(None); each response has items and next_cursor. None is the only terminal next_cursor. Tokens can be integers or strings, including 0 and the empty string. Empty pages can have a next cursor. Preserve item order and duplicates; the service guarantees a finite cursor chain. Do not modify returned page objects.
+
+Edit app.py. Run `python -m unittest discover -s tests -v` from the repository root. Python 3.13 and the standard library are sufficient; no installation or network access is needed.

--- a/benchmarks/agent_tasks/development/tasks/cursor-zero/workspace/README.md
+++ b/benchmarks/agent_tasks/development/tasks/cursor-zero/workspace/README.md
@@ -1,0 +1,11 @@
+# Cursor Zero
+
+A cursor-based export stops before all pages are read. Fix collect_pages(fetch) in app.py. The first call is fetch(None); each response has items and next_cursor. None is the only terminal next_cursor. Tokens can be integers or strings, including 0 and the empty string. Empty pages can have a next cursor. Preserve item order and duplicates; the service guarantees a finite cursor chain. Do not modify returned page objects.
+
+Run the local checks with:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The repository needs Python 3.13 and no external dependencies.

--- a/benchmarks/agent_tasks/development/tasks/cursor-zero/workspace/app.py
+++ b/benchmarks/agent_tasks/development/tasks/cursor-zero/workspace/app.py
@@ -1,0 +1,10 @@
+def collect_pages(fetch):
+    """Collect a finite cursor-based export."""
+    items = []
+    cursor = None
+    while True:
+        page = fetch(cursor)
+        items.extend(page["items"])
+        cursor = page["next_cursor"]
+        if not cursor:
+            return items

--- a/benchmarks/agent_tasks/development/tasks/cursor-zero/workspace/tests/test_public.py
+++ b/benchmarks/agent_tasks/development/tasks/cursor-zero/workspace/tests/test_public.py
@@ -1,0 +1,12 @@
+import unittest
+
+import app
+
+
+class PublicContract(unittest.TestCase):
+    def test_zero_cursor(self):
+        pages = {None: {"items": ["a"], "next_cursor": 0}, 0: {"items": ["b"], "next_cursor": None}}
+        assert app.collect_pages(pages.__getitem__) == ["a", "b"]
+
+    def test_empty_export(self):
+        assert app.collect_pages(lambda cursor: {"items": [], "next_cursor": None}) == []

--- a/benchmarks/agent_tasks/development/tasks/date-entitlement/prompt.md
+++ b/benchmarks/agent_tasks/development/tasks/date-entitlement/prompt.md
@@ -1,0 +1,3 @@
+An entitlement expires one day early. Fix active_on(start, end, day) in app.py. The service accepts datetime.date values, excluding datetime.datetime, and treats both start and end as included calendar dates. A one-day entitlement is valid. Return whether day is inside the range. Reject reversed ranges with ValueError and any non-date or datetime input with TypeError. Do not apply timestamp half-open conventions to this API.
+
+Edit app.py. Run `python -m unittest discover -s tests -v` from the repository root. Python 3.13 and the standard library are sufficient; no installation or network access is needed.

--- a/benchmarks/agent_tasks/development/tasks/date-entitlement/workspace/README.md
+++ b/benchmarks/agent_tasks/development/tasks/date-entitlement/workspace/README.md
@@ -1,0 +1,11 @@
+# Date Entitlement
+
+An entitlement expires one day early. Fix active_on(start, end, day) in app.py. The service accepts datetime.date values, excluding datetime.datetime, and treats both start and end as included calendar dates. A one-day entitlement is valid. Return whether day is inside the range. Reject reversed ranges with ValueError and any non-date or datetime input with TypeError. Do not apply timestamp half-open conventions to this API.
+
+Run the local checks with:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The repository needs Python 3.13 and no external dependencies.

--- a/benchmarks/agent_tasks/development/tasks/date-entitlement/workspace/app.py
+++ b/benchmarks/agent_tasks/development/tasks/date-entitlement/workspace/app.py
@@ -1,0 +1,12 @@
+from datetime import date, datetime
+
+
+def active_on(start, end, day):
+    """Check a calendar-date entitlement."""
+    if any(
+        not isinstance(value, date) or isinstance(value, datetime) for value in (start, end, day)
+    ):
+        raise TypeError("expected calendar dates")
+    if start > end:
+        raise ValueError("reversed entitlement")
+    return start <= day < end

--- a/benchmarks/agent_tasks/development/tasks/date-entitlement/workspace/tests/test_public.py
+++ b/benchmarks/agent_tasks/development/tasks/date-entitlement/workspace/tests/test_public.py
@@ -1,0 +1,12 @@
+import unittest
+from datetime import date
+
+import app
+
+
+class PublicContract(unittest.TestCase):
+    def test_last_day_is_active(self):
+        assert app.active_on(date(2026, 1, 1), date(2026, 1, 3), date(2026, 1, 3))
+
+    def test_outside_range(self):
+        assert not app.active_on(date(2026, 1, 1), date(2026, 1, 3), date(2025, 12, 31))

--- a/benchmarks/agent_tasks/development/tasks/offset-filtered/prompt.md
+++ b/benchmarks/agent_tasks/development/tasks/offset-filtered/prompt.md
@@ -1,0 +1,3 @@
+A filtered inventory export loses records. Fix collect_pages(fetch, page_size) in app.py. The API takes an offset into its unfiltered inventory and a positive page_size. Its response contains items (filtered matches in that window) and total (the fixed unfiltered inventory size). Advance by page_size even when a response has fewer matches or none. Stop when the next offset is at least total. Fetch offset zero once even for an empty inventory. Reject nonpositive page_size with ValueError. Preserve order and duplicates.
+
+Edit app.py. Run `python -m unittest discover -s tests -v` from the repository root. Python 3.13 and the standard library are sufficient; no installation or network access is needed.

--- a/benchmarks/agent_tasks/development/tasks/offset-filtered/workspace/README.md
+++ b/benchmarks/agent_tasks/development/tasks/offset-filtered/workspace/README.md
@@ -1,0 +1,11 @@
+# Offset Filtered
+
+A filtered inventory export loses records. Fix collect_pages(fetch, page_size) in app.py. The API takes an offset into its unfiltered inventory and a positive page_size. Its response contains items (filtered matches in that window) and total (the fixed unfiltered inventory size). Advance by page_size even when a response has fewer matches or none. Stop when the next offset is at least total. Fetch offset zero once even for an empty inventory. Reject nonpositive page_size with ValueError. Preserve order and duplicates.
+
+Run the local checks with:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The repository needs Python 3.13 and no external dependencies.

--- a/benchmarks/agent_tasks/development/tasks/offset-filtered/workspace/app.py
+++ b/benchmarks/agent_tasks/development/tasks/offset-filtered/workspace/app.py
@@ -1,0 +1,12 @@
+def collect_pages(fetch, page_size):
+    """Collect matches from offset windows over a fixed inventory."""
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    items = []
+    offset = 0
+    while True:
+        page = fetch(offset, page_size)
+        items.extend(page["items"])
+        offset += len(page["items"])
+        if len(page["items"]) < page_size:
+            return items

--- a/benchmarks/agent_tasks/development/tasks/offset-filtered/workspace/tests/test_public.py
+++ b/benchmarks/agent_tasks/development/tasks/offset-filtered/workspace/tests/test_public.py
@@ -1,0 +1,17 @@
+import unittest
+
+import app
+
+
+class PublicContract(unittest.TestCase):
+    def test_empty_middle_window(self):
+        pages = {
+            0: {"items": ["a"], "total": 5},
+            2: {"items": [], "total": 5},
+            4: {"items": ["b"], "total": 5},
+        }
+        assert app.collect_pages(lambda offset, size: pages[offset], 2) == ["a", "b"]
+
+    def test_positive_page_size(self):
+        with self.assertRaises(ValueError):  # noqa: PT027 - standalone stdlib fixture
+            app.collect_pages(lambda offset, size: None, 0)

--- a/benchmarks/agent_tasks/development/tasks/ordered-deltas/prompt.md
+++ b/benchmarks/agent_tasks/development/tasks/ordered-deltas/prompt.md
@@ -1,0 +1,3 @@
+A replay job loses counter increments. Fix replay(initial, events) in app.py. Events are ordered deltas, not full snapshots: process every event in input order. A set operation stores its value, increment adds its numeric value to the current number (default zero for an absent key), and remove deletes a key if present. A set may store None. Increment inputs and existing values at increment time are numbers. Operations can repeat for the same key. Return a fresh dictionary without changing initial or the events.
+
+Edit app.py. Run `python -m unittest discover -s tests -v` from the repository root. Python 3.13 and the standard library are sufficient; no installation or network access is needed.

--- a/benchmarks/agent_tasks/development/tasks/ordered-deltas/workspace/README.md
+++ b/benchmarks/agent_tasks/development/tasks/ordered-deltas/workspace/README.md
@@ -1,0 +1,11 @@
+# Ordered Deltas
+
+A replay job loses counter increments. Fix replay(initial, events) in app.py. Events are ordered deltas, not full snapshots: process every event in input order. A set operation stores its value, increment adds its numeric value to the current number (default zero for an absent key), and remove deletes a key if present. A set may store None. Increment inputs and existing values at increment time are numbers. Operations can repeat for the same key. Return a fresh dictionary without changing initial or the events.
+
+Run the local checks with:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The repository needs Python 3.13 and no external dependencies.

--- a/benchmarks/agent_tasks/development/tasks/ordered-deltas/workspace/app.py
+++ b/benchmarks/agent_tasks/development/tasks/ordered-deltas/workspace/app.py
@@ -1,0 +1,15 @@
+def replay(initial, events):
+    """Replay ordered counter changes."""
+    result = dict(initial)
+    latest = {event["key"]: event for event in events}
+    for event in latest.values():
+        key = event["key"]
+        if event["op"] == "set":
+            result[key] = event["value"]
+        elif event["op"] == "increment":
+            result[key] = result.get(key, 0) + event["value"]
+        elif event["op"] == "remove":
+            result.pop(key, None)
+        else:
+            raise ValueError("unknown operation")
+    return result

--- a/benchmarks/agent_tasks/development/tasks/ordered-deltas/workspace/tests/test_public.py
+++ b/benchmarks/agent_tasks/development/tasks/ordered-deltas/workspace/tests/test_public.py
@@ -1,0 +1,17 @@
+import unittest
+
+import app
+
+
+class PublicContract(unittest.TestCase):
+    def test_repeated_increments(self):
+        assert app.replay(
+            {"a": 2},
+            [
+                {"op": "increment", "key": "a", "value": 3},
+                {"op": "increment", "key": "a", "value": 4},
+            ],
+        ) == {"a": 9}
+
+    def test_remove_absent(self):
+        assert app.replay({}, [{"op": "remove", "key": "a"}]) == {}

--- a/benchmarks/agent_tasks/development/tasks/patch-clear/prompt.md
+++ b/benchmarks/agent_tasks/development/tasks/patch-clear/prompt.md
@@ -1,0 +1,3 @@
+A profile patch endpoint cannot clear optional fields. Fix apply_patch in app.py. This endpoint uses a flat merge-patch contract: None removes a key, an omitted key stays unchanged, and all other values replace or add the key. False, zero and empty containers are valid values. Removing an absent key is harmless. Return a new dictionary and preserve both inputs. Unlike an options resolver, None is a deletion here.
+
+Edit app.py. Run `python -m unittest discover -s tests -v` from the repository root. Python 3.13 and the standard library are sufficient; no installation or network access is needed.

--- a/benchmarks/agent_tasks/development/tasks/patch-clear/workspace/README.md
+++ b/benchmarks/agent_tasks/development/tasks/patch-clear/workspace/README.md
@@ -1,0 +1,11 @@
+# Patch Clear
+
+A profile patch endpoint cannot clear optional fields. Fix apply_patch in app.py. This endpoint uses a flat merge-patch contract: None removes a key, an omitted key stays unchanged, and all other values replace or add the key. False, zero and empty containers are valid values. Removing an absent key is harmless. Return a new dictionary and preserve both inputs. Unlike an options resolver, None is a deletion here.
+
+Run the local checks with:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The repository needs Python 3.13 and no external dependencies.

--- a/benchmarks/agent_tasks/development/tasks/patch-clear/workspace/app.py
+++ b/benchmarks/agent_tasks/development/tasks/patch-clear/workspace/app.py
@@ -1,0 +1,7 @@
+def apply_patch(current, patch):
+    """Apply a flat profile merge patch."""
+    result = dict(current)
+    for key, value in patch.items():
+        if value is not None:
+            result[key] = value
+    return result

--- a/benchmarks/agent_tasks/development/tasks/patch-clear/workspace/tests/test_public.py
+++ b/benchmarks/agent_tasks/development/tasks/patch-clear/workspace/tests/test_public.py
@@ -1,0 +1,13 @@
+import unittest
+
+import app
+
+
+class PublicContract(unittest.TestCase):
+    def test_clear_optional_field(self):
+        assert app.apply_patch({"nickname": "Nova", "active": True}, {"nickname": None}) == {
+            "active": True
+        }
+
+    def test_false_is_a_value(self):
+        assert app.apply_patch({"active": True}, {"active": False}) == {"active": False}

--- a/benchmarks/agent_tasks/development/tasks/versioned-events/prompt.md
+++ b/benchmarks/agent_tasks/development/tasks/versioned-events/prompt.md
@@ -1,0 +1,3 @@
+Out-of-order full-state updates resurrect deleted cache entries. Fix materialize(events) in app.py. Each event has key, integer version, deleted, and value. Select the highest version for each key; equal versions use the last event in input order. A winning deleted event removes the key regardless of its value. Lower-version events must not undo that tombstone. False and None are valid live values. Return a dictionary without changing the input events. These events are full replacements, not deltas.
+
+Edit app.py. Run `python -m unittest discover -s tests -v` from the repository root. Python 3.13 and the standard library are sufficient; no installation or network access is needed.

--- a/benchmarks/agent_tasks/development/tasks/versioned-events/workspace/README.md
+++ b/benchmarks/agent_tasks/development/tasks/versioned-events/workspace/README.md
@@ -1,0 +1,11 @@
+# Versioned Events
+
+Out-of-order full-state updates resurrect deleted cache entries. Fix materialize(events) in app.py. Each event has key, integer version, deleted, and value. Select the highest version for each key; equal versions use the last event in input order. A winning deleted event removes the key regardless of its value. Lower-version events must not undo that tombstone. False and None are valid live values. Return a dictionary without changing the input events. These events are full replacements, not deltas.
+
+Run the local checks with:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The repository needs Python 3.13 and no external dependencies.

--- a/benchmarks/agent_tasks/development/tasks/versioned-events/workspace/app.py
+++ b/benchmarks/agent_tasks/development/tasks/versioned-events/workspace/app.py
@@ -1,0 +1,6 @@
+def materialize(events):
+    """Materialize full-state cache events."""
+    latest = {}
+    for event in events:
+        latest[event["key"]] = event
+    return {key: event["value"] for key, event in latest.items() if not event["deleted"]}

--- a/benchmarks/agent_tasks/development/tasks/versioned-events/workspace/tests/test_public.py
+++ b/benchmarks/agent_tasks/development/tasks/versioned-events/workspace/tests/test_public.py
@@ -1,0 +1,17 @@
+import unittest
+
+import app
+
+
+class PublicContract(unittest.TestCase):
+    def test_old_live_event_cannot_undo_delete(self):
+        events = [
+            {"key": "a", "version": 2, "deleted": True, "value": None},
+            {"key": "a", "version": 1, "deleted": False, "value": "old"},
+        ]
+        assert app.materialize(events) == {}
+
+    def test_live_false(self):
+        assert app.materialize([{"key": "a", "version": 1, "deleted": False, "value": False}]) == {
+            "a": False
+        }

--- a/benchmarks/agent_tasks/development/tasks/window-overlap/prompt.md
+++ b/benchmarks/agent_tasks/development/tasks/window-overlap/prompt.md
@@ -1,0 +1,3 @@
+Back-to-back booking windows are being rejected as overlapping. Fix overlaps(left, right) in app.py. Each window is a pair of timezone-aware datetime objects with start strictly before end. Windows are half-open: start is included and end excluded. Touching endpoints do not overlap. Different UTC offsets still describe absolute instants. Raise ValueError for empty/reversed windows or naive datetimes. Preserve inputs.
+
+Edit app.py. Run `python -m unittest discover -s tests -v` from the repository root. Python 3.13 and the standard library are sufficient; no installation or network access is needed.

--- a/benchmarks/agent_tasks/development/tasks/window-overlap/workspace/README.md
+++ b/benchmarks/agent_tasks/development/tasks/window-overlap/workspace/README.md
@@ -1,0 +1,11 @@
+# Window Overlap
+
+Back-to-back booking windows are being rejected as overlapping. Fix overlaps(left, right) in app.py. Each window is a pair of timezone-aware datetime objects with start strictly before end. Windows are half-open: start is included and end excluded. Touching endpoints do not overlap. Different UTC offsets still describe absolute instants. Raise ValueError for empty/reversed windows or naive datetimes. Preserve inputs.
+
+Run the local checks with:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The repository needs Python 3.13 and no external dependencies.

--- a/benchmarks/agent_tasks/development/tasks/window-overlap/workspace/app.py
+++ b/benchmarks/agent_tasks/development/tasks/window-overlap/workspace/app.py
@@ -1,0 +1,6 @@
+def overlaps(left, right):
+    """Check whether two half-open booking windows overlap."""
+    for start, end in (left, right):
+        if start.utcoffset() is None or end.utcoffset() is None or start >= end:
+            raise ValueError("expected a nonempty aware window")
+    return left[0] <= right[1] and right[0] <= left[1]

--- a/benchmarks/agent_tasks/development/tasks/window-overlap/workspace/tests/test_public.py
+++ b/benchmarks/agent_tasks/development/tasks/window-overlap/workspace/tests/test_public.py
@@ -1,0 +1,17 @@
+import unittest
+from datetime import UTC, datetime, timedelta
+
+import app
+
+
+class PublicContract(unittest.TestCase):
+    def test_touching_windows(self):
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+        hour = timedelta(hours=1)
+        assert not app.overlaps((start, start + hour), (start + hour, start + 2 * hour))
+
+    def test_identical_windows(self):
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+        assert app.overlaps(
+            (start, start + timedelta(hours=1)), (start, start + timedelta(hours=1))
+        )

--- a/moon.yml
+++ b/moon.yml
@@ -1043,18 +1043,20 @@ tasks:
       cache: false
 
   agent-task-test:
-    command: uv run pytest tools/tests/test_agent_task_runner.py tools/tests/test_agent_task_coding_controller.py -v
+    command: uv run pytest tools/tests/test_agent_task_runner.py tools/tests/test_agent_task_coding_controller.py tools/tests/test_agent_task_development_corpus.py -v
     inputs:
       - packages/python/sibyl-core/src/**/*.py
       - benchmarks/agent_tasks/**/*.py
       - tools/tests/test_agent_task_runner.py
       - tools/tests/test_agent_task_coding_controller.py
+      - tools/tests/test_agent_task_development_corpus.py
+      - benchmarks/agent_tasks/development/**/*
       - tools/tests/fixtures/agent_tasks/**/*.py
 
   bench-gate-test:
     command:
       uv run pytest tools/tests/test_agent_task_runner.py tools/tests/test_agent_task_coding_controller.py
-      tools/tests/test_evidence_bundle.py
+      tools/tests/test_agent_task_development_corpus.py tools/tests/test_evidence_bundle.py
       tools/tests/test_benchmark_git_provenance.py tools/tests/test_bench_gate.py
       tools/tests/test_compare_eval_reports.py tools/tests/test_context_pack_eval_script.py
       tools/tests/test_longmemeval_agentic_traversal.py
@@ -1091,6 +1093,7 @@ tasks:
     inputs:
       - packages/python/sibyl-core/src/**/*.py
       - benchmarks/agent_tasks/**/*.py
+      - benchmarks/agent_tasks/development/**/*
       - tools/**/*.py
       - docker-compose.yml
       - .github/workflows/eval.yml

--- a/tools/tests/test_agent_task_development_corpus.py
+++ b/tools/tests/test_agent_task_development_corpus.py
@@ -1,0 +1,249 @@
+"""Generated development tasks discriminate buggy, correct and partial fixes."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+from benchmarks.agent_tasks.manifest import (
+    FIXED_ENVIRONMENT,
+    Manifest,
+    Task,
+    digest,
+    identity,
+    read_artifact,
+    runtime_identity,
+)
+from benchmarks.agent_tasks.runner import CheckerResult, _execute, run_task, snapshot
+
+CORPUS = Path(__file__).resolve().parents[2] / "benchmarks" / "agent_tasks" / "development"
+TASKS = [Task.model_validate(value) for value in json.loads((CORPUS / "tasks.json").read_bytes())]
+
+# Reference edits are applied only to disposable validation snapshots. They are
+# never task workspace artifacts, controller inputs or learning experiences.
+REPAIRS = {
+    "config-presence": [
+        ("overrides.get(key) or value", "value if overrides.get(key) is None else overrides[key]")
+    ],
+    "patch-clear": [
+        (
+            "if value is not None:",
+            "if value is None:\n            result.pop(key, None)\n        else:",
+        )
+    ],
+    "cursor-zero": [("if not cursor:", "if cursor is None:")],
+    "offset-filtered": [
+        (
+            'offset += len(page["items"])\n        if len(page["items"]) < page_size:',
+            'offset += page_size\n        if offset >= page["total"]:',
+        )
+    ],
+    "window-overlap": [
+        ("left[0] <= right[1] and right[0] <= left[1]", "left[0] < right[1] and right[0] < left[1]")
+    ],
+    "date-entitlement": [("start <= day < end", "start <= day <= end")],
+    "versioned-events": [
+        (
+            'latest[event["key"]] = event',
+            'key = event["key"]\n        if key not in latest or event["version"] >= latest[key]["version"]:\n            latest[key] = event',
+        )
+    ],
+    "ordered-deltas": [
+        (
+            '    latest = {event["key"]: event for event in events}\n    for event in latest.values():',
+            "    for event in events:",
+        )
+    ],
+}
+PARTIAL_FIXES = {
+    "config-presence": [
+        (
+            "value if overrides.get(key) is None else overrides[key]",
+            "overrides[key] if isinstance(overrides.get(key), int) else overrides.get(key) or value",
+        )
+    ],
+    "patch-clear": [
+        (
+            "else:\n            result[key] = value",
+            "elif key in current:\n            result[key] = value",
+        )
+    ],
+    "cursor-zero": [("if cursor is None:", 'if cursor is None or cursor == "":')],
+    "offset-filtered": [("return items", "return list(dict.fromkeys(items))")],
+    "window-overlap": [
+        (
+            "return left[0] < right[1] and right[0] < left[1]",
+            "return left[0].replace(tzinfo=None) < right[1].replace(tzinfo=None) and right[0].replace(tzinfo=None) < left[1].replace(tzinfo=None)",
+        )
+    ],
+    "date-entitlement": [
+        ('    if start > end:\n        raise ValueError("reversed entitlement")\n', "")
+    ],
+    "versioned-events": [
+        (
+            'if key not in latest or event["version"] >= latest[key]["version"]:',
+            "if key not in latest:",
+        )
+    ],
+    "ordered-deltas": [
+        ('result.get(key, 0) + event["value"]', 'result.get(key, 0) + max(0, event["value"])')
+    ],
+}
+
+
+def artifact(root: Path, name: str, content: bytes) -> dict:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return {"path": name, "sha256": digest(content)}
+
+
+def frozen_manifest(root: Path) -> Path:
+    root.mkdir()
+    for task in TASKS:
+        for item in [
+            task.prompt,
+            task.checker.script,
+            *(entry.artifact for entry in task.workspace),
+        ]:
+            artifact(root, item.path, read_artifact(CORPUS, item))
+    controller = artifact(
+        root,
+        "noop.py",
+        b'import json,sys\nr=json.load(sys.stdin)\njson.dump({"synthetic":True,"model":r["controller_model"],"tool_calls":0,"input_tokens":0,"output_tokens":0,"cost_usd":0.0},sys.stdout)\n',
+    )
+    lock = artifact(root, "uv.lock", (CORPUS.parents[2] / "uv.lock").read_bytes())
+    memory = artifact(root, "empty-memory.txt", b"")
+    manifest = Manifest.model_validate(
+        {
+            "schema_version": "sibyl-agent-task-manifest-v1",
+            "experiment_id": "development-corpus-validation",
+            "purpose": "trusted_development",
+            "runtime_sha256": identity(runtime_identity()),
+            "dependency_lock": lock,
+            "seed": 0,
+            "controller": {"script": controller},
+            "controller_model": "synthetic-noop-validation",
+            "controller_tools": [],
+            "controller_budget": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "tool_calls": 0,
+                "cost_usd": 0.0,
+            },
+            "controller_timeout_seconds": 5.0,
+            "checker_timeout_seconds": 5.0,
+            "experiences": [],
+            "tasks": [task.model_dump() for task in TASKS],
+            "arms": [{"id": "no-memory", "memory_pack": memory, "learning_source_ids": []}],
+        }
+    )
+    path = root / "manifest.json"
+    path.write_text(manifest.model_dump_json(indent=2))
+    return path
+
+
+def edit(workspace: Path, replacements: list[tuple[str, str]]) -> None:
+    path = workspace / "app.py"
+    source = path.read_text()
+    for old, new in replacements:
+        assert old in source, "reference edit no longer matches the fixture"
+        source = source.replace(old, new)
+    path.write_text(source)
+
+
+def public_result(workspace: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-B", "-m", "unittest", "discover", "-s", "tests", "-v"],
+        cwd=workspace,
+        env=FIXED_ENVIRONMENT,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+
+def independent_result(root: Path, workspace: Path, task: Task) -> CheckerResult:
+    root.mkdir()
+    process = _execute(
+        program=CORPUS / task.checker.script.path,
+        program_sha256=task.checker.script.sha256,
+        args=task.checker.args,
+        request={"attempt_id": root.name, "snapshot_sha256": identity(snapshot(workspace)[0])},
+        workspace=workspace,
+        output=root,
+        role="checker",
+        timeout=5,
+    )
+    assert process["returncode"] == 0
+    assert not process["timed_out"]
+    assert process["process_group_quiescent"]
+    return CheckerResult.model_validate_json((root / "checker-stdout.txt").read_bytes())
+
+
+def test_development_corpus_declares_eight_exposed_tasks_in_four_families():
+    expected_tasks = 8
+    assert len(TASKS) == expected_tasks
+    assert set(Counter(task.family_id for task in TASKS).values()) == {2}
+    assert {task.split for task in TASKS} == {"development"}
+    for task in TASKS:
+        assert task.id.startswith("dev-")
+        assert task.family_id.startswith("dev-")
+        assert task.checker.script.path not in {entry.artifact.path for entry in task.workspace}
+        assert {entry.destination for entry in task.workspace} == {
+            "app.py",
+            "README.md",
+            "tests/test_public.py",
+        }
+        for item in [
+            task.prompt,
+            task.checker.script,
+            *(entry.artifact for entry in task.workspace),
+        ]:
+            assert read_artifact(CORPUS, item)
+
+
+@pytest.mark.parametrize("task", TASKS, ids=lambda task: task.id)
+def test_development_corpus_checks_initial_correct_and_partial_patches(tmp_path, task):
+    manifest = frozen_manifest(tmp_path / "inputs")
+    output = tmp_path / "initial-attempt"
+    receipt = run_task(manifest, task_id=task.id, arm_id="no-memory", output=output)
+    assert receipt["status"] == "task_failed", receipt
+    assert receipt["checker"]["returncode"] == 0
+    assert receipt["outcome"]["detail"].startswith("AssertionError:"), receipt["outcome"]
+    assert receipt["sealed_isolation"] is False
+    assert receipt["learning_benefit_established"] is False
+    workspace = output / "controller-workspace"
+    assert {item["path"] for item in snapshot(workspace)[0] if item["kind"] == "file"} == {
+        "app.py",
+        "README.md",
+        "tests/test_public.py",
+    }
+    initial_public = public_result(workspace)
+    assert initial_public.returncode == 1
+    assert "FAIL:" in initial_public.stderr
+    assert "ERROR:" not in initial_public.stderr
+
+    correct = tmp_path / "reference-validation-workspace"
+    shutil.copytree(workspace, correct)
+    name = task.id.removeprefix("dev-")
+    edit(correct, REPAIRS[name])
+    result = independent_result(tmp_path / "correct-check", correct, task)
+    assert result.passed, result.detail
+    public = public_result(correct)
+    assert public.returncode == 0, public.stderr
+
+    partial = tmp_path / "partial-validation-workspace"
+    shutil.copytree(correct, partial)
+    edit(partial, PARTIAL_FIXES[name])
+    public = public_result(partial)
+    assert public.returncode == 0, public.stderr
+    result = independent_result(tmp_path / "partial-check", partial, task)
+    assert not result.passed
+    assert result.detail.startswith("AssertionError:"), result.detail


### PR DESCRIPTION
The coding controller needs small tasks with checked outcomes before we can run a useful consolidation experiment. This adds eight exposed Python tasks across four paired behavior families, using the existing task manifest and runner.

### 🧪 Task contracts

The pairs cover explicit configuration values versus null deletion, cursor versus filtered-offset pagination, half-open windows versus inclusive dates, and versioned state versus ordered deltas. Each candidate repository contains its contract, buggy implementation and standard-library public tests. A separate checker tests behavior that plausible partial fixes miss.

The task manifest binds prompts, workspace files and the checker by content digest. Reference repairs stay in the validation harness and are never candidate workspace inputs. Moon includes the corpus in both task-runner and benchmark gates, including non-Python artifact changes in their cache inputs.

### 🎯 Validation and limits

- All eight broken repositories fail, complete repairs pass, and partial repairs pass public tests while failing the separate checker.
- The nine corpus validations and all 1,267 benchmark gate tests pass on macOS. Repository inventory lint passes.
- All 268 task-runner, controller and corpus tests pass on the isolated Linux devbox checkout.
- Independent static review passed. All applicable hosted checks pass on commit `73265f91`, including Darwin evaluation authority, package tests, E2E and live SurrealDB ingestion.

These are exposed development tasks. Validation uses a synthetic controller and makes no model calls. The checker runs candidate Python under the same user, so this corpus provides neither sealed evaluation isolation nor evidence of a learning gain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a development coding-task corpus covering configuration handling, pagination, date ranges, time-window overlap, patch updates, event replay, and versioned state.
  - Added task definitions, workspace examples, public tests, behavioral validation, and execution guidance for the development exercises.

- **Documentation**
  - Added documentation describing task contracts, setup requirements, test commands, artifact organization, and experiment usage.

- **Tests**
  - Added comprehensive corpus validation to confirm task metadata, initial failures, partial fixes, and successful repairs.
  - Integrated the new corpus checks into standard project test and benchmark-gate workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->