### PR TITLE
fix(memory): freeze consolidation input and output budgets

### DIFF
--- a/apps/api/src/sibyl/api/routes/memory_evals.py
+++ b/apps/api/src/sibyl/api/routes/memory_evals.py
@@ -33,7 +33,7 @@ from sibyl_core.services.eval_publication import (
 )
 from sibyl_core.services.eval_publication_guards import verify_publication_admissions
 from sibyl_core.services.memory_source_validation import reconcile_raw_source_lifecycle
-from sibyl_core.tasks.consolidation import METADATA_KEY
+from sibyl_core.tasks.consolidation import METADATA_KEY, ConsolidationInputBudgetExceeded
 from sibyl_core.tasks.eval_receipts import ReceiptError, TaskAssignment
 
 
@@ -264,6 +264,16 @@ async def consolidate_admitted_attempts(
             ),
             model_override=model,
         )
+    except ConsolidationInputBudgetExceeded as exc:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "code": "consolidation_input_budget_exceeded",
+                "actual_chars": exc.actual_chars,
+                "max_input_chars": exc.max_input_chars,
+                "unit": "system_user_declared_schema_characters",
+            },
+        ) from exc
     except (ReceiptError, ConsolidationConflict) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     memory = result.memory

--- a/apps/api/tests/test_memory_eval_admission.py
+++ b/apps/api/tests/test_memory_eval_admission.py
@@ -247,6 +247,7 @@ async def test_archive_restore_preserves_consumed_attempt(eval_api, monkeypatch,
         "duplicate",
         "all_passed",
         "blank",
+        "input_budget",
     ],
 )
 async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, change):
@@ -319,6 +320,10 @@ async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, 
         request["attempt_ids"] = [api.assignment.attempt_id] * 2
     elif change == "blank":
         request["mechanism"] = "   "
+    elif change == "input_budget":
+        from sibyl_core.services.eval_publication import core_config
+
+        monkeypatch.setattr(core_config, "consolidation_max_input_chars", 10)
     response = await api.client.post(
         "/memory/eval/experiments/experiment/consolidate", json=request
     )
@@ -327,6 +332,9 @@ async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, 
     )
     if change == "blank":
         expected = 422
+    if change == "input_budget":
+        expected = 413
+        await _assert_consolidation_input_budget(api, response)
     assert response.status_code == expected, response.text
     assert len(calls) == (1 if change in {None, *candidate_changes} else 0)
     if change is None:
@@ -409,3 +417,15 @@ async def _assert_purged_consolidation_replay(api, request, response):
     assert gone.status_code == 200
     assert gone.json()["status"] == "gone"
     assert gone.json()["candidate"] is None
+
+
+async def _assert_consolidation_input_budget(api, response):
+    detail = response.json()["detail"]
+    assert detail["code"] == "consolidation_input_budget_exceeded"
+    assert detail["actual_chars"] > detail["max_input_chars"] == 10
+    from sibyl_core.services.content_client import normalize_records
+
+    assert (
+        normalize_records(await api.store.execute_query("SELECT * FROM eval_consolidations;")) == []
+    )
+    assert len(normalize_records(await api.store.execute_query("SELECT * FROM raw_captures;"))) == 2

--- a/packages/python/sibyl-core/src/sibyl_core/config.py
+++ b/packages/python/sibyl-core/src/sibyl_core/config.py
@@ -131,6 +131,12 @@ class CoreConfig(BaseSettings):
         description="LLM model for entity extraction",
     )
 
+    consolidation_max_input_chars: int = Field(
+        default=40_000,
+        gt=0,
+        description="Complete consolidation system, user, and output-schema character budget",
+    )
+
     # Anthropic configuration
     anthropic_api_key: SecretStr = Field(
         default=SecretStr(""),

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -16,6 +16,7 @@ from sibyl_core.auth.memory_policy import (
     EVAL_ADMISSION_METADATA_KEY,
     EVAL_CONSOLIDATION_METADATA_KEY,
 )
+from sibyl_core.config import core_config
 from sibyl_core.memory_pipeline.source_lifecycle import (
     SOURCE_BINDINGS_KEY,
     SOURCE_VALIDATION_PENDING_KEY,
@@ -435,9 +436,23 @@ async def store_consolidation(
     return _decode(operation, rows[0])
 
 
-async def consolidation_extractor_configuration() -> tuple[str, str]:
-    """Identify the effective extraction policy without including credentials."""
+@dataclass(frozen=True)
+class _ExtractorPolicy:
+    model: str
+    revision: str
+    max_input_chars: int
+    max_output_tokens: int
+
+
+async def _extractor_policy() -> _ExtractorPolicy:
+    """Resolve one extraction policy snapshot, including the actual build limits."""
     config = await resolve_llm_config(LLMSurface.MEMORY)
+    max_input_chars = core_config.consolidation_max_input_chars
+    max_output_tokens = config.max_tokens.value
+    if max_output_tokens is None:
+        max_output_tokens = 2_048
+    if any(type(value) is not int or value <= 0 for value in (max_input_chars, max_output_tokens)):
+        raise ValueError("consolidation build limits must be positive integers")
     revision = _digest(
         {
             "protocol": SCHEMA_VERSION,
@@ -445,11 +460,18 @@ async def consolidation_extractor_configuration() -> tuple[str, str]:
             "provider": config.provider.value,
             "model": config.model.value,
             "temperature": config.temperature.value,
-            "max_input_chars": 40_000,
-            "max_output_tokens": 2_048,
+            "max_input_chars": max_input_chars,
+            "max_output_tokens": max_output_tokens,
+            "input_budget_unit": "system_user_declared_schema_characters",
         }
     )
-    return config.model.value, revision
+    return _ExtractorPolicy(config.model.value, revision, max_input_chars, max_output_tokens)
+
+
+async def consolidation_extractor_configuration() -> tuple[str, str]:
+    """Identify the effective extraction policy without including credentials."""
+    policy = await _extractor_policy()
+    return policy.model, policy.revision
 
 
 async def consolidate_admitted_procedure(
@@ -465,10 +487,8 @@ async def consolidate_admitted_procedure(
     stored = await get_stored_consolidation(operation)
     if stored is not None:
         return stored
-    if await consolidation_extractor_configuration() != (
-        model_override,
-        operation.extractor_revision,
-    ):
+    policy = await _extractor_policy()
+    if (policy.model, policy.revision) != (model_override, operation.extractor_revision):
         raise ConsolidationConflict("extraction configuration changed")
     result = await propose_admitted_procedure(
         organization_id=operation.organization_id,
@@ -484,10 +504,9 @@ async def consolidate_admitted_procedure(
         trusted_public_key=trusted_public_key,
         expected_controller_policy_sha256=operation.controller_policy_sha256,
         model_override=model_override,
+        max_input_chars=policy.max_input_chars,
+        max_tokens=policy.max_output_tokens,
     )
-    if await consolidation_extractor_configuration() != (
-        model_override,
-        operation.extractor_revision,
-    ):
+    if await _extractor_policy() != policy:
         raise ConsolidationConflict("extraction configuration changed during consolidation")
     return await store_consolidation(operation, result.proposal)

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -408,6 +408,18 @@ def validate_candidate_content_agreement(
     return [] if candidate == expected else ["candidate differs from the untouched proposal"]
 
 
+class ConsolidationInputBudgetExceeded(ValueError):
+    """Complete declared extraction input exceeds its frozen character budget."""
+
+    def __init__(self, actual_chars: int, max_input_chars: int) -> None:
+        self.actual_chars = actual_chars
+        self.max_input_chars = max_input_chars
+        super().__init__(
+            f"complete consolidation input has {actual_chars} characters; "
+            f"the configured limit is {max_input_chars} characters"
+        )
+
+
 async def propose_conditional_procedure(
     group: ConsolidationGroup,
     *,
@@ -437,9 +449,10 @@ async def propose_conditional_procedure(
     ):
         raise ValueError("build budgets must be positive integers")
     prompt = _prompt(group)
-    if len(prompt) + len(SYSTEM_PROMPT) > max_input_chars:
-        raise ValueError("complete evidence exceeds the declared input budget")
     schema = ProcedureProposal.model_json_schema()
+    input_chars = len(prompt) + len(SYSTEM_PROMPT) + len(_canonical(schema).decode("utf-8"))
+    if input_chars > max_input_chars:
+        raise ConsolidationInputBudgetExceeded(input_chars, max_input_chars)
     extractor = Extractor(
         ProcedureProposal,
         surface=LLMSurface.MEMORY,
@@ -463,6 +476,8 @@ async def propose_conditional_procedure(
         "transfer": "not_measured",
         "configured_model": model_override,
         "max_input_chars": max_input_chars,
+        "input_chars": input_chars,
+        "input_budget_unit": "system_user_declared_schema_characters",
         "max_output_tokens": max_tokens,
         "output_retries": 0,
         "input_sha256": _digest(_canonical(group.model_dump(mode="json"))),

--- a/packages/python/sibyl-core/tests/test_eval_publication.py
+++ b/packages/python/sibyl-core/tests/test_eval_publication.py
@@ -273,3 +273,34 @@ async def test_original_admission_ledger_is_immutable(
             await p.store_consolidation(op, result)
     assert await rows("eval_consolidations") == []
     assert len(await rows("raw_captures")) == 2
+
+
+async def test_frozen_input_and_output_budgets_reach_actual_proposal(proposal, monkeypatch):
+    from sibyl_core.ai.llm.config import EnvConfigSource
+
+    op, result = proposal
+    environment = {"SIBYL_LLM_MEMORY_MODEL": "test-model", "SIBYL_LLM_MEMORY_MAX_TOKENS": "3072"}
+    monkeypatch.setattr(p, "resolve_llm_config", EnvConfigSource(environment).resolve)
+    monkeypatch.setattr(p.core_config, "consolidation_max_input_chars", 120_000)
+    model, revision = await p.consolidation_extractor_configuration()
+    calls = []
+
+    async def propose(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(proposal=result)
+
+    monkeypatch.setattr(eval_consolidation, "propose_admitted_procedure", propose)
+    stored = await p.consolidate_admitted_procedure(
+        replace(op, extractor_revision=revision),
+        trusted_issuer_id="oracle-1",
+        trusted_public_key=None,
+        model_override=model,
+    )
+    assert stored.memory is not None
+    assert calls[0]["max_input_chars"] == 120_000
+    assert calls[0]["max_tokens"] == 3072
+    monkeypatch.setattr(p.core_config, "consolidation_max_input_chars", 120_001)
+    assert (await p.consolidation_extractor_configuration())[1] != revision
+    monkeypatch.setattr(p.core_config, "consolidation_max_input_chars", 120_000)
+    environment["SIBYL_LLM_MEMORY_MAX_TOKENS"] = "3073"
+    assert (await p.consolidation_extractor_configuration())[1] != revision

--- a/packages/python/sibyl-core/tests/test_tasks_consolidation.py
+++ b/packages/python/sibyl-core/tests/test_tasks_consolidation.py
@@ -505,3 +505,21 @@ async def test_declared_cross_family_contrast_can_include_a_preventive_action(
     result = await propose(group, c.DraftConditionalProcedure.model_validate(draft), model)
     assert result.candidate is not None
     assert result.receipt["entailment"] == "pending"
+
+
+async def test_complete_input_budget_includes_schema_and_accepts_exact_boundary(group, model):
+    model[0]["proposal"] = c.ProcedureProposal(abstention_reason="No supported procedure")
+    actual = (
+        len(c.SYSTEM_PROMPT)
+        + len(c._prompt(group))
+        + len(c._canonical(c.ProcedureProposal.model_json_schema()).decode("utf-8"))
+    )
+    with pytest.raises(c.ConsolidationInputBudgetExceeded) as raised:
+        await c.propose_conditional_procedure(group, max_input_chars=actual - 1)
+    assert raised.value.actual_chars == actual
+    assert raised.value.max_input_chars == actual - 1
+    assert model[1] == []
+    result = await c.propose_conditional_procedure(group, max_input_chars=actual)
+    assert len(model[1]) == 1
+    assert result.receipt["input_chars"] == actual
+    assert result.receipt["max_input_chars"] == actual


### PR DESCRIPTION
Consolidating complete admitted task traces can exceed the extraction input allowance. The endpoint currently returns an HTTP 500 before reaching the model. Oversized input now returns HTTP 413 with the measured character count, configured allowance, and explicit measurement units before any provider call or durable candidate creation.

The extractor freezes both limits in its configuration fingerprint. The input allowance comes from `SIBYL_CONSOLIDATION_MAX_INPUT_CHARS`, retaining the existing 40,000 default. The output cap now honors the resolved memory configuration (`SIBYL_LLM_MEMORY_MAX_TOKENS` for environment configuration) instead of always forcing 2,048 tokens. A configuration change during extraction prevents publication under the earlier fingerprint.

Input measurement includes the system prompt, complete user prompt, and canonical declared output schema. Character counts describe this application allowance; they do not claim exact provider tokenization or context fit. Complete source evidence is retained. Evidence projection and a successful live extraction remain separate work.

## 🧪 Validation

- Focused consolidation, publication, and source observation tests: 183 passed after integration with the current main branch.
- API admission and consolidation tests: 24 passed, including the typed excess-input response with no extractor invocation or candidate creation.
- Independent review: six checks passed, covering input boundaries and configuration drift.
- Core and API lint and typecheck passed after integration with the current main branch.

No provider calls were made for this change. The preserved pilot failure establishes the original oversized-input trigger; these checks exercise the corrected handling and policy binding.
