### PR TITLE
feat(evals): grade JSON tasks outside candidate containers

### DIFF
--- a/benchmarks/agent_tasks/README.md
+++ b/benchmarks/agent_tasks/README.md
@@ -104,3 +104,70 @@ These are trusted development attempts. Separate processes and staging mounts do
 not provide sealed isolation against hostile same-user processes. A forced kill
 or an unavailable daemon can prevent container cleanup. Trace hashes establish
 byte consistency, not authenticated learning admission or improved task success.
+
+## Grade JSON CLI tasks
+
+A task can use a versioned JSON oracle instead of the development Python checker.
+The candidate reads one JSON value from stdin and emits one JSON value on stdout.
+The host compares the response with its private expected value. Candidate Python
+is never imported into the host checker process on this path.
+
+The checker declaration replaces the task's existing `checker` object:
+
+```json
+{
+  "schema_version": "sibyl-json-cli-oracle-v1",
+  "oracle": {"path": "private/cases.json", "sha256": "<cases digest>"},
+  "runtime": {"path": "runtime.py", "sha256": "<coding_controller.py digest>"},
+  "evaluator": {"path": "oracle.py", "sha256": "<json_oracle.py digest>"},
+  "argv": ["python", "app.py"],
+  "image": "sha256:<image digest>",
+  "docker": "/usr/bin/docker",
+  "docker_host": "unix:///run/devbox-docker/docker.sock",
+  "timeout_seconds": 10.0,
+  "memory_mb": 256
+}
+```
+
+Freeze copies of the installed `coding_controller.py` and `json_oracle.py` under
+those artifact paths. The runner checks their bytes against its installed
+implementation; supplied Python artifacts are retained but never dynamically
+imported. Existing script checkers and v1 controller execution remain supported.
+
+The private case artifact has this shape:
+
+```json
+{
+  "schema_version": "sibyl-json-cli-cases-v1",
+  "cases": [
+    {"id": "double-positive", "input": {"value": 21}, "expected": 42}
+  ]
+}
+```
+
+Each case runs in a fresh container against the final submission, mounted
+read-only. The container receives only the case input, the candidate snapshot,
+and temporary writable storage. Expected values and evaluator artifacts remain
+on the host. Oracle artifacts cannot also be declared as candidate workspace,
+prompt, experience, or memory-pack bytes. This check detects exact overlap; it
+cannot establish that task authors kept their cases private.
+
+Responses must contain one valid JSON value with no duplicate object keys,
+non-finite numbers, or trailing text. Comparisons ignore whitespace and object
+key order but preserve JSON types and numeric representation (`42` differs from
+`42.0`). A nonzero candidate exit, timeout, malformed response, wrong answer, and
+runtime failure have separate outcome statuses. The per-case timeout applies to
+candidate execution; the manifest's checker timeout limits the case loop.
+Container inspection and cleanup can take additional time.
+
+The retained `oracle-outcome.json` binds the attempt, final snapshot, private
+cases, evaluator, runtime, image, and argv. Per-case execution evidence includes
+stdout and stderr bytes. The same container lifecycle implementation serves the
+coding controller and oracle, while the controller remains a standalone script
+that works under isolated Python mode.
+
+JSON-oracle attempts still report `sealed_isolation: false`, and sealed tasks
+remain refused. Separate oracle ownership, admitted controller/runtime policy,
+authenticated outcomes, and split-aware learning admission remain required for
+sealed evaluation. The private artifact and result files share the trusted host
+user's storage. Their hashes do not authenticate the worker or prove learning.

--- a/benchmarks/agent_tasks/coding_controller.py
+++ b/benchmarks/agent_tasks/coding_controller.py
@@ -610,11 +610,24 @@ def _require_normal_stop(finish_reason: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _docker_argv(options: Options, name: str, stage: Path, command: str) -> list[str]:
-    """Fixed argv: no network, no privileges, one writable staging bind."""
+def container_argv(
+    options: Options,
+    name: str,
+    stage: Path,
+    command: list[str],
+    *,
+    read_only: bool = False,
+    stdin: bool = False,
+) -> list[str]:
+    """Build a fixed isolation boundary around a caller-selected container command."""
+    if not command or not command[0] or any("\x00" in value for value in command):
+        raise ValueError("container command requires nonempty arguments")
+    if not stage.is_absolute() or any(char in str(stage) for char in ",\n\r\x00"):
+        raise ValueError("workspace cannot be expressed as a bind mount")
     return [
         options.docker,
         "run",
+        *(["--interactive"] if stdin else []),
         "--name",
         name,
         "--network",
@@ -633,16 +646,19 @@ def _docker_argv(options: Options, name: str, stage: Path, command: str) -> list
         "--tmpfs",
         CONTAINER_TMPFS,
         "--mount",
-        f"type=bind,src={stage},dst=/workspace",
+        f"type=bind,src={stage},dst=/workspace" + (",readonly" if read_only else ""),
         "--workdir",
         "/workspace",
         *[argument for value in CONTAINER_ENVIRONMENT for argument in ("--env", value)],
         "--entrypoint",
-        "/bin/sh",
+        command[0],
         options.image,
-        "-c",
-        command,
+        *command[1:],
     ]
+
+
+def _docker_argv(options: Options, name: str, stage: Path, command: str) -> list[str]:
+    return container_argv(options, name, stage, ["/bin/sh", "-c", command])
 
 
 def _container_state(
@@ -716,6 +732,97 @@ def _tool_text(outcome: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 # Controller
 # ---------------------------------------------------------------------------
+
+
+def execute_container(
+    options: Options,
+    *,
+    name: str,
+    argv: list[str],
+    environment: dict[str, str],
+    stdin: bytes | None = None,
+) -> dict[str, Any]:
+    """Run one owned container and return execution evidence, never a verdict."""
+    timed_out = False
+    container_state: dict[str, Any] | None = None
+    completed: subprocess.CompletedProcess[bytes] | None = None
+    captured: tuple[bytes | None, bytes | None] = (b"", b"")
+    failure: str | None = None
+    try:
+        completed = subprocess.run(  # noqa: S603
+            argv,
+            capture_output=True,
+            timeout=options.tool_timeout,
+            check=False,
+            env=environment,
+            **({"input": stdin} if stdin is not None else {}),
+        )
+        captured = (completed.stdout, completed.stderr)
+        container_state = _container_state(options, name, environment)
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        captured = (exc.stdout, exc.stderr)
+    except (OSError, subprocess.SubprocessError) as exc:
+        failure = type(exc).__name__
+    finally:
+        cleanup = _cleanup_container(options, name, environment)
+    if failure is not None:
+        return _execution_outcome(options, "operational", cleanup, captured, detail=failure)
+    if not cleanup["terminated"]:
+        # A container that may still be writing forbids reading its stage.
+        detail = "the owned container was not confirmed stopped"
+        return _execution_outcome(options, "operational", cleanup, captured, detail=detail)
+    if timed_out or completed is None:
+        return _execution_outcome(options, "timeout", cleanup, captured)
+    if (
+        container_state is None
+        or container_state.get("Status") != "exited"
+        or container_state.get("Error")
+        or container_state.get("OOMKilled")
+        or container_state.get("ExitCode") != completed.returncode
+    ):
+        return _execution_outcome(
+            options,
+            "operational",
+            cleanup,
+            captured,
+            returncode=completed.returncode,
+            detail="the container did not report a completed shell command",
+        )
+    # Inspect distinguishes a shell exit (including 125..127) from launch failure.
+    return _execution_outcome(options, "ok", cleanup, captured, returncode=completed.returncode)
+
+
+def _execution_outcome(
+    options: Options,
+    status: str,
+    cleanup: dict[str, Any],
+    captured: tuple[bytes | None, bytes | None],
+    *,
+    returncode: int | None = None,
+    detail: str | None = None,
+) -> dict[str, Any]:
+    stdout, stdout_sha256 = _captured(captured[0])
+    stderr, stderr_sha256 = _captured(captured[1])
+    return {
+        "status": status,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "stdout_sha256": stdout_sha256,
+        "stdout_base64": base64.b64encode(captured[0] or b"").decode("ascii"),
+        "stderr_base64": base64.b64encode(captured[1] or b"").decode("ascii"),
+        "stderr_sha256": stderr_sha256,
+        "cleanup": cleanup,
+        "carried_back": False,
+        "refusal": None,
+        "detail": detail,
+        "timeout_seconds": options.tool_timeout,
+        "stage": None,
+        "stage_removed": False,
+        "workspace_before": None,
+        "workspace_after": None,
+    }
 
 
 class Controller:
@@ -902,83 +1009,10 @@ class Controller:
     # -- tool -------------------------------------------------------------
 
     def _invoke(self, name: str, argv: list[str], stage: Path) -> dict[str, Any]:
-        timed_out = False
-        container_state: dict[str, Any] | None = None
-        completed: subprocess.CompletedProcess[bytes] | None = None
-        captured: tuple[bytes | None, bytes | None] = (b"", b"")
-        failure: str | None = None
-        try:
-            completed = subprocess.run(  # noqa: S603
-                argv,
-                capture_output=True,
-                timeout=self.options.tool_timeout,
-                check=False,
-                env=self.environment,
-            )
-            captured = (completed.stdout, completed.stderr)
-            container_state = _container_state(self.options, name, self.environment)
-        except subprocess.TimeoutExpired as exc:
-            timed_out = True
-            captured = (exc.stdout, exc.stderr)
-        except (OSError, subprocess.SubprocessError) as exc:
-            failure = type(exc).__name__
-        finally:
-            cleanup = _cleanup_container(self.options, name, self.environment)
-        if failure is not None:
-            return self._outcome("operational", cleanup, captured, detail=failure)
-        if not cleanup["terminated"]:
-            # A container that may still be writing forbids reading its stage.
-            detail = "the owned container was not confirmed stopped"
-            return self._outcome("operational", cleanup, captured, detail=detail)
-        if timed_out or completed is None:
-            return self._outcome("timeout", cleanup, captured)
-        if (
-            container_state is None
-            or container_state.get("Status") != "exited"
-            or container_state.get("Error")
-            or container_state.get("OOMKilled")
-            or container_state.get("ExitCode") != completed.returncode
-        ):
-            return self._outcome(
-                "operational",
-                cleanup,
-                captured,
-                returncode=completed.returncode,
-                detail="the container did not report a completed shell command",
-            )
-        # Inspect distinguishes a shell exit (including 125..127) from launch failure.
-        return self._outcome("ok", cleanup, captured, returncode=completed.returncode)
+        return execute_container(self.options, name=name, argv=argv, environment=self.environment)
 
-    def _outcome(
-        self,
-        status: str,
-        cleanup: dict[str, Any],
-        captured: tuple[bytes | None, bytes | None],
-        *,
-        returncode: int | None = None,
-        detail: str | None = None,
-    ) -> dict[str, Any]:
-        stdout, stdout_sha256 = _captured(captured[0])
-        stderr, stderr_sha256 = _captured(captured[1])
-        return {
-            "status": status,
-            "returncode": returncode,
-            "stdout": stdout,
-            "stderr": stderr,
-            "stdout_sha256": stdout_sha256,
-            "stdout_base64": base64.b64encode(captured[0] or b"").decode("ascii"),
-            "stderr_base64": base64.b64encode(captured[1] or b"").decode("ascii"),
-            "stderr_sha256": stderr_sha256,
-            "cleanup": cleanup,
-            "carried_back": False,
-            "refusal": None,
-            "detail": detail,
-            "timeout_seconds": self.options.tool_timeout,
-            "stage": None,
-            "stage_removed": False,
-            "workspace_before": None,
-            "workspace_after": None,
-        }
+    def _outcome(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return _execution_outcome(self.options, *args, **kwargs)
 
     def _carry_back(self, stage: Path) -> list[dict[str, Any]]:
         """Validate before applying; an I/O failure may leave a partial copy."""

--- a/benchmarks/agent_tasks/json_oracle.py
+++ b/benchmarks/agent_tasks/json_oracle.py
@@ -1,0 +1,178 @@
+"""Judge containerized JSON programs without executing candidate code on the host.
+
+The host owns comparisons and runtime admission. Same-user controller execution
+still makes these trusted development attempts, not sealed evaluations.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+from uuid import uuid4
+
+from benchmarks.agent_tasks import coding_controller as runtime
+from benchmarks.agent_tasks.manifest import ManifestError
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from benchmarks.agent_tasks.manifest import JsonOracleChecker
+
+# These helpers live in the frozen runtime, not an unbound manifest module.
+strict_json = runtime._strict_json
+digest = runtime._digest
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def identity(value: Any) -> str:
+    return digest(canonical_bytes(value))
+
+
+class OracleModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class OracleCase(OracleModel):
+    id: str = Field(min_length=1)
+    input: Any
+    expected: Any
+
+
+class Oracle(OracleModel):
+    schema_version: Literal["sibyl-json-cli-cases-v1"]
+    cases: list[OracleCase] = Field(min_length=1)
+
+
+def validate_oracle_inputs(checker: JsonOracleChecker, inputs: dict[str, bytes]) -> Oracle:
+    """Admit only the installed evaluator/runtime bytes; never import a supplied script."""
+    for artifact, installed in (
+        (checker.runtime, Path(runtime.__file__)),
+        (checker.evaluator, Path(__file__)),
+    ):
+        if (
+            digest(inputs[artifact.path]) != artifact.sha256
+            or inputs[artifact.path] != installed.read_bytes()
+        ):
+            raise ManifestError("oracle runtime differs from the installed implementation")
+    oracle_bytes = inputs[checker.oracle.path]
+    if digest(oracle_bytes) != checker.oracle.sha256:
+        raise ManifestError("oracle differs from its frozen artifact")
+    try:
+        decoded = strict_json(oracle_bytes)
+        # Validate every input and expected value before creating an attempt.
+        # Parsing a finite-looking exponent can still produce infinity.
+        canonical_bytes(decoded)
+        oracle = Oracle.model_validate(decoded)
+    except (ValueError, UnicodeError, RecursionError) as exc:
+        raise ManifestError("oracle contains invalid or unrepresentable JSON") from exc
+    if len({case.id for case in oracle.cases}) != len(oracle.cases):
+        raise ManifestError("duplicate oracle case ID")
+    return oracle
+
+
+def _case_status(execution: dict[str, Any], expected_bytes: bytes) -> str:
+    if execution["status"] == "operational":
+        return "oracle_runtime_error"
+    if execution["status"] == "timeout":
+        return "candidate_timeout"
+    if execution["returncode"] != 0:
+        return "candidate_failed"
+    try:
+        actual = strict_json(base64.b64decode(execution["stdout_base64"], validate=True))
+        actual_bytes = canonical_bytes(actual)
+    except (ValueError, UnicodeError, RecursionError):
+        return "candidate_protocol_invalid"
+    return "passed" if actual_bytes == expected_bytes else "task_failed"
+
+
+def _verify_snapshot(workspace: Path, expected: str) -> None:
+    if identity(runtime.inventory(workspace)[0]) != expected:
+        raise ValueError("candidate snapshot differs from the frozen submission")
+
+
+def evaluate_json_oracle(
+    checker: JsonOracleChecker,
+    *,
+    inputs: dict[str, bytes],
+    workspace: Path,
+    snapshot_sha256: str,
+    attempt_id: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    """Run each case against the frozen read-only submission and compare on the host."""
+    oracle = validate_oracle_inputs(checker, inputs)
+    receipt: dict[str, Any] = {
+        "schema_version": "sibyl-json-cli-outcome-v1",
+        "attempt_id": attempt_id,
+        "snapshot_sha256": snapshot_sha256,
+        "oracle_sha256": checker.oracle.sha256,
+        "runtime_sha256": checker.runtime.sha256,
+        "evaluator_sha256": checker.evaluator.sha256,
+        "checker_sha256": identity(checker.model_dump(mode="json")),
+        "image": checker.image,
+        "argv": checker.argv,
+        "sealed_isolation": False,
+        "authentication": "none",
+        "cases": [],
+        "status": "oracle_runtime_error",
+        "passed": False,
+    }
+    try:
+        runtime._require_unprivileged_user()
+        _verify_snapshot(workspace, snapshot_sha256)
+        options = runtime.Options(
+            checker.image,
+            checker.timeout_seconds,
+            checker.memory_mb,
+            checker.docker,
+            runtime._container_user(checker.docker, checker.docker_host),
+            checker.docker_host,
+        )
+        environment = runtime._client_environment(checker.docker_host)
+        deadline = time.monotonic() + timeout_seconds
+        for case in oracle.cases:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                receipt["status"] = "oracle_timeout"
+                return receipt
+            case_options = replace(options, tool_timeout=min(options.tool_timeout, remaining))
+            name = f"sibyl-oracle-{uuid4().hex}"
+            stdin = canonical_bytes(case.input) + b"\n"
+            expected_bytes = canonical_bytes(case.expected)
+            execution = runtime.execute_container(
+                case_options,
+                name=name,
+                argv=runtime.container_argv(
+                    case_options, name, workspace, checker.argv, read_only=True, stdin=True
+                ),
+                environment=environment,
+                stdin=stdin,
+            )
+            status = _case_status(execution, expected_bytes)
+            receipt["cases"].append(
+                {
+                    "id": case.id,
+                    "input_sha256": digest(stdin),
+                    "expected_sha256": digest(expected_bytes),
+                    "status": status,
+                    "execution": execution,
+                }
+            )
+            if status == "oracle_runtime_error":
+                return receipt
+            _verify_snapshot(workspace, snapshot_sha256)
+        receipt["status"] = next(
+            (case["status"] for case in receipt["cases"] if case["status"] != "passed"),
+            "passed",
+        )
+        receipt["passed"] = receipt["status"] == "passed"
+    except (OSError, ValueError, RecursionError, runtime.ControllerError, runtime.Refusal) as exc:
+        receipt["status"] = "oracle_runtime_error"
+        receipt["detail"] = str(exc)
+    return receipt

--- a/benchmarks/agent_tasks/manifest.py
+++ b/benchmarks/agent_tasks/manifest.py
@@ -72,6 +72,51 @@ class Program(FrozenModel):
     args: list[str] = Field(default_factory=list)
 
 
+class JsonOracleChecker(FrozenModel):
+    """Frozen black-box checker; private artifacts never enter candidate execution."""
+
+    schema_version: Literal["sibyl-json-cli-oracle-v1"]
+    oracle: Artifact
+    runtime: Artifact
+    evaluator: Artifact
+    argv: list[str] = Field(min_length=1)
+    image: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    docker: str
+    docker_host: str | None = None
+    timeout_seconds: float = Field(gt=0, allow_inf_nan=False)
+    memory_mb: int = Field(gt=0)
+
+    @field_validator("argv")
+    @classmethod
+    def validate_argv(cls, value: list[str]) -> list[str]:
+        if not value[0] or any("\x00" in item for item in value):
+            raise ValueError("candidate argv requires an executable and no null bytes")
+        return value
+
+    @field_validator("docker")
+    @classmethod
+    def validate_docker(cls, value: str) -> str:
+        if not Path(value).is_absolute() or "\x00" in value:
+            raise ValueError("docker must name an absolute executable path")
+        return value
+
+    @field_validator("docker_host")
+    @classmethod
+    def validate_docker_host(cls, value: str | None) -> str | None:
+        if value is not None and (
+            not value.startswith("unix:///")
+            or any(char.isspace() or char == "\x00" for char in value)
+        ):
+            raise ValueError("docker_host must be an absolute Unix socket URL")
+        return value
+
+
+def checker_artifacts(checker: Program | JsonOracleChecker) -> list[Artifact]:
+    if isinstance(checker, Program):
+        return [checker.script]
+    return [checker.oracle, checker.runtime, checker.evaluator]
+
+
 class Experience(FrozenModel):
     id: str = Field(pattern=IDENTIFIER_PATTERN)
     family_id: str = Field(pattern=IDENTIFIER_PATTERN)
@@ -86,7 +131,7 @@ class Task(FrozenModel):
     split: Literal["learning", "development", "sealed"]
     prompt: Artifact
     workspace: list[WorkspaceFile]
-    checker: Program
+    checker: Program | JsonOracleChecker
 
 
 class Arm(FrozenModel):
@@ -177,7 +222,8 @@ def validate_partitions(manifest: Manifest) -> None:
         item.artifact.sha256 for item in manifest.experiences if item.split != "learning"
     }
     for task in manifest.tasks:
-        nonlearning_hashes.update([task.prompt.sha256, task.checker.script.sha256])
+        nonlearning_hashes.add(task.prompt.sha256)
+        nonlearning_hashes.update(item.sha256 for item in checker_artifacts(task.checker))
         nonlearning_hashes.update(item.artifact.sha256 for item in task.workspace)
     for arm in manifest.arms:
         if arm.memory_pack.sha256 != digest(b"") and arm.memory_pack.sha256 in nonlearning_hashes:
@@ -188,6 +234,18 @@ def validate_partitions(manifest: Manifest) -> None:
             for source_id in arm.learning_source_ids
         ):
             raise ManifestError("memory packs may reference only declared learning sources")
+    private_oracles = {
+        task.checker.oracle.sha256
+        for task in manifest.tasks
+        if isinstance(task.checker, JsonOracleChecker)
+    }
+    public_hashes = {arm.memory_pack.sha256 for arm in manifest.arms}
+    public_hashes.update(item.artifact.sha256 for item in manifest.experiences)
+    for task in manifest.tasks:
+        public_hashes.add(task.prompt.sha256)
+        public_hashes.update(item.artifact.sha256 for item in task.workspace)
+    if private_oracles & public_hashes:
+        raise ManifestError("private oracle overlaps a candidate-visible artifact")
     for task in manifest.tasks:
         destinations = [item.destination for item in task.workspace]
         _unique(destinations, "workspace destination")
@@ -273,7 +331,7 @@ def load_manifest(path: Path) -> tuple[Manifest, dict[str, bytes]]:
         arm.native_render_payload for arm in manifest.arms if arm.native_render_payload
     )
     for task in manifest.tasks:
-        artifacts.extend([task.prompt, task.checker.script])
+        artifacts.extend([task.prompt, *checker_artifacts(task.checker)])
         artifacts.extend(item.artifact for item in task.workspace)
     content: dict[str, bytes] = {}
     for artifact in artifacts:
@@ -291,9 +349,17 @@ def load_manifest(path: Path) -> tuple[Manifest, dict[str, bytes]]:
             raise ManifestError(
                 f"prompt and memory pack inputs require UTF-8: {artifact.path}"
             ) from exc
-    for program in [manifest.controller, *(task.checker for task in manifest.tasks)]:
+    for program in [
+        manifest.controller,
+        *(task.checker for task in manifest.tasks if isinstance(task.checker, Program)),
+    ]:
         if any("\x00" in arg for arg in program.args):
             raise ManifestError("program argument contains a null character")
+    for task in manifest.tasks:
+        if isinstance(task.checker, JsonOracleChecker):
+            from benchmarks.agent_tasks.json_oracle import validate_oracle_inputs  # noqa: PLC0415
+
+            validate_oracle_inputs(task.checker, content)
     for arm in manifest.arms:
         validate_native_render_binding(arm, content)
     return manifest, content

--- a/benchmarks/agent_tasks/runner.py
+++ b/benchmarks/agent_tasks/runner.py
@@ -24,10 +24,12 @@ from benchmarks.agent_tasks.manifest import (
     Arm,
     ControllerBudget,
     FrozenModel,
+    JsonOracleChecker,
     Manifest,
     ManifestError,
     Task,
     canonical_bytes,
+    checker_artifacts,
     digest,
     identity,
     load_manifest,
@@ -389,6 +391,31 @@ def _process_failure(process: dict[str, Any], role: str) -> str | None:
 
 
 def _check_task(manifest: Manifest, task: Task, output: Path, receipt: dict[str, Any]) -> None:
+    if isinstance(task.checker, JsonOracleChecker):
+        from benchmarks.agent_tasks.json_oracle import evaluate_json_oracle  # noqa: PLC0415
+
+        result = evaluate_json_oracle(
+            task.checker,
+            inputs={
+                item.path: (output / "inputs" / item.path).read_bytes()
+                for item in checker_artifacts(task.checker)
+            },
+            workspace=output / "checker-workspace",
+            snapshot_sha256=receipt["checker_input_snapshot_sha256"],
+            attempt_id=receipt["attempt_id"],
+            timeout_seconds=manifest.checker_timeout_seconds,
+        )
+        _write_json(output / "oracle-outcome.json", result)
+        receipt["checker"] = {
+            "kind": task.checker.schema_version,
+            "outcome_sha256": identity(result),
+        }
+        receipt["outcome"] = result
+        receipt["status"] = result["status"]
+        receipt["success"] = result["passed"] and receipt["budget_status"] != "exceeded"
+        if receipt["budget_status"] == "exceeded":
+            receipt["status"] = "controller_budget_exceeded"
+        return
     checker = _execute(
         program=output / "inputs" / task.checker.script.path,
         program_sha256=task.checker.script.sha256,
@@ -428,7 +455,7 @@ def _perform_attempt(
         manifest.dependency_lock.path,
         manifest.controller.script.path,
         task.prompt.path,
-        task.checker.script.path,
+        *(item.path for item in checker_artifacts(task.checker)),
         arm.memory_pack.path,
         *(item.artifact.path for item in task.workspace),
     }

--- a/tools/tests/test_agent_task_coding_controller.py
+++ b/tools/tests/test_agent_task_coding_controller.py
@@ -16,6 +16,7 @@ import json
 import os
 import stat
 import subprocess
+import sys
 import urllib.error
 import urllib.request
 import urllib.response
@@ -1759,3 +1760,75 @@ def test_unexpected_constructor_failure_emits_a_redacted_terminal_result(
     assert KEY not in harness.trace_path.read_text()
     assert KEY not in json.dumps(result)
     assert not provider.requests
+
+
+def test_copied_controller_remains_standalone_in_isolated_python(tmp_path):
+    copied = tmp_path / "coding_controller.py"
+    copied.write_bytes(Path(controller.__file__).read_bytes())
+    home = tmp_path / "home"
+    home.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-I", str(copied), "--unknown-offline-argument"],
+        cwd=workspace,
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+        input=b"{}",
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    assert completed.returncode == controller.EXIT_CODES["invalid_request"]
+    result = json.loads(completed.stdout)
+    assert result["synthetic"] is False
+    assert result["trace_sha256"]
+    assert "ModuleNotFoundError" not in completed.stderr.decode()
+
+
+def test_shell_controller_delegates_to_public_container_runtime(monkeypatch, tmp_path):
+
+    calls = []
+    expected = {"status": "ok", "returncode": 0}
+
+    def execute(options, **kwargs):
+        calls.append((options, kwargs))
+        return expected
+
+    monkeypatch.setattr(controller, "execute_container", execute)
+    owner = controller.Controller.__new__(controller.Controller)
+    owner.options = controller.Options("sha256:" + "a" * 64, 1.0, 256, "/docker", "0:0", None)
+    owner.environment = {"PATH": "/bin"}
+    assert controller.Controller._invoke(owner, "owned", ["docker"], tmp_path) is expected
+    assert calls == [
+        (owner.options, {"name": "owned", "argv": ["docker"], "environment": owner.environment})
+    ]
+
+
+def test_public_container_runtime_streams_only_supplied_json(monkeypatch, tmp_path):
+    calls = []
+    options = controller.Options("sha256:" + "a" * 64, 2.0, 256, "/docker", "0:0", None)
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        if argv[1] == "run":
+            assert kwargs["input"] == b'{"value":21}\n'
+            return subprocess.CompletedProcess(argv, 0, b"42\n", b"")
+        if argv[1] == "inspect":
+            return subprocess.CompletedProcess(
+                argv, 0, b'{"Status":"exited","ExitCode":0,"Error":"","OOMKilled":false}', b""
+            )
+        return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+    monkeypatch.setattr(controller.subprocess, "run", run)
+    argv = controller.container_argv(
+        options, "owned-json", tmp_path, ["python", "app.py"], read_only=True, stdin=True
+    )
+    outcome = controller.execute_container(
+        options, name="owned-json", argv=argv, environment={}, stdin=b'{"value":21}\n'
+    )
+    assert outcome["status"] == "ok"
+    assert outcome["stdout_base64"] == base64.b64encode(b"42\n").decode()
+    assert outcome["cleanup"]["terminated"] is True
+    assert outcome["carried_back"] is False
+    assert [argv[1] for argv, _ in calls] == ["run", "inspect", "stop", "rm"]
+    assert all("input" not in kwargs for _, kwargs in calls[1:])

--- a/tools/tests/test_agent_task_development_corpus.py
+++ b/tools/tests/test_agent_task_development_corpus.py
@@ -13,6 +13,7 @@ import pytest
 from benchmarks.agent_tasks.manifest import (
     FIXED_ENVIRONMENT,
     Manifest,
+    Program,
     Task,
     digest,
     identity,
@@ -106,6 +107,7 @@ def artifact(root: Path, name: str, content: bytes) -> dict:
 def frozen_manifest(root: Path) -> Path:
     root.mkdir()
     for task in TASKS:
+        assert isinstance(task.checker, Program)
         for item in [
             task.prompt,
             task.checker.script,
@@ -170,6 +172,7 @@ def public_result(workspace: Path) -> subprocess.CompletedProcess:
 
 
 def independent_result(root: Path, workspace: Path, task: Task) -> CheckerResult:
+    assert isinstance(task.checker, Program)
     root.mkdir()
     process = _execute(
         program=CORPUS / task.checker.script.path,
@@ -193,6 +196,7 @@ def test_development_corpus_declares_eight_exposed_tasks_in_four_families():
     assert set(Counter(task.family_id for task in TASKS).values()) == {2}
     assert {task.split for task in TASKS} == {"development"}
     for task in TASKS:
+        assert isinstance(task.checker, Program)
         assert task.id.startswith("dev-")
         assert task.family_id.startswith("dev-")
         assert task.checker.script.path not in {entry.artifact.path for entry in task.workspace}

--- a/tools/tests/test_agent_task_runner.py
+++ b/tools/tests/test_agent_task_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import signal
@@ -14,14 +15,18 @@ from dataclasses import asdict
 from pathlib import Path
 
 import pytest
-from benchmarks.agent_tasks import runner
+from benchmarks.agent_tasks import coding_controller, json_oracle, runner
+from benchmarks.agent_tasks import coding_controller as runtime
 from benchmarks.agent_tasks.coding_controller import inventory
+from benchmarks.agent_tasks.json_oracle import evaluate_json_oracle
 from benchmarks.agent_tasks.manifest import (
     Arm,
+    JsonOracleChecker,
     Manifest,
     ManifestError,
     digest,
     identity,
+    load_manifest,
     runtime_identity,
     validate_native_render_binding,
 )
@@ -1122,3 +1127,186 @@ def test_fresh_workspace_does_not_inherit_shared_parent_setgid(experiment):
     assert not (workspace / "tests").stat().st_mode & stat.S_ISGID
     assert (workspace / "tests/nested.txt").read_text() == "0"
     assert inventory(workspace)[0]
+
+
+@pytest.fixture
+def json_oracle_experiment(experiment):
+
+    manifest, freeze, output = experiment
+    root = freeze().parent
+
+    def artifact(name, data):
+        (root / name).write_bytes(data)
+        return {"path": name, "sha256": digest(data)}
+
+    manifest["tasks"][0]["checker"] = {
+        "schema_version": "sibyl-json-cli-oracle-v1",
+        "oracle": artifact(
+            "oracle.json",
+            json.dumps(
+                {
+                    "schema_version": "sibyl-json-cli-cases-v1",
+                    "cases": [{"id": "one", "input": {"value": 21}, "expected": 42}],
+                }
+            ).encode(),
+        ),
+        "runtime": artifact("runtime.py", Path(coding_controller.__file__).read_bytes()),
+        "evaluator": artifact("oracle.py", Path(json_oracle.__file__).read_bytes()),
+        "argv": ["python", "app.py"],
+        "image": "sha256:" + "a" * 64,
+        "docker": "/usr/bin/docker",
+        "docker_host": "unix:///run/devbox-docker/docker.sock",
+        "timeout_seconds": 1.0,
+        "memory_mb": 256,
+    }
+    return manifest, freeze, output
+
+
+@pytest.mark.parametrize(
+    ("stdout", "exit_code", "execution_status", "expected_status"),
+    [
+        (b"42\n", 0, "ok", "passed"),
+        (b"41\n", 0, "ok", "task_failed"),
+        (b"true\n", 0, "ok", "task_failed"),
+        (b"42.0\n", 0, "ok", "task_failed"),
+        (b"42 trailing", 0, "ok", "candidate_protocol_invalid"),
+        (b'{"x": 1, "x": 2}', 0, "ok", "candidate_protocol_invalid"),
+        (b"NaN", 0, "ok", "candidate_protocol_invalid"),
+        (b"1e999", 0, "ok", "candidate_protocol_invalid"),
+        (b"deep-json", 0, "ok", "candidate_protocol_invalid"),
+        (b"42\n", 3, "ok", "candidate_failed"),
+        (b"", None, "timeout", "candidate_timeout"),
+        (b"", None, "operational", "oracle_runtime_error"),
+    ],
+)
+def test_json_oracle_judges_output_outside_candidate(
+    json_oracle_experiment, monkeypatch, stdout, exit_code, execution_status, expected_status
+):
+
+    if stdout == b"deep-json":
+        depth = 100_000
+        stdout = b"[" * depth + b"0" + b"]" * depth
+    calls = []
+    monkeypatch.setattr(runtime, "_container_user", lambda *_: "0:0")
+
+    def execute_container(options, **kwargs):
+        calls.append(kwargs)
+        assert kwargs["stdin"] == b'{"value":21}\n'
+        argv = kwargs["argv"]
+        assert argv[argv.index("--entrypoint") + 1 :] == ["python", "sha256:" + "a" * 64, "app.py"]
+        assert "--interactive" in argv
+        mount = argv[argv.index("--mount") + 1]
+        assert mount.endswith("/checker-workspace,dst=/workspace,readonly")
+        assert "oracle.json" not in " ".join(argv)
+        assert "OPENROUTER_API_KEY" not in kwargs["environment"]
+        return {
+            "status": execution_status,
+            "returncode": exit_code,
+            "stdout_base64": base64.b64encode(stdout).decode(),
+            "cleanup": {"terminated": True},
+        }
+
+    monkeypatch.setattr(runtime, "execute_container", execute_container)
+    receipt = execute(json_oracle_experiment)
+    assert receipt["status"] == expected_status
+    assert receipt["success"] is (expected_status == "passed")
+    assert receipt["sealed_isolation"] is False
+    assert receipt["outcome"]["authentication"] == "none"
+    assert receipt["outcome"]["snapshot_sha256"] == receipt["controller_final_snapshot_sha256"]
+    assert receipt["outcome"]["attempt_id"] == receipt["attempt_id"]
+    checker = json_oracle_experiment[0]["tasks"][0]["checker"]
+    for field in ("oracle", "runtime", "evaluator"):
+        assert receipt["outcome"][f"{field}_sha256"] == checker[field]["sha256"]
+    assert len(calls) == 1
+    assert len(receipt["outcome"]["cases"]) == 1
+    retained = receipt["outcome"]["cases"][0]["execution"]
+    assert base64.b64decode(retained["stdout_base64"]) == stdout
+    saved = json.loads((json_oracle_experiment[2] / "receipt.json").read_bytes())
+    assert saved["status"] == expected_status
+    outcome = json.loads((json_oracle_experiment[2] / "oracle-outcome.json").read_bytes())
+    assert outcome["cases"][0]["execution"] == retained
+
+
+@pytest.mark.parametrize("field", ["runtime", "evaluator"])
+def test_json_oracle_requires_installed_frozen_runtime(json_oracle_experiment, field):
+    manifest, freeze, output = json_oracle_experiment
+    artifact = manifest["tasks"][0]["checker"][field]
+    changed = b"# another implementation\n"
+    (freeze().parent / artifact["path"]).write_bytes(changed)
+    artifact["sha256"] = digest(changed)
+    with pytest.raises(ManifestError, match="runtime differs"):
+        execute(json_oracle_experiment)
+    assert not output.exists()
+
+
+def test_json_oracle_still_rejects_sealed_tasks(json_oracle_experiment):
+    manifest, _, output = json_oracle_experiment
+    manifest["tasks"][0]["split"] = "sealed"
+    with pytest.raises(ManifestError, match="sealed execution"):
+        execute(json_oracle_experiment)
+    assert not output.exists()
+
+
+def test_json_oracle_does_not_execute_changed_snapshot(json_oracle_experiment, monkeypatch):
+
+    _, freeze, output = json_oracle_experiment
+    manifest, inputs = load_manifest(freeze())
+    assert isinstance(manifest.tasks[0].checker, JsonOracleChecker)
+    output.mkdir()
+    (output / "app.py").write_text("unexecuted candidate")
+    calls = []
+    monkeypatch.setattr(runtime, "execute_container", lambda *args, **kwargs: calls.append(kwargs))
+    outcome = evaluate_json_oracle(
+        manifest.tasks[0].checker,
+        inputs=inputs,
+        workspace=output,
+        snapshot_sha256="0" * 64,
+        attempt_id="fixture",
+        timeout_seconds=1.0,
+    )
+    assert outcome["status"] == "oracle_runtime_error"
+    assert calls == []
+
+
+def test_json_oracle_cannot_be_declared_as_candidate_workspace(json_oracle_experiment):
+    manifest, _, output = json_oracle_experiment
+    task = manifest["tasks"][0]
+    task["workspace"].append({"artifact": task["checker"]["oracle"], "destination": "oracle.json"})
+    with pytest.raises(ManifestError, match="private oracle overlaps"):
+        execute(json_oracle_experiment)
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("field", ["input", "expected"])
+@pytest.mark.parametrize("value", [b"1e999", b"deep-json"])
+def test_json_oracle_rejects_unrepresentable_cases_before_attempt(
+    json_oracle_experiment, field, value
+):
+    if value == b"deep-json":
+        depth = 100_000
+        value = b"[" * depth + b"0" + b"]" * depth
+    manifest, freeze, output = json_oracle_experiment
+    artifact = manifest["tasks"][0]["checker"]["oracle"]
+    path = freeze().parent / artifact["path"]
+    case = {"id": "one", "input": None, "expected": None}
+    case[field] = "PLACEHOLDER"
+    encoded = json.dumps({"schema_version": "sibyl-json-cli-cases-v1", "cases": [case]}).encode()
+    encoded = encoded.replace(b'"PLACEHOLDER"', value)
+    path.write_bytes(encoded)
+    artifact["sha256"] = digest(encoded)
+    with pytest.raises(ManifestError, match="unrepresentable JSON"):
+        execute(json_oracle_experiment)
+    assert not output.exists()
+
+
+def test_json_oracle_verdict_does_not_depend_on_manifest_json_helpers(monkeypatch):
+    from benchmarks.agent_tasks import manifest as manifest_module  # noqa: PLC0415
+
+    def unavailable(*args, **kwargs):
+        raise AssertionError("unbound manifest helper influenced the oracle")
+
+    for name in ("strict_json", "canonical_bytes", "identity", "digest"):
+        monkeypatch.setattr(manifest_module, name, unavailable)
+    result = {"status": "ok", "returncode": 0, "stdout_base64": base64.b64encode(b"42").decode()}
+    assert json_oracle._case_status(result, json_oracle.canonical_bytes(42)) == "passed"
+    assert json_oracle.identity({"value": 42})


### PR DESCRIPTION
Agent-task evaluations can now grade JSON command-line programs without importing candidate code into the host checker. Each case executes against a read-only submission in a fresh container, and the host compares its response with the frozen expected value.

The versioned checker binds the oracle, evaluator, runtime, image, command, and submission hashes. Malformed output, incorrect answers, nonzero exits, timeouts, and runtime failures retain distinct outcomes and execution evidence. JSON parsing and comparison helpers live inside the frozen artifacts. The coding controller and grader share container lifecycle code while preserving the controller's standalone isolated-Python contract.

These remain trusted development attempts. Sealed tasks are refused, and receipts explicitly report unauthenticated outcomes without sealed isolation. Separate oracle ownership and authenticated learning admission are required before using this path for sealed benchmarks.

## 🧪 Validation

The agent-task suite passed 293 tests with one Linux-only directory-inheritance test skipped on macOS. Inventory lint and typecheck passed. Independent adversarial review passed after regressions were added for numeric overflow, deeply nested JSON, and frozen comparison semantics.

Nine real Docker scenarios passed on the isolated devbox: correct and incorrect answers, malformed JSON, numeric overflow, deep nesting, nonzero exit, timeout, read-only enforcement, and missing image. Every scenario retained its expected outcome and confirmed container cleanup. No model calls were needed for runtime qualification.
