### PR TITLE
feat(evals): freeze authored repair corpora for development runs

### DIFF
--- a/benchmarks/agent_tasks/corpus.py
+++ b/benchmarks/agent_tasks/corpus.py
@@ -1,0 +1,214 @@
+"""Freeze authored repair tasks for trusted development, not model experiences."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import keyword
+import tokenize
+from difflib import SequenceMatcher
+from pathlib import Path
+
+from benchmarks.agent_tasks import coding_controller, json_oracle
+from benchmarks.agent_tasks.corpus_families import Family, families
+from benchmarks.agent_tasks.manifest import (
+    Artifact,
+    JsonOracleChecker,
+    Task,
+    WorkspaceFile,
+    canonical_bytes,
+    digest,
+)
+
+
+def normalized(text: str) -> list[str]:
+    """Erase identifiers and literals to expose structural fixture similarity."""
+    result = []
+    for token in tokenize.generate_tokens(io.StringIO(text).readline):
+        if token.type in {tokenize.COMMENT, tokenize.ENCODING, tokenize.NL, tokenize.ENDMARKER}:
+            continue
+        if token.type == tokenize.NAME and not keyword.iskeyword(token.string):
+            result.append("NAME")
+        elif token.type in {tokenize.NUMBER, tokenize.STRING}:
+            result.append("LITERAL")
+        else:
+            result.append(token.string)
+    return result
+
+
+def lineage_audit(items: list[Family]) -> dict:
+    """Report cross-split overlap; similarity is evidence for human review."""
+    if any(not item.mechanism_cluster.strip() for item in items):
+        raise ValueError("missing mechanism cluster")
+    if len({item.id for item in items}) != len(items):
+        raise ValueError("duplicate family identity")
+    pairs = []
+    for index, left in enumerate(items):
+        for right in items[index + 1 :]:
+            if left.split == right.split:
+                continue
+            comparisons = []
+            for lp, ls in left.workspace.items():
+                for rp, rs in right.workspace.items():
+                    comparisons.append(
+                        {
+                            "left_path": lp,
+                            "right_path": rp,
+                            "exact": ls == rs,
+                            "normalized_similarity": SequenceMatcher(
+                                None, normalized(ls), normalized(rs), autojunk=False
+                            ).ratio(),
+                        }
+                    )
+            pairs.append(
+                {
+                    "left": left.id,
+                    "right": right.id,
+                    "shared_lineage": left.lineage == right.lineage,
+                    "shared_mechanism": left.mechanism_cluster == right.mechanism_cluster,
+                    "exact_contract": left.contract == right.contract,
+                    "overlapping_case_digests": sorted(
+                        {
+                            digest(
+                                canonical_bytes(
+                                    {"input": case["input"], "expected": case["expected"]}
+                                )
+                            )
+                            for case in left.public_cases + left.private_cases
+                        }
+                        & {
+                            digest(
+                                canonical_bytes(
+                                    {"input": case["input"], "expected": case["expected"]}
+                                )
+                            )
+                            for case in right.public_cases + right.private_cases
+                        }
+                    ),
+                    "files": comparisons,
+                }
+            )
+    return {
+        "schema_version": "sibyl-authored-corpus-lineage-v1",
+        "pairs": pairs,
+        "near_duplicate_clearance": "requires independent semantic review",
+        "family_count": len(items),
+        "mechanism_cluster_count": len({item.mechanism_cluster for item in items}),
+        "independent_statistical_families": False,
+        "experience_count": 0,
+    }
+
+
+def freeze(
+    output: Path, *, seed: int, image: str, docker: str, docker_host: str | None = None
+) -> Path:
+    """Write runner Task records and bound private oracle inputs into a new root.
+
+    This task catalog must be composed with a runtime-specific Manifest by the
+    caller. Reference and partial repairs are intentionally never written here.
+    """
+    if seed < 0:
+        raise ValueError("seed must be nonnegative")
+    items = families(seed)
+    # Validate runtime configuration before creating any output.
+    placeholder = Artifact(path="unused", sha256="0" * 64)
+    checker = JsonOracleChecker(
+        schema_version="sibyl-json-cli-oracle-v1",
+        oracle=placeholder,
+        runtime=placeholder,
+        evaluator=placeholder,
+        argv=["python", "-B", "app.py"],
+        image=image,
+        docker=docker,
+        docker_host=docker_host,
+        timeout_seconds=10.0,
+        memory_mb=256,
+    )
+    output.mkdir(mode=0o700, parents=False, exist_ok=False)
+
+    def write(name: str, data: bytes) -> Artifact:
+        path = output / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return Artifact(path=name, sha256=digest(data))
+
+    runtime = write("private/coding_controller.py", Path(coding_controller.__file__).read_bytes())
+    evaluator = write("private/json_oracle.py", Path(json_oracle.__file__).read_bytes())
+    tasks = []
+    for family in items:
+        task_id = f"{family.id}-{seed}"
+        prefix = f"tasks/{task_id}"
+        prompt = write(f"{prefix}/prompt.md", family.contract.encode())
+        public = (
+            "import json, subprocess, sys\n"
+            f"cases = json.loads({json.dumps(family.public_cases)!r})\n"
+            "for case in cases:\n"
+            "    run = subprocess.run([sys.executable, '-B', 'app.py'], input=json.dumps(case['input']), text=True, capture_output=True, timeout=5, check=True)\n"
+            "    assert json.loads(run.stdout) == case['expected'], case['id']\n"
+        )
+        workspace = [
+            WorkspaceFile(
+                artifact=write(f"{prefix}/workspace/{name}", data.encode()), destination=name
+            )
+            for name, data in (family.workspace | {"public_checks.py": public}).items()
+        ]
+        oracle = write(
+            f"private/{task_id}.json",
+            canonical_bytes(
+                {
+                    "schema_version": "sibyl-json-cli-cases-v1",
+                    "cases": family.public_cases + family.private_cases,
+                }
+            ),
+        )
+        bound = checker.model_copy(
+            update={"oracle": oracle, "runtime": runtime, "evaluator": evaluator}
+        )
+        tasks.append(
+            Task(
+                id=task_id,
+                family_id=family.id,
+                split=family.split,
+                prompt=prompt,
+                workspace=workspace,
+                checker=bound,
+            )
+        )
+    catalog = {
+        "schema_version": "sibyl-authored-repair-catalog-v1",
+        "seed": seed,
+        "tasks": [task.model_dump(mode="json") for task in tasks],
+        "experiences": [],
+        "lineages": {item.id: item.lineage for item in items},
+        "mechanism_clusters": {item.id: item.mechanism_cluster for item in items},
+        "limitations": [
+            "authored fixtures, not collected episodes",
+            "trusted development only",
+            "six families do not satisfy the twenty-family release gate",
+        ],
+    }
+    write("lineage-audit.json", canonical_bytes(lineage_audit(items)))
+    write("tasks.json", canonical_bytes(catalog))
+    return output / "tasks.json"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--docker", default="/usr/bin/docker")
+    parser.add_argument("--docker-host")
+    arguments = parser.parse_args()
+    freeze(
+        arguments.output,
+        seed=arguments.seed,
+        image=arguments.image,
+        docker=arguments.docker,
+        docker_host=arguments.docker_host,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/agent_tasks/corpus.py
+++ b/benchmarks/agent_tasks/corpus.py
@@ -185,7 +185,7 @@ def freeze(
         "limitations": [
             "authored fixtures, not collected episodes",
             "trusted development only",
-            "six families do not satisfy the twenty-family release gate",
+            "authored fixtures do not satisfy the twenty-family experience release gate",
         ],
     }
     write("lineage-audit.json", canonical_bytes(lineage_audit(items)))

--- a/benchmarks/agent_tasks/corpus_families/__init__.py
+++ b/benchmarks/agent_tasks/corpus_families/__init__.py
@@ -3,8 +3,10 @@
 from .apportionment import apportionment
 from .bit_fields import bit_fields
 from .build_planner import build_planner
+from .canonical_huffman import canonical_huffman
 from .commands import commands
 from .configuration import configuration
+from .field_reconstruction import field_reconstruction
 from .indexing import indexing
 from .interval_capacity import interval_capacity
 from .knapsack import knapsack
@@ -15,9 +17,11 @@ from .reservations import reservations
 from .savepoints import savepoints
 from .sessions import sessions
 from .shortest_paths import shortest_paths
+from .sparse_product import sparse_product
 from .stream_framing import stream_framing
 from .three_valued_logic import three_valued_logic
 from .weighted_lru import weighted_lru
+from .wildcard_match import wildcard_match
 from .worker_matching import worker_matching
 
 
@@ -41,4 +45,8 @@ def families(seed: int) -> list[Family]:
         bit_fields(seed),
         knapsack(seed),
         shortest_paths(seed),
+        sparse_product(seed),
+        field_reconstruction(seed),
+        wildcard_match(seed),
+        canonical_huffman(seed),
     ]

--- a/benchmarks/agent_tasks/corpus_families/__init__.py
+++ b/benchmarks/agent_tasks/corpus_families/__init__.py
@@ -1,16 +1,20 @@
 """Authored repair-family registry with explicit split ownership."""
 
 from .apportionment import apportionment
+from .bit_fields import bit_fields
 from .build_planner import build_planner
 from .commands import commands
 from .configuration import configuration
 from .indexing import indexing
 from .interval_capacity import interval_capacity
+from .knapsack import knapsack
 from .model import Family
 from .outer_join import outer_join
 from .path_routing import path_routing
 from .reservations import reservations
+from .savepoints import savepoints
 from .sessions import sessions
+from .shortest_paths import shortest_paths
 from .stream_framing import stream_framing
 from .three_valued_logic import three_valued_logic
 from .weighted_lru import weighted_lru
@@ -33,4 +37,8 @@ def families(seed: int) -> list[Family]:
         weighted_lru(seed),
         outer_join(seed),
         three_valued_logic(seed),
+        savepoints(seed),
+        bit_fields(seed),
+        knapsack(seed),
+        shortest_paths(seed),
     ]

--- a/benchmarks/agent_tasks/corpus_families/__init__.py
+++ b/benchmarks/agent_tasks/corpus_families/__init__.py
@@ -1,12 +1,16 @@
 """Authored repair-family registry with explicit split ownership."""
 
+from .apportionment import apportionment
 from .build_planner import build_planner
 from .commands import commands
 from .configuration import configuration
 from .indexing import indexing
+from .interval_capacity import interval_capacity
 from .model import Family
+from .path_routing import path_routing
 from .reservations import reservations
 from .sessions import sessions
+from .stream_framing import stream_framing
 
 
 def families(seed: int) -> list[Family]:
@@ -17,4 +21,8 @@ def families(seed: int) -> list[Family]:
         indexing(seed),
         reservations(seed),
         build_planner(seed),
+        apportionment(seed),
+        stream_framing(seed),
+        path_routing(seed),
+        interval_capacity(seed),
     ]

--- a/benchmarks/agent_tasks/corpus_families/__init__.py
+++ b/benchmarks/agent_tasks/corpus_families/__init__.py
@@ -7,10 +7,14 @@ from .configuration import configuration
 from .indexing import indexing
 from .interval_capacity import interval_capacity
 from .model import Family
+from .outer_join import outer_join
 from .path_routing import path_routing
 from .reservations import reservations
 from .sessions import sessions
 from .stream_framing import stream_framing
+from .three_valued_logic import three_valued_logic
+from .weighted_lru import weighted_lru
+from .worker_matching import worker_matching
 
 
 def families(seed: int) -> list[Family]:
@@ -25,4 +29,8 @@ def families(seed: int) -> list[Family]:
         stream_framing(seed),
         path_routing(seed),
         interval_capacity(seed),
+        worker_matching(seed),
+        weighted_lru(seed),
+        outer_join(seed),
+        three_valued_logic(seed),
     ]

--- a/benchmarks/agent_tasks/corpus_families/__init__.py
+++ b/benchmarks/agent_tasks/corpus_families/__init__.py
@@ -1,0 +1,20 @@
+"""Authored repair-family registry with explicit split ownership."""
+
+from .build_planner import build_planner
+from .commands import commands
+from .configuration import configuration
+from .indexing import indexing
+from .model import Family
+from .reservations import reservations
+from .sessions import sessions
+
+
+def families(seed: int) -> list[Family]:
+    return [
+        configuration(seed),
+        commands(seed),
+        sessions(seed),
+        indexing(seed),
+        reservations(seed),
+        build_planner(seed),
+    ]

--- a/benchmarks/agent_tasks/corpus_families/apportionment.py
+++ b/benchmarks/agent_tasks/corpus_families/apportionment.py
@@ -1,0 +1,100 @@
+"""Exact integer allocation with deterministic remainder distribution."""
+
+from .model import Family, case, source
+
+
+def apportionment(seed: int) -> Family:
+    contract = """# Shared invoice allocator
+
+Read nonnegative integer `total` and nonempty `items` containing unique string
+`id` and nonnegative integer `weight`. At least one weight is positive.
+Allocate every unit using largest remainders: first floor each exact proportional
+share, then give remaining units to descending fractional remainder, breaking
+remainder ties by ascending id. Return {"allocations": {id: integer_share}}.
+Zero-weight items receive zero. Integers may exceed the exact range of a float.
+
+Invoices sometimes lose units and allocation changes when callers reorder items.
+Repair quota computation and remainder distribution. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from quotas import quotas
+        from distribute import distribute
+
+        def dispatch(request):
+            rows = quotas(request["total"], request["items"])
+            return {"allocations": distribute(request["total"], rows)}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    quotas = source("""
+        def quotas(total, items):
+            weight = sum(item["weight"] for item in items)
+            return [(item["id"], round(total * item["weight"] / weight), 0) for item in items]
+    """)
+    distribute = source("""
+        def distribute(total, rows):
+            result = {name: amount for name, amount, remainder in rows}
+            spare = total - sum(result.values())
+            for name, amount, remainder in rows[:spare]:
+                result[name] += 1
+            return result
+    """)
+    fixed_quotas = source("""
+        def quotas(total, items):
+            weight = sum(item["weight"] for item in items)
+            return [(item["id"], *divmod(total * item["weight"], weight)) for item in items]
+    """)
+    fixed_distribute = distribute.replace(
+        "rows[:spare]", "sorted(rows, key=lambda row: (-row[2], row[0]))[:spare]"
+    )
+
+    def request(total, pairs):
+        return {"total": total, "items": [{"id": name, "weight": weight} for name, weight in pairs]}
+
+    large = 2**54 + 1
+    return Family(
+        "integer-apportionment",
+        "learning",
+        "invoice-largest-remainder-v1",
+        contract,
+        {"app.py": app, "quotas.py": quotas, "distribute.py": distribute},
+        {"quotas.py": fixed_quotas, "distribute.py": fixed_distribute},
+        {"quotas.py": fixed_quotas},
+        [
+            case("public-tie", request(1, [("a", 1), ("b", 1)]), {"allocations": {"a": 1, "b": 0}}),
+            case(
+                "public-exact",
+                request(3 * (seed + 1), [("a", 1), ("b", 2)]),
+                {"allocations": {"a": seed + 1, "b": 2 * (seed + 1)}},
+            ),
+        ],
+        [
+            case(
+                "private-remainders",
+                request(2, [("a", 2), ("b", 1)]),
+                {"allocations": {"a": 1, "b": 1}},
+            ),
+            case(
+                "private-order", request(1, [("b", 1), ("a", 1)]), {"allocations": {"a": 1, "b": 0}}
+            ),
+            case(
+                "private-large",
+                request(large, [("a", 1), ("b", 1)]),
+                {"allocations": {"a": 2**53 + 1, "b": 2**53}},
+            ),
+            case(
+                "private-zero-weight",
+                request(2, [("empty", 0), ("b", 1), ("a", 1)]),
+                {"allocations": {"empty": 0, "b": 1, "a": 1}},
+            ),
+            case(
+                "private-zero-total",
+                request(0, [("a", 1), ("b", 1)]),
+                {"allocations": {"a": 0, "b": 0}},
+            ),
+        ],
+        mechanism_cluster="exact-integer-largest-remainder",
+    )

--- a/benchmarks/agent_tasks/corpus_families/bit_fields.py
+++ b/benchmarks/agent_tasks/corpus_families/bit_fields.py
@@ -1,0 +1,100 @@
+"""Byte-order normalization and two's-complement interpretation are separate steps."""
+
+from .model import Family, case, source
+
+
+def bit_fields(seed: int) -> Family:
+    contract = """# Packed register decoder
+
+Read `bytes` (integers 0..255), `byte_order` (little or big), and `fields` with
+unique string name, nonnegative offset, positive width, and boolean signed.
+Interpret the entire byte array as one unsigned integer in byte_order. Bit offset
+zero is always the least significant bit of that integer, independent of byte
+order. Extract width bits starting at offset. Signed fields use two's complement
+within that field's width, not the byte-array width. Fields may overlap and may
+span arbitrary byte boundaries; widths greater than 64 are valid. Return
+{"values": {name: integer}}. Any field extending beyond the available bits returns
+{"error": "invalid field"}; zero/negative widths and negative offsets do too.
+
+Cross-byte registers and signed subfields decode incorrectly. Repair byte-order
+handling and field interpretation. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from words import word
+        from fields import extract
+
+        def dispatch(request):
+            try:
+                value = word(request["bytes"], request["byte_order"])
+                return {"values": {field["name"]: extract(value, 8 * len(request["bytes"]), field) for field in request["fields"]}}
+            except ValueError:
+                return {"error": "invalid field"}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    words = source("""
+        def word(data, byte_order):
+            return int.from_bytes(bytes(data), "big")
+    """)
+    fields = source("""
+        def extract(value, bits, field):
+            offset, width = field["offset"], field["width"]
+            if offset < 0 or width <= 0 or offset + width > bits:
+                raise ValueError("invalid range")
+            return (value >> offset) & ((1 << width) - 1)
+    """)
+    fixed_words = words.replace('"big"', "byte_order")
+    fixed_fields = fields.replace(
+        "    return (value >> offset) & ((1 << width) - 1)",
+        '    extracted = (value >> offset) & ((1 << width) - 1)\n    if field["signed"] and extracted & (1 << (width - 1)):\n        extracted -= 1 << width\n    return extracted',
+    )
+
+    def field(offset, width, signed=False):
+        return {"name": f"field-{seed}", "offset": offset, "width": width, "signed": signed}
+
+    def request(data, order, selected):
+        return {"bytes": data, "byte_order": order, "fields": [selected]}
+
+    def answer(value):
+        return {"values": {f"field-{seed}": value}}
+
+    return Family(
+        "signed-register-fields",
+        "learning",
+        "packed-register-decoder-v1",
+        contract,
+        {"app.py": app, "words.py": words, "fields.py": fields},
+        {"words.py": fixed_words, "fields.py": fixed_fields},
+        {"words.py": fixed_words},
+        [
+            case("public-little", request([0x12, 0x34], "little", field(4, 8)), answer(0x41)),
+            case("public-big", request([0x12, 0x34], "big", field(4, 8)), answer(0x23)),
+        ],
+        [
+            case(
+                "private-signed-subfield",
+                request([0xF0, 0], "little", field(4, 4, True)),
+                answer(-1),
+            ),
+            case("private-signed-positive", request([0x70], "big", field(4, 4, True)), answer(7)),
+            case("private-sign-bit", request([0x80], "little", field(7, 1, True)), answer(-1)),
+            case("private-wide", request([255] * 12, "big", field(0, 96, True)), answer(-1)),
+            case(
+                "private-out-of-bounds",
+                request([0], "little", field(7, 2)),
+                {"error": "invalid field"},
+            ),
+            case(
+                "private-empty-width", request([0], "big", field(0, 0)), {"error": "invalid field"}
+            ),
+            case(
+                "private-negative-offset",
+                request([0], "little", field(-1, 1)),
+                {"error": "invalid field"},
+            ),
+        ],
+        mechanism_cluster="byte-order-signed-bit-extraction",
+    )

--- a/benchmarks/agent_tasks/corpus_families/build_planner.py
+++ b/benchmarks/agent_tasks/corpus_families/build_planner.py
@@ -1,0 +1,122 @@
+"""Dependency closure and deterministic scheduling of requested build targets."""
+
+from .model import Family, case, source
+
+
+def build_planner(seed: int) -> Family:
+    contract = """# Incremental build planner
+
+Read `targets` (mapping names to dependency-name lists) and `requested` names.
+Return {"order": [...]}, containing exactly the requested targets and their
+transitive dependencies once each. Dependencies must precede dependents. At every
+step choose the lexicographically smallest currently ready name. An unknown name
+or a cycle in the requested closure returns {"error": "invalid plan"}. Unrequested
+cycles or missing references do not invalidate a plan. Empty requests return an
+empty order. Duplicate dependency edges and requested names are harmless.
+
+Builds currently omit indirect prerequisites. A previous attempt to expand all
+targets also made unrelated broken targets block successful builds. Repair closure
+selection and scheduling. Run `python public_checks.py` for public examples.
+"""
+    app = source("""
+        import json
+        import sys
+        from closure import select
+        from schedule import order
+
+        def dispatch(request):
+            try:
+                return {"order": order(request["targets"], select(request["targets"], request["requested"]))}
+            except ValueError:
+                return {"error": "invalid plan"}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    closure = source("""
+        def select(targets, requested):
+            return set(requested)
+    """)
+    schedule = source("""
+        def order(targets, selected):
+            return sorted(selected)
+    """)
+    fixed_closure = source("""
+        def select(targets, requested):
+            selected = set()
+            pending = list(requested)
+            while pending:
+                name = pending.pop()
+                if name in selected:
+                    continue
+                if name not in targets:
+                    raise ValueError("missing target")
+                selected.add(name)
+                pending.extend(targets[name])
+            return selected
+    """)
+    fixed_schedule = source("""
+        def order(targets, selected):
+            remaining = set(selected)
+            emitted = set()
+            result = []
+            while remaining:
+                ready = sorted(name for name in remaining if set(targets[name]) <= emitted)
+                if not ready:
+                    raise ValueError("cycle")
+                name = ready[0]
+                remaining.remove(name)
+                emitted.add(name)
+                result.append(name)
+            return result
+    """)
+    leaf = f"z-lib-{seed}"
+    return Family(
+        "build-dependency-planning",
+        "development",
+        "build-closure-topological-v1",
+        contract,
+        {"app.py": app, "closure.py": closure, "schedule.py": schedule},
+        {"closure.py": fixed_closure, "schedule.py": fixed_schedule},
+        {"closure.py": fixed_closure},
+        [
+            case(
+                "public-closure",
+                {"targets": {"z": ["a"], "a": []}, "requested": ["z"]},
+                {"order": ["a", "z"]},
+            )
+        ],
+        [
+            case(
+                "private-order",
+                {"targets": {"a-app": [leaf], leaf: []}, "requested": ["a-app"]},
+                {"order": [leaf, "a-app"]},
+            ),
+            case(
+                "private-cycle",
+                {"targets": {"a": ["b"], "b": ["a"]}, "requested": ["a"]},
+                {"error": "invalid plan"},
+            ),
+            case(
+                "private-unknown",
+                {"targets": {"a": ["missing"]}, "requested": ["a"]},
+                {"error": "invalid plan"},
+            ),
+            case(
+                "private-unrelated",
+                {"targets": {"a": [], "b": ["b"]}, "requested": ["a", "a"]},
+                {"order": ["a"]},
+            ),
+            case(
+                "private-ready-tie",
+                {"targets": {"b": [], "a": ["b"], "c": []}, "requested": ["a", "c"]},
+                {"order": ["b", "a", "c"]},
+            ),
+            case(
+                "private-duplicate-edges",
+                {"targets": {"a": ["b", "b"], "b": []}, "requested": ["a"]},
+                {"order": ["b", "a"]},
+            ),
+        ],
+        mechanism_cluster="dependency-closure-topological-order",
+    )

--- a/benchmarks/agent_tasks/corpus_families/canonical_huffman.py
+++ b/benchmarks/agent_tasks/corpus_families/canonical_huffman.py
@@ -1,0 +1,190 @@
+"""Deterministic Huffman lengths and canonical prefix-code assignment repairs."""
+
+from .model import Family, case, source
+
+
+def canonical_huffman(seed: int) -> Family:
+    contract = """# Canonical telemetry token codec
+
+Read `frequencies`, an object mapping nonempty string symbols to positive integer
+weights, `text` as an array of those symbols, and a `bits` string to decode.
+Symbols are tokens, not individual characters. Construct Huffman lengths by
+repeatedly merging the two lowest-weight active trees. Break equal-weight ties
+by each tree's lexicographically smallest symbol (Python Unicode string order).
+A merged tree's weight is the sum and its tie key is the minimum of its leaves.
+Assign one-bit code "0" to a singleton alphabet. For larger alphabets, a symbol's
+length is its leaf depth. Empty alphabets are valid only for empty streams.
+
+Assign canonical codes in ascending (length, symbol) order: the first code is
+zero at its length; increment the previous code and left-shift by the increase
+in length. Pad to exactly the declared length. Return {"codes": symbol-to-bit
+strings, "encoded": concatenation of codes for text, "decoded": symbols from
+bits}. Any unknown text symbol, nonbinary bit, impossible prefix, or unfinished
+codeword returns {"error": "invalid stream"}. Never silently discard trailing
+bits. Integer weights and alphabet sizes have no fixed cap; use iterative tree
+traversal and decoding, without a call-stack depth limit.
+
+Codec tie ordering incorrectly ignores letter case, and its lengths waste bits. Repair tree
+selection and canonical ordering. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from lengths import lengths
+        from canonical import codes
+        from streams import decode
+        def dispatch(request):
+            table = codes(lengths(request["frequencies"]), request["frequencies"])
+            try:
+                encoded = "".join(table[symbol] for symbol in request["text"])
+                return {"codes": table, "encoded": encoded, "decoded": decode(request["bits"], table)}
+            except (KeyError, ValueError):
+                return {"error": "invalid stream"}
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    lengths = source("""
+        import heapq
+        def lengths(frequencies):
+            heap = [(-weight, symbol, symbol) for symbol, weight in frequencies.items()]
+            heapq.heapify(heap)
+            while len(heap) > 1:
+                wa, ka, a = heapq.heappop(heap)
+                wb, kb, b = heapq.heappop(heap)
+                heapq.heappush(heap, (wa + wb, min(ka, kb), (a, b)))
+            result = {}
+            pending = [(heap[0][2], 0)] if heap else []
+            while pending:
+                node, depth = pending.pop()
+                if isinstance(node, str):
+                    result[node] = max(1, depth)
+                else:
+                    pending.extend((child, depth + 1) for child in node)
+            return result
+    """)
+    fixed_lengths = lengths.replace("(-weight, symbol, symbol)", "(weight, symbol, symbol)")
+    canonical = source("""
+        def codes(lengths, frequencies):
+            ordered = sorted(frequencies, key=lambda symbol: (lengths[symbol], symbol.casefold()))
+            result, value, previous = {}, 0, 0
+            for symbol in ordered:
+                width = lengths[symbol]
+                value <<= width - previous
+                result[symbol] = format(value, "0" + str(width) + "b")
+                value += 1
+                previous = width
+            return result
+    """)
+    fixed_canonical = canonical.replace(
+        "key=lambda symbol: (lengths[symbol], symbol.casefold())",
+        "key=lambda symbol: (lengths[symbol], symbol)",
+    )
+    streams = source("""
+        def decode(bits, table):
+            trie = {}
+            for symbol, code in table.items():
+                node = trie
+                for bit in code:
+                    node = node.setdefault(bit, {})
+                node["symbol"] = symbol
+            result, node = [], trie
+            for bit in bits:
+                if bit not in ("0", "1") or bit not in node:
+                    raise ValueError("invalid prefix")
+                node = node[bit]
+                if "symbol" in node:
+                    result.append(node["symbol"])
+                    node = trie
+            if node is not trie:
+                raise ValueError("unfinished codeword")
+            return result
+    """)
+
+    def check(label, frequencies, text, bits, expected):
+        return case(label, {"frequencies": frequencies, "text": text, "bits": bits}, expected)
+
+    table = {"a": "0", "b": "10", "c": "11"}
+    return Family(
+        "canonical-telemetry-codec",
+        "learning",
+        "huffman-canonical-token-codec-v1",
+        contract,
+        {"app.py": app, "lengths.py": lengths, "canonical.py": canonical, "streams.py": streams},
+        {"lengths.py": fixed_lengths, "canonical.py": fixed_canonical},
+        {"lengths.py": fixed_lengths},
+        [
+            check(
+                "public-optimal-lengths",
+                {"a": 3, "b": 2, "c": 1},
+                ["a", "b", "c"],
+                "01011",
+                {"codes": table, "encoded": "01011", "decoded": ["a", "b", "c"]},
+            )
+        ],
+        [
+            check(
+                "private-case-sensitive-order",
+                {"B": 1, "a": 1},
+                ["B", "a"],
+                "01",
+                {"codes": {"B": "0", "a": "1"}, "encoded": "01", "decoded": ["B", "a"]},
+            ),
+            check(
+                "private-unicode-order",
+                {"Z": 1, "a": 1, "ß": 1, "é": 1},
+                ["Z", "a", "ß", "é"],
+                "00011011",
+                {
+                    "codes": {"Z": "00", "a": "01", "ß": "10", "é": "11"},
+                    "encoded": "00011011",
+                    "decoded": ["Z", "a", "ß", "é"],
+                },
+            ),
+            check(
+                "private-input-order",
+                {"c": 1, "b": 2, "a": 3},
+                ["a", "b", "c"],
+                "11100",
+                {"codes": table, "encoded": "01011", "decoded": ["c", "b", "a"]},
+            ),
+            check(
+                "private-tree-weight-tie",
+                {"a": 1, "b": 1, "c": 2},
+                ["a", "c", "b"],
+                "10011",
+                {
+                    "codes": {"c": "0", "a": "10", "b": "11"},
+                    "encoded": "10011",
+                    "decoded": ["a", "c", "b"],
+                },
+            ),
+            check(
+                "private-equal-weights",
+                {"d": 1, "c": 1, "b": 1, "a": 1},
+                ["d", "a"],
+                "1001",
+                {
+                    "codes": {"a": "00", "b": "01", "c": "10", "d": "11"},
+                    "encoded": "1100",
+                    "decoded": ["c", "b"],
+                },
+            ),
+            check(
+                "private-singleton-token",
+                {"token": 10**30 + seed},
+                ["token", "token"],
+                "000",
+                {"codes": {"token": "0"}, "encoded": "00", "decoded": ["token"] * 3},
+            ),
+            check(
+                "private-empty-alphabet", {}, [], "", {"codes": {}, "encoded": "", "decoded": []}
+            ),
+            check("private-impossible-prefix", {"a": 1}, [], "1", {"error": "invalid stream"}),
+            check(
+                "private-unfinished", {"a": 3, "b": 2, "c": 1}, [], "1", {"error": "invalid stream"}
+            ),
+            check("private-nonbinary", {"a": 1}, [], "x", {"error": "invalid stream"}),
+            check("private-unknown-token", {"a": 1}, ["b"], "", {"error": "invalid stream"}),
+        ],
+        mechanism_cluster="huffman-lengths-canonical-prefix-codes",
+    )

--- a/benchmarks/agent_tasks/corpus_families/commands.py
+++ b/benchmarks/agent_tasks/corpus_families/commands.py
@@ -1,0 +1,151 @@
+"""Tenant-scoped command replay with rejection and payload conflicts."""
+
+from .model import Family, case, source
+
+
+def commands(seed: int) -> Family:
+    contract = """# Account command processor
+
+Process `commands` in arrival order against integer `balances` keyed by
+`tenant/account`. Each command contains tenant, account, id, and signed integer
+amount. Missing accounts begin at zero. A command making the balance negative
+returns `rejected` and has no effect, including on replay tracking.
+
+A successfully applied command reserves its id within its tenant. Repeating the
+same account and amount under that tenant/id returns `duplicate` without applying
+it again. Reusing that tenant/id for a different account or amount returns
+`conflict`, with no effect. Other tenants may independently use the same id.
+Return {"balances": updated_balances, "results": statuses_in_input_order}.
+Do not create a missing account on rejection. All fields have the declared types.
+
+Retries and declined commands currently produce inconsistent account exports.
+Repair the processing path while retaining its state-store interface.
+Run `python public_checks.py` for the public examples.
+"""
+    entry = source("""
+        import json
+        import sys
+        from ledger import Ledger
+        from operations import execute
+
+        def process(batch):
+            ledger = Ledger(batch["balances"])
+            results = [execute(ledger, command) for command in batch["commands"]]
+            return {"balances": ledger.balances, "results": results}
+
+        if __name__ == "__main__":
+            request = json.load(sys.stdin)
+            json.dump(process(request), sys.stdout)
+    """)
+    ledger = source("""
+        class Ledger:
+            def __init__(self, balances):
+                self.balances = dict(balances)
+                self.applied = {}
+
+            def previous(self, key):
+                return self.applied.get(key)
+
+            def record(self, key, payload):
+                self.applied[key] = payload
+
+            def change(self, account, amount):
+                updated = self.balances.get(account, 0) + amount
+                if updated < 0:
+                    return False
+                self.balances[account] = updated
+                return True
+    """)
+    operations = source("""
+        def execute(ledger, command):
+            account = command["tenant"] + "/" + command["account"]
+            key = command["id"]
+            payload = (account, command["amount"])
+            ledger.record(key, payload)
+            return "applied" if ledger.change(account, command["amount"]) else "rejected"
+    """)
+    partial = operations.replace(
+        "    ledger.record(key, payload)",
+        '    if ledger.previous(key) is not None:\n        return "duplicate"\n    ledger.record(key, payload)',
+    )
+    repaired = source("""
+        def execute(ledger, command):
+            account = command["tenant"] + "/" + command["account"]
+            key = (command["tenant"], command["id"])
+            payload = (account, command["amount"])
+            previous = ledger.previous(key)
+            if previous is not None:
+                return "duplicate" if previous == payload else "conflict"
+            if not ledger.change(account, command["amount"]):
+                return "rejected"
+            ledger.record(key, payload)
+            return "applied"
+    """)
+
+    def command(identifier, amount, tenant="a", account="cash"):
+        return {"id": identifier, "amount": amount, "tenant": tenant, "account": account}
+
+    amount = seed + 3
+    return Family(
+        "idempotent-commands",
+        "learning",
+        "account-command-log-v1",
+        contract,
+        {"app.py": entry, "ledger.py": ledger, "operations.py": operations},
+        {"operations.py": repaired},
+        {"operations.py": partial},
+        [
+            case(
+                "public-retry",
+                {"balances": {}, "commands": [command("credit", amount)] * 2},
+                {"balances": {"a/cash": amount}, "results": ["applied", "duplicate"]},
+            ),
+            case(
+                "public-decline",
+                {"balances": {}, "commands": [command("debit", -amount)]},
+                {"balances": {}, "results": ["rejected"]},
+            ),
+        ],
+        [
+            case(
+                "private-tenant",
+                {
+                    "balances": {},
+                    "commands": [command("same", amount), command("same", amount, tenant="b")],
+                },
+                {
+                    "balances": {"a/cash": amount, "b/cash": amount},
+                    "results": ["applied", "applied"],
+                },
+            ),
+            case(
+                "private-retry-after-credit",
+                {
+                    "balances": {},
+                    "commands": [
+                        command("debit", -2),
+                        command("credit", amount),
+                        command("debit", -2),
+                    ],
+                },
+                {"balances": {"a/cash": amount - 2}, "results": ["rejected", "applied", "applied"]},
+            ),
+            case(
+                "private-conflicting-payload",
+                {"balances": {}, "commands": [command("same", amount), command("same", 1)]},
+                {"balances": {"a/cash": amount}, "results": ["applied", "conflict"]},
+            ),
+            case(
+                "private-conflicting-account",
+                {
+                    "balances": {},
+                    "commands": [
+                        command("same", amount),
+                        command("same", amount, account="reserve"),
+                    ],
+                },
+                {"balances": {"a/cash": amount}, "results": ["applied", "conflict"]},
+            ),
+        ],
+        mechanism_cluster="tenant-idempotency-ledger",
+    )

--- a/benchmarks/agent_tasks/corpus_families/configuration.py
+++ b/benchmarks/agent_tasks/corpus_families/configuration.py
@@ -1,0 +1,130 @@
+"""Configuration reduction and post-reduction schema validation."""
+
+from .model import Family, case, source
+
+
+def configuration(seed: int) -> Family:
+    contract = """# Release configuration service
+
+The CLI reads defaults, profiles, and requested names in `order`, then an `override`
+object. Apply defaults, each named profile in order, then the override. An absent
+profile contributes nothing. Keys present in a later layer replace earlier values,
+including false, zero and an empty string. A null value removes a key.
+
+The final configuration must contain nonempty string `service`, boolean `enabled`,
+and nonnegative integer `limit` (booleans are not integers here). Only those keys
+and optional string `label` are accepted. Validate the final result, not individual
+layers. Return {"config": result} or {"error": "invalid configuration"}. The input
+layers must remain unchanged. Malformed top-level documents are outside the task.
+
+Operations reports say valid overrides sometimes disappear and combinations of
+otherwise reasonable profiles reach deployment with invalid configurations.
+Find the interaction between reduction and validation and repair the service.
+Run `python public_checks.py` for the public examples.
+"""
+    entry = source("""
+        import json
+        import sys
+        from layers import resolve
+        from schema import valid
+
+        def dispatch(document):
+            if not valid(document["defaults"]):
+                return {"error": "invalid configuration"}
+            merged = resolve(document)
+            return {"config": merged}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    layers = source("""
+        def overlay(current, changes):
+            updated = dict(current)
+            for key, value in changes.items():
+                if value is None:
+                    updated.pop(key, None)
+                else:
+                    updated[key] = value or updated.get(key)
+            return updated
+
+        def resolve(document):
+            result = dict(document["defaults"])
+            for name in document["order"]:
+                result = overlay(result, document["profiles"].get(name, {}))
+            return overlay(result, document["override"])
+    """)
+    schema = source("""
+        def valid(configuration):
+            allowed = {"service", "enabled", "limit", "label"}
+            return (
+                not set(configuration).difference(allowed)
+                and isinstance(configuration.get("service"), str)
+                and bool(configuration["service"])
+                and type(configuration.get("enabled")) is bool
+                and type(configuration.get("limit")) is int
+                and configuration["limit"] >= 0
+                and ("label" not in configuration or isinstance(configuration["label"], str))
+            )
+    """)
+    fixed_layers = layers.replace("value or updated.get(key)", "value")
+    fixed_entry = entry.replace(
+        'if not valid(document["defaults"]):',
+        "merged = resolve(document)\n    if not valid(merged):",
+    ).replace("    merged = resolve(document)\n    return", "    return")
+    defaults = {"service": f"release-{seed}", "enabled": True, "limit": 10 + seed, "label": "old"}
+
+    def document(override, profiles=None, order=None, initial=None):
+        return {
+            "defaults": initial or defaults,
+            "profiles": profiles or {},
+            "order": order or [],
+            "override": override,
+        }
+
+    return Family(
+        "layered-configuration",
+        "learning",
+        "configuration-reducer-v1",
+        contract,
+        {"app.py": entry, "layers.py": layers, "schema.py": schema},
+        {"app.py": fixed_entry, "layers.py": fixed_layers},
+        {"layers.py": fixed_layers},
+        [
+            case(
+                "public-falsey",
+                document({"enabled": False, "limit": 0, "label": ""}),
+                {"config": defaults | {"enabled": False, "limit": 0, "label": ""}},
+            ),
+            case(
+                "public-order",
+                document({}, {"one": {"limit": 4}, "two": {"limit": 7}}, ["one", "missing", "two"]),
+                {"config": defaults | {"limit": 7}},
+            ),
+        ],
+        [
+            case(
+                "private-required-deleted",
+                document({"service": None}),
+                {"error": "invalid configuration"},
+            ),
+            case(
+                "private-final-unknown",
+                document({"surprise": 1}),
+                {"error": "invalid configuration"},
+            ),
+            case(
+                "private-repaired-layer",
+                document({"service": "fixed"}, initial=defaults | {"service": ""}),
+                {"config": defaults | {"service": "fixed"}},
+            ),
+            case(
+                "private-remove-label",
+                document({"label": None}),
+                {"config": {k: v for k, v in defaults.items() if k != "label"}},
+            ),
+            case(
+                "private-bool-limit", document({"limit": False}), {"error": "invalid configuration"}
+            ),
+        ],
+        mechanism_cluster="ordered-layer-validation",
+    )

--- a/benchmarks/agent_tasks/corpus_families/field_reconstruction.py
+++ b/benchmarks/agent_tasks/corpus_families/field_reconstruction.py
@@ -1,0 +1,120 @@
+"""Finite-field interpolation and duplicate sample normalization repairs."""
+
+from .model import Family, case, source
+
+
+def field_reconstruction(seed: int) -> Family:
+    contract = """# Shard sample reconstruction
+
+Read a prime integer `modulus` >= 2, `samples` as [x,y] integer pairs, and integer
+`queries`. The caller guarantees a prime modulus. Normalize every x, y, and query
+modulo that prime. Repeated normalized x values with equal normalized y count as
+one sample. Conflicting y values at the same normalized x return
+{"error": "conflicting sample"}. No samples returns {"error": "no samples"}.
+For n distinct samples, evaluate the unique polynomial of degree less than n
+through those samples at each query, in query order. Return {"values": [integers
+in 0..modulus-1]}. Negative and arbitrarily large integers are valid. One sample
+specifies a constant polynomial. Use exact modular arithmetic, not floating point.
+
+Shard reconstruction currently divides integers before reducing, and repeated
+sample coordinates create zero denominators. Repair sample normalization and
+interpolation. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from samples import normalize
+        from interpolate import evaluate
+        def dispatch(request):
+            try:
+                modulus = request["modulus"]
+                points = normalize(request["samples"], modulus)
+                if not points:
+                    return {"error": "no samples"}
+                return {"values": [evaluate(points, x % modulus, modulus) for x in request["queries"]]}
+            except ValueError:
+                return {"error": "conflicting sample"}
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    samples = source("""
+        def normalize(samples, modulus):
+            return [(x % modulus, y % modulus) for x, y in samples]
+    """)
+    fixed_samples = source("""
+        def normalize(samples, modulus):
+            unique = {}
+            for x, y in samples:
+                x, y = x % modulus, y % modulus
+                if x in unique and unique[x] != y:
+                    raise ValueError("conflicting sample")
+                unique[x] = y
+            return list(unique.items())
+    """)
+    interpolate = source("""
+        def evaluate(points, x, modulus):
+            total = 0
+            for i, (xi, yi) in enumerate(points):
+                numerator = denominator = 1
+                for j, (xj, _) in enumerate(points):
+                    if i != j:
+                        numerator = numerator * (x - xj) % modulus
+                        denominator = denominator * (xi - xj) % modulus
+                total = (total + yi * (numerator // denominator)) % modulus
+            return total
+    """)
+    fixed_interpolate = interpolate.replace(
+        "(numerator // denominator)", "(numerator * pow(denominator, -1, modulus))"
+    )
+
+    def check(label, modulus, samples, queries, expected):
+        return case(label, {"modulus": modulus, "samples": samples, "queries": queries}, expected)
+
+    return Family(
+        "finite-field-shard-reconstruction",
+        "learning",
+        "prime-field-interpolation-v1",
+        contract,
+        {"app.py": app, "samples.py": samples, "interpolate.py": interpolate},
+        {"samples.py": fixed_samples, "interpolate.py": fixed_interpolate},
+        {"interpolate.py": fixed_interpolate},
+        [check("public-modular-inverse", 7, [[0, 1], [2, 5]], [1, 3], {"values": [3, 0]})],
+        [
+            check(
+                "private-duplicate-coordinate",
+                7,
+                [[0, 1], [7, 8], [2, 5]],
+                [1, 3],
+                {"values": [3, 0]},
+            ),
+            check(
+                "private-conflicting-coordinate",
+                7,
+                [[0, 1], [7, 2]],
+                [0],
+                {"error": "conflicting sample"},
+            ),
+            check(
+                "private-negative-residues", 7, [[-7, -6], [-5, -2]], [-6, -4], {"values": [3, 0]}
+            ),
+            check(
+                "private-quadratic",
+                101,
+                [[0, seed], [1, seed + 1], [2, seed + 4]],
+                [3, 10, -1],
+                {"values": [(seed + 9) % 101, (seed + 100) % 101, (seed + 1) % 101]},
+            ),
+            check(
+                "private-large-prime",
+                2**61 - 1,
+                [[0, 4], [2, 10]],
+                [10**40],
+                {"values": [(3 * 10**40 + 4) % (2**61 - 1)]},
+            ),
+            check("private-constant", 7, [[3, -2]], [0, 1, 100], {"values": [5, 5, 5]}),
+            check("private-prime-two", 2, [[0, 1], [1, 0]], [0, 1, 2], {"values": [1, 0, 1]}),
+            check("private-empty-samples", 7, [], [1], {"error": "no samples"}),
+            check("private-empty-queries", 7, [[1, 2]], [], {"values": []}),
+        ],
+        mechanism_cluster="prime-field-lagrange-reconstruction",
+    )

--- a/benchmarks/agent_tasks/corpus_families/indexing.py
+++ b/benchmarks/agent_tasks/corpus_families/indexing.py
@@ -1,0 +1,144 @@
+"""Versioned document storage and incremental inverted-index maintenance."""
+
+from .model import Family, case, source
+
+
+def indexing(seed: int) -> Family:
+    contract = """# Incremental document search
+
+Apply `events` in arrival order. Each event has string id, nonnegative integer
+version, boolean deleted, and string text. An event replaces a document only if
+its version is at least the stored version; equal versions use the later event.
+Deleted documents retain their version for rejecting stale resurrection.
+
+Search terms are whitespace-separated tokens normalized with str.casefold().
+Each query matches live documents containing every query token. Empty queries
+return all live ids. Return {"matches": [sorted_ids_for_each_query]} using Python
+string ordering. Updating text or deleting a document must remove its old search
+terms; repeated tokens do not duplicate results. All fields have valid types.
+
+After replay and updates, search results disagree with the document contents.
+Repair consistency between the version store and its incremental index.
+Run `python public_checks.py` for the public examples.
+"""
+    app = source("""
+        import json
+        import sys
+        from documents import Documents
+        from postings import Postings
+
+        def search_batch(document):
+            documents = Documents()
+            index = Postings()
+            for event in document["events"]:
+                if documents.accept(event):
+                    index.replace(event["id"], "" if event["deleted"] else event["text"])
+            live = {key for key, value in documents.rows.items() if not value["deleted"]}
+            return {"matches": [sorted(index.search(query, live)) for query in document["queries"]]}
+
+        if __name__ == "__main__":
+            result = search_batch(json.load(sys.stdin))
+            sys.stdout.write(json.dumps(result))
+    """)
+    documents = source("""
+        class Documents:
+            def __init__(self):
+                self.rows = {}
+
+            def accept(self, event):
+                self.rows[event["id"]] = dict(event)
+                return True
+    """)
+    fixed_documents = documents.replace(
+        '        self.rows[event["id"]] = dict(event)',
+        '        previous = self.rows.get(event["id"])\n        if previous is not None and event["version"] < previous["version"]:\n            return False\n        self.rows[event["id"]] = dict(event)',
+    )
+    postings = source("""
+        def tokens(text):
+            return set(text.casefold().split())
+
+        class Postings:
+            def __init__(self):
+                self.terms = {}
+                self.by_document = {}
+
+            def replace(self, identifier, text):
+                current = tokens(text)
+                for term in current:
+                    self.terms.setdefault(term, set()).add(identifier)
+                self.by_document[identifier] = current
+
+            def search(self, query, live):
+                result = set(live)
+                for term in tokens(query):
+                    result.intersection_update(self.terms.get(term, set()))
+                return result
+    """)
+    fixed_postings = postings.replace(
+        "        current = tokens(text)",
+        "        for term in self.by_document.get(identifier, set()):\n            self.terms[term].discard(identifier)\n        current = tokens(text)",
+    )
+    identifier = f"doc-{seed}"
+
+    def event(version, text, deleted=False, key=identifier):
+        return {"id": key, "version": version, "text": text, "deleted": deleted}
+
+    return Family(
+        "incremental-index",
+        "learning",
+        "document-postings-projector-v1",
+        contract,
+        {"app.py": app, "documents.py": documents, "postings.py": postings},
+        {"documents.py": fixed_documents, "postings.py": fixed_postings},
+        {"documents.py": fixed_documents},
+        [
+            case(
+                "public-stale-update",
+                {"events": [event(3, "blue sky"), event(1, "red")], "queries": ["blue", "red"]},
+                {"matches": [[identifier], []]},
+            ),
+            case(
+                "public-normalization",
+                {"events": [event(1, "Blue BLUE sky")], "queries": ["blue sky", "", "snow"]},
+                {"matches": [[identifier], [identifier], []]},
+            ),
+        ],
+        [
+            case(
+                "private-term-removal",
+                {"events": [event(1, "blue"), event(2, "red")], "queries": ["blue", "red"]},
+                {"matches": [[], [identifier]]},
+            ),
+            case(
+                "private-equal-version",
+                {"events": [event(2, "old"), event(2, "new")], "queries": ["old", "new"]},
+                {"matches": [[], [identifier]]},
+            ),
+            case(
+                "private-tombstone",
+                {"events": [event(3, "", True), event(1, "ghost")], "queries": ["", "ghost"]},
+                {"matches": [[], []]},
+            ),
+            case(
+                "private-delete-recreate",
+                {
+                    "events": [event(1, "stale"), event(2, "", True), event(3, "fresh")],
+                    "queries": ["stale", "fresh"],
+                },
+                {"matches": [[], [identifier]]},
+            ),
+            case(
+                "private-multiple-documents",
+                {
+                    "events": [
+                        event(1, "red", key="other"),
+                        event(1, "red blue"),
+                        event(2, "green"),
+                    ],
+                    "queries": ["red", ""],
+                },
+                {"matches": [["other"], sorted(["other", identifier])]},
+            ),
+        ],
+        mechanism_cluster="newest-revision-active-projection",
+    )

--- a/benchmarks/agent_tasks/corpus_families/interval_capacity.py
+++ b/benchmarks/agent_tasks/corpus_families/interval_capacity.py
@@ -1,0 +1,116 @@
+"""Sweep resource demand across half-open intervals with simultaneous events."""
+
+from .model import Family, case, source
+
+
+def interval_capacity(seed: int) -> Family:
+    contract = """# Worker capacity planner
+
+Read nonnegative integer `capacity` and `jobs` with integer start/end times and
+nonnegative integer units. Jobs occupy [start, end): start is included and end is
+excluded. A job with start == end consumes nothing; start > end makes the whole
+request invalid. Return {"peak": greatest concurrent units, "overloaded": [...]}
+where overloaded is the sorted list of maximal half-open intervals with demand
+strictly greater than capacity. Merge adjacent overloaded intervals, even when
+the amount of excess changes. Empty input has peak zero and no intervals.
+Invalid input returns {"error": "invalid interval"}.
+
+The planner treats non-overlapping jobs as simultaneous and splits continuous
+overload into fragments. Repair event construction and the sweep projection.
+Run `python public_checks.py` for public examples.
+"""
+    app = source("""
+        import json
+        import sys
+        from events import events
+        from sweep import summarize
+
+        def dispatch(request):
+            try:
+                return summarize(events(request["jobs"]), request["capacity"])
+            except ValueError:
+                return {"error": "invalid interval"}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    events = source("""
+        def events(jobs):
+            result = {}
+            for job in jobs:
+                if job["start"] > job["end"]:
+                    raise ValueError("reversed")
+                result[job["start"]] = result.get(job["start"], 0) + job["units"]
+            return sorted(result.items())
+    """)
+    sweep = source("""
+        def summarize(events, capacity):
+            peak = current = 0
+            overloaded = []
+            for index, (time, delta) in enumerate(events):
+                current += delta
+                peak = max(peak, current)
+                if index + 1 < len(events) and current > capacity:
+                    overloaded.append([time, events[index + 1][0]])
+            return {"peak": peak, "overloaded": overloaded}
+    """)
+    fixed_events = events.replace(
+        '        result[job["start"]]',
+        '        result[job["end"]] = result.get(job["end"], 0) - job["units"]\n        result[job["start"]]',
+    )
+    fixed_sweep = sweep.replace(
+        "            overloaded.append([time, events[index + 1][0]])",
+        "            end = events[index + 1][0]\n            if overloaded and overloaded[-1][1] == time:\n                overloaded[-1][1] = end\n            else:\n                overloaded.append([time, end])",
+    )
+
+    def request(capacity, jobs):
+        return {
+            "capacity": capacity,
+            "jobs": [
+                {"start": start + seed, "end": end + seed, "units": units}
+                for start, end, units in jobs
+            ],
+        }
+
+    return Family(
+        "half-open-capacity-sweep",
+        "learning",
+        "worker-demand-interval-sweep-v1",
+        contract,
+        {"app.py": app, "events.py": events, "sweep.py": sweep},
+        {"events.py": fixed_events, "sweep.py": fixed_sweep},
+        {"events.py": fixed_events},
+        [
+            case(
+                "public-disjoint", request(3, [(0, 2, 3), (2, 4, 3)]), {"peak": 3, "overloaded": []}
+            ),
+            case(
+                "public-overlap",
+                request(4, [(0, 3, 3), (1, 2, 2)]),
+                {"peak": 5, "overloaded": [[seed + 1, seed + 2]]},
+            ),
+        ],
+        [
+            case(
+                "private-continuous",
+                request(2, [(0, 4, 3), (1, 3, 2)]),
+                {"peak": 5, "overloaded": [[seed, seed + 4]]},
+            ),
+            case(
+                "private-empty-interval", request(0, [(1, 1, 100)]), {"peak": 0, "overloaded": []}
+            ),
+            case("private-reversed", request(4, [(3, 2, 1)]), {"error": "invalid interval"}),
+            case(
+                "private-simultaneous",
+                request(3, [(0, 2, 4), (2, 5, 4)]),
+                {"peak": 4, "overloaded": [[seed, seed + 5]]},
+            ),
+            case(
+                "private-zero-units",
+                request(2, [(0, 5, 3), (2, 4, 0)]),
+                {"peak": 3, "overloaded": [[seed, seed + 5]]},
+            ),
+            case("private-empty", request(0, []), {"peak": 0, "overloaded": []}),
+        ],
+        mechanism_cluster="half-open-demand-event-sweep",
+    )

--- a/benchmarks/agent_tasks/corpus_families/knapsack.py
+++ b/benchmarks/agent_tasks/corpus_families/knapsack.py
@@ -1,0 +1,130 @@
+"""Exact small-set optimization with explicit tie-breaking and large integer weights."""
+
+from .model import Family, case, source
+
+
+def knapsack(seed: int) -> Family:
+    contract = """# Small release payload optimizer
+
+Read nonnegative integer `capacity` and up to 18 items, each with unique string id,
+nonnegative integer weight and value. Each item may be selected at most once.
+Maximize selected value subject to total weight <= capacity. Break ties by lower
+total weight, then fewer selected items, then lexicographically smaller tuples of
+input indices. Return {"value": total, "weight": total, "items": [selected_ids]}
+in input order. Zero-weight items are valid. Empty selection is allowed.
+
+The 18-item domain permits exact subset optimization for this NP-hard problem;
+weights/capacity can be huge integers, so a capacity-sized array is inappropriate.
+More than 18 items returns {"error": "too many items"}.
+
+Greedy payloads waste available value, and equal-value selections are unstable.
+Repair candidate generation and winner selection. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from candidates import candidates
+        from choose import choose
+
+        def dispatch(request):
+            if len(request["items"]) > 18:
+                return {"error": "too many items"}
+            winner = choose(candidates(request["items"], request["capacity"]))
+            value, weight, indices = winner
+            return {"value": value, "weight": weight, "items": [request["items"][i]["id"] for i in indices]}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    candidates = source("""
+        def candidates(items, capacity):
+            selected = []
+            weight = value = 0
+            for index in sorted(range(len(items)), key=lambda i: items[i]["value"], reverse=True):
+                item = items[index]
+                if weight + item["weight"] <= capacity:
+                    selected.append(index)
+                    weight += item["weight"]
+                    value += item["value"]
+            yield value, weight, tuple(sorted(selected))
+    """)
+    choose = source("""
+        def choose(candidates):
+            return max(candidates, key=lambda item: item[0])
+    """)
+    fixed_candidates = source("""
+        def candidates(items, capacity):
+            for mask in range(1 << len(items)):
+                indices = tuple(i for i in range(len(items)) if mask & (1 << i))
+                weight = sum(items[i]["weight"] for i in indices)
+                if weight <= capacity:
+                    yield sum(items[i]["value"] for i in indices), weight, indices
+    """)
+    fixed_choose = source("""
+        def choose(candidates):
+            return min(candidates, key=lambda item: (-item[0], item[1], len(item[2]), item[2]))
+    """)
+
+    def request(capacity, rows):
+        return {
+            "capacity": capacity,
+            "items": [
+                {"id": name, "weight": weight, "value": value} for name, weight, value in rows
+            ],
+        }
+
+    def answer(value, weight, ids):
+        return {"value": value, "weight": weight, "items": ids}
+
+    huge = 10**25 + seed
+    return Family(
+        "exact-payload-knapsack",
+        "learning",
+        "small-release-subset-optimizer-v1",
+        contract,
+        {"app.py": app, "candidates.py": candidates, "choose.py": choose},
+        {"candidates.py": fixed_candidates, "choose.py": fixed_choose},
+        {"candidates.py": fixed_candidates},
+        [
+            case(
+                "public-greedy-trap",
+                request(6, [("large", 5, 8), ("left", 3, 5), ("right", 3, 5)]),
+                answer(10, 6, ["left", "right"]),
+            )
+        ],
+        [
+            case(
+                "private-lower-weight",
+                request(5, [("heavy", 5, 7), ("light", 3, 7)]),
+                answer(7, 3, ["light"]),
+            ),
+            case(
+                "private-fewer-items",
+                request(2, [("a", 1, 2), ("b", 1, 2), ("c", 2, 4)]),
+                answer(4, 2, ["c"]),
+            ),
+            case("private-input-tie", request(1, [("z", 1, 5), ("a", 1, 5)]), answer(5, 1, ["z"])),
+            case(
+                "private-zero-weight",
+                request(0, [("free", 0, 3), ("empty", 0, 0)]),
+                answer(3, 0, ["free"]),
+            ),
+            case(
+                "private-huge-weight",
+                request(huge, [("a", huge, 8), ("b", huge - 1, 8)]),
+                answer(8, huge - 1, ["b"]),
+            ),
+            case("private-empty", request(0, []), answer(0, 0, [])),
+            case(
+                "private-domain-boundary",
+                request(18, [(str(i), 1, 1) for i in range(18)]),
+                answer(18, 18, [str(i) for i in range(18)]),
+            ),
+            case(
+                "private-outside-domain",
+                request(19, [(str(i), 1, 1) for i in range(19)]),
+                {"error": "too many items"},
+            ),
+        ],
+        mechanism_cluster="zero-one-subset-optimization",
+    )

--- a/benchmarks/agent_tasks/corpus_families/model.py
+++ b/benchmarks/agent_tasks/corpus_families/model.py
@@ -1,0 +1,27 @@
+"""Authored development fixtures, never recorded agent experiences."""
+
+from dataclasses import dataclass, field
+from textwrap import dedent
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class Family:
+    id: str
+    split: Literal["learning", "development"]
+    lineage: str
+    mechanism_cluster: str = field(kw_only=True)
+    contract: str
+    workspace: dict[str, str]
+    reference: dict[str, str]
+    partial: dict[str, str]
+    public_cases: list[dict[str, Any]]
+    private_cases: list[dict[str, Any]]
+
+
+def source(text: str) -> str:
+    return dedent(text).lstrip()
+
+
+def case(name: str, inputs: dict[str, Any], expected: Any) -> dict[str, Any]:
+    return {"id": name, "input": inputs, "expected": expected}

--- a/benchmarks/agent_tasks/corpus_families/outer_join.py
+++ b/benchmarks/agent_tasks/corpus_families/outer_join.py
@@ -1,0 +1,116 @@
+"""Left outer join retains duplicate multiplicity while NULL keys never match."""
+
+from .model import Family, case, source
+
+
+def outer_join(seed: int) -> Family:
+    contract = """# Customer enrichment join
+
+Read `left` and `right` arrays of rows with unique string id within each array
+and optional key (string or null). Produce a left outer equijoin. A missing key
+is NULL, and NULL never matches another key, including NULL. Every matching
+right row produces one result per left row; unmatched left rows produce one
+result with right:null. Return {"rows": [{"left": id, "right": id_or_null}, ...]}.
+Preserve left input order and, within each left row, right input order. Duplicate
+non-null keys are valid and retain their full multiplicity. Inputs remain unchanged.
+
+Enrichment silently loses duplicate partners and associates unknown customers.
+Repair indexing and join expansion. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from lookup import build
+        from join import expand
+
+        def dispatch(request):
+            return {"rows": expand(request["left"], build(request["right"]))}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    lookup = source("""
+        def build(rows):
+            index = {}
+            for row in rows:
+                index[row.get("key")] = [row["id"]]
+            return index
+    """)
+    join = source("""
+        def expand(left, index):
+            result = []
+            for row in left:
+                for partner in index.get(row.get("key"), [None]):
+                    result.append({"left": row["id"], "right": partner})
+            return result
+    """)
+    partial = lookup.replace(
+        'index[row.get("key")] = [row["id"]]',
+        'index.setdefault(row.get("key"), []).append(row["id"])',
+    )
+    reference = partial.replace(
+        "        index.setdefault",
+        '        if row.get("key") is None:\n            continue\n        index.setdefault',
+    )
+
+    def request(left, right):
+        return {"left": left, "right": right}
+
+    key = f"customer-{seed}"
+    return Family(
+        "null-aware-outer-join",
+        "learning",
+        "customer-multiset-left-join-v1",
+        contract,
+        {"app.py": app, "lookup.py": lookup, "join.py": join},
+        {"lookup.py": reference},
+        {"lookup.py": partial},
+        [
+            case(
+                "public-multiplicity",
+                request(
+                    [{"id": "a", "key": key}], [{"id": "x", "key": key}, {"id": "y", "key": key}]
+                ),
+                {"rows": [{"left": "a", "right": "x"}, {"left": "a", "right": "y"}]},
+            )
+        ],
+        [
+            case(
+                "private-null",
+                request([{"id": "a", "key": None}], [{"id": "x", "key": None}]),
+                {"rows": [{"left": "a", "right": None}]},
+            ),
+            case(
+                "private-missing",
+                request([{"id": "a"}], [{"id": "x"}]),
+                {"rows": [{"left": "a", "right": None}]},
+            ),
+            case(
+                "private-empty-key",
+                request([{"id": "a", "key": ""}], [{"id": "x", "key": ""}]),
+                {"rows": [{"left": "a", "right": "x"}]},
+            ),
+            case(
+                "private-unmatched",
+                request([{"id": "a", "key": "a"}], [{"id": "x", "key": "b"}]),
+                {"rows": [{"left": "a", "right": None}]},
+            ),
+            case(
+                "private-cartesian",
+                request(
+                    [{"id": "b", "key": key}, {"id": "a", "key": key}],
+                    [{"id": "y", "key": key}, {"id": "x", "key": key}],
+                ),
+                {
+                    "rows": [
+                        {"left": "b", "right": "y"},
+                        {"left": "b", "right": "x"},
+                        {"left": "a", "right": "y"},
+                        {"left": "a", "right": "x"},
+                    ]
+                },
+            ),
+            case("private-empty-left", request([], [{"id": "x", "key": None}]), {"rows": []}),
+        ],
+        mechanism_cluster="multiset-outer-join-null-semantics",
+    )

--- a/benchmarks/agent_tasks/corpus_families/path_routing.py
+++ b/benchmarks/agent_tasks/corpus_families/path_routing.py
@@ -1,0 +1,122 @@
+"""URL decoding order and lexical containment within a fixed document root."""
+
+from .model import Family, case, source
+
+
+def path_routing(seed: int) -> Family:
+    contract = """# Static document router
+
+Read a string `path` beginning with /. Strip the query and fragment before
+percent-decoding. Split on literal /, then decode each segment exactly once with
+strict UTF-8. Every percent escape must contain two hex digits. Reject decoded /
+or backslash within a segment, any literal backslash, and NUL. Empty segments and
+. are ignored; .. pops one segment, but attempting to pop an empty stack is an
+error. Resolve remaining segments under the fixed root /srv/www and return
+{"file": absolute_path}, or {"error": "invalid path"}. This is a lexical router;
+no filesystem or symlink resolution occurs. A double-encoded escape is a literal
+percent-containing filename after the single decoding pass.
+
+Encoded dot segments and sibling-root paths currently escape containment or route
+to the wrong file. Repair decoding and containment. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from paths import resolve
+
+        def dispatch(request):
+            try:
+                return {"file": resolve(request["path"])}
+            except ValueError:
+                return {"error": "invalid path"}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    paths = source("""
+        import posixpath
+        from urllib.parse import unquote
+        from segments import raw_path
+
+        def resolve(path):
+            normalized = posixpath.normpath("/srv/www/" + raw_path(path).lstrip("/"))
+            return unquote(normalized)
+    """)
+    segments = source("""
+        def raw_path(path):
+            if not path.startswith("/"):
+                raise ValueError("absolute URL path required")
+            return path.split("#", 1)[0].split("?", 1)[0]
+    """)
+    partial = paths.replace(
+        'raw_path(path).lstrip("/")', 'unquote(raw_path(path)).lstrip("/")'
+    ).replace(
+        "    return unquote(normalized)",
+        '    if not normalized.startswith("/srv/www"):\n        raise ValueError("outside root")\n    return normalized',
+    )
+    fixed_paths = source("""
+        from segments import decoded_segments
+
+        def resolve(path):
+            stack = []
+            for segment in decoded_segments(path):
+                if segment in ("", "."):
+                    continue
+                if segment == "..":
+                    if not stack:
+                        raise ValueError("outside root")
+                    stack.pop()
+                else:
+                    stack.append(segment)
+            return "/srv/www" + ("/" + "/".join(stack) if stack else "")
+    """)
+    fixed_segments = segments + source("""
+
+        import re
+        from urllib.parse import unquote
+
+        def decoded_segments(path):
+            raw = raw_path(path)
+            if "\\\\" in raw or re.search(r"%(?![0-9a-fA-F]{2})", raw):
+                raise ValueError("invalid encoding")
+            result = [unquote(segment, errors="strict") for segment in raw.split("/")]
+            if any("/" in segment or "\\\\" in segment or "\\x00" in segment for segment in result):
+                raise ValueError("invalid separator")
+            return result
+    """)
+    return Family(
+        "decoded-root-routing",
+        "learning",
+        "document-root-url-router-v1",
+        contract,
+        {"app.py": app, "paths.py": paths, "segments.py": segments},
+        {"paths.py": fixed_paths, "segments.py": fixed_segments},
+        {"paths.py": partial},
+        [
+            case(
+                "public-decoding-order",
+                {"path": f"/a/%2e%2e/report-{seed}?ignored=1"},
+                {"file": f"/srv/www/report-{seed}"},
+            ),
+            case("public-unicode", {"path": "/caf%C3%A9"}, {"file": "/srv/www/café"}),
+        ],
+        [
+            case(
+                "private-sibling-prefix",
+                {"path": "/../../srv/www2/secret"},
+                {"error": "invalid path"},
+            ),
+            case("private-encoded-separator", {"path": "/safe%2fchild"}, {"error": "invalid path"}),
+            case("private-backslash", {"path": "/safe%5cchild"}, {"error": "invalid path"}),
+            case("private-malformed-escape", {"path": "/bad%ZZ"}, {"error": "invalid path"}),
+            case("private-invalid-utf8", {"path": "/bad%ff"}, {"error": "invalid path"}),
+            case("private-null", {"path": "/bad%00"}, {"error": "invalid path"}),
+            case(
+                "private-double-encoding",
+                {"path": "/%252e%252e/data"},
+                {"file": "/srv/www/%2e%2e/data"},
+            ),
+            case("private-root", {"path": "/a/..//."}, {"file": "/srv/www"}),
+        ],
+        mechanism_cluster="decode-before-root-containment",
+    )

--- a/benchmarks/agent_tasks/corpus_families/reservations.py
+++ b/benchmarks/agent_tasks/corpus_families/reservations.py
@@ -1,0 +1,99 @@
+"""Reconcile reservation snapshots before deciding available capacity."""
+
+from .model import Family, case, source
+
+
+def reservations(seed: int) -> Family:
+    contract = """# Venue inventory reconciliation
+
+Read `capacity`, `now`, and reservation `events`. Events carry id, revision,
+seats, expires, and cancelled. For each id use its greatest revision, breaking
+revision ties by the last event in input order. A selected event consumes seats
+only when not cancelled and expires is strictly greater than now. A cancelled or
+expired revision still supersedes older revisions. Return {"available": capacity
+minus consumed seats}, clamped at zero. Inputs contain nonnegative integer seats
+and capacity, integer timestamps, and positive revisions.
+
+A feed can arrive out of order. Availability currently changes when an old event
+is replayed, and cancellations sometimes leave seats occupied. Repair the reducer
+and capacity projection. Run `python public_checks.py` for public examples.
+"""
+    app = source("""
+        import json
+        import sys
+        from reconcile import current
+        from capacity import available
+
+        def dispatch(request):
+            return {"available": available(request["capacity"], request["now"], current(request["events"]))}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    reducer = source("""
+        def current(events):
+            selected = {}
+            for event in events:
+                if not event["cancelled"]:
+                    selected[event["id"]] = event
+            return list(selected.values())
+    """)
+    projection = source("""
+        def available(capacity, now, events):
+            return max(0, capacity - sum(event["seats"] for event in events if event["expires"] >= now))
+    """)
+    fixed = source("""
+        def current(events):
+            selected = {}
+            for event in events:
+                old = selected.get(event["id"])
+                if old is None or event["revision"] >= old["revision"]:
+                    selected[event["id"]] = event
+            return list(selected.values())
+    """)
+    correct_projection = projection.replace(
+        'event["expires"] >= now', 'not event["cancelled"] and event["expires"] > now'
+    )
+
+    def event(revision, seats, *, cancelled=False, expires=100):
+        return {
+            "id": "booking",
+            "revision": revision,
+            "seats": seats,
+            "cancelled": cancelled,
+            "expires": expires,
+        }
+
+    def request(events):
+        return {"capacity": 20 + seed, "now": 50, "events": events}
+
+    return Family(
+        "reservation-reconciliation",
+        "development",
+        "venue-snapshot-reconciliation-v1",
+        contract,
+        {"app.py": app, "reconcile.py": reducer, "capacity.py": projection},
+        {"reconcile.py": fixed, "capacity.py": correct_projection},
+        {"reconcile.py": fixed},
+        [case("public-late-old", request([event(2, 3), event(1, 8)]), {"available": 17 + seed})],
+        [
+            case(
+                "private-cancel",
+                request([event(1, 8), event(2, 8, cancelled=True)]),
+                {"available": 20 + seed},
+            ),
+            case(
+                "private-expiry-boundary",
+                request([event(1, 8, expires=50)]),
+                {"available": 20 + seed},
+            ),
+            case(
+                "private-expired-supersedes",
+                request([event(2, 8, expires=10), event(1, 3)]),
+                {"available": 20 + seed},
+            ),
+            case("private-tie", request([event(2, 8), event(2, 3)]), {"available": 17 + seed}),
+            case("private-overbooked", request([event(1, 100 + seed)]), {"available": 0}),
+        ],
+        mechanism_cluster="newest-revision-active-projection",
+    )

--- a/benchmarks/agent_tasks/corpus_families/savepoints.py
+++ b/benchmarks/agent_tasks/corpus_families/savepoints.py
@@ -1,0 +1,173 @@
+"""Named savepoint stack repair with duplicate-name resolution."""
+
+from .model import Family, case, source
+
+
+def savepoints(seed: int) -> Family:
+    contract = """# Transaction savepoints
+
+Read an initial JSON object `data` and an ordered `ops` array. `set` replaces
+key with value; `delete` removes key if present. `save` pushes a named snapshot.
+`rollback` restores the snapshot of the most recent matching name, discards all
+inner savepoints, and retains that target savepoint for repeated rollback.
+`release` discards the most recent matching savepoint and all inner savepoints
+without changing data. Duplicate names are allowed and resolve from the top.
+An unknown rollback/release name appends "unknown savepoint" to errors, leaves
+both data and stack unchanged, and processing continues. Other operations are
+well formed. Return {"data": object, "savepoints": names in stack order,
+"errors": error strings in operation order}. Values are replaced as whole JSON
+values, never mutated in place.
+
+Rollback currently loses its target and release unexpectedly undoes writes.
+Repair stack selection and lifecycle semantics. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from transaction import execute
+        if __name__ == "__main__":
+            json.dump(execute(json.load(sys.stdin)), sys.stdout)
+    """)
+    lookup = source("""
+        def locate(stack, name):
+            for index, (label, _) in enumerate(stack):
+                if label == name:
+                    return index
+            raise ValueError("unknown savepoint")
+    """)
+    fixed_lookup = source("""
+        def locate(stack, name):
+            for index in range(len(stack) - 1, -1, -1):
+                if stack[index][0] == name:
+                    return index
+            raise ValueError("unknown savepoint")
+    """)
+    transaction = source("""
+        from lookup import locate
+        def execute(request):
+            data, stack, errors = dict(request["data"]), [], []
+            for op in request["ops"]:
+                action = op["op"]
+                if action == "set":
+                    data[op["key"]] = op["value"]
+                elif action == "delete":
+                    data.pop(op["key"], None)
+                elif action == "save":
+                    stack.append((op["name"], dict(data)))
+                else:
+                    try:
+                        index = locate(stack, op["name"])
+                    except ValueError as error:
+                        errors.append(str(error))
+                        continue
+                    data = dict(stack[index][1])
+                    stack = stack[:index]
+            return {"data": data, "savepoints": [name for name, _ in stack], "errors": errors}
+    """)
+    fixed_transaction = transaction.replace(
+        "            data = dict(stack[index][1])\n            stack = stack[:index]",
+        '            if action == "rollback":\n                data = dict(stack[index][1])\n                stack = stack[:index + 1]\n            else:\n                stack = stack[:index]',
+    )
+
+    def named(op, name="a"):
+        return {"op": op, "name": name}
+
+    def put(value):
+        return {"op": "set", "key": "x", "value": value}
+
+    def check(label, ops, value, names, errors=None):
+        return case(
+            label,
+            {"data": {"x": seed}, "ops": ops},
+            {"data": {"x": value}, "savepoints": names, "errors": errors or []},
+        )
+
+    return Family(
+        "named-transaction-savepoints",
+        "learning",
+        "transaction-savepoint-stack-v1",
+        contract,
+        {"app.py": app, "lookup.py": lookup, "transaction.py": transaction},
+        {"lookup.py": fixed_lookup, "transaction.py": fixed_transaction},
+        {"transaction.py": fixed_transaction},
+        [
+            check(
+                "public-rollback-retains",
+                [named("save"), put(seed + 1), named("rollback")],
+                seed,
+                ["a"],
+            ),
+            check(
+                "public-release-keeps-data",
+                [named("save"), put(seed + 2), named("release")],
+                seed + 2,
+                [],
+            ),
+        ],
+        [
+            check(
+                "private-duplicate-rollback",
+                [named("save"), put(seed + 1), named("save"), put(seed + 2), named("rollback")],
+                seed + 1,
+                ["a", "a"],
+            ),
+            check(
+                "private-duplicate-release",
+                [
+                    named("save"),
+                    put(seed + 1),
+                    named("save"),
+                    named("release"),
+                    put(seed + 2),
+                    named("rollback"),
+                ],
+                seed,
+                ["a"],
+            ),
+            check(
+                "private-inner-discard",
+                [
+                    named("save"),
+                    put(seed + 1),
+                    named("save", "b"),
+                    put(seed + 2),
+                    named("rollback"),
+                ],
+                seed,
+                ["a"],
+            ),
+            check(
+                "private-release-inner",
+                [named("save"), named("save", "b"), put(seed + 3), named("release")],
+                seed + 3,
+                [],
+            ),
+            check(
+                "private-repeat-rollback",
+                [named("save"), put(seed + 1), named("rollback"), put(seed + 2), named("rollback")],
+                seed,
+                ["a"],
+            ),
+            check(
+                "private-unknown-keeps-state",
+                [
+                    named("save"),
+                    put(seed + 1),
+                    named("release", "missing"),
+                    named("rollback", "missing"),
+                ],
+                seed + 1,
+                ["a"],
+                ["unknown savepoint", "unknown savepoint"],
+            ),
+            case(
+                "private-delete-nested-value",
+                {
+                    "data": {"x": {"nested": [seed]}},
+                    "ops": [named("save"), {"op": "delete", "key": "x"}, named("rollback")],
+                },
+                {"data": {"x": {"nested": [seed]}}, "savepoints": ["a"], "errors": []},
+            ),
+        ],
+        mechanism_cluster="named-savepoint-stack-rollback",
+    )

--- a/benchmarks/agent_tasks/corpus_families/sessions.py
+++ b/benchmarks/agent_tasks/corpus_families/sessions.py
@@ -1,0 +1,121 @@
+"""Arrival-time watermarks and event-time session boundaries."""
+
+from .model import Family, case, source
+
+
+def sessions(seed: int) -> Family:
+    contract = """# Session activity exporter
+
+Events arrive in the supplied order and contain `user` and integer `time`.
+Before each event, compute the watermark as the greatest previously accepted
+timestamp minus `lateness`. Reject an event strictly older than that watermark;
+an event exactly on the watermark is accepted. The first event is accepted.
+Only accepted events advance the greatest timestamp. Timestamps may be negative.
+
+After filtering, group accepted events separately for each user in timestamp
+order. Consecutive events whose distance is at most `gap` belong to one session,
+including duplicate timestamps. Output sessions sorted by user then start:
+{"sessions": [{"user": ..., "start": ..., "end": ..., "count": ...}],
+ "rejected": number}. Gap and lateness are nonnegative integers.
+
+The exporter loses valid boundary events and sometimes produces overlapping
+sessions after delayed delivery. Repair filtering and session construction.
+Run `python public_checks.py` for the public examples.
+"""
+    entry = source("""
+        import json
+        import sys
+        from watermark import accepted_events
+        from windows import sessions_for
+
+        def export(document):
+            accepted, rejected = accepted_events(document["events"], document["lateness"])
+            users = sorted({event["user"] for event in accepted})
+            sessions = []
+            for user in users:
+                times = [event["time"] for event in accepted if event["user"] == user]
+                sessions.extend(sessions_for(user, times, document["gap"]))
+            return {"sessions": sessions, "rejected": rejected}
+
+        if __name__ == "__main__":
+            json.dump(export(json.load(sys.stdin)), sys.stdout)
+    """)
+    watermark = source("""
+        def accepted_events(events, lateness):
+            accepted = []
+            rejected = 0
+            greatest = None
+            for event in events:
+                stamp = event["time"]
+                if greatest is not None and stamp <= greatest - lateness:
+                    rejected += 1
+                    continue
+                accepted.append(event)
+                greatest = stamp if greatest is None else max(greatest, stamp)
+            return accepted, rejected
+    """)
+    windows = source("""
+        def sessions_for(user, times, gap):
+            result = []
+            for stamp in times:
+                if not result or stamp - result[-1]["end"] > gap:
+                    result.append({"user": user, "start": stamp, "end": stamp, "count": 1})
+                else:
+                    result[-1]["end"] = stamp
+                    result[-1]["count"] += 1
+            return result
+    """)
+    fixed_watermark = watermark.replace("stamp <= greatest", "stamp < greatest")
+    fixed_windows = windows.replace("for stamp in times:", "for stamp in sorted(times):")
+    shift = seed * 10
+
+    def request(times, gap=3, lateness=10):
+        return {
+            "events": [{"user": user, "time": stamp + shift} for user, stamp in times],
+            "gap": gap,
+            "lateness": lateness,
+        }
+
+    def session(user, start, end, count):
+        return {"user": user, "start": start + shift, "end": end + shift, "count": count}
+
+    return Family(
+        "session-watermarks",
+        "learning",
+        "event-time-session-export-v1",
+        contract,
+        {"app.py": entry, "watermark.py": watermark, "windows.py": windows},
+        {"watermark.py": fixed_watermark, "windows.py": fixed_windows},
+        {"watermark.py": fixed_watermark},
+        [
+            case(
+                "public-equal-watermark",
+                request([("a", 2), ("a", 2)], lateness=0),
+                {"sessions": [session("a", 2, 2, 2)], "rejected": 0},
+            ),
+            case(
+                "public-gap",
+                request([("a", 0), ("a", 3), ("a", 7)]),
+                {"sessions": [session("a", 0, 3, 2), session("a", 7, 7, 1)], "rejected": 0},
+            ),
+        ],
+        [
+            case(
+                "private-late-bridge",
+                request([("a", 0), ("a", 6), ("a", 3)]),
+                {"sessions": [session("a", 0, 6, 3)], "rejected": 0},
+            ),
+            case(
+                "private-global-watermark",
+                request([("a", 8), ("b", 2), ("b", 3)], lateness=5),
+                {"sessions": [session("a", 8, 8, 1), session("b", 3, 3, 1)], "rejected": 1},
+            ),
+            case(
+                "private-order-and-negative",
+                request([("z", -1), ("a", -4), ("z", -3)], gap=2),
+                {"sessions": [session("a", -4, -4, 1), session("z", -3, -1, 2)], "rejected": 0},
+            ),
+            case("private-empty", request([]), {"sessions": [], "rejected": 0}),
+        ],
+        mechanism_cluster="event-time-session-finalization",
+    )

--- a/benchmarks/agent_tasks/corpus_families/shortest_paths.py
+++ b/benchmarks/agent_tasks/corpus_families/shortest_paths.py
@@ -1,0 +1,144 @@
+"""Iterative relaxation and source-reachable negative-cycle discrimination."""
+
+from .model import Family, case, source
+
+
+def shortest_paths(seed: int) -> Family:
+    contract = """# Directed route costs
+
+Read unique string `nodes`, a `source` node, and directed `edges` with from, to,
+and integer weight. Parallel edges, self edges, negative weights and arbitrarily
+large integers are valid. Return {"distances": {node: minimum cost or null when
+unreachable}}. Source starts at cost zero. Any negative cycle reachable from
+source invalidates the entire result, even if it cannot reach another node of
+interest: return {"error": "negative cycle"}. Unreachable negative cycles do not
+invalidate the result. A source or edge endpoint outside nodes returns
+{"error": "invalid graph"}. There are no other input size or graph-depth limits.
+
+Edge ordering currently changes distances, and disconnected cycles cause false
+alarms. Repair propagation and cycle detection. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from routes import distances
+        from cycles import negative_cycle
+        def dispatch(request):
+            nodes, source, edges = request["nodes"], request["source"], request["edges"]
+            if source not in nodes or any(edge["from"] not in nodes or edge["to"] not in nodes for edge in edges):
+                return {"error": "invalid graph"}
+            result = distances(nodes, source, edges)
+            if negative_cycle(result, edges):
+                return {"error": "negative cycle"}
+            return {"distances": result}
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    routes = source("""
+        def distances(nodes, source, edges):
+            result = dict.fromkeys(nodes)
+            result[source] = 0
+            for _ in range(1):
+                changed = False
+                for edge in edges:
+                    start, end, weight = edge["from"], edge["to"], edge["weight"]
+                    if result[start] is not None and (result[end] is None or result[start] + weight < result[end]):
+                        result[end] = result[start] + weight
+                        changed = True
+                if not changed:
+                    break
+            return result
+    """)
+    fixed_routes = routes.replace("range(1)", "range(len(nodes) - 1)")
+    cycles = source("""
+        def negative_cycle(result, edges):
+            for edge in edges:
+                start = result[edge["from"]]
+                end = result[edge["to"]]
+                if (start or 0) + edge["weight"] < (end or 0):
+                    return True
+            return False
+    """)
+    fixed_cycles = cycles.replace(
+        '(start or 0) + edge["weight"] < (end or 0)',
+        'start is not None and (end is None or start + edge["weight"] < end)',
+    )
+
+    def check(label, nodes, edges, expected, source_node="s"):
+        return case(
+            label,
+            {
+                "nodes": nodes,
+                "source": source_node,
+                "edges": [{"from": a, "to": b, "weight": w} for a, b, w in edges],
+            },
+            expected,
+        )
+
+    return Family(
+        "directed-route-costs",
+        "learning",
+        "signed-directed-shortest-path-v1",
+        contract,
+        {"app.py": app, "routes.py": routes, "cycles.py": cycles},
+        {"routes.py": fixed_routes, "cycles.py": fixed_cycles},
+        {"routes.py": fixed_routes},
+        [
+            check(
+                "public-reverse-order",
+                ["s", "a", "b", "c"],
+                [("b", "c", 2), ("a", "b", 3), ("s", "a", seed + 1)],
+                {"distances": {"s": 0, "a": seed + 1, "b": seed + 4, "c": seed + 6}},
+            )
+        ],
+        [
+            check(
+                "private-unreachable-cycle",
+                ["s", "x", "y"],
+                [("x", "y", -2), ("y", "x", 1)],
+                {"distances": {"s": 0, "x": None, "y": None}},
+            ),
+            check(
+                "private-reachable-cycle",
+                ["s", "x", "y", "target"],
+                [("s", "target", 4), ("s", "x", 0), ("x", "y", -2), ("y", "x", 1)],
+                {"error": "negative cycle"},
+            ),
+            check(
+                "private-negative-acyclic",
+                ["s", "a", "b"],
+                [("a", "b", -9), ("s", "a", 4), ("s", "b", 1)],
+                {"distances": {"s": 0, "a": 4, "b": -5}},
+            ),
+            check(
+                "private-parallel",
+                ["s", "a"],
+                [("s", "a", 9), ("s", "a", 2), ("s", "a", 8)],
+                {"distances": {"s": 0, "a": 2}},
+            ),
+            check("private-negative-self", ["s"], [("s", "s", -1)], {"error": "negative cycle"}),
+            check(
+                "private-zero-cycle",
+                ["s", "a"],
+                [("s", "a", -3), ("a", "s", 3)],
+                {"distances": {"s": 0, "a": -3}},
+            ),
+            check(
+                "private-large-weight",
+                ["s", "a"],
+                [("s", "a", 10**30 + seed)],
+                {"distances": {"s": 0, "a": 10**30 + seed}},
+            ),
+            check(
+                "private-invalid-endpoint", ["s"], [("s", "missing", 1)], {"error": "invalid graph"}
+            ),
+            check("private-invalid-source", ["a"], [], {"error": "invalid graph"}),
+            check(
+                "private-deep-chain",
+                ["s"] + [str(i) for i in range(1200)],
+                [("s" if i == 0 else str(i - 1), str(i), 1) for i in reversed(range(1200))],
+                {"distances": {"s": 0, **{str(i): i + 1 for i in range(1200)}}},
+            ),
+        ],
+        mechanism_cluster="signed-path-relaxation-reachable-cycle",
+    )

--- a/benchmarks/agent_tasks/corpus_families/sparse_product.py
+++ b/benchmarks/agent_tasks/corpus_families/sparse_product.py
@@ -1,0 +1,138 @@
+"""Sparse coordinate aggregation and rectangular matrix multiplication repairs."""
+
+from .model import Family, case, source
+
+
+def sparse_product(seed: int) -> Family:
+    contract = """# Sparse feature transform
+
+Read `left` and `right` matrices, each {"shape": [rows, columns], "entries":
+[[row, column, integer_value], ...]}. Shape dimensions are nonnegative integers.
+Coordinates must be in bounds. Repeated coordinates SUM, including cancellation;
+explicit zeros are legal. Multiply left by right with ordinary integer arithmetic.
+Return {"shape": [left rows, right columns], "entries": nonzero coordinates},
+ordered by row then column. Rectangular and empty dimensions are valid when the
+inner dimensions agree. Invalid coordinates, negative dimensions, or mismatched
+inner dimensions return {"error": "invalid matrix"}. Integer magnitudes and
+shape dimensions have no fixed cap; never allocate a dense shape-sized matrix.
+
+Feature transforms overwrite repeated contributions and confuse shared-axis
+coordinates. Repair normalization and sparse multiplication. Run
+`python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from coordinates import normalize
+        from multiply import product
+        def dispatch(request):
+            try:
+                left, right = request["left"], request["right"]
+                a, b = normalize(left), normalize(right)
+                if left["shape"][1] != right["shape"][0]:
+                    raise ValueError("shape")
+                result = product(a, b)
+                return {"shape": [left["shape"][0], right["shape"][1]], "entries": [[r, c, value] for (r, c), value in sorted(result.items()) if value]}
+            except ValueError:
+                return {"error": "invalid matrix"}
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    coordinates = source("""
+        def normalize(matrix):
+            rows, columns = matrix["shape"]
+            if rows < 0 or columns < 0:
+                raise ValueError("shape")
+            result = {}
+            for row, column, value in matrix["entries"]:
+                if not (0 <= row < rows and 0 <= column < columns):
+                    raise ValueError("coordinate")
+                result[row, column] = value
+            return result
+    """)
+    multiply = source("""
+        def product(left, right):
+            result = {}
+            for (row, shared), value in left.items():
+                for (other, column), factor in right.items():
+                    if row == other:
+                        result[row, column] = result.get((row, column), 0) + value * factor
+            return result
+    """)
+    fixed_coordinates = coordinates.replace(
+        "result[row, column] = value", "result[row, column] = result.get((row, column), 0) + value"
+    )
+    fixed_multiply = multiply.replace("if row == other:", "if shared == other:")
+
+    def check(label, a_shape, a, b_shape, b, expected):
+        return case(
+            label,
+            {"left": {"shape": a_shape, "entries": a}, "right": {"shape": b_shape, "entries": b}},
+            expected,
+        )
+
+    return Family(
+        "sparse-feature-product",
+        "learning",
+        "coordinate-sparse-matrix-product-v1",
+        contract,
+        {"app.py": app, "coordinates.py": coordinates, "multiply.py": multiply},
+        {"coordinates.py": fixed_coordinates, "multiply.py": fixed_multiply},
+        {"multiply.py": fixed_multiply},
+        [
+            check(
+                "public-shared-axis",
+                [1, 2],
+                [[0, 1, 3]],
+                [2, 1],
+                [[1, 0, 4]],
+                {"shape": [1, 1], "entries": [[0, 0, 12]]},
+            )
+        ],
+        [
+            check(
+                "private-duplicate-contributions",
+                [1, 1],
+                [[0, 0, seed + 2], [0, 0, 3]],
+                [1, 1],
+                [[0, 0, 2], [0, 0, 4]],
+                {"shape": [1, 1], "entries": [[0, 0, (seed + 5) * 6]]},
+            ),
+            check(
+                "private-cancellation",
+                [1, 1],
+                [[0, 0, 4], [0, 0, -4]],
+                [1, 1],
+                [[0, 0, 8]],
+                {"shape": [1, 1], "entries": []},
+            ),
+            check(
+                "private-sorted-sums",
+                [2, 2],
+                [[1, 1, 2], [0, 1, 3], [0, 0, 1]],
+                [2, 2],
+                [[1, 1, 4], [0, 1, -12], [1, 0, 5]],
+                {"shape": [2, 2], "entries": [[0, 0, 15], [1, 0, 10], [1, 1, 8]]},
+            ),
+            check(
+                "private-large-sparse-shape",
+                [10**12, 10**12],
+                [[10**12 - 1, 9, 10**30]],
+                [10**12, 2],
+                [[9, 1, -2]],
+                {"shape": [10**12, 2], "entries": [[10**12 - 1, 1, -2 * 10**30]]},
+            ),
+            check("private-empty-inner", [2, 0], [], [0, 3], [], {"shape": [2, 3], "entries": []}),
+            check("private-mismatch", [1, 2], [], [3, 1], [], {"error": "invalid matrix"}),
+            check(
+                "private-invalid-coordinate",
+                [1, 1],
+                [[0, 1, 0]],
+                [1, 1],
+                [],
+                {"error": "invalid matrix"},
+            ),
+            check("private-negative-shape", [-1, 1], [], [1, 1], [], {"error": "invalid matrix"}),
+        ],
+        mechanism_cluster="sparse-coordinate-aggregation-product",
+    )

--- a/benchmarks/agent_tasks/corpus_families/stream_framing.py
+++ b/benchmarks/agent_tasks/corpus_families/stream_framing.py
@@ -1,0 +1,80 @@
+"""Byte decoding and complete-record framing at stream boundaries."""
+
+from .model import Family, case, source
+
+
+def stream_framing(seed: int) -> Family:
+    contract = """# JSON line stream importer
+
+Read `chunks`, a list of lists of integers from 0 through 255. Chunks are pieces
+of one UTF-8 byte stream and may split a multibyte character or JSON record.
+Decode strictly. LF separates JSON records; one CR immediately preceding LF is
+part of the line ending. Ignore whitespace-only records. At end of stream parse
+any remaining nonblank record even without a trailing LF. Return {"records": [...]}
+in input order. Any invalid UTF-8, incomplete final character, or malformed JSON
+record makes the entire import return {"error": "invalid stream"}.
+
+Imports fail around network chunk boundaries and occasionally lose the final
+record. Repair decoding and record framing. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from decoding import decode
+        from framing import records
+
+        def dispatch(request):
+            try:
+                return {"records": records(decode(request["chunks"]))}
+            except (UnicodeError, ValueError):
+                return {"error": "invalid stream"}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    decoding = source("""
+        def decode(chunks):
+            return "".join(bytes(chunk).decode("utf-8") for chunk in chunks)
+    """)
+    framing = source("""
+        import json
+
+        def records(text):
+            return [json.loads(line) for line in text.split("\\n")[:-1] if line.strip()]
+    """)
+    fixed_decoding = source("""
+        import codecs
+
+        def decode(chunks):
+            decoder = codecs.getincrementaldecoder("utf-8")("strict")
+            return "".join(decoder.decode(bytes(chunk)) for chunk in chunks) + decoder.decode(b"", final=True)
+    """)
+    fixed_framing = framing.replace('text.split("\\n")[:-1]', 'text.split("\\n")')
+
+    def request(text):
+        return {"chunks": [[byte] for byte in text.encode("utf-8")]}
+
+    return Family(
+        "utf8-record-framing",
+        "learning",
+        "json-line-byte-importer-v1",
+        contract,
+        {"app.py": app, "decoding.py": decoding, "framing.py": framing},
+        {"decoding.py": fixed_decoding, "framing.py": fixed_framing},
+        {"decoding.py": fixed_decoding},
+        [
+            case("public-unicode-chunks", request('"café"\n'), {"records": ["café"]}),
+            case("public-record-splits", request(f"{seed}\ntrue\n"), {"records": [seed, True]}),
+        ],
+        [
+            case("private-no-final-lf", request("[1,2]"), {"records": [[1, 2]]}),
+            case("private-final-malformed", request("1\n{"), {"error": "invalid stream"}),
+            case(
+                "private-incomplete-codepoint", {"chunks": [[34, 195]]}, {"error": "invalid stream"}
+            ),
+            case("private-invalid-byte", {"chunks": [[255]]}, {"error": "invalid stream"}),
+            case("private-crlf-blank", request(' \r\n"雪"\r\n\nfalse'), {"records": ["雪", False]}),
+            case("private-empty-chunks", {"chunks": [[], [], []]}, {"records": []}),
+        ],
+        mechanism_cluster="incremental-utf8-record-boundaries",
+    )

--- a/benchmarks/agent_tasks/corpus_families/three_valued_logic.py
+++ b/benchmarks/agent_tasks/corpus_families/three_valued_logic.py
@@ -1,0 +1,155 @@
+"""Expression parsing and Kleene truth operations must agree on unknown values."""
+
+from .model import Family, case, source
+
+
+def three_valued_logic(seed: int) -> Family:
+    contract = """# Nullable rule evaluator
+
+Read `tokens`, a JSON array containing boolean literals true/false, null (unknown),
+and the strings NOT, AND, OR, (, ). NOT has highest precedence, then AND, then OR.
+Binary operators associate left; NOT can repeat. Parentheses override precedence.
+Return {"value": true_or_false_or_null}. Reject empty, unbalanced, adjacent-literal,
+trailing-operator, or unrecognized-token expressions with {"error": "invalid rule"}.
+
+Use three-valued logic: NOT unknown is unknown. AND is false if either operand is
+false, true if both are true, and unknown otherwise. OR is true if either operand
+is true, false if both are false, and unknown otherwise. These truth tables apply
+to every subtree; unknown is never implicitly converted to false. Valid rules
+may contain 1200 nested NOT operators or parentheses; Python call-stack depth
+is not a grammar limit.
+
+Mixed AND/OR rules and missing observations produce incorrect decisions. Repair
+parsing and truth evaluation. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from parser import parse
+        from truth import evaluate
+
+        def dispatch(request):
+            try:
+                return {"value": evaluate(parse(request["tokens"]))}
+            except ValueError:
+                return {"error": "invalid rule"}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    parser = source("""
+        def parse(tokens):
+            precedence = {"NOT": 3, "AND": 2, "OR": 1}
+            output, operators = [], []
+            operand = True
+            for token in tokens:
+                if token is None or type(token) is bool:
+                    if not operand:
+                        raise ValueError("adjacent literals")
+                    output.append(token)
+                    operand = False
+                elif token == "NOT" and operand:
+                    operators.append(token)
+                elif token == "(" and operand:
+                    operators.append(token)
+                elif token == ")" and not operand:
+                    while operators and operators[-1] != "(":
+                        output.append(operators.pop())
+                    if not operators:
+                        raise ValueError("unmatched close")
+                    operators.pop()
+                elif token in ("AND", "OR") and not operand:
+                    while operators and operators[-1] != "(" and precedence[operators[-1]] >= precedence[token]:
+                        output.append(operators.pop())
+                    operators.append(token)
+                    operand = True
+                else:
+                    raise ValueError("invalid token")
+            if operand:
+                raise ValueError("missing operand")
+            while operators:
+                operator = operators.pop()
+                if operator == "(":
+                    raise ValueError("missing close")
+                output.append(operator)
+            return output
+    """)
+    buggy_parser = parser.replace('"AND": 2', '"AND": 1')
+    truth = source("""
+        def apply(operator, left, right):
+            if operator == "NOT":
+                return not left
+            return bool(left and right) if operator == "AND" else bool(left or right)
+
+        def evaluate(program):
+            values = []
+            for token in program:
+                if token is None or type(token) is bool:
+                    values.append(token)
+                elif token == "NOT":
+                    values.append(apply(token, values.pop(), None))
+                else:
+                    right = values.pop()
+                    left = values.pop()
+                    values.append(apply(token, left, right))
+            return values[0]
+    """)
+    reference_truth = (
+        source("""
+        def apply(operator, left, right):
+            if operator == "NOT":
+                return None if left is None else not left
+            if operator == "AND":
+                if left is False or right is False:
+                    return False
+                return True if left is True and right is True else None
+            if left is True or right is True:
+                return True
+            return False if left is False and right is False else None
+
+    """)
+        + truth[truth.index("def evaluate(") :]
+    )
+    return Family(
+        "three-valued-rule-parser",
+        "learning",
+        "nullable-rule-expression-v1",
+        contract,
+        {"app.py": app, "parser.py": buggy_parser, "truth.py": truth},
+        {"parser.py": parser, "truth.py": reference_truth},
+        {"parser.py": parser},
+        [
+            case(
+                "public-precedence", {"tokens": [True, "OR", False, "AND", False]}, {"value": True}
+            ),
+            case(
+                "public-nested-not",
+                {"tokens": ["NOT"] * (2 * (seed % 3 + 1)) + [True]},
+                {"value": True},
+            ),
+        ],
+        [
+            case("private-not-unknown", {"tokens": ["NOT", None]}, {"value": None}),
+            case("private-deep-not", {"tokens": ["NOT"] * 1200 + [None]}, {"value": None}),
+            case(
+                "private-deep-parentheses",
+                {"tokens": ["("] * 1200 + [True] + [")"] * 1200},
+                {"value": True},
+            ),
+            case("private-and-unknown", {"tokens": [None, "AND", True]}, {"value": None}),
+            case("private-or-unknown", {"tokens": [False, "OR", None]}, {"value": None}),
+            case("private-and-false", {"tokens": [None, "AND", False]}, {"value": False}),
+            case("private-or-true", {"tokens": [None, "OR", True]}, {"value": True}),
+            case(
+                "private-parentheses",
+                {"tokens": ["(", True, "OR", False, ")", "AND", False]},
+                {"value": False},
+            ),
+            case("private-empty", {"tokens": []}, {"error": "invalid rule"}),
+            case("private-trailing", {"tokens": [True, "AND"]}, {"error": "invalid rule"}),
+            case("private-adjacent", {"tokens": [True, False]}, {"error": "invalid rule"}),
+            case("private-unbalanced", {"tokens": ["(", True]}, {"error": "invalid rule"}),
+            case("private-nonboolean", {"tokens": [1]}, {"error": "invalid rule"}),
+        ],
+        mechanism_cluster="kleene-logic-expression-precedence",
+    )

--- a/benchmarks/agent_tasks/corpus_families/weighted_lru.py
+++ b/benchmarks/agent_tasks/corpus_families/weighted_lru.py
@@ -1,0 +1,134 @@
+"""Weighted cache eviction requires recency updates on both reads and replacement."""
+
+from .model import Family, case, source
+
+
+def weighted_lru(seed: int) -> Family:
+    contract = """# Weighted LRU cache
+
+Read nonnegative integer `capacity` and ordered `operations`. A put operation has
+op:"put", string key, JSON value, and nonnegative integer weight. A get operation
+has op:"get" and key. Successful gets touch the entry as most recently used and
+append its value to `reads`; missing gets append null without changing recency.
+
+A put whose weight exceeds capacity is completely ignored, even for an existing
+key: retain the old value, weight, and recency. Otherwise insert or replace the
+entry and touch it as most recently used. Evict least recently used entries until
+the sum of stored weights is at most capacity. Replacements count only their new
+weight. Zero-weight entries are valid even at zero capacity and participate in
+normal eviction order. Return {"reads": [...], "keys": [least_to_most_recent],
+"weight": total_stored_weight}. A stored null value is still a cache hit and touch.
+
+Hot entries and recently replaced values are being evicted unexpectedly. Repair
+recency maintenance without changing capacity rules. Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from cache import Cache
+
+        def dispatch(request):
+            cache = Cache(request["capacity"])
+            reads = []
+            for operation in request["operations"]:
+                if operation["op"] == "put":
+                    cache.put(operation["key"], operation["value"], operation["weight"])
+                else:
+                    reads.append(cache.get(operation["key"]))
+            return {"reads": reads, "keys": list(cache.entries), "weight": cache.weight()}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    cache = source("""
+        from collections import OrderedDict
+
+        class Cache:
+            def __init__(self, capacity):
+                self.capacity = capacity
+                self.entries = OrderedDict()
+
+            def weight(self):
+                return sum(item[1] for item in self.entries.values())
+
+            def get(self, key):
+                if key not in self.entries:
+                    return None
+                return self.entries[key][0]
+
+            def put(self, key, value, weight):
+                if weight > self.capacity:
+                    return
+                self.entries[key] = (value, weight)
+                while self.weight() > self.capacity:
+                    self.entries.popitem(last=False)
+    """)
+    partial = cache.replace(
+        "        return self.entries[key][0]",
+        "        self.entries.move_to_end(key)\n        return self.entries[key][0]",
+    )
+    reference = partial.replace(
+        "        self.entries[key] = (value, weight)",
+        "        self.entries[key] = (value, weight)\n        self.entries.move_to_end(key)",
+    )
+
+    def put(key, weight=1, value=None):
+        return {"op": "put", "key": key, "value": value, "weight": weight}
+
+    def get(key):
+        return {"op": "get", "key": key}
+
+    def request(capacity, operations):
+        return {"capacity": capacity, "operations": operations}
+
+    return Family(
+        "weighted-lru-replacement",
+        "learning",
+        "weighted-object-cache-v1",
+        contract,
+        {"app.py": app, "cache.py": cache},
+        {"cache.py": reference},
+        {"cache.py": partial},
+        [
+            case(
+                "public-read-touch",
+                request(2, [put("a", value=seed), put("b"), get("a"), put("c")]),
+                {"reads": [seed], "keys": ["a", "c"], "weight": 2},
+            )
+        ],
+        [
+            case(
+                "private-replace-touch",
+                request(2, [put("a"), put("b"), put("a", value="new"), put("c")]),
+                {"reads": [], "keys": ["a", "c"], "weight": 2},
+            ),
+            case(
+                "private-oversize-no-touch",
+                request(
+                    2, [put("a", value="old"), put("b"), put("a", 3, "new"), put("c"), get("a")]
+                ),
+                {"reads": [None], "keys": ["b", "c"], "weight": 2},
+            ),
+            case(
+                "private-new-weight",
+                request(3, [put("a", 2), put("b", 1), put("a", 1), put("c", 1)]),
+                {"reads": [], "keys": ["b", "a", "c"], "weight": 3},
+            ),
+            case(
+                "private-zero-capacity",
+                request(0, [put("a", 0, "free"), put("b", 1), get("a")]),
+                {"reads": ["free"], "keys": ["a"], "weight": 0},
+            ),
+            case(
+                "private-zero-weight-eviction",
+                request(1, [put("a", 0), put("b"), put("c")]),
+                {"reads": [], "keys": ["c"], "weight": 1},
+            ),
+            case(
+                "private-null-hit",
+                request(2, [put("a"), put("b"), get("a")]),
+                {"reads": [None], "keys": ["b", "a"], "weight": 2},
+            ),
+        ],
+        mechanism_cluster="weighted-lru-access-and-replacement",
+    )

--- a/benchmarks/agent_tasks/corpus_families/wildcard_match.py
+++ b/benchmarks/agent_tasks/corpus_families/wildcard_match.py
@@ -1,0 +1,110 @@
+"""Escaped wildcard tokenization and iterative whole-string matching repairs."""
+
+from .model import Family, case, source
+
+
+def wildcard_match(seed: int) -> Family:
+    contract = r"""# Artifact-name wildcard filter
+
+Read `pattern` and `text` strings. Match the whole text, case sensitively, using
+Unicode code points (not bytes or grapheme clusters). `?` matches exactly one
+code point. `*` matches zero or more code points, including slashes and newlines.
+Backslash escapes the next code point, whatever it is; an ending backslash
+returns {"error": "dangling escape"}. All other characters, including brackets,
+are literals. Consecutive stars have the same semantics as one star. Return
+{"match": boolean}. Empty patterns and texts are valid. There is no recursion
+or nesting limit; use iterative matching for long artifact names.
+
+Stars currently consume only one character, and escaped wildcard characters
+lose their literal meaning. Repair tokenization and matching separately. Run
+`python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from tokens import tokenize
+        from matcher import matches
+        def dispatch(request):
+            try:
+                return {"match": matches(tokenize(request["pattern"]), request["text"])}
+            except ValueError:
+                return {"error": "dangling escape"}
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    tokens = source("""
+        def tokenize(pattern):
+            return [("star" if char == "*" else "any" if char == "?" else "literal", char) for char in pattern]
+    """)
+    fixed_tokens = source(r"""
+        def tokenize(pattern):
+            result, index = [], 0
+            while index < len(pattern):
+                char = pattern[index]
+                if char == "\\":
+                    index += 1
+                    if index == len(pattern):
+                        raise ValueError("dangling escape")
+                    result.append(("literal", pattern[index]))
+                else:
+                    result.append(("star" if char == "*" else "any" if char == "?" else "literal", char))
+                index += 1
+            return result
+    """)
+    matcher = source("""
+        def matches(tokens, text):
+            previous = [True] + [False] * len(text)
+            for kind, char in tokens:
+                current = [False] * (len(text) + 1)
+                for index, actual in enumerate(text, 1):
+                    current[index] = previous[index - 1] and (kind in ("star", "any") or actual == char)
+                previous = current
+            return previous[-1]
+    """)
+    fixed_matcher = source("""
+        def matches(tokens, text):
+            previous = [True] + [False] * len(text)
+            for kind, char in tokens:
+                current = [False] * (len(text) + 1)
+                current[0] = kind == "star" and previous[0]
+                for index, actual in enumerate(text, 1):
+                    if kind == "star":
+                        current[index] = previous[index] or current[index - 1]
+                    else:
+                        current[index] = previous[index - 1] and (kind == "any" or actual == char)
+                previous = current
+            return previous[-1]
+    """)
+
+    def check(label, pattern, text, expected):
+        return case(label, {"pattern": pattern, "text": text}, {"match": expected})
+
+    return Family(
+        "escaped-artifact-wildcards",
+        "learning",
+        "artifact-wildcard-dynamic-matcher-v1",
+        contract,
+        {"app.py": app, "tokens.py": tokens, "matcher.py": matcher},
+        {"tokens.py": fixed_tokens, "matcher.py": fixed_matcher},
+        {"matcher.py": fixed_matcher},
+        [
+            check("public-star-empty", "a*b", "ab", True),
+            check("public-star-many", "a*b", "a123b", True),
+        ],
+        [
+            check("private-literal-star", r"a\*b", "a*b", True),
+            check("private-escaped-question", r"\?", "?", True),
+            check("private-escaped-slash", r"\\", "\\", True),
+            check("private-escape-ordinary", r"\a", "a", True),
+            case("private-dangling", {"pattern": "a\\", "text": "a"}, {"error": "dangling escape"}),
+            check("private-unicode-codepoints", "??", "e\u0301", True),
+            check("private-single-codepoint", "?", "💜", True),
+            check("private-newline-slash", "*", "a/\nb", True),
+            check("private-full-match", "a", "ab", False),
+            check("private-empty", "", "", True),
+            check("private-repeated-stars", "***a**", "a", True),
+            check("private-brackets-literal", "[a]", "a", False),
+            check("private-deep-sequence", "?" * (1200 + seed), "x" * (1200 + seed), True),
+        ],
+        mechanism_cluster="escaped-wildcard-dynamic-programming",
+    )

--- a/benchmarks/agent_tasks/corpus_families/worker_matching.py
+++ b/benchmarks/agent_tasks/corpus_families/worker_matching.py
@@ -1,0 +1,141 @@
+"""Maximum matching requires reassignment along arbitrarily long augmenting paths."""
+
+from .model import Family, case, source
+
+
+def worker_matching(seed: int) -> Family:
+    contract = """# Worker assignment counter
+
+Read unique string `workers`, unique string `slots`, and `eligible` mapping each
+worker to a list of eligible slot names. Missing workers in eligible have no
+edges; duplicate edges are harmless. Ignore eligibility-map entries for workers
+not requested, but an unknown slot referenced by a requested worker is invalid.
+Return {"assigned": maximum_number_of_simultaneous_assignments}. Each worker and
+slot may participate in at most one assignment. Invalid input returns
+{"error": "unknown slot"}. The output does not require a particular matching.
+
+Greedy assignment leaves workers idle even when existing assignments can be
+rearranged. Chains of 1200 workers are valid and must not depend on the Python
+call-stack limit. Repair the matcher without changing the graph-validation contract.
+Run `python public_checks.py`.
+"""
+    app = source("""
+        import json
+        import sys
+        from graph import edges
+        from matching import maximum
+
+        def dispatch(request):
+            try:
+                return {"assigned": maximum(edges(request))}
+            except ValueError:
+                return {"error": "unknown slot"}
+
+        if __name__ == "__main__":
+            json.dump(dispatch(json.load(sys.stdin)), sys.stdout)
+    """)
+    graph = source("""
+        def edges(request):
+            slots = set(request["slots"])
+            result = {}
+            for worker in request["workers"]:
+                choices = list(dict.fromkeys(request["eligible"].get(worker, [])))
+                if any(slot not in slots for slot in choices):
+                    raise ValueError("unknown slot")
+                result[worker] = choices
+            return result
+    """)
+    matching = source("""
+        def maximum(edges):
+            used = set()
+            for worker, choices in edges.items():
+                for slot in choices:
+                    if slot not in used:
+                        used.add(slot)
+                        break
+            return len(used)
+    """)
+    reference = source("""
+        from collections import deque
+
+        def maximum(edges):
+            owner = {}
+            for starting in edges:
+                parents = {starting: None}
+                pending = deque([(starting, 0)])
+                augmented = False
+                while pending and not augmented:
+                    worker, depth = pending.popleft()
+                    for slot in edges[worker]:
+                        if slot not in owner:
+                            owner[slot] = worker
+                            while parents[worker] is not None:
+                                worker, slot = parents[worker]
+                                owner[slot] = worker
+                            augmented = True
+                            break
+                        previous = owner[slot]
+                        if previous not in parents:
+                            parents[previous] = (worker, slot)
+                            pending.append((previous, depth + 1))
+            return len(owner)
+    """)
+    partial = reference.replace(
+        "            for slot in edges[worker]:",
+        "            if depth > 1:\n                continue\n            for slot in edges[worker]:",
+    )
+
+    def request(workers, slots, eligible):
+        return {"workers": workers, "slots": slots, "eligible": eligible}
+
+    count = 4 + seed % 3
+    names = [f"w{i}" for i in range(count)]
+    slots = [f"s{i}" for i in range(count)]
+    chain = {names[i]: slots[i : i + 2] for i in range(count - 1)} | {names[-1]: [slots[0]]}
+    deep_count = 1200
+    deep_names = [str(i) for i in range(deep_count)]
+    deep_chain = {str(i): [str(i), str(i + 1)] for i in range(deep_count - 1)} | {
+        str(deep_count - 1): ["0"]
+    }
+    return Family(
+        "augmenting-worker-matching",
+        "learning",
+        "worker-bipartite-matcher-v1",
+        contract,
+        {"app.py": app, "graph.py": graph, "matching.py": matching},
+        {"matching.py": reference},
+        {"matching.py": partial},
+        [
+            case(
+                "public-reassignment",
+                request(["a", "b"], ["x", "y"], {"a": ["x", "y"], "b": ["x"]}),
+                {"assigned": 2},
+            )
+        ],
+        [
+            case("private-long-chain", request(names, slots, chain), {"assigned": count}),
+            case(
+                "private-deep-chain",
+                request(deep_names, deep_names, deep_chain),
+                {"assigned": deep_count},
+            ),
+            case(
+                "private-hall-deficiency",
+                request(
+                    ["a", "b", "c"], ["x", "y", "z"], {"a": ["x"], "b": ["x"], "c": ["y", "z"]}
+                ),
+                {"assigned": 2},
+            ),
+            case(
+                "private-duplicates",
+                request(["a", "b"], ["x"], {"a": ["x", "x"], "b": ["x"]}),
+                {"assigned": 1},
+            ),
+            case("private-unused-map", request([], [], {"unused": ["missing"]}), {"assigned": 0}),
+            case(
+                "private-invalid", request(["a"], [], {"a": ["missing"]}), {"error": "unknown slot"}
+            ),
+            case("private-missing-worker", request(["a"], ["x"], {}), {"assigned": 0}),
+        ],
+        mechanism_cluster="bipartite-augmenting-path-reassignment",
+    )

--- a/benchmarks/agent_tasks/corpus_manifest.py
+++ b/benchmarks/agent_tasks/corpus_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Any
 
 from benchmarks.agent_tasks import coding_controller
 from benchmarks.agent_tasks.manifest import (
@@ -43,6 +44,23 @@ def _task_inputs(root: Path, tasks: list[Task]) -> dict[str, bytes]:
     return inputs
 
 
+def _catalog_document(catalog_bytes: bytes) -> dict[str, Any]:
+    """Validate the catalog envelope before reading tasks or execution inputs."""
+    catalog = strict_json(catalog_bytes)
+    if not isinstance(catalog, dict):
+        raise ManifestError("authored catalog must be an object")
+    if catalog.get("schema_version") != "sibyl-authored-repair-catalog-v1":
+        raise ManifestError("unsupported authored catalog")
+    if catalog.get("experiences") != []:
+        raise ManifestError("authored catalog cannot declare collected experiences")
+    if not isinstance(catalog.get("tasks"), list):
+        raise ManifestError("authored catalog tasks must be an array")
+    seed = catalog.get("seed")
+    if type(seed) is not int or seed < 0:
+        raise ManifestError("authored catalog seed must be a nonnegative integer")
+    return catalog
+
+
 def compose(
     catalog_path: Path,
     output: Path,
@@ -63,18 +81,7 @@ def compose(
     if catalog_path.is_symlink():
         raise ManifestError("catalog must not be a symlink")
     catalog_bytes = catalog_path.read_bytes()
-    catalog = strict_json(catalog_bytes)
-    if not isinstance(catalog, dict):
-        raise ManifestError("authored catalog must be an object")
-    if catalog.get("schema_version") != "sibyl-authored-repair-catalog-v1":
-        raise ManifestError("unsupported authored catalog")
-    if catalog.get("experiences") != []:
-        raise ManifestError("authored catalog cannot declare collected experiences")
-    if not isinstance(catalog.get("tasks"), list):
-        raise ManifestError("authored catalog tasks must be an array")
-    seed = catalog.get("seed")
-    if type(seed) is not int or seed < 0:
-        raise ManifestError("authored catalog seed must be a nonnegative integer")
+    catalog = _catalog_document(catalog_bytes)
     tasks = [Task.model_validate(item) for item in catalog["tasks"]]
     if not tasks or any(task.split == "sealed" for task in tasks):
         raise ManifestError("authored catalog supports learning/development tasks only")

--- a/benchmarks/agent_tasks/corpus_manifest.py
+++ b/benchmarks/agent_tasks/corpus_manifest.py
@@ -64,16 +64,25 @@ def compose(
         raise ManifestError("catalog must not be a symlink")
     catalog_bytes = catalog_path.read_bytes()
     catalog = strict_json(catalog_bytes)
+    if not isinstance(catalog, dict):
+        raise ManifestError("authored catalog must be an object")
     if catalog.get("schema_version") != "sibyl-authored-repair-catalog-v1":
         raise ManifestError("unsupported authored catalog")
     if catalog.get("experiences") != []:
         raise ManifestError("authored catalog cannot declare collected experiences")
+    if not isinstance(catalog.get("tasks"), list):
+        raise ManifestError("authored catalog tasks must be an array")
+    seed = catalog.get("seed")
+    if type(seed) is not int or seed < 0:
+        raise ManifestError("authored catalog seed must be a nonnegative integer")
     tasks = [Task.model_validate(item) for item in catalog["tasks"]]
     if not tasks or any(task.split == "sealed" for task in tasks):
         raise ManifestError("authored catalog supports learning/development tasks only")
     clusters = catalog.get("mechanism_clusters", {})
-    if set(clusters) != {task.family_id for task in tasks} or any(
-        not isinstance(value, str) or not value.strip() for value in clusters.values()
+    if (
+        not isinstance(clusters, dict)
+        or set(clusters) != {task.family_id for task in tasks}
+        or any(not isinstance(value, str) or not value.strip() for value in clusters.values())
     ):
         raise ManifestError("every family needs an explicit mechanism cluster")
     cluster_splits: dict[str, set[str]] = {}

--- a/benchmarks/agent_tasks/corpus_manifest.py
+++ b/benchmarks/agent_tasks/corpus_manifest.py
@@ -1,0 +1,186 @@
+"""Compose an authored task catalog into a local trusted-development manifest."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from benchmarks.agent_tasks import coding_controller
+from benchmarks.agent_tasks.manifest import (
+    Artifact,
+    ControllerBudget,
+    JsonOracleChecker,
+    Manifest,
+    ManifestError,
+    Task,
+    canonical_bytes,
+    checker_artifacts,
+    digest,
+    identity,
+    load_manifest,
+    read_artifact,
+    runtime_identity,
+    strict_json,
+    validate_partitions,
+)
+
+
+def _task_inputs(root: Path, tasks: list[Task]) -> dict[str, bytes]:
+    inputs: dict[str, bytes] = {}
+    for task in tasks:
+        for artifact in [
+            task.prompt,
+            *checker_artifacts(task.checker),
+            *(item.artifact for item in task.workspace),
+        ]:
+            content = read_artifact(root, artifact)
+            if artifact.path in inputs and inputs[artifact.path] != content:
+                raise ManifestError("conflicting catalog artifact paths")
+            if artifact.path in {"manifest.json", "catalog.json", "composition.json"}:
+                raise ManifestError("catalog uses reserved composition path")
+            inputs[artifact.path] = content
+
+    return inputs
+
+
+def compose(
+    catalog_path: Path,
+    output: Path,
+    *,
+    experiment_id: str,
+    model: str,
+    budget: ControllerBudget,
+    dependency_lock: Path,
+    allow_mechanism_transfer: bool = False,
+) -> Path:
+    """Bind current interpreter and installed controller without executing a task.
+
+    Shared mechanism clusters are exploratory transfer only, never independent
+    unseen-mechanism holdouts. An explicit acknowledgement is retained alongside
+    the complete catalog and manifest. No experience or derived-memory arm is
+    invented by this initial no-memory composition.
+    """
+    if catalog_path.is_symlink():
+        raise ManifestError("catalog must not be a symlink")
+    catalog_bytes = catalog_path.read_bytes()
+    catalog = strict_json(catalog_bytes)
+    if catalog.get("schema_version") != "sibyl-authored-repair-catalog-v1":
+        raise ManifestError("unsupported authored catalog")
+    if catalog.get("experiences") != []:
+        raise ManifestError("authored catalog cannot declare collected experiences")
+    tasks = [Task.model_validate(item) for item in catalog["tasks"]]
+    if not tasks or any(task.split == "sealed" for task in tasks):
+        raise ManifestError("authored catalog supports learning/development tasks only")
+    clusters = catalog.get("mechanism_clusters", {})
+    if set(clusters) != {task.family_id for task in tasks} or any(
+        not isinstance(value, str) or not value.strip() for value in clusters.values()
+    ):
+        raise ManifestError("every family needs an explicit mechanism cluster")
+    cluster_splits: dict[str, set[str]] = {}
+    for task in tasks:
+        cluster_splits.setdefault(clusters[task.family_id], set()).add(task.split)
+    shared = sorted(cluster for cluster, splits in cluster_splits.items() if len(splits) > 1)
+    if shared and not allow_mechanism_transfer:
+        raise ManifestError("shared mechanism clusters require explicit exploratory transfer")
+    if any(not isinstance(task.checker, JsonOracleChecker) for task in tasks):
+        raise ManifestError("authored tasks require the host-owned JSON oracle")
+    checker = tasks[0].checker
+    assert isinstance(checker, JsonOracleChecker)
+    if any(
+        (task.checker.image, task.checker.docker, task.checker.docker_host)
+        != (checker.image, checker.docker, checker.docker_host)
+        for task in tasks
+        if isinstance(task.checker, JsonOracleChecker)
+    ):
+        raise ManifestError("one composition requires one pinned execution environment")
+    inputs = _task_inputs(catalog_path.parent, tasks)
+
+    def bind(name: str, data: bytes) -> Artifact:
+        if name in inputs:
+            raise ManifestError("catalog uses reserved execution artifact path")
+        inputs[name] = data
+        return Artifact(path=name, sha256=digest(data))
+
+    controller = bind("execution/controller.py", Path(coding_controller.__file__).read_bytes())
+    lock = bind("execution/uv.lock", dependency_lock.read_bytes())
+    empty = bind("execution/empty-memory.txt", b"")
+    args = [
+        "--image",
+        checker.image,
+        "--tool-timeout",
+        "45.0",
+        "--memory-mb",
+        "512",
+        "--docker",
+        checker.docker,
+    ]
+    if checker.docker_host:
+        args.extend(["--docker-host", checker.docker_host])
+    manifest = Manifest(
+        schema_version="sibyl-agent-task-manifest-v1",
+        experiment_id=experiment_id,
+        purpose="trusted_development",
+        runtime_sha256=identity(runtime_identity()),
+        dependency_lock=lock,
+        seed=catalog["seed"],
+        controller={"script": controller, "args": args},
+        controller_api_key_env="OPENROUTER_API_KEY",
+        controller_model=model,
+        controller_tools=coding_controller.REQUIRED_TOOLS,
+        controller_budget=budget,
+        controller_timeout_seconds=900.0,
+        checker_timeout_seconds=300.0,
+        experiences=[],
+        tasks=tasks,
+        arms=[{"id": "no-memory", "memory_pack": empty, "learning_source_ids": []}],
+    )
+    validate_partitions(manifest)
+    output.mkdir(mode=0o700, parents=False, exist_ok=False)
+    for name, data in inputs.items():
+        target = output / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    path = output / "manifest.json"
+    path.write_bytes(canonical_bytes(manifest.model_dump(mode="json")))
+    load_manifest(path)
+    (output / "catalog.json").write_bytes(catalog_bytes)
+    (output / "composition.json").write_bytes(
+        canonical_bytes(
+            {
+                "schema_version": "sibyl-authored-corpus-composition-v1",
+                "catalog_sha256": digest(catalog_bytes),
+                "manifest_sha256": digest(path.read_bytes()),
+                "shared_mechanism_clusters": shared,
+                "exploratory_mechanism_transfer": allow_mechanism_transfer,
+                "independent_statistical_families": False,
+                "sealed": False,
+                "experience_count": 0,
+            }
+        )
+    )
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--experiment-id", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--budget", type=Path, required=True)
+    parser.add_argument("--dependency-lock", type=Path, required=True)
+    parser.add_argument("--allow-mechanism-transfer", action="store_true")
+    args = parser.parse_args()
+    compose(
+        args.catalog,
+        args.output,
+        experiment_id=args.experiment_id,
+        model=args.model,
+        budget=ControllerBudget.model_validate(strict_json(args.budget.read_bytes())),
+        dependency_lock=args.dependency_lock,
+        allow_mechanism_transfer=args.allow_mechanism_transfer,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/moon.yml
+++ b/moon.yml
@@ -1055,6 +1055,8 @@ tasks:
     inputs:
       - benchmarks/agent_tasks/**/*.py
       - tools/tests/test_agent_task_learning_corpus.py
+      - tools/tests/conftest.py
+      - pyproject.toml
 
   agent-learning-run:
     command: uv run python -m benchmarks.agent_tasks.learning_run

--- a/moon.yml
+++ b/moon.yml
@@ -1035,6 +1035,27 @@ tasks:
     options:
       cache: false
 
+  agent-corpus-compose:
+    command: uv run python -m benchmarks.agent_tasks.corpus_manifest
+    options:
+      cache: false
+
+  agent-corpus-freeze:
+    command: uv run python -m benchmarks.agent_tasks.corpus
+    options:
+      cache: false
+
+  agent-corpus-format:
+    command: uv run ruff format benchmarks/agent_tasks/corpus.py benchmarks/agent_tasks/corpus_manifest.py benchmarks/agent_tasks/corpus_families tools/tests/test_agent_task_learning_corpus.py
+    options:
+      cache: false
+
+  agent-corpus-test:
+    command: uv run pytest tools/tests/test_agent_task_learning_corpus.py -v
+    inputs:
+      - benchmarks/agent_tasks/**/*.py
+      - tools/tests/test_agent_task_learning_corpus.py
+
   agent-task-run:
     command: uv run python -m benchmarks.agent_tasks
     inputs:
@@ -1043,20 +1064,22 @@ tasks:
       cache: false
 
   agent-task-test:
-    command: uv run pytest tools/tests/test_agent_task_runner.py tools/tests/test_agent_task_coding_controller.py tools/tests/test_agent_task_development_corpus.py -v
+    command: uv run pytest tools/tests/test_agent_task_runner.py tools/tests/test_agent_task_coding_controller.py tools/tests/test_agent_task_development_corpus.py tools/tests/test_agent_task_learning_corpus.py -v
     inputs:
       - packages/python/sibyl-core/src/**/*.py
       - benchmarks/agent_tasks/**/*.py
       - tools/tests/test_agent_task_runner.py
       - tools/tests/test_agent_task_coding_controller.py
       - tools/tests/test_agent_task_development_corpus.py
+      - tools/tests/test_agent_task_learning_corpus.py
       - benchmarks/agent_tasks/development/**/*
       - tools/tests/fixtures/agent_tasks/**/*.py
 
   bench-gate-test:
     command:
       uv run pytest tools/tests/test_agent_task_runner.py tools/tests/test_agent_task_coding_controller.py
-      tools/tests/test_agent_task_development_corpus.py tools/tests/test_evidence_bundle.py
+      tools/tests/test_agent_task_development_corpus.py tools/tests/test_agent_task_learning_corpus.py
+      tools/tests/test_evidence_bundle.py
       tools/tests/test_benchmark_git_provenance.py tools/tests/test_bench_gate.py
       tools/tests/test_compare_eval_reports.py tools/tests/test_context_pack_eval_script.py
       tools/tests/test_longmemeval_agentic_traversal.py

--- a/tools/tests/test_agent_task_learning_corpus.py
+++ b/tools/tests/test_agent_task_learning_corpus.py
@@ -9,7 +9,7 @@ import pytest
 from benchmarks.agent_tasks.corpus import freeze, lineage_audit
 from benchmarks.agent_tasks.corpus_families import families
 from benchmarks.agent_tasks.corpus_manifest import compose
-from benchmarks.agent_tasks.json_oracle import validate_oracle_inputs
+from benchmarks.agent_tasks.json_oracle import canonical_bytes, validate_oracle_inputs
 from benchmarks.agent_tasks.manifest import (
     ControllerBudget,
     JsonOracleChecker,
@@ -20,9 +20,10 @@ from benchmarks.agent_tasks.manifest import (
 )
 
 
+@pytest.mark.parametrize("transport", ["authored", "frozen"])
 @pytest.mark.parametrize("seed", [0, 7])
 @pytest.mark.parametrize("family_index", range(len(families(0))))
-def test_repair_discrimination(tmp_path, seed, family_index):
+def test_repair_discrimination(tmp_path, seed, family_index, transport):
     family = families(seed)[family_index]
 
     def results(repairs, cases):
@@ -33,7 +34,11 @@ def test_repair_discrimination(tmp_path, seed, family_index):
             result = subprocess.run(
                 [sys.executable, "-B", "app.py"],
                 cwd=tmp_path,
-                input=json.dumps(case["input"]),
+                input=(
+                    canonical_bytes(case["input"]).decode() + "\n"
+                    if transport == "frozen"
+                    else json.dumps(case["input"])
+                ),
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -56,7 +61,7 @@ def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
         freeze(root, seed=0, image="sha256:" + "a" * 64, docker="/usr/bin/docker").read_bytes()
     )
     tasks = [Task.model_validate(item) for item in catalog["tasks"]]
-    assert Counter(task.split for task in tasks) == {"learning": 16, "development": 2}
+    assert Counter(task.split for task in tasks) == {"learning": 20, "development": 2}
     assert catalog["experiences"] == []
     for task in tasks:
         assert isinstance(task.checker, JsonOracleChecker)
@@ -77,7 +82,7 @@ def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
 
 def test_cross_split_lineage_report():
     audit = lineage_audit(families(0))
-    assert len(audit["pairs"]) == 16 * 2
+    assert len(audit["pairs"]) == 20 * 2
     assert not any(pair["shared_lineage"] for pair in audit["pairs"])
     assert all(pair["files"] for pair in audit["pairs"])
     assert audit["experience_count"] == 0

--- a/tools/tests/test_agent_task_learning_corpus.py
+++ b/tools/tests/test_agent_task_learning_corpus.py
@@ -56,7 +56,7 @@ def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
         freeze(root, seed=0, image="sha256:" + "a" * 64, docker="/usr/bin/docker").read_bytes()
     )
     tasks = [Task.model_validate(item) for item in catalog["tasks"]]
-    assert Counter(task.split for task in tasks) == {"learning": 12, "development": 2}
+    assert Counter(task.split for task in tasks) == {"learning": 16, "development": 2}
     assert catalog["experiences"] == []
     for task in tasks:
         assert isinstance(task.checker, JsonOracleChecker)
@@ -77,7 +77,7 @@ def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
 
 def test_cross_split_lineage_report():
     audit = lineage_audit(families(0))
-    assert len(audit["pairs"]) == 12 * 2
+    assert len(audit["pairs"]) == 16 * 2
     assert not any(pair["shared_lineage"] for pair in audit["pairs"])
     assert all(pair["files"] for pair in audit["pairs"])
     assert audit["experience_count"] == 0

--- a/tools/tests/test_agent_task_learning_corpus.py
+++ b/tools/tests/test_agent_task_learning_corpus.py
@@ -26,14 +26,17 @@ from benchmarks.agent_tasks.manifest import (
 def test_repair_discrimination(tmp_path, seed, family_index, transport):
     family = families(seed)[family_index]
 
-    def results(repairs, cases):
+    def results(repairs, cases, variant):
+        workspace = tmp_path / variant
         for path, text in (family.workspace | repairs).items():
-            (tmp_path / path).write_text(text)
+            target = workspace / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text)
         outcomes = []
         for case in cases:
             result = subprocess.run(
                 [sys.executable, "-B", "app.py"],
-                cwd=tmp_path,
+                cwd=workspace,
                 input=(
                     canonical_bytes(case["input"]).decode() + "\n"
                     if transport == "frozen"
@@ -49,10 +52,12 @@ def test_repair_discrimination(tmp_path, seed, family_index, transport):
             )
         return outcomes
 
-    assert not all(results({}, family.public_cases + family.private_cases)), family.id
-    assert all(results(family.reference, family.public_cases + family.private_cases)), family.id
-    assert all(results(family.partial, family.public_cases)), family.id
-    assert not all(results(family.partial, family.private_cases)), family.id
+    assert not all(results({}, family.public_cases + family.private_cases, "baseline")), family.id
+    assert all(
+        results(family.reference, family.public_cases + family.private_cases, "reference")
+    ), family.id
+    assert all(results(family.partial, family.public_cases, "partial-public")), family.id
+    assert not all(results(family.partial, family.private_cases, "partial-private")), family.id
 
 
 def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
@@ -95,6 +100,46 @@ def test_mechanism_dependency_survives_distinct_authored_lineages():
     assert not shared[0]["shared_lineage"]
     assert audit["independent_statistical_families"] is False
     assert audit["mechanism_cluster_count"] < audit["family_count"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        (None, []),
+        (None, None),
+        ("tasks", None),
+        ("tasks", {}),
+        ("seed", None),
+        ("seed", True),
+        ("seed", -1),
+        ("seed", "7"),
+        ("mechanism_clusters", None),
+        ("mechanism_clusters", []),
+    ],
+)
+def test_runtime_composition_rejects_malformed_catalog(tmp_path, field, value):
+    catalog = freeze(
+        tmp_path / "catalog", seed=7, image="sha256:" + "a" * 64, docker="/usr/bin/docker"
+    )
+    content = json.loads(catalog.read_bytes())
+    if field is None:
+        content = value
+    else:
+        content[field] = value
+    catalog.write_text(json.dumps(content))
+    output = tmp_path / "run"
+    with pytest.raises(ManifestError):
+        compose(
+            catalog,
+            output,
+            experiment_id="invalid-catalog",
+            model="qwen/qwen3-coder-next",
+            budget=ControllerBudget(
+                input_tokens=10000, output_tokens=1000, tool_calls=10, cost_usd=0.1
+            ),
+            dependency_lock=tmp_path / "unused.lock",
+        )
+    assert not output.exists()
 
 
 def test_runtime_composition_requires_transfer_and_binds_inputs(tmp_path):

--- a/tools/tests/test_agent_task_learning_corpus.py
+++ b/tools/tests/test_agent_task_learning_corpus.py
@@ -1,0 +1,129 @@
+"""Qualify authored fixtures without pretending they are agent outcomes."""
+
+import json
+import subprocess
+import sys
+from collections import Counter
+
+import pytest
+from benchmarks.agent_tasks.corpus import freeze, lineage_audit
+from benchmarks.agent_tasks.corpus_families import families
+from benchmarks.agent_tasks.corpus_manifest import compose
+from benchmarks.agent_tasks.json_oracle import validate_oracle_inputs
+from benchmarks.agent_tasks.manifest import (
+    ControllerBudget,
+    JsonOracleChecker,
+    ManifestError,
+    Task,
+    load_manifest,
+    read_artifact,
+)
+
+
+@pytest.mark.parametrize("seed", [0, 7])
+@pytest.mark.parametrize("family_index", range(6))
+def test_repair_discrimination(tmp_path, seed, family_index):
+    family = families(seed)[family_index]
+
+    def results(repairs, cases):
+        for path, text in (family.workspace | repairs).items():
+            (tmp_path / path).write_text(text)
+        outcomes = []
+        for case in cases:
+            result = subprocess.run(
+                [sys.executable, "-B", "app.py"],
+                cwd=tmp_path,
+                input=json.dumps(case["input"]),
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            outcomes.append(
+                result.returncode == 0 and json.loads(result.stdout) == case["expected"]
+            )
+        return outcomes
+
+    assert not all(results({}, family.public_cases + family.private_cases)), family.id
+    assert all(results(family.reference, family.public_cases + family.private_cases)), family.id
+    assert all(results(family.partial, family.public_cases)), family.id
+    assert not all(results(family.partial, family.private_cases)), family.id
+
+
+def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
+    root = tmp_path / "frozen"
+    catalog = json.loads(
+        freeze(root, seed=0, image="sha256:" + "a" * 64, docker="/usr/bin/docker").read_bytes()
+    )
+    tasks = [Task.model_validate(item) for item in catalog["tasks"]]
+    assert Counter(task.split for task in tasks) == {"learning": 4, "development": 2}
+    assert catalog["experiences"] == []
+    for task in tasks:
+        assert isinstance(task.checker, JsonOracleChecker)
+        checker = task.checker
+        inputs = {
+            artifact.path: read_artifact(root, artifact)
+            for artifact in [checker.oracle, checker.runtime, checker.evaluator]
+        }
+        assert validate_oracle_inputs(checker, inputs).cases
+        assert all(not item.artifact.path.startswith("private/") for item in task.workspace)
+        assert all(
+            "reference" not in item.destination and "partial" not in item.destination
+            for item in task.workspace
+        )
+    with pytest.raises(FileExistsError):
+        freeze(root, seed=0, image="sha256:" + "a" * 64, docker="/usr/bin/docker")
+
+
+def test_cross_split_lineage_report():
+    audit = lineage_audit(families(0))
+    assert len(audit["pairs"]) == 4 * 2
+    assert not any(pair["shared_lineage"] for pair in audit["pairs"])
+    assert all(pair["files"] for pair in audit["pairs"])
+    assert audit["experience_count"] == 0
+
+
+def test_mechanism_dependency_survives_distinct_authored_lineages():
+    audit = lineage_audit(families(0))
+    shared = [pair for pair in audit["pairs"] if pair["shared_mechanism"]]
+    assert len(shared) == 1
+    assert not shared[0]["shared_lineage"]
+    assert audit["independent_statistical_families"] is False
+    assert audit["mechanism_cluster_count"] < audit["family_count"]
+
+
+def test_runtime_composition_requires_transfer_and_binds_inputs(tmp_path):
+    catalog = freeze(
+        tmp_path / "catalog", seed=7, image="sha256:" + "a" * 64, docker="/usr/bin/docker"
+    )
+    lock = tmp_path / "uv.lock"
+    lock.write_text("fixture dependency lock")
+    kwargs = {
+        "experiment_id": "corpus-test",
+        "model": "qwen/qwen3-coder-next",
+        "budget": ControllerBudget(
+            input_tokens=10000, output_tokens=1000, tool_calls=10, cost_usd=0.1
+        ),
+        "dependency_lock": lock,
+    }
+    output = tmp_path / "run"
+    with pytest.raises(ManifestError, match="shared mechanism"):
+        compose(catalog, output, **kwargs)
+    assert not output.exists()
+    manifest_path = compose(catalog, output, allow_mechanism_transfer=True, **kwargs)
+    manifest, inputs = load_manifest(manifest_path)
+    assert manifest.purpose == "trusted_development"
+    assert manifest.experiences == []
+    assert inputs[manifest.arms[0].memory_pack.path] == b""
+    assert manifest.controller_api_key_env == "OPENROUTER_API_KEY"
+    assert len(manifest.tasks) == len(families(7))
+    receipt = json.loads((output / "composition.json").read_bytes())
+    assert receipt["shared_mechanism_clusters"] == ["newest-revision-active-projection"]
+    assert receipt["sealed"] is False
+    with pytest.raises(FileExistsError):
+        compose(catalog, output, allow_mechanism_transfer=True, **kwargs)
+    altered = json.loads(catalog.read_bytes())
+    altered["tasks"][0]["split"] = "sealed"
+    catalog.write_text(json.dumps(altered))
+    with pytest.raises(ManifestError, match="learning/development"):
+        compose(catalog, tmp_path / "sealed", allow_mechanism_transfer=True, **kwargs)

--- a/tools/tests/test_agent_task_learning_corpus.py
+++ b/tools/tests/test_agent_task_learning_corpus.py
@@ -98,19 +98,27 @@ def test_runtime_composition_requires_transfer_and_binds_inputs(tmp_path):
     )
     lock = tmp_path / "uv.lock"
     lock.write_text("fixture dependency lock")
-    kwargs = {
-        "experiment_id": "corpus-test",
-        "model": "qwen/qwen3-coder-next",
-        "budget": ControllerBudget(
-            input_tokens=10000, output_tokens=1000, tool_calls=10, cost_usd=0.1
-        ),
-        "dependency_lock": lock,
-    }
+    budget = ControllerBudget(input_tokens=10000, output_tokens=1000, tool_calls=10, cost_usd=0.1)
     output = tmp_path / "run"
     with pytest.raises(ManifestError, match="shared mechanism"):
-        compose(catalog, output, **kwargs)
+        compose(
+            catalog,
+            output,
+            experiment_id="corpus-test",
+            model="qwen/qwen3-coder-next",
+            budget=budget,
+            dependency_lock=lock,
+        )
     assert not output.exists()
-    manifest_path = compose(catalog, output, allow_mechanism_transfer=True, **kwargs)
+    manifest_path = compose(
+        catalog,
+        output,
+        allow_mechanism_transfer=True,
+        experiment_id="corpus-test",
+        model="qwen/qwen3-coder-next",
+        budget=budget,
+        dependency_lock=lock,
+    )
     manifest, inputs = load_manifest(manifest_path)
     assert manifest.purpose == "trusted_development"
     assert manifest.experiences == []
@@ -121,9 +129,25 @@ def test_runtime_composition_requires_transfer_and_binds_inputs(tmp_path):
     assert receipt["shared_mechanism_clusters"] == ["newest-revision-active-projection"]
     assert receipt["sealed"] is False
     with pytest.raises(FileExistsError):
-        compose(catalog, output, allow_mechanism_transfer=True, **kwargs)
+        compose(
+            catalog,
+            output,
+            allow_mechanism_transfer=True,
+            experiment_id="corpus-test",
+            model="qwen/qwen3-coder-next",
+            budget=budget,
+            dependency_lock=lock,
+        )
     altered = json.loads(catalog.read_bytes())
     altered["tasks"][0]["split"] = "sealed"
     catalog.write_text(json.dumps(altered))
     with pytest.raises(ManifestError, match="learning/development"):
-        compose(catalog, tmp_path / "sealed", allow_mechanism_transfer=True, **kwargs)
+        compose(
+            catalog,
+            tmp_path / "sealed",
+            allow_mechanism_transfer=True,
+            experiment_id="corpus-test",
+            model="qwen/qwen3-coder-next",
+            budget=budget,
+            dependency_lock=lock,
+        )

--- a/tools/tests/test_agent_task_learning_corpus.py
+++ b/tools/tests/test_agent_task_learning_corpus.py
@@ -56,7 +56,7 @@ def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
         freeze(root, seed=0, image="sha256:" + "a" * 64, docker="/usr/bin/docker").read_bytes()
     )
     tasks = [Task.model_validate(item) for item in catalog["tasks"]]
-    assert Counter(task.split for task in tasks) == {"learning": 8, "development": 2}
+    assert Counter(task.split for task in tasks) == {"learning": 12, "development": 2}
     assert catalog["experiences"] == []
     for task in tasks:
         assert isinstance(task.checker, JsonOracleChecker)
@@ -77,7 +77,7 @@ def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
 
 def test_cross_split_lineage_report():
     audit = lineage_audit(families(0))
-    assert len(audit["pairs"]) == 8 * 2
+    assert len(audit["pairs"]) == 12 * 2
     assert not any(pair["shared_lineage"] for pair in audit["pairs"])
     assert all(pair["files"] for pair in audit["pairs"])
     assert audit["experience_count"] == 0

--- a/tools/tests/test_agent_task_learning_corpus.py
+++ b/tools/tests/test_agent_task_learning_corpus.py
@@ -21,7 +21,7 @@ from benchmarks.agent_tasks.manifest import (
 
 
 @pytest.mark.parametrize("seed", [0, 7])
-@pytest.mark.parametrize("family_index", range(6))
+@pytest.mark.parametrize("family_index", range(len(families(0))))
 def test_repair_discrimination(tmp_path, seed, family_index):
     family = families(seed)[family_index]
 
@@ -56,7 +56,7 @@ def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
         freeze(root, seed=0, image="sha256:" + "a" * 64, docker="/usr/bin/docker").read_bytes()
     )
     tasks = [Task.model_validate(item) for item in catalog["tasks"]]
-    assert Counter(task.split for task in tasks) == {"learning": 4, "development": 2}
+    assert Counter(task.split for task in tasks) == {"learning": 8, "development": 2}
     assert catalog["experiences"] == []
     for task in tasks:
         assert isinstance(task.checker, JsonOracleChecker)
@@ -77,7 +77,7 @@ def test_freeze_binds_existing_oracle_and_excludes_repairs(tmp_path):
 
 def test_cross_split_lineage_report():
     audit = lineage_audit(families(0))
-    assert len(audit["pairs"]) == 4 * 2
+    assert len(audit["pairs"]) == 8 * 2
     assert not any(pair["shared_lineage"] for pair in audit["pairs"])
     assert all(pair["files"] for pair in audit["pairs"])
     assert audit["experience_count"] == 0


### PR DESCRIPTION
The existing eight task fixtures are too small to support a useful learning experiment. Add twenty authored learning families and two development families with multi-module repair contracts, public checks, and private JSON oracles. Frozen catalogs and runtime-specific manifests make those inputs reproducible without counting generated fixtures as model episodes.

## 🧪 Corpus qualification

Independent Docker qualification exercised all 22 families across 66 baseline, partial, and reference variants and 579 oracle cases. Every reference passed; each partial passed public checks and failed private checks. Container cleanup and frozen source hashes were verified. Independent reference comparisons cover arithmetic, matching, parsing, state transitions, and graph algorithms, including deep inputs that exposed recursive reference failures.

A real Docker run caught a transport-dependent discriminator: canonical JSON sorted object keys and erased the original Huffman partial repair defect. The corrected task distinguishes case-sensitive canonical ordering from case folding, including Unicode symbols. Discrimination tests cover both authored and frozen JSON transport, with a fresh workspace for each variant. The final corpus suite passed 102 tests, including malformed-catalog rejection before output creation. Independent review passed 12 focused checks. The earlier integrated agent-task suite passed 421 tests with one Linux-only case skipped on macOS; the final inventory typecheck passed. Moon cache inputs include pytest configuration and fixtures.

## 🎯 Split boundaries

Authored lineage and shared mechanisms are recorded separately. Reservation reconciliation and incremental indexing share newest-revision/tombstone projection. The composer requires explicit exploratory-transfer acknowledgement for that overlap and rejects sealed tasks. Distinct family names are not treated as independent statistical units.

The composer binds the current runtime and installed controller, so manifests must be generated on the execution machine. It emits only an empty-memory arm with zero experiences. No reference or partial repairs enter the task workspace.

## 🔍 Remaining experiment work

The authored corpus reaches the planned twenty learning families. Actual episode collection, calibrated difficulty, matched memory arms, final holdout clearance, and measured gains remain required. Twenty small repair families do not establish real-world generalization.

Two initial development attempts exhausted their tool budgets. A separately frozen run with the budget-aware controller completed both attempts normally: reservation passed 6/6 checks, while build planning retained its duplicate-edge bug and passed 6/7. The original results remain unchanged, and the second run measures controller behavior without memory gain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a trusted learning-corpus pipeline for generating, validating, freezing, and composing repair-task catalogs.
  - Expanded the benchmark catalog from 14 to 22 repair-task families, covering configuration, commands, indexing, scheduling, routing, matching, caching, parsing, algorithms, and data processing.
  - Added catalog manifests, audit reports, private evaluation data, and configurable command-line workflows.

- **Tests**
  - Added coverage for repair discrimination, corpus freezing, lineage auditing, mechanism transfer, malformed catalogs, and manifest composition.
  - Extended project test tasks to include learning-corpus and evidence-bundle validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->