### PR TITLE
feat(graph): isolate background client leases

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_client.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_client.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any, cast
 
-from sibyl_core.backends.surreal.dedicated_client import DedicatedSurrealClient
+from sibyl_core.backends.surreal.dedicated_client import DedicatedSurrealClient, _is_embedded_url
 from sibyl_core.backends.surreal.schema import EMBEDDING_DIM, bootstrap_schema
 from sibyl_core.config import settings
 from sibyl_core.embeddings.providers import EmbeddingProvider
@@ -50,6 +53,91 @@ _client_lock = asyncio.Lock()
 _clients: OrderedDict[str, SurrealGraphClient] = OrderedDict()
 
 
+@dataclass
+class _BackgroundLease:
+    client: SurrealGraphClient
+    users: int = 0
+    closing: asyncio.Task[None] | None = None
+
+
+_background_clients: dict[str, _BackgroundLease] = {}
+_background_lock = asyncio.Lock()
+
+
+def _new_graph_client(group_id: str) -> SurrealGraphClient:
+    return SurrealGraphClient(
+        group_id=group_id,
+        url=settings.resolved_surreal_url,
+        username=settings.surreal_username,
+        password=settings.surreal_password.get_secret_value(),
+        token=settings.surreal_token.get_secret_value(),
+        namespace_prefix=settings.surreal_namespace_prefix,
+        database=settings.surreal_database,
+        pool_size=settings.surreal_client_pool_size("graph"),
+    )
+
+
+async def _close_background_lease(group_id: str, lease: _BackgroundLease) -> None:
+    try:
+        await lease.client.close()
+    finally:
+        async with _background_lock:
+            if _background_clients.get(group_id) is lease:
+                del _background_clients[group_id]
+
+
+async def _finish_background_cleanup(task: asyncio.Task[None]) -> None:
+    """Complete owned socket teardown even if shutdown cancels its waiter again."""
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    task.result()
+    if cancelled:
+        raise asyncio.CancelledError
+
+
+async def _release_background_lease(group_id: str, lease: _BackgroundLease) -> None:
+    async with _background_lock:
+        lease.users -= 1
+        if lease.users == 0:
+            lease.closing = asyncio.create_task(_close_background_lease(group_id, lease))
+        closing = lease.closing
+    if closing is not None:
+        await closing
+
+
+@asynccontextmanager
+async def background_graph_client(group_id: str) -> AsyncIterator[SurrealGraphClient]:
+    """Share one network pool across overlapping background operations per org.
+
+    The active-lease registry is separate from the foreground LRU. Its last user
+    closes the pool; a new operation waits for any old pool teardown to finish.
+    Embedded stores must share their original single writer and memory identity.
+    """
+    if _is_embedded_url(settings.resolved_surreal_url):
+        yield await get_surreal_graph_client(group_id)
+        return
+    while True:
+        async with _background_lock:
+            lease = _background_clients.get(group_id)
+            if lease is None:
+                lease = _BackgroundLease(_new_graph_client(group_id))
+                _background_clients[group_id] = lease
+            if lease.closing is None:
+                lease.users += 1
+                break
+            closing = lease.closing
+        await asyncio.shield(closing)
+    try:
+        yield lease.client
+    finally:
+        cleanup = asyncio.create_task(_release_background_lease(group_id, lease))
+        await _finish_background_cleanup(cleanup)
+
+
 def validate_native_embedding_dimensions(
     embedding_provider: EmbeddingProvider | None,
 ) -> None:
@@ -68,16 +156,7 @@ async def get_surreal_graph_client(group_id: str) -> SurrealGraphClient:
     async with _client_lock:
         client = _clients.get(group_id)
         if client is None:
-            client = SurrealGraphClient(
-                group_id=group_id,
-                url=settings.resolved_surreal_url,
-                username=settings.surreal_username,
-                password=settings.surreal_password.get_secret_value(),
-                token=settings.surreal_token.get_secret_value(),
-                namespace_prefix=settings.surreal_namespace_prefix,
-                database=settings.surreal_database,
-                pool_size=settings.surreal_client_pool_size("graph"),
-            )
+            client = _new_graph_client(group_id)
             _clients[group_id] = client
             while len(_clients) > settings.surreal_graph_client_cache_size:
                 evicted_group_id, evicted_client = _clients.popitem(last=False)
@@ -124,6 +203,7 @@ def _namespace_for_group(prefix: str, group_id: str) -> str:
 
 __all__ = [
     "SurrealGraphClient",
+    "background_graph_client",
     "close_graph_clients",
     "get_surreal_graph_client",
     "mark_graph_schema_dirty",

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_runtime.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_runtime.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -13,6 +14,7 @@ from sibyl_core.embeddings.providers import (
 from sibyl_core.models.entities import EntityType
 from sibyl_core.services.graph_client import (
     SurrealGraphClient,
+    background_graph_client,
     get_surreal_graph_client,
     prepare_graph_schema,
     validate_native_embedding_dimensions,
@@ -76,6 +78,18 @@ async def get_surreal_graph_runtime(
             embedding_provider=embedding_provider,
         ),
     )
+
+
+@asynccontextmanager
+async def background_graph_runtime(group_id: str) -> AsyncIterator[GraphRuntime]:
+    """Bind background managers to their own network pool for this operation."""
+    async with background_graph_client(group_id) as background:
+        await prepare_graph_schema(background)
+        yield GraphRuntime(
+            client=background,
+            entity_manager=EntityManager(background, group_id=group_id),
+            relationship_manager=RelationshipManager(background, group_id=group_id),
+        )
 
 
 async def get_graph_client(group_id: str = "default") -> SurrealGraphClient:
@@ -146,6 +160,7 @@ async def execute_graph_query(
 
 __all__ = [
     "GraphRuntime",
+    "background_graph_runtime",
     "count_entities_by_type",
     "execute_graph_query",
     "get_graph_client",

--- a/packages/python/sibyl-core/tests/test_background_graph_runtime.py
+++ b/packages/python/sibyl-core/tests/test_background_graph_runtime.py
@@ -1,0 +1,219 @@
+"""Background network capacity does not borrow interactive graph sockets."""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from sibyl_core.services import graph_client, graph_runtime
+from sibyl_core.services.graph_client import SurrealGraphClient
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_background_pool_saturation_preserves_interactive_capacity(monkeypatch, cancel):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    sockets = []
+
+    class Socket:
+        def __init__(self, url):
+            self.url = url
+            self.closed = False
+            sockets.append(self)
+
+        async def signin(self, credentials):
+            self.credentials = credentials
+
+        async def use(self, namespace, database):
+            self.namespace, self.database = namespace, database
+
+        async def query(self, query, params=None):
+            if query == "RETURN 'background';":
+                started.set()
+                await release.wait()
+            return [query]
+
+        async def close(self):
+            await asyncio.sleep(0)
+            self.closed = True
+
+    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=Socket))
+    foreground = SurrealGraphClient(
+        group_id="Org-A",
+        url="ws://test.invalid/rpc",
+        username="synthetic",
+        password="test-only",
+        namespace_prefix="custom_",
+        database="custom_graph",
+        pool_size=1,
+    )
+    monkeypatch.setattr(
+        graph_client,
+        "settings",
+        SimpleNamespace(
+            resolved_surreal_url="ws://test.invalid/rpc",
+            surreal_username="synthetic",
+            surreal_password=SimpleNamespace(get_secret_value=lambda: "test-only"),
+            surreal_token=SimpleNamespace(get_secret_value=lambda: ""),
+            surreal_namespace_prefix="custom_",
+            surreal_database="custom_graph",
+            surreal_client_pool_size=lambda kind: 1,
+        ),
+    )
+    monkeypatch.setattr(
+        graph_client,
+        "get_surreal_graph_client",
+        AsyncMock(side_effect=AssertionError("background touched foreground cache")),
+    )
+    monkeypatch.setattr(graph_runtime, "prepare_graph_schema", AsyncMock())
+    background_socket = None
+
+    async def work():
+        nonlocal background_socket
+        async with graph_runtime.background_graph_runtime("Org-A") as runtime:
+            assert runtime.client is not foreground
+            assert runtime.client._pool_size == foreground._pool_size
+            await runtime.client.execute_query("RETURN 'background';")
+            background_socket = sockets[0]
+
+    task = asyncio.create_task(work())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=2)
+        background_socket = sockets[0]
+        # The sole background socket is held until release; a shared pool deadlocks here.
+        result = await asyncio.wait_for(foreground.execute_query("RETURN 'interactive';"), 2)
+        assert result == ["RETURN 'interactive';"]
+        assert len(sockets) == 2
+        assert all(socket.namespace == "custom_orga" for socket in sockets)
+        assert all(socket.database == "custom_graph" for socket in sockets)
+        assert all(
+            socket.credentials == {"username": "synthetic", "password": "test-only"}
+            for socket in sockets
+        )
+        if cancel:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        else:
+            release.set()
+            await task
+        assert background_socket.closed
+        assert not sockets[1].closed
+        assert await foreground.execute_query("RETURN 'still available';")
+    finally:
+        release.set()
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        await foreground.close()
+
+
+async def test_embedded_background_preserves_database_and_client_lifetime(monkeypatch):
+    client = SurrealGraphClient(group_id="background-embedded", url="memory://")
+    monkeypatch.setattr(graph_client, "settings", SimpleNamespace(resolved_surreal_url="memory://"))
+    monkeypatch.setattr(graph_client, "get_surreal_graph_client", AsyncMock(return_value=client))
+    monkeypatch.setattr(graph_runtime, "prepare_graph_schema", AsyncMock())
+    try:
+        await client.execute_query("CREATE sentinel:one SET value = 'retained';")
+        async with graph_runtime.background_graph_runtime(client.group_id) as runtime:
+            assert runtime.client is client
+            assert await runtime.client.execute_query("SELECT VALUE value FROM sentinel:one;") == [
+                "retained"
+            ]
+        assert await client.execute_query("SELECT VALUE value FROM sentinel:one;") == ["retained"]
+    finally:
+        await client.close()
+
+
+async def test_overlapping_background_leases_share_pool_until_last_exit(monkeypatch):
+    client = SurrealGraphClient(
+        group_id="shared-background", url="ws://test.invalid/rpc", pool_size=3
+    )
+    client.close = AsyncMock()
+    factory = Mock(return_value=client)
+    monkeypatch.setattr(
+        graph_client, "settings", SimpleNamespace(resolved_surreal_url="ws://test.invalid/rpc")
+    )
+    monkeypatch.setattr(graph_client, "_new_graph_client", factory)
+    async with graph_client.background_graph_client(client.group_id) as first:
+        async with graph_client.background_graph_client(client.group_id) as second:
+            assert first is second is client
+            assert second._pool_size == 3
+            factory.assert_called_once_with(client.group_id)
+        client.close.assert_not_awaited()
+    client.close.assert_awaited_once()
+    assert client.group_id not in graph_client._background_clients
+
+
+async def test_repeated_shutdown_cancellation_finishes_socket_teardown(monkeypatch):
+    closing = asyncio.Event()
+    release = asyncio.Event()
+    client = SurrealGraphClient(group_id="cancel-background", url="ws://test.invalid/rpc")
+
+    async def close():
+        closing.set()
+        await release.wait()
+
+    client.close = AsyncMock(side_effect=close)
+    monkeypatch.setattr(
+        graph_client, "settings", SimpleNamespace(resolved_surreal_url="ws://test.invalid/rpc")
+    )
+    monkeypatch.setattr(graph_client, "_new_graph_client", lambda _: client)
+
+    async def work():
+        async with graph_client.background_graph_client(client.group_id):
+            pass
+
+    task = asyncio.create_task(work())
+    try:
+        await asyncio.wait_for(closing.wait(), 2)
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert client.group_id not in graph_client._background_clients
+        client.close.assert_awaited_once()
+    finally:
+        release.set()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+async def test_cancellation_while_release_waits_for_registry_lock_does_not_leak(monkeypatch):
+    client = SurrealGraphClient(group_id="cancel-lease-lock", url="ws://test.invalid/rpc")
+    client.close = AsyncMock()
+    monkeypatch.setattr(
+        graph_client, "settings", SimpleNamespace(resolved_surreal_url="ws://test.invalid/rpc")
+    )
+    monkeypatch.setattr(graph_client, "_new_graph_client", lambda _: client)
+    entered = asyncio.Event()
+    leave = asyncio.Event()
+
+    async def work():
+        async with graph_client.background_graph_client(client.group_id):
+            entered.set()
+            await leave.wait()
+
+    task = asyncio.create_task(work())
+    try:
+        await asyncio.wait_for(entered.wait(), 2)
+        async with graph_client._background_lock:
+            leave.set()
+            await asyncio.sleep(0)
+            task.cancel()
+            await asyncio.sleep(0)
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        client.close.assert_awaited_once()
+        assert client.group_id not in graph_client._background_clients
+    finally:
+        leave.set()
+        await asyncio.gather(task, return_exceptions=True)


### PR DESCRIPTION
Background graph operations need their own socket capacity without evicting clients from the foreground cache. This adds a leased graph runtime for that work. Overlapping operations in one organization share one background pool, and the last lease closes it.

## 🛠️ Pool ownership

A separate active-lease registry keeps background acquisition out of the foreground LRU. Both paths use the same client factory for connection settings. Arrivals during teardown wait for it to finish before acquiring a new pool. Lease release and socket cleanup complete even when the caller is cancelled repeatedly, including while release waits for the registry lock.

Embedded stores retain their original client to preserve single-writer storage and in-memory identity. The helper isolates network graph sockets only. Content-pool contention, database workload, and embedded request contention remain separate concerns.

This PR provides the runtime helper. The scheduled lifecycle-repair caller is part of the subsequent lifecycle integration, so merging this PR alone does not switch existing jobs to background pools.

## 🧪 Validation

- The clean branch passes all 3,023 core tests (14 skipped, one expected failure), plus core lint and type checks.
- Tests cover saturated background capacity, overlapping leases, connection settings, repeated cancellation, and real embedded-memory persistence.
- Independent static review passed the identical implementation. A disposable SurrealDB server probe verified shared leases, foreground queries while every background slot was held, shared data, and cleanup. The server image was pinned; the probe used an existing client environment.
- Ordinary and nested timeout probes preserved `TimeoutError` and cancellation counts. No live application instance was changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running background graph operations through a dedicated runtime.
  - Background operations can now share resources efficiently when running concurrently, while remaining separate from interactive graph activity.
  - Embedded database sessions preserve state across background operations and remain available for the duration of their use.

- **Bug Fixes**
  - Improved cleanup reliability when background operations are cancelled or shut down repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->