### PR TITLE
fix(storage): check every query result before retrying

### DIFF
--- a/apps/e2e/tests/browser/test_smoke.py
+++ b/apps/e2e/tests/browser/test_smoke.py
@@ -105,7 +105,7 @@ class TestFrontendBrowserContracts:
         search_form = authenticated_page.get_by_role("main").locator("form").first
         search_form.get_by_label("Search", exact=True).fill(query)
         search_form.get_by_role("button", name="Search", exact=True).click()
-        authenticated_page.wait_for_url(re.compile(r"/search\?q="))
+        expect(authenticated_page).to_have_url(re.compile(r"/search\?q="), timeout=30_000)
         assert_path(authenticated_page, "/search")
 
         result_titles = authenticated_page.get_by_role("heading", name=title, exact=True)
@@ -143,6 +143,6 @@ class TestFrontendBrowserContracts:
         )
         expect(task_heading).to_be_visible(timeout=20_000)
         task_heading.click()
-        authenticated_page.wait_for_url(re.compile(r"/tasks/[^/?#]+$"))
+        expect(authenticated_page).to_have_url(re.compile(r"/tasks/[^/?#]+$"), timeout=30_000)
         assert urlparse(authenticated_page.url).path.startswith("/tasks/")
         expect(authenticated_page.get_by_role("heading", name=test_task_title, exact=True)).to_be_visible()

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/connection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/connection.py
@@ -14,6 +14,8 @@ _WRITE_QUERY_TOKENS = {
     "CREATE",
     "DEFINE",
     "DELETE",
+    # Stored functions can write even when invoked through SELECT or RETURN.
+    "FN",
     "IMPORT",
     "INSERT",
     "REBUILD",

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/dedicated_client.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/dedicated_client.py
@@ -15,6 +15,7 @@ from sibyl_core.backends.surreal.connection import (
     _can_retry_query,
     _can_retry_raw_query,
     _is_transient_connection_error,
+    _query_tokens,
 )
 from sibyl_core.backends.surreal.observability import (
     elapsed_ms,
@@ -40,9 +41,73 @@ def _is_embedded_url(url: str) -> bool:
     return url.startswith(_EMBEDDED_URL_SCHEMES)
 
 
-def _is_retryable_transaction_conflict(exc: BaseException) -> bool:
+def _checked_query_result(response: object) -> object:
+    """Validate every statement before returning the SDK's first-result shape."""
+    from surrealdb.errors import SurrealError, parse_query_error, parse_rpc_error
+
+    if not isinstance(response, dict):
+        raise SurrealError("Invalid SurrealDB query response envelope")
+    if (error := response.get("error")) is not None:
+        if not isinstance(error, dict):
+            raise SurrealError("Invalid SurrealDB RPC error envelope")
+        raise parse_rpc_error(error)
+    statements = response.get("result")
+    if not isinstance(statements, list) or not statements:
+        raise SurrealError("Missing SurrealDB query statement results")
+    errors: list[dict[str, object]] = []
+    for statement in statements:
+        if not isinstance(statement, dict) or statement.get("status") not in {"OK", "ERR"}:
+            raise SurrealError("Invalid SurrealDB query statement envelope")
+        if "result" not in statement:
+            raise SurrealError("Missing SurrealDB query statement result")
+        if statement["status"] == "ERR":
+            errors.append(statement)
+    if errors:
+        # An aborted transaction marks preceding statements NotExecuted. Surface
+        # the causal error so callers retain its structured type and retry signal.
+        for error in errors:
+            details = error.get("details")
+            message = error.get("result")
+            if isinstance(message, str) and _is_retryable_transaction_conflict(message):
+                raise parse_query_error(error)
+            if isinstance(message, str) and message in {
+                "The query was not executed due to a failed transaction",
+                "The query was not executed due to a cancelled transaction",
+            }:
+                continue
+            if not isinstance(details, dict) or details.get("kind") not in {
+                "NotExecuted",
+                "Cancelled",
+            }:
+                raise parse_query_error(error)
+        raise parse_query_error(errors[0])
+    return statements[0]["result"]
+
+
+def _is_retryable_transaction_conflict(exc: BaseException | str) -> bool:
     message = str(exc).lower()
     return "transaction conflict" in message and "can be retried" in message
+
+
+def _can_replay_query(query: str, response: object = None) -> bool:
+    """Require one atomic unit before replaying a conflict."""
+    if isinstance(response, dict):
+        results = response.get("result")
+        # The server emits one result per statement. This also recognizes an
+        # implicit transaction containing semicolons inside strings or blocks.
+        if isinstance(results, list) and len(results) == 1:
+            return True
+    statements = [part.strip().upper() for part in query.split(";") if part.strip()]
+    if len(statements) == 1:
+        return True
+    if not statements or statements[0] not in {"BEGIN", "BEGIN TRANSACTION"}:
+        return False
+    if statements[-1] not in {"COMMIT", "COMMIT TRANSACTION"}:
+        return False
+    # Count conservatively, including comments and strings: extra transaction
+    # words may suppress a retry, but cannot hide an intervening commit.
+    tokens = _query_tokens(query)
+    return tokens.count("BEGIN") == 1 and tokens.count("COMMIT") == 1 and "CANCEL" not in tokens
 
 
 def _transaction_conflict_retry_delay(retry_count: int) -> float:
@@ -283,6 +348,7 @@ class DedicatedSurrealClient:
         connection = await self._available.get()
         try:
             while True:
+                transaction_retry_allowed = _can_replay_query(query)
                 try:
                     if not can_retry:
                         while True:
@@ -309,10 +375,15 @@ class DedicatedSurrealClient:
                                     exc,
                                 )
                     client = await connection.connect()
-                    result = await self._send_query(client, query, params=params, raw=raw)
+                    response = await self._send_query(client, query, params=params, raw=True)
+                    if raw:
+                        result = response
+                    else:
+                        transaction_retry_allowed = _can_replay_query(query, response)
+                        result = _checked_query_result(response)
                     break
                 except Exception as exc:
-                    if _is_retryable_transaction_conflict(exc):
+                    if transaction_retry_allowed and _is_retryable_transaction_conflict(exc):
                         if transaction_retry_count >= _MAX_TRANSACTION_CONFLICT_RETRIES:
                             raise
                         transaction_retry_count += 1
@@ -380,7 +451,7 @@ class DedicatedSurrealClient:
         bound_params = params if params else None
         if raw:
             return await client.query_raw(query, bound_params)
-        return await client.query(query, bound_params)
+        return _checked_query_result(await client.query_raw(query, bound_params))
 
 
 def _caller_origin() -> str | None:

--- a/packages/python/sibyl-core/tests/test_background_graph_runtime.py
+++ b/packages/python/sibyl-core/tests/test_background_graph_runtime.py
@@ -1,7 +1,6 @@
 """Background network capacity does not borrow interactive graph sockets."""
 
 import asyncio
-import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -42,7 +41,7 @@ async def test_background_pool_saturation_preserves_interactive_capacity(monkeyp
             await asyncio.sleep(0)
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=Socket))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", Socket)
     foreground = SurrealGraphClient(
         group_id="Org-A",
         url="ws://test.invalid/rpc",

--- a/packages/python/sibyl-core/tests/test_background_graph_runtime.py
+++ b/packages/python/sibyl-core/tests/test_background_graph_runtime.py
@@ -35,6 +35,9 @@ async def test_background_pool_saturation_preserves_interactive_capacity(monkeyp
                 await release.wait()
             return [query]
 
+        async def query_raw(self, query, params=None):
+            return {"result": [{"status": "OK", "result": await self.query(query, params)}]}
+
         async def close(self):
             await asyncio.sleep(0)
             self.closed = True

--- a/packages/python/sibyl-core/tests/test_dedicated_client_pool.py
+++ b/packages/python/sibyl-core/tests/test_dedicated_client_pool.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -34,19 +32,19 @@ def _install_overlap_surreal(monkeypatch, tracker: _ConcurrencyTracker) -> list[
             self.namespace = namespace
             self.database = database
 
-        async def query(self, query: str, params: object | None = None) -> list[dict[str, str]]:
+        async def query_raw(self, query: str, params: object | None = None) -> dict[str, object]:
             tracker.in_flight += 1
             tracker.peak = max(tracker.peak, tracker.in_flight)
             try:
                 await tracker.release.wait()
-                return [{"ok": "yes"}]
+                return {"result": [{"status": "OK", "result": [{"ok": "yes"}]}]}
             finally:
                 tracker.in_flight -= 1
 
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     return clients
 
 
@@ -88,7 +86,7 @@ def _install_live_surreal(monkeypatch) -> list[Any]:
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     return clients
 
 
@@ -324,13 +322,13 @@ async def test_ping_drops_transient_failed_connection(monkeypatch) -> None:
         async def use(self, _namespace: str, _database: str) -> None:
             return None
 
-        async def query(self, _query: str, _params: object | None = None) -> object:
+        async def query_raw(self, _query: str, _params: object | None = None) -> object:
             raise TimeoutError("timed out during opening handshake")
 
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
 
     client = DedicatedSurrealClient(
         url="ws://localhost:8000/rpc",
@@ -364,16 +362,16 @@ async def test_execute_query_retries_server_declared_transaction_conflicts(monke
         async def use(self, _namespace: str, _database: str) -> None:
             return None
 
-        async def query(self, query: str, _params: object | None = None) -> object:
+        async def query_raw(self, query: str, _params: object | None = None) -> object:
             nonlocal calls
             if query == "RETURN true;":
-                return True
+                return {"result": [{"status": "OK", "result": True}]}
             calls += 1
             if calls == 1:
                 raise RuntimeError(
                     "Transaction conflict: Resource busy. This transaction can be retried"
                 )
-            return [{"ok": True}]
+            return {"result": [{"status": "OK", "result": [{"ok": True}]}]}
 
         async def close(self) -> None:
             return None
@@ -381,7 +379,7 @@ async def test_execute_query_retries_server_declared_transaction_conflicts(monke
     async def fake_sleep(seconds: float) -> None:
         sleeps.append(seconds)
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     monkeypatch.setattr(dedicated_client_module.random, "uniform", lambda _low, high: high)
     monkeypatch.setattr(dedicated_client_module.asyncio, "sleep", fake_sleep)
     client = DedicatedSurrealClient(
@@ -414,17 +412,17 @@ async def test_execute_query_does_not_retry_unmarked_transaction_conflicts(monke
         async def use(self, _namespace: str, _database: str) -> None:
             return None
 
-        async def query(self, query: str, _params: object | None = None) -> object:
+        async def query_raw(self, query: str, _params: object | None = None) -> object:
             nonlocal calls
             if query == "RETURN true;":
-                return True
+                return {"result": [{"status": "OK", "result": True}]}
             calls += 1
             raise RuntimeError("Transaction conflict: retry safety is unknown")
 
         async def close(self) -> None:
             return None
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = DedicatedSurrealClient(
         url="ws://localhost:8000/rpc",
         username="root",

--- a/packages/python/sibyl-core/tests/test_surreal_authentication.py
+++ b/packages/python/sibyl-core/tests/test_surreal_authentication.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -43,11 +41,8 @@ def fake_surreal(monkeypatch) -> list[tuple[str, object]]:
     class FakeRecordID:
         pass
 
-    monkeypatch.setitem(
-        sys.modules,
-        "surrealdb",
-        SimpleNamespace(AsyncSurreal=FakeAsyncSurreal, RecordID=FakeRecordID),
-    )
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
+    monkeypatch.setattr("surrealdb.RecordID", FakeRecordID)
     return calls
 
 
@@ -160,7 +155,7 @@ async def test_surreal_dedicated_client_pools_connections_for_concurrent_queries
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = SurrealAuthClient(
         url="ws://localhost:8000/rpc",
         username="root",
@@ -241,7 +236,7 @@ async def test_surreal_dedicated_clients_retry_closed_read_socket(
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
 
     result = await client.execute_query("SELECT * FROM system_settings;")
 
@@ -280,7 +275,7 @@ async def test_surreal_content_client_retries_closed_raw_let_read(monkeypatch) -
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = SurrealContentClient(
         url="ws://localhost:8000/rpc",
         username="root",
@@ -322,7 +317,7 @@ async def test_surreal_dedicated_client_drops_query_id_keyerror_on_write(monkeyp
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = SurrealAuthClient(
         url="ws://localhost:8000/rpc",
         username="root",
@@ -363,7 +358,7 @@ async def test_surreal_content_client_retries_closed_socket_during_connect(monke
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = SurrealContentClient(
         url="ws://localhost:8000/rpc",
         username="root",
@@ -403,7 +398,7 @@ async def test_surreal_content_client_retries_opening_handshake_timeout(monkeypa
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = SurrealContentClient(
         url="ws://localhost:8000/rpc",
         username="root",
@@ -447,7 +442,7 @@ async def test_surreal_content_client_allows_two_closed_raw_read_retries(monkeyp
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = SurrealContentClient(
         url="ws://localhost:8000/rpc",
         username="root",
@@ -497,7 +492,7 @@ async def test_surreal_content_client_preflights_stale_write_socket(monkeypatch)
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = SurrealContentClient(
         url="ws://localhost:8000/rpc",
         username="root",
@@ -550,7 +545,7 @@ async def test_surreal_content_client_does_not_retry_closed_write(monkeypatch) -
         async def close(self) -> None:
             self.closed = True
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     client = SurrealContentClient(
         url="ws://localhost:8000/rpc",
         username="root",
@@ -592,7 +587,7 @@ async def test_surreal_content_client_emits_query_telemetry(monkeypatch) -> None
     def fake_log_query(query: str, **fields: Any) -> None:
         telemetry.append({"query": query, **fields})
 
-    monkeypatch.setitem(sys.modules, "surrealdb", SimpleNamespace(AsyncSurreal=FakeAsyncSurreal))
+    monkeypatch.setattr("surrealdb.AsyncSurreal", FakeAsyncSurreal)
     monkeypatch.setattr(
         "sibyl_core.backends.surreal.dedicated_client.query_start",
         lambda: 10.0,

--- a/packages/python/sibyl-core/tests/test_surreal_authentication.py
+++ b/packages/python/sibyl-core/tests/test_surreal_authentication.py
@@ -35,7 +35,7 @@ def fake_surreal(monkeypatch) -> list[tuple[str, object]]:
 
         async def query_raw(self, query: str, params: object | None = None) -> dict[str, Any]:
             calls.append(("query_raw", (query, params)))
-            return {"result": []}
+            return {"result": [{"status": "OK", "result": []}]}
 
         async def close(self) -> None:
             calls.append(("close", None))
@@ -154,6 +154,9 @@ async def test_surreal_dedicated_client_pools_connections_for_concurrent_queries
             await asyncio.sleep(0)
             return [{"query_count": self.query_count}]
 
+        async def query_raw(self, query, params=None):
+            return {"result": [{"status": "OK", "result": await self.query(query, params)}]}
+
         async def close(self) -> None:
             self.closed = True
 
@@ -232,6 +235,9 @@ async def test_surreal_dedicated_clients_retry_closed_read_socket(
                 raise ConnectionClosedError("sent 1011 keepalive ping timeout")
             return [{"ok": "yes"}]
 
+        async def query_raw(self, query, params=None):
+            return {"result": [{"status": "OK", "result": await self.query(query, params)}]}
+
         async def close(self) -> None:
             self.closed = True
 
@@ -309,6 +315,9 @@ async def test_surreal_dedicated_client_drops_query_id_keyerror_on_write(monkeyp
             if query == "RETURN true;":
                 return []
             raise KeyError("c87ffcce-66d3-4c07-aa06-7e40f3a9e67f")
+
+        async def query_raw(self, query, params=None):
+            return {"result": [{"status": "OK", "result": await self.query(query, params)}]}
 
         async def close(self) -> None:
             self.closed = True
@@ -482,6 +491,9 @@ async def test_surreal_content_client_preflights_stale_write_socket(monkeypatch)
                 raise ConnectionClosedError("sent 1011 keepalive ping timeout")
             return [{"ok": "yes"}]
 
+        async def query_raw(self, query, params=None):
+            return {"result": [{"status": "OK", "result": await self.query(query, params)}]}
+
         async def close(self) -> None:
             self.closed = True
 
@@ -532,6 +544,9 @@ async def test_surreal_content_client_does_not_retry_closed_write(monkeypatch) -
                 return []
             raise ConnectionClosedError("sent 1011 keepalive ping timeout")
 
+        async def query_raw(self, query, params=None):
+            return {"result": [{"status": "OK", "result": await self.query(query, params)}]}
+
         async def close(self) -> None:
             self.closed = True
 
@@ -567,6 +582,9 @@ async def test_surreal_content_client_emits_query_telemetry(monkeypatch) -> None
 
         async def query(self, query: str, params: object | None = None) -> list[Any]:
             return []
+
+        async def query_raw(self, query, params=None):
+            return {"result": [{"status": "OK", "result": await self.query(query, params)}]}
 
         async def close(self) -> None:
             return None

--- a/packages/python/sibyl-core/tests/test_surreal_query_response.py
+++ b/packages/python/sibyl-core/tests/test_surreal_query_response.py
@@ -1,0 +1,246 @@
+"""Normal queries must surface failures anywhere in a statement batch."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from surrealdb.errors import SurrealError
+
+from sibyl_core.backends.surreal.dedicated_client import (
+    DedicatedSurrealClient,
+    _can_replay_query,
+    _checked_query_result,
+)
+
+
+def test_query_response_preserves_first_result_and_ignores_data_error_shapes():
+    payload = [{"status": "ERR", "result": "ordinary stored data"}]
+    assert (
+        _checked_query_result(
+            {
+                "result": [
+                    {"status": "OK", "result": payload},
+                    {"status": "OK", "result": "later result"},
+                ]
+            }
+        )
+        is payload
+    )
+
+
+def test_query_response_raises_causal_error_after_success_and_abort_markers():
+    response = {
+        "result": [
+            {"status": "OK", "result": None},
+            {
+                "status": "ERR",
+                "kind": "Query",
+                "details": {"kind": "NotExecuted"},
+                "result": "The query was not executed due to a failed transaction",
+            },
+            {"status": "ERR", "kind": "Thrown", "result": "ownership lost"},
+            {
+                "status": "ERR",
+                "kind": "Query",
+                "details": {"kind": "Cancelled"},
+                "result": "The query was not executed due to a cancelled transaction",
+            },
+        ]
+    }
+    with pytest.raises(SurrealError, match="ownership lost") as raised:
+        _checked_query_result(response)
+    assert raised.value.kind == "Thrown"
+
+
+def test_query_response_surfaces_rpc_error():
+    with pytest.raises(SurrealError, match="denied"):
+        _checked_query_result({"error": {"kind": "NotAllowed", "message": "denied"}})
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        {},
+        {"result": []},
+        {"result": [None]},
+        {"result": [{"status": "OK"}]},
+        {"result": [{"status": "unknown", "result": None}]},
+    ],
+)
+def test_query_response_rejects_missing_or_malformed_results(response):
+    with pytest.raises(SurrealError):
+        _checked_query_result(response)
+
+
+async def test_normal_query_checks_raw_response_once_and_raw_query_preserves_envelope():
+    response = {
+        "result": [
+            {"status": "OK", "result": None},
+            {"status": "ERR", "kind": "Thrown", "result": "rejected"},
+        ]
+    }
+    transport = SimpleNamespace(query_raw=AsyncMock(return_value=response))
+    client = DedicatedSurrealClient(
+        url="memory://", username="", password="", namespace="response_contract", database="graph"
+    )
+    with pytest.raises(SurrealError, match="rejected"):
+        await client._send_query(
+            transport, "RETURN 1; THROW 'rejected';", params={"x": 1}, raw=False
+        )
+    transport.query_raw.assert_awaited_once_with("RETURN 1; THROW 'rejected';", {"x": 1})
+    assert await client._send_query(transport, "RETURN 1;", params={}, raw=True) is response
+
+
+async def test_embedded_transaction_failure_raises_and_rolls_back():
+    client = DedicatedSurrealClient(
+        url="memory://", username="", password="", namespace="response_rollback", database="graph"
+    )
+    try:
+        await client.execute_query("DEFINE TABLE response_probe SCHEMALESS;")
+        with pytest.raises(SurrealError, match="rejected"):
+            await client.execute_query(
+                "BEGIN TRANSACTION; CREATE response_probe:one; "
+                "THROW 'rejected'; COMMIT TRANSACTION;"
+            )
+        assert await client.execute_query("SELECT * FROM response_probe;") == []
+        await client.execute_query(
+            "BEGIN TRANSACTION; CREATE response_probe:two; COMMIT TRANSACTION;"
+        )
+        assert len(await client.execute_query("SELECT * FROM response_probe;")) == 1
+    finally:
+        await client.close()
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "UPDATE counter:one SET value += 1; UPDATE other:one SET value += 1;",
+        "SELECT * FROM fn::increment_counter(); SELECT * FROM fn::update_other();",
+    ],
+)
+async def test_partial_batch_must_not_replay_successful_write(query):
+    writes = 0
+
+    async def query_raw(query, params):
+        nonlocal writes
+        if query == "RETURN true;":
+            return {"result": [{"status": "OK", "result": True}]}
+        writes += 1
+        return {
+            "result": [
+                {"status": "OK", "result": [{"counter": writes}]},
+                {
+                    "status": "ERR",
+                    "kind": "Query",
+                    "result": "Transaction conflict: Resource busy. This transaction can be retried",
+                }
+                if writes == 1
+                else {"status": "OK", "result": []},
+            ]
+        }
+
+    client = DedicatedSurrealClient(
+        url="memory://", username="", password="", namespace="retry_probe", database="graph"
+    )
+    client._pool[0].connect = AsyncMock(return_value=SimpleNamespace(query_raw=query_raw))
+    with pytest.raises(SurrealError, match="Transaction conflict"):
+        await client.execute_query(query)
+    assert writes == 1
+
+
+@pytest.mark.parametrize(
+    ("query", "allowed"),
+    [
+        ("UPDATE counter:one SET value += 1;", True),
+        ("SELECT * FROM counter; SELECT * FROM other;", False),
+        ("BEGIN; UPDATE counter:one SET value += 1; COMMIT;", True),
+        ("BEGIN TRANSACTION; LET $x = (UPDATE counter:one); COMMIT TRANSACTION;", True),
+        ("UPDATE counter:one; UPDATE other:one;", False),
+        ("BEGIN; UPDATE counter:one; COMMIT; UPDATE other:one;", False),
+        ("BEGIN; UPDATE counter:one; COMMIT; BEGIN; UPDATE other:one; COMMIT;", False),
+        ("BEGIN; UPDATE counter:one; CANCEL; COMMIT;", False),
+    ],
+)
+def test_conflict_replay_requires_one_atomic_unit(query, allowed):
+    assert _can_replay_query(query) is allowed
+
+
+@pytest.mark.parametrize("commit_conflict", [False, True])
+async def test_atomic_transaction_conflict_retries_rolled_back_batch(commit_conflict):
+    attempts = 0
+
+    async def query_raw(query, params):
+        nonlocal attempts
+        if query == "RETURN true;":
+            return {"result": [{"status": "OK", "result": True}]}
+        attempts += 1
+        if attempts == 1:
+            conflict = "Transaction conflict: Resource busy. This transaction can be retried"
+            return {
+                "result": [
+                    {"status": "OK", "result": None},
+                    {
+                        "status": "ERR",
+                        "kind": "Query",
+                        "result": (
+                            "The query was not executed due to a failed transaction"
+                            if commit_conflict
+                            else conflict
+                        ),
+                    },
+                    {
+                        "status": "ERR",
+                        "kind": "Query",
+                        "details": {"kind": "NotExecuted"},
+                        "result": (
+                            conflict
+                            if commit_conflict
+                            else "Cannot COMMIT: the transaction was aborted due to a prior error"
+                        ),
+                    },
+                ]
+            }
+        return {
+            "result": [
+                {"status": "OK", "result": None},
+                {"status": "OK", "result": [{"counter": 1}]},
+            ]
+        }
+
+    client = DedicatedSurrealClient(
+        url="memory://", username="", password="", namespace="atomic_retry", database="graph"
+    )
+    client._pool[0].connect = AsyncMock(return_value=SimpleNamespace(query_raw=query_raw))
+    assert await client.execute_query("BEGIN; UPDATE counter:one SET value += 1; COMMIT;") is None
+    assert attempts == 2
+
+
+class ConnectionClosedError(RuntimeError):
+    pass
+
+
+@pytest.mark.parametrize("raw", [False, True])
+@pytest.mark.parametrize(
+    "query",
+    ["SELECT * FROM fn::increment_counter();", "RETURN fn /* note */ ::increment_counter();"],
+)
+async def test_function_query_does_not_replay_after_lost_response(raw, query):
+    writes = 0
+
+    async def query_raw(query, params):
+        nonlocal writes
+        if query == "RETURN true;":
+            return {"result": [{"status": "OK", "result": True}]}
+        writes += 1
+        if writes == 1:
+            raise ConnectionClosedError("connection closed after commit")
+        return {"result": [{"status": "OK", "result": [{"value": writes}]}]}
+
+    client = DedicatedSurrealClient(
+        url="memory://", username="", password="", namespace="reconnect_probe", database="graph"
+    )
+    client._pool[0].connect = AsyncMock(return_value=SimpleNamespace(query_raw=query_raw))
+    with pytest.raises(ConnectionClosedError):
+        await (client.execute_query_raw(query) if raw else client.execute_query(query))
+    assert writes == 1


### PR DESCRIPTION
Normal SurrealDB queries checked only their first statement result. A transaction could begin successfully, abort on a later statement, and still return `None` to its caller. The shared client now checks every statement before returning the first result, preserving the normal success shape and surfacing the SDK's structured error. Explicit raw queries retain their existing response contract.

Conflict recovery now requires one atomic unit. A non-transactional batch can commit an early write before a later conflict, so replaying the entire batch can duplicate that write. The guard accepts a single server statement or one explicit transaction. Non-atomic batches now surface conflicts instead of replaying earlier committed statements. Stored-function calls also follow the write reconnect policy: SELECT can invoke a function that writes, and a lost response does not prove the write failed. Ordinary read retries and atomic transaction retries remain available.

The browser smoke checks now assert destination URLs without waiting for the
page load event, retaining their 30-second navigation budget and visible search
result/task-heading assertions. SDK test doubles patch connection attributes
instead of replacing the package, preserving error-submodule imports.

## 🧪 Validation

The focused suite passes 61 cases, covering later-statement errors, commit-time conflicts, partial UPDATE and function-call batches, lost responses, authentication, and background pool behavior. Core and API lint/type checks pass. Full core testing passes 3,054 tests (14 live retrieval tests skipped, one existing expected ranking failure). Full API testing passes 2,372 tests (11 skipped). Independent static review found no code defects. Its outstanding full-core gate subsequently passed on the unchanged candidate; nine post-review regression checks and the selected static checks also pass.

The updated SDK fixtures pass all 61 focused cases, the full 3,054-test core
suite, and core lint/type checks. Independent static review passed both
test-only follow-up commits; post-review browser and lint spot checks pass.
An isolated Chromium regression reproduces the old URL wait timeout while a
resource remains pending, then verifies URL/content readiness and rejection of
wrong URLs and missing content. E2E lint passes. The full hosted browser suite
must pass on the revised head before merge.

Four checks pass on an isolated, pinned SurrealDB 3.2.3 server:

- Four non-atomic function batches execute exactly four times and surface conflicts, correcting a reproduction that produced eleven first-counter increments.
- An injected connection loss after a committed function result leaves one increment and propagates the error. An ordinary read with the same fault retries successfully.
- Four overlapping explicit transactions retain all four increments through observed commit conflicts.
- Database ownership guards reject stale and expired owners, permit valid index changes, and produce one winner among ten claimants.

The server receipts retain changed-file hashes and test source. The client environment uses an existing development environment; these checks do not establish packaged release readiness. Query classification is conservative around transaction words and stored-function tokens in comments or literals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database query response handling, providing clearer errors when requests fail or return malformed results.
  * Prevented unsafe automatic retries for operations that may have already changed data.
  * Improved transaction-conflict recovery while avoiding duplicate execution of multi-step or function-based writes.

* **Reliability**
  * Added safeguards for partial responses, failed transactions, and lost query results to help preserve data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
