### PR TITLE
feat(memory): persist stable legacy content checkpoints

### DIFF
--- a/apps/api/src/sibyl/persistence/surreal/content.py
+++ b/apps/api/src/sibyl/persistence/surreal/content.py
@@ -869,6 +869,10 @@ async def _replace_record(
     if organization_id is None:
         msg = f"{table} record {uuid} requires organization_id"
         raise RuntimeError(msg)
+    if table == "raw_captures":
+        from sibyl_core.services.content_raw_persistence import replace_raw_memory_records_bulk
+
+        return (await replace_raw_memory_records_bulk(client, [record]))[0]
     created = await _select_many(
         client,
         _UPSERT_RECORD[table],
@@ -1848,13 +1852,29 @@ async def update_raw_capture_review_state(
             metadata.pop("archived_at", None)
             metadata.pop("deferred_at", None)
 
-        rows = await _select_many(
+        rows = await _select_many_raw(
             client,
-            "UPDATE raw_captures SET metadata = $metadata, review_state = $review_state "
-            "WHERE uuid = $capture_id AND organization_id = $organization_id;",
+            "BEGIN TRANSACTION; "
+            "LET $current = (SELECT * FROM raw_captures WHERE uuid = $capture_id "
+            "AND organization_id = $organization_id LIMIT 1)[0]; "
+            "LET $saved = (UPDATE raw_captures MERGE {"
+            "metadata: object::from_entries(array::concat(object::entries($current.metadata), "
+            "object::entries($review_patch))), "
+            "review_state: $review_state, revision: $current.revision + 1} "
+            "WHERE uuid = $capture_id AND organization_id = $organization_id RETURN AFTER); "
+            "COMMIT TRANSACTION; RETURN $saved;",
             capture_id=str(capture_id),
             organization_id=str(organization_id),
-            metadata=metadata,
+            review_patch={
+                key: metadata.get(key)
+                for key in (
+                    "review_state",
+                    "reviewed_at",
+                    "archived_at",
+                    "deferred_at",
+                    "promoted_at",
+                )
+            },
             review_state=review_state,
         )
     return _raw_capture_from_record(rows[0]) if rows else None

--- a/apps/api/tests/test_legacy_checkpoint_persistence.py
+++ b/apps/api/tests/test_legacy_checkpoint_persistence.py
@@ -1,0 +1,144 @@
+"""Archive and review writes retain storage-owned legacy content epochs."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from sibyl.persistence import content_archive
+from sibyl.persistence.content_common import RawCaptureRecord
+from sibyl.persistence.surreal import content as api_content
+from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
+
+
+@pytest.fixture
+async def checkpoint_client(monkeypatch):
+    client = SurrealContentClient(url="memory://")
+    await bootstrap_content_schema(client, reset=True)
+
+    @asynccontextmanager
+    async def session():
+        yield client
+
+    monkeypatch.setattr(api_content, "surreal_content_client", session)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+async def test_checkpoint_archive_restore_after_bootstrap(checkpoint_client):
+    history = [{"action": "revise", "reason": "legacy corrected text"}]
+    record = {
+        "id": str(uuid4()),
+        "organization_id": str(uuid4()),
+        "revision": 9,
+        "raw_content": "restored evidence",
+        "metadata": {"correction_history": history},
+    }
+    with (
+        patch.object(
+            content_archive, "build_surreal_content_client", return_value=checkpoint_client
+        ),
+        patch.object(checkpoint_client, "close", AsyncMock()),
+    ):
+        result = await content_archive.restore_content_archive_payload(
+            {
+                "tables": {"raw_captures": [record]},
+            }
+        )
+    assert result.errors == []
+    stored = (
+        await api_content._select_many(
+            checkpoint_client, "SELECT * FROM raw_captures WHERE uuid = $uuid;", uuid=record["id"]
+        )
+    )[0]
+    assert stored["revision"] == 9
+    assert stored["metadata"]["correction_history"] == history
+    assert stored["legacy_content_checkpoint"] == {"entries": history, "observed_revision": 9}
+    record["legacy_content_checkpoint"] = {"entries": history, "observed_revision": 7}
+    with (
+        patch.object(
+            content_archive, "build_surreal_content_client", return_value=checkpoint_client
+        ),
+        patch.object(checkpoint_client, "close", AsyncMock()),
+    ):
+        result = await content_archive.restore_content_archive_payload(
+            {
+                "tables": {"raw_captures": [record]},
+            }
+        )
+    assert result.errors == []
+    stored = (
+        await api_content._select_many(
+            checkpoint_client, "SELECT * FROM raw_captures WHERE uuid = $uuid;", uuid=record["id"]
+        )
+    )[0]
+    assert stored["legacy_content_checkpoint"]["observed_revision"] == 7
+
+
+async def test_checkpoint_stale_review_preserves_concurrent_history(checkpoint_client, monkeypatch):
+    org = uuid4()
+    initial_history = [{"action": "revise", "reason": "imported capture"}]
+    capture = await api_content.save_raw_capture_record(
+        None,
+        capture=RawCaptureRecord(
+            organization_id=org,
+            principal_id="owner",
+            title="Evidence",
+            raw_content="before",
+            entity_type="raw_memory",
+            metadata={"correction_history": initial_history},
+        ),
+    )
+    select_one = api_content._select_one
+    raced = False
+    history = [*initial_history, {"action": "revise", "reason": "concurrent correction"}]
+    initial = (
+        await api_content._select_many(
+            checkpoint_client,
+            "SELECT * FROM raw_captures WHERE uuid = $uuid;",
+            uuid=str(capture.id),
+        )
+    )[0]
+    assert initial["revision"] == 1
+    assert initial["legacy_content_checkpoint"]["observed_revision"] == 1
+
+    async def read_then_correct(client, query, **params):
+        nonlocal raced
+        result = await select_one(client, query, **params)
+        if not raced and params.get("capture_id") == str(capture.id):
+            raced = True
+            await client.execute_query(
+                "UPDATE raw_captures MERGE $patch WHERE uuid = $uuid;",
+                uuid=str(capture.id),
+                patch={
+                    "revision": result["revision"] + 1,
+                    "raw_content": "after",
+                    "metadata": {**result["metadata"], "correction_history": history},
+                },
+            )
+        return result
+
+    monkeypatch.setattr(api_content, "_select_one", read_then_correct)
+    reviewed = await api_content.update_raw_capture_review_state(
+        None,
+        organization_id=org,
+        capture_id=capture.id,
+        review_state="promoted",
+    )
+    assert reviewed is not None
+    stored = (
+        await api_content._select_many(
+            checkpoint_client,
+            "SELECT * FROM raw_captures WHERE uuid = $uuid;",
+            uuid=str(capture.id),
+        )
+    )[0]
+    assert raced
+    assert stored["revision"] == 3
+    assert stored["raw_content"] == "after"
+    assert stored["metadata"]["correction_history"] == history
+    assert stored["review_state"] == "promoted"
+    assert stored["legacy_content_checkpoint"]["observed_revision"] == 2

--- a/apps/api/tests/test_legacy_checkpoint_persistence.py
+++ b/apps/api/tests/test_legacy_checkpoint_persistence.py
@@ -142,3 +142,44 @@ async def test_checkpoint_stale_review_preserves_concurrent_history(checkpoint_c
     assert stored["metadata"]["correction_history"] == history
     assert stored["review_state"] == "promoted"
     assert stored["legacy_content_checkpoint"]["observed_revision"] == 2
+
+
+@pytest.mark.parametrize("state", ["pending", "deferred", "archived", "promoted"])
+async def test_checkpoint_review_removes_inapplicable_timestamps(checkpoint_client, state):
+    org = uuid4()
+    history = [{"action": "revise"}]
+    capture = await api_content.save_raw_capture_record(
+        None,
+        capture=RawCaptureRecord(
+            organization_id=org,
+            principal_id="owner",
+            title="Review transitions",
+            raw_content="Evidence",
+            entity_type="raw_memory",
+            metadata={
+                "archived_at": "old-archive",
+                "deferred_at": "old-defer",
+                "promoted_at": "old-promotion",
+                "correction_history": history,
+                "authored": {"keep": True},
+            },
+        ),
+    )
+    await api_content.update_raw_capture_review_state(
+        None, organization_id=org, capture_id=capture.id, review_state=state
+    )
+    stored = (
+        await api_content._select_many(
+            checkpoint_client,
+            "SELECT * FROM raw_captures WHERE uuid = $uuid;",
+            uuid=str(capture.id),
+        )
+    )[0]
+    timestamps = {
+        key for key in stored["metadata"] if key in {"archived_at", "deferred_at", "promoted_at"}
+    }
+    assert timestamps == (set() if state == "pending" else {f"{state}_at"})
+    assert stored["metadata"]["correction_history"] == history
+    assert stored["metadata"]["authored"] == {"keep": True}
+    assert stored["legacy_content_checkpoint"]["observed_revision"] == 1
+    assert stored["revision"] == 2

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -62,7 +62,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 25
+CONTENT_SCHEMA_CURRENT_VERSION = 27
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -100,7 +100,11 @@ def _load_schema_file(filename: str) -> str:
 
 
 CONTENT_ANALYZER_DEFINITIONS = _load_schema_file("01_analyzers.surql")
+CONTENT_LEGACY_CONTENT_CHECKPOINT_DEFINITIONS = (
+    _SCHEMA_DIR / "35_legacy_content_checkpoint.surql"
+).read_text(encoding="utf-8")
 CONTENT_SCHEMA_DEFINITIONS = _load_schema_file("10_tables.surql")
+
 
 CONTENT_SOURCE_URL_SCOPE_MIGRATION_DEFINITIONS = """
 REMOVE INDEX IF EXISTS idx_crawl_sources_url ON TABLE crawl_sources;
@@ -626,6 +630,67 @@ FOR $projection IN ($projections ?? []) {
 """.strip()
 
 
+# Index builds rewrite existing rows under the current schema. Legacy tables
+# may have become SCHEMAFULL before all raw-capture fields were declared; define
+# the complete capture shape before a rebuild can discard their stored values.
+CONTENT_SOURCE_LINEAGE_INDEX_MIGRATION_DEFINITIONS = f"""
+DEFINE FIELD IF NOT EXISTS uuid ON raw_captures TYPE string;
+DEFINE FIELD IF NOT EXISTS organization_id ON raw_captures TYPE string;
+DEFINE FIELD IF NOT EXISTS source_id ON raw_captures TYPE string DEFAULT '';
+DEFINE FIELD IF NOT EXISTS principal_id ON raw_captures TYPE string DEFAULT '';
+DEFINE FIELD IF NOT EXISTS memory_scope ON raw_captures TYPE string DEFAULT 'private';
+DEFINE FIELD IF NOT EXISTS scope_key ON raw_captures TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS agent_id ON raw_captures TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS project_id ON raw_captures TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS review_state ON raw_captures TYPE string DEFAULT 'pending';
+DEFINE FIELD IF NOT EXISTS entity_id ON raw_captures TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS title ON raw_captures TYPE string DEFAULT '';
+DEFINE FIELD IF NOT EXISTS raw_content ON raw_captures TYPE string DEFAULT '';
+DEFINE FIELD IF NOT EXISTS entity_type ON raw_captures TYPE string DEFAULT '';
+DEFINE FIELD IF NOT EXISTS tags ON raw_captures TYPE array<string> DEFAULT [];
+DEFINE FIELD IF NOT EXISTS embedding ON raw_captures TYPE option<array<float, {EMBEDDING_DIM}>>;
+DEFINE FIELD IF NOT EXISTS metadata ON raw_captures TYPE object FLEXIBLE DEFAULT {{}};
+DEFINE FIELD IF NOT EXISTS provenance ON raw_captures TYPE object FLEXIBLE DEFAULT {{}};
+DEFINE FIELD IF NOT EXISTS capture_surface ON raw_captures TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS created_by_user_id ON raw_captures TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS revision ON raw_captures TYPE option<int> DEFAULT 1;
+DEFINE FIELD IF NOT EXISTS captured_at ON raw_captures TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS deleted_at ON raw_captures TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS purge_after ON raw_captures TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS last_recalled_at ON raw_captures TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS last_used_at ON raw_captures TYPE option<datetime>;
+DEFINE FIELD IF NOT EXISTS retrieval_count ON raw_captures TYPE option<int> DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS citation_count ON raw_captures TYPE option<int> DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS misled_count ON raw_captures TYPE option<int> DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS created_at ON raw_captures TYPE datetime DEFAULT time::now();
+DEFINE INDEX IF NOT EXISTS idx_raw_captures_source_lineage ON raw_captures FIELDS metadata.raw_source_ids.*;
+"""
+
+
+CONTENT_LEGACY_CONTENT_CHECKPOINT_BACKFILL = """
+LET $checkpoint_rows = (SELECT id, revision, metadata FROM raw_captures
+             WHERE legacy_content_checkpoint = NONE
+             AND array::len((metadata.correction_history ?? []).filter(|$entry|
+                 type::is::object($entry)
+                 AND string::lowercase(string::trim($entry.action ?? '')) = 'revise'
+                 AND $entry.prior_revision = NONE)) > 0);
+FOR $row IN $checkpoint_rows {
+    LET $history = $row.metadata.correction_history ?? [];
+    LET $legacy = $history.filter(|$entry| type::is::object($entry)
+        AND string::lowercase(string::trim($entry.action ?? '')) = 'revise'
+        AND $entry.prior_revision = NONE);
+    LET $capture_id = $row.id;
+    UPDATE $capture_id MERGE {
+        revision: $row.revision + 1,
+        legacy_content_checkpoint: {
+            entries: $legacy,
+            observed_revision: IF array::len($legacy) > 0 { $row.revision } ELSE { 0 }
+        }
+    } WHERE revision = $row.revision AND legacy_content_checkpoint = NONE;
+};
+"""
+
+
 def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
     compatible_schema = render_fulltext_compatible_sql(
         CONTENT_SCHEMA_DEFINITIONS,
@@ -781,6 +846,22 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             name="content_source_import_revision",
             statements=tuple(
                 split_statements(CONTENT_SOURCE_IMPORT_REVISION_MIGRATION_DEFINITIONS)
+            ),
+        ),
+        SchemaMigration(
+            version=26,
+            name="content_source_lineage_index",
+            statements=tuple(split_statements(CONTENT_SOURCE_LINEAGE_INDEX_MIGRATION_DEFINITIONS)),
+        ),
+        SchemaMigration(
+            version=27,
+            name="content_legacy_content_checkpoint",
+            statements=tuple(
+                render_surreal_compatible_sql(statement, url=url)
+                for statement in (
+                    CONTENT_LEGACY_CONTENT_CHECKPOINT_DEFINITIONS,
+                    CONTENT_LEGACY_CONTENT_CHECKPOINT_BACKFILL,
+                )
             ),
         ),
     )

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -672,12 +672,12 @@ LET $checkpoint_rows = (SELECT id, revision, metadata FROM raw_captures
              WHERE legacy_content_checkpoint = NONE
              AND array::len((metadata.correction_history ?? []).filter(|$entry|
                  type::is::object($entry)
-                 AND string::lowercase(string::trim($entry.action ?? '')) = 'revise'
+                 AND string::lowercase(string::trim(type::string($entry.action ?? ''))) = 'revise'
                  AND $entry.prior_revision = NONE)) > 0);
 FOR $row IN $checkpoint_rows {
     LET $history = $row.metadata.correction_history ?? [];
     LET $legacy = $history.filter(|$entry| type::is::object($entry)
-        AND string::lowercase(string::trim($entry.action ?? '')) = 'revise'
+        AND string::lowercase(string::trim(type::string($entry.action ?? ''))) = 'revise'
         AND $entry.prior_revision = NONE);
     LET $capture_id = $row.id;
     UPDATE $capture_id MERGE {

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -1140,6 +1140,8 @@ def render_surreal_compatible_sql(sql: str, *, url: str) -> str:
         rendered = (
             rendered.replace("type::is::string", "type::is_string")
             .replace("type::is::object", "type::is_object")
+            .replace("type::is::array", "type::is_array")
+            .replace("type::is::int", "type::is_int")
             .replace("type::is::number", "type::is_number")
             .replace("type::is::datetime", "type::is_datetime")
             .replace("string::is::datetime", "string::is_datetime")

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
@@ -162,6 +162,7 @@ DEFINE INDEX IF NOT EXISTS idx_raw_captures_project ON raw_captures FIELDS organ
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_review ON raw_captures FIELDS organization_id, review_state;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_purge_after ON raw_captures FIELDS purge_after;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_entity_id ON raw_captures FIELDS entity_id;
+DEFINE INDEX IF NOT EXISTS idx_raw_captures_source_lineage ON raw_captures FIELDS metadata.raw_source_ids.*;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_org_dedupe ON raw_captures FIELDS organization_id, metadata.dedupe_key;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_dedupe_lookup ON raw_captures
     FIELDS metadata.dedupe_key, organization_id, memory_scope, scope_key;

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/35_legacy_content_checkpoint.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/35_legacy_content_checkpoint.surql
@@ -1,0 +1,26 @@
+-- A checkpoint is an observed revision, never a reconstructed correction time.
+DEFINE FIELD OVERWRITE legacy_content_checkpoint ON raw_captures TYPE option<object> FLEXIBLE VALUE {
+    LET $fields = $input.metadata ?? metadata ?? {};
+    LET $history = $fields.correction_history ?? [];
+    IF type::is::array($history) = false {
+        THROW 'correction_history must be an array';
+    };
+    LET $legacy = $history.filter(|$entry| type::is::object($entry)
+        AND string::lowercase(string::trim($entry.action ?? '')) = 'revise'
+        AND $entry.prior_revision = NONE);
+    LET $clock = revision ?? 1;
+    IF $before != NONE AND $before.entries = $legacy {
+        RETURN $before;
+    };
+    IF $before != NONE
+        AND array::slice($legacy, 0, array::len($before.entries)) != $before.entries {
+        THROW 'legacy correction history cannot be replaced or removed';
+    };
+    IF $before = NONE AND $value != NONE AND $value.entries = $legacy
+        AND type::is::int($value.observed_revision)
+        AND $value.observed_revision >= 0 AND $value.observed_revision <= $clock
+        AND (array::len($legacy) = 0 OR $value.observed_revision > 0) {
+        RETURN $value;
+    };
+    RETURN {entries: $legacy, observed_revision: IF array::len($legacy) > 0 { $clock } ELSE { 0 }};
+};

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/35_legacy_content_checkpoint.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/35_legacy_content_checkpoint.surql
@@ -6,7 +6,7 @@ DEFINE FIELD OVERWRITE legacy_content_checkpoint ON raw_captures TYPE option<obj
         THROW 'correction_history must be an array';
     };
     LET $legacy = $history.filter(|$entry| type::is::object($entry)
-        AND string::lowercase(string::trim($entry.action ?? '')) = 'revise'
+        AND string::lowercase(string::trim(type::string($entry.action ?? ''))) = 'revise'
         AND $entry.prior_revision = NONE);
     LET $clock = revision ?? 1;
     IF $before != NONE AND $before.entries = $legacy {

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/source_lifecycle.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/source_lifecycle.py
@@ -1,0 +1,419 @@
+"""Revision-ordered source exclusions, independent of a derivative's lifecycle."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+CORRECTION_BLOCKERS_KEY = "correction_blockers"
+SOURCE_VALIDATION_PENDING_KEY = "source_validation_pending"
+SOURCE_BINDINGS_KEY = "source_bindings"
+RAW_SOURCE_IDS_KEY = "raw_source_ids"
+CORRECTION_HISTORY_KEY = "correction_history"
+# The binding a derived row gets for a source whose content epoch nobody
+# recorded. It is smaller than every real capture revision, so any revised
+# content blocks it: "we do not know which text this row read" has to read as
+# stale, never as current.
+UNKNOWN_SOURCE_REVISION = 0
+
+__all__ = [
+    "CORRECTION_BLOCKERS_KEY",
+    "CORRECTION_HISTORY_KEY",
+    "RAW_SOURCE_IDS_KEY",
+    "SOURCE_BINDINGS_KEY",
+    "SOURCE_VALIDATION_PENDING_KEY",
+    "UNKNOWN_SOURCE_REVISION",
+    "SourceCorrection",
+    "SourceMemoryView",
+    "correction_blocked",
+    "correction_event",
+    "declared_source_ids",
+    "merge_source_correction",
+    "public_memory_metadata",
+    "source_revision_bindings",
+]
+
+
+def public_memory_metadata(metadata: Mapping[str, object] | None) -> dict[str, object]:
+    """Copy final response metadata without other sources' IDs and clocks.
+
+    Call only after lifecycle and policy checks. Bindings can name ancestors
+    outside the reader's scope, so they stay internal alongside correction
+    clocks. The row's admission state and authored nested maps remain visible.
+    """
+    public = {
+        key: value
+        for key, value in (metadata or {}).items()
+        if key not in {CORRECTION_BLOCKERS_KEY, SOURCE_BINDINGS_KEY, "source_snapshot_sha256"}
+    }
+    identity = public.get("reflection_identity")
+    if isinstance(identity, Mapping):
+        public["reflection_identity"] = {
+            key: value for key, value in identity.items() if key != "source_snapshot_sha256"
+        }
+    for key in ("lifecycle_reconciliation_pending", SOURCE_VALIDATION_PENDING_KEY):
+        if isinstance(public.get(key), Mapping):
+            public[key] = bool(public[key])
+    return public
+
+
+class SourceMemoryView(Protocol):
+    """The three fields a corrected or observed capture is read through."""
+
+    @property
+    def id(self) -> str: ...
+
+    @property
+    def revision(self) -> int: ...
+
+    @property
+    def metadata(self) -> Mapping[str, object]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCorrection:
+    """One correction of one root source, as the derived rows must see it.
+
+    ``revision`` is the root's capture revision after the correction was saved,
+    which is the only monotone clock both lanes agree on. ``blocking`` says the
+    source itself left recall. ``content_revision`` is the first revision whose
+    text is the revised text, or ``0`` when the source's text was never revised;
+    it is what makes a ``revise`` reach the rows that read the old body without
+    also hiding the rows that already read the new one.
+    """
+
+    root_id: str
+    revision: int
+    blocking: bool
+    content_revision: int = 0
+
+
+def _valid_revision(value: object, *, minimum: int = 0) -> bool:
+    # `bool` is a subclass of `int`, so a flag written into a revision slot
+    # would read as revision 1 and silently order itself against real captures.
+    return isinstance(value, int) and not isinstance(value, bool) and value >= minimum
+
+
+def _validate_event(event: SourceCorrection) -> None:
+    if not isinstance(event.root_id, str) or not event.root_id.strip():
+        raise ValueError("source correction root_id must be a non-empty string")
+    if not _valid_revision(event.revision, minimum=1):
+        raise ValueError("source correction revision must be a positive integer")
+    if not isinstance(event.blocking, bool):
+        raise ValueError("source correction blocking must be a boolean")
+    if not _valid_revision(event.content_revision) or event.content_revision > event.revision:
+        raise ValueError(
+            "source correction content_revision must be a non-negative integer "
+            "no newer than revision"
+        )
+
+
+def _parse_blockers(metadata: Mapping[str, object] | None) -> dict[str, tuple[int, bool]]:
+    """Read the blocker bag, or refuse to guess what a malformed one meant.
+
+    A falsy value (absent, ``{}``, ``None``) is a real statement -- this row
+    inherits no exclusions -- and parses to nothing. Anything else that is not a
+    bag of ``{revision, blocking}`` entries is a bag whose exclusions we cannot
+    enumerate, so it raises rather than reading as "not excluded".
+    """
+
+    state = metadata.get(CORRECTION_BLOCKERS_KEY) if metadata else None
+    if not state:
+        return {}
+    if not isinstance(state, Mapping):
+        raise ValueError(f"{CORRECTION_BLOCKERS_KEY} must be a mapping of root id to blocker state")
+    parsed: dict[str, tuple[int, bool]] = {}
+    for root, entry in state.items():
+        if not isinstance(root, str) or not root.strip():
+            raise ValueError(f"{CORRECTION_BLOCKERS_KEY} root id must be a non-empty string")
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"{CORRECTION_BLOCKERS_KEY} entry must be a mapping")
+        revision = entry.get("revision")
+        blocking = entry.get("blocking")
+        if not _valid_revision(revision, minimum=1):
+            raise ValueError(f"{CORRECTION_BLOCKERS_KEY} revision must be a positive integer")
+        if not isinstance(blocking, bool):
+            raise ValueError(f"{CORRECTION_BLOCKERS_KEY} blocking must be a boolean")
+        parsed[root] = (revision, blocking)
+    return parsed
+
+
+def _parse_bindings(metadata: Mapping[str, object] | None) -> dict[str, int]:
+    """Read the content epochs a row is bound to, refusing malformed ones.
+
+    A binding is provenance: it asserts which revision of a source this row
+    actually read. Dropping an unreadable one would not lose an exclusion, it
+    would invent a fresher binding than the row can support, so it raises.
+    """
+
+    state = metadata.get(SOURCE_BINDINGS_KEY) if metadata else None
+    if not state:
+        return {}
+    if not isinstance(state, Mapping):
+        raise ValueError(f"{SOURCE_BINDINGS_KEY} must be a mapping of source id to revision")
+    parsed: dict[str, int] = {}
+    for source_id, revision in state.items():
+        if not isinstance(source_id, str) or not source_id.strip():
+            raise ValueError(f"{SOURCE_BINDINGS_KEY} source id must be a non-empty string")
+        if not _valid_revision(revision):
+            raise ValueError(f"{SOURCE_BINDINGS_KEY} revision must be a non-negative integer")
+        parsed[source_id] = revision
+    return parsed
+
+
+def declared_source_ids(metadata: Mapping[str, object] | None) -> tuple[str, ...]:
+    value = metadata.get(RAW_SOURCE_IDS_KEY) if metadata else None
+    if value is None:
+        return ()
+    # A bare string is one declared id; iterating it would declare one id per
+    # character. A Mapping is iterable too and its keys are not a support list.
+    if isinstance(value, str):
+        candidates: Sequence[object] = (value,)
+    elif isinstance(value, list | tuple | set | frozenset):
+        candidates = tuple(value)
+    else:
+        raise ValueError(f"{RAW_SOURCE_IDS_KEY} must be a list of source id strings")
+    declared: list[str] = []
+    for item in candidates:
+        if not isinstance(item, str):
+            raise ValueError(f"{RAW_SOURCE_IDS_KEY} entries must be strings")
+        # A blank id names nothing and no correction can ever key on it, so
+        # skipping it drops no provenance.
+        if item.strip():
+            declared.append(item)
+    return tuple(declared)
+
+
+def _revised_content_revision(
+    metadata: Mapping[str, object] | None,
+    revision: int,
+    checkpoint: Mapping[str, object] | None = None,
+) -> int:
+    """The newest revision of this source that carries revised text.
+
+    Read from ``correction_history``, which is append-only: a ``restore`` adds
+    an entry and clears lifecycle keys but never removes the ``revise`` that
+    happened, so the content epoch is retained across a later restore for free.
+
+    A history entry records ``prior_revision``, the revision *before* the
+    correction was saved, so the revised text first exists at ``prior_revision +
+    1``. Legacy entries use the storage-owned checkpoint recording when their
+    body was observed. An unnormalized source conservatively contributes its
+    current revision until storage establishes that checkpoint. An entry claiming a
+    revision the capture has not reached is impossible and raises, because
+    honouring it would block every binding forever and ignoring it would bless a
+    history we cannot explain.
+    """
+
+    history = (metadata.get(CORRECTION_HISTORY_KEY) if metadata else None) or []
+    if not isinstance(history, list | tuple):
+        raise ValueError(f"{CORRECTION_HISTORY_KEY} must be a list of correction entries")
+    legacy = [
+        entry
+        for entry in history
+        if isinstance(entry, Mapping)
+        and str(entry.get("action") or "").strip().lower() == "revise"
+        and entry.get("prior_revision") is None
+    ]
+    legacy_revision = revision
+    if checkpoint is not None:
+        epoch = checkpoint.get("observed_revision")
+        if (
+            checkpoint.get("entries") != legacy
+            or not isinstance(epoch, int)
+            or isinstance(epoch, bool)
+            or epoch < 0
+        ):
+            raise ValueError("legacy content checkpoint does not cover correction history")
+        if epoch > revision or (legacy and epoch < 1):
+            raise ValueError("legacy content checkpoint has an invalid observed revision")
+        legacy_revision = epoch
+    content_revision = UNKNOWN_SOURCE_REVISION
+    for entry in history:
+        if not isinstance(entry, Mapping):
+            continue
+        if str(entry.get("action") or "").strip().lower() != "revise":
+            continue
+        prior = entry.get("prior_revision")
+        if prior is None:
+            candidate = legacy_revision
+        elif _valid_revision(prior):
+            candidate = prior + 1
+        else:
+            raise ValueError(
+                f"{CORRECTION_HISTORY_KEY} prior_revision must be a non-negative integer"
+            )
+        if candidate > revision:
+            raise ValueError(
+                f"{CORRECTION_HISTORY_KEY} declares a revision newer than the persisted capture"
+            )
+        content_revision = max(content_revision, candidate)
+    return content_revision
+
+
+def correction_blocked(metadata: Mapping[str, object] | None) -> bool:
+    """Whether inherited correction state excludes this derived row from recall.
+
+    True when any root's entry is still blocking. Entries that are all ``False``
+    are tombstones, kept on purpose so a delayed earlier event cannot re-block a
+    cleared root, and they do not exclude anything.
+
+    A malformed non-empty blocker bag fails closed. A row whose exclusions cannot
+    be read is a row that may be excluded, and serving it would leak content a
+    user asked to have retired; the caller's own read of the bag will raise and
+    say so. Absent and empty state are not malformed and do not block.
+
+    Only the blocker bag is read. A binding is provenance rather than a verdict,
+    so a malformed one is refused where it can do harm -- at propagation, by
+    :func:`merge_source_correction` and :func:`source_revision_bindings` -- and
+    is not turned into an exclusion nothing actually asked for.
+    """
+
+    if metadata and metadata.get(SOURCE_VALIDATION_PENDING_KEY):
+        return True
+    try:
+        blockers = _parse_blockers(metadata)
+    except ValueError:
+        return True
+    return any(blocking for _revision, blocking in blockers.values())
+
+
+def correction_event(memory: SourceMemoryView, *, blocking: bool) -> SourceCorrection:
+    """Build the propagable event for a correction already saved to ``memory``.
+
+    The revision comes from the persisted capture rather than from the caller,
+    because that is the value the storage layer bumped and therefore the only one
+    that orders two propagations of the same root. Every non-correction metadata
+    write bumps it too, which costs nothing here: a later revision only ever
+    restates the same verdict, and the extra bump cannot resurrect a blocker that
+    a restore already cleared at a higher revision.
+
+    ``blocking`` is the caller's verdict on the source itself (it left recall),
+    not on the derived rows; the derived-row verdict is decided per row by
+    :func:`merge_source_correction` against that row's bindings.
+    """
+
+    if not isinstance(blocking, bool):
+        raise ValueError("source correction blocking must be a boolean")
+    if not isinstance(memory.id, str) or not memory.id.strip():
+        raise ValueError("source correction root_id must be a non-empty string")
+    if not _valid_revision(memory.revision, minimum=1):
+        raise ValueError("source correction revision must be a positive integer")
+    event = SourceCorrection(
+        root_id=memory.id,
+        revision=memory.revision,
+        blocking=blocking,
+        content_revision=_revised_content_revision(
+            memory.metadata, memory.revision, getattr(memory, "legacy_content_checkpoint", None)
+        ),
+    )
+    # The history is read off the same row as the revision, so this can only
+    # fire on a bag that contradicts itself; it must not ship as an event.
+    _validate_event(event)
+    return event
+
+
+def merge_source_correction(
+    metadata: Mapping[str, object],
+    event: SourceCorrection,
+) -> dict[str, object]:
+    """Apply one root's correction to one derived row's metadata bag.
+
+    Returns a new bag. Unrelated keys -- the row's own lifecycle, its bindings,
+    every other root's blocker -- are carried through untouched, so propagating
+    root A cannot overwrite the row's own archived state or root B's exclusion.
+    Inputs are never mutated.
+
+    The row-level verdict is the event's ``blocking`` *or* a stale content epoch:
+    a ``revise`` blocks a row whose binding for this root is older than the
+    revised revision, or missing entirely. So a ``revise`` at revision 2 followed
+    by a ``restore`` at revision 3 still blocks a row bound to revision 1, while
+    a row bound to revision 2 stays clear through both.
+
+    Ordering is resolved against the stored revision, not against arrival: a
+    lower revision leaves the entry alone, an equal revision may only strengthen
+    ``blocking``, and a cleared entry is written as ``False`` rather than deleted
+    so a late-arriving earlier event has something to lose to.
+
+    Raises ``ValueError`` on a malformed event or malformed stored state, and
+    writes nothing in that case; the caller reports the propagation as incomplete
+    instead of overwriting exclusions it could not read.
+    """
+
+    _validate_event(event)
+    stored_blockers = _parse_blockers(metadata)
+    bound = _parse_bindings(metadata).get(event.root_id)
+    stale_content = event.content_revision > UNKNOWN_SOURCE_REVISION and (
+        bound is None or bound < event.content_revision
+    )
+    effective = event.blocking or stale_content
+
+    # Rewritten in canonical form: exactly one revision/blocking pair per root,
+    # so the bag stays auditable and no reader has to guess at extra fields.
+    entries: dict[str, object] = {
+        root: {"revision": revision, "blocking": blocking}
+        for root, (revision, blocking) in stored_blockers.items()
+    }
+    prior = stored_blockers.get(event.root_id)
+    if prior is None or prior[0] < event.revision:
+        entries[event.root_id] = {"revision": event.revision, "blocking": effective}
+    elif prior[0] == event.revision:
+        entries[event.root_id] = {"revision": event.revision, "blocking": prior[1] or effective}
+    # prior[0] > event.revision: the row already carries a later statement about
+    # this root, and this event is the delayed one. Keep the later verdict.
+
+    merged = dict(metadata)
+    merged[CORRECTION_BLOCKERS_KEY] = entries
+    stored_bindings = metadata.get(SOURCE_BINDINGS_KEY)
+    if isinstance(stored_bindings, Mapping):
+        # Copied, never recomputed: rebinding a row here would bless it against
+        # content it never read. Bindings are set once, where the row is built.
+        merged[SOURCE_BINDINGS_KEY] = dict(stored_bindings)
+    return merged
+
+
+def source_revision_bindings(memories: Sequence[SourceMemoryView]) -> dict[str, int]:
+    """The content epochs a row built from ``memories`` may claim to have read.
+
+    Each observed capture binds its own id to its own revision, and each observed
+    row's existing ``source_bindings`` are inherited so a promotion two hops from
+    the capture still names the root it descends from. Overlapping paths take the
+    **minimum**: the row's claim can only be as fresh as the oldest text on any
+    path that fed it.
+
+    A support declared in ``raw_source_ids`` with no inherited binding
+    contributes ``UNKNOWN_SOURCE_REVISION``, which the minimum then keeps even
+    when the same source was read directly and newer in this batch. That is the
+    point: an old unbound review must not be rebound to source content that was
+    corrected after the review was written. Canonical unretained anchors need no
+    special case for the same reason -- an anchor never receives a real capture
+    correction, so an unknown epoch for it stays honest and inert.
+
+    Source ids are the original canonical strings. No grouping id is resolved and
+    no row is fetched: the caller supplies exactly the snapshots it is authorized
+    to read, and this helper does not claim otherwise.
+
+    Raises ``ValueError`` on a malformed binding, support list, id or revision,
+    rather than emitting provenance no observed row supports.
+    """
+
+    bindings: dict[str, int] = {}
+
+    def bind(source_id: str, revision: int) -> None:
+        current = bindings.get(source_id)
+        bindings[source_id] = revision if current is None else min(current, revision)
+
+    for memory in memories:
+        if not isinstance(memory.id, str) or not memory.id.strip():
+            raise ValueError("observed source id must be a non-empty string")
+        if not _valid_revision(memory.revision):
+            raise ValueError("observed source revision must be a non-negative integer")
+        inherited = _parse_bindings(memory.metadata)
+        bind(memory.id, memory.revision)
+        for inherited_id, inherited_revision in inherited.items():
+            bind(inherited_id, inherited_revision)
+        for declared in declared_source_ids(memory.metadata):
+            if declared not in inherited:
+                bind(declared, UNKNOWN_SOURCE_REVISION)
+    return bindings

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_client.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_client.py
@@ -176,6 +176,10 @@ async def replace_record(
     organization_id = record.get("organization_id")
     if organization_id is None:
         raise RuntimeError(f"{table} record {uuid} requires organization_id")
+    if table == "raw_captures":
+        from sibyl_core.services.content_raw_persistence import replace_raw_memory_records_bulk
+
+        return (await replace_raw_memory_records_bulk(client, [record]))[0]
     rows = await select_many(
         client,
         _UPSERT_RECORD[table],

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_models.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_models.py
@@ -138,6 +138,7 @@ class RawMemory:
     score: float = 0.0
     snippet: str | None = None
 
+    legacy_content_checkpoint: dict[str, object] | None = field(default=None, repr=False)
     observed_revision: int | None = field(default=None, repr=False, compare=False)
 
 
@@ -626,6 +627,7 @@ def raw_memory_from_record(record: Mapping[str, object]) -> RawMemory:
         capture_surface=coerce_optional_str(record.get("capture_surface")),
         created_by_user_id=coerce_optional_str(record.get("created_by_user_id")),
         revision=max(coerce_int(record.get("revision")), 1),
+        legacy_content_checkpoint=coerce_dict(record.get("legacy_content_checkpoint")) or None,
         observed_revision=observed_revision
         if type(observed_revision) is int and observed_revision > 0
         else None,
@@ -692,6 +694,7 @@ def raw_memory_record(memory: RawMemory) -> SurrealRecord:
         "capture_surface": memory.capture_surface,
         "created_by_user_id": memory.created_by_user_id or memory.principal_id,
         "revision": memory.revision,
+        "legacy_content_checkpoint": memory.legacy_content_checkpoint,
         "captured_at": memory.captured_at,
         "deleted_at": memory.deleted_at,
         "purge_after": memory.purge_after,

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
@@ -31,7 +31,15 @@ from sibyl_core.services.content_models import RawMemory, RawMemoryWrite
 _RAW_MEMORY_EMBEDDING_AUTO = object()
 
 _RAW_MEMORY_BULK_UPSERT_QUERY = """
-INSERT INTO raw_captures $rows ON DUPLICATE KEY UPDATE
+BEGIN TRANSACTION;
+LET $ids = $rows.map(|$row| $row.uuid);
+LET $organizations = object::from_entries($rows.map(|$row| [$row.uuid, $row.organization_id]));
+LET $foreign = (SELECT VALUE uuid FROM raw_captures WHERE uuid IN $ids
+    AND organization_id != $organizations[uuid]);
+IF array::len($foreign) > 0 {
+    THROW 'raw capture organization cannot change';
+};
+LET $saved = (INSERT INTO raw_captures $rows ON DUPLICATE KEY UPDATE
     uuid = $input.uuid,
     organization_id = $input.organization_id,
     source_id = $input.source_id,
@@ -65,7 +73,9 @@ INSERT INTO raw_captures $rows ON DUPLICATE KEY UPDATE
     retrieval_count = $input.retrieval_count ?? retrieval_count ?? 0,
     citation_count = $input.citation_count ?? citation_count ?? 0,
     misled_count = $input.misled_count ?? misled_count ?? 0,
-    created_at = $input.created_at;
+    created_at = $input.created_at RETURN AFTER);
+COMMIT TRANSACTION;
+RETURN $saved;
 """
 
 _RAW_PROMOTION_VISIBLE_SCOPES = (
@@ -80,14 +90,19 @@ async def replace_raw_memory_records_bulk(
 ) -> list[models.SurrealRecord]:
     if not records:
         return []
+    identities = [record.get("uuid") for record in records]
+    if any(not isinstance(value, str) or not value for value in identities):
+        raise ValueError("raw capture batch requires non-empty UUID strings")
+    if len(set(identities)) != len(identities):
+        raise ValueError("raw capture batch requires distinct UUIDs")
     for record in records:
         if record.get("organization_id") is None:
             uuid = record.get("uuid") or "<unknown>"
             raise RuntimeError(f"raw_captures record {uuid} requires organization_id")
-    rows = await content_client.select_many(
+    rows = await content_client.select_many_raw(
         client,
         _RAW_MEMORY_BULK_UPSERT_QUERY,
-        rows=list(records),
+        rows=[{**record, "revision": 1} for record in records],
     )
     if len(rows) != len(records):
         raise RuntimeError(
@@ -680,14 +695,17 @@ async def save_raw_memory(
                 client,
                 """
                     BEGIN TRANSACTION;
-                    LET $updated = (
-                        UPDATE raw_captures MERGE $record
+                    LET $current = (SELECT revision FROM raw_captures
+                        WHERE organization_id = $organization_id AND uuid = $uuid LIMIT 1)[0];
+                    LET $next = object::from_entries(array::concat(
+                        object::entries($record), [['revision', $current.revision + 1]]));
+                    LET $saved = (
+                        UPDATE raw_captures MERGE $next
                         WHERE organization_id = $organization_id
                             AND uuid = $uuid
                             AND ($expected_revision = NONE OR revision = $expected_revision)
                         RETURN AFTER
                     );
-                    LET $saved = (UPDATE $updated SET revision += 1 RETURN AFTER);
                     IF $supersession != NONE AND array::len($saved) > 0 {
                         LET $replacement = (
                             SELECT id, source_id FROM raw_captures

--- a/packages/python/sibyl-core/tests/test_legacy_content_checkpoint.py
+++ b/packages/python/sibyl-core/tests/test_legacy_content_checkpoint.py
@@ -1,0 +1,289 @@
+"""Legacy content epochs are stable across every raw storage write shape."""
+
+from dataclasses import replace
+
+from sibyl_core.memory_pipeline.source_lifecycle import correction_event
+from sibyl_core.services import content_client
+from sibyl_core.services.content_models import raw_memory_record
+from sibyl_core.services.content_raw_persistence import (
+    get_raw_memory,
+    remember_raw_memory,
+    replace_raw_memory_records_bulk,
+    save_raw_memory,
+)
+from tests.test_reflection_identity import content_store as content_store
+
+
+async def test_legacy_checkpoint_single_bulk_and_import(content_store):
+    source = await remember_raw_memory(
+        organization_id="checkpoint",
+        principal_id="owner",
+        source_id="source",
+        raw_content="old",
+        embedding_provider=None,
+    )
+    revised = await save_raw_memory(
+        replace(source, metadata={"correction_history": [{"action": "revise"}]}),
+        expected_revision=source.revision,
+        embedding_provider=None,
+    )
+    assert revised.revision == source.revision + 1
+    assert correction_event(revised, blocking=False).content_revision == revised.revision
+    again = await save_raw_memory(
+        replace(revised, metadata={**revised.metadata, "bookkeeping": True}),
+        expected_revision=revised.revision,
+        embedding_provider=None,
+    )
+    assert correction_event(again, blocking=False).content_revision == revised.revision
+    async with content_client.surreal_content_client() as client:
+        rows = await replace_raw_memory_records_bulk(client, [raw_memory_record(again)])
+        assert rows[0]["revision"] == again.revision + 1
+        await content_client.select_many(
+            client,
+            "CREATE raw_captures CONTENT $record;",
+            record={
+                **raw_memory_record(again),
+                "uuid": "restored",
+                "legacy_content_checkpoint": None,
+            },
+        )
+    stored = await get_raw_memory(organization_id="checkpoint", memory_id=source.id)
+    assert correction_event(stored, blocking=False).content_revision == revised.revision
+    restored = await get_raw_memory(organization_id="checkpoint", memory_id="restored")
+    assert correction_event(restored, blocking=False).content_revision == again.revision
+
+
+async def test_legacy_checkpoint_advances_only_with_appended_history(content_store):
+    source = await remember_raw_memory(
+        organization_id="checkpoint",
+        principal_id="owner",
+        source_id="epochs",
+        raw_content="before",
+        embedding_provider=None,
+    )
+    original = source
+    for text in ("first legacy revision", "second legacy revision"):
+        old_revision = source.revision
+        source = await save_raw_memory(
+            replace(
+                source,
+                raw_content=text,
+                metadata={
+                    **source.metadata,
+                    "correction_history": [
+                        *source.metadata.get("correction_history", []),
+                        {"action": "revise", "reason": text},
+                    ],
+                },
+            ),
+            expected_revision=old_revision,
+            embedding_provider=None,
+        )
+        assert source.revision == old_revision + 1
+        assert correction_event(source, blocking=False).content_revision == source.revision
+        epoch = source.revision
+        source = await save_raw_memory(
+            replace(source, metadata={**source.metadata, "bookkeeping": text}),
+            expected_revision=source.revision,
+            embedding_provider=None,
+        )
+        assert correction_event(source, blocking=False).content_revision == epoch
+    legacy_history = source.metadata["correction_history"]
+    legacy_checkpoint = source.legacy_content_checkpoint
+    prior = source.revision
+    modern = await save_raw_memory(
+        replace(
+            source,
+            raw_content="modern revision",
+            metadata={
+                **source.metadata,
+                "correction_history": [
+                    *legacy_history,
+                    {"action": "revise", "prior_revision": prior},
+                ],
+            },
+        ),
+        expected_revision=prior,
+        embedding_provider=None,
+    )
+    assert modern.legacy_content_checkpoint == legacy_checkpoint
+    assert correction_event(modern, blocking=False).content_revision == prior + 1
+    assert modern.metadata["correction_history"][:2] == legacy_history
+    assert original.metadata == {}
+
+
+async def test_legacy_checkpoint_cas_preserves_winner(content_store):
+    import asyncio
+
+    from sibyl_core.errors import RevisionConflictError
+
+    source = await remember_raw_memory(
+        organization_id="checkpoint",
+        principal_id="owner",
+        source_id="race",
+        raw_content="before",
+        embedding_provider=None,
+    )
+    writes = [
+        save_raw_memory(
+            replace(
+                source,
+                raw_content=text,
+                metadata={
+                    "correction_history": [
+                        {"action": "revise", "reason": text},
+                    ]
+                },
+            ),
+            expected_revision=source.revision,
+            embedding_provider=None,
+        )
+        for text in ("winner a", "winner b")
+    ]
+    results = await asyncio.gather(*writes, return_exceptions=True)
+    assert sum(isinstance(result, RevisionConflictError) for result in results) == 1
+    stored = await get_raw_memory(organization_id="checkpoint", memory_id=source.id)
+    assert stored.revision == source.revision + 1
+    assert correction_event(stored, blocking=False).content_revision == stored.revision
+    assert stored.metadata["correction_history"][0]["reason"] == stored.raw_content
+
+
+async def test_legacy_checkpoint_upgrade_preserves_observed_binding(content_store):
+    from sibyl_core.backends.surreal.content_schema import (
+        CONTENT_LEGACY_CONTENT_CHECKPOINT_BACKFILL,
+        CONTENT_LEGACY_CONTENT_CHECKPOINT_DEFINITIONS,
+    )
+    from sibyl_core.services.content_models import raw_memory_from_record
+
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query("REMOVE FIELD legacy_content_checkpoint ON raw_captures;")
+        await client.execute_query(
+            "CREATE raw_captures CONTENT $record;",
+            record={
+                "uuid": "upgrade",
+                "organization_id": "checkpoint",
+                "revision": 7,
+                "metadata": {"correction_history": [{"action": "revise"}]},
+            },
+        )
+        await client.execute_query(
+            "CREATE raw_captures CONTENT {uuid: 'ordinary', organization_id: 'checkpoint', revision: 5};"
+        )
+        await client.execute_query(CONTENT_LEGACY_CONTENT_CHECKPOINT_DEFINITIONS)
+        await client.execute_query(CONTENT_LEGACY_CONTENT_CHECKPOINT_BACKFILL)
+        first = (
+            await content_client.select_many(
+                client, "SELECT * FROM raw_captures WHERE uuid = 'upgrade';"
+            )
+        )[0]
+        await client.execute_query(CONTENT_LEGACY_CONTENT_CHECKPOINT_BACKFILL)
+        second = (
+            await content_client.select_many(
+                client, "SELECT * FROM raw_captures WHERE uuid = 'upgrade';"
+            )
+        )[0]
+        ordinary = (
+            await content_client.select_many(
+                client, "SELECT revision FROM raw_captures WHERE uuid = 'ordinary';"
+            )
+        )[0]
+    assert first == second
+    assert ordinary["revision"] == 5
+    memory = raw_memory_from_record(first)
+    assert memory.revision == 8
+    assert correction_event(memory, blocking=False).content_revision == 7
+    assert memory.metadata["correction_history"] == [{"action": "revise"}]
+
+
+async def test_legacy_checkpoint_batch_advances_existing_and_initializes_new(content_store):
+    from sibyl_core.services.content_models import raw_memory_from_record
+
+    source = await remember_raw_memory(
+        organization_id="checkpoint",
+        principal_id="owner",
+        source_id="batch",
+        raw_content="before",
+        embedding_provider=None,
+    )
+    source = await save_raw_memory(
+        replace(source, metadata={"correction_history": [{"action": "revise", "reason": "first"}]}),
+        expected_revision=source.revision,
+        embedding_provider=None,
+    )
+    record = raw_memory_record(
+        replace(
+            source,
+            raw_content="new legacy body",
+            metadata={
+                **source.metadata,
+                "correction_history": [
+                    *source.metadata["correction_history"],
+                    {"action": "revise", "reason": "second"},
+                ],
+            },
+        )
+    )
+    async with content_client.surreal_content_client() as client:
+        rows = await replace_raw_memory_records_bulk(
+            client,
+            [
+                record,
+                {**record, "uuid": "new-batch-row", "revision": 99},
+            ],
+        )
+    stored = {row["uuid"]: raw_memory_from_record(row) for row in rows}
+    assert stored[source.id].revision == source.revision + 1
+    assert (
+        correction_event(stored[source.id], blocking=False).content_revision == source.revision + 1
+    )
+    assert stored["new-batch-row"].revision == 1
+    assert correction_event(stored["new-batch-row"], blocking=False).content_revision == 1
+
+
+async def test_legacy_checkpoint_stale_history_and_tenant_collision_are_atomic(content_store):
+    import pytest
+
+    source = await remember_raw_memory(
+        organization_id="checkpoint",
+        principal_id="owner",
+        source_id="protected",
+        raw_content="current",
+        embedding_provider=None,
+    )
+    record = raw_memory_record(source)
+    record["metadata"] = {"correction_history": [{"action": "revise", "reason": "first"}]}
+    async with content_client.surreal_content_client() as client:
+        first = (await replace_raw_memory_records_bulk(client, [record]))[0]
+        record["metadata"] = {
+            "correction_history": [
+                *first["metadata"]["correction_history"],
+                {"action": "revise", "reason": "second"},
+            ]
+        }
+        second = (await replace_raw_memory_records_bulk(client, [record]))[0]
+        with pytest.raises(RuntimeError, match=r"legacy correction history|failed transaction"):
+            await replace_raw_memory_records_bulk(
+                client,
+                [
+                    {**record, "uuid": "would-be-created"},
+                    first,
+                ],
+            )
+        with pytest.raises(RuntimeError, match=r"organization cannot change|failed transaction"):
+            await replace_raw_memory_records_bulk(
+                client,
+                [
+                    {**record, "uuid": "would-be-created"},
+                    {**record, "organization_id": "different-tenant"},
+                ],
+            )
+        stored = (
+            await content_client.select_many(
+                client, "SELECT * FROM raw_captures WHERE uuid = $uuid;", uuid=source.id
+            )
+        )[0]
+        absent = await content_client.select_many(
+            client, "SELECT * FROM raw_captures WHERE uuid = 'would-be-created';"
+        )
+    assert stored == second
+    assert absent == []

--- a/packages/python/sibyl-core/tests/test_legacy_content_checkpoint.py
+++ b/packages/python/sibyl-core/tests/test_legacy_content_checkpoint.py
@@ -287,3 +287,61 @@ async def test_legacy_checkpoint_stale_history_and_tenant_collision_are_atomic(c
         )
     assert stored == second
     assert absent == []
+
+
+async def test_legacy_checkpoint_nonstring_actions_survive_upgrade_and_writes(content_store):
+    from sibyl_core.backends.surreal.content_schema import (
+        CONTENT_LEGACY_CONTENT_CHECKPOINT_BACKFILL,
+        CONTENT_LEGACY_CONTENT_CHECKPOINT_DEFINITIONS,
+    )
+
+    history = [{"action": value} for value in (5, False, {}, [], None)] + [{"action": " ReViSe "}]
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query("REMOVE FIELD legacy_content_checkpoint ON raw_captures;")
+        await client.execute_query(
+            "CREATE raw_captures CONTENT $record;",
+            record={
+                "uuid": "mixed-history",
+                "organization_id": "checkpoint",
+                "revision": 7,
+                "metadata": {"correction_history": history},
+            },
+        )
+        before = (
+            await content_client.select_many(
+                client, "SELECT metadata FROM raw_captures WHERE uuid = 'mixed-history';"
+            )
+        )[0]
+        await client.execute_query(CONTENT_LEGACY_CONTENT_CHECKPOINT_DEFINITIONS)
+        await client.execute_query(CONTENT_LEGACY_CONTENT_CHECKPOINT_BACKFILL)
+        stored = (
+            await content_client.select_many(
+                client, "SELECT * FROM raw_captures WHERE uuid = 'mixed-history';"
+            )
+        )[0]
+        assert stored["legacy_content_checkpoint"] == {
+            "entries": [history[-1]],
+            "observed_revision": 7,
+        }
+        assert stored["metadata"]["correction_history"] == before["metadata"]["correction_history"]
+        await client.execute_query(
+            "CREATE raw_captures CONTENT $record;",
+            record={
+                "uuid": "mixed-import",
+                "organization_id": "checkpoint",
+                "revision": 9,
+                "metadata": {"correction_history": history},
+            },
+        )
+        imported = (
+            await content_client.select_many(
+                client, "SELECT * FROM raw_captures WHERE uuid = 'mixed-import';"
+            )
+        )[0]
+        assert imported["legacy_content_checkpoint"] == {
+            "entries": [history[-1]],
+            "observed_revision": 9,
+        }
+        assert (
+            imported["metadata"]["correction_history"] == before["metadata"]["correction_history"]
+        )

--- a/packages/python/sibyl-core/tests/test_migration_query_compatibility.py
+++ b/packages/python/sibyl-core/tests/test_migration_query_compatibility.py
@@ -1,0 +1,37 @@
+"""Content migration predicates match the target backend."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.backends.surreal import content_schema
+
+
+@pytest.mark.parametrize("url", ["memory://", "ws://127.0.0.1:33333/rpc"])
+async def test_content_bootstrap_renders_checkpoint_migration(url, monkeypatch):
+    client = SimpleNamespace(_url=url, execute_query=AsyncMock())
+    apply = AsyncMock()
+    monkeypatch.setattr(content_schema, "_assert_content_migrations_safe", AsyncMock())
+    monkeypatch.setattr(content_schema, "apply_schema_migrations", apply)
+
+    await content_schema.bootstrap_content_schema(client)
+
+    migrations = apply.await_args.args[1]
+    assert migrations[0].version == 1
+    checkpoint = next(migration for migration in migrations if migration.version == 27)
+    definition, backfill = checkpoint.statements
+    assert definition.startswith("-- A checkpoint")
+    assert "DEFINE FIELD OVERWRITE legacy_content_checkpoint" in definition
+    assert "LET $checkpoint_rows = (SELECT id, revision, metadata" in backfill
+    assert "FOR $row IN $checkpoint_rows {" in backfill
+    assert "LET $capture_id = $row.id;" in backfill
+    assert "UPDATE $capture_id MERGE" in backfill
+    if url == "memory://":
+        assert definition == content_schema.CONTENT_LEGACY_CONTENT_CHECKPOINT_DEFINITIONS
+        assert backfill == content_schema.CONTENT_LEGACY_CONTENT_CHECKPOINT_BACKFILL
+    else:
+        for predicate in ("array", "object", "int"):
+            assert f"type::is_{predicate}(" in definition
+        assert "type::is_object(" in backfill
+        assert "type::is::" not in definition + backfill

--- a/packages/python/sibyl-core/tests/test_services_surreal_content.py
+++ b/packages/python/sibyl-core/tests/test_services_surreal_content.py
@@ -1596,7 +1596,7 @@ class TestSurrealContentHelpers:
         assert memory.principal_id == "user-bliss"
         assert memory.memory_scope is MemoryScope.PRIVATE
         assert memory.provenance == {"message_id": "msg-1"}
-        saved_record = fake_client.calls[0][1]["record"]
+        saved_record = fake_client.calls[0][1]["rows"][0]
         assert saved_record["source_id"] == "source-email-1"
         assert saved_record["principal_id"] == "user-bliss"
         assert saved_record["memory_scope"] == "private"
@@ -1799,7 +1799,7 @@ class TestSurrealContentHelpers:
                 embedding_provider=provider,
             )
 
-        saved_record = fake_client.calls[0][1]["record"]
+        saved_record = fake_client.calls[0][1]["rows"][0]
         assert provider.input_kinds == ["document"]
         assert provider.texts == [
             "Title: Architecture note\n\nSurreal stores raw memory before extraction."
@@ -1987,7 +1987,7 @@ class TestSurrealContentHelpers:
                 raw_content="Surreal stores raw memory before extraction.",
             )
 
-        saved_record = fake_client.calls[0][1]["record"]
+        saved_record = fake_client.calls[0][1]["rows"][0]
         assert provider.input_kinds == ["document"]
         assert saved_record["embedding"] == embedding
 
@@ -2053,7 +2053,8 @@ class TestSurrealContentHelpers:
         assert provider.input_kinds == ["document"]
         assert provider.texts == ["Title: First\n\nfirst body", "Title: Second\n\nsecond body"]
         query, params = fake_client.calls[0]
-        assert "INSERT INTO raw_captures $rows" in query
+        assert "BEGIN TRANSACTION" in query
+        assert "INSERT INTO raw_captures" in query
         assert len(params["rows"]) == 2
         assert [row["source_id"] for row in params["rows"]] == [
             "source-email-1",
@@ -2187,7 +2188,7 @@ class TestSurrealContentHelpers:
                 extraction_prompt_metadata={"extractor": "test"},
             )
 
-        saved_record = fake_client.calls[0][1]["record"]
+        saved_record = fake_client.calls[0][1]["rows"][0]
         assert memory.entity_type == "decision"
         assert memory.capture_surface == "reflection_candidate"
         assert memory.review_state == "pending"

--- a/packages/python/sibyl-core/tests/test_source_lineage_indexes.py
+++ b/packages/python/sibyl-core/tests/test_source_lineage_indexes.py
@@ -1,0 +1,39 @@
+"""Raw source lineage lookup uses its element index."""
+
+from uuid import uuid4
+
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+
+
+async def test_raw_lineage_element_index_returns_sources_without_table_scan():
+    organization_id = str(uuid4())
+    client = SurrealContentClient(url="memory://")
+    try:
+        await bootstrap_content_schema(client, reset=True)
+        await client.execute_query(
+            "INSERT INTO raw_captures $rows;",
+            rows=[
+                {
+                    "uuid": f"raw-{index:04}",
+                    "organization_id": organization_id,
+                    "title": "Raw source",
+                    "raw_content": "Evidence",
+                    "metadata": {"raw_source_ids": ["root" if index == 3 else "other"]},
+                }
+                for index in range(40)
+            ],
+        )
+        query = (
+            "SELECT uuid FROM raw_captures WITH INDEX idx_raw_captures_source_lineage "
+            "WHERE organization_id = $organization_id AND uuid > $cursor "
+            "AND metadata.raw_source_ids.* CONTAINSANY $source_ids "
+            "ORDER BY uuid LIMIT $limit"
+        )
+        params = dict(organization_id=organization_id, cursor="", source_ids=["root"], limit=512)
+        assert await client.execute_query(query + ";", **params) == [{"uuid": "raw-0003"}]
+        plan = await client.execute_query(query + " EXPLAIN;", **params)
+        assert any(step["operation"] == "Iterate Index" for step in plan)
+        assert all(step["operation"] != "Iterate Table" for step in plan)
+    finally:
+        await client.close()


### PR DESCRIPTION
Legacy correction entries do not record the revision at which their content changed. Using the current row revision as that clock makes bookkeeping look like a new correction. This change stores an observed legacy content checkpoint separately and preserves it when the same ordered history is saved again.

The checkpoint covers exact legacy history entries. Appending a correction advances its observed revision; replacing or removing covered history fails. Modern corrections retain their explicit revision semantics. The storage migration initializes existing legacy rows once, and archive imports can retain a valid checkpoint.

## 🛠️ Storage behavior

Single saves assign the next revision within the same update as the record. Bulk replacement retains one INSERT, checks tenant collisions transactionally, and normalizes newly created rows to revision one. API review changes merge only review fields into current metadata, preserving concurrently written correction history.

Migration 26 declares the complete raw capture shape before building the lineage index. Migration 27 installs the checkpoint field and backfills legacy rows. Its complete SQL blocks are rendered for the target backend, and query results are bound before iteration for SurrealDB 3.2.3 compatibility. Correction filters convert legacy action values before trimming so mixed metadata cannot abort the migration.

The included source-clock primitives support later lifecycle activation. This patch does not activate correction propagation or the reflection identity upgrade.

## 🧪 Validation

The extracted branch passed 80 core tests, 47 API tests, core/API lint and typecheck, and independent adversarial review. Coverage includes repeated migration, bulk replacement, concurrent saves, tenant rollback, archive imports, mixed-type correction actions, and review updates.

The exact extracted migration statements passed against an isolated SurrealDB 3.2.3 container: migration preserved the observed epoch, replay remained unchanged, bookkeeping retained the epoch, and a subsequent correction advanced it. The container was removed afterward. This qualifies representative migration rows, not a complete application upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added source-lineage tracking to improve raw content lookups and correction propagation.
  - Added support for preserving legacy content checkpoints during schema upgrades and content updates.

- **Bug Fixes**
  - Prevented stale review updates from overwriting newer content or metadata.
  - Improved concurrent write handling, revision tracking, and tenant-data isolation.
  - Added validation to reject invalid or duplicate raw capture identifiers.

- **Chores**
  - Updated database migrations and compatibility handling for supported SurrealDB environments.
  - Expanded automated coverage for legacy restoration, source lineage, migrations, and concurrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->