### PR TITLE
fix(memory): protect capture sidecar provenance

### DIFF
--- a/apps/api/src/sibyl/api/routes/entity_captures.py
+++ b/apps/api/src/sibyl/api/routes/entity_captures.py
@@ -51,13 +51,13 @@ async def archive_raw_capture(
     entity_type: str,
     tags: list[str],
     metadata: dict[str, object],
+    source_capture_id: str | None = None,
 ) -> None:
     """Persist the write-once capture sidecar.
 
-    When the entity is the projection of a raw memory (metadata carries
-    raw_memory_id), the raw row is stamped with this capture's id so the
-    review queue lists the memory once instead of raw and projection side
-    by side.
+    The optional source capture requests queue folding under the writer's
+    identity. The identifier is queue bookkeeping, not evidence provenance,
+    and is never stored in this sidecar's metadata.
     """
     capture_surface_value = metadata.get("capture_surface")
     capture = RawCaptureRecord(
@@ -80,12 +80,11 @@ async def archive_raw_capture(
         created_by_user_id=user_id,
     )
     await save_raw_capture_record(session, capture=capture)
-    raw_memory_id = metadata.get("raw_memory_id")
-    if raw_memory_id:
+    if source_capture_id:
         await content_runtime.mark_raw_capture_projected(
             session,
             organization_id=organization_id,
-            raw_capture_id=str(raw_memory_id),
+            raw_capture_id=source_capture_id,
             projected_capture_id=capture.id,
             principal_id=capture.principal_id,
         )

--- a/apps/api/src/sibyl/api/routes/entity_mutations.py
+++ b/apps/api/src/sibyl/api/routes/entity_mutations.py
@@ -330,6 +330,9 @@ async def create_entity(
             entity_type=entity.entity_type.value,
             tags=list(entity.tags or []),
             metadata=raw_capture_metadata,
+            source_capture_id=str(request_metadata["raw_memory_id"])
+            if request_metadata.get("raw_memory_id")
+            else None,
         )
 
     result_background_jobs = getattr(result, "background_jobs", {})

--- a/apps/api/src/sibyl/api/routes/entity_serialization.py
+++ b/apps/api/src/sibyl/api/routes/entity_serialization.py
@@ -15,6 +15,7 @@ from sibyl.api.schemas import (
 )
 from sibyl.persistence.content_common import RawCaptureRecord
 from sibyl_core.auth.memory_policy import (
+    MEMORY_PROVENANCE_METADATA_KEYS,
     stamp_memory_scope_metadata,
 )
 from sibyl_core.memory_pipeline.retrieval_keys import normalize_retrieval_keys
@@ -27,7 +28,7 @@ log = structlog.get_logger()
 BULK_UNSUPPORTED_TYPES = frozenset(
     {EntityType.DOCUMENT, EntityType.EPIC, EntityType.PROJECT, EntityType.TASK}
 )
-_RAW_CAPTURE_METADATA_DENYLIST = frozenset(
+_RAW_CAPTURE_METADATA_DENYLIST = MEMORY_PROVENANCE_METADATA_KEYS | frozenset(
     {
         "principal_id",
         "memory_scope",
@@ -43,7 +44,7 @@ _RAW_CAPTURE_REVIEW_STATES = frozenset({"pending", "deferred", "promoted", "arch
 
 
 def sanitize_raw_capture_metadata(metadata: dict[str, object]) -> dict[str, object]:
-    """Drop caller-controlled fields that map to authoritative capture columns."""
+    """Keep capture ownership and evidence provenance under server control."""
     return {
         key: value for key, value in metadata.items() if key not in _RAW_CAPTURE_METADATA_DENYLIST
     }

--- a/apps/api/tests/test_api_entities_raw_capture.py
+++ b/apps/api/tests/test_api_entities_raw_capture.py
@@ -31,8 +31,10 @@ def _session() -> MagicMock:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("source_capture_id", [None, "raw-1"])
 async def test_quick_capture_creates_raw_archive_record(
     monkeypatch: pytest.MonkeyPatch,
+    source_capture_id: str | None,
 ) -> None:
     from sibyl.config import settings
 
@@ -53,6 +55,9 @@ async def test_quick_capture_creates_raw_archive_record(
             "capture_mode": "quick",
             "capture_surface": "dashboard",
             "source": "notes",
+            "raw_memory_id": source_capture_id,
+            "correction_history": [],
+            "source_bindings": {},
         },
     )
 
@@ -63,11 +68,16 @@ async def test_quick_capture_creates_raw_archive_record(
 
     content_session = _session()
     save_capture = AsyncMock(side_effect=lambda _session, *, capture: capture)
+    mark_projected = AsyncMock(return_value=True)
 
     with (
         patch("sibyl_core.tools.core.add", AsyncMock(return_value=add_result)),
         patch("sibyl.api.routes.entity_mutations.broadcast_event", AsyncMock()),
         patch("sibyl.api.routes.entity_captures.save_raw_capture_record", save_capture),
+        patch(
+            "sibyl.api.routes.entity_captures.content_runtime.mark_raw_capture_projected",
+            mark_projected,
+        ),
     ):
         resp = await create_entity(
             request=_request(),
@@ -100,6 +110,16 @@ async def test_quick_capture_creates_raw_archive_record(
     }
     assert archive.capture_surface == "dashboard"
     assert archive.created_by_user_id == ctx.user.id
+    if source_capture_id is None:
+        mark_projected.assert_not_awaited()
+    else:
+        mark_projected.assert_awaited_once_with(
+            content_session,
+            organization_id=org.id,
+            raw_capture_id=source_capture_id,
+            projected_capture_id=archive.id,
+            principal_id=str(ctx.user.id),
+        )
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_api_raw_captures.py
+++ b/apps/api/tests/test_api_raw_captures.py
@@ -319,10 +319,12 @@ async def test_archive_raw_capture_stamps_the_raw_memory_it_projects() -> None:
             entity_content="paste mid-pipeline swallows stray stdin",
             entity_type="error_pattern",
             tags=[],
-            metadata={"capture_mode": "remember", "raw_memory_id": "raw-1"},
+            metadata={"capture_mode": "remember"},
+            source_capture_id="raw-1",
         )
 
     assert len(saved) == 1
+    assert "raw_memory_id" not in saved[0].metadata
     mark.assert_awaited_once_with(
         None,
         organization_id=org_id,

--- a/apps/api/tests/test_entity_capture_metadata_boundary.py
+++ b/apps/api/tests/test_entity_capture_metadata_boundary.py
@@ -1,0 +1,21 @@
+"""Entity capture sidecars retain authored metadata without trusted provenance."""
+
+from sibyl.api.routes.entity_serialization import sanitize_raw_capture_metadata
+
+
+def test_entity_capture_metadata_preserves_authored_values_only():
+    authored = {"description": "Audit notes", "details": {"source_bindings": "quoted text"}}
+    supplied = {
+        **authored,
+        "principal_id": "caller",
+        "raw_memory_id": "source",
+        "correction_history": [],
+        "source_snapshot_sha256": "digest",
+        "source_bindings": {},
+        "correction_blockers": {},
+        "source_validation_pending": True,
+        "lifecycle_reconciliation_pending": True,
+    }
+
+    assert sanitize_raw_capture_metadata(supplied) == authored
+    assert supplied["source_validation_pending"] is True

--- a/packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
+++ b/packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
@@ -38,6 +38,12 @@ MEMORY_PROVENANCE_METADATA_KEYS = frozenset(
     {
         "raw_memory_id",
         "raw_source_id",
+        "correction_blockers",
+        "correction_history",
+        "source_bindings",
+        "source_snapshot_sha256",
+        "source_validation_pending",
+        "lifecycle_reconciliation_pending",
     }
 )
 


### PR DESCRIPTION
Quick and remember captures now strip server-owned evidence metadata before saving their raw sidecars. The sidecar sanitizer uses the shared provenance policy, so correction history, source bindings, and lifecycle repair state remain under server control. Authored nested metadata is preserved.

Capture queue folding still works. The route passes the source capture identifier as an explicit queue-fold request, separate from stored metadata. The existing organization, principal, and raw-capture checks continue to govern that operation.

## 🧪 Validation

Independent review passed the seven-file change and its shared-policy consumers. Standalone core/API lint and type checks pass. The standalone API selection passed 18 tests, covering capture storage, queue folding, and metadata filtering. The core selection passed 133 tests, including policy enforcement, capture projection, and reflection identity races.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Raw captures now preserve authored metadata while protecting system-managed provenance information from being overwritten.
  * Projection updates now use an explicit source capture reference, improving accuracy when captures are consolidated.
  * Quick captures correctly retain source relationships and only mark projections when a valid source is provided.

* **Tests**
  * Expanded coverage verifies metadata protection, source capture handling, and projection marking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->