### PR TITLE
fix(auth): unify project read and write role evaluation

### DIFF
--- a/apps/api/src/sibyl/persistence/surreal/auth_runtime/projects.py
+++ b/apps/api/src/sibyl/persistence/surreal/auth_runtime/projects.py
@@ -1248,66 +1248,29 @@ def _project_ids_for_role(
         if api_key_allowed is not None:
             return accessible & {str(project_id) for project_id in api_key_allowed}
         return accessible
-    if required_role is not ProjectRole.VIEWER:
-        direct_by_project = {
-            str(record.get("project_id")): record
-            for record in _normalize_records(payload.get("direct_memberships"))
-        }
-        teams_by_project: dict[str, list[SurrealRecord]] = {}
-        for record in _normalize_records(payload.get("team_projects")):
-            teams_by_project.setdefault(str(record.get("project_id")), []).append(record)
-        writable: set[str] = set()
-        for project in project_records:
-            project_id = str(project.get("uuid"))
-            graph_id = str(project.get("graph_project_id") or "").strip()
-            role = _effective_project_role_from_records(
-                ctx=ctx,
-                project=project,
-                direct_record=direct_by_project.get(project_id),
-                team_project_records=teams_by_project.get(project_id, []),
-            )
-            if (
-                graph_id
-                and role is not None
-                and (_PROJECT_ROLE_LEVELS[role] >= _PROJECT_ROLE_LEVELS[required_role])
-            ):
-                writable.add(graph_id)
-        api_key_allowed = getattr(ctx, "api_key_project_ids", None)
-        if api_key_allowed is not None:
-            return writable & {str(project_id) for project_id in api_key_allowed}
-        return writable
+    direct_by_project = {
+        str(record.get("project_id")): record
+        for record in _normalize_records(payload.get("direct_memberships"))
+    }
+    teams_by_project: dict[str, list[SurrealRecord]] = {}
+    for record in _normalize_records(payload.get("team_projects")):
+        teams_by_project.setdefault(str(record.get("project_id")), []).append(record)
     accessible: set[str] = set()
-    org_visible = {
-        str(record["uuid"]): str(record["graph_project_id"])
-        for record in project_records
-        if record.get("visibility") == ProjectVisibility.ORG.value
-        and str(record.get("graph_project_id") or "").strip()
-    }
-    accessible.update(org_visible.values())
-    direct_memberships = _normalize_records(payload.get("direct_memberships"))
-    direct_project_ids = {
-        str(record["project_id"])
-        for record in direct_memberships
-        if str(record.get("project_id") or "").strip()
-    }
-    accessible.update(
-        str(record["graph_project_id"])
-        for record in project_records
-        if str(record.get("uuid")) in direct_project_ids
-        and str(record.get("graph_project_id") or "").strip()
-    )
-    team_projects = _normalize_records(payload.get("team_projects"))
-    granted_project_ids = {
-        str(record["project_id"])
-        for record in team_projects
-        if str(record.get("project_id") or "").strip()
-    }
-    accessible.update(
-        str(record["graph_project_id"])
-        for record in project_records
-        if str(record.get("uuid")) in granted_project_ids
-        and str(record.get("graph_project_id") or "").strip()
-    )
+    for project in project_records:
+        project_id = str(project.get("uuid"))
+        graph_id = str(project.get("graph_project_id") or "").strip()
+        role = _effective_project_role_from_records(
+            ctx=ctx,
+            project=project,
+            direct_record=direct_by_project.get(project_id),
+            team_project_records=teams_by_project.get(project_id, []),
+        )
+        if (
+            graph_id
+            and role is not None
+            and (_PROJECT_ROLE_LEVELS[role] >= _PROJECT_ROLE_LEVELS[required_role])
+        ):
+            accessible.add(graph_id)
     api_key_allowed = getattr(ctx, "api_key_project_ids", None)
     if api_key_allowed is not None:
         return accessible & {str(project_id) for project_id in api_key_allowed}
@@ -1599,15 +1562,22 @@ def _effective_project_role_from_records(
     if _coerce_optional_uuid(project.get("owner_user_id")) == ctx.user.id:
         return ProjectRole.OWNER
     roles: list[ProjectRole] = []
-    direct_role = _coerce_project_role(direct_record.get("role")) if direct_record else None
+    # A legacy grant without a role confers read access, never write access.
+    direct_role = (
+        _coerce_project_role(direct_record.get("role") or ProjectRole.VIEWER.value)
+        if direct_record
+        else None
+    )
     if direct_role is not None:
         roles.append(direct_role)
     for team_project in team_project_records:
-        team_role = _coerce_project_role(team_project.get("role"))
+        team_role = _coerce_project_role(team_project.get("role") or ProjectRole.VIEWER.value)
         if team_role is not None:
             roles.append(team_role)
     if project.get("visibility") == ProjectVisibility.ORG.value:
-        visibility_role = _coerce_project_role(project.get("default_role"))
+        visibility_role = _coerce_project_role(
+            project.get("default_role") or ProjectRole.VIEWER.value
+        )
         if visibility_role is not None:
             roles.append(visibility_role)
     if not roles:

--- a/apps/api/tests/test_surreal_auth_runtime.py
+++ b/apps/api/tests/test_surreal_auth_runtime.py
@@ -3333,9 +3333,10 @@ async def test_server_instance_id_fails_closed_if_missing_or_invalid(monkeypatch
         await auth_common.get_server_instance_id()
 
 
-@pytest.mark.parametrize("binding", [None, {"direct-editor", "team-viewer"}])
-async def test_project_contributor_listing_uses_effective_roles_and_key_binding(
-    monkeypatch, binding
+@pytest.mark.parametrize("binding", [None, {"direct-editor", "team-viewer"}, {"owned"}])
+@pytest.mark.parametrize("required_role", ["viewer", "contributor"])
+async def test_project_listing_uses_effective_roles_and_key_binding(
+    monkeypatch, binding, required_role
 ):
     from sibyl_core.auth import ProjectRole
 
@@ -3384,9 +3385,11 @@ async def test_project_contributor_listing_uses_effective_roles_and_key_binding(
         surreal_auth_runtime, "_auth_client_scope", lambda: _StaticAuthClientScope(client)
     )
     actual = await surreal_auth_runtime.list_accessible_project_graph_ids(
-        ctx, required_role=ProjectRole.CONTRIBUTOR
+        ctx, required_role=ProjectRole[required_role.upper()]
     )
     expected = {"direct-editor", "team-editor", "owned", "org-editor"}
+    if required_role == "viewer":
+        expected.update({"direct-viewer", "team-viewer", "org-viewer"})
     assert actual == (expected if binding is None else expected & binding)
     assert len(client.calls) == 1
 
@@ -3437,3 +3440,28 @@ async def test_project_read_write_snapshot_resolves_auth_and_rows_once(monkeypat
     assert writable == ({"read", "write"} if org_role == "admin" else {"write"})
     resolve.assert_awaited_once()
     assert len(client.calls) == 1
+
+
+@pytest.mark.parametrize("grant_kind", ["visibility", "direct", "team"])
+@pytest.mark.parametrize("missing_role", [None, ""])
+def test_legacy_project_grant_without_role_remains_read_only(grant_kind, missing_role):
+    from sibyl.persistence.surreal.auth_runtime import projects as project_runtime
+    from sibyl_core.auth import ProjectRole
+
+    ctx = SimpleNamespace(
+        user=SimpleNamespace(id=uuid4()), org_role="member", api_key_project_ids=None
+    )
+    project = {
+        "uuid": "legacy",
+        "graph_project_id": "legacy",
+        "visibility": "org" if grant_kind == "visibility" else "private",
+        "default_role": missing_role,
+    }
+    membership = {"project_id": "legacy", "role": missing_role}
+    payload = {
+        "direct_memberships": [membership] if grant_kind == "direct" else [],
+        "team_projects": [membership] if grant_kind == "team" else [],
+    }
+    for required_role in ProjectRole:
+        granted = project_runtime._project_ids_for_role(ctx, [project], payload, required_role)
+        assert granted == ({"legacy"} if required_role is ProjectRole.VIEWER else set())


### PR DESCRIPTION
A private-project owner without an explicit membership could pass the contributor check yet disappear from the readable-project set. Promotion could therefore reject the owner's source evidence.

Project listing now uses the same effective-role evaluator for every requested role. Ownership, direct membership, team membership, and organization visibility feed one decision, followed by the API key's project restriction. The separate viewer-listing path is removed.

Legacy grants with a missing role retain viewer access. They do not acquire contributor access. Existing organization-admin behavior and credential restrictions remain intact.

## 🧪 Validation

The standalone branch passes API lint, type checking, and all 2,382 API tests (14 live-runtime tests skipped). Regression cases cover owners without membership, credential intersections, direct and team roles, and legacy grants remaining read-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project access evaluation across direct memberships, team grants, and organization visibility.
  - Projects and memberships without an explicitly assigned role now provide viewer-level access only.
  - Viewer access no longer unintentionally grants contributor or write permissions.
  - Access checks now consistently honor the required role threshold.
  - Added coverage for API-key bindings and legacy role configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->