### PR TITLE
feat(schema): add renewable ownership and index recovery

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/dedicated_client.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/dedicated_client.py
@@ -9,7 +9,7 @@ import random
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from sibyl_core.backends.surreal.connection import (
     _can_retry_query,
@@ -23,6 +23,9 @@ from sibyl_core.backends.surreal.observability import (
     query_start,
 )
 from sibyl_core.backends.surreal.protocols import QueryParams, SurrealClient
+
+if TYPE_CHECKING:
+    from sibyl_core.backends.surreal.schema_version import SurrealExecute
 
 logger = logging.getLogger(__name__)
 _MAX_CLOSED_CONNECTION_RETRIES = 2
@@ -244,6 +247,27 @@ class DedicatedSurrealClient:
             namespace=self._namespace,
             database=self._database,
         )
+
+    @asynccontextmanager
+    async def schema_lease_executor(self) -> AsyncIterator[SurrealExecute]:
+        """Reserve renewal capacity without competing with graph query sockets."""
+        if _is_embedded_url(self._url):
+            yield self.execute_query
+            return
+        control = DedicatedSurrealClient(
+            url=self._url,
+            username=self._username,
+            password=self._password,
+            token=self._token,
+            namespace=self._namespace,
+            database=self._database,
+            client_kind=self._client_kind,
+            pool_size=1,
+        )
+        try:
+            yield control.execute_query
+        finally:
+            await control.close()
 
     async def connect(self) -> SurrealClient:
         connection = await self._available.get()

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/protocols.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/protocols.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Protocol
+from contextlib import AbstractAsyncContextManager
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from sibyl_core.backends.surreal.schema_version import SurrealExecute
 
 type QueryParams = dict[str, object]
 
@@ -35,6 +39,8 @@ class SchemaDriver(Protocol):
 
     @property
     def group_id(self) -> str: ...
+
+    def schema_lease_executor(self) -> AbstractAsyncContextManager[SurrealExecute]: ...
 
     async def execute_query(self, query: str, **params: object) -> object: ...
 

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_index_recovery.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_index_recovery.py
@@ -1,0 +1,84 @@
+"""Recover concurrent index builds while holding namespace schema ownership."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import isfinite
+
+from sibyl_core.backends.surreal.schema_ownership import SchemaOwnership
+from sibyl_core.backends.surreal.schema_version import (
+    ConcurrentIndexDefinition,
+    IndexBuildFailedError,
+    IndexBuildStalledError,
+    IndexBuildStatus,
+    _first_record,
+    _with_concurrently,
+    get_index_build_status,
+    validate_identifier,
+    wait_for_index_ready,
+)
+
+
+async def ensure_owned_concurrent_index(
+    ownership: SchemaOwnership,
+    definition: ConcurrentIndexDefinition,
+    *,
+    rebuild: bool = False,
+    stall_timeout_seconds: float = 300.0,
+) -> IndexBuildStatus:
+    """Activate an index, recovering an unfinished build from a previous owner.
+
+    Callers must hold the namespace lease for every schema mutation. An existing
+    nonterminal build is observed while it progresses, and replaced only if it
+    fails or stalls. The caller supplies the canonical definition for this name; explicit
+    definition changes require ``rebuild=True`` even when the old index is ready.
+    """
+    validate_identifier(definition.name)
+    validate_identifier(definition.table)
+    if not isfinite(stall_timeout_seconds) or stall_timeout_seconds <= 0:
+        raise ValueError("index stall timeout must be positive and finite")
+    await ownership.heartbeat()
+    info = _first_record(await ownership.read(f"INFO FOR TABLE {definition.table};"))
+    indexes = info.get("indexes") if info is not None else None
+    if not isinstance(indexes, Mapping):
+        raise TypeError("index recovery expected table index definitions")
+    exists = definition.name in indexes
+    if exists and not rebuild:
+        status = await get_index_build_status(
+            ownership.read, name=definition.name, table=definition.table
+        )
+        if status is None:
+            raise RuntimeError("existing index returned no build status")
+        if status.status in {"ready", "built"}:
+            return status
+        if status.status != "error":
+            try:
+                return await _wait_for_owned_index(ownership, definition, stall_timeout_seconds)
+            except (IndexBuildStalledError, IndexBuildFailedError):
+                # A lost lease or failed status query must never trigger removal.
+                pass
+
+    body = _with_concurrently(definition.definition)
+    if exists:
+        body = f"REMOVE INDEX {definition.name} ON {definition.table};\n{body}"
+    await ownership.mutate(body)
+    return await _wait_for_owned_index(ownership, definition, stall_timeout_seconds)
+
+
+async def _wait_for_owned_index(
+    ownership: SchemaOwnership,
+    definition: ConcurrentIndexDefinition,
+    stall_timeout_seconds: float,
+) -> IndexBuildStatus:
+    status = await wait_for_index_ready(
+        ownership.read,
+        name=definition.name,
+        table=definition.table,
+        require_status=True,
+        ownership=ownership,
+        timeout_seconds=stall_timeout_seconds,
+        track_progress=True,
+    )
+    if status is None:
+        raise RuntimeError("index recovery completed without observed readiness")
+    return status

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_ownership.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_ownership.py
@@ -1,0 +1,221 @@
+"""Namespace-local ownership for schema mutations and migration checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from sibyl_core.backends.surreal.connection import _query_tokens
+
+if TYPE_CHECKING:
+    from sibyl_core.backends.surreal.schema_version import SurrealExecute
+
+_LEASE_DEFINITIONS = (
+    "DEFINE TABLE IF NOT EXISTS schema_lease SCHEMAFULL;",
+    "DEFINE FIELD IF NOT EXISTS owner ON schema_lease TYPE string;",
+    "DEFINE FIELD IF NOT EXISTS deadline ON schema_lease TYPE datetime;",
+    "DEFINE FIELD IF NOT EXISTS claimed_at ON schema_lease TYPE datetime;",
+    "DEFINE FIELD IF NOT EXISTS stage ON schema_lease TYPE option<string>;",
+    "DEFINE FIELD IF NOT EXISTS mutation_revision ON schema_lease TYPE option<int>;",
+)
+_LOST_MARKER = "sibyl_schema_lease_lost"
+_PARAMETER_PREFIX = "sibyl_schema_"
+
+
+def _lease_duration(seconds: int) -> str:
+    if isinstance(seconds, bool) or not isinstance(seconds, int) or seconds <= 0:
+        raise ValueError("schema lease duration must be a positive integer number of seconds")
+    return f"{seconds}s"
+
+
+def _refresh_statement(seconds: int, *, require_live: bool = True) -> str:
+    live_guard = " AND deadline > time::now()" if require_live else ""
+    return (
+        f"UPDATE schema_lease:graph SET deadline = time::now() + {_lease_duration(seconds)}, "
+        "stage = $sibyl_schema_stage "
+        f"WHERE owner = $sibyl_schema_owner{live_guard} RETURN AFTER"
+    )
+
+
+class SchemaOwnershipLost(RuntimeError):
+    """A migration must stop because its lease expired or another owner took over."""
+
+
+@dataclass(slots=True)
+class SchemaOwnership:
+    """Keep reads unchanged and fence explicitly declared mutations.
+
+    The executor must be checked normal-query execution, already scoped to one
+    organization's graph namespace. Raw response envelopes are rejected.
+    Mutation bodies contain no transaction boundaries and discard their results.
+    Each body commits with an ownership-token write in one transaction. Renewal
+    updates a separate record, so heartbeats do not conflict with a long body.
+    A successor changes both records atomically and fences out the old body.
+    Network callers renew throughout operations longer than the lease duration.
+    Embedded callers renew at statement completion before releasing their sole
+    connection; a background renewal cannot execute while that connection is busy.
+    """
+
+    execute: SurrealExecute
+    owner: str
+    stage: str = "bootstrap"
+    lease_seconds: int = 60
+    lease_execute: SurrealExecute | None = None
+    renew_after_operation: bool = False
+    _lost: bool = field(default=False, init=False)
+
+    def __post_init__(self) -> None:
+        _lease_duration(self.lease_seconds)
+
+    def _completion_renewal(self) -> str:
+        return (
+            f"LET $sibyl_schema_renewed = ({_refresh_statement(self.lease_seconds, require_live=False)}); "
+            "IF array::len($sibyl_schema_renewed) != 1 "
+            f"{{ THROW '{_LOST_MARKER}'; }};"
+        )
+
+    async def read(self, statement: str, /, **params: object) -> object:
+        if not self.renew_after_operation:
+            return await self.execute(statement, **params)
+        if any(name.startswith(_PARAMETER_PREFIX) for name in params):
+            raise ValueError("schema read parameters overlap ownership parameters")
+        await self.heartbeat()
+        try:
+            return await self.execute(
+                f"{statement.rstrip().rstrip(';')}\n;\n{self._completion_renewal()}",
+                **params,
+                sibyl_schema_owner=self.owner,
+                sibyl_schema_stage=self.stage,
+            )
+        except Exception as exc:
+            if _LOST_MARKER not in str(exc):
+                raise
+            self._lost = True
+            raise SchemaOwnershipLost("schema migration ownership lost") from exc
+
+    async def mutate(self, body: str, /, **params: object) -> None:
+        """Commit a trusted schema mutation body only while this lease is live."""
+        self._require_owned()
+        if not body.strip().strip(";").strip():
+            raise ValueError("schema mutation body cannot be empty")
+        # Conservative lexical rejection also covers boundary words in literals
+        # and comments. Schema callers supply trusted, pre-rendered bodies.
+        if {"BEGIN", "COMMIT", "CANCEL"}.intersection(_query_tokens(body)):
+            raise ValueError("schema mutation body must not contain transaction boundaries")
+        if any(name.startswith(_PARAMETER_PREFIX) for name in params):
+            raise ValueError("schema mutation parameters overlap ownership parameters")
+        await self.heartbeat()
+        # Even an otherwise idempotent body must write the fence, so a
+        # successor's ownership change conflicts with its transaction.
+        completion = self._completion_renewal() if self.renew_after_operation else ""
+        try:
+            result = await self.execute(
+                "BEGIN TRANSACTION; "
+                "LET $sibyl_schema_live = (SELECT owner FROM schema_lease:graph "
+                "WHERE owner = $sibyl_schema_owner AND deadline > time::now()); "
+                "LET $sibyl_schema_owned = (UPDATE schema_lease:graph_fence "
+                "SET stage = $sibyl_schema_stage, mutation_revision = (mutation_revision ?? 0) + 1 "
+                "WHERE owner = $sibyl_schema_owner "
+                "AND array::len($sibyl_schema_live) = 1 RETURN AFTER); "
+                "IF array::len($sibyl_schema_owned) != 1 "
+                f"{{ THROW '{_LOST_MARKER}'; }}; "
+                f"{body.rstrip().rstrip(';')}\n;\n{completion}COMMIT TRANSACTION;",
+                **params,
+                sibyl_schema_owner=self.owner,
+                sibyl_schema_stage=self.stage,
+            )
+            # Checked normal execution returns the leading BEGIN's None result.
+            # A raw envelope can contain a rejected fence without raising.
+            if result is not None:
+                self._lost = True
+                raise TypeError("schema mutations require checked query execution")
+        except Exception as exc:
+            if _LOST_MARKER not in str(exc):
+                raise
+            self._lost = True
+            raise SchemaOwnershipLost("schema migration ownership lost") from exc
+
+    async def heartbeat(self) -> None:
+        """Extend ownership during index readiness polling, or stop on lease loss."""
+        self._require_owned()
+        result = await (self.lease_execute or self.execute)(
+            _refresh_statement(self.lease_seconds) + ";",
+            sibyl_schema_owner=self.owner,
+            sibyl_schema_stage=self.stage,
+        )
+        if not isinstance(result, list) or len(result) > 1:
+            self._lost = True
+            raise TypeError(
+                "schema ownership heartbeat requires checked query execution "
+                "returning at most one record"
+            )
+        if not result:
+            self._lost = True
+            raise SchemaOwnershipLost("schema migration ownership lost")
+
+    async def release(self) -> None:
+        """Expire only this owner's lease, preserving its diagnostic record."""
+        if not self._lost:
+            await (self.lease_execute or self.execute)(
+                "UPDATE schema_lease:graph SET deadline = time::now() "
+                "WHERE owner = $owner RETURN NONE;",
+                owner=self.owner,
+            )
+            self._lost = True
+
+    def _require_owned(self) -> None:
+        if self._lost:
+            raise SchemaOwnershipLost("schema migration ownership lost")
+
+
+async def try_acquire_schema_ownership(
+    execute: SurrealExecute,
+    *,
+    lease_seconds: int = 60,
+    initialize: bool = True,
+    mutation_execute: SurrealExecute | None = None,
+    renew_after_operation: bool = False,
+) -> SchemaOwnership | None:
+    """Claim an absent or expired lease without stealing from a live migration.
+
+    Lease bootstrap is idempotent DDL with no data movement. The separate table
+    survives schema-version resets, so reset cannot discard its own ownership.
+    The caller decides whether to wait for a current migration or fail readiness.
+    """
+    duration = _lease_duration(lease_seconds)
+    if initialize:
+        for statement in _LEASE_DEFINITIONS:
+            await execute(statement)
+    owner = uuid4().hex
+    claimed = await execute(
+        "BEGIN TRANSACTION; "
+        "LET $sibyl_schema_claimed = (UPSERT schema_lease:graph SET owner = $owner, "
+        f"deadline = time::now() + {duration}, claimed_at = time::now(), stage = 'bootstrap' "
+        "WHERE owner IS NONE OR deadline <= time::now() RETURN AFTER); "
+        "IF array::len($sibyl_schema_claimed) = 1 { "
+        "UPSERT schema_lease:graph_fence SET owner = $owner, "
+        "deadline = $sibyl_schema_claimed[0].deadline, "
+        "claimed_at = $sibyl_schema_claimed[0].claimed_at, stage = 'bootstrap'; "
+        "}; COMMIT TRANSACTION;",
+        owner=owner,
+    )
+    if claimed is not None:
+        raise TypeError("schema ownership claims require checked query execution")
+    result = await execute(
+        "SELECT owner FROM schema_lease:graph WHERE owner = $owner AND deadline > time::now();",
+        owner=owner,
+    )
+    if not isinstance(result, list):
+        raise TypeError("schema ownership claim expected a record list")
+    if not result:
+        return None
+    if len(result) != 1 or not isinstance(result[0], dict) or result[0].get("owner") != owner:
+        raise ValueError("schema ownership claim returned an unexpected owner")
+    return SchemaOwnership(
+        mutation_execute or execute,
+        owner,
+        lease_seconds=lease_seconds,
+        lease_execute=execute,
+        renew_after_operation=renew_after_operation,
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
@@ -7,9 +7,12 @@ import re
 from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass
 from time import monotonic
-from typing import Protocol, cast
+from typing import TYPE_CHECKING, Protocol, cast
 
 from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement, split_statements
+
+if TYPE_CHECKING:
+    from sibyl_core.backends.surreal.schema_ownership import SchemaOwnership
 
 GRAPH_SCHEMA_CURRENT_VERSION = 20
 GRAPH_SCHEMA_NAME = "graph"
@@ -56,6 +59,14 @@ class IndexBuildStatus:
     initial: int | None = None
     pending: int | None = None
     updated: int | None = None
+
+
+class IndexBuildStalledError(TimeoutError):
+    """An index has shown no build progress within its observation window."""
+
+
+class IndexBuildFailedError(RuntimeError):
+    """The server explicitly reported a failed index build."""
 
 
 async def ensure_schema_version_table(
@@ -215,20 +226,54 @@ async def wait_for_index_ready(
     table: str,
     timeout_seconds: float = 300.0,
     poll_interval_seconds: float = 1.0,
+    require_status: bool = False,
+    ownership: SchemaOwnership | None = None,
+    track_progress: bool = False,
 ) -> IndexBuildStatus | None:
+    """Wait for readiness, optionally measuring timeout since observed progress.
+
+    Initial rows scanned, updates applied, and pending work consumed establish
+    progress independently; none is a completion fraction. Stage transitions
+    also renew the observation window. A growing pending queue alone does not.
+    """
     deadline = monotonic() + timeout_seconds
     last_status: IndexBuildStatus | None = None
     while monotonic() < deadline:
+        if ownership is not None:
+            await ownership.heartbeat()
         status = await get_index_build_status(execute_query, name=name, table=table)
+        if status is None and require_status:
+            raise RuntimeError(f"index {name} on {table} returned no build status")
         if status is None or status.status in {"ready", "built"}:
             return status
         if status.status == "error":
             msg = f"index {name} on {table} failed to build"
-            raise RuntimeError(msg)
+            raise IndexBuildFailedError(msg)
+        if track_progress and _index_build_progressed(last_status, status):
+            deadline = monotonic() + timeout_seconds
         last_status = status
-        await asyncio.sleep(poll_interval_seconds)
+        sleep_seconds = poll_interval_seconds
+        if ownership is not None:
+            sleep_seconds = min(sleep_seconds, ownership.lease_seconds / 3)
+        await asyncio.sleep(sleep_seconds)
     msg = f"timed out waiting for index {name} on {table}: {last_status}"
+    if track_progress:
+        raise IndexBuildStalledError(msg)
     raise TimeoutError(msg)
+
+
+def _index_build_progressed(previous: IndexBuildStatus | None, current: IndexBuildStatus) -> bool:
+    if previous is None or current.status != previous.status:
+        return True
+    for field in ("initial", "updated"):
+        before, after = getattr(previous, field), getattr(current, field)
+        if after is not None and (before is None or after > before):
+            return True
+    return (
+        previous.pending is not None
+        and current.pending is not None
+        and current.pending < previous.pending
+    )
 
 
 def _with_concurrently(definition: str) -> str:

--- a/packages/python/sibyl-core/tests/test_dedicated_client_pool.py
+++ b/packages/python/sibyl-core/tests/test_dedicated_client_pool.py
@@ -436,3 +436,50 @@ async def test_execute_query_does_not_retry_unmarked_transaction_conflicts(monke
         await client.execute_query("UPDATE entity SET updated_at = time::now();")
 
     assert calls == 1
+
+
+async def test_schema_renewal_has_capacity_when_graph_pool_is_occupied(monkeypatch):
+    tracker = _ConcurrencyTracker()
+    clients = _install_overlap_surreal(monkeypatch, tracker)
+    client = DedicatedSurrealClient(
+        url="ws://localhost:8000/rpc",
+        username="qualification",
+        password="synthetic",
+        namespace="org_renewal",
+        database="graph",
+        pool_size=1,
+    )
+    try:
+        async with client.schema_lease_executor() as execute_lease:
+            work = asyncio.create_task(client.execute_query("RETURN 'long mutation';"))
+            renewal = asyncio.create_task(execute_lease("RETURN 'renewal';"))
+            try:
+                for _ in range(200):
+                    if tracker.in_flight == 2:
+                        break
+                    await asyncio.sleep(0.005)
+                assert tracker.in_flight == 2
+                assert all(c.namespace == "org_renewal" and c.database == "graph" for c in clients)
+            finally:
+                tracker.release.set()
+                await asyncio.gather(work, renewal)
+        assert sum(c.closed for c in clients) == 1
+        await client.execute_query("RETURN 'graph still usable';")
+    finally:
+        tracker.release.set()
+        await client.close()
+    assert all(c.closed for c in clients)
+
+
+async def test_embedded_schema_renewal_preserves_the_original_store(monkeypatch):
+    tracker = _ConcurrencyTracker()
+    tracker.release.set()
+    clients = _install_overlap_surreal(monkeypatch, tracker)
+    client = DedicatedSurrealClient(url="memory://", namespace="org_embedded", database="graph")
+    try:
+        async with client.schema_lease_executor() as execute_lease:
+            await execute_lease("RETURN 'renewal';")
+        await client.execute_query("RETURN 'same store';")
+        assert len(clients) == 1 and not clients[0].closed
+    finally:
+        await client.close()

--- a/packages/python/sibyl-core/tests/test_schema_index_progress.py
+++ b/packages/python/sibyl-core/tests/test_schema_index_progress.py
@@ -1,0 +1,76 @@
+"""Build progress extends readiness waits without hiding stalled work."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.backends.surreal import schema_version as schema
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    time = SimpleNamespace(now=0.0)
+    monkeypatch.setattr(schema, "monotonic", lambda: time.now)
+
+    async def sleep(seconds):
+        time.now += seconds
+
+    monkeypatch.setattr(schema.asyncio, "sleep", sleep)
+    return time
+
+
+@pytest.mark.parametrize("counter", ["initial", "updated"])
+async def test_progressing_build_outlives_original_timeout(monkeypatch, clock, counter):
+    statuses = [schema.IndexBuildStatus("indexing", **{counter: i}) for i in range(4)]
+    statuses.append(schema.IndexBuildStatus("ready"))
+    monkeypatch.setattr(schema, "get_index_build_status", AsyncMock(side_effect=statuses))
+    owner = SimpleNamespace(heartbeat=AsyncMock(), lease_seconds=60)
+    ready = await schema.wait_for_index_ready(
+        AsyncMock(),
+        name="idx",
+        table="sample",
+        timeout_seconds=3,
+        poll_interval_seconds=2,
+        ownership=owner,
+        require_status=True,
+        track_progress=True,
+    )
+    assert ready.status == "ready"
+    assert clock.now == 8
+    assert owner.heartbeat.await_count == 5
+
+
+async def test_growing_pending_queue_does_not_reset_stall_clock(monkeypatch, clock):
+    statuses = [schema.IndexBuildStatus("indexing", initial=16, pending=i) for i in range(4)]
+    status_read = AsyncMock(side_effect=statuses)
+    monkeypatch.setattr(schema, "get_index_build_status", status_read)
+    with pytest.raises(schema.IndexBuildStalledError):
+        await schema.wait_for_index_ready(
+            AsyncMock(),
+            name="idx",
+            table="sample",
+            timeout_seconds=3,
+            poll_interval_seconds=2,
+            require_status=True,
+            track_progress=True,
+        )
+    assert clock.now == 4
+    assert status_read.await_count == 2
+
+
+async def test_consumed_pending_work_extends_observation(monkeypatch, clock):
+    statuses = [schema.IndexBuildStatus("indexing", pending=i) for i in (10, 8, 6)]
+    statuses.append(schema.IndexBuildStatus("ready"))
+    monkeypatch.setattr(schema, "get_index_build_status", AsyncMock(side_effect=statuses))
+    ready = await schema.wait_for_index_ready(
+        AsyncMock(),
+        name="idx",
+        table="sample",
+        timeout_seconds=3,
+        poll_interval_seconds=2,
+        require_status=True,
+        track_progress=True,
+    )
+    assert ready.status == "ready"
+    assert clock.now == 6

--- a/packages/python/sibyl-core/tests/test_schema_index_recovery.py
+++ b/packages/python/sibyl-core/tests/test_schema_index_recovery.py
@@ -1,0 +1,143 @@
+"""Recovery distinguishes missing definitions from unfinished index builds."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.backends.surreal import schema_index_recovery as recovery
+from sibyl_core.backends.surreal.schema_ownership import SchemaOwnershipLost
+from sibyl_core.backends.surreal.schema_version import (
+    ConcurrentIndexDefinition,
+    IndexBuildFailedError,
+    IndexBuildStalledError,
+    IndexBuildStatus,
+)
+
+DEFINITION = ConcurrentIndexDefinition(
+    name="idx_value", table="sample", definition="DEFINE INDEX idx_value ON sample FIELDS value"
+)
+
+
+@pytest.mark.parametrize("existing_status", ["missing", "error"])
+async def test_recovery_creates_missing_or_replaces_failed_build(monkeypatch, existing_status):
+    owner = AsyncMock()
+    owner.read.return_value = {
+        "indexes": {} if existing_status == "missing" else {"idx_value": "ddl"}
+    }
+    monkeypatch.setattr(
+        recovery,
+        "get_index_build_status",
+        AsyncMock(return_value=IndexBuildStatus(existing_status) if existing_status else None),
+    )
+    ready = IndexBuildStatus("ready", initial=1000)
+    wait = AsyncMock(return_value=ready)
+    monkeypatch.setattr(recovery, "wait_for_index_ready", wait)
+
+    assert await recovery.ensure_owned_concurrent_index(owner, DEFINITION) == ready
+
+    owner.mutate.assert_awaited_once()
+    body = owner.mutate.await_args.args[0]
+    assert ("REMOVE INDEX idx_value ON sample;" in body) == (existing_status != "missing")
+    assert body.endswith("DEFINE INDEX idx_value ON sample FIELDS value CONCURRENTLY;")
+    wait.assert_awaited_once_with(
+        owner.read,
+        name="idx_value",
+        table="sample",
+        require_status=True,
+        ownership=owner,
+        timeout_seconds=300.0,
+        track_progress=True,
+    )
+
+
+async def test_ready_index_is_preserved_unless_explicitly_rebuilt(monkeypatch):
+    owner = AsyncMock()
+    owner.read.return_value = {"indexes": {"idx_value": "ddl"}}
+    ready = IndexBuildStatus("ready", initial=1000)
+    monkeypatch.setattr(recovery, "get_index_build_status", AsyncMock(return_value=ready))
+    wait = AsyncMock(return_value=ready)
+    monkeypatch.setattr(recovery, "wait_for_index_ready", wait)
+    assert await recovery.ensure_owned_concurrent_index(owner, DEFINITION) == ready
+    owner.mutate.assert_not_awaited()
+    wait.assert_not_awaited()
+    assert await recovery.ensure_owned_concurrent_index(owner, DEFINITION, rebuild=True) == ready
+    owner.mutate.assert_awaited_once()
+    wait.assert_awaited_once()
+
+
+async def test_lost_owner_cannot_inspect_or_restart_index():
+    owner = AsyncMock()
+    owner.heartbeat.side_effect = SchemaOwnershipLost("expired")
+    with pytest.raises(SchemaOwnershipLost):
+        await recovery.ensure_owned_concurrent_index(owner, DEFINITION)
+    owner.read.assert_not_awaited()
+    owner.mutate.assert_not_awaited()
+
+
+async def test_unavailable_table_metadata_is_not_treated_as_missing_index():
+    owner = AsyncMock()
+    owner.read.return_value = {}
+    with pytest.raises(TypeError, match="table index definitions"):
+        await recovery.ensure_owned_concurrent_index(owner, DEFINITION)
+    owner.mutate.assert_not_awaited()
+
+
+async def test_failed_rebuild_does_not_continue_to_readiness(monkeypatch):
+    owner = AsyncMock()
+    owner.read.return_value = {"indexes": {}}
+    owner.mutate.side_effect = SchemaOwnershipLost("expired")
+    wait = AsyncMock()
+    monkeypatch.setattr(recovery, "wait_for_index_ready", wait)
+    with pytest.raises(SchemaOwnershipLost):
+        await recovery.ensure_owned_concurrent_index(owner, DEFINITION)
+    wait.assert_not_awaited()
+
+
+async def test_progressing_predecessor_build_finishes_without_rebuild(monkeypatch):
+    owner = AsyncMock()
+    owner.read.return_value = {"indexes": {"idx_value": "ddl"}}
+    monkeypatch.setattr(
+        recovery, "get_index_build_status", AsyncMock(return_value=IndexBuildStatus("indexing"))
+    )
+    ready = IndexBuildStatus("ready", initial=1000)
+    monkeypatch.setattr(recovery, "wait_for_index_ready", AsyncMock(return_value=ready))
+    assert await recovery.ensure_owned_concurrent_index(owner, DEFINITION) == ready
+    owner.mutate.assert_not_awaited()
+
+
+@pytest.mark.parametrize("failure", [IndexBuildStalledError, IndexBuildFailedError])
+async def test_stalled_or_failed_predecessor_is_rebuilt_once(monkeypatch, failure):
+    owner = AsyncMock()
+    owner.read.return_value = {"indexes": {"idx_value": "ddl"}}
+    monkeypatch.setattr(
+        recovery, "get_index_build_status", AsyncMock(return_value=IndexBuildStatus("indexing"))
+    )
+    ready = IndexBuildStatus("ready", initial=1000)
+    wait = AsyncMock(side_effect=[failure("stopped"), ready])
+    monkeypatch.setattr(recovery, "wait_for_index_ready", wait)
+    assert await recovery.ensure_owned_concurrent_index(owner, DEFINITION) == ready
+    owner.mutate.assert_awaited_once()
+    assert owner.mutate.await_args.args[0].startswith("REMOVE INDEX idx_value ON sample;")
+    assert wait.await_count == 2
+
+
+@pytest.mark.parametrize("failure", [TimeoutError, SchemaOwnershipLost, OSError])
+async def test_read_or_ownership_failure_never_rebuilds(monkeypatch, failure):
+    owner = AsyncMock()
+    owner.read.return_value = {"indexes": {"idx_value": "ddl"}}
+    monkeypatch.setattr(
+        recovery, "get_index_build_status", AsyncMock(return_value=IndexBuildStatus("indexing"))
+    )
+    monkeypatch.setattr(recovery, "wait_for_index_ready", AsyncMock(side_effect=failure("failed")))
+    with pytest.raises(failure):
+        await recovery.ensure_owned_concurrent_index(owner, DEFINITION)
+    owner.mutate.assert_not_awaited()
+
+
+async def test_missing_build_metadata_does_not_destroy_existing_index(monkeypatch):
+    owner = AsyncMock()
+    owner.read.return_value = {"indexes": {"idx_value": "ddl"}}
+    monkeypatch.setattr(recovery, "get_index_build_status", AsyncMock(return_value=None))
+    with pytest.raises(RuntimeError, match="no build status"):
+        await recovery.ensure_owned_concurrent_index(owner, DEFINITION)
+    owner.mutate.assert_not_awaited()

--- a/packages/python/sibyl-core/tests/test_schema_ownership.py
+++ b/packages/python/sibyl-core/tests/test_schema_ownership.py
@@ -1,0 +1,274 @@
+"""Schema ownership rejects stale mutations without changing query result shape."""
+
+import asyncio
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl_core.backends.surreal.schema_ownership import (
+    SchemaOwnership,
+    SchemaOwnershipLost,
+    try_acquire_schema_ownership,
+)
+from sibyl_core.services.graph_client import SurrealGraphClient
+
+
+@pytest.fixture
+async def client():
+    connection = SurrealGraphClient(group_id=f"schema-lease-{uuid4().hex}", url="memory://")
+    try:
+        yield connection
+    finally:
+        await connection.close()
+
+
+async def test_first_claim_is_exclusive_and_release_allows_successor(client):
+    claims = await asyncio.gather(
+        *(try_acquire_schema_ownership(client.execute_query) for _ in range(10))
+    )
+    owners = [claim for claim in claims if claim is not None]
+    assert len(owners) == 1
+    owner = owners[0]
+    assert await try_acquire_schema_ownership(client.execute_query) is None
+    await owner.release()
+    successor = await try_acquire_schema_ownership(client.execute_query)
+    assert successor is not None
+    assert successor.owner != owner.owner
+    with pytest.raises(SchemaOwnershipLost):
+        await owner.mutate("CREATE protected:stale;")
+    await successor.release()
+
+
+@pytest.mark.parametrize(
+    "body", ["BEGIN TRANSACTION; CREATE protected:one; COMMIT;", "CANCEL;", "COMMIT;"]
+)
+async def test_mutation_rejects_transaction_controls(client, body):
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    with pytest.raises(ValueError, match="transaction"):
+        await owner.mutate(body)
+    await owner.release()
+
+
+async def test_mutation_reserves_guard_parameters(client):
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    with pytest.raises(ValueError, match="ownership parameters"):
+        await owner.mutate("CREATE protected:one;", sibyl_schema_owned=[{}])
+    await owner.release()
+
+
+async def test_mutation_rejects_unchecked_raw_executor(client):
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    await owner.mutate("DEFINE TABLE protected SCHEMALESS;")
+    unchecked = SchemaOwnership(client.execute_query_raw, owner.owner)
+    await client.execute_query("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+    with pytest.raises(TypeError, match="checked query"):
+        await unchecked.mutate("CREATE protected:stale;")
+    assert await client.execute_query("SELECT * FROM protected;") == []
+
+
+async def test_comment_terminated_mutation_commits(client):
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    assert await owner.mutate("CREATE protected:one SET value = 42; -- trailing comment") is None
+    assert await owner.read("SELECT VALUE value FROM protected;") == [42]
+    await owner.release()
+
+
+async def test_index_wait_renews_before_reading_status(client, monkeypatch):
+    from sibyl_core.backends.surreal import schema_version
+
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    await client.execute_query("UPDATE schema_lease:graph SET deadline = time::now() + 1s;")
+
+    async def ready(*args, **kwargs):
+        assert await owner.read(
+            "SELECT VALUE deadline > time::now() + 30s FROM schema_lease:graph;"
+        ) == [True]
+        return schema_version.IndexBuildStatus("ready")
+
+    monkeypatch.setattr(schema_version, "get_index_build_status", ready)
+    await schema_version.wait_for_index_ready(
+        owner.read, name="example", table="entity", ownership=owner
+    )
+    await owner.release()
+
+
+async def test_index_wait_stops_after_ownership_loss(client, monkeypatch):
+    from sibyl_core.backends.surreal import schema_version
+
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    polls = 0
+
+    async def building(*args, **kwargs):
+        nonlocal polls
+        polls += 1
+        await client.execute_query("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+        return schema_version.IndexBuildStatus("indexing")
+
+    monkeypatch.setattr(schema_version, "get_index_build_status", building)
+    with pytest.raises(SchemaOwnershipLost):
+        await schema_version.wait_for_index_ready(
+            owner.read, name="example", table="entity", ownership=owner, poll_interval_seconds=0
+        )
+    assert polls == 1
+
+
+async def test_configured_lease_duration_applies_to_claim_and_renewal(client):
+    owner = await try_acquire_schema_ownership(client.execute_query, lease_seconds=120)
+    assert owner is not None
+    long_deadline = "SELECT VALUE deadline > time::now() + 100s FROM schema_lease:graph;"
+    assert await owner.read(long_deadline) == [True]
+    await client.execute_query("UPDATE schema_lease:graph SET deadline = time::now() + 1s;")
+    await owner.mutate("CREATE lease_duration_probe:one;")
+    assert await owner.read(long_deadline) == [True]
+    await client.execute_query("UPDATE schema_lease:graph SET deadline = time::now() + 1s;")
+    await owner.heartbeat()
+    assert await owner.read(long_deadline) == [True]
+    await owner.release()
+
+
+async def test_invalid_lease_duration_does_not_touch_database(client):
+    execute = AsyncMock(wraps=client.execute_query)
+    for invalid in (0, -1, True):
+        with pytest.raises(ValueError, match="positive integer"):
+            await try_acquire_schema_ownership(execute, lease_seconds=invalid)
+    execute.assert_not_awaited()
+
+
+async def test_lease_duration_covers_long_atomic_mutation(client):
+    short = await try_acquire_schema_ownership(client.execute_query, lease_seconds=1)
+    assert short is not None
+    await short.mutate("SLEEP 1500ms; CREATE lease_duration_probe:short;")
+    with pytest.raises(SchemaOwnershipLost):
+        await short.heartbeat()
+    long = await try_acquire_schema_ownership(client.execute_query, lease_seconds=10)
+    assert long is not None
+    await long.mutate("SLEEP 1500ms; CREATE lease_duration_probe:long;")
+    await long.heartbeat()
+    assert await long.read("SELECT count() AS count FROM lease_duration_probe GROUP ALL;") == [
+        {"count": 2}
+    ]
+    await long.release()
+
+
+async def test_index_wait_keeps_heartbeat_within_short_lease(client, monkeypatch):
+    from sibyl_core.backends.surreal import schema_version
+
+    execute = AsyncMock(return_value=[{}])
+    owner = SchemaOwnership(execute, "synthetic", lease_seconds=3)
+    status = AsyncMock(
+        side_effect=[
+            schema_version.IndexBuildStatus("indexing"),
+            schema_version.IndexBuildStatus("ready"),
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(schema_version, "get_index_build_status", status)
+    monkeypatch.setattr(schema_version.asyncio, "sleep", sleep)
+    await schema_version.wait_for_index_ready(
+        owner.read, name="example", table="entity", ownership=owner, poll_interval_seconds=120
+    )
+    assert sleep.await_count == 1
+    assert 0 < sleep.await_args.args[0] < owner.lease_seconds
+    assert execute.await_count == 2
+
+
+async def test_expired_owner_cannot_mutate_or_release_successor(client):
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    await client.execute_query("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+    successor = await try_acquire_schema_ownership(client.execute_query)
+    assert successor is not None
+    await successor.mutate("CREATE protected:current SET value = 1;")
+    with pytest.raises(SchemaOwnershipLost):
+        await owner.mutate("REMOVE TABLE protected;")
+    await owner.release()
+    await successor.heartbeat()
+    assert await successor.read("SELECT VALUE value FROM protected;") == [1]
+    await successor.release()
+
+
+async def test_expired_heartbeat_stops_without_reviving_lease(client):
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    await client.execute_query("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+    with pytest.raises(SchemaOwnershipLost):
+        await owner.heartbeat()
+    assert await client.execute_query(
+        "SELECT VALUE deadline <= time::now() FROM schema_lease:graph;"
+    ) == [True]
+    with pytest.raises(SchemaOwnershipLost):
+        await owner.mutate("CREATE protected:stale;")
+
+
+async def test_mutation_page_rolls_back_data_and_cursor_together(client):
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    await owner.mutate("DEFINE TABLE protected SCHEMALESS;")
+    await owner.mutate("CREATE checkpoint:one SET cursor = 'before';")
+    with pytest.raises(Exception, match="abort page"):
+        await owner.mutate(
+            "CREATE protected:partial SET value = 1; "
+            "UPDATE checkpoint:one SET cursor = 'after'; THROW 'abort page';"
+        )
+    assert await owner.read("SELECT * FROM protected;") == []
+    assert await owner.read("SELECT VALUE cursor FROM checkpoint:one;") == ["before"]
+    assert await owner.read("RETURN 7;") == 7
+    await owner.mutate(
+        "CREATE protected:complete SET value = $value; UPDATE checkpoint:one SET cursor = 'after';",
+        value=2,
+    )
+    assert await owner.read("SELECT VALUE value FROM protected;") == [2]
+    assert await owner.read("SELECT VALUE cursor FROM checkpoint:one;") == ["after"]
+    await owner.release()
+
+
+async def test_schema_version_reset_preserves_owner_and_fences_advancement(client):
+    owner = await try_acquire_schema_ownership(client.execute_query)
+    assert owner is not None
+    await owner.mutate("UPSERT schema_version:graph SET name = 'graph', version = 22;")
+    await owner.mutate("REMOVE TABLE schema_version;")
+    owner.stage = "migration_23"
+    await owner.heartbeat()
+    assert await owner.read("SELECT VALUE stage FROM schema_lease:graph;") == ["migration_23"]
+    await owner.mutate("CREATE schema_version:graph SET name = 'graph', version = 22;")
+    await client.execute_query("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+    successor = await try_acquire_schema_ownership(client.execute_query)
+    assert successor is not None
+    with pytest.raises(SchemaOwnershipLost):
+        await owner.mutate("UPDATE schema_version:graph SET version = 23;")
+    assert await successor.read("SELECT VALUE version FROM schema_version:graph;") == [22]
+    await successor.mutate("UPDATE schema_version:graph SET version = 23;")
+    assert await successor.read("SELECT VALUE version FROM schema_version:graph;") == [23]
+    await successor.release()
+
+
+async def test_embedded_read_reports_takeover_and_preserves_successor(client):
+    execute = client.execute_query
+    owner = await try_acquire_schema_ownership(execute, renew_after_operation=True)
+    assert owner is not None
+    successor = None
+
+    async def take_over_before_read(statement, **params):
+        nonlocal successor
+        if statement.startswith("RETURN 7"):
+            await execute("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+            successor = await try_acquire_schema_ownership(execute, initialize=False)
+            assert successor is not None
+        return await execute(statement, **params)
+
+    owner.execute = take_over_before_read
+    with pytest.raises(SchemaOwnershipLost):
+        await owner.read("RETURN 7;")
+    assert successor is not None
+    await owner.release()
+    await successor.heartbeat()
+    with pytest.raises(SchemaOwnershipLost):
+        await owner.mutate("CREATE protected:stale;")
+    await successor.release()


### PR DESCRIPTION
Add shared migration primitives for operations that outlive a lease and index builds that need to resume without losing progress. This PR supplies the ownership and recovery components; graph bootstrap activation remains a separate change.

## 🛠️ Ownership and recovery

Each mutating transaction increments a namespace-local fence counter. A successor changes the same fence record when claiming ownership, causing an overlapping stale transaction to roll back. Lease heartbeats use a separate record so renewal can continue during a long mutation without conflicting with it.

The graph client can reserve a temporary, separately scoped renewal connection when its query pool is occupied. Embedded stores reuse their existing connection and renew at operation completion. Index recovery preserves ready and advancing builds, rebuilds a failed or stalled build once, and requires explicit readiness before completing.

The graph schema remains at version 20, and existing bootstrap callers retain their current behavior. Activating migration ownership belongs with the migration integration and its live CI regressions.

## 🧪 Validation

- The clean branch passes 3,091 core tests (14 skipped, one existing expected failure), core lint, and type checks.
- The same ownership helper passed isolated SurrealDB 3.2.3 qualification for renewal during three-second operations under a one-second lease, stale-body rollback after takeover, and successor writes. These integration receipts exercise the helper with the separate bootstrap candidate.
- Recovery qualification preserved a progressing 100,000-row index and recovered a crash-stalled 50,000-row index.

Independent review passed for this main-based prerequisite. Post-review verification passes 50 focused ownership, pool, and index tests plus type checking. All applicable hosted test jobs pass; automatic code review remains in progress. Migration activation and release readiness remain separate gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added schema ownership leases to coordinate concurrent schema changes safely.
  - Added concurrent index recovery with progress tracking, lease heartbeats, and automatic handling of stalled or failed builds.
  - Added dedicated schema-renewal connections for reliable lease maintenance.
  - Added clearer errors for failed or stalled index builds.

- **Tests**
  - Added coverage for lease acquisition, renewal, takeover, ownership loss, and index recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->