### PR TITLE
perf(graph): scope schema preparation to its storage resource

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_client.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_client.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, cast
+from weakref import WeakValueDictionary
 
 from sibyl_core.backends.surreal.dedicated_client import DedicatedSurrealClient, _is_embedded_url
 from sibyl_core.backends.surreal.schema import EMBEDDING_DIM, bootstrap_schema
@@ -48,7 +49,7 @@ class SurrealGraphClient(DedicatedSurrealClient):
 
 
 _prepared_groups: set[str] = set()
-_prepare_lock = asyncio.Lock()
+_prepare_locks: WeakValueDictionary[tuple[str, str], asyncio.Lock] = WeakValueDictionary()
 _client_lock = asyncio.Lock()
 _clients: OrderedDict[str, SurrealGraphClient] = OrderedDict()
 
@@ -179,10 +180,13 @@ async def close_graph_clients() -> None:
 
 
 async def prepare_graph_schema(client: SurrealGraphClient) -> None:
+    """Prepare once per org, coordinating embedded DDL across its shared store."""
     group_id = client.group_id
     if group_id in _prepared_groups:
         return
-    async with _prepare_lock:
+    scope = ("store", client._url) if _is_embedded_url(client._url) else ("org", group_id)
+    lock = _prepare_locks.setdefault(scope, asyncio.Lock())
+    async with lock:
         if group_id in _prepared_groups:
             return
         await bootstrap_schema(cast("Any", client))

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -653,6 +653,7 @@ async def test_graph_runtime_can_skip_schema_preparation(
 
 
 class _TransientEntityWriteClient:
+    _url = "memory://"
     group_id = "org-retry"
 
     def __init__(self) -> None:

--- a/packages/python/sibyl-core/tests/test_graph_schema_concurrency.py
+++ b/packages/python/sibyl-core/tests/test_graph_schema_concurrency.py
@@ -1,0 +1,104 @@
+"""Schema preparation shares work within an organization without blocking others."""
+
+import asyncio
+import gc
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+from weakref import WeakValueDictionary
+
+import pytest
+
+from sibyl_core.services import graph_client
+
+
+@pytest.fixture(autouse=True)
+def isolated_preparation_state(monkeypatch):
+    monkeypatch.setattr(graph_client, "_prepared_groups", set())
+    monkeypatch.setattr(graph_client, "_prepare_locks", WeakValueDictionary())
+
+
+@pytest.mark.parametrize(
+    "urls",
+    [("ws://schema-test/rpc", "ws://schema-test/rpc"), ("surrealkv://one", "surrealkv://two")],
+)
+async def test_slow_schema_preparation_does_not_block_another_org(monkeypatch, urls):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    other_started = asyncio.Event()
+
+    async def bootstrap(client):
+        if client.group_id == "slow":
+            started.set()
+            await release.wait()
+        else:
+            other_started.set()
+
+    monkeypatch.setattr(graph_client, "bootstrap_schema", bootstrap)
+    slow = asyncio.create_task(
+        graph_client.prepare_graph_schema(SimpleNamespace(group_id="slow", _url=urls[0]))
+    )
+    await started.wait()
+    other = asyncio.create_task(
+        graph_client.prepare_graph_schema(SimpleNamespace(group_id="other", _url=urls[1]))
+    )
+    try:
+        await asyncio.wait_for(other_started.wait(), 1)
+        await other
+        assert not slow.done()
+        assert graph_client._prepared_groups == {"other"}
+        gc.collect()
+        assert len(graph_client._prepare_locks) == 1
+    finally:
+        release.set()
+        await asyncio.gather(slow, other)
+
+
+async def test_same_org_shares_preparation_and_failure_can_retry(monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def bootstrap(client):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(graph_client, "bootstrap_schema", bootstrap)
+    client = SimpleNamespace(group_id="same", _url="ws://schema-test/rpc")
+    first = asyncio.create_task(graph_client.prepare_graph_schema(client))
+    await started.wait()
+    others = [asyncio.create_task(graph_client.prepare_graph_schema(client)) for _ in range(3)]
+    await asyncio.sleep(0)
+    assert calls == 1
+    assert all(not task.done() for task in others)
+    release.set()
+    await asyncio.gather(first, *others)
+    assert calls == 1
+
+    graph_client.mark_graph_schema_dirty("same")
+    failing = AsyncMock(side_effect=RuntimeError("migration failed"))
+    monkeypatch.setattr(graph_client, "bootstrap_schema", failing)
+    with pytest.raises(RuntimeError, match="migration failed"):
+        await graph_client.prepare_graph_schema(client)
+    assert "same" not in graph_client._prepared_groups
+    success = AsyncMock()
+    monkeypatch.setattr(graph_client, "bootstrap_schema", success)
+    await graph_client.prepare_graph_schema(client)
+    success.assert_awaited_once_with(client)
+
+
+async def test_shared_embedded_store_prepares_both_namespaces(tmp_path):
+    url = "surrealkv://" + str(tmp_path / "schema-store")
+    clients = [
+        graph_client.SurrealGraphClient(group_id="schema" + uuid4().hex, url=url) for _ in range(2)
+    ]
+    try:
+        await asyncio.gather(*(graph_client.prepare_graph_schema(client) for client in clients))
+        for index, client in enumerate(clients):
+            await client.execute_query("CREATE schema_probe:one SET value=$value;", value=index)
+        for index, client in enumerate(clients):
+            assert await client.execute_query("SELECT VALUE value FROM schema_probe;") == [index]
+    finally:
+        await asyncio.gather(*(client.close() for client in clients))


### PR DESCRIPTION
Schema preparation held one process-wide lock, so a slow organization migration blocked unrelated organizations. Preparation now shares a lock per organization for server-backed clients and per store URL for embedded clients. Organizations on the same embedded store retain the DDL coordination they need; separate stores can prepare independently.

Callers retain strong references while holding or waiting for a lock. A weak registry lets unused locks disappear without removing a lock that another caller still needs. The existing prepared-schema cache and failure retry behavior remain intact.

## 🧪 Validation

The cross-organization regression failed with the global lock and passes with the new scope. A real shared-SurrealKV probe caught deserialization errors when preparation was scoped only by organization; the store-scoped implementation passes that probe and verifies namespace isolation. Tests also cover independent embedded stores, same-organization reuse, cache invalidation, and retry after a failed preparation.

Independent static review passed. The clean branch passes `moon run core:test core:lint core:typecheck`: 3,027 tests passed, 14 live retrieval tests skipped, and one existing retrieval-ranking test expected to fail. Cancellation safety was reviewed structurally; the new tests do not exercise cancellation directly. These locks coordinate one process, not migration owners across replicas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved graph schema initialization when multiple requests run concurrently.
  - Prevented unrelated organizations or shared embedded databases from blocking one another during setup.
  - Ensured concurrent setup requests for the same scope are coordinated to avoid duplicate initialization.
  - Improved recovery so schema setup can be retried successfully after a failed attempt.
  - Strengthened namespace isolation when multiple clients use the same embedded database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->