### PR TITLE
feat(schema): activate owned bootstrap and resumable repair

### DIFF
--- a/apps/api/tests/test_surreal_live_runtime.py
+++ b/apps/api/tests/test_surreal_live_runtime.py
@@ -1006,3 +1006,86 @@ async def test_live_auth_replay_identity_migration_preserves_data_lineage() -> N
         await client.close()
         await replacement.close()
         await _drop_surreal_namespace(namespace)
+
+
+@pytest.mark.parametrize("operation", ["read", "mutation", "takeover"])
+async def test_live_surreal_schema_renewal_and_takeover(monkeypatch, operation):
+    import asyncio
+
+    from sibyl_core.backends.surreal import schema
+    from sibyl_core.backends.surreal.schema_ownership import (
+        SchemaOwnershipLost,
+        try_acquire_schema_ownership,
+    )
+
+    group_id = str(uuid4())
+    clients = [
+        SurrealGraphClient(
+            group_id=group_id,
+            url=_live_surreal_url(),
+            username=_surreal_username(),
+            password=_surreal_password(),
+            pool_size=1,
+        )
+        for _ in range(2)
+    ]
+    client, observer = clients
+    successor = None
+
+    async def short_claim(execute, **kwargs):
+        return await try_acquire_schema_ownership(execute, lease_seconds=1, **kwargs)
+
+    async def stopped_renewal(ownership):
+        await asyncio.Event().wait()
+
+    try:
+        await prepare_graph_schema(client)
+        await client.execute_query("DEFINE TABLE schema_renewal_probe SCHEMALESS;")
+        monkeypatch.setattr(schema, "try_acquire_schema_ownership", short_claim)
+        if operation == "takeover":
+            monkeypatch.setattr(schema, "_renew_schema_ownership", stopped_renewal)
+        async with schema._graph_schema_ownership(client) as ownership:
+            work = asyncio.create_task(
+                ownership.read("SLEEP 3s; RETURN 1;")
+                if operation == "read"
+                else ownership.mutate("SLEEP 3s; CREATE schema_renewal_probe:body SET value = 1;")
+            )
+            try:
+                await asyncio.sleep(1.3)
+                assert not work.done()
+                successor = await try_acquire_schema_ownership(
+                    observer.execute_query, initialize=False
+                )
+                assert not work.done(), "the contender must claim while the body is in flight"
+                if operation == "takeover":
+                    assert successor is not None
+                    with pytest.raises(SchemaOwnershipLost):
+                        await work
+                    assert await observer.execute_query("SELECT * FROM schema_renewal_probe;") == []
+                else:
+                    assert successor is None
+                    await work
+                    assert await observer.execute_query(
+                        "SELECT VALUE deadline > time::now() FROM schema_lease:graph;"
+                    ) == [True]
+                    if operation == "mutation":
+                        assert await observer.execute_query(
+                            "SELECT VALUE value FROM schema_renewal_probe:body;"
+                        ) == [1]
+            finally:
+                if not work.done():
+                    work.cancel()
+                await asyncio.gather(work, return_exceptions=True)
+        if successor is None:
+            successor = await try_acquire_schema_ownership(observer.execute_query, initialize=False)
+        assert successor is not None
+        await successor.mutate("CREATE schema_renewal_probe:successor SET value = 2;")
+        assert await observer.execute_query(
+            "SELECT VALUE value FROM schema_renewal_probe:successor;"
+        ) == [2]
+    finally:
+        if successor is not None:
+            await successor.release()
+        await asyncio.gather(*(connection.close() for connection in clients))
+        with suppress(Exception):
+            await _drop_surreal_namespace(client.namespace)

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from functools import partial
 from typing import TYPE_CHECKING, cast
 
 import structlog
 
 from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement, split_statements
+from sibyl_core.backends.surreal.schema_index_recovery import ensure_owned_concurrent_index
+from sibyl_core.backends.surreal.schema_lifecycle_repair import (
+    LIFECYCLE_REPAIR_FIELDS,
+    migrate_lifecycle_repair,
+)
+from sibyl_core.backends.surreal.schema_ownership import (
+    SchemaOwnership,
+    try_acquire_schema_ownership,
+)
 from sibyl_core.backends.surreal.schema_version import (
     GRAPH_SCHEMA_CURRENT_VERSION,
     SCHEMA_VERSION_TABLE,
@@ -18,8 +30,8 @@ from sibyl_core.backends.surreal.schema_version import (
     apply_schema_migrations,
     ensure_schema_version_table,
     get_schema_embedding_dimension,
+    get_schema_embedding_rebuild_dimension,
     get_schema_version,
-    rebuild_index_concurrently,
     record_schema_version,
 )
 from sibyl_core.config import core_config
@@ -108,6 +120,11 @@ DEFINE FIELD IF NOT EXISTS retrieval_keys_normalized ON entity TYPE option<array
 DEFINE FIELD IF NOT EXISTS name_embedding ON entity TYPE option<array<float, {EMBEDDING_DIM}>>;
 
 DEFINE INDEX IF NOT EXISTS idx_entity_uuid ON entity FIELDS uuid UNIQUE;
+DEFINE INDEX IF NOT EXISTS idx_entity_raw_sources ON entity FIELDS attributes.raw_source_ids.*;
+DEFINE INDEX IF NOT EXISTS idx_entity_raw_memory ON entity FIELDS attributes.raw_memory_id;
+DEFINE INDEX IF NOT EXISTS idx_entity_review_capture ON entity FIELDS attributes.review_capture_id;
+DEFINE INDEX IF NOT EXISTS idx_entity_projection_parent ON entity FIELDS attributes.parent_entity_id;
+DEFINE INDEX IF NOT EXISTS idx_entity_projection_source ON entity FIELDS attributes.source_entity_id;
 DEFINE INDEX IF NOT EXISTS idx_entity_type ON entity FIELDS entity_type;
 DEFINE INDEX IF NOT EXISTS idx_entity_labels ON entity FIELDS labels.*;
 DEFINE INDEX IF NOT EXISTS idx_entity_project ON entity FIELDS project_id;
@@ -563,6 +580,48 @@ DEFINE FIELD OVERWRITE retrieval_keys_normalized ON entity TYPE option<array<str
 DEFINE INDEX OVERWRITE idx_entity_retrieval_keys ON entity FIELDS retrieval_keys_normalized.*;
 """
 
+# Rebuilding indexes rewrites rows under the strict schema. Restore missing
+# canonical field declarations before a rebuild can discard existing values.
+ENTITY_SOURCE_LINEAGE_INDEX_DEFINITIONS = f"""
+DEFINE FIELD IF NOT EXISTS uuid ON entity TYPE string;
+DEFINE FIELD IF NOT EXISTS name ON entity TYPE string;
+DEFINE FIELD IF NOT EXISTS entity_type ON entity TYPE string;
+DEFINE FIELD IF NOT EXISTS summary ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS description ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS content ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS labels ON entity TYPE array<string> DEFAULT [];
+DEFINE FIELD IF NOT EXISTS attributes ON entity TYPE object FLEXIBLE DEFAULT {{}};
+DEFINE FIELD IF NOT EXISTS group_id ON entity TYPE string;
+DEFINE FIELD IF NOT EXISTS created_at ON entity TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS updated_at ON entity TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS created_by ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS modified_by ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS revision ON entity TYPE option<int> DEFAULT 1;
+DEFINE FIELD IF NOT EXISTS last_recalled_at ON entity TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS last_used_at ON entity TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS retrieval_count ON entity TYPE option<int> DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS citation_count ON entity TYPE option<int> DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS misled_count ON entity TYPE option<int> DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS project_id ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS epic_id ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS parent_task_id ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS task_id ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS status ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS priority ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS complexity ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS feature ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS tags ON entity TYPE option<array<string>>;
+DEFINE FIELD IF NOT EXISTS memory_scope ON entity TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS retrieval_keys ON entity TYPE option<array<string>>;
+DEFINE FIELD IF NOT EXISTS retrieval_keys_normalized ON entity TYPE option<array<string>>;
+DEFINE FIELD IF NOT EXISTS name_embedding ON entity TYPE option<array<float, {EMBEDDING_DIM}>>;
+DEFINE INDEX IF NOT EXISTS idx_entity_raw_sources ON entity FIELDS attributes.raw_source_ids.*;
+DEFINE INDEX IF NOT EXISTS idx_entity_raw_memory ON entity FIELDS attributes.raw_memory_id;
+DEFINE INDEX IF NOT EXISTS idx_entity_review_capture ON entity FIELDS attributes.review_capture_id;
+DEFINE INDEX IF NOT EXISTS idx_entity_projection_parent ON entity FIELDS attributes.parent_entity_id;
+DEFINE INDEX IF NOT EXISTS idx_entity_projection_source ON entity FIELDS attributes.source_entity_id;
+"""
+
 # Same element-vs-array distinction as idx_entity_retrieval_keys above: the
 # bare-array shape answers CONTAINS with a table scan and bare equality with
 # zero rows on SurrealDB 3.2.3. OVERWRITE converts the index every existing
@@ -749,10 +808,27 @@ GRAPH_SCHEMA_MIGRATIONS = (
         name="relation_created_at_cursor",
         statements=tuple(split_statements(RELATION_CREATED_AT_CURSOR_MIGRATION_DEFINITIONS)),
     ),
+    SchemaMigration(
+        version=21,
+        name="entity_source_lineage_indexes",
+        statements=tuple(split_statements(ENTITY_SOURCE_LINEAGE_INDEX_DEFINITIONS)),
+    ),
+    SchemaMigration(
+        version=22,
+        name="entity_lifecycle_repair_index",
+    ),
+    SchemaMigration(
+        version=23,
+        name="entity_lifecycle_repair_key_batches",
+        statements=tuple(split_statements(LIFECYCLE_REPAIR_FIELDS)),
+        action=migrate_lifecycle_repair,
+    ),
 )
 
 
-def _graph_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
+def _graph_schema_migrations(
+    *, url: str, ownership: SchemaOwnership | None = None
+) -> tuple[SchemaMigration, ...]:
     return tuple(
         SchemaMigration(
             version=migration.version,
@@ -760,6 +836,15 @@ def _graph_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             statements=tuple(
                 render_surreal_compatible_sql(statement, url=url)
                 for statement in migration.statements
+            ),
+            action=(
+                partial(
+                    migrate_lifecycle_repair,
+                    concurrent=not url.startswith(_EMBEDDED_SURREAL_SCHEMES),
+                    ownership=ownership,
+                )
+                if migration.action is migrate_lifecycle_repair
+                else migration.action
             ),
         )
         for migration in GRAPH_SCHEMA_MIGRATIONS
@@ -806,6 +891,7 @@ async def rebuild_embedding_indexes_for_dimension(
     driver: SchemaDriver,
     *,
     dimension: int,
+    ownership: SchemaOwnership | None = None,
 ) -> None:
     """Resize every HNSW vector field/index to ``dimension`` and record the new size.
 
@@ -817,26 +903,42 @@ async def rebuild_embedding_indexes_for_dimension(
         msg = "rebuild_embedding_indexes_for_dimension requires driver.clone(group_id) first"
         raise ValueError(msg)
 
+    if ownership is None:
+        async with _graph_schema_ownership(driver) as acquired:
+            await ensure_schema_version_table(acquired.mutate, group_id=driver.group_id)
+            await rebuild_embedding_indexes_for_dimension(
+                driver, dimension=dimension, ownership=acquired
+            )
+        return
+
+    await ownership.mutate(
+        "UPDATE schema_version:graph SET embedding_rebuild_dimension = $dimension RETURN NONE;",
+        dimension=dimension,
+    )
     for vector_field in EMBEDDING_VECTOR_FIELDS:
         await execute_schema_statement(
-            driver.execute_query,
+            ownership.mutate,
             vector_field.clear_statement(),
             scope="graph_embedding_dimension_rebuild",
             group_id=driver.group_id,
         )
         await execute_schema_statement(
-            driver.execute_query,
+            ownership.mutate,
             vector_field.field_redefinition(dimension),
             scope="graph_embedding_dimension_rebuild",
             group_id=driver.group_id,
         )
-        await rebuild_index_concurrently(
-            driver.execute_query,
-            vector_field.index_definition(dimension),
-        )
+        definition = vector_field.index_definition(dimension)
+        if _store_supports_concurrent_rebuild(driver._url):
+            await ensure_owned_concurrent_index(ownership, definition, rebuild=True)
+        else:
+            await ownership.mutate(
+                f"REMOVE INDEX IF EXISTS {definition.name} ON {definition.table};\n"
+                f"{definition.definition};"
+            )
 
     await record_schema_version(
-        driver.execute_query,
+        ownership.mutate,
         version=GRAPH_SCHEMA_CURRENT_VERSION,
         migrations=list(GRAPH_SCHEMA_MIGRATIONS),
         embedding_dimension=dimension,
@@ -849,14 +951,20 @@ async def rebuild_embedding_indexes_for_dimension(
 
 
 def _store_supports_concurrent_rebuild(url: str) -> bool:
-    return not url.startswith(("memory://", "surrealkv://"))
+    return not url.startswith(_EMBEDDED_SURREAL_SCHEMES)
 
 
-async def _reconcile_embedding_dimension(driver: SchemaDriver) -> None:
-    recorded = await get_schema_embedding_dimension(driver.execute_query)
+async def _reconcile_embedding_dimension(driver: SchemaDriver, ownership: SchemaOwnership) -> None:
+    pending = await get_schema_embedding_rebuild_dimension(ownership.read)
+    if pending is not None:
+        await rebuild_embedding_indexes_for_dimension(
+            driver, dimension=EMBEDDING_DIM, ownership=ownership
+        )
+        return
+    recorded = await get_schema_embedding_dimension(ownership.read)
     if recorded is None:
         await record_schema_version(
-            driver.execute_query,
+            ownership.mutate,
             version=GRAPH_SCHEMA_CURRENT_VERSION,
             migrations=list(GRAPH_SCHEMA_MIGRATIONS),
             embedding_dimension=EMBEDDING_DIM,
@@ -879,7 +987,9 @@ async def _reconcile_embedding_dimension(driver: SchemaDriver) -> None:
         recorded_dimension=recorded,
         configured_dimension=EMBEDDING_DIM,
     )
-    await rebuild_embedding_indexes_for_dimension(driver, dimension=EMBEDDING_DIM)
+    await rebuild_embedding_indexes_for_dimension(
+        driver, dimension=EMBEDDING_DIM, ownership=ownership
+    )
 
 
 def _is_relation_cleanup_statement(statement: str) -> bool:
@@ -925,10 +1035,13 @@ def _first_count_value(value: object) -> object:
     return None
 
 
-async def _dead_graph_object_count(driver: SchemaDriver, table: str) -> int:
+async def _dead_graph_object_count(
+    driver: SchemaDriver, table: str, *, ownership: SchemaOwnership | None = None
+) -> int:
     _validate_identifier(table)
     try:
-        result = await driver.execute_query(f"SELECT count() AS count FROM {table} GROUP ALL;")
+        execute = ownership.read if ownership is not None else driver.execute_query
+        result = await execute(f"SELECT count() AS count FROM {table} GROUP ALL;")
     except Exception as exc:
         if _is_missing_table_error(exc):
             return 0
@@ -936,10 +1049,12 @@ async def _dead_graph_object_count(driver: SchemaDriver, table: str) -> int:
     return _coerce_count(_first_count_value(result))
 
 
-async def _ensure_removed_graph_objects_empty(driver: SchemaDriver) -> None:
+async def _ensure_removed_graph_objects_empty(
+    driver: SchemaDriver, *, ownership: SchemaOwnership | None = None
+) -> None:
     occupied: dict[str, int] = {}
     for table in REMOVED_GRAPH_OBJECTS:
-        count = await _dead_graph_object_count(driver, table)
+        count = await _dead_graph_object_count(driver, table, ownership=ownership)
         if count:
             occupied[table] = count
 
@@ -956,6 +1071,7 @@ async def _assert_graph_migrations_safe(
     driver: SchemaDriver,
     *,
     current_version: int,
+    ownership: SchemaOwnership | None = None,
 ) -> None:
     if current_version >= 8:
         return
@@ -965,6 +1081,7 @@ async def _assert_graph_migrations_safe(
         table="entity",
         field="entity_type",
         allowed=_GRAPH_ENTITY_TYPE_VALUES,
+        ownership=ownership,
     )
     if invalid_entity_type is not None:
         raise RuntimeError(
@@ -979,11 +1096,13 @@ async def _first_invalid_graph_enum_value(
     table: str,
     field: str,
     allowed: tuple[str, ...],
+    ownership: SchemaOwnership | None = None,
 ) -> str | None:
     _validate_identifier(table)
     _validate_identifier(field)
     try:
-        result = await driver.execute_query(
+        execute = ownership.read if ownership is not None else driver.execute_query
+        result = await execute(
             f"""
             SELECT {field}
             FROM {table}
@@ -1020,11 +1139,89 @@ def render_surreal_compatible_sql(sql: str, *, url: str) -> str:
     if not url.startswith(_EMBEDDED_SURREAL_SCHEMES):
         rendered = (
             rendered.replace("type::is::string", "type::is_string")
+            .replace("type::is::object", "type::is_object")
             .replace("type::is::number", "type::is_number")
             .replace("type::is::datetime", "type::is_datetime")
             .replace("string::is::datetime", "string::is_datetime")
         )
     return rendered
+
+
+async def _renew_schema_ownership(ownership: SchemaOwnership) -> None:
+    while True:
+        await asyncio.sleep(ownership.lease_seconds / 3)
+        await ownership.heartbeat()
+
+
+@asynccontextmanager
+async def _graph_schema_ownership(driver: SchemaDriver) -> AsyncIterator[SchemaOwnership]:
+    async with driver.schema_lease_executor() as lease_execute:
+        ownership = await try_acquire_schema_ownership(
+            lease_execute,
+            mutation_execute=driver.execute_query,
+            renew_after_operation=driver._url.startswith(_EMBEDDED_SURREAL_SCHEMES),
+        )
+        while ownership is None:
+            await asyncio.sleep(0.2)
+            active = await lease_execute(
+                "SELECT owner FROM schema_lease:graph WHERE deadline > time::now();"
+            )
+            if not isinstance(active, list):
+                raise TypeError("schema ownership wait expected a record list")
+            if not active:
+                ownership = await try_acquire_schema_ownership(
+                    lease_execute,
+                    initialize=False,
+                    mutation_execute=driver.execute_query,
+                    renew_after_operation=driver._url.startswith(_EMBEDDED_SURREAL_SCHEMES),
+                )
+        try:
+            try:
+                async with asyncio.TaskGroup() as tasks:
+                    renewal = (
+                        tasks.create_task(_renew_schema_ownership(ownership))
+                        if _store_supports_concurrent_rebuild(driver._url)
+                        else None
+                    )
+                    try:
+                        yield ownership
+                    finally:
+                        if renewal is not None:
+                            renewal.cancel()
+            except BaseExceptionGroup as exc:
+                if len(exc.exceptions) == 1:
+                    raise exc.exceptions[0] from None
+                raise
+        except BaseException:
+            try:
+                await ownership.release()
+            except Exception as exc:
+                logger.warning(
+                    "surreal_schema_lease_release_failed",
+                    group_id=driver.group_id,
+                    error_type=type(exc).__name__,
+                )
+            raise
+        else:
+            await ownership.release()
+
+
+async def _graph_schema_is_current(driver: SchemaDriver) -> bool:
+    try:
+        if await get_schema_version(driver.execute_query) < GRAPH_SCHEMA_CURRENT_VERSION:
+            return False
+        if await get_schema_embedding_dimension(driver.execute_query) != EMBEDDING_DIM:
+            return False
+        if await get_schema_embedding_rebuild_dimension(driver.execute_query) is not None:
+            return False
+        active = await driver.execute_query(
+            "SELECT owner FROM schema_lease:graph WHERE deadline > time::now();"
+        )
+    except Exception as exc:
+        if _is_missing_table_error(exc):
+            return False
+        raise
+    return not active
 
 
 async def bootstrap_schema(
@@ -1037,28 +1234,45 @@ async def bootstrap_schema(
         msg = "bootstrap_schema requires driver.clone(group_id) first"
         raise ValueError(msg)
 
+    if not reset and not force and await _graph_schema_is_current(driver):
+        return
+    async with _graph_schema_ownership(driver) as ownership:
+        await _bootstrap_owned_schema(driver, ownership, reset=reset, force=force)
+
+
+async def _bootstrap_owned_schema(
+    driver: SchemaDriver,
+    ownership: SchemaOwnership,
+    *,
+    reset: bool,
+    force: bool,
+) -> None:
+    current_version = 0
     if reset:
         for table in (*GRAPH_EDGES, *GRAPH_TABLES, *REMOVED_GRAPH_EDGES, *REMOVED_GRAPH_TABLES):
-            await driver.execute_query(f"REMOVE TABLE IF EXISTS {table};")
-        await driver.execute_query(f"REMOVE TABLE IF EXISTS {SCHEMA_VERSION_TABLE};")
+            await ownership.mutate(f"REMOVE TABLE IF EXISTS {table};")
+        await ownership.mutate(f"REMOVE TABLE IF EXISTS {SCHEMA_VERSION_TABLE};")
     else:
-        await ensure_schema_version_table(driver.execute_query, group_id=driver.group_id)
-        current_version = await get_schema_version(driver.execute_query)
+        await ensure_schema_version_table(ownership.mutate, group_id=driver.group_id)
+        current_version = await get_schema_version(ownership.read)
         if current_version >= GRAPH_SCHEMA_CURRENT_VERSION:
             if not force:
-                await _reconcile_embedding_dimension(driver)
+                await _reconcile_embedding_dimension(driver, ownership)
                 return
         elif current_version > 0 and not force:
-            await _assert_graph_migrations_safe(driver, current_version=current_version)
-            await _ensure_removed_graph_objects_empty(driver)
-            await apply_schema_migrations(
-                driver.execute_query,
-                _graph_schema_migrations(url=driver._url),
-                group_id=driver.group_id,
+            await _assert_graph_migrations_safe(
+                driver, current_version=current_version, ownership=ownership
             )
-            await _reconcile_embedding_dimension(driver)
+            await _ensure_removed_graph_objects_empty(driver, ownership=ownership)
+            await apply_schema_migrations(
+                ownership.read,
+                _graph_schema_migrations(url=driver._url, ownership=ownership),
+                group_id=driver.group_id,
+                ownership=ownership,
+            )
+            await _reconcile_embedding_dimension(driver, ownership)
             return
-        await _ensure_removed_graph_objects_empty(driver)
+        await _ensure_removed_graph_objects_empty(driver, ownership=ownership)
 
     compatible_blocks = (
         ANALYZER_DEFINITIONS,
@@ -1071,13 +1285,26 @@ async def bootstrap_schema(
             driver,
             block,
             ignore_missing_relation_tables=block == RELATION_EDGE_CLEANUP_DEFINITIONS,
+            ownership=ownership,
+        )
+    if force and not reset and current_version >= 23:
+        for statement in split_statements(LIFECYCLE_REPAIR_FIELDS):
+            await execute_schema_statement(
+                ownership.mutate, statement, scope="graph", group_id=driver.group_id
+            )
+        await migrate_lifecycle_repair(
+            ownership.read,
+            concurrent=not driver._url.startswith(_EMBEDDED_SURREAL_SCHEMES),
+            resume=False,
+            ownership=ownership,
         )
     await apply_schema_migrations(
-        driver.execute_query,
-        _graph_schema_migrations(url=driver._url),
+        ownership.read,
+        _graph_schema_migrations(url=driver._url, ownership=ownership),
         group_id=driver.group_id,
+        ownership=ownership,
     )
-    await _reconcile_embedding_dimension(driver)
+    await _reconcile_embedding_dimension(driver, ownership)
 
 
 async def _execute_graph_schema_block(
@@ -1085,12 +1312,13 @@ async def _execute_graph_schema_block(
     block: str,
     *,
     ignore_missing_relation_tables: bool = False,
+    ownership: SchemaOwnership | None = None,
 ) -> bool:
     skipped_missing_relation_table = False
     for statement in split_statements(block):
         try:
             await execute_schema_statement(
-                driver.execute_query,
+                ownership.mutate if ownership is not None else driver.execute_query,
                 statement,
                 scope="graph",
                 group_id=driver.group_id,
@@ -1111,19 +1339,25 @@ async def _execute_graph_schema_block(
     return skipped_missing_relation_table
 
 
-async def drop_all_indexes(driver: SchemaDriver) -> None:
+async def drop_all_indexes(
+    driver: SchemaDriver, *, ownership: SchemaOwnership | None = None
+) -> None:
     if not driver.group_id:
+        return
+    if ownership is None:
+        async with _graph_schema_ownership(driver) as acquired:
+            await drop_all_indexes(driver, ownership=acquired)
         return
 
     for table in (*GRAPH_TABLES, *GRAPH_EDGES):
-        info = await driver.execute_query(f"INFO FOR TABLE {table};")
+        info = await ownership.read(f"INFO FOR TABLE {table};")
         index_names = _index_names_from_info(info)
         if not index_names and isinstance(info, list) and info:
             index_names = _index_names_from_info(info[0])
 
         for index_name in index_names:
             _validate_identifier(index_name)
-            await driver.execute_query(f"REMOVE INDEX IF EXISTS {index_name} ON TABLE {table};")
+            await ownership.mutate(f"REMOVE INDEX IF EXISTS {index_name} ON TABLE {table};")
 
 
 __all__ = [

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_lifecycle_repair.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_lifecycle_repair.py
@@ -1,0 +1,95 @@
+"""Restartable backfill and index activation for pending lifecycle discovery."""
+
+from __future__ import annotations
+
+from sibyl_core.backends.surreal.schema_index_recovery import ensure_owned_concurrent_index
+from sibyl_core.backends.surreal.schema_ownership import SchemaOwnership
+from sibyl_core.backends.surreal.schema_version import (
+    ConcurrentIndexDefinition,
+    SurrealExecute,
+    _first_record,
+    wait_for_index_ready,
+)
+
+LIFECYCLE_REPAIR_FIELDS = """
+DEFINE FIELD IF NOT EXISTS lifecycle_repair_key ON entity TYPE option<string>
+    VALUE IF attributes.lifecycle_reconciliation_pending OR attributes.source_validation_pending
+          THEN uuid ELSE NONE END;
+DEFINE FIELD IF NOT EXISTS lifecycle_repair_cursor ON schema_version TYPE option<string>;
+"""
+
+_BATCH_SIZE = 512
+_INDEX = "idx_entity_lifecycle_repair_key"
+
+
+async def migrate_lifecycle_repair(
+    execute_query: SurrealExecute,
+    *,
+    concurrent: bool = False,
+    resume: bool = True,
+    ownership: SchemaOwnership | None = None,
+) -> None:
+    """Commit each bounded row refresh with its cursor before activating discovery.
+
+    New writes derive their own key as soon as the field exists. A source that
+    becomes pending behind the cursor therefore does not need another backfill.
+    The unique key gives repair sweeps an unambiguous pagination boundary;
+    healthy rows have NONE, which permits multiple rows under this index.
+    """
+    mutate = ownership.mutate if ownership is not None else execute_query
+    if not resume:
+        await mutate("UPDATE schema_version:graph SET lifecycle_repair_cursor = NONE RETURN NONE;")
+    progress = _first_record(
+        await execute_query("SELECT lifecycle_repair_cursor FROM schema_version:graph;")
+    )
+    cursor = str(progress.get("lifecycle_repair_cursor") or "") if progress else ""
+    while True:
+        rows = await execute_query(
+            "SELECT id, uuid FROM entity WITH INDEX idx_entity_uuid "
+            "WHERE uuid > $cursor ORDER BY uuid LIMIT $limit;",
+            cursor=cursor,
+            limit=_BATCH_SIZE,
+        )
+        if not isinstance(rows, list):
+            raise TypeError("lifecycle repair backfill expected a record list")
+        if not rows:
+            break
+        next_cursor = str(rows[-1]["uuid"])
+        page = (
+            "UPDATE $rows SET lifecycle_repair_key = uuid "
+            "WHERE lifecycle_repair_key IS NONE AND "
+            "(attributes.lifecycle_reconciliation_pending OR attributes.source_validation_pending) "
+            "RETURN NONE; "
+            "UPDATE schema_version:graph SET lifecycle_repair_cursor = $cursor RETURN NONE;"
+        )
+        if ownership is None:
+            page = f"BEGIN TRANSACTION; {page} COMMIT TRANSACTION;"
+        await mutate(
+            page,
+            rows=[row["id"] for row in rows],
+            cursor=next_cursor,
+        )
+        cursor = next_cursor
+
+    # Keep the legacy index until its replacement has reached readiness.
+    if concurrent and ownership is not None:
+        await ensure_owned_concurrent_index(
+            ownership,
+            ConcurrentIndexDefinition(
+                name=_INDEX,
+                table="entity",
+                definition=f"DEFINE INDEX {_INDEX} ON entity FIELDS lifecycle_repair_key UNIQUE",
+            ),
+        )
+    else:
+        await mutate(
+            f"DEFINE INDEX IF NOT EXISTS {_INDEX} ON entity FIELDS lifecycle_repair_key UNIQUE"
+            + (" CONCURRENTLY;" if concurrent else ";")
+        )
+        if concurrent:
+            await wait_for_index_ready(
+                execute_query, name=_INDEX, table="entity", require_status=True
+            )
+    await mutate("REMOVE INDEX IF EXISTS idx_entity_lifecycle_repair ON entity;")
+    await mutate("REMOVE FIELD IF EXISTS lifecycle_repair_pending ON entity;")
+    await mutate("UPDATE schema_version:graph SET lifecycle_repair_cursor = NONE RETURN NONE;")

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import re
-from collections.abc import Awaitable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from time import monotonic
 from typing import TYPE_CHECKING, Protocol, cast
@@ -14,7 +14,7 @@ from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement,
 if TYPE_CHECKING:
     from sibyl_core.backends.surreal.schema_ownership import SchemaOwnership
 
-GRAPH_SCHEMA_CURRENT_VERSION = 20
+GRAPH_SCHEMA_CURRENT_VERSION = 23
 GRAPH_SCHEMA_NAME = "graph"
 SCHEMA_VERSION_TABLE = "schema_version"
 
@@ -24,6 +24,7 @@ ALTER TABLE IF EXISTS schema_version SCHEMAFULL;
 DEFINE FIELD IF NOT EXISTS name ON schema_version TYPE string;
 DEFINE FIELD IF NOT EXISTS version ON schema_version TYPE int;
 DEFINE FIELD IF NOT EXISTS embedding_dimension ON schema_version TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS embedding_rebuild_dimension ON schema_version TYPE option<int>;
 DEFINE FIELD IF NOT EXISTS migrations ON schema_version TYPE array<object> DEFAULT [];
 DEFINE FIELD IF NOT EXISTS migrations.*.version ON schema_version TYPE int;
 DEFINE FIELD IF NOT EXISTS migrations.*.name ON schema_version TYPE string;
@@ -44,6 +45,7 @@ class SchemaMigration:
     version: int
     name: str
     statements: tuple[str, ...] = ()
+    action: Callable[[SurrealExecute], Awaitable[None]] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -118,6 +120,8 @@ async def record_schema_version(
             name = $name,
             version = $version,
             embedding_dimension = $embedding_dimension ?? embedding_dimension,
+            embedding_rebuild_dimension = IF $embedding_dimension IS NOT NONE
+                THEN NONE ELSE embedding_rebuild_dimension END,
             migrations = $migrations,
             created_at = created_at ?? time::now(),
             updated_at = time::now();
@@ -145,6 +149,13 @@ async def get_schema_embedding_dimension(
     return int(raw_dimension) if isinstance(raw_dimension, int | float | str) else None
 
 
+async def get_schema_embedding_rebuild_dimension(execute_query: SurrealExecute) -> int | None:
+    result = await execute_query("SELECT embedding_rebuild_dimension FROM schema_version:graph;")
+    first = _first_record(result)
+    dimension = first.get("embedding_rebuild_dimension") if first is not None else None
+    return int(dimension) if isinstance(dimension, int | float | str) else None
+
+
 async def apply_schema_migrations(
     execute_query: SurrealExecute,
     migrations: Sequence[SchemaMigration],
@@ -152,9 +163,11 @@ async def apply_schema_migrations(
     name: str = GRAPH_SCHEMA_NAME,
     group_id: str | None = None,
     scope: str = "schema_migration",
+    ownership: SchemaOwnership | None = None,
 ) -> list[SchemaMigration]:
+    mutate = ownership.mutate if ownership is not None else execute_query
     await ensure_schema_version_table(
-        execute_query,
+        mutate,
         group_id=group_id,
         scope=f"{scope}_version",
     )
@@ -166,17 +179,19 @@ async def apply_schema_migrations(
             continue
         for statement in migration.statements:
             await execute_schema_statement(
-                execute_query,
+                mutate,
                 statement,
                 scope=scope,
                 group_id=group_id,
             )
+        if migration.action is not None:
+            await migration.action(execute_query)
         applied.append(migration)
         migration_history = [
             item for item in sorted_migrations if item.version <= migration.version
         ]
         await record_schema_version(
-            execute_query,
+            mutate,
             version=migration.version,
             migrations=migration_history,
             name=name,

--- a/packages/python/sibyl-core/tests/test_lifecycle_repair_backfill.py
+++ b/packages/python/sibyl-core/tests/test_lifecycle_repair_backfill.py
@@ -1,0 +1,188 @@
+"""Populated repair backfills retain progress across interrupted execution."""
+
+import pytest
+
+from sibyl_core.backends.surreal import schema_lifecycle_repair as migration
+from sibyl_core.backends.surreal.schema import bootstrap_schema
+from sibyl_core.backends.surreal.schema_helpers import split_statements
+from sibyl_core.backends.surreal.schema_ownership import (
+    SchemaOwnershipLost,
+    try_acquire_schema_ownership,
+)
+from sibyl_core.models.entities import Entity, EntityType
+from tests.test_reflection_identity import runtime as runtime
+
+_PENDING_ROWS_QUERY = (
+    "SELECT uuid, lifecycle_repair_key FROM entity WITH INDEX idx_entity_lifecycle_repair_key "
+    "WHERE lifecycle_repair_key > $cursor "
+    "AND group_id = $group_id ORDER BY lifecycle_repair_key LIMIT $limit"
+)
+
+
+async def test_backfill_resumes_committed_pages_and_derives_new_writes(runtime, monkeypatch):
+    monkeypatch.setattr(migration, "_BATCH_SIZE", 2)
+    execute = runtime.client.execute_query
+    await execute("REMOVE INDEX idx_entity_lifecycle_repair_key ON entity;")
+    await execute("REMOVE FIELD lifecycle_repair_key ON entity;")
+    for i in range(7):
+        await runtime.entity_manager.create_direct(
+            Entity(
+                id=f"old-{i}",
+                name=f"Old {i}",
+                entity_type=EntityType.EPISODE,
+                metadata={"source_validation_pending": {"parent:absent": True}},
+            ),
+            generate_embedding=False,
+        )
+    for statement in split_statements(migration.LIFECYCLE_REPAIR_FIELDS):
+        await execute(statement)
+
+    pages = []
+
+    async def interrupted(statement, **params):
+        if statement.startswith("SELECT id, uuid"):
+            pages.append(params["cursor"])
+            if len(pages) == 2:
+                raise RuntimeError("injected interruption after committed page")
+        return await execute(statement, **params)
+
+    with pytest.raises(RuntimeError, match="injected interruption"):
+        await migration.migrate_lifecycle_repair(interrupted)
+    checkpoint = await execute("SELECT lifecycle_repair_cursor FROM schema_version:graph;")
+    cursor = checkpoint[0]["lifecycle_repair_cursor"]
+    assert cursor == pages[1]
+    assert cursor
+
+    # A concurrent write behind the durable cursor derives its key immediately.
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="a-new",
+            name="New pending source",
+            entity_type=EntityType.EPISODE,
+            metadata={"source_validation_pending": True},
+        ),
+        generate_embedding=False,
+    )
+    resumed_pages = []
+    batch_sizes = []
+
+    async def resumed(statement, **params):
+        if statement.startswith("SELECT id, uuid"):
+            resumed_pages.append(params["cursor"])
+        if statement.startswith("BEGIN TRANSACTION"):
+            batch_sizes.append(len(params["rows"]))
+        return await execute(statement, **params)
+
+    await migration.migrate_lifecycle_repair(resumed)
+    assert resumed_pages[0] == cursor
+    assert all(size <= 2 for size in batch_sizes)
+    rows = await execute(
+        _PENDING_ROWS_QUERY + ";", cursor="", limit=100, group_id=runtime.client.group_id
+    )
+    assert [row["uuid"] for row in rows] == ["a-new", *[f"old-{i}" for i in range(7)]]
+    checkpoint = await execute("SELECT lifecycle_repair_cursor FROM schema_version:graph;")
+    assert not checkpoint[0].get("lifecycle_repair_cursor")
+
+
+async def test_experimental_v22_upgrades_and_force_restores_repair_schema(runtime):
+    execute = runtime.client.execute_query
+    await execute("REMOVE INDEX idx_entity_lifecycle_repair_key ON entity;")
+    await execute("REMOVE FIELD lifecycle_repair_key ON entity;")
+    await execute(
+        "DEFINE FIELD lifecycle_repair_pending ON entity TYPE bool DEFAULT false "
+        "VALUE IF attributes.source_validation_pending THEN true ELSE false END;"
+    )
+    await execute(
+        "UPDATE entity SET lifecycle_repair_pending = false WHERE lifecycle_repair_pending IS NONE;"
+    )
+    await execute(
+        "DEFINE INDEX idx_entity_lifecycle_repair ON entity FIELDS lifecycle_repair_pending, uuid;"
+    )
+    await execute("UPDATE schema_version:graph SET version = 22;")
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="old-pending",
+            name="Old pending",
+            entity_type=EntityType.EPISODE,
+            metadata={"source_validation_pending": True},
+        ),
+        generate_embedding=False,
+    )
+    await bootstrap_schema(runtime.client)
+    params = {"cursor": "", "limit": 10, "group_id": runtime.client.group_id}
+    rows = await execute(_PENDING_ROWS_QUERY + ";", **params)
+    assert [row["uuid"] for row in rows] == ["old-pending"]
+    info = await execute("INFO FOR TABLE entity;")
+    assert "idx_entity_lifecycle_repair" not in info["indexes"]
+    assert "lifecycle_repair_pending" not in info["fields"]
+    assert (await execute("SELECT version FROM schema_version:graph;"))[0]["version"] == 23
+
+    await execute("REMOVE INDEX idx_entity_lifecycle_repair_key ON entity;")
+    await execute("REMOVE FIELD lifecycle_repair_key ON entity;")
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="a-lost",
+            name="Pending row without a derived key",
+            entity_type=EntityType.EPISODE,
+            metadata={"source_validation_pending": True},
+        ),
+        generate_embedding=False,
+    )
+    await execute("UPDATE schema_version:graph SET lifecycle_repair_cursor = 'zzz';")
+    await bootstrap_schema(runtime.client, force=True)
+    rows = await execute(_PENDING_ROWS_QUERY + ";", **params)
+    assert [row["uuid"] for row in rows] == ["a-lost", "old-pending"]
+
+
+async def test_owned_backfill_resumes_after_loss_without_stale_cursor_write(
+    runtime, monkeypatch, *, concurrent=False
+):
+    monkeypatch.setattr(migration, "_BATCH_SIZE", 2)
+    execute = runtime.client.execute_query
+    for i in range(5):
+        await runtime.entity_manager.create_direct(
+            Entity(
+                id=f"owned-{i}",
+                name=f"Owned {i}",
+                entity_type=EntityType.EPISODE,
+                metadata={"source_validation_pending": True},
+            ),
+            generate_embedding=False,
+        )
+    await execute("REMOVE INDEX idx_entity_lifecycle_repair_key ON entity;")
+    owner = await try_acquire_schema_ownership(execute)
+    assert owner is not None
+    pages = []
+
+    async def lose_after_page(statement, **params):
+        if statement.startswith("SELECT id, uuid"):
+            pages.append(params["cursor"])
+            if len(pages) == 2:
+                await execute("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+        return await execute(statement, **params)
+
+    with pytest.raises(SchemaOwnershipLost):
+        await migration.migrate_lifecycle_repair(
+            lose_after_page, ownership=owner, concurrent=concurrent
+        )
+    checkpoint = await execute("SELECT lifecycle_repair_cursor FROM schema_version:graph;")
+    assert checkpoint[0]["lifecycle_repair_cursor"] == pages[1]
+    info = await execute("INFO FOR TABLE entity;")
+    assert "idx_entity_lifecycle_repair_key" not in info["indexes"]
+
+    successor = await try_acquire_schema_ownership(execute)
+    assert successor is not None
+    try:
+        await migration.migrate_lifecycle_repair(
+            execute, ownership=successor, concurrent=concurrent
+        )
+        # A late predecessor cannot clear the successor's checkpoint or schema.
+        with pytest.raises(SchemaOwnershipLost):
+            await migration.migrate_lifecycle_repair(execute, resume=False, ownership=owner)
+        await successor.heartbeat()
+        rows = await execute(
+            _PENDING_ROWS_QUERY + ";", cursor="", limit=10, group_id=runtime.client.group_id
+        )
+        assert [row["uuid"] for row in rows] == [f"owned-{i}" for i in range(5)]
+    finally:
+        await successor.release()

--- a/packages/python/sibyl-core/tests/test_schema_bootstrap_ownership.py
+++ b/packages/python/sibyl-core/tests/test_schema_bootstrap_ownership.py
@@ -1,0 +1,206 @@
+"""Bootstrap owns resets and version advancement while current schemas stay read-only."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.backends.surreal import schema
+from sibyl_core.backends.surreal.schema_ownership import (
+    SchemaOwnershipLost,
+    try_acquire_schema_ownership,
+)
+from tests.test_reflection_identity import runtime as runtime
+
+
+async def test_current_bootstrap_does_not_claim_or_mutate(runtime, monkeypatch):
+    acquire = AsyncMock(side_effect=AssertionError("current schema claimed ownership"))
+    monkeypatch.setattr(schema, "try_acquire_schema_ownership", acquire)
+    original = runtime.client.execute_query
+    statements = []
+
+    async def read_only(statement, **params):
+        statements.append(statement)
+        assert statement.lstrip().startswith("SELECT")
+        return await original(statement, **params)
+
+    monkeypatch.setattr(runtime.client, "execute_query", read_only)
+    await schema.bootstrap_schema(runtime.client)
+    assert statements
+    acquire.assert_not_awaited()
+
+
+async def test_lost_bootstrap_cannot_advance_version_and_successor_recovers(runtime, monkeypatch):
+    original = runtime.client.execute_query
+    await original("UPDATE schema_version:graph SET version = 22;")
+    injected = False
+
+    async def expire_before_version(statement, **params):
+        nonlocal injected
+        if (
+            "UPSERT schema_version:graph" in statement
+            and params.get("version") == 23
+            and not injected
+        ):
+            injected = True
+            await original("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+        return await original(statement, **params)
+
+    monkeypatch.setattr(runtime.client, "execute_query", expire_before_version)
+    with pytest.raises(SchemaOwnershipLost):
+        await schema.bootstrap_schema(runtime.client)
+    assert injected
+    assert (await original("SELECT version FROM schema_version:graph;"))[0]["version"] == 22
+    await schema.bootstrap_schema(runtime.client)
+    assert (await original("SELECT version FROM schema_version:graph;"))[0]["version"] == 23
+
+
+async def test_reset_waits_for_live_owner_and_preserves_lease_table(runtime, monkeypatch):
+    original = runtime.client.execute_query
+    incumbent = await try_acquire_schema_ownership(original)
+    assert incumbent is not None
+    waiting = asyncio.Event()
+
+    async def observe_claim(execute, **kwargs):
+        result = await try_acquire_schema_ownership(execute, **kwargs)
+        if result is None:
+            waiting.set()
+        return result
+
+    monkeypatch.setattr(schema, "try_acquire_schema_ownership", observe_claim)
+    reset = asyncio.create_task(schema.bootstrap_schema(runtime.client, reset=True))
+    try:
+        await asyncio.wait_for(waiting.wait(), 2)
+        assert not reset.done()
+        row = (await original("SELECT owner FROM schema_lease:graph;"))[0]
+        assert row["owner"] == incumbent.owner
+        await incumbent.release()
+
+        await reset
+        row = (await original("SELECT owner FROM schema_lease:graph;"))[0]
+        assert row["owner"] != incumbent.owner
+        assert (await original("SELECT version FROM schema_version:graph;"))[0]["version"] == 23
+    finally:
+        if not reset.done():
+            reset.cancel()
+        await asyncio.gather(reset, return_exceptions=True)
+        await incumbent.release()
+
+
+async def test_bootstrap_resumes_interrupted_embedding_rebuild(runtime, monkeypatch):
+    original = runtime.client.execute_query
+    interrupted = False
+
+    async def fail_second_index(statement, **params):
+        nonlocal interrupted
+        if (
+            "REMOVE INDEX" in statement
+            and "idx_relates_fact_embedding" in statement
+            and not interrupted
+        ):
+            interrupted = True
+            raise RuntimeError("injected second index failure")
+        return await original(statement, **params)
+
+    monkeypatch.setattr(runtime.client, "execute_query", fail_second_index)
+    with pytest.raises(RuntimeError, match="injected second index failure"):
+        await schema.rebuild_embedding_indexes_for_dimension(runtime.client, dimension=8)
+    assert interrupted
+    intent = (await original("SELECT embedding_rebuild_dimension FROM schema_version:graph;"))[0]
+    assert intent["embedding_rebuild_dimension"] == 8
+    await schema.bootstrap_schema(runtime.client)
+    info = await original("INFO FOR TABLE entity;")
+    assert f"DIMENSION {schema.EMBEDDING_DIM}" in info["indexes"]["idx_entity_embedding"]
+    intent = (await original("SELECT embedding_rebuild_dimension FROM schema_version:graph;"))[0]
+    assert intent.get("embedding_rebuild_dimension") is None
+
+
+@pytest.mark.parametrize("version", [22, 23])
+@pytest.mark.parametrize("lease_table_exists", [False, True])
+async def test_bootstrap_upgrades_version_table_without_rebuild_intent(
+    runtime, version, lease_table_exists
+):
+    original = runtime.client.execute_query
+    await original("REMOVE FIELD embedding_rebuild_dimension ON schema_version;")
+    await original("UPDATE schema_version:graph SET version = $version;", version=version)
+    if not lease_table_exists:
+        await original("REMOVE TABLE schema_lease;")
+    before = await original("INFO FOR TABLE schema_version;")
+    assert "embedding_rebuild_dimension" not in before["fields"]
+    await schema.bootstrap_schema(runtime.client)
+    rows = await original("SELECT version, embedding_dimension FROM schema_version:graph;")
+    assert rows[0]["version"] == schema.GRAPH_SCHEMA_CURRENT_VERSION
+    assert rows[0]["embedding_dimension"] == schema.EMBEDDING_DIM
+
+
+async def test_renewal_loss_cancels_bootstrap_and_preserves_error(runtime, monkeypatch):
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+    original = runtime.client.execute_query
+
+    async def lose_ownership(ownership):
+        await entered.wait()
+        await original("UPDATE schema_lease:graph SET deadline = time::now() - 1s;")
+        await ownership.heartbeat()
+
+    monkeypatch.setattr(schema, "_store_supports_concurrent_rebuild", lambda url: True)
+    monkeypatch.setattr(schema, "_renew_schema_ownership", lose_ownership)
+    with pytest.raises(SchemaOwnershipLost):
+        async with schema._graph_schema_ownership(runtime.client):
+            entered.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+    assert cancelled.is_set()
+
+
+@pytest.mark.parametrize("operation", ["read", "mutation"])
+async def test_embedded_bootstrap_continues_after_long_operation(runtime, monkeypatch, operation):
+    async def short_claim(execute, **kwargs):
+        return await try_acquire_schema_ownership(execute, lease_seconds=1, **kwargs)
+
+    monkeypatch.setattr(schema, "try_acquire_schema_ownership", short_claim)
+    async with schema._graph_schema_ownership(runtime.client) as ownership:
+        if operation == "mutation":
+            await ownership.mutate("SLEEP 1500ms; CREATE embedded_renewal:first;")
+        else:
+            await ownership.read("SLEEP 1500ms; RETURN 1;")
+        await ownership.mutate("CREATE embedded_renewal:complete;")
+    assert await runtime.client.execute_query("SELECT VALUE id FROM embedded_renewal:complete;")
+
+
+@pytest.mark.parametrize("slow_read", ["version", "count", "page"])
+async def test_embedded_migration_renews_all_owned_reads(runtime, monkeypatch, slow_read):
+    original = runtime.client.execute_query
+    await original("UPDATE schema_version:graph SET version = 22;")
+    for table in schema.REMOVED_GRAPH_OBJECTS:
+        await original(f"DEFINE TABLE IF NOT EXISTS {table} SCHEMALESS;")
+    claimed = False
+    delayed = False
+    prefix = {
+        "version": "SELECT version FROM schema_version",
+        "count": "SELECT count() AS count FROM",
+        "page": "SELECT id, uuid FROM entity WITH INDEX",
+    }[slow_read]
+
+    async def slow_owned_read(statement, **params):
+        nonlocal claimed, delayed
+        if "$sibyl_schema_claimed" in statement:
+            result = await original(statement, **params)
+            claimed = True
+            return result
+        if claimed and not delayed and statement.lstrip().startswith(prefix):
+            delayed = True
+            first, _, remaining = statement.partition(";")
+            statement = f"{first}; SLEEP 1500ms; {remaining}"
+        return await original(statement, **params)
+
+    async def short_claim(execute, **kwargs):
+        return await try_acquire_schema_ownership(execute, lease_seconds=1, **kwargs)
+
+    monkeypatch.setattr(runtime.client, "execute_query", slow_owned_read)
+    monkeypatch.setattr(schema, "try_acquire_schema_ownership", short_claim)
+    await schema.bootstrap_schema(runtime.client)
+    assert delayed
+    assert await original("SELECT VALUE version FROM schema_version:graph;") == [23]

--- a/packages/python/sibyl-core/tests/test_surreal_schema_dimension.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_dimension.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+
 import pytest
 
 from sibyl_core.backends.surreal import schema as schema_module
@@ -35,9 +37,28 @@ class _FakeSchemaDriver:
     def group_id(self) -> str:
         return self._group_id
 
+    @asynccontextmanager
+    async def schema_lease_executor(self):
+        yield self.execute_query
+
     async def execute_query(self, query: str, **params: object) -> object:
-        self.statements.append(query)
         stripped = query.strip()
+        owned = stripped.startswith("BEGIN TRANSACTION;") and "$sibyl_schema_owned" in stripped
+        if owned:
+            stripped = (
+                stripped.split("}; ", 1)[1].rsplit("\n;\nCOMMIT TRANSACTION;", 1)[0].strip() + ";"
+            )
+        self.statements.append(stripped)
+        if "$sibyl_schema_claimed" in stripped:
+            return None
+        if stripped.startswith("SELECT owner FROM schema_lease:graph") and "owner" in params:
+            return [{"owner": params["owner"]}]
+        if stripped.startswith("UPDATE schema_lease:graph") and "RETURN AFTER" in stripped:
+            return [{"owner": params["sibyl_schema_owner"]}]
+        if stripped.startswith("INFO FOR TABLE"):
+            return {
+                "indexes": {field.index: "existing definition" for field in EMBEDDING_VECTOR_FIELDS}
+            }
         if stripped.startswith("SELECT version FROM schema_version"):
             return [] if self.version is None else [{"version": self.version}]
         if stripped.startswith("SELECT embedding_dimension FROM schema_version"):
@@ -49,10 +70,10 @@ class _FakeSchemaDriver:
             recorded = params.get("embedding_dimension")
             if recorded is not None:
                 self.embedding_dimension = int(recorded)  # type: ignore[arg-type]
-            return [{"version": self.version}]
+            return None if owned else [{"version": self.version}]
         if stripped.startswith("INFO FOR INDEX"):
             return [{"building": {"status": "ready"}}]
-        return []
+        return None if owned else []
 
 
 def _rebuild_statements(driver: _FakeSchemaDriver) -> list[str]:
@@ -73,13 +94,15 @@ async def test_bootstrap_rebuilds_indexes_on_dimension_change() -> None:
     await bootstrap_schema(driver)  # type: ignore[arg-type]
 
     for vector_field in EMBEDDING_VECTOR_FIELDS:
-        remove = f"REMOVE INDEX IF EXISTS {vector_field.index} ON TABLE {vector_field.table};"
+        remove = f"REMOVE INDEX {vector_field.index} ON {vector_field.table};"
         define = (
             f"DEFINE INDEX {vector_field.index} ON {vector_field.table} "
             f"FIELDS {vector_field.field} HNSW DIMENSION {EMBEDDING_DIM}"
         )
-        assert remove in driver.statements
-        assert any(s.startswith(define) and s.endswith("CONCURRENTLY;") for s in driver.statements)
+        assert any(
+            s.startswith(remove) and define in s and s.endswith("CONCURRENTLY;")
+            for s in driver.statements
+        )
         field_redef = vector_field.field_redefinition(EMBEDDING_DIM)
         assert field_redef in driver.statements
         assert vector_field.clear_statement() in driver.statements
@@ -130,7 +153,7 @@ async def test_rebuild_covers_every_vector_field_and_records_dimension() -> None
             f"DEFINE INDEX {vector_field.index} ON {vector_field.table} "
             f"FIELDS {vector_field.field} HNSW DIMENSION {target_dimension}"
         )
-        assert any(s.startswith(define) for s in driver.statements)
+        assert any(define in s for s in driver.statements)
     assert driver.embedding_dimension == target_dimension
 
 

--- a/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_syntax.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
+from contextlib import asynccontextmanager
 from pathlib import Path
 from uuid import UUID
 
@@ -58,6 +59,7 @@ from sibyl_core.backends.surreal.schema import (
     CURRENT_SCHEMA_MAINTENANCE_DEFINITIONS,
     DEAD_GRAPH_OBJECT_REMOVAL_DEFINITIONS,
     EDGE_DEFINITIONS,
+    EMBEDDING_DIM,
     ENTITY_ACTOR_ATTRIBUTION_DEFINITIONS,
     ENTITY_MISLED_USAGE_SIGNAL_DEFINITIONS,
     ENTITY_REQUIRED_FIELD_REPAIR_DEFINITIONS,
@@ -106,9 +108,29 @@ class _RecordingSchemaClient:
         self._url = ""
         self.group_id = "org_123"
 
+    @asynccontextmanager
+    async def schema_lease_executor(self):
+        yield self.execute_query
+
     async def execute_query(self, statement: str, **params: object) -> object:
         self.calls.append(statement)
         stripped = statement.strip()
+        # Syntax fixtures inspect the mutation body; database ownership is
+        # exercised separately against embedded and server stores.
+        if stripped.startswith("BEGIN TRANSACTION;") and "$sibyl_schema_owned" in stripped:
+            stripped = stripped.split("}; ", 1)[1].rsplit("\n;\nCOMMIT TRANSACTION;", 1)[0].strip()
+        if "$sibyl_schema_claimed" in stripped:
+            return None
+        if stripped.startswith("SELECT owner FROM schema_lease:graph") and "owner" in params:
+            return [{"owner": params["owner"]}]
+        if stripped.startswith("UPDATE schema_lease:graph") and "RETURN AFTER" in stripped:
+            return [{"owner": params["sibyl_schema_owner"]}]
+        if stripped.startswith("SELECT owner FROM schema_lease:graph"):
+            return []
+        if stripped.startswith("SELECT embedding_dimension FROM schema_version"):
+            return [{"embedding_dimension": EMBEDDING_DIM}]
+        if stripped.startswith("INFO FOR TABLE entity"):
+            return {"indexes": {}}
         if stripped.startswith("SELECT version FROM schema_version"):
             return [{"version": self.schema_version}]
         if stripped.startswith("SELECT count() AS count FROM "):
@@ -130,6 +152,10 @@ class _RecordingSchemaClient:
                 self.missing_tables.discard(table)
             if stripped.startswith(f"DEFINE TABLE OVERWRITE {table}"):
                 self.missing_tables.discard(table)
+        if statement.startswith("SELECT id, uuid FROM entity"):
+            return []
+        if statement.startswith("INFO FOR INDEX idx_entity_lifecycle_repair_key"):
+            return [{"building": {"status": "ready"}}]
         if self.duplicate_index_name and self.duplicate_index_name in statement:
             raise RuntimeError(
                 f"Database index `{self.duplicate_index_name}` already contains 'dirty-row'"

--- a/packages/python/sibyl-core/tests/test_surreal_schema_version.py
+++ b/packages/python/sibyl-core/tests/test_surreal_schema_version.py
@@ -155,3 +155,31 @@ async def test_concurrent_index_helpers_reject_unsafe_identifiers() -> None:
 
     with pytest.raises(ValueError, match="invalid SurrealDB identifier"):
         await rebuild_index_concurrently(fake.execute_query, definition)
+
+
+async def test_migration_action_failure_does_not_advance_version():
+    fake = _FakeSurreal(version=21)
+    attempts = []
+
+    async def backfill(execute_query):
+        attempts.append(True)
+        assert fake.version == 21
+        if len(attempts) == 1:
+            raise RuntimeError("interrupted backfill")
+        await execute_query("RETURN true;")
+
+    migration = SchemaMigration(version=23, name="backfill", action=backfill)
+    with pytest.raises(RuntimeError, match="interrupted backfill"):
+        await apply_schema_migrations(fake.execute_query, [migration])
+    assert fake.version == 21
+    await apply_schema_migrations(fake.execute_query, [migration])
+    assert fake.version == 23
+    assert len(attempts) == 2
+
+
+async def test_index_ready_requires_status_when_requested():
+    async def execute_query(statement, **params):
+        return [{}]
+
+    with pytest.raises(RuntimeError, match="returned no build status"):
+        await wait_for_index_ready(execute_query, name="idx", table="entity", require_status=True)


### PR DESCRIPTION
Long schema work can outlive a lease, and an interrupted index rebuild can leave startup repeating expensive work. Activate renewable schema ownership so stale workers cannot advance schema state, while a successor can resume committed backfill pages and preserve an index build that is still progressing.

## 🛠️ Bootstrap and recovery

Graph bootstrap now uses the ownership and index recovery primitives from merged PR #506. Network stores renew through a separate scoped connection; embedded stores renew before releasing their single connection. Embedded RocksDB and file URLs now follow the same completion-renewal and index-build path as other embedded stores. Schema, reset, embedding, and version writes run under the ownership fence. Already-current schemas keep their read-only startup path.

The graph schema advances from version 20 to 23. Source-lineage indexes support descendant lookup, and a derived lifecycle repair key indexes pending rows. The backfill commits each page together with its cursor, then waits for the replacement index before retiring the old index. A persisted embedding rebuild intent lets interrupted resizes resume before the new dimension is recorded as complete.

Three regression cases join the existing live database CI suite: renewal during a long read, renewal during a long mutation, and rejection of a stale transaction after takeover.

## 🧪 Validation

- The isolated main-based branch passes 3,110 core tests (14 skipped, one existing expected failure) and 2,372 API tests (14 skipped). Core and API lint and type checks pass.
- The same bootstrap implementation passed 12 isolated SurrealDB 3.2.3 server scenarios. The three new live CI cases also passed on the devbox with a one-connection graph pool.
- Earlier recovery qualification preserved a progressing 100,000-row index and recovered a crash-stalled 50,000-row index. These remote receipts used the same implementation within the larger lifecycle candidate; they are not a deployment receipt for this branch.

Independent review and all applicable hosted checks passed. Post-review verification passes 28 focused tests and type checking. Hosted live database CI passes all 13 cases, including the three renewal and takeover regressions. The broader source lifecycle implementation, measured learning improvement, and release readiness remain separate gates.
