### PR TITLE
fix(evals): clear inherited setgid on fresh task workspaces

### DIFF
--- a/benchmarks/agent_tasks/runner.py
+++ b/benchmarks/agent_tasks/runner.py
@@ -438,6 +438,8 @@ def _perform_attempt(
         _put(output / "inputs" / name, inputs[name], 292)
     workspace = output / "controller-workspace"
     workspace.mkdir()
+    # Shared parents can propagate setgid into otherwise ordinary task folders.
+    workspace.chmod(stat.S_IMODE(workspace.stat().st_mode) & ~stat.S_ISGID)
     for item in task.workspace:
         _put(workspace / item.destination, inputs[item.artifact.path], item.mode)
     initial, _ = snapshot(workspace)

--- a/tools/tests/test_agent_task_runner.py
+++ b/tools/tests/test_agent_task_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import stat
 import subprocess
 import sys
 import time
@@ -14,6 +15,7 @@ from pathlib import Path
 
 import pytest
 from benchmarks.agent_tasks import runner
+from benchmarks.agent_tasks.coding_controller import inventory
 from benchmarks.agent_tasks.manifest import (
     Arm,
     Manifest,
@@ -1100,3 +1102,23 @@ def test_timeout_still_kills_a_controller_that_ignores_interrupt(experiment, mon
     assert receipt["controller"]["exited_during_termination_grace"] is False
     assert receipt["controller"]["returncode"] == -signal.SIGKILL
     assert receipt["controller"]["process_group_quiescent"] is True
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux directory setgid inheritance")
+def test_fresh_workspace_does_not_inherit_shared_parent_setgid(experiment):
+    manifest, _freeze, output = experiment
+    output.parent.chmod(stat.S_IMODE(output.parent.stat().st_mode) | stat.S_ISGID)
+    manifest["tasks"][0]["workspace"].append(
+        {
+            "artifact": manifest["tasks"][0]["workspace"][0]["artifact"],
+            "destination": "tests/nested.txt",
+        }
+    )
+    receipt = execute(experiment)
+    assert receipt["success"]
+    assert output.stat().st_mode & stat.S_ISGID
+    workspace = output / "controller-workspace"
+    assert not workspace.stat().st_mode & stat.S_ISGID
+    assert not (workspace / "tests").stat().st_mode & stat.S_ISGID
+    assert (workspace / "tests/nested.txt").read_text() == "0"
+    assert inventory(workspace)[0]


### PR DESCRIPTION
Coding tasks stored beneath a shared Linux directory failed before their first model call because nested workspace folders inherited the parent's setgid bit. The controller correctly refused those special permissions, but the runner had introduced them while materializing ordinary task files.

Clear only the inherited setgid bit on the newly created controller workspace, before creating nested folders. Ordinary permissions still follow the caller's umask. The controller continues to reject special permission bits, and checker copies retain the final workspace's recorded modes.

## 🧪 Validation

The runner/controller/corpus suite passes 269 tests on Linux. The Linux regression asserts that the attempt directory actually inherited setgid, checks that the workspace and nested folders did not, and invokes the real controller inventory. The strengthened inheritance and checker-mode cases pass after independent static review. Inventory lint and formatting checks pass; macOS passes 268 tests with the Linux-only case skipped.

On the isolated devbox, all eight exposed coding tasks originally stopped during preflight with zero model calls. With this runner fix, all eight passed their separate checkers under the same frozen model, task inputs, and budgets. Provider-reported cost was about $0.0475. Those are development runtime results, not held-out accuracy or evidence of learning benefit.
