### PR TITLE
feat(memory): enforce durable source lifecycle through publication

### DIFF
--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -695,6 +695,11 @@ async def reflect_context(
             organization_id=str(org.id),
             principal_id=getattr(ctx, "user_id", None),
             accessible_projects=accessible_projects,
+            writable_projects=(
+                await list_accessible_project_graph_ids(ctx, required_role=ProjectRole.CONTRIBUTOR)
+                if request.persist
+                else set()
+            ),
             memory_scope="project" if request.project else "private",
             scope_key=request.project,
             persist=request.persist,

--- a/apps/api/src/sibyl/api/routes/entity_serialization.py
+++ b/apps/api/src/sibyl/api/routes/entity_serialization.py
@@ -19,6 +19,7 @@ from sibyl_core.auth.memory_policy import (
     stamp_memory_scope_metadata,
 )
 from sibyl_core.memory_pipeline.retrieval_keys import normalize_retrieval_keys
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
 from sibyl_core.memory_pipeline.structure import strip_structure_metadata
 from sibyl_core.models.entities import Entity, EntityType
 from sibyl_core.tools.helpers import _generate_id
@@ -87,7 +88,7 @@ def serialize_raw_capture_summary(capture: RawCaptureRecord) -> RawCaptureSummar
         title=capture.title,
         entity_type=capture.entity_type,
         tags=list(capture.tags or []),
-        metadata=dict(capture.metadata or {}),
+        metadata=public_memory_metadata(capture.metadata),
         capture_surface=capture.capture_surface,
         review_state=_raw_capture_review_state(capture),
         created_by_user_id=str(capture.created_by_user_id) if capture.created_by_user_id else None,

--- a/apps/api/src/sibyl/api/routes/memory_auth.py
+++ b/apps/api/src/sibyl/api/routes/memory_auth.py
@@ -531,8 +531,6 @@ async def accessible_projects_for_promotion(
             request=http_request,
         )
 
-    if project_ids:
-        return project_ids
     accessible_projects = await list_accessible_project_graph_ids(ctx)
     return {str(project_id) for project_id in accessible_projects or set()}
 
@@ -765,3 +763,9 @@ async def accessible_teams_for_share(
 ) -> set[str] | None:
     accessible_teams = await list_accessible_team_scope_keys(ctx)
     return {str(team_id) for team_id in accessible_teams or set()}
+
+
+async def writable_projects_for_memory(*, ctx: AuthContext) -> set[str]:
+    """Resolve contributor grants independently of readable memory evidence."""
+    projects = await list_accessible_project_graph_ids(ctx, required_role=ProjectRole.CONTRIBUTOR)
+    return {str(project_id) for project_id in projects or set()}

--- a/apps/api/src/sibyl/api/routes/memory_promotion.py
+++ b/apps/api/src/sibyl/api/routes/memory_promotion.py
@@ -79,6 +79,7 @@ async def preview_reflection_promotion(
         domain=request.domain,
         project=request.project,
         accessible_projects=accessible_projects,
+        writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
     )
     await memory_auth.log_memory_audit(
         action="memory.reflect.promote.preview",
@@ -139,6 +140,7 @@ async def preview_memory_promotion(
         domain=request.domain,
         project=request.project,
         accessible_projects=accessible_projects,
+        writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
     )
     if result.reason == "not_reflection_candidate":
         await memory_auth.authorize_raw_promotion_api_key_scopes(
@@ -158,6 +160,7 @@ async def preview_memory_promotion(
             domain=request.domain,
             project=request.project,
             accessible_projects=accessible_projects,
+            writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
         )
     await memory_auth.log_memory_audit(
         action="memory.promote.preview",
@@ -219,6 +222,7 @@ async def promote_reflection_candidate(
             project=request.project,
             related_to=request.related_to,
             accessible_projects=accessible_projects,
+            writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
         )
         await memory_auth.log_memory_audit(
             action="memory.reflect.promote",
@@ -295,6 +299,7 @@ async def promote_memory(
             project=request.project,
             related_to=request.related_to,
             accessible_projects=accessible_projects,
+            writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
         )
         if result.reason == "not_reflection_candidate":
             await memory_auth.authorize_raw_promotion_api_key_scopes(
@@ -315,6 +320,7 @@ async def promote_memory(
                 project=request.project,
                 related_to=request.related_to,
                 accessible_projects=accessible_projects,
+                writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
             )
         await memory_auth.log_memory_audit(
             action="memory.promote",

--- a/apps/api/src/sibyl/api/routes/memory_raw.py
+++ b/apps/api/src/sibyl/api/routes/memory_raw.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -147,6 +148,17 @@ async def remember_raw(
             agent_id=request.agent_id,
             project_id=request.project_id,
         )
+        source_context: dict[str, Any] = {}
+        if metadata.get("raw_source_ids"):
+            projects, teams = await asyncio.gather(
+                memory_auth.list_accessible_project_graph_ids(ctx),
+                memory_auth.list_accessible_team_scope_keys(ctx),
+            )
+            source_context = {
+                "accessible_projects": projects,
+                "accessible_teams": teams,
+                "allowed_memory_scope_keys": ctx.api_key_memory_scope_keys,
+            }
         memory = await remember_raw_memory(
             organization_id=str(org.id),
             principal_id=principal_id,
@@ -159,6 +171,7 @@ async def remember_raw(
             metadata=metadata,
             provenance=request.provenance,
             capture_surface=capture_surface,
+            **source_context,
         )
         await memory_auth.log_memory_audit(
             action="memory.remember",

--- a/apps/api/src/sibyl/api/routes/memory_review.py
+++ b/apps/api/src/sibyl/api/routes/memory_review.py
@@ -192,6 +192,7 @@ async def _auto_review_reflection_candidate(
         domain=request.domain,
         project=request.project,
         accessible_projects=accessible_projects,
+        writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
     )
     confidence_threshold = (
         request.confidence_threshold
@@ -215,6 +216,7 @@ async def _auto_review_reflection_candidate(
             project=request.project,
             related_to=request.related_to,
             accessible_projects=accessible_projects,
+            writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
         )
 
     audit_action = (

--- a/apps/api/src/sibyl/api/routes/memory_serialization.py
+++ b/apps/api/src/sibyl/api/routes/memory_serialization.py
@@ -39,6 +39,7 @@ from sibyl_core.auth import OrganizationRole
 from sibyl_core.auth.memory_policy import (
     MemoryPolicyDecision,
 )
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
 from sibyl_core.models.reflection import (
     claim_records_from_metadata,
     memory_lifecycle_from_metadata,
@@ -98,7 +99,7 @@ def raw_memory_response(
         title=memory.title,
         raw_content=memory.raw_content,
         tags=memory.tags,
-        metadata=memory.metadata,
+        metadata=public_memory_metadata(memory.metadata),
         provenance=memory.provenance,
         capture_surface=memory.capture_surface,
         captured_at=memory.captured_at,
@@ -159,7 +160,7 @@ def memory_space_response(
 
 
 def promotion_response(result: ReflectionPromotionResult) -> ReflectionPromotionResponse:
-    metadata = dict(result.metadata or {})
+    metadata = public_memory_metadata(result.metadata)
     return ReflectionPromotionResponse(
         success=result.success,
         candidate_id=result.candidate_id,
@@ -455,6 +456,10 @@ def correction_result_response(
     # `applied: true` with nothing else said would read as a complete one.
     recall_impact = dict(response.recall_impact)
     recall_impact["graph_entity_ids"] = list(result.affected_entity_ids)
+    recall_impact["derived_raw_memory_ids"] = list(result.affected_raw_memory_ids)
+    recall_impact["propagation_complete"] = result.propagation_complete
+    if not result.propagation_complete:
+        recall_impact["partially_applied"] = True
     if result.refused_entity_ids:
         recall_impact["refused_entity_ids"] = list(result.refused_entity_ids)
         recall_impact["partially_applied"] = True
@@ -758,7 +763,7 @@ def memory_source_inspect_response(
     audit_events: list[MemoryAuditEventResponse],
 ) -> MemorySourceInspectResponse:
     content_redacted = not policy_decision.allowed or _memory_lifecycle_redacts_content(memory)
-    metadata = dict(memory.metadata)
+    metadata = public_memory_metadata(memory.metadata)
     if content_redacted:
         metadata.pop("memory_lifecycle", None)
         metadata.pop("reflection_findings", None)

--- a/apps/api/src/sibyl/api/routes/memory_sharing.py
+++ b/apps/api/src/sibyl/api/routes/memory_sharing.py
@@ -86,6 +86,7 @@ async def preview_memory_share_route(
         target_scope_key=request.target_scope_key,
         recipient_organization_id=request.recipient_organization_id,
         accessible_projects=accessible_projects,
+        writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
         accessible_teams=accessible_teams,
     )
     await memory_auth.log_memory_audit(
@@ -158,6 +159,7 @@ async def share_memory_route(
         recipient_organization_id=request.recipient_organization_id,
         project=project_id,
         accessible_projects=accessible_projects,
+        writable_projects=await memory_auth.writable_projects_for_memory(ctx=ctx),
         accessible_teams=accessible_teams,
     )
     promoted_ids = [

--- a/apps/api/src/sibyl/api/routes/memory_sources.py
+++ b/apps/api/src/sibyl/api/routes/memory_sources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import structlog
@@ -25,7 +26,8 @@ from sibyl.api.schemas import (
 from sibyl.auth.context import AuthContext
 from sibyl.auth.dependencies import get_auth_context, get_current_organization, require_org_role
 from sibyl.jobs.source_imports import get_source_import_status
-from sibyl_core.auth import AuthOrganization, OrganizationRole
+from sibyl.services.memory_correction_disclosure import filter_correction_disclosure
+from sibyl_core.auth import AuthOrganization, OrganizationRole, ProjectRole
 from sibyl_core.auth.memory_policy import (
     MemoryPolicyAction,
 )
@@ -240,15 +242,15 @@ async def preview_memory_correction_route(
         surface="memory_correction_preview",
         request=http_request,
     )
-    accessible_projects = await memory_auth.project_accessible_for_policy(
+    await memory_auth.authorize_project_scope_write(
         ctx=ctx,
         memory_scope=memory.memory_scope.value,
         scope_key=memory.scope_key,
     )
-    accessible_teams = await memory_auth.team_accessible_for_policy(
-        ctx=ctx,
-        memory_scope=memory.memory_scope.value,
-        scope_key=memory.scope_key,
+    accessible_projects, accessible_teams, writable_projects = await asyncio.gather(
+        memory_auth.list_accessible_project_graph_ids(ctx),
+        memory_auth.list_accessible_team_scope_keys(ctx),
+        memory_auth.list_accessible_project_graph_ids(ctx, required_role=ProjectRole.CONTRIBUTOR),
     )
     preview = await preview_memory_correction(
         organization_id=str(org.id),
@@ -257,10 +259,12 @@ async def preview_memory_correction_route(
         action=request.action,
         reason=request.reason,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         accessible_teams=accessible_teams,
         replacement_source_id=request.replacement_source_id,
         duplicate_of_source_id=request.duplicate_of_source_id,
         revised_content=request.revised_content,
+        allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
     )
     response = serialization.correction_response(preview)
     await memory_auth.log_memory_audit(
@@ -317,15 +321,15 @@ async def apply_memory_correction_route(
         surface="memory_correction",
         request=http_request,
     )
-    accessible_projects = await memory_auth.project_accessible_for_policy(
+    await memory_auth.authorize_project_scope_write(
         ctx=ctx,
         memory_scope=memory.memory_scope.value,
         scope_key=memory.scope_key,
     )
-    accessible_teams = await memory_auth.team_accessible_for_policy(
-        ctx=ctx,
-        memory_scope=memory.memory_scope.value,
-        scope_key=memory.scope_key,
+    accessible_projects, accessible_teams, writable_projects = await asyncio.gather(
+        memory_auth.list_accessible_project_graph_ids(ctx),
+        memory_auth.list_accessible_team_scope_keys(ctx),
+        memory_auth.list_accessible_project_graph_ids(ctx, required_role=ProjectRole.CONTRIBUTOR),
     )
     idempotency_path = f"/memory/inspect/{source_id}/corrections"
     idempotency_payload = {"body": request.model_dump(mode="json")}
@@ -340,7 +344,16 @@ async def apply_memory_correction_route(
         content_session=None,
     )
     if replayed is not None:
-        return replayed
+        return MemoryCorrectionResponse.model_validate(
+            await filter_correction_disclosure(
+                replayed.model_dump(mode="python"),
+                organization_id=str(org.id),
+                principal_id=principal_id,
+                accessible_projects=accessible_projects,
+                accessible_teams=accessible_teams,
+                allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
+            )
+        )
     correction_kwargs: dict[str, Any] = {
         "organization_id": str(org.id),
         "source_id": memory.id,
@@ -348,10 +361,12 @@ async def apply_memory_correction_route(
         "action": request.action,
         "reason": request.reason,
         "accessible_projects": accessible_projects,
+        "writable_projects": writable_projects,
         "accessible_teams": accessible_teams,
         "replacement_source_id": request.replacement_source_id,
         "duplicate_of_source_id": request.duplicate_of_source_id,
         "revised_content": request.revised_content,
+        "allowed_memory_scope_keys": ctx.api_key_memory_scope_keys,
     }
     if request.expected_revision is not None:
         correction_kwargs["expected_revision"] = request.expected_revision

--- a/apps/api/src/sibyl/api/routes/search.py
+++ b/apps/api/src/sibyl/api/routes/search.py
@@ -42,6 +42,7 @@ from sibyl_core.embeddings.providers import (
     capture_embedding_usage,
     configured_embedding_provider,
 )
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
 from sibyl_core.observability import elapsed_ms, telemetry_registry
 
 log = structlog.get_logger()
@@ -338,9 +339,12 @@ async def explore(
         entities_list = []
         for entity in result.entities:
             if hasattr(entity, "__dataclass_fields__"):
-                entities_list.append(asdict(entity))
+                payload = asdict(entity)
             else:
-                entities_list.append(entity)
+                payload = dict(entity)
+            if isinstance(payload.get("metadata"), dict):
+                payload["metadata"] = public_memory_metadata(payload["metadata"])
+            entities_list.append(payload)
 
         response = ExploreResponse(
             mode=result.mode,

--- a/apps/api/src/sibyl/api/schemas/entities.py
+++ b/apps/api/src/sibyl/api/schemas/entities.py
@@ -10,6 +10,7 @@ from sibyl_core.memory_pipeline.retrieval_keys import (
     MAX_RETRIEVAL_KEY_LENGTH,
     MAX_RETRIEVAL_KEYS,
 )
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
 from sibyl_core.memory_pipeline.spans import MAX_AGENT_SPANS, MAX_SPAN_LABEL_CHARS
 from sibyl_core.memory_pipeline.structure import MAX_PROBE_CHARS, MAX_PROBES_PER_MEMORY
 from sibyl_core.models.entities import EntityType
@@ -182,6 +183,11 @@ class RelatedEntitySummary(BaseModel):
 
 class EntityResponse(EntityBase):
     """Full entity response with all fields."""
+
+    @field_validator("metadata")
+    @classmethod
+    def filter_source_clocks(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return public_memory_metadata(value)
 
     id: str = Field(..., description="Unique entity ID")
     entity_type: EntityType = Field(..., description="Type of entity")

--- a/apps/api/src/sibyl/api/schemas/search.py
+++ b/apps/api/src/sibyl/api/schemas/search.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
 
 
 class SearchRequest(BaseModel):
@@ -110,6 +112,11 @@ class SearchRequest(BaseModel):
 
 class SearchResult(BaseModel):
     """Single search result - unified across graph entities and documents."""
+
+    @field_validator("metadata")
+    @classmethod
+    def filter_source_clocks(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return public_memory_metadata(value)
 
     id: str = Field(..., description="Entity or chunk ID")
     type: str = Field(..., description="Entity type (pattern, rule, episode, etc.) or 'document'")

--- a/apps/api/src/sibyl/api/schemas/traverse.py
+++ b/apps/api/src/sibyl/api/schemas/traverse.py
@@ -13,8 +13,9 @@ the bound it actually applied.
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
 from sibyl_core.tools.traverse import (
     DEFAULT_EXPAND_LIMIT,
     DEFAULT_NEIGHBOR_CONTENT_MAX_CHARS,
@@ -78,6 +79,11 @@ class ExpandNeighborsRequest(BaseModel):
 
 class NeighborEntityResponse(BaseModel):
     """One entity reached by a bounded traversal step."""
+
+    @field_validator("metadata")
+    @classmethod
+    def filter_source_clocks(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return public_memory_metadata(value)
 
     id: str
     type: str

--- a/apps/api/src/sibyl/jobs/lifecycle_repair.py
+++ b/apps/api/src/sibyl/jobs/lifecycle_repair.py
@@ -1,0 +1,90 @@
+"""Scheduled recovery of captures and graph rows awaiting source checks."""
+
+import asyncio
+from dataclasses import asdict
+from typing import Any
+
+import structlog
+
+from sibyl.persistence.auth_common import InvalidAuthClaimsError, UserNotFoundError
+from sibyl.persistence.auth_runtime import (
+    list_accessible_delegated_scope_keys,
+    list_accessible_project_graph_ids,
+    list_accessible_team_scope_keys,
+    resolve_auth_context,
+)
+from sibyl.persistence.organization_runtime import list_org_ids
+from sibyl_core.projection.repair import repair_graph_lifecycle
+from sibyl_core.services.graph_runtime import background_graph_runtime
+from sibyl_core.services.memory_source_validation import (
+    SourceReadAuthority,
+    repair_raw_source_lifecycle,
+)
+
+log = structlog.get_logger()
+
+
+async def resolve_source_authority(
+    organization_id: str, principal_id: str
+) -> SourceReadAuthority | None:
+    """Continue an accepted capture using current membership and its saved ceiling."""
+    try:
+        context = await resolve_auth_context(claims={"sub": principal_id, "org": organization_id})
+    except (InvalidAuthClaimsError, UserNotFoundError):
+        return None
+    if (
+        context.user_id != principal_id
+        or context.organization_id != organization_id
+        or context.org_role is None
+    ):
+        return None
+    projects, teams, delegations = await asyncio.gather(
+        list_accessible_project_graph_ids(context),
+        list_accessible_team_scope_keys(context),
+        list_accessible_delegated_scope_keys(context),
+    )
+    return SourceReadAuthority(
+        principal_id=principal_id,
+        projects=frozenset(projects),
+        teams=frozenset(teams),
+        delegations=frozenset(delegations),
+    )
+
+
+async def _repair_graph(organization_id: str):
+    async with background_graph_runtime(organization_id) as runtime:
+        return await repair_graph_lifecycle(runtime)
+
+
+async def repair_lifecycle_all_orgs(ctx: dict[str, Any]) -> dict[str, int]:  # noqa: ARG001
+    summary = {
+        "organizations": 0,
+        "failed_organizations": 0,
+        "checked": 0,
+        "recovered": 0,
+        "pending": 0,
+        "failed": 0,
+    }
+    for organization_id in await list_org_ids():
+        summary["organizations"] += 1
+        results = await asyncio.gather(
+            _repair_graph(organization_id),
+            repair_raw_source_lifecycle(
+                organization_id, authority_resolver=resolve_source_authority
+            ),
+            return_exceptions=True,
+        )
+        if any(isinstance(result, BaseException) for result in results):
+            summary["failed_organizations"] += 1
+        for result in results:
+            if isinstance(result, BaseException):
+                log.warning(
+                    "lifecycle_repair_org_failed",
+                    group_id=organization_id,
+                    error_type=type(result).__name__,
+                )
+            else:
+                for key, value in asdict(result).items():
+                    summary[key] += value
+    log.info("lifecycle_repair_completed", **summary)
+    return summary

--- a/apps/api/src/sibyl/jobs/reflection.py
+++ b/apps/api/src/sibyl/jobs/reflection.py
@@ -14,6 +14,7 @@ from sibyl.persistence.auth_runtime import (
     log_memory_audit_event,
     resolve_accessible_project_graph_ids,
 )
+from sibyl_core.auth import ProjectRole
 from sibyl_core.models.reflection import ReflectionPack
 from sibyl_core.services.memory import (
     ReflectionPromotionResult,
@@ -239,6 +240,11 @@ async def _reflect_dream_source(
         organization_id=group_id,
         principal_id=source.principal_id,
         accessible_projects=accessible_projects,
+        writable_projects=await _resolve_accessible_projects(
+            group_id=group_id,
+            principal_id=source.principal_id,
+            required_role=ProjectRole.CONTRIBUTOR,
+        ),
         memory_scope=source.memory_scope,
         scope_key=source.scope_key,
         suggested_memory_scope=_metadata_str(source.metadata, "suggested_memory_scope"),
@@ -328,6 +334,11 @@ async def _drain_dream_candidate(
         domain=_metadata_str(candidate.metadata, "domain"),
         project=project,
         accessible_projects=accessible_projects,
+        writable_projects=await _resolve_accessible_projects(
+            group_id=group_id,
+            principal_id=candidate.principal_id,
+            required_role=ProjectRole.CONTRIBUTOR,
+        ),
     )
     policy = ReflectionAutonomyPolicy(
         confidence_threshold=confidence_threshold
@@ -351,6 +362,11 @@ async def _drain_dream_candidate(
             project=project,
             related_to=_metadata_str_list(candidate.metadata.get("related_to")),
             accessible_projects=accessible_projects,
+            writable_projects=await _resolve_accessible_projects(
+                group_id=group_id,
+                principal_id=candidate.principal_id,
+                required_role=ProjectRole.CONTRIBUTOR,
+            ),
         )
 
     archived = False
@@ -507,6 +523,7 @@ async def _resolve_accessible_projects(
     *,
     group_id: str,
     principal_id: str | None,
+    required_role: ProjectRole = ProjectRole.VIEWER,
 ) -> set[str]:
     if not principal_id:
         return set()
@@ -514,6 +531,7 @@ async def _resolve_accessible_projects(
         project_ids = await resolve_accessible_project_graph_ids(
             user_id=principal_id,
             org_id=group_id,
+            required_role=required_role,
         )
     except Exception as exc:
         log.warning(

--- a/apps/api/src/sibyl/jobs/worker.py
+++ b/apps/api/src/sibyl/jobs/worker.py
@@ -37,6 +37,7 @@ from sibyl.jobs.entities import (
     update_entity,
     update_task,
 )
+from sibyl.jobs.lifecycle_repair import repair_lifecycle_all_orgs
 from sibyl.jobs.memory_extraction import extract_memory_entities
 from sibyl.jobs.operational_distillation import distill_operational_experience_notes
 from sibyl.jobs.privacy import purge_due_deleted_personal_memories
@@ -229,6 +230,13 @@ def get_schedule_specs() -> list[ScheduleSpec]:
 
     schedule_specs.append(
         ScheduleSpec(
+            name="repair_lifecycle_all_orgs",
+            function=repair_lifecycle_all_orgs,
+            schedule_label="* * * * *",
+        )
+    )
+    schedule_specs.append(
+        ScheduleSpec(
             name="consolidate_all_orgs",
             function=consolidate_all_orgs,
             schedule_label="0 3 * * *",
@@ -313,6 +321,7 @@ class WorkerSettings:
         poll_raw_capture_changefeed,
         poll_all_raw_capture_changefeeds,
         # Consolidation jobs
+        repair_lifecycle_all_orgs,
         consolidate_org,
         consolidate_all_orgs,
         priority_decay,

--- a/apps/api/src/sibyl/mcp_tools/management.py
+++ b/apps/api/src/sibyl/mcp_tools/management.py
@@ -16,13 +16,18 @@ from sibyl.api.idempotency import (
     idempotency_request_hash,
     reserve_idempotency_record,
 )
+from sibyl.auth.authorization import ProjectAuthorizationError
 from sibyl.mcp_tools import serialization
 from sibyl.persistence.auth_runtime import (
     log_memory_audit_event,
     resolve_accessible_team_scope_keys,
+    resolve_auth_context,
+    verify_entity_project_access,
 )
 from sibyl.persistence.content_common import ApiIdempotencyRecord
+from sibyl.services.memory_correction_disclosure import filter_correction_disclosure
 from sibyl.services.work_item_workflow import WorkItemAction
+from sibyl_core.auth import ProjectRole
 from sibyl_core.auth.memory_policy import MemoryPolicyAction, MemoryPolicyDecision
 from sibyl_core.services.surreal_content import (
     MemoryScope,
@@ -72,6 +77,24 @@ async def _mcp_entity_write_target(
     return _project_id_for_policy(entity), dict(metadata) if isinstance(metadata, dict) else {}
 
 
+async def _require_correction_project_write(ctx: mcp_context.McpContext, project_id: str) -> None:
+    """Resolve the real project role before treating visibility as write authority."""
+    if ctx.api_key_project_ids is not None and project_id not in ctx.api_key_project_ids:
+        raise ValueError("project_write_not_allowed")
+    auth_ctx = await resolve_auth_context(
+        claims={"sub": ctx.user_id, "org": ctx.org_id, "scopes": list(ctx.scopes or [])}
+    )
+    try:
+        await verify_entity_project_access(
+            ctx=auth_ctx,
+            entity_project_id=project_id,
+            required_role=ProjectRole.CONTRIBUTOR,
+            require_existing_project=True,
+        )
+    except ProjectAuthorizationError as exc:
+        raise ValueError("project_write_not_allowed") from exc
+
+
 async def _authorize_mcp_manage_action(
     *,
     ctx: mcp_context.McpContext,
@@ -97,6 +120,8 @@ async def _authorize_mcp_manage_action(
             return None
         if memory.memory_scope is MemoryScope.PRIVATE and memory.principal_id != ctx.user_id:
             raise ValueError("principal_mismatch")
+        if memory.memory_scope is MemoryScope.PROJECT and memory.scope_key:
+            await _require_correction_project_write(ctx, memory.scope_key)
         accessible_teams = (
             await resolve_accessible_team_scope_keys(
                 user_id=ctx.user_id,
@@ -445,6 +470,7 @@ async def _manage_memory_correction(
             if policy_decision is not None and policy_decision.policy_context is not None
             else None
         ),
+        writable_projects=await mcp_context.get_writable_projects(ctx),
         replacement_source_id=(
             str(data["replacement_source_id"]) if data.get("replacement_source_id") else None
         ),
@@ -455,6 +481,7 @@ async def _manage_memory_correction(
             str(data["revised_content"]) if data.get("revised_content") is not None else None
         ),
         expected_revision=expected_revision,
+        allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
     )
     revision = result.updated_memory.revision if result.updated_memory else None
     affected_records = (
@@ -595,6 +622,20 @@ async def _manage_mcp_action(
                     receipt = response_data.get("mutation_receipt")
                     if isinstance(receipt, dict):
                         response_data["mutation_receipt"] = {**receipt, "replayed": True}
+                if normalized_action == "correct_memory" and isinstance(raw_response_data, dict):
+                    replayed["data"] = await filter_correction_disclosure(
+                        raw_response_data,
+                        organization_id=ctx.org_id,
+                        principal_id=ctx.user_id,
+                        accessible_projects=accessible_projects,
+                        accessible_teams=(
+                            set(policy_decision.policy_context.accessible_teams or ())
+                            if policy_decision is not None
+                            and policy_decision.policy_context is not None
+                            else None
+                        ),
+                        allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
+                    )
                 return replayed
         else:
             idempotency_claim = record

--- a/apps/api/src/sibyl/mcp_tools/memory.py
+++ b/apps/api/src/sibyl/mcp_tools/memory.py
@@ -1,5 +1,6 @@
 """Knowledge capture and reflection MCP tools."""
 
+import asyncio
 from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any, Literal, cast
@@ -20,10 +21,14 @@ from sibyl.api.idempotency import (
 )
 from sibyl.mcp_tools import serialization
 from sibyl.mcp_tools.contracts import DeclaredRelatedTo, MemoryKind
-from sibyl.persistence.auth_runtime import create_project_record
+from sibyl.persistence.auth_runtime import create_project_record, resolve_accessible_team_scope_keys
 from sibyl.persistence.content_common import ApiIdempotencyRecord
 from sibyl_core.auth.memory_policy import server_provenance_metadata, stamp_memory_scope_metadata
 from sibyl_core.memory_pipeline.capture import MemoryCaptureRequest, MemoryCaptureService
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    SOURCE_BINDINGS_KEY,
+    source_revision_bindings,
+)
 
 log = structlog.get_logger()
 
@@ -128,6 +133,20 @@ async def _remember_mcp_memory(
         accessible_projects=accessible_projects,
     )
 
+    source_context: dict[str, Any] = {}
+    if metadata and metadata.get("raw_source_ids"):
+        source_projects, source_teams = await asyncio.gather(
+            mcp_context.get_accessible_projects(ctx),
+            resolve_accessible_team_scope_keys(
+                user_id=principal_id, org_id=ctx.org_id, scopes=ctx.scopes
+            ),
+        )
+        source_context = {
+            "accessible_projects": source_projects,
+            "accessible_teams": source_teams,
+            "allowed_memory_scope_keys": ctx.api_key_memory_scope_keys,
+        }
+
     idempotency_payload = {
         "title": title,
         "content": content,
@@ -200,9 +219,14 @@ async def _remember_mcp_memory(
             metadata=dict(request.metadata),
             provenance=dict(request.provenance),
             capture_surface=request.capture_surface,
+            **source_context,
         )
         raw_revision = getattr(raw_memory, "revision", 1)
-        return {"id": raw_memory.id, "source_id": raw_memory.source_id}
+        return {
+            "id": raw_memory.id,
+            "source_id": raw_memory.source_id,
+            SOURCE_BINDINGS_KEY: source_revision_bindings([raw_memory]),
+        }
 
     async def create_graph_entity(
         request: MemoryCaptureRequest,
@@ -329,6 +353,7 @@ async def _reflect_mcp_memory(
         organization_id=ctx.org_id,
         principal_id=ctx.user_id,
         accessible_projects=accessible_projects,
+        writable_projects=await mcp_context.get_writable_projects(ctx) if persist else set(),
         memory_scope=memory_scope,
         scope_key=scope_key,
         persist=persist,

--- a/apps/api/src/sibyl/mcp_tools/serialization.py
+++ b/apps/api/src/sibyl/mcp_tools/serialization.py
@@ -1,13 +1,34 @@
 """Serialization helpers for MCP tool responses."""
 
-from dataclasses import asdict
+from dataclasses import asdict, fields, is_dataclass
 from typing import Any
+
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
+from sibyl_core.tools.responses import EntitySummary, NeighborEntity, SearchResult
+
+
+def _filter_source_clocks(obj: Any, payload: Any) -> None:
+    """Filter typed response rows, leaving arbitrary dictionaries opaque."""
+    if is_dataclass(obj) and not isinstance(obj, type):
+        for item in fields(obj):
+            value = getattr(obj, item.name)
+            if item.name == "metadata" and isinstance(
+                obj, EntitySummary | NeighborEntity | SearchResult
+            ):
+                payload[item.name] = public_memory_metadata(payload[item.name])
+            else:
+                _filter_source_clocks(value, payload[item.name])
+    elif isinstance(obj, list | tuple):
+        for value, serialized in zip(obj, payload, strict=True):
+            _filter_source_clocks(value, serialized)
 
 
 def to_dict(obj: Any) -> Any:
-    """Convert dataclass values recursively for JSON serialization."""
-    if hasattr(obj, "__dataclass_fields__"):
-        return asdict(obj)
+    """Serialize dataclasses, omitting live source clocks from row metadata."""
+    if is_dataclass(obj) and not isinstance(obj, type):
+        payload = asdict(obj)
+        _filter_source_clocks(obj, payload)
+        return payload
     if isinstance(obj, list):
         return [to_dict(item) for item in obj]
     return obj

--- a/apps/api/src/sibyl/services/memory_correction_disclosure.py
+++ b/apps/api/src/sibyl/services/memory_correction_disclosure.py
@@ -1,0 +1,126 @@
+"""Recheck correction receipts under the credential reading their stored result."""
+
+from collections.abc import Iterable
+from copy import deepcopy
+from typing import Any
+
+from sibyl_core.auth.memory_policy import (
+    memory_metadata_read_allowed,
+    memory_row_project_id,
+    private_scope_granted_for,
+)
+from sibyl_core.services.graph import get_surreal_graph_runtime
+from sibyl_core.services.memory_policy import _authorize_share_source_read
+from sibyl_core.services.surreal_content import get_raw_memory
+
+
+async def filter_correction_disclosure(
+    payload: dict[str, Any],
+    *,
+    organization_id: str,
+    principal_id: str | None,
+    accessible_projects: set[str] | None,
+    accessible_teams: set[str] | None,
+    allowed_memory_scope_keys: Iterable[str] | None,
+) -> dict[str, Any]:
+    """Retain mutation identity while checking current access to referenced rows.
+
+    Cached correction results belong to a principal, so a later narrower key
+    may replay the same mutation. The stored receipt is evidence of a write,
+    not a durable grant to read every row named by the original credential.
+    """
+    allowed_memory_scope_keys = (
+        None if allowed_memory_scope_keys is None else frozenset(allowed_memory_scope_keys)
+    )
+    result = deepcopy(payload)
+    decisions: dict[tuple[str, str], bool] = {}
+    runtime = None
+
+    async def visible(kind: str, identifier: str) -> bool:
+        nonlocal runtime
+        key = (kind, identifier)
+        if key in decisions:
+            return decisions[key]
+        allowed = False
+        try:
+            if kind == "raw_captures":
+                row = await get_raw_memory(organization_id=organization_id, memory_id=identifier)
+                if row is not None:
+                    allowed = _authorize_share_source_read(
+                        memory=row,
+                        principal_id=principal_id,
+                        accessible_projects=accessible_projects,
+                        accessible_teams=accessible_teams,
+                        allowed_memory_scope_keys=allowed_memory_scope_keys,
+                    ).allowed
+            elif kind == "entity":
+                if runtime is None:
+                    runtime = await get_surreal_graph_runtime(organization_id)
+                row = await runtime.entity_manager.get(identifier)
+                if row is not None:
+                    allowed = memory_metadata_read_allowed(
+                        row.metadata,
+                        row_project_id=memory_row_project_id(
+                            row.metadata,
+                            entity_type=str(getattr(row, "entity_type", "") or ""),
+                            entity_id=str(getattr(row, "id", "") or ""),
+                        ),
+                        principal_id=principal_id,
+                        accessible_projects=accessible_projects,
+                        private_scope_granted=private_scope_granted_for(
+                            allowed_memory_scope_keys, principal_id=principal_id
+                        ),
+                        allowed_memory_scope_keys=allowed_memory_scope_keys,
+                    )
+        except Exception:
+            # An unavailable row cannot authorize disclosure; the mutation
+            # receipt still describes the original completed operation.
+            allowed = False
+        decisions[key] = allowed
+        return allowed
+
+    impact = result.get("recall_impact")
+    if isinstance(impact, dict):
+        for field, kind in (
+            ("graph_entity_ids", "entity"),
+            ("refused_entity_ids", "entity"),
+            ("derived_raw_memory_ids", "raw_captures"),
+        ):
+            if isinstance(impact.get(field), list):
+                impact[field] = [
+                    value
+                    for value in impact[field]
+                    if isinstance(value, str) and await visible(kind, value)
+                ]
+    for container, field in (
+        (result, "affected_derived_ids"),
+        (result.get("lifecycle"), "derived_ids"),
+    ):
+        if isinstance(container, dict) and isinstance(container.get(field), list):
+            container[field] = [
+                value
+                for value in container[field]
+                if isinstance(value, str) and await visible("entity", value)
+            ]
+    receipt = result.get("mutation_receipt")
+    if isinstance(receipt, dict) and isinstance(receipt.get("affected_records"), list):
+        receipt["affected_records"] = [
+            value
+            for value in receipt["affected_records"]
+            if isinstance(value, str) and ":" in value and await visible(*value.split(":", 1))
+        ]
+    for field in ("metadata", "lifecycle", "reflection_finding"):
+        metadata = result.get(field)
+        if isinstance(metadata, dict):
+            for key in ("replacement_source_id", "duplicate_of_source_id"):
+                value = metadata.get(key)
+                if isinstance(value, str) and not await visible("raw_captures", value):
+                    metadata.pop(key)
+    finding = result.get("reflection_finding")
+    if isinstance(finding, dict) and isinstance(finding.get("related_source_ids"), list):
+        finding["related_source_ids"] = [
+            value
+            for value in finding["related_source_ids"]
+            if isinstance(value, str) and await visible("raw_captures", value)
+        ]
+    return result

--- a/apps/api/tests/harness/mocks.py
+++ b/apps/api/tests/harness/mocks.py
@@ -4,12 +4,27 @@ Provides mock versions of the graph client, EntityManager, and
 RelationshipManager so tools can be tested without a real SurrealDB connection.
 """
 
+from collections.abc import Sequence
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
+from sibyl_core.errors import RevisionConflictError
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+
+
+def _merge_metadata(current: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(current)
+    for key, value in patch.items():
+        if value is None:
+            merged.pop(key, None)
+        elif isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _merge_metadata(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
 
 
 @dataclass
@@ -56,7 +71,9 @@ class MockEntityManager:
 
     def add_entity(self, entity: Entity) -> None:
         """Add an entity to the mock store."""
-        self._entities[entity.id] = entity
+        self._entities[entity.id] = entity.model_copy(
+            deep=True, update={"observed_revision": entity.revision}
+        )
 
     def set_search_results(self, results: list[tuple[Entity, float]]) -> None:
         """Set results for the next search call."""
@@ -66,7 +83,7 @@ class MockEntityManager:
         """Create entity and return ID."""
         entity_id = entity.id or f"entity-{uuid4().hex[:8]}"
         entity.id = entity_id
-        self._entities[entity_id] = entity
+        self.add_entity(entity)
         return entity_id
 
     async def create_direct(self, entity: Entity, *, generate_embedding: bool = True) -> str:
@@ -80,7 +97,7 @@ class MockEntityManager:
             from sibyl_core.errors import EntityNotFoundError
 
             raise EntityNotFoundError("Entity", entity_id)
-        return self._entities[entity_id]
+        return self._entities[entity_id].model_copy(deep=True)
 
     async def search(
         self,
@@ -98,19 +115,40 @@ class MockEntityManager:
 
         return results
 
-    async def update(self, entity_id: str, updates: dict[str, Any]) -> Entity | None:
-        """Update entity fields."""
+    async def update(
+        self,
+        entity_id: str,
+        updates: dict[str, Any],
+        *,
+        expected_revision: int | None = None,
+        replace_metadata_keys: Sequence[str] = (),
+    ) -> Entity | None:
+        """Apply a mutation with the same revision fence as the graph store."""
         if entity_id not in self._entities:
             return None
-
         entity = self._entities[entity_id]
+        if not updates:
+            return entity.model_copy(deep=True)
+        if expected_revision is not None and expected_revision < 1:
+            raise ValueError("expected_revision must be at least 1")
+        if expected_revision is not None and expected_revision != entity.revision:
+            raise RevisionConflictError(entity_id, expected_revision, entity.revision)
+        updated = entity.model_copy(deep=True)
         for key, value in updates.items():
-            if hasattr(entity, key):
-                setattr(entity, key, value)
-            elif entity.metadata is not None:
-                entity.metadata[key] = value
-
-        return entity
+            if key == "metadata":
+                updated.metadata = _merge_metadata(updated.metadata, value)
+                for replaced in replace_metadata_keys:
+                    if replaced in value and value[replaced] is not None:
+                        updated.metadata[replaced] = deepcopy(value[replaced])
+            elif hasattr(updated, key):
+                setattr(updated, key, deepcopy(value))
+            else:
+                updated.metadata[key] = deepcopy(value)
+        updated.revision = entity.revision + 1
+        updated.observed_revision = updated.revision
+        updated.updated_at = datetime.now(UTC)
+        self._entities[entity_id] = updated
+        return updated.model_copy(deep=True)
 
     async def delete(self, entity_id: str) -> bool:
         """Delete entity."""

--- a/apps/api/tests/test_correction_scope_disclosure.py
+++ b/apps/api/tests/test_correction_scope_disclosure.py
@@ -1,0 +1,584 @@
+"""Correction replay reuses the write while honoring the current reader."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl.api.routes import memory_sources
+from sibyl.api.schemas import MemoryCorrectionRequest, MemoryCorrectionResponse
+from sibyl.mcp_tools import context, management
+from sibyl.mcp_tools.context import McpContext
+from sibyl.services import memory_correction_disclosure as disclosure
+from sibyl_core.services.surreal_content import MemoryScope, RawMemory
+
+
+@pytest.fixture
+def correction_disclosure_rows(monkeypatch):
+    monkeypatch.setattr(context, "get_writable_projects", AsyncMock(return_value=set()))
+    monkeypatch.setattr(memory_sources.memory_auth, "authorize_project_scope_write", AsyncMock())
+    org = str(uuid4())
+    root = RawMemory(
+        id="root",
+        organization_id=org,
+        source_id="root",
+        principal_id="owner",
+        memory_scope=MemoryScope.PROJECT,
+        scope_key="project-a",
+    )
+    private = RawMemory(
+        id="private",
+        organization_id=org,
+        source_id="private",
+        principal_id="owner",
+    )
+    raw = AsyncMock(
+        side_effect=lambda **kwargs: {"root": root, "private": private}.get(kwargs["memory_id"])
+    )
+    graph = AsyncMock(
+        return_value=SimpleNamespace(
+            metadata={
+                "memory_scope": "private",
+                "principal_id": "owner",
+            }
+        )
+    )
+    monkeypatch.setattr(disclosure, "get_raw_memory", raw)
+    monkeypatch.setattr(
+        disclosure,
+        "get_surreal_graph_runtime",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                entity_manager=SimpleNamespace(get=graph),
+            )
+        ),
+    )
+    return root
+
+
+def stored_correction():
+    return {
+        "allowed": True,
+        "applied": True,
+        "source_id": "root",
+        "action": "hide",
+        "reason": "outdated",
+        "target_lifecycle_state": "active",
+        "reversible": True,
+        "audit_action": "memory.correction.hide",
+        "affected_source_ids": ["root"],
+        "affected_derived_ids": ["private-graph"],
+        "lifecycle": {"derived_ids": ["private-graph"]},
+        "recall_impact": {
+            "graph_entity_ids": ["private-graph"],
+            "refused_entity_ids": ["private-graph"],
+            "derived_raw_memory_ids": ["private"],
+            "propagation_complete": True,
+        },
+        "metadata": {"replacement_source_id": "private", "requested_source_id": "root"},
+        "reflection_finding": {"related_source_ids": ["private", "root"], "reason": "outdated"},
+        "mutation_receipt": {
+            "operation_id": "original",
+            "applied": True,
+            "revision": 2,
+            "idempotency_key": "original",
+            "replayed": True,
+            "affected_records": [
+                "raw_captures:root",
+                "raw_captures:private",
+                "entity:private-graph",
+            ],
+        },
+    }
+
+
+@pytest.mark.parametrize("private", [False, True])
+async def test_correction_scope_replay_filters_only_inaccessible_details(
+    correction_disclosure_rows, private
+):
+    original = stored_correction()
+    before = deepcopy(original)
+    keys = ["project\x1fproject-a"] + (["private\x1fowner"] if private else [])
+    result = await disclosure.filter_correction_disclosure(
+        original,
+        organization_id=correction_disclosure_rows.organization_id,
+        principal_id="owner",
+        accessible_projects={"project-a"},
+        accessible_teams=None,
+        allowed_memory_scope_keys=iter(keys),
+    )
+    assert original == before
+    assert result["mutation_receipt"]["operation_id"] == "original"
+    assert result["mutation_receipt"]["revision"] == 2
+    assert result["recall_impact"]["propagation_complete"] is True
+    assert result["metadata"]["requested_source_id"] == "root"
+    assert ("replacement_source_id" in result["metadata"]) is private
+    assert result["reflection_finding"]["related_source_ids"] == (
+        ["private", "root"] if private else ["root"]
+    )
+    assert bool(result["recall_impact"]["graph_entity_ids"]) is private
+    assert bool(result["recall_impact"]["refused_entity_ids"]) is private
+    assert bool(result["affected_derived_ids"]) is private
+    assert bool(result["lifecycle"]["derived_ids"]) is private
+    assert bool(result["recall_impact"]["derived_raw_memory_ids"]) is private
+    assert len(result["mutation_receipt"]["affected_records"]) == (3 if private else 1)
+
+
+async def test_correction_scope_rest_replay_rechecks_grants_without_reapplying(
+    correction_disclosure_rows, monkeypatch
+):
+    root = correction_disclosure_rows
+    ctx = SimpleNamespace(user_id="owner", api_key_memory_scope_keys={"project\x1fproject-a"})
+    monkeypatch.setattr(
+        memory_sources.memory_auth, "load_memory_source_for_org", AsyncMock(return_value=root)
+    )
+    monkeypatch.setattr(memory_sources.memory_auth, "require_source_policy", AsyncMock())
+    monkeypatch.setattr(
+        memory_sources.memory_auth,
+        "list_accessible_project_graph_ids",
+        AsyncMock(return_value={"project-a"}),
+    )
+    monkeypatch.setattr(
+        memory_sources.memory_auth, "list_accessible_team_scope_keys", AsyncMock(return_value=set())
+    )
+    monkeypatch.setattr(
+        memory_sources,
+        "replay_idempotent_response",
+        AsyncMock(return_value=MemoryCorrectionResponse.model_validate(stored_correction())),
+    )
+    apply = AsyncMock()
+    monkeypatch.setattr(memory_sources, "apply_memory_correction", apply)
+    result = await memory_sources.apply_memory_correction_route(
+        "root",
+        MemoryCorrectionRequest(action="hide", reason="outdated"),
+        http_request=SimpleNamespace(headers={}),
+        org=SimpleNamespace(id=root.organization_id),
+        ctx=ctx,
+    )
+    apply.assert_not_awaited()
+    assert result.mutation_receipt.replayed
+    assert result.mutation_receipt.affected_records == ["raw_captures:root"]
+    assert result.recall_impact["graph_entity_ids"] == []
+
+
+async def test_correction_scope_mcp_replay_rechecks_grants_without_reapplying(
+    correction_disclosure_rows, monkeypatch
+):
+    from sibyl_core.services import memory as memory_service
+    from sibyl_core.services.memory_contract import MemoryCorrectionPreview, MemoryCorrectionResult
+
+    root = correction_disclosure_rows
+    ctx = McpContext(
+        org_id=root.organization_id,
+        user_id="owner",
+        scopes=["mcp"],
+        api_key_memory_scope_keys=["project\x1fproject-a"],
+    )
+    monkeypatch.setattr(context, "require_context", AsyncMock(return_value=ctx))
+    monkeypatch.setattr(context, "get_accessible_projects", AsyncMock(return_value={"project-a"}))
+    monkeypatch.setattr(management, "_authorize_mcp_manage_action", AsyncMock(return_value=None))
+    data = {"action": "hide", "reason": "outdated", "idempotency_key": "original"}
+    monkeypatch.setattr(management, "get_raw_memory", AsyncMock(return_value=root))
+    monkeypatch.setattr(management, "log_memory_audit_event", AsyncMock())
+    preview = MemoryCorrectionPreview(
+        allowed=True,
+        source_id=root.id,
+        action="hide",
+        reason="outdated",
+        target_lifecycle_state="active",
+        target_lifecycle_flags=["hidden"],
+        affected_source_ids=[root.id],
+        affected_derived_ids=["private-graph"],
+        reversible=True,
+        recall_impact={},
+        synthesis_impact={},
+        audit_action="memory.correction.hide",
+    )
+    monkeypatch.setattr(
+        memory_service,
+        "apply_memory_correction",
+        AsyncMock(
+            return_value=MemoryCorrectionResult(applied=True, preview=preview, updated_memory=root)
+        ),
+    )
+    original_payload = await management._manage_memory_correction(
+        ctx=McpContext(org_id=root.organization_id, user_id="owner", scopes=["mcp"]),
+        entity_id=root.id,
+        data=data,
+        accessible_projects={"project-a"},
+        policy_decision=None,
+    )
+    assert original_payload["data"]["affected_derived_ids"] == ["private-graph"]
+    assert "recall_impact" not in original_payload["data"]
+    stored = SimpleNamespace(
+        request_hash=management.idempotency_request_hash({"entity_id": "root", "data": data}),
+        response_body=original_payload,
+    )
+    monkeypatch.setattr(
+        management, "reserve_idempotency_record", AsyncMock(return_value=(stored, False))
+    )
+    monkeypatch.setattr(management, "idempotency_record_pending", lambda record: False)
+    apply = AsyncMock()
+    monkeypatch.setattr(management, "_manage_memory_correction", apply)
+    result = await management._manage_mcp_action.__wrapped__(
+        action="correct_memory",
+        entity_id="root",
+        data=data,
+    )
+    apply.assert_not_awaited()
+    assert result["data"]["mutation_receipt"]["replayed"]
+    assert result["data"]["mutation_receipt"]["affected_records"] == ["raw_captures:root"]
+    assert result["data"]["affected_derived_ids"] == []
+    assert original_payload["data"]["affected_derived_ids"] == ["private-graph"]
+    assert result["data"]["correction_action"] == "hide"
+
+
+@pytest.mark.parametrize("surface", ["rest-preview", "rest-apply", "mcp"])
+async def test_correction_scope_fresh_entry_points_forward_grants(
+    correction_disclosure_rows, monkeypatch, surface
+):
+    from sibyl_core.auth import ProjectRole
+    from sibyl_core.services.memory_contract import MemoryCorrectionPreview, MemoryCorrectionResult
+
+    readable = {"project-a", "project-b", "project-c"}
+    writable = {"project-a", "project-b"}
+    monkeypatch.setattr(context, "get_writable_projects", AsyncMock(return_value=writable))
+    root = correction_disclosure_rows
+    keys = ["project\x1fproject-a"]
+    preview = MemoryCorrectionPreview(
+        allowed=True,
+        source_id="root",
+        action="hide",
+        reason="outdated",
+        target_lifecycle_state="active",
+        target_lifecycle_flags=["hidden"],
+        affected_source_ids=["root"],
+        affected_derived_ids=[],
+        reversible=True,
+        audit_action="memory.correction.hide",
+        recall_impact={},
+        synthesis_impact={},
+    )
+    result = MemoryCorrectionResult(applied=True, preview=preview, updated_memory=root)
+    apply = AsyncMock(return_value=result)
+    if surface == "mcp":
+        import sibyl_core.services.memory as memory_service
+
+        ctx = McpContext(
+            org_id=root.organization_id,
+            user_id="owner",
+            scopes=["mcp"],
+            api_key_memory_scope_keys=keys,
+        )
+        monkeypatch.setattr(management, "get_raw_memory", AsyncMock(return_value=root))
+        monkeypatch.setattr(management, "log_memory_audit_event", AsyncMock())
+        monkeypatch.setattr(memory_service, "apply_memory_correction", apply)
+        await management._manage_memory_correction(
+            ctx=ctx,
+            entity_id="root",
+            data={"action": "hide", "reason": "outdated"},
+            accessible_projects=readable,
+            policy_decision=None,
+        )
+    else:
+        ctx = SimpleNamespace(user_id="owner", api_key_memory_scope_keys=keys)
+        monkeypatch.setattr(
+            memory_sources.memory_auth, "load_memory_source_for_org", AsyncMock(return_value=root)
+        )
+        monkeypatch.setattr(memory_sources.memory_auth, "require_source_policy", AsyncMock())
+        monkeypatch.setattr(
+            memory_sources.memory_auth,
+            "list_accessible_project_graph_ids",
+            AsyncMock(
+                side_effect=lambda ctx, required_role=None: (
+                    writable if required_role == ProjectRole.CONTRIBUTOR else readable
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            memory_sources.memory_auth,
+            "list_accessible_team_scope_keys",
+            AsyncMock(return_value=set()),
+        )
+        monkeypatch.setattr(memory_sources.memory_auth, "log_memory_audit", AsyncMock())
+        monkeypatch.setattr(
+            memory_sources, "replay_idempotent_response", AsyncMock(return_value=None)
+        )
+        monkeypatch.setattr(memory_sources, "save_idempotent_response", AsyncMock())
+        monkeypatch.setattr(memory_sources, "apply_memory_correction", apply)
+        if surface == "rest-preview":
+            apply.return_value = preview
+            monkeypatch.setattr(memory_sources, "preview_memory_correction", apply)
+        route = (
+            memory_sources.preview_memory_correction_route
+            if surface == "rest-preview"
+            else memory_sources.apply_memory_correction_route
+        )
+        await route(
+            "root",
+            MemoryCorrectionRequest(action="hide", reason="outdated"),
+            http_request=SimpleNamespace(headers={}),
+            org=SimpleNamespace(id=root.organization_id),
+            ctx=ctx,
+        )
+    assert apply.await_args.kwargs["allowed_memory_scope_keys"] == keys
+
+    assert apply.await_args.kwargs["writable_projects"] == writable
+    assert apply.await_args.kwargs["accessible_projects"] == readable
+
+
+@pytest.mark.parametrize("accessible", [False, True])
+async def test_correction_scope_project_identity_requires_membership(monkeypatch, accessible):
+    from sibyl_core.models.entities import Entity, EntityType
+
+    project = Entity(id="project-b", name="Project B", entity_type=EntityType.PROJECT)
+    monkeypatch.setattr(
+        disclosure,
+        "get_surreal_graph_runtime",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                entity_manager=SimpleNamespace(get=AsyncMock(return_value=project)),
+            )
+        ),
+    )
+    output = await disclosure.filter_correction_disclosure(
+        {"recall_impact": {"graph_entity_ids": ["project-b"]}},
+        organization_id="org",
+        principal_id="owner",
+        accessible_projects={"project-b"} if accessible else {"project-a"},
+        accessible_teams=None,
+        allowed_memory_scope_keys={"project\x1fproject-b", "project\x1fproject-a"},
+    )
+    assert output["recall_impact"]["graph_entity_ids"] == (["project-b"] if accessible else [])
+
+
+@pytest.mark.parametrize("private", [False, True])
+async def test_correction_scope_real_preview_and_serializer_filter_declared_ids(
+    correction_disclosure_rows, monkeypatch, private
+):
+    from sibyl.api.routes.memory_serialization import correction_result_response
+    from sibyl_core.services import memory_correction, memory_lifecycle
+    from sibyl_core.services.memory_lineage import CorrectionPropagation
+
+    root = correction_disclosure_rows
+    root.metadata = {"promoted_entity_id": "private-graph"}
+    root.observed_revision = 1
+    monkeypatch.setattr(memory_correction, "_load_correction_memory", AsyncMock(return_value=root))
+    monkeypatch.setattr(
+        memory_correction, "save_raw_memory", AsyncMock(side_effect=lambda row, **kwargs: row)
+    )
+    monkeypatch.setattr(
+        memory_lifecycle, "get_surreal_graph_runtime", disclosure.get_surreal_graph_runtime
+    )
+    monkeypatch.setattr(
+        memory_correction,
+        "_project_correction_to_graph",
+        AsyncMock(
+            return_value=(
+                [],
+                ["private-graph"],
+                False,
+                CorrectionPropagation(),
+            )
+        ),
+    )
+    keys = {"project\x1fproject-a"} | ({"private\x1fowner"} if private else set())
+    arguments = {
+        "organization_id": root.organization_id,
+        "source_id": root.id,
+        "principal_id": "owner",
+        "action": "hide",
+        "accessible_projects": {"project-a"},
+        "allowed_memory_scope_keys": keys,
+    }
+    preview = await memory_correction.preview_memory_correction(**arguments)
+    result = await memory_correction.apply_memory_correction(**arguments)
+    response = correction_result_response(result)
+    assert preview.affected_derived_ids == (["private-graph"] if private else [])
+    assert response.affected_derived_ids == (["private-graph"] if private else [])
+    assert response.lifecycle["derived_ids"] == (["private-graph"] if private else [])
+    assert response.recall_impact.get("refused_entity_ids", []) == (
+        ["private-graph"] if private else []
+    )
+    assert ("private-graph" in response.model_dump_json()) is private
+
+
+@pytest.mark.asyncio
+async def test_private_root_retains_readable_project_reference(monkeypatch):
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.services import memory_correction
+
+    root = RawMemory(
+        id="root",
+        organization_id="org",
+        source_id="root",
+        principal_id="owner",
+        memory_scope=MemoryScope.PRIVATE,
+        revision=2,
+        observed_revision=2,
+        metadata={"promoted_entity_id": "project-a"},
+    )
+    ctx = SimpleNamespace(
+        user_id="owner", api_key_memory_scope_keys={"private\x1fowner", "project\x1fproject-a"}
+    )
+    project = Entity(id="project-a", name="Readable project", entity_type=EntityType.PROJECT)
+    monkeypatch.setattr(memory_correction, "_load_correction_memory", AsyncMock(return_value=root))
+    monkeypatch.setattr(
+        memory_correction.memory_lifecycle,
+        "get_surreal_graph_runtime",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                entity_manager=SimpleNamespace(get=AsyncMock(return_value=project))
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        memory_sources.memory_auth, "load_memory_source_for_org", AsyncMock(return_value=root)
+    )
+    monkeypatch.setattr(memory_sources.memory_auth, "require_source_policy", AsyncMock())
+    projects = AsyncMock(return_value={"project-a"})
+    monkeypatch.setattr(memory_sources.memory_auth, "list_accessible_project_graph_ids", projects)
+    monkeypatch.setattr(
+        memory_sources.memory_auth, "list_accessible_team_scope_keys", AsyncMock(return_value=set())
+    )
+    monkeypatch.setattr(memory_sources.memory_auth, "log_memory_audit", AsyncMock())
+    response = await memory_sources.preview_memory_correction_route(
+        "root",
+        MemoryCorrectionRequest(action="hide", reason="outdated"),
+        http_request=SimpleNamespace(headers={}),
+        org=SimpleNamespace(id="org"),
+        ctx=ctx,
+    )
+    assert response.allowed
+    assert response.affected_derived_ids == ["project-a"]
+
+
+@pytest.mark.parametrize("surface", ["preview", "apply"])
+async def test_correction_rest_requires_project_contributor_before_execution(
+    correction_disclosure_rows, monkeypatch, surface
+):
+    from fastapi import HTTPException
+
+    root = correction_disclosure_rows
+    monkeypatch.setattr(
+        memory_sources.memory_auth, "load_memory_source_for_org", AsyncMock(return_value=root)
+    )
+    monkeypatch.setattr(memory_sources.memory_auth, "require_source_policy", AsyncMock())
+    role = AsyncMock(side_effect=HTTPException(status_code=403, detail="contributor required"))
+    monkeypatch.setattr(memory_sources.memory_auth, "authorize_project_scope_write", role)
+    execution = AsyncMock()
+    monkeypatch.setattr(memory_sources, "preview_memory_correction", execution)
+    monkeypatch.setattr(memory_sources, "apply_memory_correction", execution)
+    route = (
+        memory_sources.preview_memory_correction_route
+        if surface == "preview"
+        else memory_sources.apply_memory_correction_route
+    )
+    ctx = SimpleNamespace(user_id="owner", api_key_memory_scope_keys=None)
+    with pytest.raises(HTTPException) as error:
+        await route(
+            root.id,
+            MemoryCorrectionRequest(action="hide", reason="outdated"),
+            http_request=SimpleNamespace(headers={}),
+            org=SimpleNamespace(id=root.organization_id),
+            ctx=ctx,
+        )
+    assert error.value.status_code == 403
+    role.assert_awaited_once_with(ctx=ctx, memory_scope="project", scope_key="project-a")
+    execution.assert_not_awaited()
+
+
+@pytest.mark.parametrize("contributor", [False, True])
+async def test_correction_mcp_checks_actual_project_role(monkeypatch, contributor):
+    from sibyl.auth.authorization import ProjectAuthorizationError
+    from sibyl_core.auth import ProjectRole
+
+    ctx = McpContext(org_id="org", user_id="owner", scopes=["mcp"])
+    resolved = SimpleNamespace()
+    monkeypatch.setattr(management, "resolve_auth_context", AsyncMock(return_value=resolved))
+    check = AsyncMock(
+        return_value=ProjectRole.CONTRIBUTOR,
+        side_effect=None
+        if contributor
+        else ProjectAuthorizationError(
+            project_id="project-a",
+            required_role=ProjectRole.CONTRIBUTOR,
+            actual_role=ProjectRole.VIEWER,
+        ),
+    )
+    monkeypatch.setattr(management, "verify_entity_project_access", check)
+    if contributor:
+        await management._require_correction_project_write(ctx, "project-a")
+    else:
+        with pytest.raises(ValueError, match="project_write_not_allowed"):
+            await management._require_correction_project_write(ctx, "project-a")
+    check.assert_awaited_once_with(
+        ctx=resolved,
+        entity_project_id="project-a",
+        required_role=ProjectRole.CONTRIBUTOR,
+        require_existing_project=True,
+    )
+
+
+async def test_correction_mcp_entry_rejects_readable_project_without_write_role(
+    correction_disclosure_rows, monkeypatch
+):
+    root = correction_disclosure_rows
+    ctx = McpContext(org_id=root.organization_id, user_id="owner", scopes=["mcp"])
+    monkeypatch.setattr(management, "get_raw_memory", AsyncMock(return_value=root))
+    role = AsyncMock(side_effect=ValueError("project_write_not_allowed"))
+    monkeypatch.setattr(management, "_require_correction_project_write", role)
+    with pytest.raises(ValueError, match="project_write_not_allowed"):
+        await management._authorize_mcp_manage_action(
+            ctx=ctx, action="correct_memory", entity_id=root.id
+        )
+    role.assert_awaited_once_with(ctx, "project-a")
+
+
+async def test_correction_mcp_project_binding_is_checked_before_role_lookup(monkeypatch):
+    ctx = McpContext(
+        org_id="org", user_id="owner", scopes=["mcp"], api_key_project_ids=["project-b"]
+    )
+    resolve = AsyncMock()
+    monkeypatch.setattr(management, "resolve_auth_context", resolve)
+    with pytest.raises(ValueError, match="project_write_not_allowed"):
+        await management._require_correction_project_write(ctx, "project-a")
+    resolve.assert_not_awaited()
+
+
+async def test_mcp_writable_projects_resolves_roles_and_intersects_key(monkeypatch):
+    from sibyl.persistence.surreal.auth_runtime import projects
+    from sibyl_core.auth import ProjectRole
+
+    auth_ctx = SimpleNamespace(
+        organization=object(), org_role="member", user=SimpleNamespace(id=uuid4())
+    )
+    records = [
+        {
+            "uuid": name,
+            "graph_project_id": name,
+            "visibility": "org",
+            "default_role": role.value,
+        }
+        for name, role in (
+            ("project-a", ProjectRole.CONTRIBUTOR),
+            ("project-b", ProjectRole.CONTRIBUTOR),
+            ("read-only", ProjectRole.VIEWER),
+        )
+    ]
+    resolve = AsyncMock(return_value=auth_ctx)
+    load = AsyncMock(return_value=(records, {}))
+    monkeypatch.setattr(projects, "_resolve_auth_context_from_claims", resolve)
+    monkeypatch.setattr(projects, "_load_project_access_records", load)
+    ctx = McpContext(
+        org_id="org",
+        user_id="owner",
+        scopes=["mcp"],
+        api_key_project_ids=["project-b", "read-only"],
+    )
+    assert await context.get_writable_projects(ctx) == {"project-b"}
+    assert await context.get_accessible_projects(ctx) == {"project-b", "read-only"}
+    load.assert_awaited_once_with(auth_ctx)
+    resolve.assert_awaited_once()

--- a/apps/api/tests/test_harness.py
+++ b/apps/api/tests/test_harness.py
@@ -111,6 +111,47 @@ class TestMockEntityManager:
         assert updated.name == "Updated"
 
     @pytest.mark.asyncio
+    async def test_persisted_revision_fences_stale_metadata_writes(self) -> None:
+        from sibyl_core.errors import RevisionConflictError
+
+        manager = MockEntityManager()
+        entity = create_test_entity(metadata={"keep": "original"})
+        await manager.create(entity)
+        observed = await manager.get(entity.id)
+        assert observed.observed_revision == observed.revision
+        updated = await manager.update(
+            entity.id, {"metadata": {"new": True}}, expected_revision=observed.observed_revision
+        )
+        assert updated is not None
+        assert updated.revision == observed.revision + 1
+        assert updated.observed_revision == updated.revision
+        assert updated.metadata == {"keep": "original", "new": True}
+        with pytest.raises(RevisionConflictError):
+            await manager.update(
+                entity.id,
+                {"metadata": {"keep": "stale"}},
+                expected_revision=observed.observed_revision,
+            )
+        assert (await manager.get(entity.id)).metadata == updated.metadata
+        observed.metadata["keep"] = "changed outside the store"
+        assert (await manager.get(entity.id)).metadata["keep"] == "original"
+
+    @pytest.mark.asyncio
+    async def test_replacement_metadata_drops_old_nested_pending_keys(self) -> None:
+        manager = MockEntityManager()
+        entity = create_test_entity(metadata={"clock": {"old": 1}, "keep": True})
+        manager.add_entity(entity)
+        observed = await manager.get(entity.id)
+        updated = await manager.update(
+            entity.id,
+            {"metadata": {"clock": {"new": 2}}},
+            expected_revision=observed.observed_revision,
+            replace_metadata_keys=("clock",),
+        )
+        assert updated is not None
+        assert updated.metadata == {"clock": {"new": 2}, "keep": True}
+
+    @pytest.mark.asyncio
     async def test_delete_entity(self) -> None:
         """Delete should remove entity."""
         manager = MockEntityManager()
@@ -300,4 +341,5 @@ class TestMockToolsContextManager:
             ctx.entity_manager.add_entity(entity)
 
             retrieved = await ctx.entity_manager.get(entity.id)
-            assert retrieved == entity
+            assert retrieved.model_dump() == entity.model_dump()
+            assert retrieved.observed_revision == entity.revision

--- a/apps/api/tests/test_jobs_entities_correction_race.py
+++ b/apps/api/tests/test_jobs_entities_correction_race.py
@@ -258,8 +258,11 @@ async def test_a_row_projected_after_its_capture_was_corrected_is_born_retired(
 
     stored = await graph.entity_manager.get(result["entity_id"])
     assert stored is not None, "the row is still written; it is written retired"
-    assert stored.metadata.get("excluded_from_recall") is True
-    assert stored.metadata.get("lifecycle_state") == "contested"
+    assert stored.metadata["correction_blockers"][RAW_MEMORY_ID] == {
+        "revision": _corrected_capture().revision,
+        "blocking": True,
+    }
+    assert "excluded_from_recall" not in stored.metadata
 
     served = await _served_ids(graph, "fly hosting rollout body")
     assert parent_id not in served
@@ -342,8 +345,11 @@ async def test_a_correction_landing_inside_the_write_still_retires_the_row(
 
     stored = await graph.entity_manager.get(parent_id)
     assert stored is not None
-    assert stored.metadata.get("excluded_from_recall") is True
-    assert stored.metadata.get("lifecycle_state") == "contested"
+    assert stored.metadata["correction_blockers"][RAW_MEMORY_ID] == {
+        "revision": _corrected_capture().revision,
+        "blocking": True,
+    }
+    assert "excluded_from_recall" not in stored.metadata
 
     served = await _served_ids(graph, "fly hosting rollout body")
     assert parent_id not in served

--- a/apps/api/tests/test_jobs_lifecycle_repair.py
+++ b/apps/api/tests/test_jobs_lifecycle_repair.py
@@ -1,0 +1,94 @@
+"""Shared scheduler registration and organization failure isolation."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+from sibyl.jobs import lifecycle_repair
+from sibyl.jobs.worker import WorkerSettings, get_schedule_specs
+from sibyl_core.projection.repair import LifecycleRepairResult
+
+
+async def test_scheduled_repair_continues_after_org_failure(monkeypatch):
+    monkeypatch.setattr(lifecycle_repair, "list_org_ids", AsyncMock(return_value=["a", "b"]))
+    entered = []
+    closed = []
+    runtime = object()
+
+    @asynccontextmanager
+    async def background(group_id):
+        entered.append(group_id)
+        if group_id == "a":
+            raise ConnectionError("unavailable")
+        try:
+            yield runtime
+        finally:
+            closed.append(group_id)
+
+    monkeypatch.setattr(lifecycle_repair, "background_graph_runtime", background)
+    repair = AsyncMock(return_value=LifecycleRepairResult(checked=3, recovered=2, pending=1))
+    monkeypatch.setattr(lifecycle_repair, "repair_graph_lifecycle", repair)
+    raw_repair = AsyncMock(return_value=LifecycleRepairResult(checked=1, recovered=1))
+    monkeypatch.setattr(lifecycle_repair, "repair_raw_source_lifecycle", raw_repair)
+    result = await lifecycle_repair.repair_lifecycle_all_orgs({})
+    assert result == {
+        "organizations": 2,
+        "failed_organizations": 1,
+        "checked": 5,
+        "recovered": 4,
+        "pending": 1,
+        "failed": 0,
+    }
+    repair.assert_awaited_once_with(runtime)
+    assert entered == ["a", "b"]
+    assert closed == ["b"]
+    assert raw_repair.await_count == 2
+
+
+def test_repair_uses_shared_local_and_redis_schedule():
+    specs = [spec for spec in get_schedule_specs() if spec.name == "repair_lifecycle_all_orgs"]
+    assert len(specs) == 1
+    assert specs[0].function is lifecycle_repair.repair_lifecycle_all_orgs
+    assert specs[0].schedule_label == "* * * * *"
+    assert lifecycle_repair.repair_lifecycle_all_orgs in WorkerSettings.functions
+
+
+async def test_repair_resolves_current_memberships_with_one_auth_context(monkeypatch):
+    from types import SimpleNamespace
+
+    context = SimpleNamespace(user_id="owner", organization_id="org", org_role="member")
+    resolve = AsyncMock(return_value=context)
+    projects = AsyncMock(return_value={"project"})
+    teams = AsyncMock(return_value={"team"})
+    delegated = AsyncMock(return_value={"delegated"})
+    monkeypatch.setattr(lifecycle_repair, "resolve_auth_context", resolve)
+    monkeypatch.setattr(lifecycle_repair, "list_accessible_project_graph_ids", projects)
+    monkeypatch.setattr(lifecycle_repair, "list_accessible_team_scope_keys", teams)
+    monkeypatch.setattr(lifecycle_repair, "list_accessible_delegated_scope_keys", delegated)
+    authority = await lifecycle_repair.resolve_source_authority("org", "owner")
+    assert authority.projects == {"project"}
+    assert authority.teams == {"team"}
+    assert authority.delegations == {"delegated"}
+    assert authority.scope_keys is None
+    resolve.assert_awaited_once_with(claims={"sub": "owner", "org": "org"})
+    for reader in (projects, teams, delegated):
+        reader.assert_awaited_once_with(context)
+
+
+async def test_repair_rejects_revoked_org_membership_before_reading_grants(monkeypatch):
+    from types import SimpleNamespace
+
+    context = SimpleNamespace(user_id="owner", organization_id="org", org_role=None)
+    projects = AsyncMock()
+    monkeypatch.setattr(lifecycle_repair, "resolve_auth_context", AsyncMock(return_value=context))
+    monkeypatch.setattr(lifecycle_repair, "list_accessible_project_graph_ids", projects)
+    assert await lifecycle_repair.resolve_source_authority("org", "owner") is None
+    projects.assert_not_awaited()
+
+
+async def test_repair_rejects_deleted_user(monkeypatch):
+    from sibyl.persistence.auth_common import UserNotFoundError
+
+    monkeypatch.setattr(
+        lifecycle_repair, "resolve_auth_context", AsyncMock(side_effect=UserNotFoundError("gone"))
+    )
+    assert await lifecycle_repair.resolve_source_authority("org", "owner") is None

--- a/apps/api/tests/test_reflection_write_grants.py
+++ b/apps/api/tests/test_reflection_write_grants.py
@@ -1,0 +1,28 @@
+"""REST reflection carries project write roles separately from readable evidence."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+from sibyl.api.routes.context import reflect_context
+from sibyl.api.schemas import ReflectionRequest
+from sibyl_core.auth import ProjectRole
+from tests.test_routes_context import _ctx, _reflection_pack
+
+
+async def test_rest_reflection_preserves_separate_project_write_grants(monkeypatch):
+    def projects(ctx, required_role=ProjectRole.VIEWER):
+        return {"writer"} if required_role == ProjectRole.CONTRIBUTOR else {"reader", "writer"}
+
+    memberships = AsyncMock(side_effect=projects)
+    reflection = AsyncMock(return_value=_reflection_pack(project=None, source_id=None))
+    monkeypatch.setattr("sibyl.api.routes.context.list_accessible_project_graph_ids", memberships)
+    monkeypatch.setattr("sibyl_core.tools.core.reflect_memory", reflection)
+    monkeypatch.setattr("sibyl.api.routes.context.log_reflection_audit", AsyncMock())
+    await reflect_context(
+        ReflectionRequest(content="Useful session evidence", persist=True, active_task=False),
+        org=SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111")),
+        ctx=_ctx(),
+    )
+    assert reflection.await_args.kwargs["accessible_projects"] == {"reader", "writer"}
+    assert reflection.await_args.kwargs["writable_projects"] == {"writer"}

--- a/apps/api/tests/test_routes_context.py
+++ b/apps/api/tests/test_routes_context.py
@@ -1155,7 +1155,7 @@ class TestReflectRoute:
                 ctx=ctx,
             )
 
-        list_projects.assert_not_awaited()
+        list_projects.assert_awaited_once_with(ctx, required_role=ProjectRole.CONTRIBUTOR)
         verify_project.assert_awaited_once_with(
             None,
             ctx,
@@ -1298,6 +1298,10 @@ class TestReflectRoute:
 
         with (
             patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_1"}),
+            ),
+            patch(
                 "sibyl.api.routes.context.verify_entity_project_access",
                 AsyncMock(),
             ),
@@ -1364,7 +1368,7 @@ class TestReflectRoute:
                 ctx=ctx,
             )
 
-        list_projects.assert_not_awaited()
+        list_projects.assert_awaited_once_with(ctx, required_role=ProjectRole.CONTRIBUTOR)
         verify_project.assert_awaited_once_with(
             None,
             ctx,
@@ -1386,6 +1390,10 @@ class TestReflectRoute:
         ctx = _ctx()
 
         with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_1"}),
+            ),
             patch(
                 "sibyl.api.routes.context.verify_entity_project_access",
                 AsyncMock(),
@@ -1424,6 +1432,10 @@ class TestReflectRoute:
         http_request = _http_request()
 
         with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_1"}),
+            ),
             patch(
                 "sibyl.api.routes.context.verify_entity_project_access",
                 AsyncMock(),
@@ -1535,6 +1547,10 @@ class TestReflectRoute:
         org = SimpleNamespace(id=UUID("00000000-0000-0000-0000-000000000111"))
 
         with (
+            patch(
+                "sibyl.api.routes.context.list_accessible_project_graph_ids",
+                AsyncMock(return_value={"proj_1"}),
+            ),
             patch(
                 "sibyl.api.routes.context.verify_entity_project_access",
                 AsyncMock(),

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -1836,8 +1836,23 @@ async def test_blame_memory_source_hides_revision_bodies_after_redaction() -> No
     assert "content_revisions" not in response.source.metadata
 
 
+@pytest.fixture
+def correction_memberships():
+    with (
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_project_graph_ids",
+            AsyncMock(return_value=set()),
+        ),
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_team_scope_keys",
+            AsyncMock(return_value=set()),
+        ),
+    ):
+        yield
+
+
 @pytest.mark.asyncio
-async def test_preview_memory_correction_audits_lifecycle_action() -> None:
+async def test_preview_memory_correction_audits_lifecycle_action(correction_memberships) -> None:
     org = _org()
     memory = _memory(id="memory-1", organization_id=str(org.id), source_id="source-1")
     preview = MemoryCorrectionPreview(
@@ -1882,11 +1897,13 @@ async def test_preview_memory_correction_audits_lifecycle_action() -> None:
         principal_id="user-123",
         action="hide",
         reason="outdated",
-        accessible_projects=None,
-        accessible_teams=None,
+        accessible_projects=set(),
+        writable_projects=set(),
+        accessible_teams=set(),
         replacement_source_id=None,
         duplicate_of_source_id=None,
         revised_content=None,
+        allowed_memory_scope_keys=None,
     )
     audit.assert_awaited_once()
     assert audit.await_args.kwargs["action"] == "memory.correction.hide.preview"
@@ -1894,7 +1911,7 @@ async def test_preview_memory_correction_audits_lifecycle_action() -> None:
 
 
 @pytest.mark.asyncio
-async def test_apply_memory_correction_returns_updated_review_state() -> None:
+async def test_apply_memory_correction_returns_updated_review_state(correction_memberships) -> None:
     org = _org()
     memory = _memory(id="memory-1", organization_id=str(org.id), source_id="source-1")
     updated = _memory(
@@ -1972,11 +1989,13 @@ async def test_apply_memory_correction_returns_updated_review_state() -> None:
         principal_id="user-123",
         action="hide",
         reason="outdated",
-        accessible_projects=None,
-        accessible_teams=None,
+        accessible_projects=set(),
+        writable_projects=set(),
+        accessible_teams=set(),
         replacement_source_id=None,
         duplicate_of_source_id=None,
         revised_content=None,
+        allowed_memory_scope_keys=None,
         expected_revision=1,
     )
     audit.assert_awaited_once()
@@ -1985,7 +2004,7 @@ async def test_apply_memory_correction_returns_updated_review_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_correction_receipt_names_the_graph_rows_it_retired() -> None:
+async def test_correction_receipt_names_the_graph_rows_it_retired(correction_memberships) -> None:
     """The receipt has to show the write reached retrieval, not just the capture.
 
     A correction that stamps entity rows but reports only `raw_captures:` reads
@@ -2051,7 +2070,9 @@ async def test_correction_receipt_names_the_graph_rows_it_retired() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_partially_applied_correction_says_so_in_recall_impact() -> None:
+async def test_a_partially_applied_correction_says_so_in_recall_impact(
+    correction_memberships,
+) -> None:
     """`applied: true` with a refused target must not read as a complete write."""
 
     org = _org()
@@ -2108,7 +2129,7 @@ async def test_a_partially_applied_correction_says_so_in_recall_impact() -> None
 
 
 @pytest.mark.asyncio
-async def test_denied_memory_correction_receipt_reports_no_write() -> None:
+async def test_denied_memory_correction_receipt_reports_no_write(correction_memberships) -> None:
     org = _org()
     memory = _memory(id="memory-1", organization_id=str(org.id), source_id="source-1")
     preview = MemoryCorrectionPreview(
@@ -2209,7 +2230,11 @@ async def test_preview_memory_share_returns_disabled_contract_and_audit() -> Non
             ctx=ctx,
         )
 
-    accessible.assert_awaited_once_with(ctx)
+    assert accessible.await_count == 2
+    assert accessible.await_args_list[0].args == (ctx,)
+    assert accessible.await_args_list[0].kwargs == {}
+    assert accessible.await_args_list[1].args == (ctx,)
+    assert accessible.await_args_list[1].kwargs == {"required_role": ProjectRole.CONTRIBUTOR}
     accessible_teams.assert_awaited_once_with(ctx)
     preview.assert_awaited_once_with(
         source_ids=["memory-1"],
@@ -2219,6 +2244,7 @@ async def test_preview_memory_share_returns_disabled_contract_and_audit() -> Non
         target_scope_key=None,
         recipient_organization_id="org-2",
         accessible_projects={"project_123"},
+        writable_projects={"project_123"},
         accessible_teams=set(),
     )
     audit.assert_awaited_once_with(
@@ -2382,6 +2408,7 @@ async def test_share_memory_applies_promotions_and_returns_audit_receipt() -> No
         recipient_organization_id=None,
         project="project_123",
         accessible_projects={"project_123"},
+        writable_projects={"project_123"},
         accessible_teams=set(),
     )
     audit.assert_awaited_once()
@@ -2482,6 +2509,7 @@ async def test_share_memory_applies_team_promotions_with_membership_scope() -> N
         recipient_organization_id=None,
         project=None,
         accessible_projects={"project_123"},
+        writable_projects={"project_123"},
         accessible_teams={"team_123"},
     )
     audit.assert_awaited_once()
@@ -2599,6 +2627,16 @@ async def test_preview_reflection_promotion_verifies_project_target() -> None:
         },
     )
     with (
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_project_graph_ids",
+            AsyncMock(
+                side_effect=lambda ctx, required_role=ProjectRole.VIEWER: (
+                    {"project_123"}
+                    if required_role == ProjectRole.CONTRIBUTOR
+                    else {"project_123", "read_only_source"}
+                )
+            ),
+        ),
         patch("sibyl.api.routes.memory_auth.verify_entity_project_access", AsyncMock()) as verify,
         patch(
             "sibyl.api.routes.memory_promotion.preview_reflection_candidate_promotion",
@@ -2635,7 +2673,8 @@ async def test_preview_reflection_promotion_verifies_project_target() -> None:
         promote_to_scope_key="project_123",
         domain="sibyl",
         project="project_123",
-        accessible_projects={"project_123"},
+        accessible_projects={"project_123", "read_only_source"},
+        writable_projects={"project_123"},
     )
     audit.assert_awaited_once_with(
         action="memory.reflect.promote.preview",
@@ -2695,6 +2734,16 @@ async def test_preview_memory_promotion_routes_imported_raw_memory() -> None:
     )
 
     with (
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_project_graph_ids",
+            AsyncMock(
+                side_effect=lambda ctx, required_role=ProjectRole.VIEWER: (
+                    {"project_123"}
+                    if required_role == ProjectRole.CONTRIBUTOR
+                    else {"project_123", "read_only_source"}
+                )
+            ),
+        ),
         patch("sibyl.api.routes.memory_auth.verify_entity_project_access", AsyncMock()),
         patch(
             "sibyl.api.routes.memory_promotion.preview_reflection_candidate_promotion",
@@ -2727,7 +2776,8 @@ async def test_preview_memory_promotion_routes_imported_raw_memory() -> None:
         promote_to_scope_key="project_123",
         domain=None,
         project="project_123",
-        accessible_projects={"project_123"},
+        accessible_projects={"project_123", "read_only_source"},
+        writable_projects={"project_123"},
     )
     audit.assert_awaited_once()
     assert response.allowed is True
@@ -2891,6 +2941,16 @@ async def test_auto_review_reflection_candidate_promotes_safe_candidate() -> Non
         },
     )
     with (
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_project_graph_ids",
+            AsyncMock(
+                side_effect=lambda ctx, required_role=ProjectRole.VIEWER: (
+                    {"project_123"}
+                    if required_role == ProjectRole.CONTRIBUTOR
+                    else {"project_123", "read_only_source"}
+                )
+            ),
+        ),
         patch("sibyl.api.routes.memory_auth.verify_entity_project_access", AsyncMock()) as verify,
         patch(
             "sibyl.api.routes.memory_review.preview_reflection_candidate_promotion",
@@ -2931,7 +2991,8 @@ async def test_auto_review_reflection_candidate_promotes_safe_candidate() -> Non
         promote_to_scope_key="project_123",
         domain="sibyl",
         project="project_123",
-        accessible_projects={"project_123"},
+        accessible_projects={"project_123", "read_only_source"},
+        writable_projects={"project_123"},
     )
     promote.assert_awaited_once_with(
         candidate_id="candidate-1",
@@ -2942,7 +3003,8 @@ async def test_auto_review_reflection_candidate_promotes_safe_candidate() -> Non
         domain="sibyl",
         project="project_123",
         related_to=["task_123"],
-        accessible_projects={"project_123"},
+        accessible_projects={"project_123", "read_only_source"},
+        writable_projects={"project_123"},
     )
     audit.assert_awaited_once_with(
         action="memory.reflect.auto_promote",
@@ -3312,6 +3374,16 @@ async def test_promote_reflection_candidate_verifies_project_target() -> None:
         },
     )
     with (
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_project_graph_ids",
+            AsyncMock(
+                side_effect=lambda ctx, required_role=ProjectRole.VIEWER: (
+                    {"project_123"}
+                    if required_role == ProjectRole.CONTRIBUTOR
+                    else {"project_123", "read_only_source"}
+                )
+            ),
+        ),
         patch("sibyl.api.routes.memory_auth.verify_entity_project_access", AsyncMock()) as verify,
         patch(
             "sibyl.api.routes.memory_promotion.promote_reflection_candidate_review",
@@ -3349,7 +3421,8 @@ async def test_promote_reflection_candidate_verifies_project_target() -> None:
         domain="sibyl",
         project="project_123",
         related_to=["task_123"],
-        accessible_projects={"project_123"},
+        accessible_projects={"project_123", "read_only_source"},
+        writable_projects={"project_123"},
     )
     audit.assert_awaited_once_with(
         action="memory.reflect.promote",
@@ -3404,6 +3477,16 @@ async def test_promote_memory_routes_imported_raw_memory() -> None:
         raw_source_ids=[],
     )
     with (
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_project_graph_ids",
+            AsyncMock(
+                side_effect=lambda ctx, required_role=ProjectRole.VIEWER: (
+                    {"project_123"}
+                    if required_role == ProjectRole.CONTRIBUTOR
+                    else {"project_123", "read_only_source"}
+                )
+            ),
+        ),
         patch("sibyl.api.routes.memory_auth.verify_entity_project_access", AsyncMock()),
         patch(
             "sibyl.api.routes.memory_promotion.promote_reflection_candidate_review",
@@ -3437,7 +3520,8 @@ async def test_promote_memory_routes_imported_raw_memory() -> None:
         domain=None,
         project="project_123",
         related_to=[],
-        accessible_projects={"project_123"},
+        accessible_projects={"project_123", "read_only_source"},
+        writable_projects={"project_123"},
     )
     audit.assert_awaited_once()
     assert response.success is True
@@ -3555,7 +3639,9 @@ async def test_promote_reflection_candidate_returns_404_for_missing_candidate() 
 
 
 @pytest.mark.asyncio
-async def test_a_truncated_projection_walk_says_the_correction_was_partial() -> None:
+async def test_a_truncated_projection_walk_says_the_correction_was_partial(
+    correction_memberships,
+) -> None:
     """The lineage walk stopping early is a partial write, not a complete one.
 
     A capture with more projected rows than the walk's page ceiling admits
@@ -3613,3 +3699,40 @@ async def test_a_truncated_projection_walk_says_the_correction_was_partial() -> 
 
     assert response.recall_impact["projection_walk_truncated"] is True
     assert response.recall_impact["partially_applied"] is True
+
+
+@pytest.mark.asyncio
+async def test_remember_raw_forwards_source_memberships_and_credential_grants() -> None:
+    org = _org()
+    grants = {api_key_memory_scope_key("private", "user-123")}
+    ctx = _ctx(api_key_memory_scope_keys=grants)
+    with (
+        patch(
+            "sibyl.api.routes.memory_raw.remember_raw_memory",
+            AsyncMock(return_value=_memory(organization_id=str(org.id))),
+        ) as remember,
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_project_graph_ids",
+            AsyncMock(return_value={"source-project", "other-project"}),
+        ) as projects,
+        patch(
+            "sibyl.api.routes.memory_auth.list_accessible_team_scope_keys",
+            AsyncMock(return_value={"source-team"}),
+        ) as teams,
+        patch("sibyl.api.routes.memory_auth.log_memory_audit_event", AsyncMock()),
+        patch("sibyl.api.routes.memory_raw.publish_raw_capture_changed", AsyncMock()),
+    ):
+        await remember_raw(
+            RawMemoryRememberRequest(
+                raw_content="Private note derived from shared source material.",
+                metadata={"raw_source_ids": ["source-capture"]},
+            ),
+            http_request=_http_request(),
+            org=org,
+            ctx=ctx,
+        )
+    projects.assert_awaited_once_with(ctx)
+    teams.assert_awaited_once_with(ctx)
+    assert remember.await_args.kwargs["accessible_projects"] == {"source-project", "other-project"}
+    assert remember.await_args.kwargs["accessible_teams"] == {"source-team"}
+    assert remember.await_args.kwargs["allowed_memory_scope_keys"] == grants

--- a/apps/api/tests/test_routes_synthesis.py
+++ b/apps/api/tests/test_routes_synthesis.py
@@ -370,3 +370,60 @@ async def test_handbook_route_is_stable_across_identical_requests() -> None:
 
     assert first.run_id == second.run_id
     assert first.markdown == second.markdown
+
+
+@pytest.mark.parametrize("surface", ["plan", "draft", "remember"])
+async def test_synthesis_keeps_source_clocks_out_of_responses_and_saved_json(surface):
+    packs = []
+
+    async def context_with_clock(**kwargs):
+        pack = await _fake_context_pack(**kwargs)
+        pack.items[0].metadata.update(
+            {
+                "correction_blockers": {"private-root-clock": {"revision": 9, "blocking": False}},
+                "source_bindings": {"declared-source": 2},
+                "authored": {"correction_blockers": "literal documentation"},
+            }
+        )
+        packs.append(pack)
+        return pack
+
+    remember = AsyncMock(return_value=SimpleNamespace(id="saved", source_id="saved-source"))
+    with (
+        patch(
+            "sibyl.api.routes.synthesis.list_accessible_project_graph_ids",
+            AsyncMock(return_value=["project-sibyl"]),
+        ),
+        patch("sibyl_core.services.synthesis.default_search", _fake_search),
+        patch("sibyl_core.services.synthesis.default_related_sources", _empty_related),
+        patch("sibyl_core.services.synthesis.default_context_pack", context_with_clock),
+        patch("sibyl_core.services.synthesis.default_remember_artifact", remember),
+    ):
+        if surface == "plan":
+            response = await plan_synthesis_route(
+                SynthesisPlanRequest(goal="Write a sourced roadmap"), org=_org(), ctx=_ctx()
+            )
+        else:
+            response = await draft_synthesis_route(
+                SynthesisDraftRequest(
+                    goal="Write a sourced roadmap",
+                    output_format=SynthesisArtifactFormat.JSON,
+                    remember=surface == "remember",
+                ),
+                org=_org(),
+                ctx=_ctx(),
+            )
+    assert "private-root-clock" not in response.model_dump_json()
+    for pack in response.source_packs:
+        for source in pack.sources:
+            assert "correction_blockers" not in source.metadata
+            assert "source_bindings" not in source.metadata
+            assert source.metadata["authored"] == {"correction_blockers": "literal documentation"}
+    assert packs
+    assert all("correction_blockers" in pack.items[0].metadata for pack in packs)
+    if surface == "remember":
+        remember.assert_awaited_once()
+        assert "private-root-clock" not in remember.await_args.kwargs["raw_content"]
+        assert '"declared-source"' not in remember.await_args.kwargs["raw_content"]
+    else:
+        remember.assert_not_awaited()

--- a/apps/api/tests/test_server_accessible_projects.py
+++ b/apps/api/tests/test_server_accessible_projects.py
@@ -435,7 +435,9 @@ async def test_remember_mcp_memory_scopes_project_metadata(monkeypatch) -> None:
     ctx = McpContext(org_id=str(uuid4()), user_id=str(uuid4()), scopes=["mcp"])
     add = AsyncMock(return_value={"success": True, "id": "decision_123"})
     remember_raw = AsyncMock(
-        return_value=SimpleNamespace(id="raw_123", source_id="mcp:remember:decision")
+        return_value=SimpleNamespace(
+            id="raw_123", source_id="mcp:remember:decision", revision=1, metadata={}
+        )
     )
 
     with (
@@ -516,6 +518,7 @@ async def test_remember_mcp_memory_scopes_project_metadata(monkeypatch) -> None:
             "memory_scope": "project",
             "scope_key": "project-a",
             "principal_id": ctx.user_id,
+            "source_bindings": {"raw_123": 1},
             "raw_memory_id": "raw_123",
             "raw_source_id": "mcp:remember:decision",
         },
@@ -524,6 +527,7 @@ async def test_remember_mcp_memory_scopes_project_metadata(monkeypatch) -> None:
         # argument the row reaches the graph naming no capture, and a later
         # correction on this memory can neither find it nor retire it.
         capture_provenance={
+            "source_bindings": {"raw_123": 1},
             "raw_memory_id": "raw_123",
             "raw_source_id": "mcp:remember:decision",
         },
@@ -557,6 +561,7 @@ async def test_remember_mcp_memory_replays_idempotent_receipt(monkeypatch) -> No
             id="raw_123",
             source_id="mcp:remember:decision",
             revision=3,
+            metadata={},
         )
     )
     get_idempotency = AsyncMock(return_value=None)
@@ -1140,7 +1145,10 @@ async def test_manage_mcp_complete_task_routes_through_workflow_service(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_manage_memory_correction_returns_audited_receipt() -> None:
+async def test_manage_memory_correction_returns_audited_receipt(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sibyl.mcp_tools.context.get_writable_projects", AsyncMock(return_value=set())
+    )
     ctx = McpContext(org_id="org-1", user_id="user-1", scopes=["mcp"])
     memory = SimpleNamespace(
         id="raw-1",
@@ -1203,10 +1211,12 @@ async def test_manage_memory_correction_returns_audited_receipt() -> None:
         reason="Incorrect",
         accessible_projects={"project-a"},
         accessible_teams=None,
+        writable_projects=set(),
         replacement_source_id=None,
         duplicate_of_source_id=None,
         revised_content=None,
         expected_revision=1,
+        allowed_memory_scope_keys=None,
     )
     audit.assert_awaited_once()
     assert audit.await_args.kwargs["action"] == "memory.correction.mark_wrong"
@@ -1423,7 +1433,9 @@ async def test_remember_mcp_memory_links_single_active_project_task(monkeypatch)
     ctx = McpContext(org_id=str(uuid4()), user_id=str(uuid4()), scopes=["mcp"])
     add = AsyncMock(return_value={"success": True, "id": "decision_123"})
     remember_raw = AsyncMock(
-        return_value=SimpleNamespace(id="raw_123", source_id="mcp:remember:decision")
+        return_value=SimpleNamespace(
+            id="raw_123", source_id="mcp:remember:decision", revision=1, metadata={}
+        )
     )
     explore = AsyncMock(return_value=SimpleNamespace(entities=[SimpleNamespace(id="task_active")]))
 
@@ -2215,3 +2227,66 @@ async def test_manage_dispatch_does_not_mutate_a_foreign_private_target(monkeypa
     transitions.clear()
     assert await _dispatch(_target(None, None), bob) == "executed"
     assert transitions == ["complete_task"]
+
+
+@pytest.mark.asyncio
+async def test_remember_mcp_resolves_source_access_beyond_the_target_project(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mcp_context_module, "get_writable_projects", AsyncMock(return_value={"project-a"})
+    )
+    grants = [api_key_memory_scope_key("project", "project-a")]
+    ctx = McpContext(
+        org_id=str(uuid4()),
+        user_id=str(uuid4()),
+        scopes=["mcp"],
+        api_key_memory_scope_keys=grants,
+    )
+    remember = AsyncMock(
+        return_value=SimpleNamespace(
+            id="raw_123",
+            source_id="mcp:remember:decision",
+            revision=3,
+            metadata={
+                "raw_source_ids": ["source-capture"],
+                "source_bindings": {"source-capture": 2},
+            },
+        )
+    )
+    with (
+        patch("sibyl.mcp_tools.context.require_context", AsyncMock(return_value=ctx)),
+        patch(
+            "sibyl.mcp_tools.context.get_accessible_projects",
+            AsyncMock(return_value={"project-a", "source-project"}),
+        ),
+        patch(
+            "sibyl.mcp_tools.memory.resolve_accessible_team_scope_keys",
+            AsyncMock(return_value={"source-team"}),
+        ) as teams,
+        patch(
+            "sibyl_core.tools.core.add", AsyncMock(return_value={"success": True, "id": "row"})
+        ) as add,
+        patch("sibyl_core.services.surreal_content.remember_raw_memory", remember),
+        patch(
+            "sibyl_core.tools.core.explore", AsyncMock(return_value=SimpleNamespace(entities=[]))
+        ),
+        patch("sibyl.mcp_tools.policy.validate_relationship_targets_for_caller", AsyncMock()),
+    ):
+        await _remember_mcp_memory(
+            title="Derived memory",
+            content="A note citing another project.",
+            kind="decision",
+            domain="sibyl",
+            project="project-a",
+            tags=None,
+            related_to=None,
+            metadata={"raw_source_ids": ["source-capture"]},
+        )
+    assert remember.await_args.kwargs["accessible_projects"] == {"project-a", "source-project"}
+    assert remember.await_args.kwargs["accessible_teams"] == {"source-team"}
+    assert remember.await_args.kwargs["allowed_memory_scope_keys"] == grants
+    teams.assert_awaited_once_with(user_id=ctx.user_id, org_id=ctx.org_id, scopes=ctx.scopes)
+
+    assert add.await_args.kwargs["capture_provenance"]["source_bindings"] == {
+        "raw_123": 3,
+        "source-capture": 2,
+    }

--- a/apps/api/tests/test_source_clock_visibility.py
+++ b/apps/api/tests/test_source_clock_visibility.py
@@ -1,0 +1,325 @@
+"""Public memory responses omit live foreign clocks, including clear tombstones."""
+
+from copy import deepcopy
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from sibyl.api.routes.entity_serialization import serialize_raw_capture
+from sibyl.api.routes.memory_serialization import (
+    memory_source_inspect_response,
+    raw_memory_response,
+)
+from sibyl.api.routes.search import explore
+from sibyl.api.schemas import EntityResponse, ExploreRequest
+from sibyl.api.schemas.search import SearchResponse as ApiSearchResponse
+from sibyl.api.schemas.traverse import ExpandNeighborsResponse as ApiNeighborsResponse
+from sibyl.mcp_tools.serialization import to_dict
+from sibyl.persistence.content_common import RawCaptureRecord
+from sibyl_core.auth import ProjectRole
+from sibyl_core.auth.memory_policy import MemoryPolicyAction, MemoryPolicyDecision
+from sibyl_core.services.content_models import MemoryScope, RawMemory
+from sibyl_core.tools.responses import (
+    EntitySummary,
+    ExpandNeighborsResponse,
+    ExploreResponse,
+    NeighborEntity,
+    SearchResponse,
+    SearchResult,
+)
+from tests.harness.auth import stub_auth_context
+
+
+@pytest.fixture
+def clock_metadata() -> dict:
+    return {
+        "correction_blockers": {"foreign-root": {"revision": 17, "blocking": False}},
+        "source_bindings": {"known-source": 2},
+        "source_validation_pending": False,
+        "raw_source_ids": ["declared-source"],
+        "authored": {"metadata": {"correction_blockers": "literal example"}},
+    }
+
+
+def _assert_public(public: dict, original: dict) -> None:
+    assert "correction_blockers" not in public
+    assert "source_bindings" not in public
+    for key, value in original.items():
+        if key not in {"correction_blockers", "source_bindings"}:
+            assert public[key] == value
+    assert original["correction_blockers"] == {"foreign-root": {"revision": 17, "blocking": False}}
+
+
+def test_source_clock_visibility_raw_response(clock_metadata: dict) -> None:
+    memory = RawMemory(
+        id="derivative",
+        organization_id="org",
+        source_id="manual",
+        principal_id="owner",
+        metadata=clock_metadata,
+        revision=9,
+        raw_content="Own body",
+    )
+    response = raw_memory_response(memory)
+    _assert_public(response.metadata, clock_metadata)
+    assert response.revision == 9
+    assert response.raw_content == "Own body"
+
+
+@pytest.mark.parametrize("allowed", [False, True])
+def test_source_clock_visibility_inspect_and_blame(clock_metadata: dict, allowed: bool) -> None:
+    memory = RawMemory(
+        id="derivative",
+        organization_id="org",
+        source_id="manual",
+        principal_id="owner",
+        metadata=clock_metadata,
+        revision=9,
+        raw_content="Own body",
+    )
+    response = memory_source_inspect_response(
+        memory=memory,
+        policy_decision=MemoryPolicyDecision(
+            action=MemoryPolicyAction.READ,
+            allowed=allowed,
+            reason="allowed" if allowed else "private_principal_mismatch",
+            memory_scope=MemoryScope.PRIVATE,
+        ),
+        audit_events=[],
+    )
+    _assert_public(response.metadata, clock_metadata)
+    assert response.content_redacted is not allowed
+    assert response.revision == 9
+    assert "foreign-root" not in str(response.lifecycle)
+    assert "foreign-root" not in str(response.visibility)
+
+
+def test_source_clock_visibility_raw_capture(clock_metadata: dict) -> None:
+    capture = RawCaptureRecord(
+        organization_id=uuid4(),
+        title="Capture",
+        raw_content="Own body",
+        entity_type="pattern",
+        metadata=clock_metadata,
+        created_at=datetime(2026, 9, 7, tzinfo=UTC),
+    )
+    response = serialize_raw_capture(capture)
+    _assert_public(response.metadata, clock_metadata)
+    assert response.raw_content == "Own body"
+
+
+def test_source_clock_visibility_entity_output(clock_metadata: dict) -> None:
+    response = EntityResponse(
+        id="derivative",
+        entity_type="pattern",
+        name="Pattern",
+        content="Own body",
+        metadata=clock_metadata,
+    )
+    _assert_public(response.metadata, clock_metadata)
+    _assert_public(response.model_dump()["metadata"], clock_metadata)
+
+
+@pytest.mark.parametrize("surface", ["search", "explore", "neighbors"])
+def test_source_clock_visibility_mcp_rows(clock_metadata: dict, surface: str) -> None:
+    before = deepcopy(clock_metadata)
+    if surface == "search":
+        result = SearchResponse(
+            results=[
+                SearchResult(
+                    id="derivative",
+                    type="pattern",
+                    name="Pattern",
+                    content="Own body",
+                    score=1,
+                    metadata=clock_metadata,
+                )
+            ],
+            total=1,
+            query="pattern",
+            filters={},
+        )
+        key = "results"
+    elif surface == "explore":
+        result = ExploreResponse(
+            mode="list",
+            entities=[
+                EntitySummary(
+                    id="derivative",
+                    type="pattern",
+                    name="Pattern",
+                    description="Own body",
+                    metadata=clock_metadata,
+                )
+            ],
+            total=1,
+            filters={},
+        )
+        key = "entities"
+    else:
+        result = ExpandNeighborsResponse(
+            origins=["seed"],
+            neighbors=[
+                NeighborEntity(
+                    id="derivative",
+                    type="pattern",
+                    name="Pattern",
+                    relationship="supports",
+                    direction="outgoing",
+                    distance=1,
+                    score=1,
+                    metadata=clock_metadata,
+                )
+            ],
+            total=1,
+            depth=1,
+            limit=10,
+        )
+        key = "neighbors"
+    payload = to_dict(result)
+    _assert_public(payload[key][0]["metadata"], clock_metadata)
+    assert clock_metadata == before
+    # Arbitrary caller dictionaries are not response DTOs.
+    assert to_dict({"metadata": clock_metadata}) == {"metadata": clock_metadata}
+
+
+@pytest.mark.parametrize("surface", ["search", "neighbors"])
+def test_source_clock_visibility_rest_nested_rows(clock_metadata: dict, surface: str) -> None:
+    row = {
+        "id": "derivative",
+        "type": "pattern",
+        "name": "Pattern",
+        "score": 1,
+        "content": "Own body",
+        "metadata": clock_metadata,
+    }
+    if surface == "search":
+        response = ApiSearchResponse(results=[row], total=1, query="pattern", filters={})
+        public = response.results[0].metadata
+    else:
+        row.update(relationship="supports", direction="outgoing")
+        response = ApiNeighborsResponse(
+            origins=["seed"],
+            neighbors=[row],
+            total=1,
+            depth=1,
+            limit=10,
+        )
+        public = response.neighbors[0].metadata
+    _assert_public(public, clock_metadata)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("as_mapping", [False, True])
+async def test_source_clock_visibility_rest_explore(clock_metadata: dict, as_mapping: bool) -> None:
+    entity = EntitySummary(
+        id="derivative",
+        type="pattern",
+        name="Pattern",
+        description="Own body",
+        metadata=clock_metadata,
+    )
+    row = vars(entity) if as_mapping else entity
+    result = SimpleNamespace(mode="list", entities=[row], total=1, filters={})
+    with (
+        patch(
+            "sibyl.api.routes.search.verify_entity_project_access",
+            AsyncMock(return_value=ProjectRole.VIEWER),
+        ),
+        patch("sibyl_core.tools.core.explore", AsyncMock(return_value=result)),
+    ):
+        response = await explore(
+            request=ExploreRequest(mode="list", project_ids=["project"]),
+            org=SimpleNamespace(id=uuid4()),
+            ctx=stub_auth_context(),
+        )
+    _assert_public(response.entities[0]["metadata"], clock_metadata)
+
+
+@pytest.mark.parametrize("surface", ["promotion", "share", "autonomy"])
+def test_source_clock_visibility_promotion_result_wrappers(clock_metadata, surface):
+    from sibyl.api.routes.memory_serialization import (
+        autonomy_response,
+        promotion_response,
+        share_response,
+    )
+    from sibyl_core.services.memory_autonomy import (
+        ReflectionAutonomyAction,
+        ReflectionAutonomyDecision,
+        ReflectionAutonomyOutcome,
+    )
+    from sibyl_core.services.memory_contract import (
+        MemorySharePreview,
+        MemoryShareResult,
+        ReflectionPromotionPreview,
+        ReflectionPromotionResult,
+    )
+
+    before = deepcopy(clock_metadata)
+    result = ReflectionPromotionResult(
+        success=True,
+        candidate_id="candidate",
+        promoted_id="promoted",
+        reason="promoted",
+        review_state="promoted",
+        memory_scope=MemoryScope.PRIVATE,
+        scope_key=None,
+        raw_source_ids=["source"],
+        metadata=clock_metadata,
+    )
+    if surface == "promotion":
+        public = promotion_response(result)
+    elif surface == "share":
+        preview = MemorySharePreview(
+            allowed=True,
+            reason="allowed",
+            target_scope=MemoryScope.PRIVATE,
+            target_scope_key=None,
+            source_ids=["source"],
+            visible_source_ids=["source"],
+            denied_source_ids=[],
+            missing_source_ids=[],
+            redacted_count=0,
+            hidden_but_relevant_count=0,
+        )
+        response = share_response(
+            MemoryShareResult(
+                applied=True,
+                reason="shared",
+                preview=preview,
+                promotions=(result,),
+            ),
+            audit_event_ids=[],
+        )
+        public = response.promotions[0]
+    else:
+        decision = ReflectionAutonomyDecision(
+            outcome=ReflectionAutonomyOutcome.AUTO_PROMOTE,
+            recommended_action=ReflectionAutonomyAction.PROMOTE,
+            candidate_id="candidate",
+            reason="promoted",
+            review_state="promoted",
+            memory_scope=MemoryScope.PRIVATE,
+            scope_key=None,
+            raw_source_ids=["source"],
+            policy_reasons=[],
+            exception_reasons=[],
+            confidence=1.0,
+            confidence_threshold=0.9,
+        )
+        preview = ReflectionPromotionPreview(
+            allowed=True,
+            candidate_id="candidate",
+            reason="allowed",
+            review_state="pending",
+            memory_scope=MemoryScope.PRIVATE,
+            scope_key=None,
+            raw_source_ids=["source"],
+        )
+        response = autonomy_response(decision=decision, preview=preview, promotion=result)
+        public = response.promotion
+    _assert_public(public.metadata, clock_metadata)
+    assert clock_metadata == before

--- a/apps/api/tests/test_surreal_content_persistence.py
+++ b/apps/api/tests/test_surreal_content_persistence.py
@@ -1367,6 +1367,9 @@ async def test_content_schema_migration_normalizes_legacy_enum_values() -> None:
                 "entity_type": "episode",
                 "memory_scope": "PRIVATE",
                 "review_state": "PENDING",
+                "metadata": {"raw_source_ids": ["legacy-source"], "custom": {"kept": True}},
+                "provenance": {"origin": "legacy-import"},
+                "tags": ["retained"],
             },
         )
 
@@ -1391,6 +1394,17 @@ async def test_content_schema_migration_normalizes_legacy_enum_values() -> None:
         )
         assert source_rows[0]["source_type"] == SourceType.LOCAL.value
         assert source_rows[0]["crawl_status"] == "pending"
+        assert capture_rows[0]["uuid"] == capture_id
+        assert capture_rows[0]["organization_id"] == organization_id
+        assert capture_rows[0]["title"] == "Legacy raw capture"
+        assert capture_rows[0]["raw_content"] == "remember me"
+        assert capture_rows[0]["entity_type"] == "episode"
+        assert capture_rows[0]["metadata"] == {
+            "raw_source_ids": ["legacy-source"],
+            "custom": {"kept": True},
+        }
+        assert capture_rows[0]["provenance"] == {"origin": "legacy-import"}
+        assert capture_rows[0]["tags"] == ["retained"]
         assert capture_rows[0]["memory_scope"] == "private"
         assert capture_rows[0]["review_state"] == "pending"
         assert capture_rows[0]["retrieval_count"] == 0

--- a/packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
+++ b/packages/python/sibyl-core/src/sibyl_core/auth/memory_policy.py
@@ -46,6 +46,7 @@ MEMORY_PROVENANCE_METADATA_KEYS = frozenset(
         "source_bindings",
         "source_snapshot_sha256",
         "source_validation_pending",
+        "source_validation_context",
         "lifecycle_reconciliation_pending",
     }
 )

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -63,7 +63,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 28
+CONTENT_SCHEMA_CURRENT_VERSION = 29
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -894,6 +894,14 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             version=28,
             name="content_eval_attempts",
             statements=tuple(split_statements(CONTENT_EVAL_ATTEMPTS_MIGRATION_DEFINITIONS)),
+        ),
+        SchemaMigration(
+            version=29,
+            name="content_raw_source_validation_index",
+            statements=(
+                "DEFINE INDEX IF NOT EXISTS idx_raw_captures_source_validation "
+                "ON raw_captures FIELDS organization_id, metadata.source_validation_pending, uuid",
+            ),
         ),
     )
 

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
@@ -152,6 +152,8 @@ DEFINE FIELD IF NOT EXISTS created_at ON raw_captures TYPE datetime DEFAULT time
 
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_uuid ON raw_captures FIELDS uuid UNIQUE;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_org ON raw_captures FIELDS organization_id;
+DEFINE INDEX IF NOT EXISTS idx_raw_captures_source_validation ON raw_captures
+    FIELDS organization_id, metadata.source_validation_pending, uuid;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_source ON raw_captures FIELDS source_id;
 DEFINE INDEX IF NOT EXISTS idx_raw_captures_source_lookup ON raw_captures
     FIELDS source_id, organization_id, memory_scope, scope_key;

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/capture.py
@@ -9,6 +9,7 @@ from typing import Any
 from sibyl_core.auth.memory_policy import stamp_memory_scope_metadata
 from sibyl_core.memory_pipeline.quality import normalize_memory_quality_metadata
 from sibyl_core.memory_pipeline.retrieval_keys import normalize_retrieval_keys
+from sibyl_core.memory_pipeline.source_lifecycle import SOURCE_BINDINGS_KEY
 from sibyl_core.memory_pipeline.structure import MemoryStructure, build_memory_structure
 
 
@@ -138,6 +139,9 @@ class MemoryCaptureService:
             graph_metadata["raw_memory_id"] = raw_memory_id
         if raw_source_id:
             graph_metadata["raw_source_id"] = raw_source_id
+        source_bindings = raw_memory.get(SOURCE_BINDINGS_KEY)
+        if isinstance(source_bindings, Mapping):
+            graph_metadata[SOURCE_BINDINGS_KEY] = dict(source_bindings)
         if raw_policy_reason:
             graph_metadata["raw_policy_reason"] = raw_policy_reason
 

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/lifecycle.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/lifecycle.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Protocol
 
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    CORRECTION_BLOCKERS_KEY,
+    SOURCE_BINDINGS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+    correction_blocked,
+    correction_event,
+    merge_source_correction,
+)
 from sibyl_core.models.reflection import MemoryLifecycleState, memory_lifecycle_from_metadata
 
 RECALL_EXCLUDED_REVIEW_STATES = frozenset(
@@ -35,6 +43,9 @@ class MemoryLifecycleView(Protocol):
     def source_id(self) -> str: ...
 
     @property
+    def revision(self) -> int: ...
+
+    @property
     def review_state(self) -> str: ...
 
     @property
@@ -59,8 +70,12 @@ def memory_lifecycle_state(
     return _normalized_state(lifecycle.state)
 
 
-def raw_memory_lifecycle_recallable(memory: MemoryLifecycleView) -> bool:
+def raw_memory_lifecycle_recallable(
+    memory: MemoryLifecycleView, *, include_source_corrections: bool = True
+) -> bool:
     metadata = dict(memory.metadata)
+    if include_source_corrections and correction_blocked(metadata):
+        return False
     review_state = _normalized_state(memory.review_state)
     lifecycle = memory_lifecycle_from_metadata(
         metadata,
@@ -86,50 +101,32 @@ def raw_memory_lifecycle_recallable(memory: MemoryLifecycleView) -> bool:
 
 
 def graph_lifecycle_stamp(memory: MemoryLifecycleView) -> dict[str, object]:
-    """The verdict a graph row projected from this capture has to be born with.
+    """Inherit source verdicts without turning them into the graph row's own flags.
 
-    Projection is asynchronous: `remember` writes the capture, queues the graph
-    write, and returns an id the caller can correct immediately. The worker
-    then builds the row from the payload it was handed, which was serialized
-    before the correction existed, so a row created after a correction is
-    created recallable and nothing later reconciles it. The capture is the
-    authority (it is the row the correction actually mutated), and this is the
-    verdict a reader of that row must inherit.
-
-    Empty for a capture that is still recallable, so a caller can merge the
-    result unconditionally.
-
-    `excluded_from_recall` carries the exclusion on its own rather than
-    depending on the state name, because a capture can fall out of recall on a
-    review state or a bare replacement marker while its lifecycle state still
-    reads active.
+    Source clocks preserve independent exclusions and let a later restore clear
+    only its own inherited verdict. Unknown content bindings remain conservative
+    after revision; reading a current verdict does not prove which text was used.
     """
-
-    if raw_memory_lifecycle_recallable(memory):
-        return {}
     metadata = dict(memory.metadata)
-    lifecycle = memory_lifecycle_from_metadata(
-        metadata,
-        source_id=memory.source_id or memory.id,
-        review_state=memory.review_state,
+    inherited: dict[str, object] = {
+        key: metadata[key]
+        for key in (CORRECTION_BLOCKERS_KEY, SOURCE_BINDINGS_KEY, SOURCE_VALIDATION_PENDING_KEY)
+        if key in metadata
+    }
+    return merge_source_correction(
+        inherited,
+        correction_event(
+            memory,
+            blocking=not raw_memory_lifecycle_recallable(memory, include_source_corrections=False),
+        ),
     )
-    state = _normalized_state(lifecycle.state)
-    stamp: dict[str, object] = {"excluded_from_recall": True}
-    if state and state != MemoryLifecycleState.ACTIVE.value:
-        stamp["lifecycle_state"] = state
-    flags = [_normalized_state(flag) for flag in lifecycle.flags]
-    if flags:
-        stamp["lifecycle_flags"] = flags
-    replacement = lifecycle.replacement_source_id or metadata.get("superseded_by_source_id")
-    if replacement:
-        stamp["superseded_by_source_id"] = str(replacement)
-    duplicate = lifecycle.duplicate_of_source_id or metadata.get("duplicate_of_source_id")
-    if duplicate:
-        stamp["duplicate_of_source_id"] = str(duplicate)
-    return stamp
+
+
+RECONCILE_PENDING_KEY = "lifecycle_reconciliation_pending"
 
 
 GRAPH_RECALL_EXCLUSION_KEYS = (
+    RECONCILE_PENDING_KEY,
     "excluded_from_recall",
     "superseded_by_source_id",
     "superseded_by_raw_memory_id",
@@ -167,6 +164,8 @@ def graph_metadata_recallable(metadata: Mapping[str, object] | None) -> bool:
 
     if not metadata:
         return True
+    if correction_blocked(metadata):
+        return False
     state = _normalized_state(metadata.get("lifecycle_state"))
     if _normalized_state(metadata.get("review_state")) in RECALL_EXCLUDED_REVIEW_STATES:
         return False

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/source_lifecycle.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/source_lifecycle.py
@@ -45,7 +45,13 @@ def public_memory_metadata(metadata: Mapping[str, object] | None) -> dict[str, o
     public = {
         key: value
         for key, value in (metadata or {}).items()
-        if key not in {CORRECTION_BLOCKERS_KEY, SOURCE_BINDINGS_KEY, "source_snapshot_sha256"}
+        if key
+        not in {
+            CORRECTION_BLOCKERS_KEY,
+            SOURCE_BINDINGS_KEY,
+            "source_snapshot_sha256",
+            "source_validation_context",
+        }
     }
     identity = public.get("reflection_identity")
     if isinstance(identity, Mapping):

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/collapse_epics.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/collapse_epics.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from sibyl_core.backends.surreal.records import normalize_records, raise_on_error
+from sibyl_core.backends.surreal.schema import render_surreal_compatible_sql
 from sibyl_core.models.entities import Entity, EntityType
 from sibyl_core.models.tasks import EpicStatus, TaskStatus
 from sibyl_core.services.graph_entity_store import (
@@ -311,6 +312,7 @@ async def _apply_records(
     # that meant the removed migration marker came straight back on the next read.
     await heal_entity_metadata_snapshots(client, records, group_id=group_id)
     query = f"BEGIN TRANSACTION;\n{_ENTITY_BULK_UPSERT_QUERY}\nCOMMIT TRANSACTION;"
+    query = render_surreal_compatible_sql(query, url=client._url)
     result = await client.execute_query_raw(query, rows=records)
     direction = "reverse" if reverse else "forward"
     raise_on_error(result, query=f"collapse_epics:{direction}:{group_id}")

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/scope_backfill.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/scope_backfill.py
@@ -49,6 +49,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from sibyl_core.backends.surreal.records import normalize_records, raise_on_error
+from sibyl_core.backends.surreal.schema import render_surreal_compatible_sql
 from sibyl_core.models.memory_scope import MemoryScope
 from sibyl_core.services.graph_entity_store import (
     _ENTITY_BULK_UPSERT_QUERY,
@@ -587,6 +588,7 @@ async def _apply(
     # that meant the removal was undone by the snapshot the moment it was read.
     await heal_entity_metadata_snapshots(client, records, group_id=group_id)
     query = f"BEGIN TRANSACTION;\n{_ENTITY_BULK_UPSERT_QUERY}\nCOMMIT TRANSACTION;"
+    query = render_surreal_compatible_sql(query, url=client._url)
     result = await client.execute_query_raw(query, rows=records)
     raise_on_error(result, query=f"scope_backfill:{operation}:{group_id}")
 

--- a/packages/python/sibyl-core/src/sibyl_core/projection/inheritance.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/inheritance.py
@@ -19,17 +19,28 @@ from typing import Any
 
 import structlog
 
+from sibyl_core.memory_pipeline.lifecycle import RECONCILE_PENDING_KEY
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    CORRECTION_BLOCKERS_KEY,
+    SOURCE_BINDINGS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+)
+
 log = structlog.get_logger()
 
 # What a correction stamps onto a memory. A derived row that does not carry
 # these keeps serving the retired body under its own id.
 LIFECYCLE_METADATA_KEYS = (
+    RECONCILE_PENDING_KEY,
     "lifecycle_state",
     "lifecycle_flags",
     "lifecycle_action",
     "excluded_from_recall",
     "superseded_by_source_id",
     "duplicate_of_source_id",
+    CORRECTION_BLOCKERS_KEY,
+    SOURCE_BINDINGS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
 )
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/memory.py
@@ -18,6 +18,7 @@ from sibyl_core.projection.inheritance import (
     LIFECYCLE_METADATA_KEYS,
     parent_lifecycle_as_stored,
 )
+from sibyl_core.projection.pending import PENDING_KEYS, inherited_pending, pending_patch
 from sibyl_core.projection.reconcile import reconcile_with_parent
 from sibyl_core.retrieval.dedup import DedupConfig, EntityDeduplicator
 from sibyl_core.retrieval.fact_frames import FactFrame, extract_evidence_fact_frames
@@ -776,7 +777,10 @@ def _add_projection_candidates(
             now=now,
             source=source,
         )
-        projected_by_id.setdefault(entity.id, entity)
+        shared = projected_by_id.setdefault(entity.id, entity)
+        shared.metadata.update(
+            pending_patch(shared.metadata, entity.metadata, authority=f"parent:{source.id}")
+        )
         projected_links.append(
             ProjectedEntitySourceLink(
                 entity_id=entity.id,
@@ -1230,11 +1234,14 @@ def _inherited_scope_metadata(source: Entity) -> dict[str, object]:
     would.
     """
     metadata = dict(source.metadata or {})
-    return {
+    inherited = {
         key: metadata[key]
         for key in (*_SCOPE_METADATA_KEYS, *LIFECYCLE_METADATA_KEYS)
-        if key in metadata and metadata[key] is not None
+        if key not in PENDING_KEYS and key in metadata and metadata[key] is not None
     }
+    inherited.update(inherited_pending(metadata, f"parent:{source.id}"))
+    inherited["lifecycle_reconciliation_pending"] = {f"parent:{source.id}": True}
+    return inherited
 
 
 def _projection_allowed(source: Entity) -> bool:

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -34,6 +34,7 @@ from sibyl_core.projection.inheritance import (
     LIFECYCLE_METADATA_KEYS,
     parent_lifecycle_as_stored,
 )
+from sibyl_core.projection.pending import PENDING_KEYS, inherited_pending
 from sibyl_core.projection.reconcile import reconcile_with_parent
 from sibyl_core.projection.slicing import HARD_MAX, Slice, render_slice, slice_prose
 from sibyl_core.tools.helpers import _generate_id
@@ -822,11 +823,14 @@ def _inherited_scope_metadata(source: Entity) -> dict[str, object]:
     the retirement never named.
     """
     metadata = dict(source.metadata or {})
-    return {
+    inherited = {
         key: metadata[key]
         for key in (*_SCOPE_METADATA_KEYS, *LIFECYCLE_METADATA_KEYS)
-        if key in metadata and metadata[key] is not None
+        if key not in PENDING_KEYS and key in metadata and metadata[key] is not None
     }
+    inherited.update(inherited_pending(metadata, f"parent:{source.id}"))
+    inherited["lifecycle_reconciliation_pending"] = {f"parent:{source.id}": True}
+    return inherited
 
 
 __all__ = [

--- a/packages/python/sibyl-core/src/sibyl_core/projection/pending.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/pending.py
@@ -1,0 +1,43 @@
+"""Keep independent projection authorities from clearing each other's work."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from sibyl_core.memory_pipeline.lifecycle import RECONCILE_PENDING_KEY
+from sibyl_core.memory_pipeline.source_lifecycle import SOURCE_VALIDATION_PENDING_KEY
+
+PENDING_KEYS = (RECONCILE_PENDING_KEY, SOURCE_VALIDATION_PENDING_KEY)
+_LEGACY_OWNER = "unknown"
+
+
+def inherited_pending(metadata: Mapping[str, Any], authority: str) -> dict[str, Any]:
+    """An inherited exclusion belongs to the immediate parent that supplied it."""
+    return {key: {authority: True} for key in PENDING_KEYS if metadata.get(key)}
+
+
+def pending_patch(
+    metadata: Mapping[str, Any],
+    verdict: Mapping[str, Any],
+    *,
+    authority: str,
+) -> dict[str, Any]:
+    """Replace only one authority's pending verdict under the caller's row CAS.
+
+    Boolean markers predate source ownership. Retain those as unknown rather
+    than allowing an arbitrary source to certify them. New inherited markers
+    acquire an owner before their derived row is inserted.
+    """
+    patch: dict[str, Any] = {}
+    for key in PENDING_KEYS:
+        previous = metadata.get(key)
+        owners = dict(previous) if isinstance(previous, Mapping) else {}
+        if previous and not isinstance(previous, Mapping):
+            owners[_LEGACY_OWNER] = True
+        if verdict.get(key):
+            owners[authority] = True
+        else:
+            owners.pop(authority, None)
+        value = owners or None
+        if previous != value:
+            patch[key] = value
+    return patch

--- a/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/reconcile.py
@@ -31,11 +31,24 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Coroutine, Mapping, Sequence
 from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 import structlog
 
+from sibyl_core.memory_pipeline.lifecycle import (
+    RECONCILE_PENDING_KEY,
+    graph_metadata_recallable,
+)
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    CORRECTION_BLOCKERS_KEY,
+    SOURCE_BINDINGS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+    SourceCorrection,
+    merge_source_correction,
+)
 from sibyl_core.projection.inheritance import inherited_lifecycle_metadata
+from sibyl_core.projection.pending import PENDING_KEYS, inherited_pending, pending_patch
 
 log = structlog.get_logger()
 
@@ -57,19 +70,9 @@ RECONCILE_FENCE_ATTEMPTS = 5
 # not check" and "it is fine" are not the same statement and a reader cannot
 # tell them apart from the row. Cleared by the next pass that manages to read a
 # verdict, and by a correction or restore that writes one.
-RECONCILE_PENDING_KEY = "lifecycle_reconciliation_pending"
+_UNVERIFIED_STAMP: dict[str, Any] = {RECONCILE_PENDING_KEY: True}
 
-_UNVERIFIED_STAMP: dict[str, Any] = {
-    "excluded_from_recall": True,
-    RECONCILE_PENDING_KEY: True,
-}
-
-# What a row carries once somebody could read its verdict and it said nothing
-# is wrong. `None` removes a key on the graph's merge patch, which is how the
-# marker actually leaves the row rather than merely reading falsy.
-_CLEARED_MARKER: dict[str, Any] = {RECONCILE_PENDING_KEY: None}
-
-_VerdictReader = Callable[[], Coroutine[Any, Any, dict[str, Any]]]
+_VerdictReader = Callable[[Mapping[str, Any]], Coroutine[Any, Any, dict[str, Any]]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -143,8 +146,8 @@ def _row_metadata(row: Any) -> dict[str, Any]:
 
 
 def _row_revision(row: Any) -> int | None:
-    revision = getattr(row, "revision", None)
-    return revision if isinstance(revision, int) else None
+    revision = getattr(row, "observed_revision", None)
+    return revision if type(revision) is int and revision > 0 else None
 
 
 def _revision_conflict(exc: BaseException) -> bool:
@@ -184,6 +187,7 @@ async def _write_stamp(
                 row_id,
                 {"metadata": dict(patch)},
                 expected_revision=expected_revision,
+                replace_metadata_keys=tuple(key for key in PENDING_KEYS if key in patch),
             )
         except Exception as exc:
             if _revision_conflict(exc):
@@ -223,18 +227,47 @@ async def _read_row(entity_manager: Any, row_id: str) -> tuple[Any, bool]:
 
 
 def _desired_patch(verdict: Mapping[str, Any], current: Mapping[str, Any]) -> dict[str, Any]:
-    """What has to change on a row whose verdict is now known.
+    """Merge observed source clocks without changing authored exclusions or bindings.
 
-    An empty verdict on a row that carries an exclusion is a real change, not a
-    no-op: the capture was corrected and then restored while this row was being
-    written, so the exclusion has to come back off.
+    A post-write read observes source state, not which source text the row used.
+    Existing bindings therefore remain immutable. Root clocks merge by revision,
+    including when the row already carries a later correction than this read.
     """
 
-    if verdict:
-        return {key: value for key, value in verdict.items() if current.get(key) != value}
-    if current.get("excluded_from_recall"):
-        return {"excluded_from_recall": False}
-    return {}
+    merged = dict(current)
+    for key, value in verdict.items():
+        if key == SOURCE_BINDINGS_KEY:
+            continue
+        if key == CORRECTION_BLOCKERS_KEY:
+            if not isinstance(value, Mapping):
+                raise ValueError("correction clocks must be a mapping")
+            for root_id, entry in value.items():
+                if not isinstance(entry, Mapping):
+                    raise ValueError("source correction clock must be a mapping")
+                revision = entry.get("revision")
+                blocking = entry.get("blocking")
+                if (
+                    not isinstance(root_id, str)
+                    or not isinstance(revision, int)
+                    or isinstance(revision, bool)
+                    or not isinstance(blocking, bool)
+                ):
+                    raise ValueError("source correction clock has invalid fields")
+                merged = merge_source_correction(
+                    merged,
+                    SourceCorrection(root_id=root_id, revision=revision, blocking=blocking),
+                )
+            continue
+        if (
+            key not in {SOURCE_VALIDATION_PENDING_KEY, RECONCILE_PENDING_KEY}
+            and key in current
+            and not graph_metadata_recallable({key: current[key]})
+        ):
+            # Flat legacy/parent verdicts cannot establish ownership of an
+            # existing exclusion. A clear verdict must not erase an own hide.
+            continue
+        merged[key] = value
+    return {key: value for key, value in merged.items() if current.get(key) != value}
 
 
 async def _reconcile_row(
@@ -244,6 +277,7 @@ async def _reconcile_row(
     operation: str,
     organization_id: str | None,
     read_verdict: _VerdictReader,
+    authority: str,
 ) -> str:
     """Bring one written row into agreement with its verdict, under the fence."""
 
@@ -254,27 +288,27 @@ async def _reconcile_row(
             # no safe write from here. An unfenced write at this point is how a
             # run of failed reads ends up overwriting a correction that landed
             # while they were failing.
-            return await _force_exclusion(entity_manager, row_id, operation, organization_id)
+            return await _force_exclusion(
+                entity_manager, row_id, operation, organization_id, authority
+            )
         if row is None:
             # The row is gone. Nothing to reconcile and nothing to fail over.
             return "missing"
         metadata = _row_metadata(row)
         revision = _row_revision(row)
 
-        verdict, verified = await _with_retries(operation, read_verdict)
+        verdict, verified = await _with_retries(operation, partial(read_verdict, metadata))
         if not verified:
-            if metadata and inherited_lifecycle_metadata(metadata):
-                # Somebody authoritative already wrote a verdict onto this row,
-                # so an unread capture does not make it unverified.
-                return "unchanged"
             if revision is None:
                 # Every write is fenced, so a row that cannot supply a revision
                 # cannot be written from here.
-                return await _force_exclusion(entity_manager, row_id, operation, organization_id)
+                return await _force_exclusion(
+                    entity_manager, row_id, operation, organization_id, authority
+                )
             applied, fenced_out = await _write_stamp(
                 entity_manager,
                 row_id,
-                _UNVERIFIED_STAMP,
+                pending_patch(metadata, _UNVERIFIED_STAMP, authority=authority),
                 expected_revision=revision,
             )
             if applied:
@@ -290,17 +324,30 @@ async def _reconcile_row(
             continue
 
         current = dict(verdict or {})
-        patch = _desired_patch(current, metadata)
-        if metadata.get(RECONCILE_PENDING_KEY):
-            # A verdict was readable this time, so the marker that said nobody
-            # could read one has to come off with the same write.
-            patch.update(_CLEARED_MARKER)
+        try:
+            patch = _desired_patch(
+                {key: value for key, value in current.items() if key not in PENDING_KEYS},
+                metadata,
+            )
+            patch.update(pending_patch(metadata, current, authority=authority))
+        except (TypeError, ValueError) as exc:
+            log.warning(
+                "lifecycle_reconciliation_invalid_verdict",
+                operation=operation,
+                entity_id=row_id,
+                error_type=type(exc).__name__,
+            )
+            return await _force_exclusion(
+                entity_manager, row_id, operation, organization_id, authority
+            )
         if not patch:
             return "unchanged"
         if revision is None:
             # The row needs a write and cannot be fenced, which is the one
             # combination this pass refuses to resolve by writing anyway.
-            return await _force_exclusion(entity_manager, row_id, operation, organization_id)
+            return await _force_exclusion(
+                entity_manager, row_id, operation, organization_id, authority
+            )
 
         applied, fenced_out = await _write_stamp(
             entity_manager,
@@ -309,15 +356,23 @@ async def _reconcile_row(
             expected_revision=revision,
         )
         if applied:
+            remaining = {**metadata, **patch}
+            unverified = any(remaining.get(key) for key in PENDING_KEYS)
+            cleared_marker = not unverified and any(
+                metadata.get(key) and key in patch for key in PENDING_KEYS
+            )
             log.info(
                 "lifecycle_reconciliation_restamped",
                 operation=operation,
                 organization_id=organization_id,
                 entity_id=row_id,
                 lifecycle_state=current.get("lifecycle_state"),
-                cleared_marker=RECONCILE_PENDING_KEY in patch,
+                cleared_marker=cleared_marker,
+                unverified=unverified,
             )
-            return "cleared" if set(patch) == {RECONCILE_PENDING_KEY} else "restamped"
+            if unverified:
+                return "unverified"
+            return "cleared" if cleared_marker else "restamped"
         if fenced_out:
             # Somebody wrote between this pass's read and its write. Re-read and
             # agree with them rather than overwriting a newer verdict.
@@ -326,7 +381,7 @@ async def _reconcile_row(
 
     # Every attempt lost the fence or failed to apply. The row's verdict is
     # unknown to this pass, so it is excluded rather than left servable.
-    return await _force_exclusion(entity_manager, row_id, operation, organization_id)
+    return await _force_exclusion(entity_manager, row_id, operation, organization_id, authority)
 
 
 async def _force_exclusion(
@@ -334,6 +389,7 @@ async def _force_exclusion(
     row_id: str,
     operation: str,
     organization_id: str | None,
+    authority: str,
 ) -> str:
     """Exclude a row this pass could not settle, or say plainly that it could not.
 
@@ -348,9 +404,6 @@ async def _force_exclusion(
         if row_read and row is None:
             return "missing"
         metadata = _row_metadata(row)
-        if inherited_lifecycle_metadata(metadata):
-            # A verdict landed while this pass was losing its fences.
-            return "unchanged"
         revision = _row_revision(row)
         applied = False
         if revision is not None:
@@ -361,7 +414,7 @@ async def _force_exclusion(
             applied, _fenced_out = await _write_stamp(
                 entity_manager,
                 row_id,
-                _UNVERIFIED_STAMP,
+                pending_patch(metadata, _UNVERIFIED_STAMP, authority=authority),
                 expected_revision=revision,
             )
         if applied:
@@ -393,6 +446,7 @@ async def _reconcile(
     organization_id: str | None,
     read_verdict: _VerdictReader,
     row_ids: Sequence[str],
+    authority: str,
 ) -> ReconcileOutcome:
     ids = [str(row_id) for row_id in dict.fromkeys(row_ids) if row_id]
     if not ids:
@@ -408,6 +462,7 @@ async def _reconcile(
             operation=operation,
             organization_id=organization_id,
             read_verdict=read_verdict,
+            authority=authority,
         )
         if result == "restamped":
             restamped += 1
@@ -421,6 +476,17 @@ async def _reconcile(
         unverified=unverified,
         cleared=cleared,
     )
+
+
+def _capture_authority(metadata: Mapping[str, Any] | None) -> str:
+    fields = metadata or {}
+    memory_id = fields.get("raw_memory_id")
+    if isinstance(memory_id, str) and memory_id.strip():
+        return f"capture:{memory_id.strip()}"
+    source_id = fields.get("raw_source_id")
+    if isinstance(source_id, str) and source_id.strip():
+        return f"capture-source:{source_id.strip()}"
+    return "capture:unbound"
 
 
 async def prewrite_capture_stamp(
@@ -445,7 +511,16 @@ async def prewrite_capture_stamp(
         )
 
     stamp, verified = await _with_retries("capture_prewrite", read)
-    return dict(stamp or {}), verified
+    verdict = dict(stamp or {})
+    if not verified or (metadata or {}).get("raw_memory_id"):
+        # The insert is not source-validated until its post-write check lands.
+        # A row read failure must leave durable exclusion, not a servable row.
+        verdict[RECONCILE_PENDING_KEY] = True
+    authority = _capture_authority(metadata)
+    return {
+        **{key: value for key, value in verdict.items() if key not in PENDING_KEYS},
+        **inherited_pending(verdict, authority),
+    }, verified
 
 
 async def reconcile_with_capture(
@@ -454,20 +529,41 @@ async def reconcile_with_capture(
     organization_id: str,
     metadata: Mapping[str, Any] | None,
     row_ids: Sequence[str],
+    expected_signature: str | None = None,
 ) -> ReconcileOutcome:
     """Re-check written rows against the capture they were projected from."""
 
     from sibyl_core.services.memory import projected_row_lifecycle_stamp
 
-    async def read() -> dict[str, Any]:
+    authority = _capture_authority(metadata)
+    if expected_signature is not None:
+        if (
+            not authority.startswith("capture:")
+            or authority == "capture:unbound"
+            or len(expected_signature) != 64
+            or any(char not in "0123456789abcdef" for char in expected_signature)
+        ):
+            raise ValueError("signature reconciliation requires a capture ID and SHA256 digest")
+        authority = (
+            f"capture-signature-v1:{authority.removeprefix('capture:')}:{expected_signature}"
+        )
+
+    async def read(row_metadata: Mapping[str, Any]) -> dict[str, Any]:
         return await projected_row_lifecycle_stamp(
             organization_id=organization_id,
-            metadata=metadata,
+            metadata={
+                **(metadata or {}),
+                SOURCE_BINDINGS_KEY: row_metadata.get(SOURCE_BINDINGS_KEY, {}),
+            },
+            **(
+                {"expected_signature": expected_signature} if expected_signature is not None else {}
+            ),
         )
 
     return await _reconcile(
         entity_manager,
         operation="capture",
+        authority=authority,
         organization_id=organization_id,
         read_verdict=read,
         row_ids=row_ids,
@@ -483,19 +579,24 @@ async def reconcile_with_parent(
 ) -> ReconcileOutcome:
     """Re-check written derived rows against the parent they were derived from."""
 
-    async def read() -> dict[str, Any]:
+    async def read(_row_metadata: Mapping[str, Any]) -> dict[str, Any]:
         get = getattr(entity_manager, "get", None)
         if not callable(get):
-            return {}
+            return dict(_UNVERIFIED_STAMP)
         try:
             stored = await get(str(source_id))
         except KeyError:
-            return {}
+            stored = None
+        if stored is None:
+            # Absence supplies no lifecycle verdict. Keep this parent's check
+            # pending so a later read can recover it without retiring the child.
+            return dict(_UNVERIFIED_STAMP)
         return inherited_lifecycle_metadata(getattr(stored, "metadata", None))
 
     return await _reconcile(
         entity_manager,
         operation="parent",
+        authority=f"parent:{source_id}",
         organization_id=organization_id,
         read_verdict=read,
         row_ids=row_ids,

--- a/packages/python/sibyl-core/src/sibyl_core/projection/repair.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/repair.py
@@ -1,0 +1,129 @@
+"""Discover and retry pending graph lifecycle checks without regenerating text."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import structlog
+
+from sibyl_core.projection.pending import PENDING_KEYS
+from sibyl_core.projection.reconcile import reconcile_with_capture, reconcile_with_parent
+from sibyl_core.services.graph_common import normalize_graph_records
+from sibyl_core.services.graph_runtime import GraphRuntime
+
+log = structlog.get_logger()
+_PAGE_SIZE = 512
+# Leave the terminator to callers so qualification can append EXPLAIN.
+PENDING_REPAIR_QUERY = (
+    "SELECT uuid, lifecycle_repair_key FROM entity WITH INDEX idx_entity_lifecycle_repair_key "
+    "WHERE lifecycle_repair_key > $cursor "
+    "AND group_id = $group_id ORDER BY lifecycle_repair_key LIMIT $limit"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleRepairResult:
+    """Recovered counts cleared checks; authored exclusions may still apply."""
+
+    checked: int = 0
+    recovered: int = 0
+    pending: int = 0
+    failed: int = 0
+
+
+async def _repair_row(runtime: GraphRuntime, row_id: str) -> str:
+    manager = runtime.entity_manager
+    try:
+        row = await manager.get(row_id)
+    except KeyError:
+        return "missing"
+    owners: set[str] = set()
+    for key in PENDING_KEYS:
+        value = row.metadata.get(key)
+        if isinstance(value, Mapping):
+            owners.update(
+                owner for owner, pending in value.items() if pending and isinstance(owner, str)
+            )
+    for owner in sorted(owners):
+        kind, separator, source_id = owner.partition(":")
+        if not separator or not source_id or owner == "capture:unbound":
+            continue
+        if kind == "capture-signature-v1":
+            capture_id, separator, signature = source_id.rpartition(":")
+            if (
+                not separator
+                or not capture_id
+                or len(signature) != 64
+                or any(char not in "0123456789abcdef" for char in signature)
+            ):
+                continue
+            await reconcile_with_capture(
+                manager,
+                organization_id=runtime.client.group_id,
+                metadata={"raw_memory_id": capture_id},
+                row_ids=[row_id],
+                expected_signature=signature,
+            )
+        elif kind == "parent":
+            await reconcile_with_parent(
+                manager,
+                source_id=source_id,
+                row_ids=[row_id],
+                organization_id=runtime.client.group_id,
+            )
+        elif kind in {"capture", "capture-source"}:
+            locator = "raw_memory_id" if kind == "capture" else "raw_source_id"
+            await reconcile_with_capture(
+                manager,
+                organization_id=runtime.client.group_id,
+                metadata={locator: source_id},
+                row_ids=[row_id],
+            )
+    try:
+        current = await manager.get(row_id)
+    except KeyError:
+        return "missing"
+    return "pending" if any(current.metadata.get(key) for key in PENDING_KEYS) else "recovered"
+
+
+async def repair_graph_lifecycle(runtime: GraphRuntime) -> LifecycleRepairResult:
+    """Retry each pending row once per sweep with the existing source-owned CAS.
+
+    Unknown legacy owners stay pending until their provenance can be migrated.
+    Keyset pagination advances past unresolved rows so they cannot starve later
+    work. Concurrent sweeps are safe because every reconciliation is fenced.
+    """
+    cursor = ""
+    counts = {"checked": 0, "recovered": 0, "pending": 0, "failed": 0}
+    while True:
+        rows = normalize_graph_records(
+            await runtime.client.execute_query(
+                PENDING_REPAIR_QUERY + ";",
+                cursor=cursor,
+                group_id=runtime.client.group_id,
+                limit=_PAGE_SIZE,
+            )
+        )
+        if not rows:
+            break
+        outcomes = await asyncio.gather(
+            *(_repair_row(runtime, str(row["uuid"])) for row in rows),
+            return_exceptions=True,
+        )
+        counts["checked"] += len(rows)
+        for outcome in outcomes:
+            if isinstance(outcome, BaseException):
+                counts["failed"] += 1
+                log.warning(
+                    "lifecycle_repair_row_failed",
+                    group_id=runtime.client.group_id,
+                    error_type=type(outcome).__name__,
+                )
+            elif outcome in counts:
+                counts[outcome] += 1
+        cursor = str(rows[-1]["lifecycle_repair_key"])
+        if len(rows) < _PAGE_SIZE:
+            break
+    return LifecycleRepairResult(**counts)

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+import asyncio
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime
 from typing import cast
 from uuid import uuid4
 
-from sibyl_core.auth.memory_policy import EVAL_ADMISSION_METADATA_KEY
+from sibyl_core.auth.memory_policy import MEMORY_PROVENANCE_METADATA_KEYS
 from sibyl_core.backends.surreal import SurrealContentClient
 from sibyl_core.embeddings.providers import (
     EmbeddingProvider,
@@ -16,6 +17,12 @@ from sibyl_core.embeddings.providers import (
 from sibyl_core.errors import RevisionConflictError
 from sibyl_core.memory_pipeline.quality import (
     normalize_memory_quality_metadata,
+)
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    SOURCE_BINDINGS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+    declared_source_ids,
+    source_revision_bindings,
 )
 from sibyl_core.models.memory_scope import MemoryScope
 from sibyl_core.models.reflection import (
@@ -138,7 +145,12 @@ def _raw_memory_from_write(write: RawMemoryWrite, *, captured_at: datetime) -> R
     normalized_scope = models.coerce_memory_scope(write.memory_scope)
     models.validate_raw_memory_scope(normalized_scope, write.scope_key)
     metadata = normalize_memory_quality_metadata(write.metadata or {})
-    metadata.pop(EVAL_ADMISSION_METADATA_KEY, None)
+    for key in MEMORY_PROVENANCE_METADATA_KEYS:
+        metadata.pop(key, None)
+    sources = declared_source_ids(metadata)
+    if sources:
+        metadata["raw_source_ids"] = list(sources)
+        metadata[SOURCE_VALIDATION_PENDING_KEY] = True
     return RawMemory(
         id=str(uuid4()),
         organization_id=write.organization_id,
@@ -165,7 +177,11 @@ async def _raw_memory_with_embedding(
     memory: RawMemory,
     embedding_provider: EmbeddingProvider | None,
 ) -> RawMemory:
-    if embedding_provider is None or memory.embedding is not None:
+    if (
+        embedding_provider is None
+        or memory.embedding is not None
+        or not models.raw_memory_recallable(memory)
+    ):
         return memory
     embeddings = await embedding_provider.embed_texts(
         [
@@ -194,10 +210,16 @@ async def _raw_memories_with_embeddings(
 ) -> list[RawMemory]:
     if embedding_provider is None:
         return list(memories)
-    pending = [memory for memory in memories if memory.embedding is None]
+    pending = [
+        memory
+        for memory in memories
+        if memory.embedding is None and models.raw_memory_recallable(memory)
+    ]
     if not pending:
         return list(memories)
 
+    if not pending:
+        return list(memories)
     embeddings = await embedding_provider.embed_texts(
         [
             models.raw_memory_embedding_text(
@@ -322,7 +344,23 @@ async def remember_raw_memory(
     capture_surface: str | None = None,
     entity_type: str = "raw_memory",
     embedding_provider: EmbeddingProvider | object | None = _RAW_MEMORY_EMBEDDING_AUTO,
+    source_memories: Sequence[RawMemory] = (),
+    accessible_projects: Iterable[str] | None = None,
+    accessible_teams: Iterable[str] | None = None,
+    accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> RawMemory:
+    from sibyl_core.services.memory_source_validation import (
+        SOURCE_VALIDATION_CONTEXT_KEY,
+        SourceReadAuthority,
+    )
+
+    accessible_projects = tuple(accessible_projects or ())
+    accessible_teams = tuple(accessible_teams or ())
+    accessible_delegations = tuple(accessible_delegations or ())
+    allowed_memory_scope_keys = (
+        None if allowed_memory_scope_keys is None else frozenset(allowed_memory_scope_keys)
+    )
     memory = _raw_memory_from_write(
         RawMemoryWrite(
             organization_id=organization_id,
@@ -340,6 +378,22 @@ async def remember_raw_memory(
         ),
         captured_at=models.utcnow(),
     )
+    if source_memories:
+        memory.metadata[SOURCE_BINDINGS_KEY] = source_revision_bindings(source_memories)
+        memory.metadata["raw_source_ids"] = list(
+            dict.fromkeys(
+                [*declared_source_ids(memory.metadata), *(source.id for source in source_memories)]
+            )
+        )
+        memory.metadata[SOURCE_VALIDATION_PENDING_KEY] = True
+    if memory.metadata.get(SOURCE_VALIDATION_PENDING_KEY):
+        memory.metadata[SOURCE_VALIDATION_CONTEXT_KEY] = SourceReadAuthority(
+            principal_id=principal_id,
+            projects=frozenset(accessible_projects),
+            teams=frozenset(accessible_teams),
+            delegations=frozenset(accessible_delegations),
+            scope_keys=allowed_memory_scope_keys,
+        ).ceiling_metadata()
     provider = (
         models.configured_raw_memory_embedding_provider()
         if embedding_provider is _RAW_MEMORY_EMBEDDING_AUTO
@@ -353,18 +407,57 @@ async def remember_raw_memory(
             uuid=memory.id,
             record=models.raw_memory_record(memory),
         )
-    return models.raw_memory_from_record(record)
+    stored = models.raw_memory_from_record(record)
+    if stored.metadata.get(SOURCE_VALIDATION_PENDING_KEY):
+        from sibyl_core.services.memory_source_validation import reconcile_raw_source_lifecycle
+
+        stored = await reconcile_raw_source_lifecycle(
+            stored,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            accessible_teams=accessible_teams,
+            accessible_delegations=accessible_delegations,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
+            embedding_provider=provider,
+        )
+    return stored
 
 
 async def remember_raw_memories(
     writes: Sequence[RawMemoryWrite],
     *,
     embedding_provider: EmbeddingProvider | object | None = _RAW_MEMORY_EMBEDDING_AUTO,
+    accessible_projects: Iterable[str] | None = None,
+    accessible_teams: Iterable[str] | None = None,
+    accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> list[RawMemory]:
+    from sibyl_core.services.memory_source_validation import (
+        SOURCE_VALIDATION_CONTEXT_KEY,
+        SourceReadAuthority,
+    )
+
     if not writes:
         return []
+    accessible_projects = None if accessible_projects is None else tuple(accessible_projects)
+    accessible_teams = None if accessible_teams is None else tuple(accessible_teams)
+    accessible_delegations = (
+        None if accessible_delegations is None else tuple(accessible_delegations)
+    )
+    allowed_memory_scope_keys = (
+        None if allowed_memory_scope_keys is None else frozenset(allowed_memory_scope_keys)
+    )
     now = models.utcnow()
     memories = [_raw_memory_from_write(write, captured_at=now) for write in writes]
+    for memory in memories:
+        if memory.metadata.get(SOURCE_VALIDATION_PENDING_KEY):
+            memory.metadata[SOURCE_VALIDATION_CONTEXT_KEY] = SourceReadAuthority(
+                principal_id=memory.principal_id,
+                projects=frozenset(accessible_projects or ()),
+                teams=frozenset(accessible_teams or ()),
+                delegations=frozenset(accessible_delegations or ()),
+                scope_keys=allowed_memory_scope_keys,
+            ).ceiling_metadata()
     provider = (
         models.configured_raw_memory_embedding_provider()
         if embedding_provider is _RAW_MEMORY_EMBEDDING_AUTO
@@ -377,7 +470,32 @@ async def remember_raw_memories(
             [models.raw_memory_record(memory) for memory in memories],
         )
     ordered_records = _order_raw_memory_records_by_input(memories, records)
-    return [models.raw_memory_from_record(record) for record in ordered_records]
+    stored = [models.raw_memory_from_record(record) for record in ordered_records]
+    if any(memory.metadata.get(SOURCE_VALIDATION_PENDING_KEY) for memory in stored):
+        from sibyl_core.services.memory_source_validation import reconcile_raw_source_lifecycle
+
+        pending = [
+            (index, memory)
+            for index, memory in enumerate(stored)
+            if memory.metadata.get(SOURCE_VALIDATION_PENDING_KEY)
+        ]
+        checked = await asyncio.gather(
+            *(
+                reconcile_raw_source_lifecycle(
+                    memory,
+                    principal_id=memory.principal_id,
+                    accessible_projects=accessible_projects,
+                    accessible_teams=accessible_teams,
+                    accessible_delegations=accessible_delegations,
+                    allowed_memory_scope_keys=allowed_memory_scope_keys,
+                    embedding_provider=provider,
+                )
+                for _, memory in pending
+            )
+        )
+        for (index, _), memory in zip(pending, checked, strict=True):
+            stored[index] = memory
+    return stored
 
 
 async def remember_reflection_candidate_review(
@@ -392,6 +510,11 @@ async def remember_reflection_candidate_review(
     suggested_memory_scope: MemoryScope | str | None = None,
     suggested_scope_key: str | None = None,
     extraction_prompt_metadata: dict[str, object] | None = None,
+    source_memories: Sequence[RawMemory] = (),
+    accessible_projects: Iterable[str] | None = None,
+    accessible_teams: Iterable[str] | None = None,
+    accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> RawMemory:
     normalized_scope = models.coerce_memory_scope(memory_scope)
     suggested_scope = (
@@ -437,6 +560,11 @@ async def remember_reflection_candidate_review(
         provenance={"raw_source_ids": source_ids},
         capture_surface="reflection_candidate",
         entity_type=candidate.kind,
+        source_memories=source_memories,
+        accessible_projects=accessible_projects,
+        accessible_teams=accessible_teams,
+        accessible_delegations=accessible_delegations,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
     )
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from sibyl_core.backends.surreal.connection import _is_transient_connection_error
-from sibyl_core.backends.surreal.schema import EMBEDDING_DIM
+from sibyl_core.backends.surreal.schema import EMBEDDING_DIM, render_surreal_compatible_sql
 from sibyl_core.embeddings.providers import entity_embedding_text
 from sibyl_core.memory_pipeline.retrieval_keys import coerce_retrieval_keys
 from sibyl_core.models.entities import Entity, EntityType
@@ -67,6 +67,23 @@ CLEAR_SENTINEL_VALUES = frozenset({CLEAR_MEMORY_SCOPE})
 # write path would hold the caller's own write open indefinitely.
 _MAX_SNAPSHOT_HEAL_ATTEMPTS = 5
 
+
+def _pending_upsert_entries(key: str) -> str:
+    """An insert may add pending owners; only a fenced update may clear them."""
+    return """
+        IF attributes.@key@ OR $input.attributes.@key@ {
+            [["@key@", object::from_entries(array::concat(
+                IF type::is::object(attributes.@key@) {
+                    object::entries(attributes.@key@)
+                } ELSE IF attributes.@key@ { [["unknown", true]] } ELSE { [] },
+                IF type::is::object($input.attributes.@key@) {
+                    object::entries($input.attributes.@key@)
+                } ELSE IF $input.attributes.@key@ { [["unknown", true]] } ELSE { [] }
+            ))]]
+        } ELSE { [] }
+    """.replace("@key@", key)
+
+
 _ENTITY_BULK_UPSERT_QUERY = f"""
 INSERT INTO entity $rows ON DUPLICATE KEY UPDATE
     uuid = $input.uuid,
@@ -88,7 +105,9 @@ INSERT INTO entity $rows ON DUPLICATE KEY UPDATE
     -- the slot and no later write puts it back.
     attributes = object::from_entries(array::concat(
         object::entries(attributes ?? {{}}),
-        object::entries($input.attributes)
+        object::entries($input.attributes),
+        {_pending_upsert_entries("lifecycle_reconciliation_pending")},
+        {_pending_upsert_entries("source_validation_pending")}
     )),
     attributes.memory_scope = IF $input.memory_scope = '{CLEAR_MEMORY_SCOPE}' {{ NONE }}
         ELSE {{ $input.memory_scope ?? memory_scope }},
@@ -553,7 +572,8 @@ async def _execute_replace_entities_bulk_query(
     client: SurrealGraphClient,
     records: Sequence[SurrealRecord],
 ) -> object:
-    return await client.execute_query(_ENTITY_BULK_UPSERT_QUERY, rows=list(records))
+    query = render_surreal_compatible_sql(_ENTITY_BULK_UPSERT_QUERY, url=client._url)
+    return await client.execute_query(query, rows=list(records))
 
 
 async def _execute_replace_entities_with_schema_retry(

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_records.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_records.py
@@ -157,11 +157,22 @@ def entity_from_surreal_row(row: Mapping[str, object]) -> Entity:
     if record_id and record_id != entity_id and metadata.get("record_id") is None:
         metadata["record_id"] = record_id
     metadata = normalize_memory_quality_metadata(metadata)
+    name = _first_text(normalized_row.get("name"), normalized_row.get("title"), entity_id)
+    identity = metadata.get("reflection_identity")
+    stored_name = normalized_row.get("name")
+    if (
+        isinstance(identity, Mapping)
+        and identity.get("version") == 2
+        and isinstance(stored_name, str)
+    ):
+        # A v2 identity can bind an empty title. Preserve the actual stored
+        # value so identity verification cannot confuse it with an ID fallback.
+        name = stored_name.strip()
 
     entity = Entity(
         id=entity_id,
         entity_type=_entity_type_from_row(normalized_row, attributes=attributes),
-        name=_first_text(normalized_row.get("name"), normalized_row.get("title"), entity_id),
+        name=name,
         description=_first_text(
             normalized_row.get("description"),
             normalized_row.get("summary"),

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_contract.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_contract.py
@@ -138,6 +138,8 @@ class MemoryCorrectionResult:
     # capture may still be servable. Reported rather than logged alone, because
     # a caller told "applied" has no other way to learn the write was partial.
     projection_walk_truncated: bool = False
+    affected_raw_memory_ids: list[str] = field(default_factory=list)
+    propagation_complete: bool = True
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_correction.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_correction.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from sibyl_core.auth.memory_policy import MemoryPolicyDecision
+from sibyl_core.errors import RevisionConflictError
 from sibyl_core.models.reflection import (
     MemoryLifecycle,
     MemoryLifecycleFlag,
@@ -18,6 +19,7 @@ from sibyl_core.models.reflection import (
     with_memory_lifecycle_metadata,
     with_reflection_finding_metadata,
 )
+from sibyl_core.services import memory_lifecycle
 from sibyl_core.services.memory_contract import MemoryCorrectionPreview, MemoryCorrectionResult
 from sibyl_core.services.memory_lifecycle import _project_correction_to_graph
 from sibyl_core.services.memory_policy import (
@@ -154,6 +156,7 @@ async def _validate_correction_reference(
     accessible_projects: Iterable[str] | None,
     accessible_teams: Iterable[str] | None,
     accessible_delegations: Iterable[str] | None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> tuple[RawMemory | None, str | None]:
     reference = await _load_correction_memory(
         organization_id=organization_id,
@@ -169,6 +172,7 @@ async def _validate_correction_reference(
         accessible_projects=accessible_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
     )
     if not read_decision.allowed:
         return None, f"{reference_kind}_source_not_found"
@@ -198,6 +202,32 @@ def _correction_impact(
     return recall, synthesis
 
 
+async def _visible_correction_derived_ids(
+    *,
+    organization_id: str,
+    source_id: str,
+    entity_ids: Sequence[str],
+    principal_id: str | None,
+    accessible_projects: Iterable[str] | None,
+    allowed_memory_scope_keys: Iterable[str] | None,
+) -> list[str]:
+    if not entity_ids:
+        return []
+    try:
+        runtime = await memory_lifecycle.get_surreal_graph_runtime(organization_id)
+    except Exception:
+        return []
+    return await memory_lifecycle._readable_correction_targets(
+        runtime,
+        entity_ids=entity_ids,
+        source_id=source_id,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
+        log_event="memory_correction_reference_unreadable",
+    )
+
+
 async def preview_memory_correction(
     *,
     organization_id: str,
@@ -206,12 +236,58 @@ async def preview_memory_correction(
     action: str,
     reason: str | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
     replacement_source_id: str | None = None,
     duplicate_of_source_id: str | None = None,
     revised_content: str | None = None,
 ) -> MemoryCorrectionPreview:
+    memory = await _load_correction_memory(organization_id=organization_id, source_id=source_id)
+    return await _preview_loaded_memory_correction(
+        memory=memory,
+        organization_id=organization_id,
+        source_id=source_id,
+        principal_id=principal_id,
+        action=action,
+        reason=reason,
+        accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
+        accessible_teams=accessible_teams,
+        accessible_delegations=accessible_delegations,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
+        replacement_source_id=replacement_source_id,
+        duplicate_of_source_id=duplicate_of_source_id,
+        revised_content=revised_content,
+    )
+
+
+async def _preview_loaded_memory_correction(
+    *,
+    memory: RawMemory | None,
+    organization_id: str,
+    source_id: str,
+    principal_id: str | None,
+    action: str,
+    reason: str | None = None,
+    accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
+    accessible_teams: Iterable[str] | None = None,
+    accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
+    replacement_source_id: str | None = None,
+    duplicate_of_source_id: str | None = None,
+    revised_content: str | None = None,
+) -> MemoryCorrectionPreview:
+    accessible_projects = None if accessible_projects is None else tuple(accessible_projects)
+    accessible_teams = None if accessible_teams is None else tuple(accessible_teams)
+    accessible_delegations = (
+        None if accessible_delegations is None else tuple(accessible_delegations)
+    )
+    allowed_memory_scope_keys = (
+        None if allowed_memory_scope_keys is None else frozenset(allowed_memory_scope_keys)
+    )
     requested_action = action.strip().lower()
     normalized_action = _CORRECTION_ACTION_ALIASES.get(requested_action, requested_action)
     if normalized_action not in _CORRECTION_ACTIONS:
@@ -221,10 +297,6 @@ async def preview_memory_correction(
             reason="invalid_correction_action",
         )
 
-    memory = await _load_correction_memory(
-        organization_id=organization_id,
-        source_id=source_id,
-    )
     if memory is None:
         return _correction_preview_denied(
             source_id=source_id,
@@ -247,7 +319,9 @@ async def preview_memory_correction(
     write_decision = _authorize_correction_source_write(
         memory=memory,
         principal_id=principal_id,
-        accessible_projects=accessible_projects,
+        accessible_projects=(
+            accessible_projects if writable_projects is None else tuple(writable_projects)
+        ),
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
     )
@@ -265,6 +339,25 @@ async def preview_memory_correction(
                 "requested_source_id": source_id,
             },
         )
+
+    if allowed_memory_scope_keys is not None:
+        read_decision = _authorize_share_source_read(
+            memory=memory,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            accessible_teams=accessible_teams,
+            accessible_delegations=accessible_delegations,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
+        )
+        if not read_decision.allowed:
+            return _correction_preview_denied(
+                source_id=memory.id,
+                action=normalized_action,
+                reason=read_decision.reason,
+                target_lifecycle_state=target_lifecycle_state,
+                target_lifecycle_flags=target_lifecycle_flags,
+                policy_decisions=(write_decision, read_decision),
+            )
 
     requirement_reason = _correction_requirement_reason(
         action=normalized_action,
@@ -300,6 +393,7 @@ async def preview_memory_correction(
             accessible_projects=accessible_projects,
             accessible_teams=accessible_teams,
             accessible_delegations=accessible_delegations,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
         )
         if reference_reason:
             return _correction_preview_denied(
@@ -327,6 +421,7 @@ async def preview_memory_correction(
             accessible_projects=accessible_projects,
             accessible_teams=accessible_teams,
             accessible_delegations=accessible_delegations,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
         )
         if reference_reason:
             return _correction_preview_denied(
@@ -349,7 +444,14 @@ async def preview_memory_correction(
         target_lifecycle_state,
         target_lifecycle_flags,
     )
-    affected_derived_ids = _correction_derived_ids(memory)
+    affected_derived_ids = await _visible_correction_derived_ids(
+        organization_id=organization_id,
+        source_id=memory.id,
+        entity_ids=_correction_derived_ids(memory),
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
+    )
     metadata = {
         "duplicate_of_source_id": canonical_duplicate_of_source_id,
         "policy_allowed": True,
@@ -504,22 +606,37 @@ async def apply_memory_correction(
     action: str,
     reason: str | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
     replacement_source_id: str | None = None,
     duplicate_of_source_id: str | None = None,
     revised_content: str | None = None,
     expected_revision: int | None = None,
 ) -> MemoryCorrectionResult:
-    preview = await preview_memory_correction(
+    accessible_projects = None if accessible_projects is None else tuple(accessible_projects)
+    writable_projects = None if writable_projects is None else tuple(writable_projects)
+    accessible_teams = None if accessible_teams is None else tuple(accessible_teams)
+    accessible_delegations = (
+        None if accessible_delegations is None else tuple(accessible_delegations)
+    )
+    allowed_memory_scope_keys = (
+        None if allowed_memory_scope_keys is None else frozenset(allowed_memory_scope_keys)
+    )
+    memory = await _load_correction_memory(organization_id=organization_id, source_id=source_id)
+    preview = await _preview_loaded_memory_correction(
+        memory=memory,
         organization_id=organization_id,
         source_id=source_id,
         principal_id=principal_id,
         action=action,
         reason=reason,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
         replacement_source_id=replacement_source_id,
         duplicate_of_source_id=duplicate_of_source_id,
         revised_content=revised_content,
@@ -527,7 +644,6 @@ async def apply_memory_correction(
     if not preview.allowed:
         return MemoryCorrectionResult(applied=False, preview=preview)
 
-    memory = await _load_correction_memory(organization_id=organization_id, source_id=source_id)
     if memory is None:
         denied = _correction_preview_denied(
             source_id=source_id,
@@ -537,6 +653,17 @@ async def apply_memory_correction(
             target_lifecycle_flags=preview.target_lifecycle_flags,
         )
         return MemoryCorrectionResult(applied=False, preview=denied)
+    if memory.observed_revision is None:
+        denied = _correction_preview_denied(
+            source_id=memory.id,
+            action=preview.action,
+            reason="memory_source_revision_unavailable",
+            target_lifecycle_state=preview.target_lifecycle_state,
+            target_lifecycle_flags=preview.target_lifecycle_flags,
+        )
+        return MemoryCorrectionResult(applied=False, preview=denied)
+    if expected_revision is not None and expected_revision != memory.observed_revision:
+        raise RevisionConflictError(memory.id, expected_revision, memory.observed_revision)
     preview_metadata = preview.metadata or {}
     canonical_replacement_source_id = (
         _metadata_str(preview_metadata, "replacement_source_id") or replacement_source_id
@@ -570,9 +697,7 @@ async def apply_memory_correction(
             principal_id=principal_id,
         ),
     )
-    save_kwargs: dict[str, Any] = {}
-    if expected_revision is not None:
-        save_kwargs["expected_revision"] = expected_revision
+    save_kwargs: dict[str, Any] = {"expected_revision": memory.observed_revision}
     if preview.action == "supersede" and canonical_replacement_source_id is not None:
         save_kwargs["superseded_by_memory_id"] = canonical_replacement_source_id
     saved = await save_raw_memory(updated, **save_kwargs)
@@ -580,20 +705,34 @@ async def apply_memory_correction(
         affected_entity_ids,
         refused_entity_ids,
         projection_walk_truncated,
+        propagation,
     ) = await _project_correction_to_graph(
         organization_id=organization_id,
         memory=saved,
         preview=preview,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         replacement_source_id=canonical_replacement_source_id,
         duplicate_of_source_id=canonical_duplicate_of_source_id,
+        accessible_teams=accessible_teams,
+        accessible_delegations=accessible_delegations,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
     )
     return MemoryCorrectionResult(
         applied=True,
         preview=preview,
         updated_memory=saved,
         affected_entity_ids=affected_entity_ids,
-        refused_entity_ids=refused_entity_ids,
+        refused_entity_ids=await _visible_correction_derived_ids(
+            organization_id=organization_id,
+            source_id=memory.id,
+            entity_ids=refused_entity_ids,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
+        ),
         projection_walk_truncated=projection_walk_truncated,
+        affected_raw_memory_ids=propagation.raw_memory_ids,
+        propagation_complete=propagation.complete and not refused_entity_ids,
     )

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_identity.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_identity.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import hashlib
 import json
+from typing import Literal
 
 from sibyl_core.models.entities import Entity
 
 IDENTITY_KEY = "reflection_identity"
+SOURCE_SNAPSHOT_KEY = "source_snapshot_sha256"
 
 
-def reflection_identity(entity: Entity) -> dict[str, object]:
+def reflection_identity(
+    entity: Entity, *, version: Literal[2, 3] | None = None
+) -> dict[str, object]:
     """Bind full evidence to its authoritative ownership and provenance.
 
     Title whitespace follows graph read normalization; content is byte-exact. Extraction
@@ -18,6 +22,7 @@ def reflection_identity(entity: Entity) -> dict[str, object]:
     Legacy title-derived IDs remain readable and are never rewritten here.
     """
     metadata = entity.metadata
+    version = version or (3 if metadata.get(SOURCE_SNAPSHOT_KEY) else 2)
     source_ids = {
         str(value)
         for key in ("raw_source_ids", "source_ids")
@@ -27,7 +32,8 @@ def reflection_identity(entity: Entity) -> dict[str, object]:
     if entity.source_file:
         source_ids.add(entity.source_file)
     identity = {
-        "version": 2,
+        "version": version,
+        SOURCE_SNAPSHOT_KEY: metadata.get(SOURCE_SNAPSHOT_KEY) if version == 3 else None,
         "purpose": "source" if metadata.get("reflection_source") is True else "candidate",
         "kind": entity.entity_type.value,
         "title": entity.name.strip(),
@@ -49,10 +55,11 @@ def reflection_identity(entity: Entity) -> dict[str, object]:
     return {key: value for key, value in identity.items() if value is not None}
 
 
-def reflection_entity_id(entity: Entity) -> str:
-    payload = json.dumps(reflection_identity(entity), sort_keys=True, separators=(",", ":"))
+def reflection_entity_id(entity: Entity, *, version: Literal[2, 3] | None = None) -> str:
+    identity = reflection_identity(entity, version=version)
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":"))
     digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
-    return f"{entity.entity_type.value}_v2_{digest}"
+    return f"{entity.entity_type.value}_v{identity['version']}_{digest}"
 
 
 def verify_reflection_identity(expected: Entity, stored: Entity) -> None:

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_lifecycle.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_lifecycle.py
@@ -9,8 +9,20 @@ from typing import Any
 
 import structlog
 
-from sibyl_core.auth.memory_policy import memory_metadata_read_allowed, memory_row_project_id
-from sibyl_core.memory_pipeline.lifecycle import graph_lifecycle_stamp
+from sibyl_core.auth.memory_policy import (
+    memory_metadata_read_allowed,
+    memory_row_project_id,
+    private_scope_granted_for,
+)
+from sibyl_core.memory_pipeline.lifecycle import (
+    RECONCILE_PENDING_KEY,
+    graph_lifecycle_stamp,
+    graph_metadata_recallable,
+)
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    SOURCE_BINDINGS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+)
 from sibyl_core.models.entities import Relationship, RelationshipType
 from sibyl_core.models.reflection import (
     ReflectionCandidate,
@@ -18,9 +30,9 @@ from sibyl_core.models.reflection import (
     claim_records_from_metadata,
     reflection_findings_from_metadata,
 )
-from sibyl_core.projection.reconcile import RECONCILE_PENDING_KEY
 from sibyl_core.services.graph import get_surreal_graph_runtime, normalize_records
 from sibyl_core.services.memory_contract import MemoryCorrectionPreview
+from sibyl_core.services.memory_lineage import CorrectionPropagation, propagate_source_correction
 from sibyl_core.services.memory_policy import (
     _candidate_source_ids,
     _correction_derived_ids,
@@ -29,6 +41,8 @@ from sibyl_core.services.memory_policy import (
     _metadata_str_values,
     _promoted_entity_write_allowed,
     _raw_memory_write_allowed,
+    raw_memory_source_fingerprint,
+    suppression_target_visible,
 )
 from sibyl_core.services.surreal_content import (
     RawMemory,
@@ -62,6 +76,7 @@ async def projected_row_lifecycle_stamp(
     *,
     organization_id: str,
     metadata: Mapping[str, Any] | None,
+    expected_signature: str | None = None,
 ) -> dict[str, Any]:
     """Read the current verdict for the capture a row is about to be projected from.
 
@@ -76,8 +91,9 @@ async def projected_row_lifecycle_stamp(
     recall path consults this, because the stamp it returns is exactly what
     the recall gate already reads off the row.
 
-    Empty whenever the capture is unknown, unreadable, or still recallable, so
-    the caller can merge it unconditionally.
+    A declared capture that is absent remains pending. Unbound graph rows have
+    no capture authority to check; an unavailable store raises for the caller's
+    reconciliation retry path.
     """
 
     fields = metadata if isinstance(metadata, Mapping) else {}
@@ -111,11 +127,25 @@ async def projected_row_lifecycle_stamp(
         )
         raise
     if memory is None:
-        # An absent capture is not an unreadable one. Nothing was stamped on a
-        # row that does not exist, so there is no verdict to inherit.
-        return {}
-    stamp = graph_lifecycle_stamp(memory)
-    if stamp:
+        # Absence cannot certify the source lifecycle. Use the same pending
+        # marker as an unavailable read so recovery can clear its owned check.
+        return {RECONCILE_PENDING_KEY: True}
+    # A source revision is stale only relative to the text this row used.
+    stamp = graph_lifecycle_stamp(
+        replace(
+            memory,
+            metadata={
+                **memory.metadata,
+                SOURCE_BINDINGS_KEY: fields.get(SOURCE_BINDINGS_KEY, {}),
+            },
+        )
+    )
+    if (
+        expected_signature is not None
+        and raw_memory_source_fingerprint(memory) != expected_signature
+    ):
+        stamp[SOURCE_VALIDATION_PENDING_KEY] = True
+    if not graph_metadata_recallable(stamp):
         log.info(
             "projected_row_born_retired",
             raw_memory_id=memory.id,
@@ -151,11 +181,12 @@ class _CorrectionGraphTargets:
     authorized: list[str]
     refused: list[str]
     projections: list[str] = field(default_factory=list)
+    direct: list[str] = field(default_factory=list)
     truncated: bool = False
 
     @property
     def stampable(self) -> list[str]:
-        return [*self.authorized, *self.projections]
+        return [*self.direct, *self.projections]
 
 
 async def _correction_graph_entity_ids(
@@ -165,6 +196,8 @@ async def _correction_graph_entity_ids(
     memory: RawMemory,
     principal_id: str | None,
     accessible_projects: Iterable[str] | None,
+    writable_projects: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> _CorrectionGraphTargets:
     """Find the graph rows projected from this capture.
 
@@ -216,19 +249,24 @@ async def _correction_graph_entity_ids(
     (`_authorized_superseded_entity_ids`).
     """
 
-    rows = normalize_records(
-        await runtime.client.execute_query(
-            """
-            SELECT uuid FROM entity
-            WHERE group_id = $group_id
-              AND attributes.raw_memory_id = $raw_memory_id
-            LIMIT $limit;
-            """,
-            group_id=str(organization_id),
-            raw_memory_id=memory.id,
-            limit=_GRAPH_CORRECTION_LOOKUP_LIMIT,
+    rows: list[dict[str, Any]] = []
+    cursor = ""
+    while True:
+        batch = normalize_records(
+            await runtime.client.execute_query(
+                "SELECT uuid FROM entity WHERE group_id = $group_id "
+                "AND attributes.raw_memory_id = $raw_memory_id AND uuid > $cursor "
+                "ORDER BY uuid LIMIT $limit;",
+                group_id=str(organization_id),
+                raw_memory_id=memory.id,
+                cursor=cursor,
+                limit=_GRAPH_CORRECTION_LOOKUP_LIMIT,
+            )
         )
-    )
+        rows.extend(batch)
+        if len(batch) < _GRAPH_CORRECTION_LOOKUP_LIMIT:
+            break
+        cursor = str(batch[-1]["uuid"])
     projected_ids = [uuid for row in rows if (uuid := str(row.get("uuid") or ""))]
     declared = [
         entity_id
@@ -269,7 +307,14 @@ async def _correction_graph_entity_ids(
             allowed = _promoted_entity_write_allowed(
                 entity=target,
                 principal_id=principal_id,
+                writable_projects=tuple(writable_projects or ()),
+            )
+        if allowed and allowed_memory_scope_keys is not None:
+            allowed = suppression_target_visible(
+                target,
+                principal_id=principal_id,
                 accessible_projects=accessible_projects,
+                allowed_memory_scope_keys=allowed_memory_scope_keys,
             )
         if allowed:
             authorized.append(entity_id)
@@ -285,13 +330,14 @@ async def _correction_graph_entity_ids(
         runtime,
         organization_id=organization_id,
         memory=memory,
-        parent_ids=authorized,
+        parent_ids=projected,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
     )
     known = set(authorized)
     return _CorrectionGraphTargets(
         authorized=authorized,
+        direct=projected,
         refused=refused,
         projections=[
             entity_id for entity_id in dict.fromkeys(projections) if entity_id not in known
@@ -308,6 +354,7 @@ async def _readable_correction_targets(
     principal_id: str | None,
     accessible_projects: Iterable[str] | None,
     log_event: str,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> list[str]:
     """Keep the rows a correction found that this principal can still read.
 
@@ -330,9 +377,16 @@ async def _readable_correction_targets(
         if not memory_metadata_read_allowed(
             row_metadata,
             principal_id=principal_id,
-            private_scope_granted=principal_id is not None,
+            private_scope_granted=private_scope_granted_for(
+                allowed_memory_scope_keys, principal_id=principal_id
+            ),
             accessible_projects=accessible_projects,
-            row_project_id=memory_row_project_id(row_metadata),
+            row_project_id=memory_row_project_id(
+                row_metadata,
+                entity_type=str(getattr(row, "entity_type", "") or ""),
+                entity_id=str(getattr(row, "id", "") or ""),
+            ),
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
         ):
             log.warning(log_event, source_id=source_id, entity_id=entity_id)
             continue
@@ -442,36 +496,6 @@ async def _correction_projected_row_ids(
     return readable, truncated
 
 
-def _correction_graph_metadata(
-    preview: MemoryCorrectionPreview,
-    *,
-    replacement_source_id: str | None,
-    duplicate_of_source_id: str | None,
-) -> dict[str, Any]:
-    """Build the verdict the graph row carries from here on.
-
-    Every marker is written on every correction, including the cleared form a
-    restore needs. A patch that only ever adds keys cannot undo itself, and
-    the graph merge has no way to remove one.
-    """
-
-    restoring = preview.action == "restore"
-    excluded = bool(preview.recall_impact.get("excluded_from_recall")) and not restoring
-    return {
-        "lifecycle_state": preview.target_lifecycle_state,
-        "lifecycle_flags": list(preview.target_lifecycle_flags),
-        "lifecycle_action": preview.action,
-        "excluded_from_recall": excluded,
-        "superseded_by_source_id": "" if restoring else (replacement_source_id or ""),
-        "duplicate_of_source_id": "" if restoring else (duplicate_of_source_id or ""),
-        # A correction is somebody reading the verdict and writing it down, so
-        # a marker saying nobody could read one is answered by this write.
-        # `None` removes the key on the graph's merge patch rather than
-        # leaving it present and falsy.
-        RECONCILE_PENDING_KEY: None,
-    }
-
-
 async def _project_correction_to_graph(
     *,
     organization_id: str,
@@ -481,7 +505,11 @@ async def _project_correction_to_graph(
     accessible_projects: Iterable[str] | None,
     replacement_source_id: str | None,
     duplicate_of_source_id: str | None,
-) -> tuple[list[str], list[str], bool]:
+    writable_projects: Iterable[str] | None = None,
+    accessible_teams: Iterable[str] | None = None,
+    accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
+) -> tuple[list[str], list[str], bool, CorrectionPropagation]:
     """Carry a correction across to the rows retrieval actually ranks.
 
     Correction used to stop at `raw_captures`. The projected entity kept its
@@ -492,6 +520,9 @@ async def _project_correction_to_graph(
     reports failure after mutating the substrate.
     """
 
+    runtime = None
+    targets = _CorrectionGraphTargets(authorized=[], refused=[])
+    graph_discovery_complete = True
     try:
         runtime = await get_surreal_graph_runtime(str(organization_id))
         targets = await _correction_graph_entity_ids(
@@ -500,6 +531,8 @@ async def _project_correction_to_graph(
             memory=memory,
             principal_id=principal_id,
             accessible_projects=accessible_projects,
+            writable_projects=writable_projects,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
         )
     except Exception as exc:
         log.warning(
@@ -507,52 +540,44 @@ async def _project_correction_to_graph(
             source_id=memory.id,
             error_type=type(exc).__name__,
         )
-        return [], [], False
-    entity_ids = targets.stampable
-
-    updates = _correction_graph_metadata(
-        preview,
-        replacement_source_id=replacement_source_id,
-        duplicate_of_source_id=duplicate_of_source_id,
+        graph_discovery_complete = False
+    propagation = await propagate_source_correction(
+        runtime,
+        memory=memory,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        accessible_teams=accessible_teams,
+        accessible_delegations=accessible_delegations,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
+        projected_entity_ids=targets.stampable,
+        declared_entity_ids=[value for value in targets.authorized if value not in targets.direct],
     )
-    applied: list[str] = []
-    for entity_id in entity_ids:
-        try:
-            updated = await runtime.entity_manager.update(entity_id, {"metadata": updates})
-        except Exception as exc:
-            log.warning(
-                "memory_correction_graph_update_failed",
-                source_id=memory.id,
-                entity_id=entity_id,
-                error_type=type(exc).__name__,
-            )
-            continue
-        # A miss is expected rather than exceptional. `_correction_derived_ids`
-        # reports everything derived from the capture, relationship ids
-        # included, and only the rows that were really stamped may reach the
-        # mutation receipt or become an endpoint for the supersession edge.
-        if updated is not None:
-            applied.append(entity_id)
+    propagation.complete = propagation.complete and graph_discovery_complete
+    applied = propagation.stamped_entity_ids
 
-    if preview.action == "restore" and applied:
-        await _unlink_graph_supersession(
+    if applied:
+        cleaned = await _unlink_graph_supersession(
             runtime,
             organization_id=organization_id,
             source_id=memory.id,
             restored_entity_ids=applied,
         )
-    projected_ids = set(targets.projections)
-    superseded_memories = [entity_id for entity_id in applied if entity_id not in projected_ids]
-    if preview.action == "supersede" and replacement_source_id and superseded_memories:
-        await _link_graph_supersession(
-            runtime,
-            organization_id=organization_id,
-            principal_id=principal_id,
-            accessible_projects=accessible_projects,
-            replacement_source_id=replacement_source_id,
-            superseded_entity_ids=superseded_memories,
-        )
-    return applied, list(targets.refused), targets.truncated
+        propagation.complete = propagation.complete and cleaned
+    disclosed = await _readable_correction_targets(
+        runtime,
+        entity_ids=list(dict.fromkeys([*applied, *propagation.entity_ids])),
+        source_id=memory.id,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
+        log_event="memory_correction_receipt_unreadable",
+    )
+    return (
+        disclosed,
+        list(targets.refused),
+        targets.truncated,
+        propagation,
+    )
 
 
 async def _unlink_graph_supersession(
@@ -561,7 +586,7 @@ async def _unlink_graph_supersession(
     organization_id: str,
     source_id: str,
     restored_entity_ids: Sequence[str],
-) -> None:
+) -> bool:
     """Remove the supersession edges a correction minted, so restore can undo.
 
     Clearing the lifecycle stamp is not enough on its own. The admission gate
@@ -573,7 +598,7 @@ async def _unlink_graph_supersession(
     """
 
     if not restored_entity_ids:
-        return
+        return True
     try:
         await runtime.client.execute_query(
             """
@@ -581,11 +606,14 @@ async def _unlink_graph_supersession(
             WHERE group_id = $group_id
               AND name = $predicate
               AND target_id IN $target_ids
+              AND (attributes.correction_root_id = $correction_root_id
+                   OR attributes.correction_root_id IS NONE)
               AND attributes.native_write_path = $write_path;
             """,
             group_id=str(organization_id),
             predicate=RelationshipType.SUPERSEDES.value,
             target_ids=list(restored_entity_ids),
+            correction_root_id=source_id,
             write_path=_CORRECTION_NATIVE_WRITE_PATH,
         )
     except Exception as exc:
@@ -594,73 +622,8 @@ async def _unlink_graph_supersession(
             source_id=source_id,
             error_type=type(exc).__name__,
         )
-
-
-async def _link_graph_supersession(
-    runtime: Any,
-    *,
-    organization_id: str,
-    principal_id: str | None,
-    accessible_projects: Iterable[str] | None,
-    replacement_source_id: str,
-    superseded_entity_ids: Sequence[str],
-) -> None:
-    """Record the replacement as a real edge, in the direction retrieval reads.
-
-    Source is the surviving row and target is the retired one, matching the
-    promotion write path, which is what lets the retrieval gate recognize a
-    row as superseded from a single inbound-edge lookup.
-    """
-
-    try:
-        replacement = await get_raw_memory_by_source_id(
-            organization_id=str(organization_id),
-            source_id=replacement_source_id,
-        )
-        if replacement is None:
-            return
-        replacement_targets = await _correction_graph_entity_ids(
-            runtime,
-            organization_id=organization_id,
-            memory=replacement,
-            principal_id=principal_id,
-            accessible_projects=accessible_projects,
-        )
-        replacement_entity_ids = replacement_targets.authorized
-    except Exception as exc:
-        log.warning(
-            "memory_correction_replacement_lookup_failed",
-            source_id=replacement_source_id,
-            error_type=type(exc).__name__,
-        )
-        return
-
-    now = datetime.now(UTC).isoformat()
-    for replacement_entity_id in replacement_entity_ids:
-        for superseded_entity_id in superseded_entity_ids:
-            if replacement_entity_id == superseded_entity_id:
-                continue
-            try:
-                await runtime.relationship_manager.create(
-                    _relationship(
-                        replacement_entity_id,
-                        superseded_entity_id,
-                        RelationshipType.SUPERSEDES,
-                        metadata={
-                            "native_write_path": _CORRECTION_NATIVE_WRITE_PATH,
-                            "replacement_reason": "memory_correction_supersede",
-                            "replacement_source_id": replacement_source_id,
-                            "created_by": principal_id,
-                            "valid_from": now,
-                        },
-                    )
-                )
-            except Exception as exc:
-                log.warning(
-                    "memory_correction_supersedes_edge_failed",
-                    entity_id=superseded_entity_id,
-                    error_type=type(exc).__name__,
-                )
+        return False
+    return True
 
 
 @dataclass(frozen=True, slots=True)
@@ -790,7 +753,7 @@ async def _invalidate_promoted_entity_targets(
     runtime: Any,
     entity_ids: Sequence[str],
     principal_id: str | None,
-    accessible_projects: Iterable[str] | None,
+    writable_projects: Iterable[str] | None,
     invalid_at: datetime,
     reason: str,
     replacement_entity_id: str,
@@ -806,7 +769,7 @@ async def _invalidate_promoted_entity_targets(
         if not _promoted_entity_write_allowed(
             entity=target,
             principal_id=principal_id,
-            accessible_projects=accessible_projects,
+            writable_projects=writable_projects,
         ):
             continue
         metadata = _temporal_invalidation_metadata(
@@ -826,7 +789,7 @@ async def _apply_candidate_temporal_invalidations(
     runtime: Any,
     organization_id: str,
     principal_id: str | None,
-    accessible_projects: Iterable[str] | None,
+    writable_projects: Iterable[str] | None,
     candidate: ReflectionCandidate,
     replacement_entity_id: str,
     replacement_source_ids: Sequence[str],
@@ -850,7 +813,7 @@ async def _apply_candidate_temporal_invalidations(
                 if _raw_memory_write_allowed(
                     memory=candidate,
                     principal_id=principal_id,
-                    accessible_projects=accessible_projects,
+                    accessible_projects=writable_projects,
                 )
             ),
             None,
@@ -874,7 +837,7 @@ async def _apply_candidate_temporal_invalidations(
                     runtime=runtime,
                     entity_ids=[promoted_entity_id],
                     principal_id=principal_id,
-                    accessible_projects=accessible_projects,
+                    writable_projects=writable_projects,
                     invalid_at=invalid_at,
                     reason=target.reason,
                     replacement_entity_id=replacement_entity_id,
@@ -887,7 +850,7 @@ async def _apply_candidate_temporal_invalidations(
             runtime=runtime,
             entity_ids=authorized_entity_ids,
             principal_id=principal_id,
-            accessible_projects=accessible_projects,
+            writable_projects=writable_projects,
             invalid_at=invalid_at,
             reason="supersession",
             replacement_entity_id=replacement_entity_id,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_lineage.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_lineage.py
@@ -1,0 +1,311 @@
+"""Propagate source corrections without replacing a derivative's own verdict."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterable, Sequence
+from dataclasses import dataclass, field, replace
+
+import structlog
+
+from sibyl_core.auth.memory_policy import (
+    memory_metadata_read_allowed,
+    memory_row_project_id,
+    private_scope_granted_for,
+)
+from sibyl_core.errors import RevisionConflictError
+from sibyl_core.memory_pipeline.lifecycle import raw_memory_lifecycle_recallable
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    CORRECTION_BLOCKERS_KEY,
+    correction_event,
+    merge_source_correction,
+)
+from sibyl_core.projection.pending import pending_patch
+from sibyl_core.projection.reconcile import RECONCILE_PENDING_KEY
+from sibyl_core.services import content_client, content_models
+from sibyl_core.services.content_raw_persistence import get_raw_memory, save_raw_memory
+from sibyl_core.services.graph_runtime import GraphRuntime
+from sibyl_core.services.memory_policy import _authorize_share_source_read
+
+log = structlog.get_logger()
+_PAGE_SIZE = 512
+
+
+@dataclass(slots=True)
+class CorrectionPropagation:
+    raw_memory_ids: list[str] = field(default_factory=list)
+    entity_ids: list[str] = field(default_factory=list)
+    complete: bool = True
+    # Internal bookkeeping must also reach successfully stamped private rows.
+    stamped_entity_ids: list[str] = field(default_factory=list, repr=False)
+
+
+async def _graph_descendant_ids(
+    runtime: GraphRuntime,
+    *,
+    organization_id: str,
+    raw_ids: Sequence[str],
+    graph_ids: Sequence[str],
+    lookup_failures: set[str] | None = None,
+) -> AsyncIterator[str]:
+    # Separate predicates keep each lookup index-served. Combining the
+    # provenance and projection arms with OR causes a table scan.
+    lookups = (
+        ("raw_source_ids.*", "idx_entity_raw_sources", "CONTAINSANY", raw_ids, False),
+        ("review_capture_id", "idx_entity_review_capture", "IN", raw_ids, False),
+        ("raw_memory_id", "idx_entity_raw_memory", "IN", raw_ids, False),
+        ("parent_entity_id", "idx_entity_projection_parent", "IN", graph_ids, True),
+        ("source_entity_id", "idx_entity_projection_source", "IN", graph_ids, True),
+    )
+    for attribute, index, operator, values, projection in lookups:
+        for batch in content_client.value_batches(values):
+            cursor = ""
+            try:
+                while True:
+                    projection_filter = (
+                        " AND attributes.projection_kind IS NOT NONE" if projection else ""
+                    )
+                    rows = content_client.normalize_records(
+                        await runtime.client.execute_query(
+                            f"SELECT uuid FROM entity WITH INDEX {index} "
+                            "WHERE group_id = $group_id AND uuid > $cursor "
+                            f"AND attributes.{attribute} {operator} $source_ids"
+                            f"{projection_filter} ORDER BY uuid LIMIT $limit;",
+                            group_id=organization_id,
+                            cursor=cursor,
+                            source_ids=batch,
+                            limit=_PAGE_SIZE,
+                        )
+                    )
+                    for row in rows:
+                        yield str(row["uuid"])
+                    if len(rows) < _PAGE_SIZE:
+                        break
+                    cursor = str(rows[-1]["uuid"])
+            except Exception as exc:
+                if lookup_failures is None:
+                    raise
+                _failed_lookup(lookup_failures, index, exc)
+
+
+def _failed_lookup(failures: set[str], index: str, exc: Exception) -> None:
+    failures.add(index)
+    log.warning(
+        "memory_correction_lineage_lookup_failed", index=index, error_type=type(exc).__name__
+    )
+
+
+async def _raw_descendant_ids(
+    *, organization_id: str, source_ids: Sequence[str], lookup_failures: set[str]
+) -> AsyncIterator[str]:
+    index = "idx_raw_captures_source_lineage"
+    if not source_ids:
+        return
+    try:
+        async with content_client.surreal_content_client() as client:
+            for batch in content_client.value_batches(source_ids):
+                cursor = ""
+                try:
+                    while True:
+                        rows = await content_client.select_many(
+                            client,
+                            "SELECT uuid FROM raw_captures WITH INDEX idx_raw_captures_source_lineage "
+                            "WHERE organization_id = $organization_id AND uuid > $cursor "
+                            "AND metadata.raw_source_ids.* CONTAINSANY $source_ids "
+                            "ORDER BY uuid LIMIT $limit;",
+                            organization_id=organization_id,
+                            cursor=cursor,
+                            source_ids=batch,
+                            limit=_PAGE_SIZE,
+                        )
+                        for row in rows:
+                            yield str(row["uuid"])
+                        if len(rows) < _PAGE_SIZE:
+                            break
+                        cursor = str(rows[-1]["uuid"])
+                except Exception as exc:
+                    _failed_lookup(lookup_failures, index, exc)
+    except Exception as exc:
+        _failed_lookup(lookup_failures, index, exc)
+
+
+async def propagate_source_correction(
+    runtime: GraphRuntime | None,
+    *,
+    memory: content_models.RawMemory,
+    principal_id: str | None,
+    accessible_projects: Iterable[str] | None,
+    accessible_teams: Iterable[str] | None = None,
+    accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
+    declared_entity_ids: Sequence[str] = (),
+    projected_entity_ids: Sequence[str] = (),
+) -> CorrectionPropagation:
+    """Walk canonical capture IDs and projection links with one clock per root.
+
+    Each row is read and written with a revision check. A conflicting writer
+    causes a fresh merge, so different source corrections cannot erase one
+    another. The walk has a page size, but no total row or depth ceiling.
+
+    The caller authorizes the source correction and any declared target IDs.
+    Server-discovered descendants inherit that correction even when private;
+    the caller's read authority controls which IDs the receipt may disclose.
+    """
+    receipt = CorrectionPropagation(complete=runtime is not None)
+    try:
+        event = correction_event(
+            memory,
+            blocking=not raw_memory_lifecycle_recallable(memory, include_source_corrections=False),
+        )
+    except ValueError:
+        return CorrectionPropagation(complete=False)
+    projects = None if accessible_projects is None else tuple(accessible_projects)
+    teams = None if accessible_teams is None else tuple(accessible_teams)
+    delegations = None if accessible_delegations is None else tuple(accessible_delegations)
+    grants = None if allowed_memory_scope_keys is None else frozenset(allowed_memory_scope_keys)
+    seen_raw = {memory.id}
+    seen_graph: set[str] = set()
+    raw_frontier = [memory.id]
+    graph_frontier: list[str] = list(projected_entity_ids)
+    # Direct projections also contain source-era text. The flat source stamp
+    # alone cannot retire an old copy after a content revision.
+    seeds = list(dict.fromkeys([*projected_entity_ids, *declared_entity_ids]))
+
+    def failed_row(kind: str, exc: Exception) -> None:
+        receipt.complete = False
+        log.warning(
+            "memory_correction_lineage_row_failed",
+            source_id=memory.id,
+            row_kind=kind,
+            error_type=type(exc).__name__,
+        )
+
+    async def stamp_graph(entity_id: str) -> bool | None:
+        if runtime is None:
+            return None
+        while True:
+            row = await runtime.entity_manager.get(entity_id)
+            if row is None:
+                receipt.complete = False
+                return None
+            if row.observed_revision is None:
+                receipt.complete = False
+                return None
+            readable = memory_metadata_read_allowed(
+                row.metadata,
+                principal_id=principal_id,
+                private_scope_granted=private_scope_granted_for(grants, principal_id=principal_id),
+                allowed_memory_scope_keys=grants,
+                accessible_projects=projects,
+                row_project_id=memory_row_project_id(
+                    row.metadata,
+                    entity_type=str(getattr(row, "entity_type", "") or ""),
+                    entity_id=str(getattr(row, "id", "") or ""),
+                ),
+            )
+            metadata = merge_source_correction(row.metadata, event)
+            patch: dict[str, object] = {CORRECTION_BLOCKERS_KEY: metadata[CORRECTION_BLOCKERS_KEY]}
+            if row.metadata.get("raw_memory_id") == memory.id and row.metadata.get(
+                RECONCILE_PENDING_KEY
+            ):
+                # Reading this capture can clear only its own pending check.
+                # A second parent may still be unresolved on the same row.
+                resolved = pending_patch(row.metadata, {}, authority=f"capture:{memory.id}")
+                if RECONCILE_PENDING_KEY in resolved:
+                    patch[RECONCILE_PENDING_KEY] = resolved[RECONCILE_PENDING_KEY]
+            if metadata == row.metadata and RECONCILE_PENDING_KEY not in patch:
+                return readable
+            try:
+                updated = await runtime.entity_manager.update(
+                    entity_id,
+                    {"metadata": patch},
+                    expected_revision=row.observed_revision,
+                    replace_metadata_keys=tuple(patch),
+                )
+                if updated is None:
+                    receipt.complete = False
+                    return None
+                return readable
+            except RevisionConflictError:
+                continue
+
+    async def stamp_raw(memory_id: str) -> bool | None:
+        while True:
+            row = await get_raw_memory(organization_id=memory.organization_id, memory_id=memory_id)
+            if row is None:
+                receipt.complete = False
+                return None
+            if row.observed_revision is None:
+                receipt.complete = False
+                return None
+            readable = _authorize_share_source_read(
+                memory=row,
+                principal_id=principal_id,
+                accessible_projects=projects,
+                accessible_teams=teams,
+                accessible_delegations=delegations,
+                allowed_memory_scope_keys=grants,
+            ).allowed
+            metadata = merge_source_correction(row.metadata, event)
+            if metadata == row.metadata:
+                return readable
+            try:
+                await save_raw_memory(
+                    replace(row, metadata=metadata), expected_revision=row.observed_revision
+                )
+                return readable
+            except RevisionConflictError:
+                continue
+
+    try:
+        while raw_frontier or graph_frontier or seeds:
+            next_raw: list[str] = []
+            next_graph: list[str] = []
+            lookup_failures: set[str] = set()
+            async for memory_id in _raw_descendant_ids(
+                organization_id=memory.organization_id,
+                source_ids=raw_frontier,
+                lookup_failures=lookup_failures,
+            ):
+                if memory_id not in seen_raw:
+                    seen_raw.add(memory_id)
+                    try:
+                        applied = await stamp_raw(memory_id)
+                    except Exception as exc:
+                        failed_row("capture", exc)
+                        applied = None
+                    if applied:
+                        receipt.raw_memory_ids.append(memory_id)
+                    next_raw.append(memory_id)
+            if runtime is not None:
+                async for entity_id in _graph_descendant_ids(
+                    runtime,
+                    organization_id=memory.organization_id,
+                    raw_ids=raw_frontier,
+                    graph_ids=graph_frontier,
+                    lookup_failures=lookup_failures,
+                ):
+                    seeds.append(entity_id)
+            if lookup_failures:
+                receipt.complete = False
+            for entity_id in seeds:
+                if entity_id not in seen_graph:
+                    seen_graph.add(entity_id)
+                    try:
+                        applied = await stamp_graph(entity_id)
+                    except Exception as exc:
+                        failed_row("entity", exc)
+                        applied = None
+                    if applied is not None:
+                        receipt.stamped_entity_ids.append(entity_id)
+                    if applied:
+                        receipt.entity_ids.append(entity_id)
+                    next_graph.append(entity_id)
+            raw_frontier, graph_frontier, seeds = next_raw, next_graph, []
+    except Exception as exc:
+        receipt.complete = False
+        log.warning(
+            "memory_correction_lineage_incomplete",
+            source_id=memory.id,
+            error_type=type(exc).__name__,
+        )
+    return receipt

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_policy.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_policy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, cast
 
@@ -16,6 +18,7 @@ from sibyl_core.auth.memory_policy import (
     authorize_memory_write,
     memory_metadata_read_allowed,
     memory_row_project_id,
+    memory_scope_policy_key,
     private_scope_granted_for,
 )
 from sibyl_core.errors import EntityNotFoundError
@@ -85,6 +88,13 @@ def _authorize_reflection_write(
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
 ) -> tuple[MemoryPolicyDecision, MemoryPolicyDecision]:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    accessible_teams = frozenset(accessible_teams) if accessible_teams is not None else None
+    accessible_delegations = (
+        tuple(accessible_delegations) if accessible_delegations is not None else None
+    )
     reflect_decision = authorize_memory_reflect(
         principal_id=principal_id,
         memory_scope=memory_scope,
@@ -249,6 +259,7 @@ def _authorize_share_source_read(
     accessible_projects: Iterable[str] | None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> MemoryPolicyDecision:
     if memory.memory_scope is MemoryScope.PRIVATE and memory.principal_id != principal_id:
         return MemoryPolicyDecision(
@@ -258,6 +269,16 @@ def _authorize_share_source_read(
             memory_scope=memory.memory_scope,
             scope_key=memory.scope_key,
         )
+    if allowed_memory_scope_keys is not None:
+        scope_key = principal_id if memory.memory_scope is MemoryScope.PRIVATE else memory.scope_key
+        if memory_scope_policy_key(memory.memory_scope, scope_key) not in allowed_memory_scope_keys:
+            return MemoryPolicyDecision(
+                action=MemoryPolicyAction.READ,
+                allowed=False,
+                reason="api_key_memory_space_denied",
+                memory_scope=memory.memory_scope,
+                scope_key=memory.scope_key,
+            )
     return authorize_memory_read(
         principal_id=principal_id,
         memory_scope=memory.memory_scope,
@@ -356,6 +377,47 @@ def _raw_source_ids(memory: RawMemory) -> list[str]:
     return list(dict.fromkeys(_metadata_str_list(memory.metadata, "raw_source_ids")))
 
 
+def _source_content_generation(memory: RawMemory) -> int:
+    """Count persisted revisions without using bookkeeping's mutable row revision.
+
+    Correction history is append-only. Its revise count also stays stable for
+    legacy entries without prior_revision, whose conservative lifecycle clock
+    cannot be used as an immutable identity.
+    """
+    history = memory.metadata.get("correction_history") or ()
+    if not isinstance(history, list | tuple):
+        raise ValueError("correction_history must be a list of correction entries")
+    return sum(
+        1
+        for entry in history
+        if isinstance(entry, Mapping) and str(entry.get("action") or "").strip().lower() == "revise"
+    )
+
+
+def raw_memory_source_signature(memory: RawMemory) -> tuple[object, ...]:
+    """The source fields whose observed values justify a promotion."""
+    return (
+        memory.organization_id,
+        memory.principal_id,
+        memory.memory_scope,
+        memory.scope_key,
+        memory.source_id,
+        memory.title,
+        memory.raw_content,
+        memory.entity_type,
+        _source_content_generation(memory),
+        memory.metadata.get("domain"),
+        memory.metadata.get("category"),
+        tuple(sorted(source_id for source_id in _raw_source_ids(memory) if source_id != memory.id)),
+    )
+
+
+def raw_memory_source_fingerprint(memory: RawMemory) -> str:
+    """Retain the expected source signature without persisting its private text."""
+    encoded = json.dumps(raw_memory_source_signature(memory), sort_keys=True).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def _candidate_source_ids(
     candidate: ReflectionCandidate,
     source_id: str | None,
@@ -428,7 +490,7 @@ def _promoted_entity_write_allowed(
     *,
     entity: Any,
     principal_id: str | None,
-    accessible_projects: Iterable[str] | None,
+    writable_projects: Iterable[str] | None,
 ) -> bool:
     raw_metadata = getattr(entity, "metadata", {})
     metadata = raw_metadata if isinstance(raw_metadata, Mapping) else {}
@@ -449,7 +511,7 @@ def _promoted_entity_write_allowed(
         principal_id=principal_id,
         memory_scope=target_scope,
         scope_key=target_scope_key,
-        accessible_projects=accessible_projects,
+        accessible_projects=writable_projects,
     )
     return decision.allowed
 
@@ -526,7 +588,7 @@ async def _authorized_superseded_entity_ids(
     *,
     runtime: Any,
     principal_id: str | None,
-    accessible_projects: Iterable[str] | None,
+    writable_projects: Iterable[str] | None,
     candidate: ReflectionCandidate,
 ) -> list[str]:
     authorized_ids: list[str] = []
@@ -543,7 +605,7 @@ async def _authorized_superseded_entity_ids(
         if _promoted_entity_write_allowed(
             entity=target_entity,
             principal_id=principal_id,
-            accessible_projects=accessible_projects,
+            writable_projects=writable_projects,
         ):
             authorized_ids.append(entity_id)
     return authorized_ids

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_promotion.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_promotion.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
@@ -15,6 +17,7 @@ from sibyl_core.models.relations import declared_relation_targets
 from sibyl_core.services.memory_contract import ReflectionPromotionResult
 from sibyl_core.services.memory_identity import (
     IDENTITY_KEY,
+    SOURCE_SNAPSHOT_KEY,
     reflection_entity_id,
     reflection_identity,
 )
@@ -24,6 +27,7 @@ from sibyl_core.services.memory_policy import (
     _metadata_float,
     _metadata_str,
     _promotion_denied,
+    raw_memory_source_fingerprint,
     suppression_target_visible,
 )
 from sibyl_core.services.surreal_content import (
@@ -267,6 +271,8 @@ def _entity_from_candidate(
     memory_scope: MemoryScope,
     scope_key: str | None,
     policy_metadata: Mapping[str, Any],
+    source_memories: Sequence[RawMemory] = (),
+    reserved_entity_id: str | None = None,
 ) -> Entity:
     entity_type = _entity_type(candidate.kind)
     source_ids = sorted(_candidate_source_ids(candidate, source_id))
@@ -313,10 +319,18 @@ def _entity_from_candidate(
     if primary_source_id:
         metadata["reflection_source_id"] = primary_source_id
 
+    if source_memories:
+        snapshots = sorted(
+            {(memory.id, raw_memory_source_fingerprint(memory)) for memory in source_memories}
+        )
+        metadata[SOURCE_SNAPSHOT_KEY] = hashlib.sha256(
+            json.dumps(snapshots, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
     entity = Entity(
         id="reflection_pending",
         entity_type=entity_type,
-        name=candidate.title,
+        name=candidate.title.strip() or "Untitled memory",
         description=candidate.content[:500],
         content=candidate.content,
         organization_id=organization_id,
@@ -325,6 +339,13 @@ def _entity_from_candidate(
         source_file=primary_source_id,
     )
     entity.id = reflection_entity_id(entity)
+    if reserved_entity_id is not None and reserved_entity_id != entity.id:
+        legacy = entity.model_copy(update={"name": candidate.title})
+        if reserved_entity_id != reflection_entity_id(legacy, version=2):
+            raise ValueError("reserved reflection identity does not match the candidate")
+        entity = legacy
+        entity.metadata.pop(SOURCE_SNAPSHOT_KEY, None)
+        entity.id = reflection_entity_id(entity)
     entity.metadata[IDENTITY_KEY] = reflection_identity(entity)
     return entity
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
@@ -11,9 +11,16 @@ from typing import Any
 import structlog
 
 from sibyl_core.errors import EntityNotFoundError, RevisionConflictError
-from sibyl_core.memory_pipeline.lifecycle import graph_lifecycle_stamp, graph_metadata_recallable
+from sibyl_core.memory_pipeline.lifecycle import RECONCILE_PENDING_KEY, graph_metadata_recallable
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    SOURCE_BINDINGS_KEY,
+    UNKNOWN_SOURCE_REVISION,
+    source_revision_bindings,
+)
 from sibyl_core.models.entities import EntityType, Relationship
 from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.projection.pending import pending_patch
+from sibyl_core.projection.reconcile import reconcile_with_capture
 from sibyl_core.services.graph import get_surreal_graph_runtime
 from sibyl_core.services.memory_autonomy import reflection_autonomy_candidate_metadata
 from sibyl_core.services.memory_contract import (
@@ -24,7 +31,11 @@ from sibyl_core.services.memory_contract import (
     _ReflectionPromotionPlan,
     _RelationshipWriteReceipt,
 )
-from sibyl_core.services.memory_identity import verify_reflection_identity
+from sibyl_core.services.memory_identity import (
+    IDENTITY_KEY,
+    reflection_entity_id,
+    verify_reflection_identity,
+)
 from sibyl_core.services.memory_lifecycle import (
     _apply_candidate_temporal_invalidations,
     _candidate_temporal_invalidation_targets,
@@ -44,6 +55,10 @@ from sibyl_core.services.memory_policy import (
     _resolve_memory_scope,
     _resolve_scope_key,
     _with_authorized_supersedes,
+    raw_memory_source_fingerprint,
+)
+from sibyl_core.services.memory_policy import (
+    raw_memory_source_signature as _promotion_source_signature,
 )
 from sibyl_core.services.memory_promotion import (
     _broadest_scope,
@@ -119,11 +134,16 @@ async def persist_reflection_source(
     project: str | None = None,
     related_to: Sequence[str] | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
     memory_scope: MemoryScope | str | None = None,
     scope_key: str | None = None,
 ) -> ReflectionWriteResult:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects) if writable_projects is not None else None
     candidate = ReflectionCandidate(
         kind=EntityType.SESSION.value,
         title=title,
@@ -142,6 +162,7 @@ async def persist_reflection_source(
         source_id=None,
         related_to=related_to,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
         memory_scope=memory_scope,
@@ -159,20 +180,28 @@ async def persist_reflection_candidate(
     source_id: str | None = None,
     related_to: Sequence[str] | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
     memory_scope: MemoryScope | str | None = None,
     scope_key: str | None = None,
     link_source_entity: bool = True,
     source_memories: Sequence[RawMemory] = (),
+    reserved_entity_id: str | None = None,
 ) -> ReflectionWriteResult:
+    writable_projects = frozenset(writable_projects) if writable_projects is not None else None
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
     scope = _resolve_memory_scope(memory_scope, project)
     resolved_scope_key = _resolve_scope_key(scope, scope_key, project)
     policy_decisions = _authorize_reflection_write(
         principal_id=principal_id,
         memory_scope=scope,
         scope_key=resolved_scope_key,
-        accessible_projects=accessible_projects,
+        accessible_projects=writable_projects
+        if writable_projects is not None
+        else accessible_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
     )
@@ -193,7 +222,7 @@ async def persist_reflection_candidate(
     superseded_ids = await _authorized_superseded_entity_ids(
         runtime=runtime,
         principal_id=principal_id,
-        accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         candidate=candidate,
     )
     entity = _entity_from_candidate(
@@ -206,6 +235,8 @@ async def persist_reflection_candidate(
         memory_scope=scope,
         scope_key=resolved_scope_key,
         policy_metadata=policy_metadata,
+        source_memories=source_memories or (),
+        reserved_entity_id=reserved_entity_id,
     )
     entity = entity.model_copy(
         update={
@@ -225,6 +256,23 @@ async def persist_reflection_candidate(
     # Resolved before the row lands. A store that fails here fails the whole
     # promotion rather than persisting a memory and then reporting a complete
     # write that requested no edges at all.
+    legacy_reservation = (
+        reserved_entity_id is not None and entity.metadata[IDENTITY_KEY]["version"] == 2
+    )
+    if source_memories:
+        bindings = source_revision_bindings(source_memories)
+        if legacy_reservation:
+            # A v2 reservation proves its output, not the source epochs it read.
+            bindings = dict.fromkeys(bindings, UNKNOWN_SOURCE_REVISION)
+            for memory in source_memories:
+                entity.metadata.update(
+                    pending_patch(
+                        entity.metadata,
+                        {RECONCILE_PENDING_KEY: True},
+                        authority=f"capture:{memory.id}",
+                    )
+                )
+        entity.metadata[SOURCE_BINDINGS_KEY] = bindings
     linkable_related_to = await _linkable_related_targets(
         runtime=runtime,
         related_to=related_to,
@@ -264,6 +312,16 @@ async def persist_reflection_candidate(
         return _retired_reflection_result(entity.id)
     stored, created = await runtime.entity_manager.create_direct_if_absent(entity)
     verify_reflection_identity(entity, stored)
+    if legacy_reservation:
+        for memory in source_memories:
+            await reconcile_with_capture(
+                runtime.entity_manager,
+                organization_id=organization_id,
+                metadata={"raw_memory_id": memory.id},
+                row_ids=[stored.id],
+            )
+        stored = await runtime.entity_manager.get(stored.id)
+        verify_reflection_identity(entity, stored)
     if not await _verify_promotion_sources(runtime, source_memories, entity_id=stored.id):
         return _retired_reflection_result(stored.id)
     if not graph_metadata_recallable(stored.metadata):
@@ -289,7 +347,7 @@ async def persist_reflection_candidate(
         runtime=runtime,
         organization_id=organization_id,
         principal_id=principal_id,
-        accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         candidate=candidate,
         replacement_entity_id=created_id,
         replacement_source_ids=source_ids,
@@ -456,9 +514,14 @@ async def promote_reflection_candidate_review(
     project: str | None = None,
     related_to: Sequence[str] | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
 ) -> ReflectionPromotionResult:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects) if writable_projects is not None else None
     plan = await _resolve_reflection_promotion_plan(
         candidate_id=candidate_id,
         organization_id=organization_id,
@@ -481,6 +544,7 @@ async def promote_reflection_candidate_review(
         domain=domain,
         related_to=related_to,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
         native_source_id=plan.raw_source_ids[0] if plan.raw_source_ids else None,
@@ -500,9 +564,14 @@ async def promote_raw_memory(
     project: str | None = None,
     related_to: Sequence[str] | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
 ) -> ReflectionPromotionResult:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects) if writable_projects is not None else None
     plan = await _resolve_raw_memory_promotion_plan(
         raw_memory_id=raw_memory_id,
         organization_id=organization_id,
@@ -525,6 +594,7 @@ async def promote_raw_memory(
         domain=domain,
         related_to=related_to,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
         native_source_id=plan.candidate_memory.id,
@@ -543,9 +613,14 @@ async def preview_reflection_candidate_promotion(
     domain: str | None = None,
     project: str | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
 ) -> ReflectionPromotionPreview:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects) if writable_projects is not None else None
     plan = await _resolve_reflection_promotion_plan(
         candidate_id=candidate_id,
         organization_id=organization_id,
@@ -565,7 +640,9 @@ async def preview_reflection_candidate_promotion(
         principal_id=principal_id,
         memory_scope=plan.target_scope,
         scope_key=plan.target_scope_key,
-        accessible_projects=accessible_projects,
+        accessible_projects=writable_projects
+        if writable_projects is not None
+        else accessible_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
     )
@@ -600,9 +677,14 @@ async def preview_raw_memory_promotion(
     domain: str | None = None,
     project: str | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
 ) -> ReflectionPromotionPreview:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects) if writable_projects is not None else None
     plan = await _resolve_raw_memory_promotion_plan(
         raw_memory_id=raw_memory_id,
         organization_id=organization_id,
@@ -622,7 +704,9 @@ async def preview_raw_memory_promotion(
         principal_id=principal_id,
         memory_scope=plan.target_scope,
         scope_key=plan.target_scope_key,
-        accessible_projects=accessible_projects,
+        accessible_projects=writable_projects
+        if writable_projects is not None
+        else accessible_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
     )
@@ -655,17 +739,24 @@ async def _apply_promotion_plan(
     domain: str | None,
     related_to: Sequence[str] | None,
     accessible_projects: Iterable[str] | None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None,
     accessible_delegations: Iterable[str] | None,
     native_source_id: str | None,
     lifecycle_source_id: str,
     lifecycle_reason: str,
 ) -> ReflectionPromotionResult:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects) if writable_projects is not None else None
     policy_decisions = _authorize_reflection_write(
         principal_id=principal_id,
         memory_scope=plan.target_scope,
         scope_key=plan.target_scope_key,
-        accessible_projects=accessible_projects,
+        accessible_projects=writable_projects
+        if writable_projects is not None
+        else accessible_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
     )
@@ -690,8 +781,15 @@ async def _apply_promotion_plan(
         memory_scope=plan.target_scope,
         scope_key=_resolve_scope_key(plan.target_scope, plan.target_scope_key, plan.target_project),
         policy_metadata=policy_metadata,
+        source_memories=plan.input_memories,
     )
-    reservation = await _reserve_promotion(plan, prospective.id)
+    reservation = await _reserve_promotion(
+        plan,
+        prospective.id,
+        legacy_entity_id=reflection_entity_id(
+            prospective.model_copy(update={"name": plan.promotion_candidate.title}), version=2
+        ),
+    )
     if isinstance(reservation, ReflectionPromotionResult):
         return reservation
     plan = reservation
@@ -704,12 +802,14 @@ async def _apply_promotion_plan(
         source_id=native_source_id,
         related_to=related_to,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
         memory_scope=plan.target_scope,
         scope_key=plan.target_scope_key,
         link_source_entity=False,
         source_memories=plan.input_memories,
+        reserved_entity_id=_metadata_str(plan.candidate_memory.metadata, "promoted_entity_id"),
     )
     if not result.response.success or result.metadata.get("promotion_state") == "partial":
         return _promotion_write_denied(plan=plan, result=result)
@@ -721,22 +821,6 @@ async def _apply_promotion_plan(
     )
 
 
-def _promotion_source_signature(memory: RawMemory) -> tuple[object, ...]:
-    return (
-        memory.organization_id,
-        memory.principal_id,
-        memory.memory_scope,
-        memory.scope_key,
-        memory.source_id,
-        memory.title,
-        memory.raw_content,
-        memory.entity_type,
-        memory.metadata.get("domain"),
-        memory.metadata.get("category"),
-        tuple(sorted(source_id for source_id in _raw_source_ids(memory) if source_id != memory.id)),
-    )
-
-
 async def _verify_promotion_sources(
     runtime: Any,
     memories: Sequence[RawMemory],
@@ -744,33 +828,45 @@ async def _verify_promotion_sources(
     entity_id: str | None = None,
 ) -> bool:
     """Close correction's read-before-insert gap without restoring retired rows."""
+    verified = True
     for expected in memories:
-        current = await get_raw_memory(
-            organization_id=expected.organization_id, memory_id=expected.id
-        )
-        stamp: dict[str, object] = {}
-        if current is None:
-            stamp = {"excluded_from_recall": True, "lifecycle_state": "deleted"}
-        elif not raw_memory_recallable(current):
-            stamp = graph_lifecycle_stamp(current)
-        elif _promotion_source_signature(current) != _promotion_source_signature(expected):
-            stamp = {"excluded_from_recall": True, "lifecycle_state": "contested"}
-        if stamp:
-            if entity_id is not None:
-                await runtime.entity_manager.update(entity_id, {"metadata": stamp})
-            return False
-    return True
+        signature = raw_memory_source_fingerprint(expected)
+        try:
+            current = await get_raw_memory(
+                organization_id=expected.organization_id, memory_id=expected.id
+            )
+        except Exception as exc:
+            log.warning("promotion_source_read_failed", error_type=type(exc).__name__)
+            current = None
+        if (
+            current is not None
+            and raw_memory_recallable(current)
+            and _promotion_source_signature(current) == _promotion_source_signature(expected)
+        ):
+            continue
+        if entity_id is not None:
+            await reconcile_with_capture(
+                runtime.entity_manager,
+                organization_id=expected.organization_id,
+                metadata={"raw_memory_id": expected.id},
+                row_ids=[entity_id],
+                expected_signature=signature,
+            )
+        verified = False
+    return verified
 
 
 async def _reserve_promotion(
     plan: _ReflectionPromotionPlan,
     entity_id: str,
+    *,
+    legacy_entity_id: str | None = None,
 ) -> _ReflectionPromotionPlan | ReflectionPromotionResult:
     """Reserve correction's existing pointer before publishing any graph row."""
     memory = plan.candidate_memory
     recorded_id = _metadata_str(memory.metadata, "promoted_entity_id")
     if recorded_id or memory.review_state == _PROMOTED_REVIEW_STATE:
-        if recorded_id != entity_id:
+        if not recorded_id or (recorded_id != entity_id and recorded_id != legacy_entity_id):
             return _promotion_denied(
                 candidate_id=memory.id,
                 reason="candidate_already_promoted",
@@ -803,10 +899,11 @@ async def _reserve_promotion(
                 scope_key=plan.target_scope_key,
                 raw_source_ids=plan.raw_source_ids,
             )
-        if _metadata_str(
-            current.metadata, "promoted_entity_id"
-        ) != entity_id or _promotion_source_signature(current) != _promotion_source_signature(
-            memory
+        recorded_id = _metadata_str(current.metadata, "promoted_entity_id")
+        if (
+            not recorded_id
+            or (recorded_id != entity_id and recorded_id != legacy_entity_id)
+            or _promotion_source_signature(current) != _promotion_source_signature(memory)
         ):
             return _promotion_denied(
                 candidate_id=memory.id,
@@ -1012,6 +1109,18 @@ async def _resolve_reflection_promotion_plan(
     )
     if source_scope_denial is not None:
         return source_scope_denial
+
+    if candidate_memory.metadata.get("source_validation_pending"):
+        from sibyl_core.services.memory_source_validation import reconcile_raw_source_lifecycle
+
+        candidate_memory = await reconcile_raw_source_lifecycle(
+            candidate_memory,
+            principal_id=str(principal_id),
+            accessible_projects=accessible_projects,
+            accessible_teams=accessible_teams,
+            accessible_delegations=accessible_delegations,
+        )
+        input_memories[0] = candidate_memory
 
     if not sources_complete or any(not raw_memory_recallable(memory) for memory in input_memories):
         return _promotion_denied(

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_sharing.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_sharing.py
@@ -12,6 +12,7 @@ from sibyl_core.auth.memory_policy import (
     MemoryPolicyDecision,
     authorize_memory_read,
 )
+from sibyl_core.memory_pipeline.lifecycle import raw_memory_lifecycle_recallable
 from sibyl_core.models.reflection import ReflectionCandidate
 from sibyl_core.services.memory_contract import (
     MemoryAccessPreview,
@@ -70,9 +71,14 @@ async def preview_memory_share(
     target_scope_key: str | None = None,
     recipient_organization_id: str | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
 ) -> MemorySharePreview:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects or ())
     requested_source_ids = [str(source_id) for source_id in source_ids]
     normalized_target = _coerce_promotion_scope(target_scope)
     target_decision = _authorize_share_target(
@@ -81,7 +87,7 @@ async def preview_memory_share(
         target_scope_key=target_scope_key,
         recipient_organization_id=recipient_organization_id,
         organization_id=organization_id,
-        accessible_projects=accessible_projects,
+        accessible_projects=writable_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
     )
@@ -208,9 +214,14 @@ async def share_memory(
     project: str | None = None,
     related_to: Sequence[str] | None = None,
     accessible_projects: Iterable[str] | None = None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
 ) -> MemoryShareResult:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects or ())
     preview = await preview_memory_share(
         source_ids=source_ids,
         organization_id=organization_id,
@@ -219,6 +230,7 @@ async def share_memory(
         target_scope_key=target_scope_key,
         recipient_organization_id=recipient_organization_id,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
     )
@@ -262,6 +274,7 @@ async def share_memory(
                 domain=domain,
                 related_to=related_to,
                 accessible_projects=accessible_projects,
+                writable_projects=writable_projects,
                 accessible_teams=accessible_teams,
                 accessible_delegations=accessible_delegations,
             )
@@ -526,7 +539,9 @@ async def _resolve_raw_memory_share_plan(
     if not raw_memory_recallable(memory):
         return _promotion_denied(
             candidate_id=memory.id,
-            reason="raw_memory_not_recallable",
+            reason="source_not_recallable"
+            if raw_memory_lifecycle_recallable(memory, include_source_corrections=False)
+            else "raw_memory_not_recallable",
             review_state=memory.review_state,
             memory_scope=memory.memory_scope,
             scope_key=memory.scope_key,
@@ -620,9 +635,14 @@ async def _apply_share_plan(
     domain: str | None,
     related_to: Sequence[str] | None,
     accessible_projects: Iterable[str] | None,
+    writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None,
     accessible_delegations: Iterable[str] | None,
 ) -> ReflectionPromotionResult:
+    accessible_projects = (
+        frozenset(accessible_projects) if accessible_projects is not None else None
+    )
+    writable_projects = frozenset(writable_projects or ())
     result = await persist_reflection_candidate(
         candidate=plan.promotion_candidate,
         organization_id=organization_id,
@@ -632,6 +652,7 @@ async def _apply_share_plan(
         source_id=plan.candidate_memory.id,
         related_to=related_to,
         accessible_projects=accessible_projects,
+        writable_projects=writable_projects,
         accessible_teams=accessible_teams,
         accessible_delegations=accessible_delegations,
         memory_scope=plan.target_scope,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_source_validation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_source_validation.py
@@ -1,0 +1,272 @@
+"""Verify source lifecycles before admitting a newly derived capture to recall."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass, replace
+
+from sibyl_core.errors import RevisionConflictError
+from sibyl_core.memory_pipeline.lifecycle import raw_memory_lifecycle_recallable
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    SOURCE_VALIDATION_PENDING_KEY,
+    correction_event,
+    merge_source_correction,
+    source_revision_bindings,
+)
+from sibyl_core.services import content_client, content_models
+from sibyl_core.services.content_raw_persistence import _RAW_MEMORY_EMBEDDING_AUTO
+from sibyl_core.services.memory_policy import _authorize_share_source_read
+
+SOURCE_VALIDATION_CONTEXT_KEY = "source_validation_context"
+_PAGE_SIZE = 512
+
+
+@dataclass(frozen=True, slots=True)
+class SourceReadAuthority:
+    """Resolved memberships, also used as the original capture's grant ceiling."""
+
+    principal_id: str
+    projects: frozenset[str] = frozenset()
+    teams: frozenset[str] = frozenset()
+    delegations: frozenset[str] = frozenset()
+    scope_keys: frozenset[str] | None = None
+
+    def ceiling_metadata(self) -> dict[str, object]:
+        """Persist restrictions, never a bearer credential or renewable authority."""
+        return {
+            "version": 1,
+            "principal_id": self.principal_id,
+            "projects": sorted(self.projects),
+            "teams": sorted(self.teams),
+            "delegations": sorted(self.delegations),
+            "scope_restricted": self.scope_keys is not None,
+            "scope_keys": sorted(self.scope_keys or ()),
+        }
+
+
+type SourceAuthorityResolver = Callable[[str, str], Awaitable[SourceReadAuthority | None]]
+
+
+def _saved_ceiling(memory: content_models.RawMemory) -> SourceReadAuthority | None:
+    value = memory.metadata.get(SOURCE_VALIDATION_CONTEXT_KEY)
+    if not isinstance(value, Mapping):
+        return None
+    if type(value.get("version")) is not int or value["version"] != 1:
+        return None
+    if value.get("principal_id") != memory.principal_id or not memory.principal_id:
+        return None
+    if type(value.get("scope_restricted")) is not bool:
+        return None
+    for key in ("projects", "teams", "delegations", "scope_keys"):
+        items = value.get(key)
+        if not isinstance(items, list) or any(not isinstance(v, str) or not v for v in items):
+            return None
+    if not value["scope_restricted"] and value["scope_keys"]:
+        return None
+    return SourceReadAuthority(
+        principal_id=memory.principal_id,
+        projects=frozenset(value["projects"]),
+        teams=frozenset(value["teams"]),
+        delegations=frozenset(value["delegations"]),
+        scope_keys=frozenset(value["scope_keys"]) if value["scope_restricted"] else None,
+    )
+
+
+async def _current_authority(
+    memory: content_models.RawMemory, resolver: SourceAuthorityResolver
+) -> SourceReadAuthority | None:
+    ceiling = _saved_ceiling(memory)
+    if ceiling is None:
+        return None
+    current = await resolver(memory.organization_id, ceiling.principal_id)
+    if current is None or current.principal_id != ceiling.principal_id:
+        return None
+    scopes = ceiling.scope_keys
+    if current.scope_keys is not None:
+        scopes = current.scope_keys if scopes is None else scopes & current.scope_keys
+    return SourceReadAuthority(
+        principal_id=ceiling.principal_id,
+        projects=ceiling.projects & current.projects,
+        teams=ceiling.teams & current.teams,
+        delegations=ceiling.delegations & current.delegations,
+        scope_keys=scopes,
+    )
+
+
+def _stored_source_ids(memory: content_models.RawMemory) -> set[str]:
+    ids = set(source_revision_bindings([memory]))
+    # Unretained input anchors explicitly have no capture or source revision.
+    if re.fullmatch(r"reflection:input:[0-9a-f]{16}", memory.source_id):
+        ids.discard(memory.source_id)
+    ids.discard(memory.id)
+    return ids
+
+
+async def reconcile_raw_source_lifecycle(
+    memory: content_models.RawMemory,
+    *,
+    principal_id: str,
+    accessible_projects: Iterable[str] | None = None,
+    accessible_teams: Iterable[str] | None = None,
+    accessible_delegations: Iterable[str] | None = None,
+    embedding_provider: object = _RAW_MEMORY_EMBEDDING_AUTO,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
+    authority_resolver: SourceAuthorityResolver | None = None,
+) -> content_models.RawMemory:
+    """Read current source verdicts and release a pending capture under its CAS.
+
+    Bindings describe the text that was read and are never refreshed here.
+    Each source contributes its own lifecycle under its actual revision. Walking
+    ancestors avoids copying a stale inherited verdict from an intermediate row.
+    Missing or inaccessible evidence leaves the capture pending without exposing
+    an inaccessible source's revision or inventing a correction clock.
+    """
+    from sibyl_core.services.content_raw_persistence import get_raw_memory, save_raw_memory
+
+    projects = None if accessible_projects is None else tuple(accessible_projects)
+    teams = None if accessible_teams is None else tuple(accessible_teams)
+    delegations = None if accessible_delegations is None else tuple(accessible_delegations)
+    grants = None if allowed_memory_scope_keys is None else frozenset(allowed_memory_scope_keys)
+    while True:
+        if authority_resolver is not None:
+            authority = await _current_authority(memory, authority_resolver)
+            if authority is None:
+                return memory
+            principal_id = authority.principal_id
+            projects = tuple(authority.projects)
+            teams = tuple(authority.teams)
+            delegations = tuple(authority.delegations)
+            grants = authority.scope_keys
+        if not _authorize_share_source_read(
+            memory=memory,
+            principal_id=principal_id,
+            accessible_projects=projects,
+            accessible_teams=teams,
+            accessible_delegations=delegations,
+            allowed_memory_scope_keys=grants,
+        ).allowed:
+            if authority_resolver is not None:
+                return memory
+            raise PermissionError("Memory capture is no longer accessible.")
+        if memory.observed_revision is None:
+            raise ValueError("Memory capture revision is unavailable.")
+        metadata = dict(memory.metadata)
+        frontier = _stored_source_ids(memory)
+        seen = {memory.id}
+        complete = True
+        while frontier:
+            seen.update(frontier)
+            records = []
+            async with content_client.surreal_content_client() as client:
+                for batch in content_client.value_batches(sorted(frontier)):
+                    records.extend(
+                        await content_client.select_many(
+                            client,
+                            "SELECT * FROM raw_captures WHERE organization_id = $organization_id "
+                            "AND uuid IN $source_ids;",
+                            organization_id=memory.organization_id,
+                            source_ids=batch,
+                        )
+                    )
+            sources = [content_models.raw_memory_from_record(record) for record in records]
+            if {source.id for source in sources} != frontier:
+                complete = False
+            next_frontier: set[str] = set()
+            for source in sources:
+                if not _authorize_share_source_read(
+                    memory=source,
+                    principal_id=principal_id,
+                    accessible_projects=projects,
+                    accessible_teams=teams,
+                    accessible_delegations=delegations,
+                    allowed_memory_scope_keys=grants,
+                ).allowed:
+                    complete = False
+                    continue
+                if source.observed_revision is None:
+                    complete = False
+                    continue
+                metadata = merge_source_correction(
+                    metadata,
+                    correction_event(
+                        source,
+                        blocking=not raw_memory_lifecycle_recallable(
+                            source, include_source_corrections=False
+                        ),
+                    ),
+                )
+                next_frontier.update(_stored_source_ids(source) - seen)
+            frontier = next_frontier
+        if complete:
+            metadata[SOURCE_VALIDATION_PENDING_KEY] = False
+        else:
+            metadata[SOURCE_VALIDATION_PENDING_KEY] = True
+        if metadata == memory.metadata:
+            return memory
+        try:
+            return await save_raw_memory(
+                replace(memory, metadata=metadata),
+                expected_revision=memory.observed_revision,
+                embedding_provider=embedding_provider,
+            )
+        except RevisionConflictError:
+            current = await get_raw_memory(
+                organization_id=memory.organization_id, memory_id=memory.id
+            )
+            if current is None:
+                raise
+            memory = current
+
+
+async def repair_raw_source_lifecycle(
+    organization_id: str,
+    *,
+    authority_resolver: SourceAuthorityResolver,
+    embedding_provider: object = _RAW_MEMORY_EMBEDDING_AUTO,
+):
+    """Page past unresolved captures so unavailable evidence cannot starve recovery."""
+    from sibyl_core.projection.repair import LifecycleRepairResult
+    from sibyl_core.services.content_raw_persistence import get_raw_memory
+
+    counts = {"checked": 0, "recovered": 0, "pending": 0, "failed": 0}
+    cursor = ""
+
+    async def recover(memory_id: str) -> str:
+        memory = await get_raw_memory(organization_id=organization_id, memory_id=memory_id)
+        if memory is None:
+            return "missing"
+        if not memory.metadata.get(SOURCE_VALIDATION_PENDING_KEY):
+            return "recovered"
+        memory = await reconcile_raw_source_lifecycle(
+            memory,
+            principal_id=memory.principal_id,
+            authority_resolver=authority_resolver,
+            embedding_provider=embedding_provider,
+        )
+        return "pending" if memory.metadata.get(SOURCE_VALIDATION_PENDING_KEY) else "recovered"
+
+    while True:
+        async with content_client.surreal_content_client() as client:
+            records = await content_client.select_many(
+                client,
+                "SELECT uuid FROM raw_captures WITH INDEX idx_raw_captures_source_validation "
+                "WHERE organization_id = $organization_id "
+                "AND metadata.source_validation_pending = true AND uuid > $cursor "
+                "ORDER BY uuid LIMIT $limit;",
+                organization_id=organization_id,
+                cursor=cursor,
+                limit=_PAGE_SIZE,
+            )
+        if not records:
+            return LifecycleRepairResult(**counts)
+        ids = [str(row["uuid"]) for row in records]
+        outcomes = await asyncio.gather(*(recover(id_) for id_ in ids), return_exceptions=True)
+        for outcome in outcomes:
+            counts["checked"] += 1
+            if isinstance(outcome, BaseException):
+                counts["failed"] += 1
+            elif outcome in counts:
+                counts[outcome] += 1
+        cursor = ids[-1]

--- a/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import asdict, replace
 from typing import Any
 
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
 from sibyl_core.models.context import ContextIntent, ContextLayer, ContextPack
 from sibyl_core.models.synthesis import (
     SynthesisArtifact,
@@ -683,7 +684,7 @@ async def materialize_synthesis_section_packs(
             }
             if not redacted:
                 source_metadata = {
-                    **metadata,
+                    **public_memory_metadata(metadata),
                     **source_metadata,
                 }
             sources.append(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/add.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/add.py
@@ -47,9 +47,9 @@ from sibyl_core.models.tasks import (
     TaskStatus,
 )
 from sibyl_core.projection import project_entity_passages, project_memory_entity
+from sibyl_core.projection.reconcile import prewrite_capture_stamp, reconcile_with_capture
 from sibyl_core.runtime_ports import get_queue_port
 from sibyl_core.services.graph import get_surreal_graph_runtime
-from sibyl_core.services.memory import projected_row_lifecycle_stamp
 from sibyl_core.tools.helpers import (
     MAX_CONTENT_LENGTH,
     MAX_TITLE_LENGTH,
@@ -229,7 +229,7 @@ async def _create_entity_record(
     # entity that carries no capture provenance, which is every entity this
     # path creates that no correction can ever name.
     if organization_id:
-        stamp = await projected_row_lifecycle_stamp(
+        stamp, _verified = await prewrite_capture_stamp(
             organization_id=organization_id,
             metadata=entity.metadata,
         )
@@ -240,9 +240,19 @@ async def _create_entity_record(
     create_direct = getattr(entity_manager, "create_direct", None)
     if inspect.iscoroutinefunction(create_direct):
         if _accepts_keyword(create_direct, "generate_embedding"):
-            return await create_direct(entity, generate_embedding=generate_embeddings)
-        return await create_direct(entity)
-    return await entity_manager.create(entity)
+            created_id = await create_direct(entity, generate_embedding=generate_embeddings)
+        else:
+            created_id = await create_direct(entity)
+    else:
+        created_id = await entity_manager.create(entity)
+    if organization_id:
+        await reconcile_with_capture(
+            entity_manager,
+            organization_id=organization_id,
+            metadata=entity.metadata,
+            row_ids=[created_id],
+        )
+    return created_id
 
 
 async def _create_relationships_bulk(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/context.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/context.py
@@ -17,7 +17,13 @@ from sibyl_core.auth.memory_policy import (
 from sibyl_core.embeddings.providers import configured_embedding_provider
 from sibyl_core.memory_pipeline.lifecycle import (
     GRAPH_RECALL_EXCLUSION_KEYS,
+    RECONCILE_PENDING_KEY,
     graph_metadata_recallable,
+)
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    CORRECTION_BLOCKERS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+    public_memory_metadata,
 )
 from sibyl_core.models.context import (
     ContextFacet,
@@ -616,6 +622,9 @@ async def _default_related_items_batch(
 
 
 _ITEM_METADATA_KEYS = (
+    CORRECTION_BLOCKERS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+    RECONCILE_PENDING_KEY,
     "status",
     "priority",
     "complexity",
@@ -1162,6 +1171,9 @@ def _sections_from_response(
 
 
 _LIFECYCLE_ADMISSION_KEYS = (
+    CORRECTION_BLOCKERS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+    RECONCILE_PENDING_KEY,
     "lifecycle_state",
     "lifecycle_flags",
     "review_state",
@@ -1567,7 +1579,13 @@ async def compile_context(
 
 
 def context_pack_to_dict(pack: ContextPack) -> dict[str, Any]:
-    return asdict(pack)
+    payload = asdict(pack)
+    for section in payload["sections"]:
+        for item in section["items"]:
+            item["metadata"] = public_memory_metadata(item["metadata"])
+            for related in item["related"]:
+                related["metadata"] = public_memory_metadata(related["metadata"])
+    return payload
 
 
 __all__ = [

--- a/packages/python/sibyl-core/src/sibyl_core/tools/manage.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/manage.py
@@ -468,6 +468,9 @@ async def manage(
     organization_id: str | None = None,
     principal_id: str | None = None,
     accessible_projects: set[str] | None = None,
+    writable_projects: set[str] | None = None,
+    accessible_teams: set[str] | None = None,
+    accessible_delegations: set[str] | None = None,
     allowed_memory_scope_keys: set[str] | None = None,
 ) -> ManageResponse:
     """Manage operations that modify state in the knowledge graph.
@@ -552,6 +555,9 @@ async def manage(
             organization_id=organization_id,
             principal_id=principal_id,
             accessible_projects=accessible_projects,
+            writable_projects=writable_projects,
+            accessible_teams=accessible_teams,
+            accessible_delegations=accessible_delegations,
             allowed_memory_scope_keys=allowed_memory_scope_keys,
         )
     except Exception as e:
@@ -576,6 +582,9 @@ async def _dispatch(
     organization_id: str,
     principal_id: str | None = None,
     accessible_projects: set[str] | None = None,
+    writable_projects: set[str] | None = None,
+    accessible_teams: set[str] | None = None,
+    accessible_delegations: set[str] | None = None,
     allowed_memory_scope_keys: set[str] | None = None,
 ) -> ManageResponse:
     """Route a validated action to its category handler (exhaustive)."""
@@ -589,7 +598,16 @@ async def _dispatch(
         )
     if action in SOURCE_ACTIONS:
         return await _handle_source_action(
-            cast("SourceAction", action), entity_id, data, organization_id=organization_id
+            cast("SourceAction", action),
+            entity_id,
+            data,
+            organization_id=organization_id,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            writable_projects=writable_projects,
+            accessible_teams=accessible_teams,
+            accessible_delegations=accessible_delegations,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
         )
     return await _handle_analysis_action(
         cast("AnalysisAction", action),
@@ -1295,6 +1313,12 @@ async def _handle_source_action(
     data: dict[str, Any],
     *,
     organization_id: str | None,
+    principal_id: str | None = None,
+    accessible_projects: set[str] | None = None,
+    writable_projects: set[str] | None = None,
+    accessible_teams: set[str] | None = None,
+    accessible_delegations: set[str] | None = None,
+    allowed_memory_scope_keys: set[str] | None = None,
 ) -> ManageResponse:
     """Handle source operations (crawl, sync, refresh)."""
     # Validate inputs BEFORE connecting to database
@@ -1382,12 +1406,14 @@ async def _handle_source_action(
         result = await apply_memory_correction(
             organization_id=organization_id,
             source_id=entity_id,
-            principal_id=str(data["user_id"]) if data.get("user_id") else None,
+            principal_id=principal_id,
             action=correction_action,
             reason=reason.strip(),
-            accessible_projects=data.get("accessible_projects"),
-            accessible_teams=data.get("accessible_teams"),
-            accessible_delegations=data.get("accessible_delegations"),
+            accessible_projects=accessible_projects,
+            writable_projects=writable_projects or set(),
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
+            accessible_teams=accessible_teams,
+            accessible_delegations=accessible_delegations,
             replacement_source_id=(
                 str(data["replacement_source_id"]) if data.get("replacement_source_id") else None
             ),

--- a/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
@@ -26,6 +26,7 @@ from sibyl_core.services.reflection import (
 from sibyl_core.services.surreal_content import (
     MemoryScope,
     RawMemory,
+    get_raw_memory,
     list_raw_memories_for_scope,
     raw_memory_recallable,
 )
@@ -52,6 +53,7 @@ async def reflect_memory(
     organization_id: str | None = None,
     principal_id: str | None = None,
     accessible_projects: set[str] | None = None,
+    writable_projects: set[str] | None = None,
     memory_scope: str | MemoryScope | None = None,
     scope_key: str | None = None,
     suggested_memory_scope: str | MemoryScope | None = None,
@@ -75,6 +77,16 @@ async def reflect_memory(
     if persist and persist_review and principal_id is None:
         msg = "principal_id is required when persist_review=True"
         raise ValueError(msg)
+
+    source_memory: RawMemory | None = None
+    if persist and persist_review and existing_source_id is not None:
+        source_memory = await _reflection_source_snapshot(
+            organization_id=str(organization_id),
+            principal_id=str(principal_id),
+            source_id=existing_source_id,
+            content=content,
+            accessible_projects=accessible_projects,
+        )
 
     limit = max(1, min(limit, 25))
     resolved_scope = _resolve_reflection_scope(memory_scope, project)
@@ -114,7 +126,9 @@ async def reflect_memory(
             principal_id=principal_id,
             memory_scope=resolved_scope,
             scope_key=resolved_scope_key,
-            accessible_projects=accessible_projects,
+            accessible_projects=writable_projects
+            if writable_projects is not None
+            else accessible_projects,
         )
         persist_policy_metadata = _reflect_policy_metadata(persist_decisions)
         if any(not decision.allowed for decision in persist_decisions):
@@ -143,7 +157,7 @@ async def reflect_memory(
     source_id: str | None = existing_source_id
     if persist and persist_source and source_id is None:
         if persist_review:
-            source = await _persist_reflection_source_review(
+            source, source_memory = await _persist_reflection_source_review(
                 title=source_title,
                 content=content,
                 organization_id=str(organization_id),
@@ -166,6 +180,7 @@ async def reflect_memory(
                 project=project,
                 related_to=related_to,
                 accessible_projects=accessible_projects,
+                writable_projects=writable_projects,
                 memory_scope=memory_scope,
                 scope_key=scope_key,
             )
@@ -260,6 +275,8 @@ async def reflect_memory(
                 principal_id=str(principal_id),
                 raw_source_ids=raw_source_ids,
                 source_id=source_id,
+                source_memories=[source_memory] if source_memory is not None else [],
+                accessible_projects=accessible_projects,
                 memory_scope=resolved_scope,
                 scope_key=resolved_scope_key,
                 suggested_memory_scope=resolved_suggested_scope,
@@ -284,6 +301,7 @@ async def reflect_memory(
             source_id=source_id,
             related_to=related_to,
             accessible_projects=accessible_projects,
+            writable_projects=writable_projects,
             memory_scope=memory_scope,
             scope_key=scope_key,
         )
@@ -456,7 +474,32 @@ async def _load_reflection_decision_memories(
     return [memory for memory in memories if raw_memory_recallable(memory)]
 
 
-async def _persist_reflection_source_review(**kwargs: Any) -> AddResponse:
+async def _reflection_source_snapshot(
+    *,
+    organization_id: str,
+    principal_id: str,
+    source_id: str,
+    content: str,
+    accessible_projects: set[str] | None,
+) -> RawMemory:
+    from sibyl_core.services.memory_policy import _authorize_share_source_read
+
+    source = await get_raw_memory(organization_id=organization_id, memory_id=source_id)
+    if (
+        source is None
+        or not _authorize_share_source_read(
+            memory=source,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+        ).allowed
+        or not raw_memory_recallable(source)
+        or source.raw_content.strip() != content
+    ):
+        raise ValueError("Reflection source is unavailable or changed")
+    return source
+
+
+async def _persist_reflection_source_review(**kwargs: Any) -> tuple[AddResponse, RawMemory]:
     from sibyl_core.services.surreal_content import remember_raw_memory
 
     policy_metadata = dict(kwargs.get("policy_metadata") or {})
@@ -486,11 +529,14 @@ async def _persist_reflection_source_review(**kwargs: Any) -> AddResponse:
         capture_surface="reflection_source",
         entity_type="session",
     )
-    return AddResponse(
-        success=True,
-        id=memory.id,
-        message=f"Stored reflection source for review: {memory.title}",
-        timestamp=datetime.now(UTC),
+    return (
+        AddResponse(
+            success=True,
+            id=memory.id,
+            message=f"Stored reflection source for review: {memory.title}",
+            timestamp=datetime.now(UTC),
+        ),
+        memory,
     )
 
 

--- a/packages/python/sibyl-core/tests/test_capture_projection_recovery.py
+++ b/packages/python/sibyl-core/tests/test_capture_projection_recovery.py
@@ -1,0 +1,109 @@
+"""Capture projection recovery through isolated content and graph stores."""
+
+import pytest
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.projection import reconcile
+from sibyl_core.services.content_models import RawMemory
+from sibyl_core.services.content_raw_persistence import save_raw_memory
+from sibyl_core.services.memory_lifecycle import projected_row_lifecycle_stamp
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+@pytest.mark.parametrize("locator", ["raw_memory_id", "raw_source_id"])
+async def test_absent_capture_remains_pending_until_stored(runtime, content_store, locator):
+    metadata = {locator: "late-capture"}
+    stamp, _ = await reconcile.prewrite_capture_stamp(
+        organization_id=runtime.client.group_id, metadata=metadata
+    )
+    assert not graph_metadata_recallable(stamp)
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="capture-child",
+            name="Capture child",
+            entity_type=EntityType.EPISODE,
+            metadata={**metadata, **stamp},
+        ),
+        generate_embedding=False,
+    )
+    await reconcile.reconcile_with_capture(
+        runtime.entity_manager,
+        organization_id=runtime.client.group_id,
+        metadata=metadata,
+        row_ids=["capture-child"],
+    )
+    child = await runtime.entity_manager.get("capture-child")
+    assert not graph_metadata_recallable(child.metadata)
+    assert child.metadata[reconcile.RECONCILE_PENDING_KEY]
+    assert "excluded_from_recall" not in child.metadata
+
+    await save_raw_memory(
+        RawMemory(
+            id="late-capture",
+            organization_id=runtime.client.group_id,
+            source_id="late-capture",
+            principal_id="user_a",
+            raw_content="Recovered source",
+        ),
+        embedding_provider=None,
+    )
+    outcome = await reconcile.reconcile_with_capture(
+        runtime.entity_manager,
+        organization_id=runtime.client.group_id,
+        metadata=metadata,
+        row_ids=["capture-child"],
+    )
+    child = await runtime.entity_manager.get("capture-child")
+    assert graph_metadata_recallable(child.metadata)
+    assert reconcile.RECONCILE_PENDING_KEY not in child.metadata
+    assert outcome.cleared == 1
+
+
+async def test_unbound_projection_has_no_capture_check(content_store):
+    assert await projected_row_lifecycle_stamp(organization_id="org", metadata={}) == {}
+
+
+async def test_alias_capture_recovery_preserves_other_capture_owner(runtime, content_store):
+    await runtime.entity_manager.create_direct(
+        Entity(id="shared-child", name="Shared child", entity_type=EntityType.EPISODE),
+        generate_embedding=False,
+    )
+    for source_id in ("source-a", "source-b"):
+        await reconcile.reconcile_with_capture(
+            runtime.entity_manager,
+            organization_id=runtime.client.group_id,
+            metadata={"raw_source_id": source_id},
+            row_ids=["shared-child"],
+        )
+    child = await runtime.entity_manager.get("shared-child")
+    assert child.metadata[reconcile.RECONCILE_PENDING_KEY] == {
+        "capture-source:source-a": True,
+        "capture-source:source-b": True,
+    }
+    for index, source_id in enumerate(("source-a", "source-b")):
+        await save_raw_memory(
+            RawMemory(
+                id=f"capture-{source_id}",
+                organization_id=runtime.client.group_id,
+                source_id=source_id,
+                principal_id="user_a",
+                raw_content="Recovered evidence",
+            ),
+            embedding_provider=None,
+        )
+        await reconcile.reconcile_with_capture(
+            runtime.entity_manager,
+            organization_id=runtime.client.group_id,
+            metadata={"raw_source_id": source_id},
+            row_ids=["shared-child"],
+        )
+        child = await runtime.entity_manager.get("shared-child")
+        assert graph_metadata_recallable(child.metadata) is (index == 1)
+        if index == 0:
+            assert child.metadata[reconcile.RECONCILE_PENDING_KEY] == {
+                "capture-source:source-b": True
+            }
+        else:
+            assert reconcile.RECONCILE_PENDING_KEY not in child.metadata

--- a/packages/python/sibyl-core/tests/test_correction_partial_propagation.py
+++ b/packages/python/sibyl-core/tests/test_correction_partial_propagation.py
@@ -1,0 +1,225 @@
+"""Correction failure and ordering checks from independent fault probes."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.services import memory_lifecycle as life
+from sibyl_core.services import memory_lineage as lineage
+from sibyl_core.services.content_models import RawMemory
+from sibyl_core.services.memory_contract import MemoryCorrectionPreview
+
+
+def preview(action):
+    return MemoryCorrectionPreview(
+        allowed=True,
+        source_id="root",
+        action=action,
+        reason="test",
+        target_lifecycle_state="active",
+        target_lifecycle_flags=[],
+        affected_source_ids=["root"],
+        affected_derived_ids=[],
+        reversible=True,
+        recall_impact={},
+        synthesis_impact={},
+        audit_action="test",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["lookup", "runtime"])
+async def test_initial_graph_failure_keeps_raw_propagation(monkeypatch, failure):
+    root = RawMemory(
+        id="root",
+        organization_id="org",
+        source_id="root",
+        principal_id="owner",
+        revision=2,
+        observed_revision=2,
+        metadata={"lifecycle_flags": ["hidden"]},
+    )
+    child = RawMemory(
+        id="child",
+        organization_id="org",
+        source_id="child",
+        principal_id="owner",
+        revision=1,
+        observed_revision=1,
+        metadata={"raw_source_ids": ["root"]},
+    )
+
+    async def raw_children(*, source_ids, **kwargs):
+        if "root" in source_ids:
+            yield "child"
+
+    save = AsyncMock(return_value=child)
+    runtime = SimpleNamespace(
+        client=SimpleNamespace(
+            execute_query=AsyncMock(side_effect=RuntimeError("graph lookup unavailable"))
+        )
+    )
+    monkeypatch.setattr(
+        life,
+        "get_surreal_graph_runtime",
+        AsyncMock(
+            side_effect=RuntimeError("runtime unavailable") if failure == "runtime" else None,
+            return_value=runtime,
+        ),
+    )
+    monkeypatch.setattr(lineage, "_raw_descendant_ids", raw_children)
+    monkeypatch.setattr(lineage, "get_raw_memory", AsyncMock(return_value=child))
+    monkeypatch.setattr(lineage, "save_raw_memory", save)
+    result = await life._project_correction_to_graph(
+        organization_id="org",
+        memory=root,
+        preview=preview("hide"),
+        principal_id="owner",
+        accessible_projects=set(),
+        replacement_source_id=None,
+        duplicate_of_source_id=None,
+    )
+    assert not result[3].complete
+    assert save.await_count == 1, (
+        "Healthy raw descendants were never attempted after graph lookup failure"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_edge_unlink_is_incomplete(monkeypatch):
+    root = RawMemory(
+        id="root",
+        organization_id="org",
+        source_id="root",
+        principal_id="owner",
+        revision=3,
+        observed_revision=3,
+    )
+    graph = Entity(
+        id="copy",
+        name="copy",
+        entity_type=EntityType.EPISODE,
+        observed_revision=1,
+        metadata={"memory_scope": "private", "principal_id": "owner"},
+    )
+
+    async def execute(query, **kwargs):
+        if query.strip().startswith("DELETE"):
+            raise RuntimeError("edge deletion unavailable")
+        return []
+
+    runtime = SimpleNamespace(
+        client=SimpleNamespace(execute_query=execute),
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(return_value=graph), update=AsyncMock(return_value=graph)
+        ),
+    )
+
+    async def raw_children(**kwargs):
+        if False:
+            yield ""
+
+    monkeypatch.setattr(life, "get_surreal_graph_runtime", AsyncMock(return_value=runtime))
+    monkeypatch.setattr(
+        life,
+        "_correction_graph_entity_ids",
+        AsyncMock(
+            return_value=life._CorrectionGraphTargets(
+                authorized=["copy"], refused=[], direct=["copy"]
+            )
+        ),
+    )
+    monkeypatch.setattr(lineage, "_raw_descendant_ids", raw_children)
+    result = await life._project_correction_to_graph(
+        organization_id="org",
+        memory=root,
+        preview=preview("restore"),
+        principal_id="owner",
+        accessible_projects=set(),
+        replacement_source_id=None,
+        duplicate_of_source_id=None,
+    )
+    assert not result[3].complete, (
+        "Restore claims complete although its correction edge still excludes the row"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_supersede_does_not_recreate_restored_edge(monkeypatch):
+    root = RawMemory(
+        id="root",
+        organization_id="org",
+        source_id="root",
+        principal_id="owner",
+        revision=2,
+        observed_revision=2,
+        metadata={"lifecycle_state": "superseded"},
+    )
+    replacement = RawMemory(
+        id="replacement",
+        organization_id="org",
+        source_id="replacement",
+        principal_id="owner",
+        revision=1,
+        observed_revision=1,
+    )
+    # The newer restore already cleared this root before the supersede worker resumed.
+    copy = Entity(
+        id="copy",
+        name="copy",
+        entity_type=EntityType.EPISODE,
+        observed_revision=3,
+        metadata={
+            "memory_scope": "private",
+            "principal_id": "owner",
+            "correction_blockers": {"root": {"revision": 3, "blocking": False}},
+        },
+    )
+    new = Entity(
+        id="new",
+        name="new",
+        entity_type=EntityType.EPISODE,
+        observed_revision=1,
+        metadata={"memory_scope": "private", "principal_id": "owner"},
+    )
+
+    async def raw_children(**kwargs):
+        if False:
+            yield ""
+
+    async def targets(_runtime, *, memory, **kwargs):
+        ids = ["copy"] if memory.id == "root" else ["new"]
+        return life._CorrectionGraphTargets(authorized=ids, refused=[], direct=ids)
+
+    edges = []
+
+    async def create(edge):
+        edges.append(edge)
+        return edge.id
+
+    runtime = SimpleNamespace(
+        client=SimpleNamespace(execute_query=AsyncMock(return_value=[])),
+        entity_manager=SimpleNamespace(
+            get=AsyncMock(side_effect=lambda entity_id: copy if entity_id == "copy" else new),
+            update=AsyncMock(),
+        ),
+        relationship_manager=SimpleNamespace(create=create),
+    )
+    monkeypatch.setattr(life, "get_surreal_graph_runtime", AsyncMock(return_value=runtime))
+    monkeypatch.setattr(life, "_correction_graph_entity_ids", targets)
+    monkeypatch.setattr(life, "get_raw_memory_by_source_id", AsyncMock(return_value=replacement))
+    monkeypatch.setattr(lineage, "_raw_descendant_ids", raw_children)
+    result = await life._project_correction_to_graph(
+        organization_id="org",
+        memory=root,
+        preview=preview("supersede"),
+        principal_id="owner",
+        accessible_projects=set(),
+        replacement_source_id="replacement",
+        duplicate_of_source_id=None,
+    )
+    assert result[3].complete
+    runtime.entity_manager.update.assert_not_awaited()
+    assert edges == [], "Stale supersede recreates an inbound exclusion after a newer restore"

--- a/packages/python/sibyl-core/tests/test_correction_scope_grants.py
+++ b/packages/python/sibyl-core/tests/test_correction_scope_grants.py
@@ -1,0 +1,372 @@
+"""Credential grants constrain correction disclosure without suppressing writes."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl_core.auth.memory_policy import memory_scope_policy_key
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.services import content_client
+from sibyl_core.services.graph_client import SurrealGraphClient, prepare_graph_schema
+from sibyl_core.services.graph_entities import EntityManager
+from sibyl_core.services.graph_relationships import RelationshipManager
+from sibyl_core.services.graph_runtime import GraphRuntime
+from sibyl_core.services.memory_correction import apply_memory_correction, preview_memory_correction
+from sibyl_core.services.surreal_content import get_raw_memory, remember_raw_memory
+
+
+@pytest.fixture
+async def correction_store(monkeypatch):
+    org = str(uuid4())
+    content = SurrealContentClient(url="memory://")
+    graph = SurrealGraphClient(group_id=org, url="memory://")
+    try:
+        await bootstrap_content_schema(content, reset=True)
+        await prepare_graph_schema(graph)
+        runtime = GraphRuntime(
+            client=graph,
+            entity_manager=EntityManager(graph, group_id=org),
+            relationship_manager=RelationshipManager(graph, group_id=org),
+        )
+
+        @asynccontextmanager
+        async def session():
+            yield content
+
+        monkeypatch.setattr(content_client, "surreal_content_client", session)
+        monkeypatch.setattr(
+            "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+            AsyncMock(return_value=runtime),
+        )
+        yield SimpleNamespace(org=org, runtime=runtime)
+    finally:
+        await content.close()
+        await graph.close()
+
+
+async def capture(store, source_id, **kwargs):
+    return await remember_raw_memory(
+        organization_id=store.org,
+        principal_id="owner",
+        source_id=source_id,
+        raw_content=f"Advice from {source_id}",
+        embedding_provider=None,
+        **kwargs,
+    )
+
+
+def grants(private):
+    keys = {memory_scope_policy_key("project", "project-a")}
+    if private:
+        keys.add(memory_scope_policy_key("private", "owner"))
+    return keys
+
+
+@pytest.mark.parametrize("private", [False, True])
+async def test_correction_scope_grants_filter_receipts_without_skipping_writes(
+    correction_store, private
+):
+    store = correction_store
+    root = await capture(store, "root", memory_scope="project", scope_key="project-a")
+    child = await capture(
+        store,
+        "child",
+        metadata={"raw_source_ids": [root.id]},
+        accessible_projects={"project-a"},
+    )
+    for entity_id, lineage in (
+        ("direct", {"raw_memory_id": root.id}),
+        ("passage", {"parent_entity_id": "direct", "projection_kind": "passage"}),
+        ("indirect", {"raw_source_ids": [root.id]}),
+    ):
+        await store.runtime.entity_manager.create_direct(
+            Entity(
+                id=entity_id,
+                name=entity_id,
+                content="Private advice",
+                entity_type=EntityType.EPISODE,
+                metadata={"memory_scope": "private", "principal_id": "owner", **lineage},
+            ),
+            generate_embedding=False,
+        )
+    result = await apply_memory_correction(
+        organization_id=store.org,
+        source_id=root.id,
+        principal_id="owner",
+        action="hide",
+        accessible_projects=iter(["project-a"]),
+        allowed_memory_scope_keys=iter(grants(private)),
+    )
+    assert result.applied and result.propagation_complete
+    stored = await get_raw_memory(organization_id=store.org, memory_id=child.id)
+    assert stored.metadata["correction_blockers"][root.id]["blocking"] is True
+    assert (child.id in result.affected_raw_memory_ids) is private
+    for entity_id in ("direct", "passage", "indirect"):
+        row = await store.runtime.entity_manager.get(entity_id)
+        assert row.metadata["correction_blockers"][root.id]["blocking"] is True
+        assert (entity_id in result.affected_entity_ids) is private
+
+
+@pytest.mark.parametrize(
+    "action,reference_key",
+    [
+        ("supersede", "replacement_source_id"),
+        ("mark_duplicate", "duplicate_of_source_id"),
+    ],
+)
+@pytest.mark.parametrize("private", [False, True])
+async def test_correction_scope_grants_gate_private_references(
+    correction_store, action, reference_key, private
+):
+    store = correction_store
+    root = await capture(store, "root", memory_scope="project", scope_key="project-a")
+    reference = await capture(store, "private-reference")
+    result = await preview_memory_correction(
+        organization_id=store.org,
+        source_id=root.id,
+        principal_id="owner",
+        action=action,
+        accessible_projects=iter(["project-a"]),
+        allowed_memory_scope_keys=iter(grants(private)),
+        **{reference_key: reference.id},
+    )
+    assert result.allowed is private
+    if not private:
+        assert result.reason.endswith("_source_not_found")
+
+
+@pytest.mark.parametrize("private", [False, True])
+async def test_correction_scope_grants_gate_caller_declared_graph_target(correction_store, private):
+    store = correction_store
+    root = await capture(
+        store,
+        "root",
+        memory_scope="project",
+        scope_key="project-a",
+        metadata={"promoted_entity_id": "declared-private"},
+    )
+    await store.runtime.entity_manager.create_direct(
+        Entity(
+            id="declared-private",
+            name="Declared private target",
+            content="Private advice",
+            entity_type=EntityType.EPISODE,
+            metadata={"memory_scope": "private", "principal_id": "owner"},
+        ),
+        generate_embedding=False,
+    )
+    result = await apply_memory_correction(
+        organization_id=store.org,
+        source_id=root.id,
+        principal_id="owner",
+        action="hide",
+        accessible_projects={"project-a"},
+        allowed_memory_scope_keys=grants(private),
+    )
+    row = await store.runtime.entity_manager.get("declared-private")
+    assert (root.id in row.metadata.get("correction_blockers", {})) is private
+    assert result.refused_entity_ids == []
+    assert result.propagation_complete is private
+    assert result.preview.affected_derived_ids == (["declared-private"] if private else [])
+    assert result.updated_memory.metadata["memory_lifecycle"]["derived_ids"] == (
+        ["declared-private"] if private else []
+    )
+    assert result.updated_memory.metadata["promoted_entity_id"] == "declared-private"
+
+
+async def test_correction_scope_grants_gate_direct_core_root(correction_store):
+    store = correction_store
+    root = await capture(store, "private-root")
+    result = await apply_memory_correction(
+        organization_id=store.org,
+        source_id=root.id,
+        principal_id="owner",
+        action="hide",
+        allowed_memory_scope_keys=grants(False),
+    )
+    assert not result.applied
+    assert result.preview.reason == "api_key_memory_space_denied"
+    stored = await get_raw_memory(organization_id=store.org, memory_id=root.id)
+    assert stored.revision == root.revision
+
+
+@pytest.mark.parametrize("expected_delta", [None, 0, 1])
+async def test_correction_scope_authority_race_cannot_write_new_owner_snapshot(
+    correction_store, monkeypatch, expected_delta
+):
+    from dataclasses import replace
+
+    from sibyl_core.errors import RevisionConflictError
+    from sibyl_core.services import memory_correction
+    from sibyl_core.services.surreal_content import save_raw_memory
+
+    store = correction_store
+    root = await capture(store, "root")
+    original_load = memory_correction._load_correction_memory
+    loads = 0
+
+    async def transfer_after_read(**kwargs):
+        nonlocal loads
+        row = await original_load(**kwargs)
+        loads += 1
+        if loads == 1:
+            await save_raw_memory(
+                replace(row, principal_id="new-owner"),
+                expected_revision=row.observed_revision,
+            )
+        return row
+
+    monkeypatch.setattr(memory_correction, "_load_correction_memory", transfer_after_read)
+    with pytest.raises(RevisionConflictError):
+        await apply_memory_correction(
+            organization_id=store.org,
+            source_id=root.id,
+            principal_id="owner",
+            action="hide",
+            expected_revision=None if expected_delta is None else root.revision + expected_delta,
+        )
+    stored = await get_raw_memory(organization_id=store.org, memory_id=root.id)
+    assert stored.principal_id == "new-owner"
+    assert "memory_lifecycle" not in stored.metadata
+
+
+async def test_correction_scope_unknown_revision_cannot_write(correction_store, monkeypatch):
+    from dataclasses import replace
+
+    from sibyl_core.services import memory_correction
+
+    store = correction_store
+    root = await capture(store, "root")
+    monkeypatch.setattr(
+        memory_correction,
+        "_load_correction_memory",
+        AsyncMock(return_value=replace(root, observed_revision=None)),
+    )
+    save = AsyncMock()
+    monkeypatch.setattr(memory_correction, "save_raw_memory", save)
+    result = await apply_memory_correction(
+        organization_id=store.org,
+        source_id=root.id,
+        principal_id="owner",
+        action="hide",
+    )
+    assert not result.applied
+    assert result.preview.reason == "memory_source_revision_unavailable"
+    save.assert_not_awaited()
+
+
+async def test_correction_scope_readable_refusal_remains_visible(correction_store):
+    store = correction_store
+    root = await capture(
+        store,
+        "root",
+        memory_scope="project",
+        scope_key="project-a",
+        metadata={"promoted_entity_id": "project-a"},
+    )
+    await store.runtime.entity_manager.create_direct(
+        Entity(id="project-a", name="Project A", entity_type=EntityType.PROJECT),
+        generate_embedding=False,
+    )
+    result = await apply_memory_correction(
+        organization_id=store.org,
+        source_id=root.id,
+        principal_id="owner",
+        action="hide",
+        accessible_projects={"project-a"},
+        allowed_memory_scope_keys=grants(False),
+    )
+    assert result.applied and not result.propagation_complete
+    assert result.preview.affected_derived_ids == ["project-a"]
+    assert result.refused_entity_ids == ["project-a"]
+    row = await store.runtime.entity_manager.get("project-a")
+    assert "correction_blockers" not in row.metadata
+
+
+@pytest.mark.parametrize("write_granted", [False, True])
+async def test_correction_write_projects_are_distinct_from_reference_visibility(
+    correction_store, write_granted
+):
+    store = correction_store
+    root = await capture(
+        store,
+        "role-root",
+        memory_scope="project",
+        scope_key="project-a",
+        metadata={"promoted_entity_id": "project-b"},
+    )
+    await store.runtime.entity_manager.create_direct(
+        Entity(id="project-b", name="Readable project", entity_type=EntityType.PROJECT),
+        generate_embedding=False,
+    )
+    kwargs = {
+        "organization_id": store.org,
+        "source_id": root.id,
+        "principal_id": "owner",
+        "action": "hide",
+        "accessible_projects": {"project-a", "project-b"},
+        "writable_projects": {"project-a"} if write_granted else set(),
+    }
+    preview = await preview_memory_correction(**kwargs)
+    assert preview.allowed is write_granted
+    if write_granted:
+        assert preview.affected_derived_ids == ["project-b"]
+    applied = await apply_memory_correction(**kwargs)
+    assert applied.applied is write_granted
+    stored = await get_raw_memory(organization_id=store.org, memory_id=root.id)
+    assert stored is not None
+    assert (stored.revision > root.revision) is write_granted
+
+
+async def test_correction_reloaded_root_cannot_use_another_projects_write_grant(correction_store):
+    store = correction_store
+    root = await capture(store, "moved-root", memory_scope="project", scope_key="read-only")
+    result = await apply_memory_correction(
+        organization_id=store.org,
+        source_id=root.id,
+        principal_id="owner",
+        action="delete",
+        accessible_projects={"original-writable", "read-only"},
+        writable_projects={"original-writable"},
+    )
+    assert not result.applied
+    stored = await get_raw_memory(organization_id=store.org, memory_id=root.id)
+    assert stored is not None
+    assert stored.raw_content == root.raw_content
+    assert stored.revision == root.revision
+
+
+@pytest.mark.parametrize("target_writable", [False, True])
+async def test_declared_project_target_requires_its_own_write_grant(
+    correction_store, target_writable
+):
+    store = correction_store
+    root = await capture(
+        store, "declared-role-root", metadata={"promoted_entity_id": "declared-project-row"}
+    )
+    await store.runtime.entity_manager.create_direct(
+        Entity(
+            id="declared-project-row",
+            name="Project row",
+            entity_type=EntityType.EPISODE,
+            metadata={"memory_scope": "project", "scope_key": "project-b"},
+        ),
+        generate_embedding=False,
+    )
+    result = await apply_memory_correction(
+        organization_id=store.org,
+        source_id=root.id,
+        principal_id="owner",
+        action="hide",
+        accessible_projects={"project-b"},
+        writable_projects={"project-b"} if target_writable else set(),
+    )
+    assert result.applied
+    target = await store.runtime.entity_manager.get("declared-project-row")
+    assert ("correction_blockers" in target.metadata) is target_writable
+    assert result.refused_entity_ids == ([] if target_writable else [target.id])

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -67,6 +67,7 @@ from sibyl_core.services.usage import (
 
 
 class _EmbeddingWriteClient:
+    _url = "memory://"
     group_id = "org-native"
 
     def __init__(self) -> None:
@@ -668,6 +669,7 @@ class _TransientEntityWriteClient:
 
 
 class _LegacyUpdatedAtEntityWriteClient:
+    _url = "memory://"
     group_id = "org-legacy-updated-at"
 
     def __init__(self) -> None:

--- a/packages/python/sibyl-core/tests/test_legacy_source_reconciliation.py
+++ b/packages/python/sibyl-core/tests/test_legacy_source_reconciliation.py
@@ -1,0 +1,48 @@
+"""Legacy source repair preserves evidence across bookkeeping-only writes."""
+
+from dataclasses import replace
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.projection.reconcile import reconcile_with_capture
+from sibyl_core.services.memory_policy import raw_memory_source_fingerprint
+from sibyl_core.services.memory_reflection import persist_reflection_candidate
+from sibyl_core.services.surreal_content import save_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+from tests.test_reflection_legacy_epoch_identity import legacy_source
+
+
+async def test_legacy_source_repair_does_not_retire_unchanged_observed_text(runtime, content_store):
+    source = await legacy_source(runtime)
+    published = await persist_reflection_candidate(
+        candidate=ReflectionCandidate(
+            kind="decision",
+            title="Audit trail",
+            content=source.raw_content,
+            confidence=1.0,
+            reason="Recorded decision",
+            raw_source_ids=[source.id],
+        ),
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id=source.id,
+        source_memories=[source],
+        link_source_entity=False,
+    )
+    assert published.response.success
+    await save_raw_memory(
+        replace(source, metadata={**source.metadata, "reflection_run_id": "later"}),
+        expected_revision=source.revision,
+        embedding_provider=None,
+    )
+    await reconcile_with_capture(
+        runtime.entity_manager,
+        organization_id=runtime.client.group_id,
+        metadata={"raw_memory_id": source.id},
+        row_ids=[published.response.id],
+        expected_signature=raw_memory_source_fingerprint(source),
+    )
+    row = await runtime.entity_manager.get(published.response.id)
+    assert graph_metadata_recallable(row.metadata)
+    assert row.metadata["source_bindings"] == {source.id: source.revision}

--- a/packages/python/sibyl-core/tests/test_lifecycle_repair.py
+++ b/packages/python/sibyl-core/tests/test_lifecycle_repair.py
@@ -1,0 +1,86 @@
+"""Repair sweeps recover healthy sources without starving unresolved rows."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.projection import repair
+from tests.test_reflection_identity import runtime as runtime
+
+
+async def test_repair_sweeps_cross_pages_and_preserve_unknown_owners(runtime, monkeypatch):
+    monkeypatch.setattr(repair, "_PAGE_SIZE", 2)
+    for row_id, metadata in (
+        ("parent", {}),
+        ("a-legacy", {"source_validation_pending": True}),
+        ("b-missing", {"lifecycle_reconciliation_pending": {"parent:absent": True}}),
+        (
+            "c-ready",
+            {
+                "lifecycle_reconciliation_pending": {"parent:parent": True},
+                "excluded_from_recall": True,
+            },
+        ),
+        ("d-ready", {"lifecycle_reconciliation_pending": {"parent:parent": True}}),
+        ("e-ready", {"lifecycle_reconciliation_pending": {"parent:parent": True}}),
+    ):
+        await runtime.entity_manager.create_direct(
+            Entity(id=row_id, name=row_id, entity_type=EntityType.EPISODE, metadata=metadata),
+            generate_embedding=False,
+        )
+    result = await repair.repair_graph_lifecycle(runtime)
+    assert (result.checked, result.recovered, result.pending, result.failed) == (5, 3, 2, 0)
+    authored = await runtime.entity_manager.get("c-ready")
+    assert authored.metadata["excluded_from_recall"] is True
+    repeated = await repair.repair_graph_lifecycle(runtime)
+    assert (repeated.checked, repeated.pending, repeated.recovered) == (2, 2, 0)
+    await runtime.entity_manager.create_direct(
+        Entity(id="absent", name="Available parent", entity_type=EntityType.EPISODE),
+        generate_embedding=False,
+    )
+    await asyncio.gather(
+        repair.repair_graph_lifecycle(runtime), repair.repair_graph_lifecycle(runtime)
+    )
+    pending = await repair.repair_graph_lifecycle(runtime)
+    assert (pending.checked, pending.pending, pending.failed) == (1, 1, 0)
+    legacy = await runtime.entity_manager.get("a-legacy")
+    assert legacy.metadata["source_validation_pending"]
+
+
+@pytest.mark.parametrize("row_id,key", [("z-row", "a-key"), ("a-row", "z-key")])
+async def test_repair_cursor_uses_the_ordered_key(monkeypatch, row_id, key):
+    monkeypatch.setattr(repair, "_PAGE_SIZE", 1)
+    query = AsyncMock(side_effect=[[{"uuid": row_id, "lifecycle_repair_key": key}], []])
+    repair_row = AsyncMock(return_value="pending")
+    monkeypatch.setattr(repair, "_repair_row", repair_row)
+    runtime = SimpleNamespace(client=SimpleNamespace(group_id="org", execute_query=query))
+
+    result = await repair.repair_graph_lifecycle(runtime)
+
+    assert result.checked == result.pending == 1
+    assert query.await_args_list[0].kwargs["cursor"] == ""
+    assert query.await_args_list[1].kwargs["cursor"] == key
+    repair_row.assert_awaited_once_with(runtime, row_id)
+
+
+@pytest.mark.parametrize("digest", ["", "short", "z" * 64])
+async def test_malformed_signature_does_not_starve_other_repair_owners(runtime, digest):
+    malformed = f"capture-signature-v1:source:{digest}"
+    for row_id, metadata in (
+        ("parent", {}),
+        (
+            "child",
+            {"lifecycle_reconciliation_pending": {malformed: True, "parent:parent": True}},
+        ),
+    ):
+        await runtime.entity_manager.create_direct(
+            Entity(id=row_id, name=row_id, entity_type=EntityType.EPISODE, metadata=metadata),
+            generate_embedding=False,
+        )
+    result = await repair.repair_graph_lifecycle(runtime)
+    assert result.checked == result.pending == 1 and result.failed == 0
+    row = await runtime.entity_manager.get("child")
+    assert row.metadata["lifecycle_reconciliation_pending"] == {malformed: True}

--- a/packages/python/sibyl-core/tests/test_lifecycle_repair_index.py
+++ b/packages/python/sibyl-core/tests/test_lifecycle_repair_index.py
@@ -1,0 +1,126 @@
+"""Pending repair discovery and schema upgrade against an isolated graph."""
+
+from sibyl_core.backends.surreal.schema import bootstrap_schema
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.projection.repair import PENDING_REPAIR_QUERY as QUERY
+from sibyl_core.services.graph_common import normalize_graph_records
+from tests.test_reflection_identity import runtime as runtime
+
+
+async def test_repair_index_upgrades_existing_pending_rows_and_tracks_recovery(runtime):
+    await runtime.client.execute_query("REMOVE INDEX idx_entity_lifecycle_repair_key ON entity;")
+    await runtime.client.execute_query("REMOVE FIELD lifecycle_repair_key ON entity;")
+    await runtime.client.execute_query(
+        "UPDATE schema_version SET version = 21 WHERE name = 'graph';"
+    )
+    for row_id, metadata in (
+        ("repair-a", {"lifecycle_reconciliation_pending": {"parent:a": True}}),
+        ("repair-b", {"source_validation_pending": True}),
+        ("healthy", {}),
+    ):
+        await runtime.entity_manager.create_direct(
+            Entity(id=row_id, name=row_id, entity_type=EntityType.EPISODE, metadata=metadata),
+            generate_embedding=False,
+        )
+    await bootstrap_schema(runtime.client)
+    params = {"cursor": "", "limit": 10, "group_id": runtime.client.group_id}
+    rows = normalize_graph_records(await runtime.client.execute_query(QUERY + ";", **params))
+    assert [row["uuid"] for row in rows] == ["repair-a", "repair-b"]
+    assert all(row["uuid"] == row["lifecycle_repair_key"] for row in rows)
+    plan = normalize_graph_records(
+        await runtime.client.execute_query(QUERY + " EXPLAIN;", **params)
+    )
+    _assert_repair_index(plan)
+    page_params = {**params, "cursor": "repair-a", "limit": 1}
+    page = normalize_graph_records(await runtime.client.execute_query(QUERY + ";", **page_params))
+    assert [row["uuid"] for row in page] == ["repair-b"]
+    bounded_plan = normalize_graph_records(
+        await runtime.client.execute_query(QUERY + " EXPLAIN;", **page_params)
+    )
+    _assert_repair_index(bounded_plan, cursor="repair-a")
+    # This checks predicate evaluation within one namespace, not tenant isolation.
+    assert not normalize_graph_records(
+        await runtime.client.execute_query(QUERY + ";", **{**params, "group_id": "other"})
+    )
+    row = await runtime.entity_manager.get("repair-a")
+    await runtime.entity_manager.update(
+        row.id,
+        {"metadata": {"lifecycle_reconciliation_pending": None}},
+        expected_revision=row.observed_revision,
+        replace_metadata_keys=("lifecycle_reconciliation_pending",),
+    )
+    rows = normalize_graph_records(await runtime.client.execute_query(QUERY + ";", **params))
+    assert [row["uuid"] for row in rows] == ["repair-b"]
+    assert (await runtime.entity_manager.get("repair-b")).metadata["source_validation_pending"]
+    await bootstrap_schema(runtime.client, force=True)
+    rows = normalize_graph_records(await runtime.client.execute_query(QUERY + ";", **params))
+    assert [row["uuid"] for row in rows] == ["repair-b"]
+
+
+def _assert_repair_index(plan, *, cursor=None):
+    """Check range discovery in both supported planner representations.
+
+    Index use does not establish how many records an ordered collector reads.
+    Scale qualification must measure that separately on populated databases.
+    The server branch is exercised by the external isolated-server qualification;
+    this module's default runtime fixture uses the embedded backend.
+    """
+    nodes = []
+
+    def visit(node):
+        nodes.append(node)
+        for child in node.get("children", []):
+            visit(child)
+
+    for node in plan:
+        visit(node)
+    assert not any(
+        str(node.get("operation", "")).startswith("Iterate Table")
+        or node.get("operator") == "TableScan"
+        for node in nodes
+    ), plan
+    indexes = [
+        node
+        for node in nodes
+        if node.get("operation") == "Iterate Index" or node.get("operator") == "IndexScan"
+    ]
+    assert indexes, plan
+    for node in indexes:
+        if node.get("operation") == "Iterate Index":
+            access = node["detail"]["plan"]
+            assert access["index"] == "idx_entity_lifecycle_repair_key", plan
+            assert access["from"]["inclusive"] is False, plan
+            assert access["from"]["value"] == (cursor or ""), plan
+        else:
+            access = node["attributes"]
+            assert access["index"] == "idx_entity_lifecycle_repair_key", plan
+            assert access["access"] == f">{cursor or ''!r}", plan
+
+
+async def test_repair_key_tracks_updates_and_allows_multiple_healthy_rows(runtime):
+    for row_id in ("healthy-a", "healthy-b", "healthy-c"):
+        await runtime.entity_manager.create_direct(
+            Entity(id=row_id, name=row_id, entity_type=EntityType.EPISODE),
+            generate_embedding=False,
+        )
+    params = {"cursor": "", "limit": 10, "group_id": runtime.client.group_id}
+    assert not normalize_graph_records(await runtime.client.execute_query(QUERY + ";", **params))
+
+    row = await runtime.entity_manager.get("healthy-b")
+    await runtime.entity_manager.update(
+        row.id,
+        {"metadata": {"lifecycle_reconciliation_pending": {"parent:absent": True}}},
+        expected_revision=row.observed_revision,
+        replace_metadata_keys=("lifecycle_reconciliation_pending",),
+    )
+    rows = normalize_graph_records(await runtime.client.execute_query(QUERY + ";", **params))
+    assert rows == [{"uuid": "healthy-b", "lifecycle_repair_key": "healthy-b"}]
+
+    row = await runtime.entity_manager.get("healthy-b")
+    await runtime.entity_manager.update(
+        row.id,
+        {"metadata": {"lifecycle_reconciliation_pending": None}},
+        expected_revision=row.observed_revision,
+        replace_metadata_keys=("lifecycle_reconciliation_pending",),
+    )
+    assert not normalize_graph_records(await runtime.client.execute_query(QUERY + ";", **params))

--- a/packages/python/sibyl-core/tests/test_manage_correction_grants.py
+++ b/packages/python/sibyl-core/tests/test_manage_correction_grants.py
@@ -1,0 +1,80 @@
+"""Core correction dispatch keeps read, write, and credential grants distinct."""
+
+import pytest
+
+from sibyl_core.auth.memory_policy import memory_scope_policy_key
+from sibyl_core.services.surreal_content import get_raw_memory, remember_raw_memory
+from sibyl_core.tools.manage import manage
+from tests.test_correction_scope_grants import correction_store as correction_store
+
+
+@pytest.mark.parametrize("writable", [False, True])
+@pytest.mark.parametrize("credential_allows", [False, True])
+async def test_core_correction_requires_explicit_write_and_credential_grants(
+    correction_store, writable, credential_allows
+):
+    org = correction_store.org
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="owner",
+        source_id="manage-grants",
+        raw_content="Evidence",
+        memory_scope="project",
+        scope_key="project-a",
+        embedding_provider=None,
+    )
+    response = await manage(
+        action="correct_memory",
+        entity_id=source.id,
+        organization_id=org,
+        principal_id="owner",
+        accessible_projects={"project-a"},
+        writable_projects={"project-a"} if writable else set(),
+        allowed_memory_scope_keys=(
+            {memory_scope_policy_key("project", "project-a")} if credential_allows else set()
+        ),
+        data={
+            "action": "hide",
+            "reason": "Outdated evidence",
+            "user_id": "owner",
+            "accessible_projects": {"project-a"},
+            "writable_projects": {"project-a"},
+            "allowed_memory_scope_keys": {memory_scope_policy_key("project", "project-a")},
+        },
+    )
+    assert response.success is (writable and credential_allows)
+    current = await get_raw_memory(organization_id=org, memory_id=source.id)
+    assert current is not None
+    assert (current.revision > source.revision) is (writable and credential_allows)
+
+
+@pytest.mark.parametrize("scope", ["private", "team"])
+async def test_core_correction_ignores_identity_and_team_grants_in_action_data(
+    correction_store, scope
+):
+    org = correction_store.org
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="owner",
+        source_id="manage-forged-authority",
+        raw_content="Evidence",
+        memory_scope=scope,
+        scope_key="team-a" if scope == "team" else None,
+        embedding_provider=None,
+    )
+    response = await manage(
+        action="correct_memory",
+        entity_id=source.id,
+        organization_id=org,
+        principal_id="owner" if scope == "team" else "another-user",
+        accessible_teams=set(),
+        data={
+            "action": "hide",
+            "reason": "Outdated evidence",
+            "user_id": "owner",
+            "accessible_teams": {"team-a"},
+        },
+    )
+    assert not response.success
+    current = await get_raw_memory(organization_id=org, memory_id=source.id)
+    assert current is not None and current.revision == source.revision

--- a/packages/python/sibyl-core/tests/test_memory.py
+++ b/packages/python/sibyl-core/tests/test_memory.py
@@ -62,6 +62,7 @@ def _raw_review_candidate(**overrides: object) -> RawMemory:
         "created_at": datetime(2026, 5, 12, 12, 0, 0, tzinfo=UTC),
     }
     values.update(overrides)
+    values.setdefault("observed_revision", values.get("revision", 1))
     return RawMemory(**values)
 
 
@@ -88,6 +89,7 @@ def _raw_import_memory(**overrides: object) -> RawMemory:
         "created_at": datetime(2026, 5, 12, 12, 0, 0, tzinfo=UTC),
     }
     values.update(overrides)
+    values.setdefault("observed_revision", values.get("revision", 1))
     return RawMemory(**values)
 
 
@@ -631,7 +633,7 @@ async def test_apply_memory_correction_marks_hidden_and_preserves_history(
         principal_id="user-1",
         metadata={"correction_history": [{"action": "mark_stale"}]},
     )
-    save_raw_memory = AsyncMock(side_effect=lambda updated: updated)
+    save_raw_memory = AsyncMock(side_effect=lambda updated, **_kwargs: updated)
     monkeypatch.setattr(correction_module, "get_raw_memory", AsyncMock(return_value=memory))
     monkeypatch.setattr(correction_module, "get_raw_memory_by_source_id", AsyncMock())
     monkeypatch.setattr(correction_module, "save_raw_memory", save_raw_memory)
@@ -666,6 +668,8 @@ async def test_apply_memory_correction_marks_hidden_and_preserves_history(
     assert result.updated_memory.metadata["correction_history"][0] == {"action": "mark_stale"}
     assert result.updated_memory.metadata["correction_history"][1]["action"] == "hide"
     save_raw_memory.assert_awaited_once()
+
+    assert save_raw_memory.await_args.kwargs["expected_revision"] == memory.revision
 
 
 @pytest.mark.asyncio
@@ -886,7 +890,7 @@ async def test_apply_memory_correction_restore_preserves_prior_review_state(
             "prior_review_state": "promoted",
         },
     )
-    save_raw_memory = AsyncMock(side_effect=lambda updated: updated)
+    save_raw_memory = AsyncMock(side_effect=lambda updated, **_kwargs: updated)
     monkeypatch.setattr(correction_module, "get_raw_memory", AsyncMock(return_value=memory))
     monkeypatch.setattr(correction_module, "get_raw_memory_by_source_id", AsyncMock())
     monkeypatch.setattr(correction_module, "save_raw_memory", save_raw_memory)
@@ -914,6 +918,8 @@ async def test_apply_memory_correction_restore_preserves_prior_review_state(
     assert lifecycle.flags == []
     assert lifecycle.action == "restore"
     assert findings[-1].action == "restore"
+
+    assert save_raw_memory.await_args.kwargs["expected_revision"] == memory.revision
 
 
 @pytest.mark.asyncio
@@ -1100,6 +1106,7 @@ async def test_share_memory_promotes_same_org_visible_sources_without_marking_so
         target_scope="project",
         target_scope_key="project_123",
         accessible_projects={"project_123"},
+        writable_projects={"project_123"},
     )
 
     assert result.applied is True

--- a/packages/python/sibyl-core/tests/test_memory_pipeline_capture.py
+++ b/packages/python/sibyl-core/tests/test_memory_pipeline_capture.py
@@ -9,6 +9,30 @@ from sibyl_core.memory_pipeline.capture import MemoryCaptureRequest, MemoryCaptu
 
 
 @pytest.mark.asyncio
+async def test_capture_preserves_observed_bindings_over_caller_claims() -> None:
+    observed = {"capture": 5, "ancestor": 2}
+
+    async def remember_raw(_request):
+        return {"id": "capture", "source_bindings": observed}
+
+    async def create_graph(_request, metadata):
+        # A later source revision must not relabel the text already captured.
+        observed["capture"] = 6
+        assert metadata["source_bindings"] == {"capture": 5, "ancestor": 2}
+        return {"id": "derived"}
+
+    await MemoryCaptureService(
+        remember_raw_memory=remember_raw, create_graph_entity=create_graph
+    ).capture(
+        MemoryCaptureRequest(
+            title="Evidence",
+            content="The observed text",
+            metadata={"source_bindings": {"capture": 999, "forged": 999}},
+        )
+    )
+
+
+@pytest.mark.asyncio
 async def test_memory_capture_service_writes_raw_source_before_graph_entity() -> None:
     events: list[tuple[str, object]] = []
 

--- a/packages/python/sibyl-core/tests/test_memory_policy.py
+++ b/packages/python/sibyl-core/tests/test_memory_policy.py
@@ -794,3 +794,15 @@ def test_search_scope_policy_wont_let_a_named_project_beat_membership() -> None:
         allowed_memory_scope_keys=None,
         accessible_projects=None,
     )
+
+
+@pytest.mark.parametrize("pending", [True, False, {}, None, {"parent:other": True}])
+def test_caller_cannot_supply_reconciliation_pending_owners(pending):
+    stamped = stamp_memory_scope_metadata(
+        {"lifecycle_reconciliation_pending": pending, "note": "keep"},
+        memory_scope="private",
+        scope_key=None,
+        principal_id="owner",
+    )
+    assert "lifecycle_reconciliation_pending" not in stamped
+    assert stamped["note"] == "keep"

--- a/packages/python/sibyl-core/tests/test_migration_query_compatibility.py
+++ b/packages/python/sibyl-core/tests/test_migration_query_compatibility.py
@@ -1,4 +1,4 @@
-"""Content migration predicates match the target backend."""
+"""Migration transactions render the canonical upsert for the target backend."""
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -6,6 +6,35 @@ from unittest.mock import AsyncMock
 import pytest
 
 from sibyl_core.backends.surreal import content_schema
+from sibyl_core.migrate import collapse_epics, scope_backfill
+from sibyl_core.models.entities import Entity, EntityType
+
+
+@pytest.mark.parametrize("module", [collapse_epics, scope_backfill])
+@pytest.mark.parametrize(
+    ("url", "expected", "absent"),
+    [
+        ("memory://", "type::is::object", "type::is_object"),
+        ("ws://127.0.0.1:33333/rpc", "type::is_object", "type::is::object"),
+    ],
+)
+async def test_migration_transaction_renders_backend_predicates(
+    module, url, expected, absent, monkeypatch
+):
+    client = SimpleNamespace(_url=url, execute_query_raw=AsyncMock(return_value=[]))
+    monkeypatch.setattr(module, "heal_entity_metadata_snapshots", AsyncMock())
+    if module is collapse_epics:
+        records = [{"uuid": "migration-row"}]
+        await module._apply_records(client, records, group_id="test-org", reverse=False)
+    else:
+        entity = Entity(id="migration-row", name="row", entity_type=EntityType.EPISODE)
+        await module._apply(client, [entity], group_id="test-org", operation="forward")
+    query = client.execute_query_raw.await_args.args[0]
+    assert expected in query
+    assert absent not in query
+    assert query.startswith("BEGIN TRANSACTION;")
+    assert query.endswith("COMMIT TRANSACTION;")
+    assert client.execute_query_raw.await_args.kwargs["rows"][0]["uuid"] == "migration-row"
 
 
 @pytest.mark.parametrize("url", ["memory://", "ws://127.0.0.1:33333/rpc"])

--- a/packages/python/sibyl-core/tests/test_projection_pending.py
+++ b/packages/python/sibyl-core/tests/test_projection_pending.py
@@ -1,0 +1,271 @@
+import pytest
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.projection import reconcile
+from tests.test_reflection_identity import runtime as runtime
+
+
+@pytest.mark.parametrize(
+    "pending_key", [reconcile.RECONCILE_PENDING_KEY, "source_validation_pending"]
+)
+async def test_healthy_parent_cannot_clear_other_parent_pending(runtime, pending_key):
+    for row_id, metadata in (
+        ("uncertain-parent", {pending_key: True}),
+        ("healthy-parent", {pending_key: False}),
+        ("shared-derived", {}),
+    ):
+        await runtime.entity_manager.create_direct(
+            Entity(id=row_id, name=row_id, entity_type=EntityType.EPISODE, metadata=metadata),
+            generate_embedding=False,
+        )
+    await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id="uncertain-parent", row_ids=["shared-derived"]
+    )
+    before = await runtime.entity_manager.get("shared-derived")
+    assert not graph_metadata_recallable(before.metadata)
+    await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id="healthy-parent", row_ids=["shared-derived"]
+    )
+    after = await runtime.entity_manager.get("shared-derived")
+    assert not graph_metadata_recallable(after.metadata)
+
+
+@pytest.mark.parametrize(
+    "pending_key", [reconcile.RECONCILE_PENDING_KEY, "source_validation_pending"]
+)
+async def test_each_parent_recovers_only_its_own_pending_state(runtime, pending_key):
+    for row_id in ("parent-a", "parent-b", "shared"):
+        await runtime.entity_manager.create_direct(
+            Entity(
+                id=row_id,
+                name=row_id,
+                entity_type=EntityType.EPISODE,
+                metadata={pending_key: True} if row_id != "shared" else {},
+            ),
+            generate_embedding=False,
+        )
+    for source_id in ("parent-a", "parent-b"):
+        await reconcile.reconcile_with_parent(
+            runtime.entity_manager, source_id=source_id, row_ids=["shared"]
+        )
+    for index, source_id in enumerate(("parent-a", "parent-b")):
+        parent = await runtime.entity_manager.get(source_id)
+        await runtime.entity_manager.update(
+            source_id,
+            {"metadata": {pending_key: None}},
+            expected_revision=parent.observed_revision,
+        )
+        await reconcile.reconcile_with_parent(
+            runtime.entity_manager, source_id=source_id, row_ids=["shared"]
+        )
+        child = await runtime.entity_manager.get("shared")
+        assert graph_metadata_recallable(child.metadata) is (index == 1)
+        if index == 0:
+            assert child.metadata[pending_key] == {"parent:parent-b": True}
+        else:
+            assert pending_key not in child.metadata
+
+
+async def test_unreadable_parent_is_recorded_when_another_parent_already_blocks(
+    runtime, monkeypatch
+):
+    from unittest.mock import AsyncMock
+
+    for row_id, metadata in (
+        ("known-parent", {reconcile.RECONCILE_PENDING_KEY: True}),
+        ("shared", {}),
+    ):
+        await runtime.entity_manager.create_direct(
+            Entity(id=row_id, name=row_id, entity_type=EntityType.EPISODE, metadata=metadata),
+            generate_embedding=False,
+        )
+    await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id="known-parent", row_ids=["shared"]
+    )
+    get = runtime.entity_manager.get
+
+    async def unavailable_parent(entity_id):
+        if entity_id == "unavailable-parent":
+            raise ConnectionError("parent unavailable")
+        return await get(entity_id)
+
+    monkeypatch.setattr(runtime.entity_manager, "get", unavailable_parent)
+    monkeypatch.setattr(reconcile.asyncio, "sleep", AsyncMock())
+    await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id="unavailable-parent", row_ids=["shared"]
+    )
+    parent = await get("known-parent")
+    await runtime.entity_manager.update(
+        parent.id,
+        {"metadata": {reconcile.RECONCILE_PENDING_KEY: None}},
+        expected_revision=parent.observed_revision,
+    )
+    await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id=parent.id, row_ids=["shared"]
+    )
+    child = await get("shared")
+    assert not graph_metadata_recallable(child.metadata)
+    assert child.metadata[reconcile.RECONCILE_PENDING_KEY] == {"parent:unavailable-parent": True}
+
+
+def test_public_pending_metadata_does_not_disclose_source_owners():
+    from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
+
+    metadata = {
+        reconcile.RECONCILE_PENDING_KEY: {"parent:private-parent": True},
+        "source_validation_pending": {"capture:private-capture": True},
+        "authored": {"parent": "preserve"},
+    }
+    public = public_memory_metadata(metadata)
+    assert public == {
+        reconcile.RECONCILE_PENDING_KEY: True,
+        "source_validation_pending": True,
+        "authored": {"parent": "preserve"},
+    }
+    assert isinstance(metadata[reconcile.RECONCILE_PENDING_KEY], dict)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_shared_candidate_keeps_all_parent_pending_state_before_insert(reverse):
+    from datetime import UTC, datetime
+
+    from sibyl_core.projection.memory import ProjectedMemoryEntity, _add_projection_candidates
+
+    sources = [
+        Entity(
+            id=source_id,
+            name=source_id,
+            entity_type=EntityType.SESSION,
+            metadata={"memory_scope": "org", reconcile.RECONCILE_PENDING_KEY: True},
+        )
+        for source_id in ("parent-a", "parent-b")
+    ]
+    if reverse:
+        sources.reverse()
+    projected = {}
+    for source in sources:
+        _add_projection_candidates(
+            group_id="org",
+            now=datetime.now(UTC),
+            source=source,
+            source_id=source.id,
+            candidates=[ProjectedMemoryEntity(name="Shared topic", context="Shared evidence")],
+            projected_by_id=projected,
+            relationships=[],
+        )
+    assert len(projected) == 1
+    entity = next(iter(projected.values()))
+    assert entity.metadata[reconcile.RECONCILE_PENDING_KEY] == {
+        "parent:parent-a": True,
+        "parent:parent-b": True,
+    }
+
+
+async def test_unreadable_capture_is_pending_before_insert(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(reconcile.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        "sibyl_core.services.memory.projected_row_lifecycle_stamp",
+        AsyncMock(side_effect=ConnectionError("capture unavailable")),
+    )
+    stamp, verified = await reconcile.prewrite_capture_stamp(
+        organization_id="org", metadata={"raw_memory_id": "capture-a"}
+    )
+    assert not verified
+    assert not graph_metadata_recallable(stamp)
+    assert stamp[reconcile.RECONCILE_PENDING_KEY] == {"capture:capture-a": True}
+
+
+@pytest.mark.parametrize(
+    "pending_key", [reconcile.RECONCILE_PENDING_KEY, "source_validation_pending"]
+)
+async def test_late_duplicate_insert_preserves_another_batches_pending_owner(runtime, pending_key):
+    # Both batches decided this deterministic candidate ID was absent before
+    # either inserted it. The second insert lands after A has reconciled.
+    first = Entity(
+        id="shared-batch-row",
+        name="Shared candidate",
+        entity_type=EntityType.TOPIC,
+        metadata={pending_key: {"parent:a": True}},
+    )
+    second = first.model_copy(update={"metadata": {pending_key: {"parent:b": True}}})
+    await runtime.entity_manager.create_direct(first, generate_embedding=False)
+    await runtime.entity_manager.create_direct(second, generate_embedding=False)
+    stored = await runtime.entity_manager.get(first.id)
+    assert stored.metadata[pending_key] == {"parent:a": True, "parent:b": True}
+    await runtime.entity_manager.create_direct(
+        Entity(id="b", name="Healthy B", entity_type=EntityType.EPISODE),
+        generate_embedding=False,
+    )
+    await reconcile.reconcile_with_parent(runtime.entity_manager, source_id="b", row_ids=[first.id])
+    stored = await runtime.entity_manager.get(first.id)
+    assert stored.metadata[pending_key] == {"parent:a": True}
+    assert not graph_metadata_recallable(stored.metadata)
+
+
+def test_raw_capture_drops_caller_supplied_reconciliation_owners():
+    from datetime import UTC, datetime
+
+    from sibyl_core.services.content_models import RawMemoryWrite
+    from sibyl_core.services.content_raw_persistence import _raw_memory_from_write
+
+    memory = _raw_memory_from_write(
+        RawMemoryWrite(
+            organization_id="org",
+            principal_id="owner",
+            source_id="source",
+            raw_content="Body",
+            metadata={reconcile.RECONCILE_PENDING_KEY: {"capture:other": True}, "note": "keep"},
+        ),
+        captured_at=datetime.now(UTC),
+    )
+    assert reconcile.RECONCILE_PENDING_KEY not in memory.metadata
+    assert memory.metadata["note"] == "keep"
+
+
+@pytest.mark.parametrize("missing_result", ["none", "key_error"])
+async def test_missing_parent_stays_pending_until_present(runtime, monkeypatch, missing_result):
+    await runtime.entity_manager.create_direct(
+        Entity(id="child", name="child", entity_type=EntityType.EPISODE, metadata={}),
+        generate_embedding=False,
+    )
+    original_get = runtime.entity_manager.get
+    parent_available = False
+
+    async def read(entity_id):
+        if entity_id == "parent" and not parent_available:
+            if missing_result == "key_error":
+                raise KeyError(entity_id)
+            return None
+        return await original_get(entity_id)
+
+    monkeypatch.setattr(runtime.entity_manager, "get", read)
+    outcome = await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id="parent", row_ids=["child"]
+    )
+    assert outcome.unverified == 1
+    assert outcome.cleared == 0
+    repeated = await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id="parent", row_ids=["child"]
+    )
+    assert repeated.cleared == 0
+    child = await original_get("child")
+    assert not graph_metadata_recallable(child.metadata)
+    assert child.metadata[reconcile.RECONCILE_PENDING_KEY] == {"parent:parent": True}
+    assert "excluded_from_recall" not in child.metadata
+
+    await runtime.entity_manager.create_direct(
+        Entity(id="parent", name="parent", entity_type=EntityType.EPISODE, metadata={}),
+        generate_embedding=False,
+    )
+    parent_available = True
+    outcome = await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id="parent", row_ids=["child"]
+    )
+    assert outcome.cleared == 1
+    assert outcome.unverified == 0
+    child = await original_get("child")
+    assert graph_metadata_recallable(child.metadata)
+    assert reconcile.RECONCILE_PENDING_KEY not in child.metadata

--- a/packages/python/sibyl-core/tests/test_projection_query_compatibility.py
+++ b/packages/python/sibyl-core/tests/test_projection_query_compatibility.py
@@ -1,0 +1,24 @@
+"""Bulk projection writes select the connected database's function spelling."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.services.graph_entity_store import _execute_replace_entities_bulk_query
+
+
+@pytest.mark.parametrize(
+    ("url", "expected", "absent"),
+    [
+        ("memory://", "type::is::object", "type::is_object"),
+        ("ws://127.0.0.1:33333/rpc", "type::is_object", "type::is::object"),
+    ],
+)
+async def test_bulk_projection_renders_object_checks_for_backend(url, expected, absent):
+    client = SimpleNamespace(_url=url, execute_query=AsyncMock(return_value=[]))
+    await _execute_replace_entities_bulk_query(client, [])
+    query = client.execute_query.await_args.args[0]
+    assert expected in query
+    assert absent not in query
+    assert client.execute_query.await_args.kwargs == {"rows": []}

--- a/packages/python/sibyl-core/tests/test_projection_source_clocks.py
+++ b/packages/python/sibyl-core/tests/test_projection_source_clocks.py
@@ -1,0 +1,228 @@
+"""Post-write reconciliation preserves source ordering and authored verdicts."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.memory_pipeline.lifecycle import graph_lifecycle_stamp, graph_metadata_recallable
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.projection import reconcile
+from sibyl_core.services import memory_lifecycle
+from sibyl_core.services.memory_correction import apply_memory_correction
+from sibyl_core.services.surreal_content import remember_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+@pytest.mark.parametrize(
+    "own_verdict", [{}, {"excluded_from_recall": True}, {"lifecycle_flags": ["hidden"]}]
+)
+async def test_postwrite_failure_recovers_without_erasing_own_verdict(
+    runtime, content_store, monkeypatch, own_verdict
+):
+    monkeypatch.setattr(
+        memory_lifecycle, "get_surreal_graph_runtime", AsyncMock(return_value=runtime)
+    )
+    monkeypatch.setattr(reconcile.asyncio, "sleep", AsyncMock())
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="owner",
+        source_id="race-source",
+        raw_content="Old instructions",
+        embedding_provider=None,
+    )
+    stamp = graph_lifecycle_stamp(raw)
+    await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        source_id=raw.id,
+        principal_id="owner",
+        action="hide",
+    )
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="raced-copy",
+            name="Raced copy",
+            entity_type=EntityType.EPISODE,
+            content=raw.raw_content,
+            metadata={
+                "memory_scope": "private",
+                "principal_id": "owner",
+                "raw_memory_id": raw.id,
+                **stamp,
+                **own_verdict,
+            },
+        ),
+        generate_embedding=False,
+    )
+    read = memory_lifecycle.get_raw_memory
+    monkeypatch.setattr(
+        memory_lifecycle, "get_raw_memory", AsyncMock(side_effect=ConnectionError("unavailable"))
+    )
+    failed = await reconcile.reconcile_with_capture(
+        runtime.entity_manager,
+        organization_id=runtime.client.group_id,
+        metadata={"raw_memory_id": raw.id},
+        row_ids=["raced-copy"],
+    )
+    stored = await runtime.entity_manager.get("raced-copy")
+    assert not graph_metadata_recallable(stored.metadata)
+    if not own_verdict:
+        assert failed.unverified == 1
+        assert stored.metadata[reconcile.RECONCILE_PENDING_KEY] == {f"capture:{raw.id}": True}
+        assert "excluded_from_recall" not in stored.metadata
+    monkeypatch.setattr(memory_lifecycle, "get_raw_memory", read)
+    await reconcile.reconcile_with_capture(
+        runtime.entity_manager,
+        organization_id=runtime.client.group_id,
+        metadata={"raw_memory_id": raw.id},
+        row_ids=["raced-copy"],
+    )
+    stored = await runtime.entity_manager.get("raced-copy")
+    assert reconcile.RECONCILE_PENDING_KEY not in stored.metadata
+    assert stored.metadata["correction_blockers"][raw.id]["blocking"] is True
+    await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        source_id=raw.id,
+        principal_id="owner",
+        action="restore",
+    )
+    stored = await runtime.entity_manager.get("raced-copy")
+    assert graph_metadata_recallable(stored.metadata) is (not own_verdict)
+    for key, value in own_verdict.items():
+        assert stored.metadata[key] == value
+
+
+async def test_fallback_exclusion_does_not_trust_a_clear_clock(runtime):
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="fallback-copy",
+            name="Fallback",
+            entity_type=EntityType.EPISODE,
+            metadata={"correction_blockers": {"root": {"revision": 1, "blocking": False}}},
+        ),
+        generate_embedding=False,
+    )
+    result = await reconcile._force_exclusion(
+        runtime.entity_manager, "fallback-copy", "capture", runtime.client.group_id, "capture:root"
+    )
+    stored = await runtime.entity_manager.get("fallback-copy")
+    assert result == "unverified"
+    assert not graph_metadata_recallable(stored.metadata)
+    assert stored.metadata[reconcile.RECONCILE_PENDING_KEY] == {"capture:root": True}
+    assert "excluded_from_recall" not in stored.metadata
+
+
+@pytest.mark.parametrize("newer_blocking", [False, True])
+async def test_reconcile_merges_root_clocks_without_rebinding_text(
+    runtime, monkeypatch, newer_blocking
+):
+    current = {
+        "correction_blockers": {
+            "root": {"revision": 3, "blocking": newer_blocking},
+            "other-root": {"revision": 4, "blocking": True},
+        },
+        "source_bindings": {"root": 1, "other-root": 2},
+        "authored": "Keep this",
+    }
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="ordered-copy",
+            name="Ordered",
+            entity_type=EntityType.EPISODE,
+            metadata=deepcopy(current),
+        ),
+        generate_embedding=False,
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.memory.projected_row_lifecycle_stamp",
+        AsyncMock(
+            return_value={
+                "correction_blockers": {
+                    "root": {"revision": 2, "blocking": not newer_blocking},
+                    "new-root": {"revision": 1, "blocking": True},
+                },
+                "source_bindings": {"root": 7, "new-root": 5},
+            }
+        ),
+    )
+    await reconcile.reconcile_with_capture(
+        runtime.entity_manager,
+        organization_id=runtime.client.group_id,
+        metadata={"raw_memory_id": "root"},
+        row_ids=["ordered-copy"],
+    )
+    stored = await runtime.entity_manager.get("ordered-copy")
+    assert stored.metadata["correction_blockers"] == {
+        **current["correction_blockers"],
+        "new-root": {"revision": 1, "blocking": True},
+    }
+    assert stored.metadata["source_bindings"] == current["source_bindings"]
+    assert stored.metadata["authored"] == "Keep this"
+
+
+async def test_reconcile_never_fences_on_a_normalized_default_revision(monkeypatch):
+    row = Entity(id="unversioned", name="Unversioned", entity_type=EntityType.EPISODE)
+    assert row.revision == 1 and row.observed_revision is None
+    manager = SimpleNamespace(get=AsyncMock(return_value=row), update=AsyncMock())
+    monkeypatch.setattr(reconcile.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        "sibyl_core.services.memory.projected_row_lifecycle_stamp",
+        AsyncMock(
+            return_value={"correction_blockers": {"root": {"revision": 2, "blocking": True}}}
+        ),
+    )
+    with pytest.raises(reconcile.ReconcileExclusionError):
+        await reconcile.reconcile_with_capture(
+            manager, organization_id="org", metadata={"raw_memory_id": "root"}, row_ids=[row.id]
+        )
+    manager.update.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "own_verdict", [{"excluded_from_recall": True}, {"lifecycle_flags": ["hidden"]}]
+)
+def test_readable_empty_or_flat_verdict_cannot_remove_own_exclusion(own_verdict):
+    assert reconcile._desired_patch({}, own_verdict) == {}
+    clearing = {"excluded_from_recall": False, "lifecycle_flags": []}
+    merged = {**own_verdict, **reconcile._desired_patch(clearing, own_verdict)}
+    assert not graph_metadata_recallable(merged)
+
+
+def test_source_validation_recovery_is_not_an_authored_exclusion():
+    patch = reconcile._desired_patch(
+        {"source_validation_pending": False}, {"source_validation_pending": True}
+    )
+    assert patch == {"source_validation_pending": False}
+    assert graph_metadata_recallable(patch)
+
+
+async def test_parent_pending_verdict_keeps_child_excluded_until_parent_recovers(runtime):
+    for row_id, metadata in (
+        ("pending-parent", {reconcile.RECONCILE_PENDING_KEY: True}),
+        ("pending-child", {}),
+    ):
+        await runtime.entity_manager.create_direct(
+            Entity(id=row_id, name=row_id, entity_type=EntityType.EPISODE, metadata=metadata),
+            generate_embedding=False,
+        )
+    for _ in range(2):
+        await reconcile.reconcile_with_parent(
+            runtime.entity_manager, source_id="pending-parent", row_ids=["pending-child"]
+        )
+        child = await runtime.entity_manager.get("pending-child")
+        assert not graph_metadata_recallable(child.metadata)
+        assert child.metadata[reconcile.RECONCILE_PENDING_KEY] == {"parent:pending-parent": True}
+    parent = await runtime.entity_manager.get("pending-parent")
+    await runtime.entity_manager.update(
+        parent.id,
+        {"metadata": {reconcile.RECONCILE_PENDING_KEY: None}},
+        expected_revision=parent.observed_revision,
+    )
+    await reconcile.reconcile_with_parent(
+        runtime.entity_manager, source_id="pending-parent", row_ids=["pending-child"]
+    )
+    child = await runtime.entity_manager.get("pending-child")
+    assert graph_metadata_recallable(child.metadata)
+    assert reconcile.RECONCILE_PENDING_KEY not in child.metadata

--- a/packages/python/sibyl-core/tests/test_promotion_content_epoch_race.py
+++ b/packages/python/sibyl-core/tests/test_promotion_content_epoch_race.py
@@ -1,0 +1,69 @@
+"""A text round-trip during insertion must not publish an obsolete source epoch."""
+
+from unittest.mock import AsyncMock
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services.memory_correction import apply_memory_correction
+from sibyl_core.services.memory_reflection import persist_reflection_candidate
+from sibyl_core.services.surreal_content import remember_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+async def test_promotion_rejects_source_epoch_roundtrip_during_insert(
+    runtime, content_store, monkeypatch
+):
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    org = runtime.client.group_id
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="user_a",
+        source_id="epoch-race-source",
+        raw_content="Retain the audit trail.",
+        embedding_provider=None,
+    )
+    insert = runtime.entity_manager.create_direct_if_absent
+
+    async def insert_after_roundtrip(entity):
+        for text in ("Delete the audit trail.", source.raw_content):
+            revised = await apply_memory_correction(
+                organization_id=org,
+                principal_id="user_a",
+                source_id=source.id,
+                action="revise",
+                revised_content=text,
+            )
+            assert revised.applied
+            restored = await apply_memory_correction(
+                organization_id=org,
+                principal_id="user_a",
+                source_id=source.id,
+                action="restore",
+            )
+            assert restored.applied
+        return await insert(entity)
+
+    monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", insert_after_roundtrip)
+    result = await persist_reflection_candidate(
+        candidate=ReflectionCandidate(
+            kind="decision",
+            title="Audit trail",
+            content=source.raw_content,
+            reason="Recorded decision",
+            confidence=1.0,
+            raw_source_ids=[source.id],
+        ),
+        organization_id=org,
+        principal_id="user_a",
+        source_id=source.id,
+        link_source_entity=False,
+        source_memories=[source],
+    )
+    assert not result.response.success
+    row = await runtime.entity_manager.get(result.response.id)
+    assert not graph_metadata_recallable(row.metadata)
+    assert row.metadata["source_bindings"] == {source.id: source.revision}

--- a/packages/python/sibyl-core/tests/test_promotion_raw_write_grants.py
+++ b/packages/python/sibyl-core/tests/test_promotion_raw_write_grants.py
@@ -1,0 +1,100 @@
+"""Temporal invalidation uses write authority independently of source visibility."""
+
+import pytest
+
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services.memory_reflection import persist_reflection_candidate, promote_raw_memory
+from sibyl_core.services.memory_sharing import share_memory
+from sibyl_core.services.surreal_content import get_raw_memory, remember_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+@pytest.mark.parametrize("can_write", [False, True])
+async def test_project_source_invalidation_requires_write_grants(runtime, content_store, can_write):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="source-author",
+        source_id="project-decision-source",
+        title="Existing project guidance",
+        raw_content="Use the original project convention.",
+        memory_scope="project",
+        scope_key="project_b",
+        metadata={"project_id": "project_b"},
+        embedding_provider=None,
+    )
+    result = await persist_reflection_candidate(
+        candidate=ReflectionCandidate(
+            kind="decision",
+            title="Updated personal guidance",
+            content="Use the revised convention.",
+            reason="A new conclusion",
+            confidence=1.0,
+            metadata={"supersedes_source_ids": [source.id]},
+        ),
+        organization_id=runtime.client.group_id,
+        principal_id="owner",
+        accessible_projects={"project_b"},
+        writable_projects={"project_b"} if can_write else set(),
+        memory_scope="private",
+    )
+    assert result.response.success
+    current = await get_raw_memory(organization_id=source.organization_id, memory_id=source.id)
+    assert current is not None
+    if can_write:
+        assert current.metadata["invalidated_by_entity_id"] == result.response.id
+        assert source.id in result.metadata["invalidated_source_ids"]
+    else:
+        assert current == source
+        assert source.id in result.metadata["invalidation_skipped_source_ids"]
+
+
+@pytest.mark.parametrize("grant_iterator", [False, True])
+async def test_project_promotion_preserves_write_grants_across_stages(
+    runtime, content_store, grant_iterator
+):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="owner",
+        source_id="personal-promotion-source",
+        title="Reusable guidance",
+        raw_content="Apply the project convention consistently.",
+        embedding_provider=None,
+    )
+    grants = iter(["project_b"]) if grant_iterator else {"project_b"}
+    result = await promote_raw_memory(
+        raw_memory_id=source.id,
+        organization_id=source.organization_id,
+        principal_id="owner",
+        promote_to_scope="project",
+        promote_to_scope_key="project_b",
+        accessible_projects={"project_b"},
+        writable_projects=grants,
+    )
+    assert result.success, result.reason
+
+
+@pytest.mark.parametrize("can_write", [False, True])
+async def test_sharing_requires_project_write_grants(runtime, content_store, can_write):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="owner",
+        source_id="personal-share-source",
+        title="Reusable shared guidance",
+        raw_content="Apply the shared convention consistently.",
+        embedding_provider=None,
+    )
+    result = await share_memory(
+        source_ids=[source.id],
+        organization_id=source.organization_id,
+        principal_id="owner",
+        target_scope="project",
+        target_scope_key="project_b",
+        accessible_projects={"project_b"},
+        writable_projects={"project_b"} if can_write else set(),
+    )
+    assert result.applied is can_write
+    if can_write:
+        assert result.reason == "shared"
+    else:
+        assert result.reason == "unverified_membership"

--- a/packages/python/sibyl-core/tests/test_promotion_reservation_upgrade.py
+++ b/packages/python/sibyl-core/tests/test_promotion_reservation_upgrade.py
@@ -1,0 +1,329 @@
+"""Interrupted v2 reservations retain their identity across v3 promotion."""
+
+import hashlib
+import json
+from dataclasses import replace
+
+import pytest
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.services import memory_reflection
+from sibyl_core.services.memory_identity import verify_reflection_identity
+from sibyl_core.services.memory_promotion import _entity_from_candidate
+from sibyl_core.services.surreal_content import (
+    get_raw_memory,
+    remember_raw_memory,
+    remember_reflection_candidate_review,
+    save_raw_memory,
+)
+from tests.test_reflection_identity import candidate
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+async def legacy_input(runtime, mode="raw", title="Reserved evidence"):
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="upgrade-source",
+        title=title,
+        raw_content="The original candidate remains immutable.",
+        embedding_provider=None,
+    )
+    if mode == "review":
+        raw = await remember_reflection_candidate_review(
+            organization_id=raw.organization_id,
+            principal_id="user_a",
+            candidate=replace(candidate(), title=title),
+            raw_source_ids=[raw.id],
+        )
+    args = dict(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        promote_to_scope="private",
+    )
+    if mode == "review":
+        args["candidate_id"] = raw.id
+        plan = await memory_reflection._resolve_reflection_promotion_plan(**args)
+    else:
+        args["raw_memory_id"] = raw.id
+        plan = await memory_reflection._resolve_raw_memory_promotion_plan(**args)
+    legacy = _entity_from_candidate(
+        plan.promotion_candidate,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        domain=None,
+        project=plan.target_project,
+        source_id=plan.raw_source_ids[0],
+        memory_scope=plan.target_scope,
+        scope_key=plan.target_scope_key,
+        policy_metadata={},
+    )
+    legacy.metadata.pop("source_bindings", None)
+    # Reconstruct the shipped v2 payload independently of the current identity
+    # helpers and builder's title normalization.
+    legacy.name = title
+    fields = legacy.metadata
+    identity = {
+        "version": 2,
+        "purpose": "source" if fields.get("reflection_source") is True else "candidate",
+        "kind": legacy.entity_type.value,
+        "title": title.strip(),
+        "content_sha256": hashlib.sha256(legacy.content.encode()).hexdigest(),
+        "organization_id": legacy.organization_id,
+        "principal_id": fields.get("principal_id"),
+        "created_by": legacy.created_by,
+        "memory_scope": fields.get("memory_scope"),
+        "scope_key": fields.get("scope_key"),
+        "project_id": fields.get("project_id"),
+        "domain": fields.get("category") or None,
+        "primary_source_id": legacy.source_file,
+        "source_ids": sorted(
+            {
+                *fields.get("raw_source_ids", []),
+                *fields.get("source_ids", []),
+                *([legacy.source_file] if legacy.source_file else []),
+            }
+        ),
+        "review_capture_id": fields.get("review_capture_id"),
+        "imported_capture_id": fields.get("imported_capture_id"),
+    }
+    identity = {key: value for key, value in identity.items() if value is not None}
+    payload = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    legacy.id = f"{legacy.entity_type.value}_v2_{hashlib.sha256(payload).hexdigest()}"
+    legacy.metadata["reflection_identity"] = identity
+    assert "_v2_" in legacy.id
+    return raw, legacy, args
+
+
+async def publish(args):
+    if "candidate_id" in args:
+        return await memory_reflection.promote_reflection_candidate_review(**args)
+    return await memory_reflection.promote_raw_memory(**args)
+
+
+async def reserve_legacy(raw, legacy):
+    return await save_raw_memory(
+        replace(
+            raw,
+            metadata={
+                **raw.metadata,
+                "promoted_entity_id": legacy.id,
+                "promotion_state": "pending",
+            },
+        ),
+        expected_revision=raw.revision,
+        embedding_provider=None,
+    )
+
+
+@pytest.mark.parametrize("mode", ["raw", "review"])
+@pytest.mark.parametrize("old_first", [False, True])
+@pytest.mark.parametrize("title", ["Reserved evidence", "", " \t\n "])
+async def test_v2_reservation_old_and_new_publishers_converge(
+    runtime, content_store, old_first, mode, title, monkeypatch
+):
+    raw, legacy, args = await legacy_input(runtime, mode, title)
+    await reserve_legacy(raw, legacy)
+    if old_first:
+        await runtime.entity_manager.create_direct_if_absent(legacy)
+    real_insert = runtime.entity_manager.create_direct_if_absent
+
+    async def checked_insert(entity):
+        assert entity.id == legacy.id
+        assert not graph_metadata_recallable(entity.metadata)
+        assert all(value == 0 for value in entity.metadata["source_bindings"].values())
+        return await real_insert(entity)
+
+    monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", checked_insert)
+    result = await publish(args)
+    monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", real_insert)
+    assert result.success
+    assert result.promoted_id == legacy.id
+    stored, created = await runtime.entity_manager.create_direct_if_absent(legacy)
+    assert not created
+    verify_reflection_identity(legacy, stored)
+    if not title.strip():
+        assert stored.name == ""
+        assert stored.metadata["reflection_identity"]["title"] == ""
+        with pytest.raises(ValueError, match="identity conflict"):
+            verify_reflection_identity(legacy, stored.model_copy(update={"name": "renamed"}))
+        with pytest.raises(ValueError, match="identity conflict"):
+            verify_reflection_identity(legacy, stored.model_copy(update={"content": "changed"}))
+    assert "source_snapshot_sha256" not in stored.metadata
+    bindings = stored.metadata.get("source_bindings", {})
+    assert all(value == 0 for value in bindings.values())
+    saved = await get_raw_memory(organization_id=raw.organization_id, memory_id=raw.id)
+    assert saved.metadata["promoted_entity_id"] == legacy.id
+    rows = await runtime.client.execute_query(
+        "SELECT VALUE uuid FROM entity WHERE entity_type != 'project';"
+    )
+    assert rows == [legacy.id]
+    replay = await publish(args)
+    assert replay.success and replay.promoted_id == legacy.id
+
+
+@pytest.mark.parametrize("title", ["Reserved evidence", "", " \t "])
+async def test_v2_reservation_winning_cas_is_resumed(runtime, content_store, monkeypatch, title):
+    raw, legacy, args = await legacy_input(runtime, title=title)
+    real_save = memory_reflection.save_raw_memory
+    intercepted = False
+
+    async def racing_save(memory, **kwargs):
+        nonlocal intercepted
+        if not intercepted and memory.metadata.get("promotion_state") == "pending":
+            intercepted = True
+            await reserve_legacy(raw, legacy)
+        return await real_save(memory, **kwargs)
+
+    monkeypatch.setattr(memory_reflection, "save_raw_memory", racing_save)
+    result = await publish(args)
+    assert intercepted
+    assert result.success and result.promoted_id == legacy.id
+
+
+@pytest.mark.parametrize("existing", [False, True])
+async def test_v2_replay_never_binds_to_corrected_source(runtime, content_store, existing):
+    raw, legacy, args = await legacy_input(runtime)
+    reserved = await reserve_legacy(raw, legacy)
+    if existing:
+        await runtime.entity_manager.create_direct_if_absent(legacy)
+    await save_raw_memory(
+        replace(
+            reserved,
+            metadata={
+                **reserved.metadata,
+                "correction_history": [{"action": "revise", "prior_revision": reserved.revision}],
+            },
+        ),
+        expected_revision=reserved.revision,
+        embedding_provider=None,
+    )
+    result = await publish(args)
+    assert not result.success and result.reason == "retired"
+    stored = await runtime.entity_manager.get(legacy.id)
+    assert not graph_metadata_recallable(stored.metadata)
+    assert "source_snapshot_sha256" not in stored.metadata
+    assert stored.metadata.get("source_bindings", {}).get(raw.id, 0) == 0
+
+
+@pytest.mark.parametrize("retired", [False, True])
+async def test_v2_existing_bindings_and_own_retirement_survive(runtime, content_store, retired):
+    raw, legacy, args = await legacy_input(runtime)
+    await reserve_legacy(raw, legacy)
+    legacy.metadata["source_bindings"] = {raw.id: raw.revision}
+    if retired:
+        legacy.metadata["excluded_from_recall"] = True
+    await runtime.entity_manager.create_direct_if_absent(legacy)
+    result = await publish(args)
+    assert result.success is not retired
+    stored = await runtime.entity_manager.get(legacy.id)
+    assert stored.metadata["source_bindings"] == {raw.id: raw.revision}
+    assert graph_metadata_recallable(stored.metadata) is not retired
+    assert "source_snapshot_sha256" not in stored.metadata
+
+
+@pytest.mark.parametrize("change", ["domain", "content", "pointer"])
+async def test_v2_reservation_requires_exact_reconstruction(runtime, content_store, change):
+    raw, legacy, args = await legacy_input(runtime)
+    reserved = await reserve_legacy(raw, legacy)
+    if change == "domain":
+        args["domain"] = "different-domain"
+    elif change == "content":
+        await save_raw_memory(
+            replace(reserved, raw_content="Different output."),
+            expected_revision=reserved.revision,
+            embedding_provider=None,
+        )
+    else:
+        await save_raw_memory(
+            replace(
+                reserved,
+                metadata={
+                    **reserved.metadata,
+                    "promoted_entity_id": "note_v2_not-a-canonical-identity",
+                },
+            ),
+            expected_revision=reserved.revision,
+            embedding_provider=None,
+        )
+    before = await get_raw_memory(organization_id=raw.organization_id, memory_id=raw.id)
+    result = await publish(args)
+    assert not result.success and result.reason == "candidate_already_promoted"
+    assert await get_raw_memory(organization_id=raw.organization_id, memory_id=raw.id) == before
+    assert (
+        await runtime.client.execute_query(
+            "SELECT VALUE uuid FROM entity WHERE entity_type != 'project';"
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize("title", ["Reserved evidence", "", " \t "])
+async def test_unreserved_promotion_uses_v3(runtime, content_store, title):
+    raw, legacy, args = await legacy_input(runtime, title=title)
+    result = await publish(args)
+    assert result.success and "_v3_" in result.promoted_id
+    assert result.promoted_id != legacy.id
+    stored = await runtime.entity_manager.get(result.promoted_id)
+    assert stored.name == (title.strip() or "Untitled memory")
+    assert stored.metadata["source_snapshot_sha256"]
+    assert stored.metadata["source_bindings"][raw.id] > 0
+
+
+async def test_v2_partial_publication_resumes_its_existing_receipt(
+    runtime, content_store, monkeypatch
+):
+    raw, legacy, args = await legacy_input(runtime)
+    await reserve_legacy(raw, legacy)
+    real_relationships = runtime.relationship_manager.create_bulk
+    args["related_to"] = ["project_a"]
+    args["accessible_projects"] = {"project_a"}
+
+    async def unavailable(relationships):
+        return 0, len(relationships)
+
+    monkeypatch.setattr(runtime.relationship_manager, "create_bulk", unavailable)
+    first = await publish(args)
+    assert not first.success and first.reason == "promotion_incomplete"
+    pending = await get_raw_memory(organization_id=raw.organization_id, memory_id=raw.id)
+    assert pending.metadata["promoted_entity_id"] == legacy.id
+    assert pending.metadata["promotion_state"] == "pending"
+    monkeypatch.setattr(runtime.relationship_manager, "create_bulk", real_relationships)
+    resumed = await publish(args)
+    assert resumed.success and resumed.promoted_id == legacy.id
+    assert resumed.metadata["publication_outcome"] == "resumed"
+    complete = await runtime.entity_manager.get(legacy.id)
+    replayed = await publish(args)
+    assert replayed.success and replayed.metadata["publication_outcome"] == "replayed"
+    stored = await runtime.entity_manager.get(legacy.id)
+    assert stored.metadata["reflection_publication"] == complete.metadata["reflection_publication"]
+    assert stored.metadata["source_bindings"] == complete.metadata["source_bindings"]
+
+
+@pytest.mark.parametrize("title", ["", " \t "])
+async def test_literal_uuid_title_is_not_proof_of_blank_storage(runtime, content_store, title):
+    _, legacy, _ = await legacy_input(runtime, title=title)
+    await runtime.entity_manager.create_direct_if_absent(legacy)
+    original = await runtime.entity_manager.get(legacy.id)
+    assert original.name == ""
+    verify_reflection_identity(legacy, original)
+    await runtime.client.execute_query(
+        "UPDATE entity SET name = $name WHERE uuid = $uuid;", name=legacy.id, uuid=legacy.id
+    )
+    rows = await runtime.client.execute_query(
+        "SELECT name FROM entity WHERE uuid = $uuid;", uuid=legacy.id
+    )
+    assert rows == [{"name": legacy.id}]
+    stored = await runtime.entity_manager.get(legacy.id)
+    assert stored.metadata["reflection_identity"] == original.metadata["reflection_identity"]
+    assert stored.name == legacy.id
+    with pytest.raises(ValueError, match="identity conflict"):
+        verify_reflection_identity(legacy, stored)
+
+
+def test_unversioned_graph_names_retain_display_fallback():
+    from sibyl_core.services.graph_records import entity_from_surreal_row
+
+    row = {"uuid": "ordinary", "entity_type": "note", "name": "", "metadata": {}}
+    assert entity_from_surreal_row(row).name == "ordinary"

--- a/packages/python/sibyl-core/tests/test_promotion_signature_reconciliation.py
+++ b/packages/python/sibyl-core/tests/test_promotion_signature_reconciliation.py
@@ -1,0 +1,189 @@
+"""A changed promotion source cannot overwrite the derived row's own verdict."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.projection.repair import repair_graph_lifecycle
+from sibyl_core.services.memory_correction import apply_memory_correction
+from sibyl_core.services.memory_reflection import _verify_promotion_sources
+from sibyl_core.services.surreal_content import remember_raw_memory, save_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+@pytest.mark.parametrize("own_state", [None, "deleted"])
+async def test_changed_promotion_source_preserves_authored_verdict(
+    runtime, content_store, monkeypatch, own_state
+):
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    org = runtime.client.group_id
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="user_a",
+        source_id="signature-source",
+        raw_content="Original evidence",
+        embedding_provider=None,
+    )
+    revised = await apply_memory_correction(
+        organization_id=org,
+        principal_id="user_a",
+        source_id=source.id,
+        action="revise",
+        revised_content="Corrected evidence",
+    )
+    assert revised.applied
+    restored = await apply_memory_correction(
+        organization_id=org,
+        principal_id="user_a",
+        source_id=source.id,
+        action="restore",
+    )
+    assert restored.applied
+    metadata = {
+        "memory_scope": "private",
+        "principal_id": "user_a",
+        "raw_source_ids": [source.id],
+        "source_bindings": {source.id: source.revision},
+    }
+    if own_state is not None:
+        metadata["lifecycle_state"] = own_state
+    entity = Entity(
+        id="stale-promotion",
+        name="Derived evidence",
+        entity_type=EntityType.EPISODE,
+        content=source.raw_content,
+        metadata=metadata,
+    )
+    await runtime.entity_manager.create_direct(entity, generate_embedding=False)
+
+    assert not await _verify_promotion_sources(runtime, [source], entity_id=entity.id)
+
+    row = await runtime.entity_manager.get(entity.id)
+    assert not graph_metadata_recallable(row.metadata)
+    assert row.metadata.get("lifecycle_state") == own_state
+    assert "excluded_from_recall" not in row.metadata
+    assert row.metadata["source_bindings"] == {source.id: source.revision}
+    assert row.metadata["correction_blockers"][source.id]["blocking"] is True
+
+
+@pytest.mark.parametrize("own_state", [None, "deleted"])
+@pytest.mark.parametrize("hidden_during_check", [False, True])
+async def test_signature_repair_requires_the_original_source_values(
+    runtime, content_store, monkeypatch, own_state, hidden_during_check
+):
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="signature-title-source",
+        raw_content="Retained evidence",
+        title="Original title",
+        embedding_provider=None,
+    )
+    changed = await save_raw_memory(
+        replace(source, title="Changed title"),
+        expected_revision=source.revision,
+        embedding_provider=None,
+    )
+    metadata = {
+        "memory_scope": "private",
+        "principal_id": "user_a",
+        "raw_source_ids": [source.id],
+        "source_bindings": {source.id: source.revision},
+    }
+    if own_state is not None:
+        metadata["lifecycle_state"] = own_state
+    entity = Entity(
+        id="signature-title-row",
+        name="Derived evidence",
+        entity_type=EntityType.EPISODE,
+        content=source.raw_content,
+        metadata=metadata,
+    )
+    await runtime.entity_manager.create_direct(entity, generate_embedding=False)
+    if hidden_during_check:
+        hidden = await apply_memory_correction(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            source_id=source.id,
+            action="hide",
+        )
+        assert hidden.applied
+    assert not await _verify_promotion_sources(runtime, [source], entity_id=entity.id)
+    if hidden_during_check:
+        restored = await apply_memory_correction(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            source_id=source.id,
+            action="restore",
+        )
+        assert restored.applied and restored.updated_memory is not None
+        changed = restored.updated_memory
+    for _ in range(2):
+        result = await repair_graph_lifecycle(runtime)
+        assert result.checked == 1 and result.pending == 1 and result.failed == 0
+        row = await runtime.entity_manager.get(entity.id)
+        assert not graph_metadata_recallable(row.metadata)
+        assert row.metadata.get("lifecycle_state") == own_state
+        assert "excluded_from_recall" not in row.metadata
+
+    await save_raw_memory(
+        replace(changed, title=source.title),
+        expected_revision=changed.revision,
+        embedding_provider=None,
+    )
+    result = await repair_graph_lifecycle(runtime)
+    assert result.recovered == 1 and result.failed == 0
+    row = await runtime.entity_manager.get(entity.id)
+    assert not row.metadata.get("source_validation_pending")
+    assert graph_metadata_recallable(row.metadata) is (own_state is None)
+    assert row.metadata.get("lifecycle_state") == own_state
+
+
+async def test_promotion_source_read_outage_is_excluded_until_rechecked(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.services import memory_lifecycle, memory_reflection
+
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="outage-source",
+        raw_content="Evidence awaiting its post-create check",
+        embedding_provider=None,
+    )
+    entity = Entity(
+        id="outage-promotion",
+        name="Derived evidence",
+        entity_type=EntityType.EPISODE,
+        content=source.raw_content,
+        metadata={
+            "raw_source_ids": [source.id],
+            "source_bindings": {source.id: source.revision},
+        },
+    )
+    await runtime.entity_manager.create_direct(entity, generate_embedding=False)
+    with monkeypatch.context() as outage:
+        for module in (memory_reflection, memory_lifecycle):
+            outage.setattr(
+                module, "get_raw_memory", AsyncMock(side_effect=ConnectionError("offline"))
+            )
+        assert not await _verify_promotion_sources(runtime, [source], entity_id=entity.id)
+    row = await runtime.entity_manager.get(entity.id)
+    assert not graph_metadata_recallable(row.metadata)
+    assert row.metadata.get("lifecycle_reconciliation_pending")
+    assert "excluded_from_recall" not in row.metadata
+    result = await repair_graph_lifecycle(runtime)
+    assert result.recovered == 1 and result.failed == 0
+    row = await runtime.entity_manager.get(entity.id)
+    assert graph_metadata_recallable(row.metadata)

--- a/packages/python/sibyl-core/tests/test_promotion_write_grants.py
+++ b/packages/python/sibyl-core/tests/test_promotion_write_grants.py
@@ -1,0 +1,63 @@
+"""Promotion keeps source read access separate from target mutation authority."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services.memory_reflection import persist_reflection_candidate
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+@pytest.mark.parametrize("can_write", [False, True])
+async def test_project_supersession_requires_write_grants(
+    runtime, content_store, monkeypatch, can_write
+):
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="project-target",
+            name="Existing decision",
+            entity_type=EntityType.DECISION,
+            metadata={
+                "memory_scope": "project",
+                "scope_key": "project_b",
+                "project_id": "project_b",
+            },
+        ),
+        generate_embedding=False,
+    )
+    before = await runtime.entity_manager.get("project-target")
+    writes = AsyncMock(wraps=runtime.relationship_manager.create_bulk)
+    monkeypatch.setattr(runtime.relationship_manager, "create_bulk", writes)
+    result = await persist_reflection_candidate(
+        candidate=ReflectionCandidate(
+            kind="decision",
+            title="New personal decision",
+            content="New private guidance",
+            reason="Personal update",
+            confidence=1.0,
+            metadata={"supersedes": ["project-target"]},
+        ),
+        organization_id=runtime.client.group_id,
+        principal_id="owner",
+        accessible_projects={"project_b"},
+        memory_scope="private",
+        writable_projects=(value for value in (["project_b"] if can_write else [])),
+        related_to=["project-target"],
+    )
+    assert result.response.success
+    target = await runtime.entity_manager.get("project-target")
+    relationships = [edge for call in writes.call_args_list for edge in call.args[0]]
+    assert any(
+        edge.target_id == "project-target" and edge.relationship_type.value == "RELATED_TO"
+        for edge in relationships
+    )
+    if can_write:
+        assert target.observed_revision > before.observed_revision
+        assert target.metadata["invalidated_by_entity_id"] == result.response.id
+    else:
+        assert target.observed_revision == before.observed_revision
+        assert "invalidated_by_entity_id" not in target.metadata
+        assert all(edge.relationship_type.value != "SUPERSEDES" for edge in relationships)

--- a/packages/python/sibyl-core/tests/test_raw_source_recovery.py
+++ b/packages/python/sibyl-core/tests/test_raw_source_recovery.py
@@ -1,0 +1,212 @@
+"""Accepted captures recover using live authority bounded by their original grants."""
+
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.errors import RevisionConflictError
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
+from sibyl_core.services import content_client
+from sibyl_core.services import content_raw_persistence as store
+from sibyl_core.services import memory_source_validation as validation
+from sibyl_core.services.content_models import RawMemoryWrite, raw_memory_recallable
+from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
+
+@pytest.fixture
+async def content_store(monkeypatch):
+    client = SurrealContentClient(url="memory://")
+    try:
+        await bootstrap_content_schema(client, reset=True)
+
+        @asynccontextmanager
+        async def session():
+            yield client
+
+        monkeypatch.setattr(content_client, "surreal_content_client", session)
+        yield str(uuid4())
+    finally:
+        await client.close()
+
+
+async def pending_child(org, *, scope="private", ceiling=True, bulk=False):
+    source = await store.remember_raw_memory(
+        organization_id=org,
+        principal_id="owner",
+        source_id="source",
+        raw_content="Original source",
+        memory_scope=scope,
+        scope_key=None if scope == "private" else "source-scope",
+        embedding_provider=None,
+    )
+    # A missing source at birth, later restored with precisely the observed identity.
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query("DELETE raw_captures WHERE uuid = $id;", id=source.id)
+    grants = {
+        "accessible_projects": ["source-scope"] if ceiling else [],
+        "accessible_teams": ["source-scope"] if ceiling else [],
+        "accessible_delegations": ["source-scope"] if ceiling else [],
+    }
+    common = {
+        "organization_id": org,
+        "principal_id": "owner",
+        "source_id": str(uuid4()),
+        "raw_content": "Derived source",
+        "metadata": {"raw_source_ids": [source.id]},
+    }
+    if bulk:
+        child = (
+            await store.remember_raw_memories(
+                [RawMemoryWrite(**common)], embedding_provider=None, **grants
+            )
+        )[0]
+    else:
+        child = await store.remember_raw_memory(
+            **common, source_memories=[source], embedding_provider=None, **grants
+        )
+    assert child.metadata["source_validation_pending"] is True
+    async with content_client.surreal_content_client() as client:
+        from sibyl_core.services.content_models import raw_memory_record
+
+        await content_client.replace_record(
+            client, "raw_captures", uuid=source.id, record=raw_memory_record(source)
+        )
+    return source, child
+
+
+@pytest.mark.parametrize("bulk", [False, True])
+async def test_missing_source_recovers_without_rebinding(content_store, bulk):
+    _, child = await pending_child(content_store, bulk=bulk)
+    bindings = child.metadata.get("source_bindings")
+    resolver = AsyncMock(return_value=SourceReadAuthority("owner"))
+    result = await validation.repair_raw_source_lifecycle(
+        content_store, embedding_provider=None, authority_resolver=resolver
+    )
+    saved = await store.get_raw_memory(organization_id=content_store, memory_id=child.id)
+    assert result.recovered == 1
+    assert raw_memory_recallable(saved)
+    assert saved.metadata.get("source_bindings") == bindings
+    assert "source_validation_context" not in public_memory_metadata(saved.metadata)
+    resolver.assert_awaited_once_with(content_store, "owner")
+
+
+@pytest.mark.parametrize("scope", ["project", "team", "delegated"])
+@pytest.mark.parametrize("revoked", [True, False])
+async def test_current_membership_and_original_ceiling_are_both_required(
+    content_store, scope, revoked
+):
+    _, child = await pending_child(content_store, scope=scope, ceiling=revoked)
+    current = frozenset() if revoked else frozenset({"source-scope"})
+    resolver = AsyncMock(return_value=SourceReadAuthority("owner", current, current, current))
+    result = await validation.repair_raw_source_lifecycle(
+        content_store, embedding_provider=None, authority_resolver=resolver
+    )
+    saved = await store.get_raw_memory(organization_id=content_store, memory_id=child.id)
+    assert result.pending == 1
+    assert not raw_memory_recallable(saved)
+    assert saved.metadata == child.metadata
+
+
+@pytest.mark.parametrize("context", [None, {}, {"version": 99}])
+async def test_legacy_or_malformed_context_stays_pending(content_store, context):
+    _, child = await pending_child(content_store)
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE raw_captures UNSET metadata.source_validation_context WHERE uuid = $id;",
+            id=child.id,
+        )
+        if context is not None:
+            await client.execute_query(
+                "UPDATE raw_captures SET metadata.source_validation_context = $context "
+                "WHERE uuid = $id;",
+                id=child.id,
+                context=context,
+            )
+    resolver = AsyncMock(return_value=SourceReadAuthority("owner"))
+    result = await validation.repair_raw_source_lifecycle(
+        content_store, embedding_provider=None, authority_resolver=resolver
+    )
+    assert result.pending == 1
+    resolver.assert_not_awaited()
+
+
+async def test_revoked_principal_remains_pending(content_store):
+    await pending_child(content_store)
+    result = await validation.repair_raw_source_lifecycle(
+        content_store, embedding_provider=None, authority_resolver=AsyncMock(return_value=None)
+    )
+    assert result.pending == 1
+
+
+async def test_cas_loss_resolves_authority_again(content_store, monkeypatch):
+    _, child = await pending_child(content_store)
+    resolver = AsyncMock(side_effect=[SourceReadAuthority("owner"), None])
+    original_save = store.save_raw_memory
+
+    async def lose_once(memory, **kwargs):
+        await original_save(replace(child, tags=["concurrent"]), embedding_provider=None)
+        raise RevisionConflictError(child.id, child.revision, child.revision + 1)
+
+    monkeypatch.setattr(store, "save_raw_memory", lose_once)
+    result = await validation.repair_raw_source_lifecycle(
+        content_store, embedding_provider=None, authority_resolver=resolver
+    )
+    assert result.pending == 1
+    assert resolver.await_count == 2
+    saved = await store.get_raw_memory(organization_id=content_store, memory_id=child.id)
+    assert saved.tags == ["concurrent"]
+    assert saved.metadata["source_validation_pending"] is True
+
+
+async def test_paging_does_not_starve_later_rows(content_store, monkeypatch):
+    children = [(await pending_child(content_store))[1] for _ in range(5)]
+    first = min(children, key=lambda row: row.id)
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE raw_captures UNSET metadata.source_validation_context WHERE uuid = $id;",
+            id=first.id,
+        )
+    monkeypatch.setattr(validation, "_PAGE_SIZE", 2)
+    result = await validation.repair_raw_source_lifecycle(
+        content_store,
+        embedding_provider=None,
+        authority_resolver=AsyncMock(return_value=SourceReadAuthority("owner")),
+    )
+    assert result.checked == 5
+    assert result.pending == 1
+    assert result.recovered == 4
+
+
+async def test_explicit_empty_scope_ceiling_survives_storage(content_store):
+    _, child = await pending_child(content_store)
+    metadata = dict(child.metadata)
+    metadata["source_validation_context"] = SourceReadAuthority(
+        "owner", scope_keys=frozenset()
+    ).ceiling_metadata()
+    await store.save_raw_memory(replace(child, metadata=metadata), embedding_provider=None)
+    result = await validation.repair_raw_source_lifecycle(
+        content_store,
+        embedding_provider=None,
+        authority_resolver=AsyncMock(return_value=SourceReadAuthority("owner")),
+    )
+    assert result.pending == 1
+
+
+async def test_public_input_cannot_supply_recovery_authority(content_store):
+    forged = SourceReadAuthority("other", projects=frozenset({"secret"})).ceiling_metadata()
+    child = await store.remember_raw_memory(
+        organization_id=content_store,
+        principal_id="owner",
+        source_id="forged",
+        raw_content="Forged authority",
+        metadata={"raw_source_ids": [str(uuid4())], "source_validation_context": forged},
+        embedding_provider=None,
+    )
+    saved = child.metadata["source_validation_context"]
+    assert saved["principal_id"] == "owner"
+    assert saved["projects"] == []

--- a/packages/python/sibyl-core/tests/test_reflect.py
+++ b/packages/python/sibyl-core/tests/test_reflect.py
@@ -259,9 +259,18 @@ async def test_reflect_memory_can_persist_review_queue(
 ) -> None:
     calls: list[tuple[str, dict[str, Any]]] = []
 
-    async def fake_remember_source(**kwargs: Any) -> SimpleNamespace:
+    async def fake_remember_source(**kwargs: Any) -> RawMemory:
         calls.append(("source", kwargs))
-        return SimpleNamespace(id="raw-source-1", title=kwargs["title"])
+        return RawMemory(
+            id="raw-source-1",
+            organization_id=kwargs["organization_id"],
+            principal_id=kwargs["principal_id"],
+            source_id=kwargs["source_id"],
+            title=kwargs["title"],
+            raw_content=kwargs["raw_content"],
+            memory_scope=kwargs["memory_scope"],
+            scope_key=kwargs["scope_key"],
+        )
 
     async def fake_candidate_review(**kwargs: Any) -> RawMemory:
         calls.append(("candidate", kwargs))

--- a/packages/python/sibyl-core/tests/test_reflection_content_epoch_identity.py
+++ b/packages/python/sibyl-core/tests/test_reflection_content_epoch_identity.py
@@ -1,0 +1,85 @@
+"""Equal text after a correction still belongs to a new source epoch."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services.memory_correction import apply_memory_correction
+from sibyl_core.services.memory_reflection import persist_reflection_candidate
+from sibyl_core.services.surreal_content import remember_raw_memory, save_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+async def test_reextraction_after_text_roundtrip_keeps_historical_epoch_retired(
+    runtime, content_store, monkeypatch
+):
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    org = runtime.client.group_id
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="user_a",
+        source_id="identity-content-roundtrip",
+        raw_content="Retain the audit trail.",
+        embedding_provider=None,
+    )
+    candidate = ReflectionCandidate(
+        kind="decision",
+        title="Audit trail",
+        content="Retain the audit trail.",
+        confidence=1.0,
+        reason="Recorded decision",
+        raw_source_ids=[source.id],
+    )
+
+    async def publish(snapshot):
+        return await persist_reflection_candidate(
+            candidate=candidate,
+            organization_id=org,
+            principal_id="user_a",
+            source_id=source.id,
+            link_source_entity=False,
+            source_memories=[snapshot],
+        )
+
+    original = await publish(source)
+    assert original.response.success
+    for text in ("Delete the audit trail.", source.raw_content):
+        revised = await apply_memory_correction(
+            organization_id=org,
+            principal_id="user_a",
+            source_id=source.id,
+            action="revise",
+            revised_content=text,
+        )
+        assert revised.applied
+        restored = await apply_memory_correction(
+            organization_id=org,
+            principal_id="user_a",
+            source_id=source.id,
+            action="restore",
+        )
+        assert restored.applied and restored.updated_memory is not None
+    current = await publish(restored.updated_memory)
+    assert current.response.success
+    assert current.response.id != original.response.id
+    old_row = await runtime.entity_manager.get(original.response.id)
+    new_row = await runtime.entity_manager.get(current.response.id)
+    assert not graph_metadata_recallable(old_row.metadata)
+    assert graph_metadata_recallable(new_row.metadata)
+    assert old_row.metadata["source_bindings"] == {source.id: source.revision}
+
+    bookkeeping = await save_raw_memory(
+        replace(
+            restored.updated_memory,
+            metadata={**restored.updated_memory.metadata, "reflection_run_id": "later"},
+        ),
+        expected_revision=restored.updated_memory.revision,
+        embedding_provider=None,
+    )
+    replay = await publish(bookkeeping)
+    assert replay.response.success and replay.response.id == current.response.id

--- a/packages/python/sibyl-core/tests/test_reflection_extractor.py
+++ b/packages/python/sibyl-core/tests/test_reflection_extractor.py
@@ -77,13 +77,16 @@ async def test_reflect_memory_persists_claim_receipts_with_source_grounding(
     monkeypatch.setattr("sibyl_core.tools.reflect._persist_reflection_source", native_write)
     monkeypatch.setattr("sibyl_core.tools.reflect._persist_reflection_candidate", native_write)
 
-    async def fake_source_review(**kwargs: Any) -> AddResponse:
+    async def fake_source_review(**kwargs: Any) -> tuple[AddResponse, RawMemory]:
         calls.append(("source", kwargs))
-        return AddResponse(
-            success=True,
-            id="raw-source-1",
-            message="stored",
-            timestamp=datetime.now(UTC),
+        return (
+            AddResponse(
+                success=True,
+                id="raw-source-1",
+                message="stored",
+                timestamp=datetime.now(UTC),
+            ),
+            _raw_memory("raw-source-1", kwargs["content"]),
         )
 
     async def fake_candidate_review(**kwargs: Any) -> RawMemory:
@@ -158,13 +161,16 @@ async def test_reflect_memory_marks_duplicate_candidates_before_review_persisten
         "Observed reflection quality gate is now a named release check.",
     )
 
-    async def fake_source_review(**kwargs: Any) -> AddResponse:
+    async def fake_source_review(**kwargs: Any) -> tuple[AddResponse, RawMemory]:
         calls.append(("source", kwargs))
-        return AddResponse(
-            success=True,
-            id="raw-source-1",
-            message="stored",
-            timestamp=datetime.now(UTC),
+        return (
+            AddResponse(
+                success=True,
+                id="raw-source-1",
+                message="stored",
+                timestamp=datetime.now(UTC),
+            ),
+            _raw_memory("raw-source-1", kwargs["content"]),
         )
 
     async def fake_candidate_review(**kwargs: Any) -> RawMemory:
@@ -250,6 +256,17 @@ async def test_reflect_memory_uses_existing_source_id_without_rewriting_source(
         AsyncMock(return_value=[]),
     )
 
+    source = RawMemory(
+        id="raw-existing-source",
+        organization_id="org_123",
+        source_id="raw-existing-source",
+        principal_id="user_123",
+        memory_scope=MemoryScope.PRIVATE,
+        raw_content="Observed reflection dream cycles reuse raw sources.",
+        revision=7,
+    )
+    monkeypatch.setattr("sibyl_core.tools.reflect.get_raw_memory", AsyncMock(return_value=source))
+
     pack = await reflect_memory(
         "Observed reflection dream cycles reuse raw sources.",
         source_title="Existing raw source",
@@ -268,6 +285,8 @@ async def test_reflect_memory_uses_existing_source_id_without_rewriting_source(
     assert pack.candidates[0].raw_source_ids == ["raw-existing-source"]
     assert candidate_calls[0]["source_id"] == "raw-existing-source"
     assert candidate_calls[0]["raw_source_ids"] == ["raw-existing-source"]
+
+    assert candidate_calls[0]["source_memories"] == [source]
 
 
 def test_reflection_lifecycle_decisions_mark_duplicate_candidates() -> None:

--- a/packages/python/sibyl-core/tests/test_reflection_identity.py
+++ b/packages/python/sibyl-core/tests/test_reflection_identity.py
@@ -380,6 +380,7 @@ async def test_public_promotion_and_share_replay_preserve_raw_lifecycle(
             organization_id=runtime.client.group_id,
             principal_id="user_a",
             accessible_projects={project},
+            writable_projects={project},
         )
         if mode == "share":
             result = await share_memory(
@@ -441,6 +442,7 @@ async def test_partial_promotion_is_retryable_before_raw_review_transition(
             organization_id=runtime.client.group_id,
             principal_id="user_a",
             accessible_projects={"project_a"},
+            writable_projects={"project_a"},
         )
         if mode == "share":
             result = await share_memory(
@@ -1166,6 +1168,7 @@ async def test_source_change_during_share_cannot_publish_live_evidence(
         organization_id=runtime.client.group_id,
         principal_id="user_a",
         accessible_projects={"project_a"},
+        writable_projects={"project_a"},
         target_scope="project",
         target_scope_key="project_a",
     )
@@ -1209,6 +1212,7 @@ async def test_sharing_review_requires_available_authorized_support(
         organization_id=runtime.client.group_id,
         principal_id="user_a",
         accessible_projects={"project_a"},
+        writable_projects={"project_a"},
         target_scope="project",
         target_scope_key="project_a",
     )
@@ -1235,3 +1239,640 @@ async def test_sharing_review_requires_available_authorized_support(
             )
             == []
         )
+
+
+@pytest.mark.parametrize("mode", ["share", "review"])
+@pytest.mark.parametrize("action", ["delete", "hide", "revise"])
+async def test_upstream_correction_retires_published_derivatives(
+    runtime: GraphRuntime,
+    content_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    action: str,
+) -> None:
+    from sibyl_core.services.surreal_content import raw_memory_recallable
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="upstream-policy",
+        title="Original policy",
+        raw_content="Keep the original policy.",
+        embedding_provider=None,
+    )
+    review = None
+    if mode == "share":
+        shared = await share_memory(
+            source_ids=[source.id],
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            accessible_projects={"project_a"},
+            writable_projects={"project_a"},
+            target_scope="project",
+            target_scope_key="project_a",
+        )
+        publication = shared.promotions[0]
+    else:
+        review = await remember_reflection_candidate_review(
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            candidate=candidate(),
+            raw_source_ids=[source.id],
+        )
+        publication = await promote_reflection_candidate_review(
+            candidate_id=review.id,
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            accessible_projects={"project_a"},
+            promote_to_scope="project",
+            promote_to_scope_key="project_a",
+        )
+    assert publication.success
+    before = await runtime.entity_manager.get(publication.promoted_id)
+    assert graph_metadata_recallable(before.metadata)
+    correction = await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        source_id=source.id,
+        principal_id="user_a",
+        action=action,
+        revised_content="Use the revised policy." if action == "revise" else None,
+        accessible_projects={"project_a"},
+    )
+    assert correction.applied
+    row = await runtime.entity_manager.get(publication.promoted_id)
+    assert not graph_metadata_recallable(row.metadata)
+    if review is not None:
+        retained = await get_raw_memory(
+            organization_id=runtime.client.group_id, memory_id=review.id
+        )
+        assert not raw_memory_recallable(retained)
+
+
+@pytest.mark.parametrize("action", ["hide", "revise"])
+@pytest.mark.parametrize("independent_hide", [False, True])
+async def test_source_restore_preserves_content_epoch_and_independent_verdict(
+    runtime, content_store, monkeypatch, action, independent_hide
+):
+    from sibyl_core.services.surreal_content import raw_memory_recallable
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    org = runtime.client.group_id
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="user_a",
+        source_id="root",
+        raw_content="Original rule",
+        embedding_provider=None,
+    )
+    review = await remember_reflection_candidate_review(
+        organization_id=org,
+        principal_id="user_a",
+        candidate=candidate(),
+        raw_source_ids=[source.id],
+        source_memories=[source],
+    )
+    publication = await promote_reflection_candidate_review(
+        candidate_id=review.id,
+        organization_id=org,
+        principal_id="user_a",
+        promote_to_scope="private",
+    )
+    assert publication.success
+    if independent_hide:
+        await apply_memory_correction(
+            organization_id=org,
+            source_id=review.id,
+            principal_id="user_a",
+            action="hide",
+        )
+    await apply_memory_correction(
+        organization_id=org,
+        source_id=source.id,
+        principal_id="user_a",
+        action=action,
+        revised_content="New rule" if action == "revise" else None,
+    )
+    result = await apply_memory_correction(
+        organization_id=org,
+        source_id=source.id,
+        principal_id="user_a",
+        action="restore",
+    )
+    assert result.applied and result.propagation_complete
+    retained = await get_raw_memory(organization_id=org, memory_id=review.id)
+    row = await runtime.entity_manager.get(publication.promoted_id)
+    expected = action == "hide" and not independent_hide
+    assert raw_memory_recallable(retained) is expected
+    assert graph_metadata_recallable(row.metadata) is expected
+
+
+async def test_new_review_binds_revised_source_without_reviving_old_review(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.services.surreal_content import raw_memory_recallable
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    org = runtime.client.group_id
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="user_a",
+        source_id="root",
+        raw_content="Original rule",
+        embedding_provider=None,
+    )
+    old_review = await remember_reflection_candidate_review(
+        organization_id=org,
+        principal_id="user_a",
+        candidate=candidate(),
+        raw_source_ids=[source.id],
+        source_memories=[source],
+    )
+    revised = await apply_memory_correction(
+        organization_id=org,
+        source_id=source.id,
+        principal_id="user_a",
+        action="revise",
+        revised_content="New rule",
+    )
+    new_review = await remember_reflection_candidate_review(
+        organization_id=org,
+        principal_id="user_a",
+        candidate=replace(candidate(), content="Follow the new rule."),
+        raw_source_ids=[source.id],
+        source_memories=[revised.updated_memory],
+    )
+    await apply_memory_correction(
+        organization_id=org,
+        source_id=source.id,
+        principal_id="user_a",
+        action="restore",
+    )
+    old_current = await get_raw_memory(organization_id=org, memory_id=old_review.id)
+    new_current = await get_raw_memory(organization_id=org, memory_id=new_review.id)
+    assert not raw_memory_recallable(old_current)
+    assert raw_memory_recallable(new_current)
+
+
+@pytest.mark.parametrize("source_state", ["new", "existing", "revised"])
+async def test_production_reflection_binds_the_extracted_source_revision(
+    runtime: GraphRuntime,
+    content_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+    source_state: str,
+) -> None:
+    from sibyl_core.memory_pipeline.source_lifecycle import SOURCE_BINDINGS_KEY
+
+    org = runtime.client.group_id
+    text = "We decided to preserve exact source evidence before publishing a procedure."
+    source = None
+    if source_state != "new":
+        source = await remember_raw_memory(
+            organization_id=org,
+            principal_id="user_a",
+            source_id="binding-source",
+            raw_content="Old evidence" if source_state == "revised" else text,
+        )
+        if source_state == "revised":
+            monkeypatch.setattr(
+                "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+                AsyncMock(return_value=runtime),
+            )
+            correction = await apply_memory_correction(
+                organization_id=org,
+                principal_id="user_a",
+                source_id=source.id,
+                action="revise",
+                revised_content=text,
+            )
+            source = correction.updated_memory
+    pack = await reflect_memory(
+        text,
+        organization_id=org,
+        principal_id="user_a",
+        persist=True,
+        persist_review=True,
+        persist_source=source is None,
+        existing_source_id=source.id if source else None,
+    )
+    assert pack.persisted_count == 1
+    observed_source = source or await get_raw_memory(
+        organization_id=org, memory_id=str(pack.source_id)
+    )
+    assert observed_source is not None
+    review = await get_raw_memory(
+        organization_id=org, memory_id=str(pack.candidates[0].persisted_id)
+    )
+    assert review is not None
+    bindings = review.metadata.get(SOURCE_BINDINGS_KEY, {})
+    assert bindings.get(observed_source.id) == observed_source.revision
+
+
+@pytest.mark.parametrize(
+    "unavailable", ["missing", "foreign_org", "foreign_owner", "project", "hidden", "changed"]
+)
+async def test_reflection_rejects_unavailable_source_before_extraction(
+    runtime: GraphRuntime,
+    content_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+    unavailable: str,
+) -> None:
+    from types import SimpleNamespace
+
+    org = runtime.client.group_id
+    text = "We decided to preserve original evidence."
+    source = await remember_raw_memory(
+        organization_id="other-org" if unavailable == "foreign_org" else org,
+        principal_id="other-user" if unavailable == "foreign_owner" else "user_a",
+        source_id="unavailable-source",
+        raw_content="Changed evidence" if unavailable == "changed" else text,
+        memory_scope="project" if unavailable == "project" else "private",
+        scope_key="project_b" if unavailable == "project" else None,
+    )
+    if unavailable == "hidden":
+        monkeypatch.setattr(
+            "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+            AsyncMock(return_value=runtime),
+        )
+        await apply_memory_correction(
+            organization_id=org, principal_id="user_a", source_id=source.id, action="hide"
+        )
+    extractor = SimpleNamespace(extract=AsyncMock())
+    with pytest.raises(ValueError, match=r"^Reflection source is unavailable or changed$"):
+        await reflect_memory(
+            text,
+            organization_id=org,
+            principal_id="user_a",
+            accessible_projects=set(),
+            persist=True,
+            persist_review=True,
+            persist_source=False,
+            existing_source_id="missing" if unavailable == "missing" else source.id,
+            extractor=extractor,
+        )
+    extractor.extract.assert_not_awaited()
+
+
+@pytest.mark.parametrize("bound", [False, True])
+async def test_revise_retires_direct_graph_copies_and_their_projections(
+    runtime, content_store, monkeypatch, bound
+):
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="projected-source",
+        raw_content="Original instructions",
+        embedding_provider=None,
+    )
+    metadata = {"memory_scope": "private", "principal_id": "user_a"}
+    if bound:
+        metadata["source_bindings"] = {raw.id: raw.observed_revision}
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="direct-copy",
+            name="Original source",
+            entity_type=EntityType.EPISODE,
+            content=raw.raw_content,
+            metadata={**metadata, "raw_memory_id": raw.id},
+        ),
+        generate_embedding=False,
+    )
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="projected-copy",
+            name="Original passage",
+            entity_type=EntityType.EPISODE,
+            content=raw.raw_content,
+            metadata={**metadata, "parent_entity_id": "direct-copy", "projection_kind": "passage"},
+        ),
+        generate_embedding=False,
+    )
+    for action in ("revise", "restore"):
+        result = await apply_memory_correction(
+            organization_id=runtime.client.group_id,
+            source_id=raw.id,
+            principal_id="user_a",
+            action=action,
+            revised_content="Corrected instructions" if action == "revise" else None,
+        )
+        assert result.applied
+        for row_id in ("direct-copy", "projected-copy"):
+            row = await runtime.entity_manager.get(row_id)
+            assert row.content == "Original instructions"
+            assert not graph_metadata_recallable(row.metadata)
+            assert row.metadata["correction_blockers"][raw.id]["blocking"] is True
+
+
+async def test_source_restore_preserves_graph_copy_own_hide(runtime, content_store, monkeypatch):
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="independently-hidden-source",
+        raw_content="Original instructions",
+        embedding_provider=None,
+    )
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="independently-hidden-copy",
+            name="Hidden copy",
+            entity_type=EntityType.EPISODE,
+            content=raw.raw_content,
+            metadata={
+                "memory_scope": "private",
+                "principal_id": "user_a",
+                "raw_memory_id": raw.id,
+                "lifecycle_state": "hidden",
+                "lifecycle_flags": ["hidden"],
+                "excluded_from_recall": True,
+            },
+        ),
+        generate_embedding=False,
+    )
+    for action in ("hide", "restore"):
+        await apply_memory_correction(
+            organization_id=runtime.client.group_id,
+            source_id=raw.id,
+            principal_id="user_a",
+            action=action,
+        )
+    copy = await runtime.entity_manager.get("independently-hidden-copy")
+    assert copy.metadata["lifecycle_flags"] == ["hidden"]
+    assert copy.metadata["excluded_from_recall"] is True
+    assert not graph_metadata_recallable(copy.metadata)
+    assert copy.metadata["correction_blockers"][raw.id]["blocking"] is False
+
+
+async def test_graph_copy_born_during_hide_can_follow_source_restore(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.services.memory_lifecycle import projected_row_lifecycle_stamp
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="late-copy-source",
+        raw_content="Source instructions",
+        embedding_provider=None,
+    )
+    await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        source_id=raw.id,
+        principal_id="user_a",
+        action="hide",
+    )
+    provenance = {"raw_memory_id": raw.id}
+    stamp = await projected_row_lifecycle_stamp(
+        organization_id=runtime.client.group_id,
+        metadata=provenance,
+    )
+    assert not graph_metadata_recallable(stamp)
+    await runtime.entity_manager.create_direct(
+        Entity(
+            id="late-hidden-copy",
+            name="Late copy",
+            entity_type=EntityType.EPISODE,
+            content=raw.raw_content,
+            metadata={"memory_scope": "private", "principal_id": "user_a", **provenance, **stamp},
+        ),
+        generate_embedding=False,
+    )
+    await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        source_id=raw.id,
+        principal_id="user_a",
+        action="restore",
+    )
+    copy = await runtime.entity_manager.get("late-hidden-copy")
+    assert graph_metadata_recallable(copy.metadata)
+
+
+async def test_promotion_check_preserves_concurrent_source_restore(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.services.memory_reflection import _verify_promotion_sources
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    org = runtime.client.group_id
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="user_a",
+        source_id="promotion-race-source",
+        raw_content="Keep the original rule.",
+        embedding_provider=None,
+    )
+    entity = Entity(
+        id="promotion-race-row",
+        name="Derived rule",
+        entity_type=EntityType.EPISODE,
+        content=source.raw_content,
+        metadata={
+            "memory_scope": "private",
+            "principal_id": "user_a",
+            "raw_memory_id": source.id,
+            "raw_source_ids": [source.id],
+            "source_bindings": {source.id: source.revision},
+        },
+    )
+    hidden = await apply_memory_correction(
+        organization_id=org, principal_id="user_a", source_id=source.id, action="hide"
+    )
+    assert hidden.applied and hidden.propagation_complete
+    await runtime.entity_manager.create_direct(entity, generate_embedding=False)
+    update = runtime.entity_manager.update
+    restored = False
+
+    async def restore_before_stale_write(*args, **kwargs):
+        nonlocal restored
+        if not restored:
+            restored = True
+            result = await apply_memory_correction(
+                organization_id=org,
+                principal_id="user_a",
+                source_id=source.id,
+                action="restore",
+            )
+            assert result.applied and result.propagation_complete
+            row = await runtime.entity_manager.get(entity.id)
+            assert graph_metadata_recallable(row.metadata)
+        return await update(*args, **kwargs)
+
+    monkeypatch.setattr(runtime.entity_manager, "update", restore_before_stale_write)
+    await _verify_promotion_sources(runtime, [source], entity_id=entity.id)
+    assert restored
+    row = await runtime.entity_manager.get(entity.id)
+    assert graph_metadata_recallable(row.metadata)
+    assert row.metadata["correction_blockers"][source.id]["blocking"] is False
+
+
+async def test_promotion_missing_capture_recovers_without_authored_deletion(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.projection.repair import repair_graph_lifecycle
+    from sibyl_core.services.memory_reflection import _verify_promotion_sources
+
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="temporarily-missing-promotion-source",
+        raw_content="Retain the source evidence.",
+        embedding_provider=None,
+    )
+    entity = Entity(
+        id="pending-promotion-row",
+        name="Pending source verification",
+        entity_type=EntityType.EPISODE,
+        metadata={
+            "memory_scope": "private",
+            "principal_id": "user_a",
+            "raw_source_ids": [source.id],
+            "source_bindings": {source.id: source.revision},
+        },
+    )
+    await runtime.entity_manager.create_direct(entity, generate_embedding=False)
+    with monkeypatch.context() as unavailable:
+        for module in ("memory_reflection", "memory_lifecycle"):
+            unavailable.setattr(
+                f"sibyl_core.services.{module}.get_raw_memory", AsyncMock(return_value=None)
+            )
+        assert not await _verify_promotion_sources(runtime, [source], entity_id=entity.id)
+    pending = await runtime.entity_manager.get(entity.id)
+    assert not graph_metadata_recallable(pending.metadata)
+    owners = pending.metadata["lifecycle_reconciliation_pending"]
+    assert len(owners) == 1 and list(owners.values()) == [True]
+    assert next(iter(owners)).startswith(f"capture-signature-v1:{source.id}:")
+    assert not pending.metadata.get("excluded_from_recall")
+    repaired = await repair_graph_lifecycle(runtime)
+    assert repaired.recovered == 1 and repaired.pending == repaired.failed == 0
+    recovered = await runtime.entity_manager.get(entity.id)
+    assert graph_metadata_recallable(recovered.metadata)
+    assert recovered.metadata["source_bindings"] == {source.id: source.revision}
+
+
+async def test_promotion_checks_every_hidden_source_before_restore(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.services.memory_reflection import _verify_promotion_sources
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    org = runtime.client.group_id
+    sources = [
+        await remember_raw_memory(
+            organization_id=org,
+            principal_id="user_a",
+            source_id=f"late-promotion-source-{index}",
+            raw_content=f"Supporting evidence {index}",
+            embedding_provider=None,
+        )
+        for index in range(2)
+    ]
+    for source in sources:
+        hidden = await apply_memory_correction(
+            organization_id=org, principal_id="user_a", source_id=source.id, action="hide"
+        )
+        assert hidden.applied and hidden.propagation_complete
+    entity = Entity(
+        id="late-multiple-source-promotion",
+        name="Combined evidence",
+        entity_type=EntityType.EPISODE,
+        metadata={
+            "memory_scope": "private",
+            "principal_id": "user_a",
+            "raw_source_ids": [source.id for source in sources],
+            "source_bindings": {source.id: source.revision for source in sources},
+        },
+    )
+    await runtime.entity_manager.create_direct(entity, generate_embedding=False)
+    assert not await _verify_promotion_sources(runtime, sources, entity_id=entity.id)
+    restored = await apply_memory_correction(
+        organization_id=org, principal_id="user_a", source_id=sources[0].id, action="restore"
+    )
+    assert restored.applied and restored.propagation_complete
+    row = await runtime.entity_manager.get(entity.id)
+    assert not graph_metadata_recallable(row.metadata)
+    assert row.metadata["correction_blockers"][sources[1].id]["blocking"] is True
+    restored = await apply_memory_correction(
+        organization_id=org, principal_id="user_a", source_id=sources[1].id, action="restore"
+    )
+    assert restored.applied and restored.propagation_complete
+    row = await runtime.entity_manager.get(entity.id)
+    assert graph_metadata_recallable(row.metadata)
+
+
+async def test_capture_reconciliation_respects_the_derived_content_binding(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.projection.reconcile import reconcile_with_capture
+
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    org = runtime.client.group_id
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="user_a",
+        source_id="reconciled-content-epoch",
+        raw_content="Original evidence",
+        embedding_provider=None,
+    )
+    revised = await apply_memory_correction(
+        organization_id=org,
+        principal_id="user_a",
+        source_id=source.id,
+        action="revise",
+        revised_content="Corrected evidence",
+    )
+    assert revised.applied and revised.updated_memory is not None
+    restored = await apply_memory_correction(
+        organization_id=org, principal_id="user_a", source_id=source.id, action="restore"
+    )
+    assert restored.applied and restored.propagation_complete
+    for name, binding in (("old", source.revision), ("current", revised.updated_memory.revision)):
+        entity = Entity(
+            id=f"reconciled-{name}-content",
+            name=f"Derived {name} evidence",
+            entity_type=EntityType.EPISODE,
+            metadata={
+                "memory_scope": "private",
+                "principal_id": "user_a",
+                "raw_source_ids": [source.id],
+                "source_bindings": {source.id: binding},
+            },
+        )
+        await runtime.entity_manager.create_direct(entity, generate_embedding=False)
+        await reconcile_with_capture(
+            runtime.entity_manager,
+            organization_id=org,
+            metadata={"raw_memory_id": source.id},
+            row_ids=[entity.id],
+        )
+        row = await runtime.entity_manager.get(entity.id)
+        assert graph_metadata_recallable(row.metadata) is (name == "current")
+        assert row.metadata["source_bindings"] == {source.id: binding}

--- a/packages/python/sibyl-core/tests/test_reflection_legacy_epoch_identity.py
+++ b/packages/python/sibyl-core/tests/test_reflection_legacy_epoch_identity.py
@@ -1,0 +1,100 @@
+"""Legacy correction history must not turn bookkeeping into new evidence."""
+
+from dataclasses import replace
+
+import pytest
+
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services import memory_reflection
+from sibyl_core.services.surreal_content import remember_raw_memory, save_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+async def legacy_source(runtime):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="legacy-epoch-source",
+        raw_content="Retain the audit trail.",
+        embedding_provider=None,
+    )
+    return await save_raw_memory(
+        replace(source, metadata={"correction_history": [{"action": "revise"}]}),
+        expected_revision=source.revision,
+        embedding_provider=None,
+    )
+
+
+async def test_legacy_epoch_bookkeeping_replays_existing_evidence(runtime, content_store):
+    source = await legacy_source(runtime)
+    candidate = ReflectionCandidate(
+        kind="decision",
+        title="Audit trail",
+        content=source.raw_content,
+        reason="Recorded decision",
+        confidence=1.0,
+        raw_source_ids=[source.id],
+    )
+
+    async def publish(snapshot):
+        return await memory_reflection.persist_reflection_candidate(
+            candidate=candidate,
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            source_id=source.id,
+            link_source_entity=False,
+            source_memories=[snapshot],
+        )
+
+    first = await publish(source)
+    assert first.response.success
+    updated = await save_raw_memory(
+        replace(source, metadata={**source.metadata, "reflection_run_id": "later"}),
+        expected_revision=source.revision,
+        embedding_provider=None,
+    )
+    replay = await publish(updated)
+    assert replay.response.success and replay.response.id == first.response.id
+
+
+async def test_legacy_epoch_reservation_recovers_after_interruption(
+    runtime, content_store, monkeypatch
+):
+    source = await legacy_source(runtime)
+
+    async def interrupted(**kwargs):
+        raise RuntimeError("simulated interruption after reservation")
+
+    async def promote():
+        return await memory_reflection.promote_raw_memory(
+            raw_memory_id=source.id,
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            promote_to_scope="private",
+        )
+
+    with monkeypatch.context() as patch:
+        patch.setattr(memory_reflection, "persist_reflection_candidate", interrupted)
+        with pytest.raises(RuntimeError, match="simulated interruption"):
+            await promote()
+    recovered = await promote()
+    assert recovered.success
+
+
+async def test_raw_capture_cannot_supply_correction_history(runtime, content_store):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="forged-content-generation",
+        raw_content="Retain the audit trail.",
+        metadata={
+            "correction_history": [{"action": "revise", "prior_revision": 999}],
+            "source_snapshot_sha256": "forged",
+            "description": "authored metadata survives",
+        },
+        embedding_provider=None,
+    )
+    assert "correction_history" not in source.metadata
+    assert "source_snapshot_sha256" not in source.metadata
+    assert source.metadata["description"] == "authored metadata survives"

--- a/packages/python/sibyl-core/tests/test_reflection_source_snapshot_identity.py
+++ b/packages/python/sibyl-core/tests/test_reflection_source_snapshot_identity.py
@@ -1,0 +1,88 @@
+"""Re-extraction creates new evidence without relabeling an older source snapshot."""
+
+from copy import deepcopy
+from dataclasses import replace
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services.memory_reflection import (
+    _verify_promotion_sources,
+    persist_reflection_candidate,
+)
+from sibyl_core.services.surreal_content import remember_raw_memory, save_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+
+
+async def test_reextraction_preserves_old_snapshot_and_can_publish_current_evidence(
+    runtime, content_store
+):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="snapshot-identity-source",
+        title="Original evidence title",
+        raw_content="We decided to retain the audit trail.",
+        embedding_provider=None,
+    )
+    candidate = ReflectionCandidate(
+        kind="decision",
+        title="Retain the audit trail",
+        content="Keep the audit trail.",
+        reason="Source decision",
+        confidence=1.0,
+        raw_source_ids=[source.id],
+    )
+
+    async def publish(snapshot):
+        return await persist_reflection_candidate(
+            candidate=candidate,
+            organization_id=runtime.client.group_id,
+            principal_id="user_a",
+            source_id=source.id,
+            link_source_entity=False,
+            source_memories=[snapshot],
+        )
+
+    original = await publish(source)
+    assert original.response.success
+    changed = await save_raw_memory(
+        replace(source, title="Corrected evidence title"),
+        expected_revision=source.revision,
+        embedding_provider=None,
+    )
+    assert not await _verify_promotion_sources(runtime, [source], entity_id=original.response.id)
+    current = await publish(changed)
+    assert current.response.success
+    assert current.response.id != original.response.id
+    old_row = await runtime.entity_manager.get(original.response.id)
+    new_row = await runtime.entity_manager.get(current.response.id)
+    assert not graph_metadata_recallable(old_row.metadata)
+    assert graph_metadata_recallable(new_row.metadata)
+    assert old_row.metadata["source_bindings"] == {source.id: source.revision}
+    assert new_row.metadata["source_bindings"] == {source.id: changed.revision}
+
+    bookkeeping = await save_raw_memory(
+        replace(changed, metadata={**changed.metadata, "reflection_run_id": "later-run"}),
+        expected_revision=changed.revision,
+        embedding_provider=None,
+    )
+    replay = await publish(bookkeeping)
+    assert replay.response.success and replay.response.id == current.response.id
+
+
+def test_snapshot_fingerprints_are_redacted_without_mutating_stored_identity():
+    metadata = {
+        "source_snapshot_sha256": "private-fingerprint",
+        "reflection_identity": {
+            "version": 3,
+            "source_snapshot_sha256": "private-fingerprint",
+            "kind": "decision",
+        },
+    }
+    before = deepcopy(metadata)
+    public = public_memory_metadata(metadata)
+    assert "source_snapshot_sha256" not in public
+    assert public["reflection_identity"] == {"version": 3, "kind": "decision"}
+    assert metadata == before

--- a/packages/python/sibyl-core/tests/test_source_admission_batches.py
+++ b/packages/python/sibyl-core/tests/test_source_admission_batches.py
@@ -1,0 +1,66 @@
+"""Wide source frontiers remain fully validated through indexed lookup batches."""
+
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+import pytest
+
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.services import content_client, content_raw_persistence
+from sibyl_core.services.content_models import RawMemoryWrite, raw_memory_recallable
+
+
+@pytest.mark.parametrize("missing_tail", [False, True])
+async def test_admission_validates_every_source_batch(monkeypatch, missing_tail):
+    client = SurrealContentClient(url="memory://")
+    try:
+        await bootstrap_content_schema(client, reset=True)
+
+        @asynccontextmanager
+        async def session():
+            yield client
+
+        monkeypatch.setattr(content_client, "surreal_content_client", session)
+        org = str(uuid4())
+        sources = await content_raw_persistence.remember_raw_memories(
+            [
+                RawMemoryWrite(
+                    organization_id=org,
+                    principal_id="owner",
+                    source_id=f"source-{index}",
+                    raw_content=f"Evidence {index}",
+                )
+                for index in range(content_client.DEFAULT_BATCH_SIZE + 1)
+            ],
+            embedding_provider=None,
+        )
+        source_ids = [source.id for source in sources]
+        if missing_tail:
+            # This lexical suffix falls in the second batch.
+            source_ids.append("zz-missing-source")
+        original_select = content_client.select_many
+        batches = []
+
+        async def observe(client, query, **params):
+            if "source_ids" in params:
+                batches.append(list(params["source_ids"]))
+                assert len(params["source_ids"]) <= content_client.DEFAULT_BATCH_SIZE
+            return await original_select(client, query, **params)
+
+        monkeypatch.setattr(content_client, "select_many", observe)
+        child = await content_raw_persistence.remember_raw_memory(
+            organization_id=org,
+            principal_id="owner",
+            source_id="derived",
+            raw_content="Derived instructions",
+            metadata={"raw_source_ids": source_ids},
+            embedding_provider=None,
+        )
+        assert len(batches) == 2
+        assert {value for batch in batches for value in batch} == set(source_ids)
+        assert child.metadata["source_validation_pending"] is missing_tail
+        assert raw_memory_recallable(child) is not missing_tail
+        assert set(child.metadata["correction_blockers"]) == {source.id for source in sources}
+    finally:
+        await client.close()

--- a/packages/python/sibyl-core/tests/test_source_admission_grants.py
+++ b/packages/python/sibyl-core/tests/test_source_admission_grants.py
@@ -1,0 +1,164 @@
+"""Source admission preserves both membership and credential restrictions."""
+
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+import pytest
+
+from sibyl_core.auth.memory_policy import memory_scope_policy_key
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.services import content_client, content_raw_persistence
+from sibyl_core.services.content_models import RawMemoryWrite, raw_memory_recallable
+
+
+@pytest.fixture
+async def content_store(monkeypatch):
+    client = SurrealContentClient(url="memory://")
+    try:
+        await bootstrap_content_schema(client, reset=True)
+
+        @asynccontextmanager
+        async def session():
+            yield client
+
+        monkeypatch.setattr(content_client, "surreal_content_client", session)
+        yield str(uuid4())
+    finally:
+        await client.close()
+
+
+@pytest.mark.parametrize("bulk", [False, True])
+@pytest.mark.parametrize("source_access", ["allowed", "credential_denied", "membership_denied"])
+async def test_source_admission_requires_membership_and_credential_grant(
+    content_store, bulk, source_access
+):
+    org = content_store
+    source = await content_raw_persistence.remember_raw_memory(
+        organization_id=org,
+        principal_id="owner",
+        source_id="source",
+        raw_content="Project source material",
+        memory_scope="project",
+        scope_key="source-project",
+        embedding_provider=None,
+    )
+    projects = ["target-project"]
+    if source_access != "membership_denied":
+        projects.append("source-project")
+    grants = [memory_scope_policy_key("project", "target-project")]
+    if source_access != "credential_denied":
+        grants.append(memory_scope_policy_key("project", "source-project"))
+    context = {
+        "accessible_projects": iter(projects),
+        "allowed_memory_scope_keys": iter(grants),
+        "embedding_provider": None,
+    }
+    common = {
+        "organization_id": org,
+        "principal_id": "owner",
+        "raw_content": "Derived project material",
+        "memory_scope": "project",
+        "scope_key": "target-project",
+        "metadata": {"raw_source_ids": [source.id]},
+    }
+    if bulk:
+        children = await content_raw_persistence.remember_raw_memories(
+            [RawMemoryWrite(source_id=f"derived-{index}", **common) for index in range(2)],
+            **context,
+        )
+    else:
+        children = [
+            await content_raw_persistence.remember_raw_memory(
+                source_id="derived", **common, **context
+            )
+        ]
+    for child in children:
+        stored = await content_raw_persistence.get_raw_memory(
+            organization_id=org, memory_id=child.id
+        )
+        allowed = source_access == "allowed"
+        assert raw_memory_recallable(stored) is allowed
+        assert stored.metadata["source_validation_pending"] is not allowed
+        if not allowed:
+            assert source.id not in stored.metadata.get("correction_blockers", {})
+            assert source.id not in stored.metadata.get("source_bindings", {})
+
+
+async def test_admission_rechecks_target_authority_after_a_conflict(content_store, monkeypatch):
+    from dataclasses import replace
+
+    from sibyl_core.services.memory_source_validation import reconcile_raw_source_lifecycle
+
+    org = content_store
+    source = await content_raw_persistence.remember_raw_memory(
+        organization_id=org,
+        principal_id="owner",
+        source_id="project-source",
+        raw_content="Source material",
+        memory_scope="project",
+        scope_key="project-a",
+        embedding_provider=None,
+    )
+    child = await content_raw_persistence.remember_raw_memory(
+        organization_id=org,
+        principal_id="owner",
+        source_id="derived",
+        raw_content="Original content",
+        metadata={"raw_source_ids": [source.id]},
+        embedding_provider=None,
+    )
+    assert child.metadata["source_validation_pending"] is True
+    original_save = content_raw_persistence.save_raw_memory
+    raced = False
+
+    async def race(memory, **kwargs):
+        nonlocal raced
+        if not raced:
+            raced = True
+            await original_save(
+                replace(child, principal_id="someone-else", raw_content="New private content"),
+                expected_revision=child.observed_revision,
+                embedding_provider=None,
+            )
+        return await original_save(memory, **kwargs)
+
+    monkeypatch.setattr(content_raw_persistence, "save_raw_memory", race)
+    with pytest.raises(PermissionError, match=r"^Memory capture is no longer accessible\.$"):
+        await reconcile_raw_source_lifecycle(
+            child,
+            principal_id="owner",
+            accessible_projects={"project-a"},
+            embedding_provider=None,
+        )
+    assert raced
+    stored = await content_raw_persistence.get_raw_memory(organization_id=org, memory_id=child.id)
+    assert stored.principal_id == "someone-else"
+    assert stored.raw_content == "New private content"
+    assert stored.metadata["source_validation_pending"] is True
+
+
+async def test_admission_refuses_a_normalized_but_unobserved_revision(content_store, monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.services.content_models import raw_memory_from_record, raw_memory_record
+    from sibyl_core.services.memory_source_validation import reconcile_raw_source_lifecycle
+
+    child = await content_raw_persistence.remember_raw_memory(
+        organization_id=content_store,
+        principal_id="owner",
+        source_id="derived",
+        raw_content="Original content",
+        metadata={"raw_source_ids": ["missing-source"]},
+        embedding_provider=None,
+    )
+    record = raw_memory_record(child)
+    record["revision"] = None
+    legacy = raw_memory_from_record(record)
+    assert legacy.revision == 1
+    assert legacy.observed_revision is None
+    save = AsyncMock()
+    monkeypatch.setattr(content_raw_persistence, "save_raw_memory", save)
+    with pytest.raises(ValueError, match=r"^Memory capture revision is unavailable\.$"):
+        await reconcile_raw_source_lifecycle(legacy, principal_id="owner", embedding_provider=None)
+    save.assert_not_awaited()

--- a/packages/python/sibyl-core/tests/test_source_birth.py
+++ b/packages/python/sibyl-core/tests/test_source_birth.py
@@ -1,0 +1,396 @@
+"""Derived capture admission under source corrections and concurrent writes."""
+
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import EMBEDDING_DIM, bootstrap_content_schema
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    CORRECTION_BLOCKERS_KEY,
+    SOURCE_BINDINGS_KEY,
+    SOURCE_VALIDATION_PENDING_KEY,
+)
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services import content_client, content_raw_persistence
+from sibyl_core.services.graph_client import SurrealGraphClient, prepare_graph_schema
+from sibyl_core.services.graph_entities import EntityManager
+from sibyl_core.services.graph_relationships import RelationshipManager
+from sibyl_core.services.graph_runtime import GraphRuntime
+from sibyl_core.services.memory_correction import apply_memory_correction
+from sibyl_core.services.surreal_content import (
+    get_raw_memory,
+    raw_memory_recallable,
+    remember_raw_memory,
+    remember_reflection_candidate_review,
+)
+
+
+@pytest.fixture
+async def store(monkeypatch):
+    org = str(uuid4())
+    content = SurrealContentClient(url="memory://")
+    graph = SurrealGraphClient(group_id=org, url="memory://")
+    try:
+        await bootstrap_content_schema(content, reset=True)
+        await prepare_graph_schema(graph)
+        runtime = GraphRuntime(
+            client=graph,
+            entity_manager=EntityManager(graph, group_id=org),
+            relationship_manager=RelationshipManager(graph, group_id=org),
+        )
+
+        @asynccontextmanager
+        async def session():
+            yield content
+
+        monkeypatch.setattr(content_client, "surreal_content_client", session)
+        monkeypatch.setattr(
+            "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+            AsyncMock(return_value=runtime),
+        )
+        yield SimpleNamespace(org=org, content=content)
+    finally:
+        await content.close()
+        await graph.close()
+
+
+async def source(store, *, owner="owner", content="Source advice"):
+    return await remember_raw_memory(
+        organization_id=store.org,
+        principal_id=owner,
+        source_id="source",
+        raw_content=content,
+    )
+
+
+async def review(store, sources, *, snapshots=(), owner="owner", accessible_projects=None):
+    return await remember_reflection_candidate_review(
+        organization_id=store.org,
+        principal_id=owner,
+        raw_source_ids=[item.id for item in sources],
+        source_memories=snapshots,
+        accessible_projects=accessible_projects,
+        candidate=ReflectionCandidate(
+            kind="procedure",
+            title="Advice",
+            content="Derived advice",
+            reason="Evidence",
+            confidence=1.0,
+        ),
+    )
+
+
+async def correct(store, root, action, **kwargs):
+    return await apply_memory_correction(
+        organization_id=store.org,
+        principal_id="owner",
+        source_id=root.id,
+        action=action,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("snapshot", ["current", "stale", "absent"])
+async def test_review_created_after_hide_follows_later_restore(store, snapshot, monkeypatch):
+    from sibyl_core.embeddings.providers import DeterministicEmbeddingProvider
+
+    root = await source(store)
+    hidden = (await correct(store, root, "hide")).updated_memory
+    snapshots = [hidden] if snapshot == "current" else [root] if snapshot == "stale" else []
+    child = await review(store, [root], snapshots=snapshots)
+    assert not raw_memory_recallable(child)
+    assert child.metadata[SOURCE_VALIDATION_PENDING_KEY] is False
+    assert child.metadata[CORRECTION_BLOCKERS_KEY][root.id]["blocking"] is True
+    assert child.embedding is None
+    provider = DeterministicEmbeddingProvider(
+        replace(DeterministicEmbeddingProvider().metadata, dimensions=EMBEDDING_DIM)
+    )
+    monkeypatch.setattr(
+        content_raw_persistence.models, "configured_raw_memory_embedding_provider", lambda: provider
+    )
+    await correct(store, root, "restore")
+    restored = await get_raw_memory(organization_id=store.org, memory_id=child.id)
+    assert raw_memory_recallable(restored)
+    assert not restored.metadata.get("excluded_from_recall")
+    expected = await provider.embed_texts(
+        [
+            content_raw_persistence.models.raw_memory_embedding_text(
+                title=child.title, raw_content=child.raw_content
+            )
+        ],
+        input_kind="document",
+    )
+    assert restored.embedding == pytest.approx(expected[0])
+
+
+@pytest.mark.parametrize("race", ["insert", "admit"])
+@pytest.mark.parametrize("action", ["hide", "revise"])
+@pytest.mark.parametrize("owner", ["owner", "another-owner"])
+async def test_correction_during_birth_cannot_publish_stale_evidence(
+    store, monkeypatch, race, action, owner
+):
+    root = await remember_raw_memory(
+        organization_id=store.org,
+        principal_id="owner",
+        source_id="project-source",
+        raw_content="Shared project advice",
+        memory_scope="project",
+        scope_key="project-a",
+    )
+    raced = False
+    original_insert = content_client.replace_record
+    original_save = content_raw_persistence.save_raw_memory
+
+    async def fire():
+        nonlocal raced
+        raced = True
+        await correct(
+            store,
+            root,
+            action,
+            accessible_projects={"project-a"},
+            **({"revised_content": "Corrected advice"} if action == "revise" else {}),
+        )
+
+    async def insert(client, table, **kwargs):
+        record = await original_insert(client, table, **kwargs)
+        if not raced and record.get("metadata", {}).get("raw_source_ids"):
+            born = content_raw_persistence.models.raw_memory_from_record(record)
+            assert not raw_memory_recallable(born)
+            await fire()
+        return record
+
+    async def save(memory, **kwargs):
+        if not raced and memory.metadata.get("raw_source_ids"):
+            await fire()
+        return await original_save(memory, **kwargs)
+
+    if race == "insert":
+        monkeypatch.setattr(content_client, "replace_record", insert)
+    else:
+        monkeypatch.setattr(content_raw_persistence, "save_raw_memory", save)
+    child = await review(
+        store, [root], snapshots=[root], owner=owner, accessible_projects={"project-a"}
+    )
+    assert raced
+    assert not raw_memory_recallable(child)
+    assert child.metadata[SOURCE_BINDINGS_KEY][root.id] == root.revision
+    await correct(store, root, "restore", accessible_projects={"project-a"})
+    restored = await get_raw_memory(organization_id=store.org, memory_id=child.id)
+    assert raw_memory_recallable(restored) is (action == "hide")
+
+
+async def test_unreadable_source_stays_pending_without_exposing_its_clock(store):
+    foreign = await source(store, owner="someone-else")
+    child = await review(store, [foreign])
+    assert not raw_memory_recallable(child)
+    assert child.metadata[SOURCE_VALIDATION_PENDING_KEY] is True
+    assert foreign.id not in child.metadata.get(CORRECTION_BLOCKERS_KEY, {})
+    assert foreign.id not in child.metadata.get(SOURCE_BINDINGS_KEY, {})
+
+
+async def test_old_and_new_review_paths_preserve_the_oldest_content_epoch(store):
+    root = await source(store)
+    old = await review(store, [root], snapshots=[root])
+    revised = (await correct(store, root, "revise", revised_content="New advice")).updated_memory
+    new = await review(store, [revised], snapshots=[revised])
+    assert raw_memory_recallable(new)
+    combined = await review(store, [old, new], snapshots=[old, new])
+    assert not raw_memory_recallable(combined)
+    assert combined.metadata[SOURCE_BINDINGS_KEY][root.id] == root.revision
+    await correct(store, root, "restore")
+    combined = await get_raw_memory(organization_id=store.org, memory_id=combined.id)
+    assert not raw_memory_recallable(combined)
+
+
+async def test_projection_inherits_pending_source_validation(store):
+    from sibyl_core.memory_pipeline.lifecycle import (
+        graph_lifecycle_stamp,
+        graph_metadata_recallable,
+    )
+    from sibyl_core.projection.inheritance import inherited_lifecycle_metadata
+
+    foreign = await source(store, owner="someone-else")
+    child = await review(store, [foreign])
+    stamp = graph_lifecycle_stamp(child)
+    assert stamp[SOURCE_VALIDATION_PENDING_KEY] is True
+    assert not graph_metadata_recallable(stamp)
+    inherited = inherited_lifecycle_metadata(stamp)
+    assert inherited[SOURCE_VALIDATION_PENDING_KEY] is True
+    assert not graph_metadata_recallable(inherited)
+
+
+async def test_bulk_capture_creation_cannot_bypass_source_validation(store):
+    from sibyl_core.services.content_models import RawMemoryWrite
+
+    root = await source(store)
+    await correct(store, root, "hide")
+    writes = [
+        RawMemoryWrite(
+            organization_id=store.org,
+            principal_id="owner",
+            source_id=f"derived-{index}",
+            raw_content="Derived advice",
+            metadata={"raw_source_ids": [root.id]},
+        )
+        for index in range(3)
+    ]
+    children = await content_raw_persistence.remember_raw_memories(writes)
+    assert len(children) == 3
+    assert all(not raw_memory_recallable(child) for child in children)
+    await correct(store, root, "restore")
+    for child in children:
+        restored = await get_raw_memory(organization_id=store.org, memory_id=child.id)
+        assert raw_memory_recallable(restored)
+
+
+async def test_promotion_retry_embeds_a_newly_admitted_capture(store, monkeypatch):
+    from sibyl_core.embeddings.providers import DeterministicEmbeddingProvider
+    from sibyl_core.services.memory_reflection import _resolve_reflection_promotion_plan
+
+    root = await remember_raw_memory(
+        organization_id=store.org,
+        principal_id="owner",
+        source_id="project-source",
+        raw_content="Verified project advice",
+        memory_scope="project",
+        scope_key="project-a",
+    )
+    child = await review(store, [root], snapshots=[root])
+    assert child.metadata[SOURCE_VALIDATION_PENDING_KEY] is True
+    assert child.embedding is None
+    provider = DeterministicEmbeddingProvider(
+        replace(DeterministicEmbeddingProvider().metadata, dimensions=EMBEDDING_DIM)
+    )
+    embed = AsyncMock(wraps=provider.embed_texts)
+    monkeypatch.setattr(provider, "embed_texts", embed)
+    monkeypatch.setattr(
+        content_raw_persistence.models,
+        "configured_raw_memory_embedding_provider",
+        lambda: provider,
+    )
+
+    plan = await _resolve_reflection_promotion_plan(
+        candidate_id=child.id,
+        organization_id=store.org,
+        principal_id="owner",
+        promote_to_scope="project",
+        promote_to_scope_key="project-a",
+        accessible_projects={"project-a"},
+    )
+
+    stored = await get_raw_memory(organization_id=store.org, memory_id=child.id)
+    assert stored.metadata[SOURCE_VALIDATION_PENDING_KEY] is False
+    assert raw_memory_recallable(stored)
+    assert stored.embedding is not None
+    assert len(stored.embedding) == provider.metadata.dimensions
+    assert plan.candidate_memory.embedding == stored.embedding
+    assert stored.metadata["embedding_metadata"]["model"] == provider.metadata.model
+    embed.assert_awaited_once_with(
+        [
+            content_raw_persistence.models.raw_memory_embedding_text(
+                title=stored.title, raw_content=stored.raw_content
+            )
+        ],
+        input_kind="document",
+    )
+
+
+@pytest.mark.parametrize("embedding_mode", ["configured", "disabled", "explicit"])
+async def test_admission_retry_preserves_embedding_provider_selection(
+    store, monkeypatch, embedding_mode
+):
+    from sibyl_core.embeddings.providers import DeterministicEmbeddingProvider
+    from sibyl_core.services.memory_source_validation import reconcile_raw_source_lifecycle
+
+    root = await remember_raw_memory(
+        organization_id=store.org,
+        principal_id="owner",
+        source_id="project-source",
+        raw_content="Verified project advice",
+        memory_scope="project",
+        scope_key="project-a",
+    )
+    child = await review(store, [root], snapshots=[root])
+    assert child.embedding is None
+    assert not raw_memory_recallable(child)
+    provider = DeterministicEmbeddingProvider(
+        replace(DeterministicEmbeddingProvider().metadata, dimensions=EMBEDDING_DIM)
+    )
+    embed = AsyncMock(wraps=provider.embed_texts)
+    monkeypatch.setattr(provider, "embed_texts", embed)
+    configured = Mock(return_value=provider)
+    monkeypatch.setattr(
+        content_raw_persistence.models, "configured_raw_memory_embedding_provider", configured
+    )
+    options = {}
+    if embedding_mode == "disabled":
+        options["embedding_provider"] = None
+    elif embedding_mode == "explicit":
+        options["embedding_provider"] = provider
+    admitted = await reconcile_raw_source_lifecycle(
+        child,
+        principal_id="owner",
+        accessible_projects={"project-a"},
+        **options,
+    )
+    stored = await get_raw_memory(organization_id=store.org, memory_id=child.id)
+    assert raw_memory_recallable(stored)
+    assert stored.embedding == admitted.embedding
+    if embedding_mode == "disabled":
+        assert stored.embedding is None
+        embed.assert_not_awaited()
+    else:
+        assert stored.embedding is not None
+        embed.assert_awaited_once()
+    if embedding_mode == "configured":
+        configured.assert_called_once_with()
+    else:
+        configured.assert_not_called()
+
+
+@pytest.mark.parametrize("action", ["hide", "revise"])
+async def test_shared_source_correction_retires_private_derivative_without_disclosure(
+    store, action
+):
+    root = await remember_raw_memory(
+        organization_id=store.org,
+        principal_id="owner",
+        source_id="project-source",
+        raw_content="Shared project advice",
+        memory_scope="project",
+        scope_key="project-a",
+    )
+    child = await remember_reflection_candidate_review(
+        organization_id=store.org,
+        principal_id="another-owner",
+        raw_source_ids=[root.id],
+        source_memories=[root],
+        accessible_projects={"project-a"},
+        candidate=ReflectionCandidate(
+            kind="procedure",
+            title="Private derived advice",
+            content="Keep this owner's operational details private.",
+            reason="Derived from the shared source",
+            confidence=1.0,
+        ),
+    )
+    assert raw_memory_recallable(child)
+    result = await correct(
+        store,
+        root,
+        action,
+        accessible_projects={"project-a"},
+        **({"revised_content": "Corrected shared advice"} if action == "revise" else {}),
+    )
+    stored = await get_raw_memory(organization_id=store.org, memory_id=child.id)
+    assert not raw_memory_recallable(stored)
+    assert stored.metadata[CORRECTION_BLOCKERS_KEY][root.id]["blocking"] is True
+    assert child.id not in result.affected_raw_memory_ids
+    assert child.id not in str(result)
+    assert result.propagation_complete is True

--- a/packages/python/sibyl-core/tests/test_source_clock_visibility.py
+++ b/packages/python/sibyl-core/tests/test_source_clock_visibility.py
@@ -1,0 +1,155 @@
+"""Live source clocks stay internal while authored provenance remains visible."""
+
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
+from sibyl_core.models.context import (
+    ContextFacet,
+    ContextIntent,
+    ContextPack,
+    ContextRelatedItem,
+    ContextSection,
+)
+from sibyl_core.tools.context import (
+    _drop_retired_items,
+    _item_from_result,
+    context_pack_to_dict,
+)
+from sibyl_core.tools.responses import SearchResult
+
+
+def test_source_clock_visibility_preserves_authored_metadata() -> None:
+    metadata = {
+        "correction_blockers": {"foreign-root": {"revision": 17, "blocking": False}},
+        "source_bindings": {"known-source": 2},
+        "source_validation_pending": False,
+        "raw_source_ids": ["declared-source"],
+        "authored": {"metadata": {"correction_blockers": "literal example"}},
+    }
+    before = deepcopy(metadata)
+    public = public_memory_metadata(metadata)
+    assert public == {
+        key: value
+        for key, value in before.items()
+        if key not in {"correction_blockers", "source_bindings"}
+    }
+    assert metadata == before
+
+
+def test_source_clock_visibility_filters_context_only_after_lifecycle_gate() -> None:
+    metadata = {
+        "correction_blockers": {"foreign-root": {"revision": 17, "blocking": False}},
+        "source_bindings": {"known-source": 2},
+        "source_validation_pending": False,
+        "raw_source_ids": ["declared-source"],
+        "authored": {"metadata": {"correction_blockers": "literal example"}},
+    }
+    before = deepcopy(metadata)
+    result = SearchResult(
+        id="derivative",
+        type="pattern",
+        name="Pattern",
+        content="Body",
+        score=1,
+        metadata=metadata,
+    )
+    admitted = _item_from_result(result, ContextFacet.PRIOR_ART, audit=True)
+    related = ContextRelatedItem(
+        id="related",
+        type="pattern",
+        name="Related",
+        relationship="supports",
+        direction="outgoing",
+        metadata=metadata,
+    )
+    admitted = replace(admitted, related=[related])
+    blocked_metadata = {
+        **metadata,
+        "correction_blockers": {"foreign-root": {"revision": 18, "blocking": True}},
+    }
+    blocked = _item_from_result(
+        replace(result, id="retired", metadata=blocked_metadata),
+        ContextFacet.PRIOR_ART,
+        audit=True,
+    )
+    assert blocked.metadata["correction_blockers"] == blocked_metadata["correction_blockers"]
+    sections = _drop_retired_items(
+        [ContextSection(facet=ContextFacet.PRIOR_ART, title="Prior art", items=[blocked, admitted])]
+    )
+    pack = ContextPack(
+        goal="Use memory",
+        intent=ContextIntent.BUILD,
+        query="memory",
+        domain=None,
+        project=None,
+        sections=sections,
+        total_items=1,
+    )
+    payload = context_pack_to_dict(pack)
+    assert [item["id"] for item in payload["sections"][0]["items"]] == ["derivative"]
+    item = payload["sections"][0]["items"][0]
+    for public in (item["metadata"], item["related"][0]["metadata"]):
+        assert "correction_blockers" not in public
+        assert "source_bindings" not in public
+        assert public["source_validation_pending"] is False
+        assert public["raw_source_ids"] == metadata["raw_source_ids"]
+        assert public["authored"] == metadata["authored"]
+    assert admitted.metadata["correction_blockers"] == metadata["correction_blockers"]
+    assert metadata == before
+
+
+@pytest.mark.parametrize("lane", ["active", "lean", "audit"])
+@pytest.mark.parametrize("state", ["clear", "blocked", "pending", "reconcile_pending"])
+def test_source_clock_visibility_keeps_admission_state_until_final_output(lane, state):
+    from types import SimpleNamespace
+
+    from sibyl_core.tools.context import _item_from_active_entity
+
+    metadata = {
+        "correction_blockers": {"foreign-root": {"revision": 17, "blocking": state == "blocked"}},
+        "source_validation_pending": state == "pending",
+        "lifecycle_reconciliation_pending": state == "reconcile_pending",
+    }
+    if lane == "active":
+        item = _item_from_active_entity(
+            SimpleNamespace(
+                id="task",
+                name="Task",
+                entity_type="task",
+                description="Task instructions",
+                metadata=metadata,
+                status="doing",
+            )
+        )
+    else:
+        item = _item_from_result(
+            SearchResult(
+                id="task",
+                type="task",
+                name="Task",
+                content="Task instructions",
+                score=1,
+                metadata=metadata,
+            ),
+            ContextFacet.ACTIVE_WORK,
+            audit=lane == "audit",
+        )
+    sections = _drop_retired_items(
+        [ContextSection(facet=ContextFacet.ACTIVE_WORK, title="Active work", items=[item])]
+    )
+    admitted = [entry for section in sections for entry in section.items]
+    assert [entry.id for entry in admitted] == (["task"] if state == "clear" else [])
+    pack = ContextPack(
+        goal="Work",
+        intent=ContextIntent.BUILD,
+        query="task",
+        domain=None,
+        project=None,
+        sections=sections,
+        total_items=len(admitted),
+    )
+    assert "correction_blockers" not in str(context_pack_to_dict(pack))
+    assert "correction_blockers" in metadata

--- a/packages/python/sibyl-core/tests/test_source_lifecycle.py
+++ b/packages/python/sibyl-core/tests/test_source_lifecycle.py
@@ -1,0 +1,749 @@
+"""Correction lineage: one root's correction reaching independent derived rows.
+
+The adversarial sequences pinned here are the ones a plain "blocked" set and
+per-immediate-parent blockers both get wrong: propagations that arrive in the
+wrong order, a revise whose staleness has to outlive a later restore, and two
+roots whose verdicts must not read each other's mail.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+import pytest
+
+from sibyl_core.memory_pipeline.lifecycle import (
+    memory_lifecycle_state,
+    raw_memory_lifecycle_recallable,
+)
+from sibyl_core.memory_pipeline.source_lifecycle import (
+    CORRECTION_BLOCKERS_KEY,
+    CORRECTION_HISTORY_KEY,
+    RAW_SOURCE_IDS_KEY,
+    SOURCE_BINDINGS_KEY,
+    UNKNOWN_SOURCE_REVISION,
+    SourceCorrection,
+    correction_blocked,
+    correction_event,
+    merge_source_correction,
+    source_revision_bindings,
+)
+from sibyl_core.models.reflection import (
+    MemoryLifecycle,
+    MemoryLifecycleState,
+    with_memory_lifecycle_metadata,
+)
+from sibyl_core.services.memory_identity import IDENTITY_KEY
+
+ROOT_A = "source-a"
+ROOT_B = "source-b"
+
+
+@dataclass(slots=True)
+class SourceView:
+    """A capture as this model reads it: an id, a revision, a metadata bag.
+
+    ``source_id`` and ``review_state`` are here only so the same fake can be
+    handed to the local lifecycle policy, which is what shows the two verdicts
+    stay apart.
+    """
+
+    id: str = ROOT_A
+    revision: int = 1
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    source_id: str = ""
+    review_state: str = "pending"
+
+
+def blocker_state(entries: Mapping[str, tuple[int, bool]]) -> dict[str, object]:
+    return {
+        CORRECTION_BLOCKERS_KEY: {
+            root: {"revision": revision, "blocking": blocking}
+            for root, (revision, blocking) in entries.items()
+        }
+    }
+
+
+def stored_entry(metadata: Mapping[str, object], root: str) -> object:
+    blockers = metadata[CORRECTION_BLOCKERS_KEY]
+    assert isinstance(blockers, Mapping)
+    return blockers[root]
+
+
+MALFORMED_BLOCKER_STATES: list[tuple[dict[str, object], str]] = [
+    ({CORRECTION_BLOCKERS_KEY: [{"revision": 2, "blocking": True}]}, "must be a mapping"),
+    ({CORRECTION_BLOCKERS_KEY: "blocked"}, "must be a mapping"),
+    ({CORRECTION_BLOCKERS_KEY: {ROOT_A: "blocked"}}, "entry must be a mapping"),
+    ({CORRECTION_BLOCKERS_KEY: {ROOT_A: {"blocking": True}}}, "revision must be a positive"),
+    (
+        {CORRECTION_BLOCKERS_KEY: {ROOT_A: {"revision": 0, "blocking": True}}},
+        "revision must be a positive",
+    ),
+    (
+        {CORRECTION_BLOCKERS_KEY: {ROOT_A: {"revision": True, "blocking": True}}},
+        "revision must be a positive",
+    ),
+    (
+        {CORRECTION_BLOCKERS_KEY: {ROOT_A: {"revision": "2", "blocking": True}}},
+        "revision must be a positive",
+    ),
+    (
+        {CORRECTION_BLOCKERS_KEY: {ROOT_A: {"revision": 2, "blocking": "yes"}}},
+        "blocking must be a boolean",
+    ),
+    (
+        {CORRECTION_BLOCKERS_KEY: {ROOT_A: {"revision": 2, "blocking": 1}}},
+        "blocking must be a boolean",
+    ),
+    (
+        {CORRECTION_BLOCKERS_KEY: {"": {"revision": 2, "blocking": True}}},
+        "root id must be a non-empty string",
+    ),
+]
+
+MALFORMED_BINDING_STATES: list[tuple[dict[str, object], str]] = [
+    ({SOURCE_BINDINGS_KEY: [2]}, "source_bindings must be a mapping"),
+    ({SOURCE_BINDINGS_KEY: "3"}, "source_bindings must be a mapping"),
+    ({SOURCE_BINDINGS_KEY: {ROOT_A: -1}}, "revision must be a non-negative integer"),
+    ({SOURCE_BINDINGS_KEY: {ROOT_A: True}}, "revision must be a non-negative integer"),
+    ({SOURCE_BINDINGS_KEY: {ROOT_A: "3"}}, "revision must be a non-negative integer"),
+    ({SOURCE_BINDINGS_KEY: {"  ": 3}}, "source id must be a non-empty string"),
+]
+
+MALFORMED_EVENTS: list[tuple[SourceCorrection, str]] = [
+    (SourceCorrection(root_id="", revision=2, blocking=True), "root_id must be a non-empty"),
+    (SourceCorrection(root_id="   ", revision=2, blocking=True), "root_id must be a non-empty"),
+    (SourceCorrection(root_id=ROOT_A, revision=0, blocking=True), "revision must be a positive"),
+    (SourceCorrection(root_id=ROOT_A, revision=-2, blocking=True), "revision must be a positive"),
+    (SourceCorrection(root_id=ROOT_A, revision=True, blocking=True), "revision must be a positive"),
+    (SourceCorrection(root_id=ROOT_A, revision="2", blocking=True), "revision must be a positive"),
+    (SourceCorrection(root_id=ROOT_A, revision=2, blocking="yes"), "blocking must be a boolean"),
+    (SourceCorrection(root_id=ROOT_A, revision=2, blocking=1), "blocking must be a boolean"),
+    (
+        SourceCorrection(root_id=ROOT_A, revision=2, blocking=True, content_revision=3),
+        "content_revision must be a non-negative integer",
+    ),
+    (
+        SourceCorrection(root_id=ROOT_A, revision=2, blocking=True, content_revision=-1),
+        "content_revision must be a non-negative integer",
+    ),
+    (
+        SourceCorrection(root_id=ROOT_A, revision=2, blocking=True, content_revision=True),
+        "content_revision must be a non-negative integer",
+    ),
+]
+
+
+# --- correction_blocked -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        None,
+        {},
+        {"lifecycle_state": "active"},
+        {CORRECTION_BLOCKERS_KEY: {}},
+        {CORRECTION_BLOCKERS_KEY: None},
+        # An empty container of any shape says the same thing: no exclusions.
+        {CORRECTION_BLOCKERS_KEY: []},
+    ],
+)
+def test_correction_blocked_reads_empty_state_as_unblocked(
+    metadata: Mapping[str, object] | None,
+) -> None:
+    assert correction_blocked(metadata) is False
+
+
+def test_correction_blocked_ignores_all_false_tombstones() -> None:
+    metadata = blocker_state({ROOT_A: (3, False), ROOT_B: (7, False)})
+
+    assert correction_blocked(metadata) is False
+
+
+def test_correction_blocked_reports_any_blocking_root() -> None:
+    metadata = blocker_state({ROOT_A: (3, False), ROOT_B: (7, True)})
+
+    assert correction_blocked(metadata) is True
+
+
+@pytest.mark.parametrize(("metadata", "_message"), MALFORMED_BLOCKER_STATES)
+def test_correction_blocked_fails_closed_on_malformed_blockers(
+    metadata: dict[str, object],
+    _message: str,
+) -> None:
+    assert correction_blocked(metadata) is True
+
+
+@pytest.mark.parametrize(("metadata", "_message"), MALFORMED_BINDING_STATES)
+def test_correction_blocked_does_not_invent_an_exclusion_from_a_bad_binding(
+    metadata: dict[str, object],
+    _message: str,
+) -> None:
+    # A binding is provenance, not a verdict: nothing has excluded this row, so
+    # recall says so. The refusal happens at propagation instead.
+    assert correction_blocked(metadata) is False
+
+
+# --- correction_event -------------------------------------------------------
+
+
+def test_correction_event_reads_root_and_revision_from_persisted_capture() -> None:
+    memory = SourceView(id=ROOT_A, revision=4)
+
+    event = correction_event(memory, blocking=True)
+
+    assert event == SourceCorrection(
+        root_id=ROOT_A,
+        revision=4,
+        blocking=True,
+        content_revision=UNKNOWN_SOURCE_REVISION,
+    )
+
+
+def test_correction_event_derives_content_revision_from_revise_history() -> None:
+    memory = SourceView(
+        revision=2,
+        metadata={CORRECTION_HISTORY_KEY: [{"action": "revise", "prior_revision": 1}]},
+    )
+
+    event = correction_event(memory, blocking=False)
+
+    assert (event.revision, event.content_revision, event.blocking) == (2, 2, False)
+
+
+def test_correction_event_retains_content_revision_across_later_restore() -> None:
+    memory = SourceView(
+        revision=3,
+        metadata={
+            CORRECTION_HISTORY_KEY: [
+                {"action": "revise", "prior_revision": 1},
+                {"action": "restore", "prior_revision": 2},
+            ]
+        },
+    )
+
+    event = correction_event(memory, blocking=False)
+
+    assert (event.revision, event.content_revision, event.blocking) == (3, 2, False)
+
+
+def test_correction_event_takes_the_newest_revise_and_skips_unreadable_entries() -> None:
+    memory = SourceView(
+        revision=5,
+        metadata={
+            CORRECTION_HISTORY_KEY: [
+                {"action": "revise", "prior_revision": 3},
+                "revise",
+                {"action": "hide", "prior_revision": 4},
+                {"action": "REVISE", "prior_revision": 1},
+            ]
+        },
+    )
+
+    event = correction_event(memory, blocking=False)
+
+    assert event.content_revision == 4
+
+
+def test_correction_event_uses_current_revision_for_a_legacy_unstamped_revise() -> None:
+    memory = SourceView(revision=6, metadata={CORRECTION_HISTORY_KEY: [{"action": "revise"}]})
+
+    event = correction_event(memory, blocking=False)
+
+    assert event.content_revision == 6
+
+
+@pytest.mark.parametrize("prior_revision", [3, 4, 9])
+def test_correction_event_rejects_an_impossible_future_revision_history(
+    prior_revision: int,
+) -> None:
+    memory = SourceView(
+        revision=3,
+        metadata={CORRECTION_HISTORY_KEY: [{"action": "revise", "prior_revision": prior_revision}]},
+    )
+
+    with pytest.raises(ValueError, match="newer than the persisted capture"):
+        correction_event(memory, blocking=False)
+
+
+@pytest.mark.parametrize("prior_revision", [True, "2", -1, 1.5])
+def test_correction_event_rejects_a_malformed_prior_revision(prior_revision: object) -> None:
+    memory = SourceView(
+        revision=4,
+        metadata={CORRECTION_HISTORY_KEY: [{"action": "revise", "prior_revision": prior_revision}]},
+    )
+
+    with pytest.raises(ValueError, match="prior_revision must be a non-negative integer"):
+        correction_event(memory, blocking=False)
+
+
+def test_correction_event_rejects_a_history_that_is_not_a_list() -> None:
+    memory = SourceView(revision=2, metadata={CORRECTION_HISTORY_KEY: {"action": "revise"}})
+
+    with pytest.raises(ValueError, match="must be a list of correction entries"):
+        correction_event(memory, blocking=False)
+
+
+@pytest.mark.parametrize(
+    ("memory", "message"),
+    [
+        (SourceView(id="", revision=2), "root_id must be a non-empty string"),
+        (SourceView(id="  ", revision=2), "root_id must be a non-empty string"),
+        (SourceView(revision=0), "revision must be a positive integer"),
+        (SourceView(revision=True), "revision must be a positive integer"),
+        (SourceView(revision="2"), "revision must be a positive integer"),
+    ],
+)
+def test_correction_event_rejects_a_malformed_capture(memory: SourceView, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        correction_event(memory, blocking=True)
+
+
+@pytest.mark.parametrize("blocking", [1, 0, "true", None])
+def test_correction_event_rejects_non_boolean_blocking(blocking: object) -> None:
+    with pytest.raises(ValueError, match="blocking must be a boolean"):
+        correction_event(SourceView(revision=2), blocking=blocking)
+
+
+# --- merge_source_correction: ordering ---------------------------------------
+
+
+def test_merge_blocks_a_derived_row_on_a_hidden_root() -> None:
+    merged = merge_source_correction({}, SourceCorrection(ROOT_A, 2, True))
+
+    assert stored_entry(merged, ROOT_A) == {"revision": 2, "blocking": True}
+    assert correction_blocked(merged) is True
+
+
+def test_merge_clears_a_root_as_a_tombstone_not_a_deletion() -> None:
+    hidden = merge_source_correction({}, SourceCorrection(ROOT_A, 2, True))
+
+    restored = merge_source_correction(hidden, SourceCorrection(ROOT_A, 3, False))
+
+    assert stored_entry(restored, ROOT_A) == {"revision": 3, "blocking": False}
+    assert correction_blocked(restored) is False
+
+
+def test_merge_keeps_the_restore_when_the_earlier_hide_arrives_last() -> None:
+    restored = merge_source_correction({}, SourceCorrection(ROOT_A, 3, False))
+
+    delayed = merge_source_correction(restored, SourceCorrection(ROOT_A, 2, True))
+
+    assert stored_entry(delayed, ROOT_A) == {"revision": 3, "blocking": False}
+    assert correction_blocked(delayed) is False
+
+
+def test_merge_does_not_weaken_blocking_at_an_equal_revision() -> None:
+    stored = blocker_state({ROOT_A: (2, True)})
+
+    merged = merge_source_correction(stored, SourceCorrection(ROOT_A, 2, False))
+
+    assert stored_entry(merged, ROOT_A) == {"revision": 2, "blocking": True}
+    assert correction_blocked(merged) is True
+
+
+def test_merge_strengthens_blocking_at_an_equal_revision() -> None:
+    stored = blocker_state({ROOT_A: (2, False)})
+
+    merged = merge_source_correction(stored, SourceCorrection(ROOT_A, 2, True))
+
+    assert stored_entry(merged, ROOT_A) == {"revision": 2, "blocking": True}
+
+
+# --- merge_source_correction: content epochs ---------------------------------
+
+
+def test_merge_revise_then_restore_still_blocks_a_stale_binding() -> None:
+    derived = {SOURCE_BINDINGS_KEY: {ROOT_A: 1}}
+    revise = SourceCorrection(ROOT_A, 2, False, content_revision=2)
+    restore = SourceCorrection(ROOT_A, 3, False, content_revision=2)
+
+    merged = merge_source_correction(merge_source_correction(derived, revise), restore)
+
+    assert stored_entry(merged, ROOT_A) == {"revision": 3, "blocking": True}
+    assert correction_blocked(merged) is True
+
+
+def test_merge_revise_still_blocks_a_stale_binding_when_it_arrives_after_restore() -> None:
+    derived = {SOURCE_BINDINGS_KEY: {ROOT_A: 1}}
+    restore = SourceCorrection(ROOT_A, 3, False, content_revision=2)
+    revise = SourceCorrection(ROOT_A, 2, False, content_revision=2)
+
+    merged = merge_source_correction(merge_source_correction(derived, restore), revise)
+
+    assert stored_entry(merged, ROOT_A) == {"revision": 3, "blocking": True}
+    assert correction_blocked(merged) is True
+
+
+@pytest.mark.parametrize("bound_revision", [2, 3])
+def test_merge_leaves_a_fresh_binding_clear_through_revise_and_restore(
+    bound_revision: int,
+) -> None:
+    derived = {SOURCE_BINDINGS_KEY: {ROOT_A: bound_revision}}
+    revise = SourceCorrection(ROOT_A, 2, False, content_revision=2)
+    restore = SourceCorrection(ROOT_A, 3, False, content_revision=2)
+
+    after_revise = merge_source_correction(derived, revise)
+    after_restore = merge_source_correction(after_revise, restore)
+
+    assert correction_blocked(after_revise) is False
+    assert correction_blocked(after_restore) is False
+    assert stored_entry(after_restore, ROOT_A) == {"revision": 3, "blocking": False}
+
+
+def test_merge_blocks_a_row_with_no_binding_for_the_revised_root() -> None:
+    derived = {SOURCE_BINDINGS_KEY: {ROOT_B: 9}}
+
+    merged = merge_source_correction(derived, SourceCorrection(ROOT_A, 2, False, 2))
+
+    assert stored_entry(merged, ROOT_A) == {"revision": 2, "blocking": True}
+
+
+def test_merge_blocks_a_row_bound_to_an_unknown_epoch() -> None:
+    derived = {SOURCE_BINDINGS_KEY: {ROOT_A: UNKNOWN_SOURCE_REVISION}}
+
+    merged = merge_source_correction(derived, SourceCorrection(ROOT_A, 2, False, 2))
+
+    assert stored_entry(merged, ROOT_A) == {"revision": 2, "blocking": True}
+
+
+def test_merge_hides_a_fresh_binding_when_the_root_itself_left_recall() -> None:
+    derived = {SOURCE_BINDINGS_KEY: {ROOT_A: 5}}
+
+    merged = merge_source_correction(derived, SourceCorrection(ROOT_A, 6, True))
+
+    assert correction_blocked(merged) is True
+
+
+def test_merge_does_not_rebind_the_row_to_newer_content() -> None:
+    derived = {SOURCE_BINDINGS_KEY: {ROOT_A: 1}}
+
+    merged = merge_source_correction(derived, SourceCorrection(ROOT_A, 3, False, 2))
+
+    assert merged[SOURCE_BINDINGS_KEY] == {ROOT_A: 1}
+
+
+# --- merge_source_correction: independence -----------------------------------
+
+
+def test_merge_keeps_other_roots_blocking_when_one_root_is_cleared() -> None:
+    stored = blocker_state({ROOT_A: (2, True), ROOT_B: (4, True)})
+
+    merged = merge_source_correction(stored, SourceCorrection(ROOT_A, 3, False))
+
+    assert stored_entry(merged, ROOT_A) == {"revision": 3, "blocking": False}
+    assert stored_entry(merged, ROOT_B) == {"revision": 4, "blocking": True}
+    assert correction_blocked(merged) is True
+
+
+def test_merge_runs_two_roots_on_independent_clocks() -> None:
+    derived: Mapping[str, object] = {SOURCE_BINDINGS_KEY: {ROOT_A: 1, ROOT_B: 4}}
+
+    # Root A: revise at 2 then restore at 3, arriving out of order.
+    # Root B: hide at 5 then restore at 6, arriving in order.
+    for event in (
+        SourceCorrection(ROOT_A, 3, False, 2),
+        SourceCorrection(ROOT_B, 5, True),
+        SourceCorrection(ROOT_A, 2, False, 2),
+        SourceCorrection(ROOT_B, 6, False),
+    ):
+        derived = merge_source_correction(derived, event)
+
+    assert stored_entry(derived, ROOT_A) == {"revision": 3, "blocking": True}
+    assert stored_entry(derived, ROOT_B) == {"revision": 6, "blocking": False}
+    assert correction_blocked(derived) is True
+
+
+def test_merge_preserves_unrelated_metadata() -> None:
+    derived = {
+        "content_sha256": "abc",
+        RAW_SOURCE_IDS_KEY: [ROOT_A],
+        "review_capture_id": "capture-1",
+        SOURCE_BINDINGS_KEY: {ROOT_A: 2},
+    }
+
+    merged = merge_source_correction(derived, SourceCorrection(ROOT_A, 3, True))
+
+    assert merged["content_sha256"] == "abc"
+    assert merged[RAW_SOURCE_IDS_KEY] == [ROOT_A]
+    assert merged["review_capture_id"] == "capture-1"
+    assert merged[SOURCE_BINDINGS_KEY] == {ROOT_A: 2}
+
+
+def test_merge_does_not_touch_reflection_identity() -> None:
+    identity = {"version": 2, "source_ids": [ROOT_A]}
+    derived = {IDENTITY_KEY: dict(identity)}
+
+    merged = merge_source_correction(derived, SourceCorrection(ROOT_A, 3, True, 3))
+
+    assert merged[IDENTITY_KEY] == identity
+
+
+def test_merge_does_not_mutate_its_inputs() -> None:
+    derived = {SOURCE_BINDINGS_KEY: {ROOT_A: 1}, **blocker_state({ROOT_B: (4, True)})}
+    snapshot = copy.deepcopy(derived)
+    event = SourceCorrection(ROOT_A, 3, False, 2)
+
+    merged = merge_source_correction(derived, event)
+
+    assert derived == snapshot
+    assert event == SourceCorrection(ROOT_A, 3, False, 2)
+    assert merged[CORRECTION_BLOCKERS_KEY] is not derived[CORRECTION_BLOCKERS_KEY]
+    assert merged[SOURCE_BINDINGS_KEY] is not derived[SOURCE_BINDINGS_KEY]
+
+    blockers = merged[CORRECTION_BLOCKERS_KEY]
+    assert isinstance(blockers, dict)
+    blockers[ROOT_B] = {"revision": 99, "blocking": False}
+
+    assert derived == snapshot
+
+
+# --- merge_source_correction: refusals ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("metadata", "message"),
+    [*MALFORMED_BLOCKER_STATES, *MALFORMED_BINDING_STATES],
+)
+def test_merge_refuses_malformed_stored_state(
+    metadata: dict[str, object],
+    message: str,
+) -> None:
+    snapshot = copy.deepcopy(metadata)
+
+    with pytest.raises(ValueError, match=message):
+        merge_source_correction(metadata, SourceCorrection(ROOT_A, 3, True))
+
+    assert metadata == snapshot
+
+
+@pytest.mark.parametrize(("event", "message"), MALFORMED_EVENTS)
+def test_merge_refuses_a_malformed_event(event: SourceCorrection, message: str) -> None:
+    derived = blocker_state({ROOT_B: (4, True)})
+    snapshot = copy.deepcopy(derived)
+
+    with pytest.raises(ValueError, match=message):
+        merge_source_correction(derived, event)
+
+    assert derived == snapshot
+
+
+# --- local lifecycle stays local ---------------------------------------------
+
+
+def test_merge_preserves_a_derived_rows_own_archived_verdict() -> None:
+    archived = with_memory_lifecycle_metadata(
+        {},
+        MemoryLifecycle(
+            state=MemoryLifecycleState.ARCHIVED,
+            source_id="review-1",
+            action="archive",
+            reason="the reviewer retired it",
+        ),
+    )
+
+    merged = merge_source_correction(archived, SourceCorrection(ROOT_A, 3, False))
+    row = SourceView(id="review-1", revision=3, metadata=merged, source_id="review-1")
+
+    assert memory_lifecycle_state(merged, source_id="review-1") == "archived"
+    assert raw_memory_lifecycle_recallable(row) is False
+    assert correction_blocked(merged) is False
+
+
+def test_inherited_correction_state_does_not_forge_a_local_verdict() -> None:
+    active = with_memory_lifecycle_metadata(
+        {},
+        MemoryLifecycle(
+            state=MemoryLifecycleState.ACTIVE,
+            source_id="review-1",
+            action="promote",
+            reason="promoted from a frozen episode",
+        ),
+    )
+
+    merged = merge_source_correction(active, SourceCorrection(ROOT_A, 3, True))
+    row = SourceView(id="review-1", revision=3, metadata=merged, source_id="review-1")
+
+    assert memory_lifecycle_state(merged, source_id="review-1") == "active"
+    assert raw_memory_lifecycle_recallable(row) is False
+    assert correction_blocked(merged) is True
+
+
+# --- source_revision_bindings ------------------------------------------------
+
+
+def test_source_revision_bindings_binds_directly_observed_revisions() -> None:
+    bindings = source_revision_bindings(
+        [SourceView(id=ROOT_A, revision=3), SourceView(id=ROOT_B, revision=1)]
+    )
+
+    assert bindings == {ROOT_A: 3, ROOT_B: 1}
+
+
+def test_source_revision_bindings_takes_the_minimum_over_overlapping_paths() -> None:
+    left = SourceView(id="review-1", revision=2, metadata={SOURCE_BINDINGS_KEY: {ROOT_A: 5}})
+    right = SourceView(
+        id="review-2",
+        revision=9,
+        metadata={SOURCE_BINDINGS_KEY: {ROOT_A: 2, ROOT_B: 7}},
+    )
+
+    bindings = source_revision_bindings([left, right])
+
+    assert bindings == {"review-1": 2, "review-2": 9, ROOT_A: 2, ROOT_B: 7}
+
+
+def test_source_revision_bindings_is_order_independent() -> None:
+    left = SourceView(id="review-1", revision=2, metadata={SOURCE_BINDINGS_KEY: {ROOT_A: 5}})
+    right = SourceView(id="review-2", revision=9, metadata={SOURCE_BINDINGS_KEY: {ROOT_A: 2}})
+
+    assert source_revision_bindings([left, right]) == source_revision_bindings([right, left])
+
+
+def test_source_revision_bindings_marks_unbound_declared_support_unknown() -> None:
+    review = SourceView(id="review-1", revision=4, metadata={RAW_SOURCE_IDS_KEY: [ROOT_A]})
+    capture = SourceView(id=ROOT_A, revision=7)
+
+    bindings = source_revision_bindings([review, capture])
+
+    assert bindings == {"review-1": 4, ROOT_A: UNKNOWN_SOURCE_REVISION}
+
+
+def test_source_revision_bindings_keeps_an_inherited_binding_for_declared_support() -> None:
+    review = SourceView(
+        id="review-1",
+        revision=4,
+        metadata={RAW_SOURCE_IDS_KEY: [ROOT_A, ROOT_B], SOURCE_BINDINGS_KEY: {ROOT_A: 3}},
+    )
+    capture = SourceView(id=ROOT_A, revision=7)
+
+    bindings = source_revision_bindings([review, capture])
+
+    assert bindings == {"review-1": 4, ROOT_A: 3, ROOT_B: UNKNOWN_SOURCE_REVISION}
+
+
+def test_source_revision_bindings_reads_a_bare_declared_id_as_one_source() -> None:
+    review = SourceView(id="review-1", revision=1, metadata={RAW_SOURCE_IDS_KEY: ROOT_A})
+
+    bindings = source_revision_bindings([review])
+
+    assert bindings == {"review-1": 1, ROOT_A: UNKNOWN_SOURCE_REVISION}
+
+
+def test_source_revision_bindings_keeps_canonical_source_ids() -> None:
+    anchor = "Anchor:Team-Norms_1"
+    review = SourceView(id="review-1", revision=1, metadata={RAW_SOURCE_IDS_KEY: [anchor, "  "]})
+
+    bindings = source_revision_bindings([review])
+
+    assert bindings == {"review-1": 1, anchor: UNKNOWN_SOURCE_REVISION}
+
+
+def test_source_revision_bindings_accepts_an_unsaved_zero_revision() -> None:
+    bindings = source_revision_bindings([SourceView(id=ROOT_A, revision=0)])
+
+    assert bindings == {ROOT_A: UNKNOWN_SOURCE_REVISION}
+
+
+def test_source_revision_bindings_does_not_mutate_its_inputs() -> None:
+    metadata = {SOURCE_BINDINGS_KEY: {ROOT_A: 3}, RAW_SOURCE_IDS_KEY: [ROOT_A, ROOT_B]}
+    snapshot = copy.deepcopy(metadata)
+
+    bindings = source_revision_bindings([SourceView(id="review-1", revision=2, metadata=metadata)])
+    bindings[ROOT_A] = 99
+
+    assert metadata == snapshot
+
+
+@pytest.mark.parametrize(
+    ("memory", "message"),
+    [
+        (SourceView(id="", revision=1), "observed source id must be a non-empty string"),
+        (SourceView(id="  ", revision=1), "observed source id must be a non-empty string"),
+        (SourceView(revision=-1), "observed source revision must be a non-negative integer"),
+        (SourceView(revision=True), "observed source revision must be a non-negative integer"),
+        (SourceView(revision="3"), "observed source revision must be a non-negative integer"),
+        (
+            SourceView(revision=1, metadata={SOURCE_BINDINGS_KEY: {ROOT_B: "3"}}),
+            "source_bindings revision must be a non-negative integer",
+        ),
+        (
+            SourceView(revision=1, metadata={SOURCE_BINDINGS_KEY: [ROOT_B]}),
+            "source_bindings must be a mapping",
+        ),
+        (
+            SourceView(revision=1, metadata={RAW_SOURCE_IDS_KEY: {ROOT_B: 1}}),
+            "raw_source_ids must be a list of source id strings",
+        ),
+        (
+            SourceView(revision=1, metadata={RAW_SOURCE_IDS_KEY: [ROOT_B, 7]}),
+            "raw_source_ids entries must be strings",
+        ),
+    ],
+)
+def test_source_revision_bindings_refuses_malformed_provenance(
+    memory: SourceView,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        source_revision_bindings([memory])
+
+
+# --- the two halves together -------------------------------------------------
+
+
+def test_an_old_unbound_review_is_not_rebound_to_newly_corrected_content() -> None:
+    """The promotion-time failure this model exists for.
+
+    A review written before bindings existed declares its support but records no
+    epoch. Reading the corrected capture in the same batch must not let the
+    review claim the revised text it never saw.
+    """
+
+    review = SourceView(id="review-1", revision=4, metadata={RAW_SOURCE_IDS_KEY: [ROOT_A]})
+    capture = SourceView(
+        id=ROOT_A,
+        revision=3,
+        metadata={CORRECTION_HISTORY_KEY: [{"action": "revise", "prior_revision": 1}]},
+    )
+
+    promoted: Mapping[str, object] = {
+        RAW_SOURCE_IDS_KEY: [ROOT_A],
+        SOURCE_BINDINGS_KEY: source_revision_bindings([review, capture]),
+    }
+    merged = merge_source_correction(promoted, correction_event(capture, blocking=False))
+
+    assert promoted[SOURCE_BINDINGS_KEY] == {"review-1": 4, ROOT_A: UNKNOWN_SOURCE_REVISION}
+    assert correction_blocked(merged) is True
+
+
+def test_a_freshly_bound_promotion_survives_a_revise_and_restore_of_its_source() -> None:
+    capture = SourceView(
+        id=ROOT_A,
+        revision=2,
+        metadata={CORRECTION_HISTORY_KEY: [{"action": "revise", "prior_revision": 1}]},
+    )
+    restored = SourceView(
+        id=ROOT_A,
+        revision=3,
+        metadata={
+            CORRECTION_HISTORY_KEY: [
+                {"action": "revise", "prior_revision": 1},
+                {"action": "restore", "prior_revision": 2},
+            ]
+        },
+    )
+    promoted = {SOURCE_BINDINGS_KEY: source_revision_bindings([capture])}
+
+    after_revise = merge_source_correction(promoted, correction_event(capture, blocking=False))
+    after_restore = merge_source_correction(
+        after_revise,
+        correction_event(restored, blocking=False),
+    )
+
+    assert promoted[SOURCE_BINDINGS_KEY] == {ROOT_A: 2}
+    assert correction_blocked(after_revise) is False
+    assert correction_blocked(after_restore) is False

--- a/packages/python/sibyl-core/tests/test_source_lineage_failures.py
+++ b/packages/python/sibyl-core/tests/test_source_lineage_failures.py
@@ -1,0 +1,374 @@
+"""A damaged derivative must not prevent correction of reachable descendants."""
+
+from contextlib import asynccontextmanager
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.errors import RevisionConflictError
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.services import memory_lineage
+from sibyl_core.services.content_models import RawMemory
+
+
+@pytest.mark.parametrize("lane", ["graph", "raw"])
+@pytest.mark.parametrize("damaged", ["malformed", "vanished", "private", "unversioned"])
+async def test_correction_reports_damaged_row_and_still_retires_descendants(
+    monkeypatch, lane, damaged
+):
+    root = RawMemory(
+        id="root",
+        organization_id="org",
+        source_id="source",
+        principal_id="owner",
+        revision=2,
+        metadata={"lifecycle_flags": ["hidden"]},
+    )
+    rows = {}
+    for row_id in ("bad", "good", "grandchild"):
+        owner = "someone-else" if row_id == "bad" and damaged == "private" else "owner"
+        metadata = {"memory_scope": "private", "principal_id": owner}
+        if row_id == "bad" and damaged == "malformed":
+            metadata["correction_blockers"] = "malformed"
+        if lane == "graph":
+            rows[row_id] = Entity(
+                id=row_id,
+                name=row_id,
+                entity_type=EntityType.EPISODE,
+                metadata=metadata,
+                observed_revision=None if row_id == "bad" and damaged == "unversioned" else 1,
+            )
+        else:
+            rows[row_id] = RawMemory(
+                id=row_id,
+                organization_id="org",
+                source_id=row_id,
+                principal_id=owner,
+                revision=1,
+                observed_revision=None if row_id == "bad" and damaged == "unversioned" else 1,
+                metadata=metadata,
+            )
+    if damaged == "vanished":
+        rows["bad"] = None
+
+    @asynccontextmanager
+    async def session():
+        yield object()
+
+    async def descendants(_runtime, *, raw_ids, graph_ids, **_kwargs):
+        if lane == "graph":
+            if "root" in raw_ids:
+                yield "bad"
+                yield "good"
+            if "bad" in graph_ids:
+                yield "grandchild"
+
+    async def select(_client, _query, *, source_ids, **_kwargs):
+        if lane == "raw":
+            if "root" in source_ids:
+                return [{"uuid": "bad"}, {"uuid": "good"}]
+            if "bad" in source_ids:
+                return [{"uuid": "grandchild"}]
+        return []
+
+    def graph_get(entity_id):
+        row = rows[entity_id]
+        if row is None:
+            raise KeyError(entity_id)
+        return row
+
+    manager = SimpleNamespace(
+        get=AsyncMock(side_effect=graph_get),
+        update=AsyncMock(side_effect=lambda entity_id, *_args, **_kwargs: rows[entity_id]),
+    )
+    raw_save = AsyncMock(side_effect=lambda row, **_kwargs: row)
+    monkeypatch.setattr(memory_lineage.content_client, "surreal_content_client", session)
+    monkeypatch.setattr(memory_lineage.content_client, "select_many", select)
+    monkeypatch.setattr(memory_lineage, "_graph_descendant_ids", descendants)
+    monkeypatch.setattr(
+        memory_lineage,
+        "get_raw_memory",
+        AsyncMock(side_effect=lambda *, memory_id, **_kwargs: rows[memory_id]),
+    )
+    monkeypatch.setattr(memory_lineage, "save_raw_memory", raw_save)
+    receipt = await memory_lineage.propagate_source_correction(
+        SimpleNamespace(entity_manager=manager),
+        memory=root,
+        principal_id="owner",
+        accessible_projects=set(),
+    )
+    assert receipt.complete is (damaged == "private")
+    expected = ["good", "grandchild"]
+    written = ["bad", *expected] if damaged == "private" else expected
+    if lane == "graph":
+        assert receipt.entity_ids == expected
+        assert receipt.raw_memory_ids == []
+        assert [call.args[0] for call in manager.update.await_args_list] == written
+        for call in manager.update.await_args_list:
+            assert call.args[1]["metadata"]["correction_blockers"]["root"]["blocking"] is True
+        raw_save.assert_not_awaited()
+    else:
+        assert receipt.raw_memory_ids == expected
+        assert receipt.entity_ids == []
+        assert [call.args[0].id for call in raw_save.await_args_list] == written
+        for call in raw_save.await_args_list:
+            assert call.args[0].metadata["correction_blockers"]["root"]["blocking"] is True
+        manager.update.assert_not_awaited()
+
+
+@pytest.mark.parametrize("failed_lane", ["raw", "graph"])
+async def test_lookup_failure_preserves_other_graph_arms(monkeypatch, failed_lane):
+    root = RawMemory(
+        id="root",
+        organization_id="org",
+        source_id="source",
+        principal_id="owner",
+        revision=2,
+        observed_revision=2,
+        metadata={"lifecycle_flags": ["hidden"]},
+    )
+    rows = {
+        row_id: Entity(
+            id=row_id,
+            name=row_id,
+            entity_type=EntityType.EPISODE,
+            observed_revision=1,
+            metadata={"memory_scope": "private", "principal_id": "owner"},
+        )
+        for row_id in ("early", "late")
+    }
+
+    @asynccontextmanager
+    async def session():
+        yield object()
+
+    async def select(*_args, **_kwargs):
+        if failed_lane == "raw":
+            raise RuntimeError("Unavailable raw lineage index")
+        return []
+
+    async def query(statement, **_kwargs):
+        if "idx_entity_raw_sources" in statement:
+            return [{"uuid": "early"}]
+        if "idx_entity_review_capture" in statement and failed_lane == "graph":
+            raise RuntimeError("Unavailable review lineage index")
+        if "idx_entity_raw_memory" in statement:
+            return [{"uuid": "late"}]
+        return []
+
+    manager = SimpleNamespace(
+        get=AsyncMock(side_effect=lambda entity_id: rows[entity_id]),
+        update=AsyncMock(side_effect=lambda entity_id, *_args, **_kwargs: rows[entity_id]),
+    )
+    monkeypatch.setattr(memory_lineage.content_client, "surreal_content_client", session)
+    monkeypatch.setattr(memory_lineage.content_client, "select_many", select)
+    receipt = await memory_lineage.propagate_source_correction(
+        SimpleNamespace(entity_manager=manager, client=SimpleNamespace(execute_query=query)),
+        memory=root,
+        principal_id="owner",
+        accessible_projects=set(),
+    )
+    assert not receipt.complete
+    assert receipt.entity_ids == ["early", "late"]
+    assert [call.args[0] for call in manager.update.await_args_list] == ["early", "late"]
+
+
+@pytest.mark.parametrize("lane", ["graph", "raw"])
+async def test_lookup_failure_does_not_discard_later_source_batches(monkeypatch, lane):
+    batch_size = memory_lineage.content_client.DEFAULT_BATCH_SIZE
+    source_ids = [f"source-{index}" for index in range(batch_size + 1)]
+    seen_batches = []
+
+    @asynccontextmanager
+    async def session():
+        yield object()
+
+    async def query(*_args, source_ids, **_kwargs):
+        seen_batches.append(source_ids)
+        if "source-0" in source_ids:
+            raise RuntimeError("The first index batch is unavailable")
+        return [{"uuid": "survivor"}]
+
+    failures = set()
+    if lane == "raw":
+        monkeypatch.setattr(memory_lineage.content_client, "surreal_content_client", session)
+        monkeypatch.setattr(memory_lineage.content_client, "select_many", query)
+        descendants = memory_lineage._raw_descendant_ids(
+            organization_id="org", source_ids=source_ids, lookup_failures=failures
+        )
+    else:
+        descendants = memory_lineage._graph_descendant_ids(
+            SimpleNamespace(client=SimpleNamespace(execute_query=query)),
+            organization_id="org",
+            raw_ids=source_ids,
+            graph_ids=[],
+            lookup_failures=failures,
+        )
+    found = [row_id async for row_id in descendants]
+    assert failures
+    assert "survivor" in found
+    assert all(len(batch) <= batch_size for batch in seen_batches)
+    assert set().union(*(set(batch) for batch in seen_batches)) == set(source_ids)
+
+
+@pytest.mark.parametrize("lane", ["graph", "raw"])
+@pytest.mark.parametrize("other_writer_applied_root", [False, True])
+async def test_conflicting_correction_merges_fresh_state(
+    monkeypatch, lane, other_writer_applied_root
+):
+    root = RawMemory(
+        id="root",
+        organization_id="org",
+        source_id="source",
+        principal_id="owner",
+        revision=2,
+        observed_revision=2,
+        metadata={"lifecycle_flags": ["hidden"]},
+    )
+    original = {
+        "memory_scope": "private",
+        "principal_id": "owner",
+        "correction_blockers": {"other-root": {"revision": 3, "blocking": False}},
+    }
+    fresh = deepcopy(original)
+    fresh["correction_blockers"]["other-root"] = {"revision": 4, "blocking": True}
+    fresh["authored_marker"] = "concurrent edit"
+    if other_writer_applied_root:
+        fresh["correction_blockers"]["root"] = {"revision": 2, "blocking": True}
+    saved = {"metadata": original, "revision": 1}
+    attempts = []
+
+    def row():
+        if lane == "raw":
+            return RawMemory(
+                id="child",
+                organization_id="org",
+                source_id="child",
+                principal_id="owner",
+                revision=saved["revision"],
+                observed_revision=saved["revision"],
+                metadata=deepcopy(saved["metadata"]),
+            )
+        return Entity(
+            id="child",
+            name="child",
+            entity_type=EntityType.EPISODE,
+            observed_revision=saved["revision"],
+            metadata=deepcopy(saved["metadata"]),
+        )
+
+    def write(metadata, expected_revision):
+        attempts.append(expected_revision)
+        if len(attempts) == 1:
+            saved.update(metadata=fresh, revision=2)
+            raise RevisionConflictError("child", expected_revision, 2)
+        assert expected_revision == saved["revision"]
+        saved["metadata"].update(metadata)
+        saved["revision"] += 1
+        return row()
+
+    async def graph_update(_id, fields, *, expected_revision, **_kwargs):
+        return write(fields["metadata"], expected_revision)
+
+    async def raw_save(value, *, expected_revision):
+        return write(value.metadata, expected_revision)
+
+    async def raw_descendants(*, source_ids, **_kwargs):
+        if lane == "raw" and "root" in source_ids:
+            yield "child"
+
+    async def graph_descendants(_runtime, *, raw_ids, **_kwargs):
+        if lane == "graph" and "root" in raw_ids:
+            yield "child"
+
+    monkeypatch.setattr(memory_lineage, "_raw_descendant_ids", raw_descendants)
+    monkeypatch.setattr(memory_lineage, "_graph_descendant_ids", graph_descendants)
+    monkeypatch.setattr(memory_lineage, "get_raw_memory", AsyncMock(side_effect=lambda **_: row()))
+    monkeypatch.setattr(memory_lineage, "save_raw_memory", raw_save)
+    manager = SimpleNamespace(get=AsyncMock(side_effect=lambda _: row()), update=graph_update)
+    receipt = await memory_lineage.propagate_source_correction(
+        SimpleNamespace(entity_manager=manager),
+        memory=root,
+        principal_id="owner",
+        accessible_projects=set(),
+    )
+    assert receipt.complete
+    assert (receipt.raw_memory_ids if lane == "raw" else receipt.entity_ids) == ["child"]
+    assert attempts == ([1] if other_writer_applied_root else [1, 2])
+    assert saved["metadata"]["authored_marker"] == "concurrent edit"
+    assert saved["metadata"]["correction_blockers"] == {
+        "root": {"revision": 2, "blocking": True},
+        "other-root": {"revision": 4, "blocking": True},
+    }
+
+
+@pytest.mark.parametrize("lane", ["graph", "raw"])
+@pytest.mark.parametrize("grants", [None, frozenset(), frozenset({"project\x1fproject-a"})])
+async def test_credential_scope_filters_receipt_without_skipping_correction(
+    monkeypatch, lane, grants
+):
+    root = RawMemory(
+        id="root",
+        organization_id="org",
+        source_id="source",
+        principal_id="owner",
+        revision=2,
+        observed_revision=2,
+        metadata={"lifecycle_flags": ["hidden"]},
+    )
+    metadata = {"memory_scope": "private", "principal_id": "owner"}
+    child = (
+        RawMemory(
+            id="child",
+            organization_id="org",
+            source_id="child",
+            principal_id="owner",
+            revision=1,
+            observed_revision=1,
+            metadata=metadata,
+        )
+        if lane == "raw"
+        else Entity(
+            id="child",
+            name="child",
+            entity_type=EntityType.EPISODE,
+            observed_revision=1,
+            metadata=metadata,
+        )
+    )
+
+    async def raw_descendants(*, source_ids, **_kwargs):
+        if lane == "raw" and "root" in source_ids:
+            yield "child"
+
+    async def graph_descendants(_runtime, *, raw_ids, **_kwargs):
+        if lane == "graph" and "root" in raw_ids:
+            yield "child"
+
+    manager = SimpleNamespace(
+        get=AsyncMock(return_value=child), update=AsyncMock(return_value=child)
+    )
+    save = AsyncMock(return_value=child)
+    monkeypatch.setattr(memory_lineage, "_raw_descendant_ids", raw_descendants)
+    monkeypatch.setattr(memory_lineage, "_graph_descendant_ids", graph_descendants)
+    monkeypatch.setattr(memory_lineage, "get_raw_memory", AsyncMock(return_value=child))
+    monkeypatch.setattr(memory_lineage, "save_raw_memory", save)
+    receipt = await memory_lineage.propagate_source_correction(
+        SimpleNamespace(entity_manager=manager),
+        memory=root,
+        principal_id="owner",
+        accessible_projects={"project-a"},
+        allowed_memory_scope_keys=grants,
+    )
+    assert receipt.complete
+    assert (receipt.raw_memory_ids if lane == "raw" else receipt.entity_ids) == (
+        ["child"] if grants is None else []
+    )
+    written = (
+        save.await_args.args[0].metadata
+        if lane == "raw"
+        else manager.update.await_args.args[1]["metadata"]
+    )
+    assert written["correction_blockers"]["root"] == {"revision": 2, "blocking": True}

--- a/packages/python/sibyl-core/tests/test_source_lineage_indexes.py
+++ b/packages/python/sibyl-core/tests/test_source_lineage_indexes.py
@@ -1,11 +1,89 @@
-"""Raw source lineage lookup uses its element index."""
+"""Exercise reverse provenance queries against populated embedded indexes."""
 
+from types import SimpleNamespace
 from uuid import uuid4
+
+import pytest
 
 from sibyl_core.backends.surreal import SurrealContentClient
 from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.services.graph_client import SurrealGraphClient, prepare_graph_schema
+from sibyl_core.services.memory_lineage import _graph_descendant_ids
 
 
+@pytest.mark.asyncio
+async def test_graph_lineage_queries_use_each_index_and_cross_page_boundary(monkeypatch):
+    organization_id = str(uuid4())
+    client = SurrealGraphClient(group_id=organization_id, url="memory://")
+    try:
+        await prepare_graph_schema(client)
+        rows = [
+            {
+                "uuid": f"derived-{index:04}",
+                "group_id": organization_id,
+                "name": "Derived memory",
+                "entity_type": "note",
+                "labels": [],
+                "attributes": {"raw_source_ids": ["root"]},
+            }
+            for index in range(513)
+        ]
+        for field, source in (
+            ("review_capture_id", "root"),
+            ("raw_memory_id", "root"),
+            ("parent_entity_id", "parent"),
+            ("source_entity_id", "parent"),
+        ):
+            rows.append(
+                {
+                    "uuid": field,
+                    "group_id": organization_id,
+                    "name": "Linked memory",
+                    "entity_type": "note",
+                    "labels": [],
+                    "attributes": {field: source, "projection_kind": "passage"},
+                }
+            )
+        rows.append(
+            {
+                "uuid": "unrelated",
+                "group_id": organization_id,
+                "name": "Unrelated memory",
+                "entity_type": "note",
+                "labels": [],
+                "attributes": {"raw_source_ids": ["different-root"]},
+            }
+        )
+        await client.execute_query("INSERT INTO entity $rows;", rows=rows)
+        execute = client.execute_query
+        plans = []
+
+        async def inspect_query(query, **params):
+            result = await execute(query, **params)
+            plans.append(await execute(query.rstrip(";") + " EXPLAIN;", **params))
+            return result
+
+        monkeypatch.setattr(client, "execute_query", inspect_query)
+        found = [
+            entity_id
+            async for entity_id in _graph_descendant_ids(
+                SimpleNamespace(client=client),
+                organization_id=organization_id,
+                raw_ids=["root"],
+                graph_ids=["parent"],
+            )
+        ]
+        assert set(found) == {row["uuid"] for row in rows[:-1]}
+        assert len(found) == 517
+        assert len(plans) == 6  # Two source pages, then four other indexed arms.
+        for plan in plans:
+            assert any(step["operation"] == "Iterate Index" for step in plan)
+            assert all(step["operation"] != "Iterate Table" for step in plan)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_raw_lineage_element_index_returns_sources_without_table_scan():
     organization_id = str(uuid4())
     client = SurrealContentClient(url="memory://")
@@ -35,5 +113,60 @@ async def test_raw_lineage_element_index_returns_sources_without_table_scan():
         plan = await client.execute_query(query + " EXPLAIN;", **params)
         assert any(step["operation"] == "Iterate Index" for step in plan)
         assert all(step["operation"] != "Iterate Table" for step in plan)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing_name_field", [False, True])
+async def test_graph_lineage_upgrade_preserves_existing_entity_fields(missing_name_field):
+    from sibyl_core.backends.surreal.schema import bootstrap_schema
+
+    org = str(uuid4())
+    client = SurrealGraphClient(group_id=org, url="memory://")
+    try:
+        await prepare_graph_schema(client)
+        for suffix in (
+            "raw_sources",
+            "raw_memory",
+            "review_capture",
+            "projection_parent",
+            "projection_source",
+        ):
+            await client.execute_query(f"REMOVE INDEX idx_entity_{suffix} ON entity;")
+        await client.execute_query("UPDATE schema_version SET version = 20 WHERE name = 'graph';")
+        await client.execute_query(
+            "CREATE entity:retained CONTENT $row;",
+            row={
+                "uuid": "retained",
+                "group_id": org,
+                "name": "Original title",
+                "entity_type": "note",
+                "labels": ["retained"],
+                "attributes": {
+                    "raw_source_ids": ["root"],
+                    "content": "Original evidence",
+                    "nested": {"kept": True},
+                },
+            },
+        )
+        before = await client.execute_query("SELECT * FROM entity:retained;")
+        assert before[0]["name"] == "Original title"
+        assert before[0]["attributes"]["content"] == "Original evidence"
+        if missing_name_field:
+            await client.execute_query("REMOVE FIELD name ON entity;")
+            assert await client.execute_query("SELECT * FROM entity:retained;") == before
+        await bootstrap_schema(client)
+        assert await client.execute_query("SELECT * FROM entity:retained;") == before
+        found = [
+            entity_id
+            async for entity_id in _graph_descendant_ids(
+                SimpleNamespace(client=client),
+                organization_id=org,
+                raw_ids=["root"],
+                graph_ids=[],
+            )
+        ]
+        assert found == ["retained"]
     finally:
         await client.close()

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -21,7 +21,6 @@ import sibyl_core.retrieval.search as search_module
 import sibyl_core.tools.context as context_module
 from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
 from sibyl_core.models.context import ContextFacet
-from sibyl_core.models.entities import RelationshipType
 from sibyl_core.retrieval import _search_database as database_module
 from sibyl_core.retrieval import _search_expansion as expansion_module
 from sibyl_core.retrieval import _search_lifecycle as lifecycle_module
@@ -429,10 +428,14 @@ class _CorrectionGraphRuntime:
         return SimpleNamespace(
             id=entity_id,
             created_by=owner,
+            revision=1,
+            observed_revision=1,
             metadata={"memory_scope": "private", "principal_id": owner},
         )
 
-    async def update(self, entity_id: str, updates: dict[str, Any]) -> object | None:
+    async def update(
+        self, entity_id: str, updates: dict[str, Any], **_kwargs: object
+    ) -> object | None:
         if entity_id in self.missing:
             return None
         self.updates.append((entity_id, dict(updates["metadata"])))
@@ -446,6 +449,8 @@ class _CorrectionGraphRuntime:
 def _raw_capture(**overrides: Any) -> RawMemory:
     values: dict[str, Any] = {
         "id": "candidate-1",
+        "revision": 1,
+        "observed_revision": 1,
         "organization_id": "org-1",
         "source_id": "source-1",
         "principal_id": "user-1",
@@ -499,8 +504,7 @@ async def test_correction_stamps_the_graph_row_so_recall_stops_serving_it(
     assert result.affected_entity_ids == ["entity-old"]
     entity_id, stamped = runtime.updates[0]
     assert entity_id == "entity-old"
-    assert stamped["lifecycle_state"] == "contested"
-    assert stamped["excluded_from_recall"] is True
+    assert stamped["correction_blockers"][memory.id]["blocking"] is True
 
     # The stamp is exactly what the retrieval gate reads, so the same query
     # that ranked this row first now refuses it admission.
@@ -508,10 +512,10 @@ async def test_correction_stamps_the_graph_row_so_recall_stops_serving_it(
 
 
 @pytest.mark.asyncio
-async def test_supersede_writes_the_replacement_edge_in_the_direction_retrieval_reads(
+async def test_supersede_retires_graph_through_ordered_source_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Source is the survivor, target is the retired row."""
+    """The source verdict retires graph rows without a second exclusion writer."""
 
     memory = _raw_capture(id="source-1")
     replacement = _raw_capture(id="replacement-1", title="Deploy to Hetzner")
@@ -519,6 +523,8 @@ async def test_supersede_writes_the_replacement_edge_in_the_direction_retrieval_
     seen_uuids = iter(["entity-old", "entity-new"])
 
     async def execute_query(query: str, **_params: object) -> list[dict[str, object]]:
+        if "source_ids" in _params:
+            return []
         if "parent_entity_id" in query:
             # This capture projected no passages, so the lineage cascade finds
             # nothing. Answering it with a provenance row would hand the test a
@@ -563,11 +569,9 @@ async def test_supersede_writes_the_replacement_edge_in_the_direction_retrieval_
 
     assert result.applied
     assert result.affected_entity_ids == ["entity-old"]
-    assert len(runtime.relationships) == 1
-    edge = runtime.relationships[0]
-    assert edge.source_id == "entity-new"
-    assert edge.target_id == "entity-old"
-    assert edge.relationship_type is RelationshipType.SUPERSEDES
+    assert runtime.relationships == []
+    assert result.updated_memory.metadata["superseded_by_source_id"] == replacement.id
+    assert graph_metadata_recallable(runtime.updates[0][1]) is False
 
 
 @pytest.mark.asyncio
@@ -588,6 +592,8 @@ async def test_a_span_takes_the_stamp_but_never_the_supersession_edge(
     seen_uuids = iter(["entity-old", "entity-new"])
 
     async def execute_query(query: str, **_params: object) -> list[dict[str, object]]:
+        if "source_ids" in _params:
+            return []
         if "parent_entity_id" in query:
             return [{"uuid": "passage-of-entity-old"}]
         return [{"uuid": next(seen_uuids)}]
@@ -631,7 +637,7 @@ async def test_a_span_takes_the_stamp_but_never_the_supersession_edge(
     assert result.affected_entity_ids == ["entity-old", "passage-of-entity-old"]
     stamped = {entity_id for entity_id, _updates in runtime.updates}
     assert stamped == {"entity-old", "passage-of-entity-old"}
-    assert [edge.target_id for edge in runtime.relationships] == ["entity-old"]
+    assert runtime.relationships == []
 
 
 @pytest.mark.asyncio
@@ -671,8 +677,7 @@ async def test_restore_clears_the_graph_stamp_it_wrote(
 
     assert result.applied
     _entity_id, stamped = runtime.updates[0]
-    assert stamped["excluded_from_recall"] is False
-    assert stamped["superseded_by_source_id"] == ""
+    assert stamped["correction_blockers"][memory.id]["blocking"] is False
     assert graph_metadata_recallable(stamped) is True
 
 
@@ -1052,25 +1057,12 @@ def test_an_active_state_never_rescues_a_flagged_or_genuinely_duplicate_row() ->
     ],
 )
 @pytest.mark.asyncio
-async def test_a_correction_retires_only_projected_rows_it_can_still_see(
+async def test_correction_stamps_projections_but_discloses_only_readable_rows(
     monkeypatch: pytest.MonkeyPatch,
     scope_metadata: dict[str, Any],
     reachable: bool,
 ) -> None:
-    """Provenance is server-owned now, but rows written before that are not.
-
-    `raw_memory_id` was patchable until this branch, so a row can carry a
-    planted capture id. The attack is to plant it on a row you can write, lose
-    access, then correct your own capture to retire it. Requiring that the
-    projected row still be readable by the correcting principal closes that
-    without refusing anything legitimate, because a genuine projection
-    inherits its capture's audience.
-
-    The reachable cases are the ones that can actually be served: read
-    authorization admits private, project, and the legacy fail-open, while
-    organization, shared, and public all reach `scope_not_enabled`
-    (`migrate/scope_backfill.py:70-79`), so no servable row carries them.
-    """
+    """Source ownership authorizes invalidation; row visibility controls the receipt."""
 
     memory = _raw_capture(id="source-1")
     runtime = _CorrectionGraphRuntime()
@@ -1079,7 +1071,9 @@ async def test_a_correction_retires_only_projected_rows_it_can_still_see(
         return [{"uuid": "entity-projected"}]
 
     async def get(entity_id: str) -> Any:
-        return SimpleNamespace(id=entity_id, created_by=None, metadata=dict(scope_metadata))
+        return SimpleNamespace(
+            id=entity_id, created_by=None, observed_revision=1, metadata=dict(scope_metadata)
+        )
 
     runtime.execute_query = execute_query  # type: ignore[method-assign]
     runtime.get = get  # type: ignore[method-assign]
@@ -1105,13 +1099,10 @@ async def test_a_correction_retires_only_projected_rows_it_can_still_see(
     )
 
     assert result.applied
-    if reachable:
-        assert result.affected_entity_ids == ["entity-projected"]
-        _entity_id, stamped = runtime.updates[0]
-        assert graph_metadata_recallable(stamped) is False
-    else:
-        assert result.affected_entity_ids == []
-        assert runtime.updates == []
+    assert result.affected_entity_ids == (["entity-projected"] if reachable else [])
+    assert len(runtime.updates) == 1
+    _entity_id, stamped = runtime.updates[0]
+    assert graph_metadata_recallable(stamped) is False
 
 
 @pytest.mark.asyncio
@@ -1154,7 +1145,8 @@ async def test_a_refused_target_is_reported_rather_than_silently_skipped(
     )
 
     assert result.affected_entity_ids == ["entity-own"]
-    assert result.refused_entity_ids == ["entity-victim"]
+    assert result.refused_entity_ids == []
+    assert not result.propagation_complete
 
 
 @pytest.mark.asyncio
@@ -1389,13 +1381,13 @@ async def test_a_missing_id_and_a_denied_id_are_reported_identically(
         )
         assert result.applied
         assert result.affected_entity_ids == []
+        assert not result.propagation_complete
         return result.refused_entity_ids
 
     denied = await run("entity-exists-denied", exists=True)
     missing = await run("entity-does-not-exist", exists=False)
 
-    assert denied == ["entity-exists-denied"]
-    assert missing == ["entity-does-not-exist"]
+    assert denied == missing == []
 
 
 @pytest.mark.asyncio
@@ -1449,9 +1441,8 @@ async def test_a_synchronous_create_reconciles_the_capture_before_writing_the_ro
     )
 
     assert created_id == "sync-row"
-    assert written[0].metadata["excluded_from_recall"] is True
-    assert written[0].metadata["lifecycle_state"] == "contested"
     assert graph_metadata_recallable(written[0].metadata) is False
+    assert written[0].metadata["correction_blockers"]["raw-corrected"]["blocking"] is True
 
 
 @pytest.mark.asyncio
@@ -1629,7 +1620,7 @@ async def test_an_unreadable_verdict_retires_the_row_instead_of_poisoning_the_jo
 
     class _Manager:
         async def get(self, entity_id: str) -> Any:
-            return SimpleNamespace(id=entity_id, metadata={}, revision=1)
+            return SimpleNamespace(id=entity_id, metadata={}, revision=1, observed_revision=1)
 
         async def update(
             self,
@@ -1637,6 +1628,7 @@ async def test_an_unreadable_verdict_retires_the_row_instead_of_poisoning_the_jo
             updates: dict[str, Any],
             *,
             expected_revision: int | None = None,
+            replace_metadata_keys: tuple[str, ...] = (),
         ) -> object:
             stamped.append((entity_id, dict(updates["metadata"])))
             return object()
@@ -1650,7 +1642,7 @@ async def test_an_unreadable_verdict_retires_the_row_instead_of_poisoning_the_jo
 
     assert len(attempts) == RECONCILE_MAX_ATTEMPTS, "transient failures are retried, bounded"
     assert outcome.unverified == 1
-    assert stamped == [("row-1", {"excluded_from_recall": True, RECONCILE_PENDING_KEY: True})]
+    assert stamped == [("row-1", {RECONCILE_PENDING_KEY: {"capture:raw-1": True}})]
     assert graph_metadata_recallable(stamped[0][1]) is False
 
 
@@ -1757,7 +1749,9 @@ async def test_failed_row_reads_never_produce_an_unfenced_write(
                 msg = "graph unreachable"
                 raise ConnectionError(msg)
             # The correction landed while the reads were failing.
-            return SimpleNamespace(id=entity_id, metadata=dict(newer), revision=7)
+            return SimpleNamespace(
+                id=entity_id, metadata=dict(newer), revision=7, observed_revision=7
+            )
 
         async def update(
             self,
@@ -1765,6 +1759,7 @@ async def test_failed_row_reads_never_produce_an_unfenced_write(
             updates: dict[str, Any],
             *,
             expected_revision: int | None = None,
+            replace_metadata_keys: tuple[str, ...] = (),
         ) -> object:
             writes.append({"revision": expected_revision, **dict(updates["metadata"])})
             return object()
@@ -1782,7 +1777,8 @@ async def test_failed_row_reads_never_produce_an_unfenced_write(
         row_ids=["row-1"],
     )
 
-    assert writes == [], "a pass that could not read the row must not write to it"
+    assert writes == [{"revision": 7, "lifecycle_reconciliation_pending": {"capture:raw-1": True}}]
+    assert "excluded_from_recall" not in writes[0], "an unread verdict cannot replace a correction"
 
 
 @pytest.mark.asyncio
@@ -1802,7 +1798,7 @@ async def test_a_transient_write_failure_is_retried_rather_than_escaping(
 
     class _Manager:
         async def get(self, entity_id: str) -> Any:
-            return SimpleNamespace(id=entity_id, metadata={}, revision=3)
+            return SimpleNamespace(id=entity_id, metadata={}, revision=3, observed_revision=3)
 
         async def update(
             self,
@@ -1810,6 +1806,7 @@ async def test_a_transient_write_failure_is_retried_rather_than_escaping(
             updates: dict[str, Any],
             *,
             expected_revision: int | None = None,
+            replace_metadata_keys: tuple[str, ...] = (),
         ) -> object:
             attempts.append(expected_revision)
             if len(attempts) == 1:

--- a/packages/python/sibyl-core/tests/test_supersession_live_graph.py
+++ b/packages/python/sibyl-core/tests/test_supersession_live_graph.py
@@ -32,6 +32,7 @@ import sibyl_core.services.memory_correction as memory_correction_module
 import sibyl_core.services.memory_lifecycle as memory_lifecycle_module
 import sibyl_core.tools.context as context_module
 from sibyl_core.auth.memory_policy import stamp_memory_scope_metadata
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
 from sibyl_core.models.context import ContextFacet, ContextPack
 from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
 from sibyl_core.projection.memory import project_memory_entity
@@ -40,6 +41,7 @@ from sibyl_core.retrieval import _search_database as database_module
 from sibyl_core.retrieval import _search_expansion as expansion_module
 from sibyl_core.retrieval import _search_lifecycle as lifecycle_module
 from sibyl_core.retrieval.search import build_context_retrieval_plan
+from sibyl_core.services.content_raw_persistence import save_raw_memory
 from sibyl_core.services.graph import (
     EntityManager,
     RelationshipManager,
@@ -47,6 +49,7 @@ from sibyl_core.services.graph import (
     prepare_graph_schema,
 )
 from sibyl_core.services.surreal_content import MemoryScope, RawMemory
+from tests.test_reflection_identity import content_store as content_store
 
 PROJECT_ID = "proj-supersession"
 PRINCIPAL = "user-supersession"
@@ -508,6 +511,7 @@ async def _correct(
     """
 
     memory = RawMemory(
+        observed_revision=1,
         id=raw_memory_id,
         organization_id=graph.group_id,
         source_id=f"source-{raw_memory_id}",
@@ -623,8 +627,7 @@ async def test_spans_cut_after_the_correction_are_born_retired(
     )
     assert projection.passages >= 2, "the spans have to exist for the test to mean anything"
     for span in projection.created_passages:
-        assert span.metadata.get("excluded_from_recall") is True
-        assert span.metadata.get("lifecycle_state") == "contested"
+        assert not graph_metadata_recallable(span.metadata)
 
     served = _pack_ids(await _pack(graph, "interleaved passage body"))
     assert "raced-parent" not in served
@@ -699,7 +702,7 @@ async def test_correcting_a_memory_retires_the_entities_and_facts_projected_from
     for row_id in projected:
         stored = await graph.entity_manager.get(row_id)
         assert stored is not None
-        assert stored.metadata.get("excluded_from_recall") is True
+        assert not graph_metadata_recallable(stored.metadata)
 
     after = _pack_ids(await _pack(graph, "Grafana dashboard reads from Prometheus"))
     assert not (after & set(projected))
@@ -727,7 +730,7 @@ async def test_rows_projected_after_the_correction_are_born_retired(
     for row_id in projected:
         stored = await graph.entity_manager.get(row_id)
         assert stored is not None
-        assert stored.metadata.get("excluded_from_recall") is True
+        assert not graph_metadata_recallable(stored.metadata)
 
     served = _pack_ids(await _pack(graph, "Grafana dashboard reads from Prometheus"))
     assert not (served & set(projected))
@@ -737,6 +740,7 @@ async def test_rows_projected_after_the_correction_are_born_retired(
 async def test_a_row_written_through_add_is_reachable_by_a_correction(
     graph: _Runtime,
     monkeypatch: pytest.MonkeyPatch,
+    content_store,
 ) -> None:
     """The write path and the correction path have to agree on one key.
 
@@ -754,6 +758,16 @@ async def test_a_row_written_through_add_is_reachable_by_a_correction(
         return graph
 
     monkeypatch.setattr(add_module, "get_graph_runtime", runtime_factory)
+    await save_raw_memory(
+        RawMemory(
+            id="raw-through-add",
+            organization_id=graph.group_id,
+            source_id="source-raw-through-add",
+            principal_id=PRINCIPAL,
+            raw_content="We decided to deploy to fly.io.",
+        ),
+        embedding_provider=None,
+    )
 
     response = await add_module.add(
         title="Deploy to Fly",
@@ -1127,10 +1141,10 @@ async def test_a_readable_verdict_clears_the_pending_marker(
     await graph.entity_manager.create_direct(row)
     await graph.entity_manager.update(
         "pending-row",
-        {"metadata": {"excluded_from_recall": True, RECONCILE_PENDING_KEY: True}},
+        {"metadata": {RECONCILE_PENDING_KEY: {"capture:raw-pending": True}}},
     )
     marked = await graph.entity_manager.get("pending-row")
-    assert marked.metadata.get(RECONCILE_PENDING_KEY) is True
+    assert marked.metadata[RECONCILE_PENDING_KEY] == {"capture:raw-pending": True}
     assert "pending-row" not in _pack_ids(await _pack(graph, "pending marker hosting body"))
 
     async def healthy_verdict(**_kwargs: object) -> dict[str, Any]:
@@ -1151,7 +1165,7 @@ async def test_a_readable_verdict_clears_the_pending_marker(
     assert outcome.changed
     settled = await graph.entity_manager.get("pending-row")
     assert RECONCILE_PENDING_KEY not in settled.metadata, "the marker has to be gone, not falsy"
-    assert settled.metadata.get("excluded_from_recall") is False
+    assert not settled.metadata.get("excluded_from_recall")
     assert "pending-row" in _pack_ids(await _pack(graph, "pending marker hosting body"))
 
 
@@ -1174,7 +1188,7 @@ async def test_a_correction_clears_the_pending_marker_it_finds(
     await graph.entity_manager.create_direct(row)
     await graph.entity_manager.update(
         "marked-parent",
-        {"metadata": {RECONCILE_PENDING_KEY: True}},
+        {"metadata": {RECONCILE_PENDING_KEY: {"capture:raw-marked-parent": True}}},
     )
 
     result = await _correct(graph, monkeypatch, raw_memory_id="raw-marked-parent")
@@ -1183,4 +1197,26 @@ async def test_a_correction_clears_the_pending_marker_it_finds(
 
     settled = await graph.entity_manager.get("marked-parent")
     assert RECONCILE_PENDING_KEY not in settled.metadata
-    assert settled.metadata.get("excluded_from_recall") is True
+    assert not graph_metadata_recallable(settled.metadata)
+
+
+async def test_legacy_pending_without_an_owner_is_not_cleared_by_one_capture(graph, monkeypatch):
+    from sibyl_core.projection.reconcile import RECONCILE_PENDING_KEY, reconcile_with_capture
+
+    row = _entity(graph, "legacy-pending", "Legacy pending", "Legacy pending body")
+    await graph.entity_manager.create_direct(row)
+    await graph.entity_manager.update(row.id, {"metadata": {RECONCILE_PENDING_KEY: True}})
+
+    async def healthy_verdict(**_kwargs):
+        return {}
+
+    monkeypatch.setattr("sibyl_core.services.memory.projected_row_lifecycle_stamp", healthy_verdict)
+    await reconcile_with_capture(
+        graph.entity_manager,
+        organization_id=graph.group_id,
+        metadata={"raw_memory_id": "one-capture"},
+        row_ids=[row.id],
+    )
+    stored = await graph.entity_manager.get(row.id)
+    assert stored.metadata[RECONCILE_PENDING_KEY] == {"unknown": True}
+    assert not graph_metadata_recallable(stored.metadata)

--- a/packages/python/sibyl-core/tests/test_tools.py
+++ b/packages/python/sibyl-core/tests/test_tools.py
@@ -3737,11 +3737,11 @@ class TestAddTool:
         class RecordingEntityManager:
             async def create(self, entity: Any, **_kwargs: Any) -> Any:
                 written.update(entity.metadata)
-                return entity
+                return entity.id
 
             async def upsert(self, entity: Any, **_kwargs: Any) -> Any:
                 written.update(entity.metadata)
-                return entity
+                return entity.id
 
             async def get(self, _entity_id: str) -> None:
                 return None

--- a/packages/python/sibyl-core/tests/test_tools_manage.py
+++ b/packages/python/sibyl-core/tests/test_tools_manage.py
@@ -1356,6 +1356,7 @@ class TestSourceActions:
                     "idempotency_key": "correct-1",
                 },
                 organization_id="org-1",
+                principal_id="user-1",
             )
 
         assert response.success is True
@@ -1375,6 +1376,8 @@ class TestSourceActions:
             action="mark_wrong",
             reason="Incorrect",
             accessible_projects=None,
+            writable_projects=set(),
+            allowed_memory_scope_keys=None,
             accessible_teams=None,
             accessible_delegations=None,
             replacement_source_id=None,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   postcss: ^8.5.18
-  sharp: 0.35.3
+  sharp: 0.35.4
 
 importers:
 
@@ -637,160 +637,160 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.35.3':
-    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.3':
-    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.35.3':
-    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.35.3':
-    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.3':
-    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.35.3':
-    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.3':
-    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.35.3':
-    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.35.3':
-    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
     engines: {node: '>=20.9.0'}
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.35.3':
-    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.3':
-    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
     engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.35.3':
-    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
@@ -4340,8 +4340,8 @@ packages:
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
-  sharp@0.35.3:
-    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       '@types/node': '*'
@@ -5245,108 +5245,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.35.3':
+  '@img/sharp-darwin-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.3':
+  '@img/sharp-darwin-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.3
     optional: true
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
+  '@img/sharp-freebsd-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.3
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
+  '@img/sharp-libvips-darwin-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
+  '@img/sharp-libvips-linux-arm@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
+  '@img/sharp-libvips-linux-x64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
     optional: true
 
-  '@img/sharp-linux-arm64@0.35.3':
+  '@img/sharp-linux-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-arm@0.35.3':
+  '@img/sharp-linux-arm@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.3':
+  '@img/sharp-linux-ppc64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-riscv64@0.35.3':
+  '@img/sharp-linux-riscv64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.3':
+  '@img/sharp-linux-s390x@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.3
     optional: true
 
-  '@img/sharp-linux-x64@0.35.3':
+  '@img/sharp-linux-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
+  '@img/sharp-linuxmusl-arm64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
+  '@img/sharp-linuxmusl-x64@0.35.4':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
     optional: true
 
-  '@img/sharp-wasm32@0.35.3':
+  '@img/sharp-wasm32@0.35.4':
     dependencies:
       '@emnapi/runtime': 1.11.3
     optional: true
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
+  '@img/sharp-webcontainers-wasm32@0.35.4':
     dependencies:
-      '@img/sharp-wasm32': 0.35.3
+      '@img/sharp-wasm32': 0.35.4
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.3':
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.3':
+  '@img/sharp-win32-ia32@0.35.4':
     optional: true
 
-  '@img/sharp-win32-x64@0.35.3':
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@inquirer/ansi@2.0.7': {}
@@ -8497,7 +8497,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.3.3
       '@next/swc-win32-x64-msvc': 16.3.3
       babel-plugin-react-compiler: 1.0.0
-      sharp: 0.35.3(@types/node@26.2.0)
+      sharp: 0.35.4(@types/node@26.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -8976,37 +8976,37 @@ snapshots:
 
   set-cookie-parser@3.1.2: {}
 
-  sharp@0.35.3(@types/node@26.2.0):
+  sharp@0.35.4(@types/node@26.2.0):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
       '@types/node': 26.2.0
     optional: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ minimumReleaseAgeExclude:
 
 overrides:
   postcss: ^8.5.18
-  sharp: 0.35.3
+  sharp: 0.35.4
 
 # Skip minimumReleaseAge re-verification of the committed lockfile. The
 # 24h cooldown still applies during fresh resolution (and lockfile diffs


### PR DESCRIPTION
Derived memories can outlive the source evidence they summarize when corrections race publication or a write stops before its projection finishes. This change preserves the original source observations, propagates lifecycle corrections, and resumes interrupted raw and graph work without publishing stale evidence.

## 🛠️ Source checks and recovery

Publication verifies source content identity around insertion and review transitions. Legacy reflection reservations retain their original content epoch across bookkeeping and replay. Correction paths carry explicit read/write grants and avoid disclosing inaccessible source clocks.

Pending raw captures retain the original authorization ceiling. Scheduled recovery intersects that ceiling with current membership and resolves authority again after CAS conflicts. Graph recovery failure does not prevent raw recovery. Migration 29 adds the pending-capture index after the authenticated admission migration. Caller-supplied provenance remains stripped, including the admission stamp.

## 🧪 Validation

The combined branch passed 3,536 core tests (14 skipped, one expected failure), 2,447 API tests (15 skipped), and all four core/API static gates. Independent integration review passed 99 core and 17 API checks; root spot checks passed seven cases. The review verified parity with the previously reviewed lifecycle snapshot and preserved admission paths, rather than re-reviewing every imported file from scratch.

An isolated SurrealDB 3.2.3 run passed 19 recovery cases and migration 28 to 29 through the actual WebSocket SDK. Source hashes matched and owned containers were removed. Authority resolution and CAS conflicts were controlled, embeddings were disabled, and the migration fixture explicitly removed the pending index before applying migration 29.

The hosted coverage task also runs extended E2E tests excluded by the ordinary local API task. Two creation failures reproduced because the test harness lacked observed revisions and revision-fenced update arguments. The test-only correction passed 169 extended tests and 181 harness consumers, plus API lint and typecheck. Independent parent verification passed 171 extended/adversarial cases, including competing writes and metadata snapshot isolation. The branch also carries the reviewed Sharp 0.35.4 security update.

## 🔍 Remaining gates

Hosted checks and final review remain required. The SDK probe does not establish live HTTP authorization, membership-store integration, scheduler activation, or complete application upgrade readiness. This change does not establish learning gains or complete graph-native synthesis lineage.
