### PR TITLE
fix(ai): retain SDK retry receipts in extraction accounting

### DIFF
--- a/apps/api/src/sibyl/ai/llm/config_source.py
+++ b/apps/api/src/sibyl/ai/llm/config_source.py
@@ -66,6 +66,7 @@ class DBSettingsConfigSource:
                 env_config.timeout_seconds,
             ),
             api_key=await self._resolve_api_key(provider.value),
+            transport_max_retries=env_config.transport_max_retries,
             cached_at=datetime.now(UTC),
         )
         self._cache[surface] = resolved

--- a/apps/api/src/sibyl/api/routes/memory_evals.py
+++ b/apps/api/src/sibyl/api/routes/memory_evals.py
@@ -13,6 +13,8 @@ from sibyl.api.routes import memory_auth
 from sibyl.auth.context import AuthContext
 from sibyl.auth.dependencies import get_auth_context, get_current_organization, require_org_role
 from sibyl.config import EvalIssuerSettings, settings
+from sibyl_core.ai.errors import LLMError
+from sibyl_core.ai.transport import FailedExtractionUsage
 from sibyl_core.auth import AuthOrganization, OrganizationRole
 from sibyl_core.auth.memory_policy import EVAL_CONSOLIDATION_METADATA_KEY, MemoryPolicyAction
 from sibyl_core.memory_pipeline.source_lifecycle import public_memory_metadata
@@ -264,6 +266,15 @@ async def consolidate_admitted_attempts(
             ),
             model_override=model,
         )
+    except LLMError as exc:
+        usage = FailedExtractionUsage.model_validate(exc.details.get("extraction_usage", {}))
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "consolidation_extraction_failed",
+                "usage": usage.model_dump(mode="json"),
+            },
+        ) from exc
     except ConsolidationInputBudgetExceeded as exc:
         raise HTTPException(
             status_code=413,

--- a/apps/api/tests/test_jobs_operational_distillation.py
+++ b/apps/api/tests/test_jobs_operational_distillation.py
@@ -123,6 +123,8 @@ async def test_distillation_writes_current_notes_and_removes_stale_kind(
         "total_tokens": 160,
         "cost_usd": 0.00042,
         "cost_complete": True,
+        "transport_attempts": [],
+        "transport_usage_complete": None,
     }
     assert result["distillation_receipt"]["observed_absence"] == {
         "proposed_count": 0,

--- a/apps/api/tests/test_memory_eval_admission.py
+++ b/apps/api/tests/test_memory_eval_admission.py
@@ -22,6 +22,7 @@ from sibyl.config import EvalIssuerSettings
 from sibyl_core.auth import OrganizationRole
 from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
 from sibyl_core.services import content_client
+from sibyl_core.tasks import consolidation
 from sibyl_core.tasks.eval_receipts import TaskAssignment, sign_outcome
 
 
@@ -248,10 +249,10 @@ async def test_archive_restore_preserves_consumed_attempt(eval_api, monkeypatch,
         "all_passed",
         "blank",
         "input_budget",
+        "transport_failure",
     ],
 )
 async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, change):
-    from sibyl_core.tasks import consolidation
 
     api = eval_api
     assert (await _register(api)).status_code == 200
@@ -298,6 +299,8 @@ async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, 
 
     async def extract(_self, prompt):
         calls.append(prompt)
+        if change == "transport_failure":
+            _raise_transport_failure()
         if change in candidate_changes:
             return _candidate_extraction_result(prompt)
         return SimpleNamespace(
@@ -335,6 +338,9 @@ async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, 
     if change == "input_budget":
         expected = 413
         await _assert_consolidation_input_budget(api, response)
+    if change == "transport_failure":
+        await _assert_transport_failure(api, response)
+        return
     assert response.status_code == expected, response.text
     assert len(calls) == (1 if change in {None, *candidate_changes} else 0)
     if change is None:
@@ -343,12 +349,7 @@ async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, 
         assert "sibyl-signed-eval-outcome-v1" in calls[0]
 
     if change in {None, *candidate_changes}:
-        replay = await api.client.post(
-            "/memory/eval/experiments/experiment/consolidate", json=request
-        )
-        assert replay.status_code == 200
-        assert replay.json() == response.json()
-        assert len(calls) == 1
+        await _assert_same_consolidation_replay(api, request, response, calls)
     if change in {"source_deleted_replay", "stamp_changed_replay"}:
         await _assert_unavailable_consolidation_replay(api, request, change)
     if change == "candidate":
@@ -429,3 +430,43 @@ async def _assert_consolidation_input_budget(api, response):
         normalize_records(await api.store.execute_query("SELECT * FROM eval_consolidations;")) == []
     )
     assert len(normalize_records(await api.store.execute_query("SELECT * FROM raw_captures;"))) == 2
+
+
+def _raise_transport_failure():
+    from sibyl_core.ai.errors import LLMProviderError
+    from sibyl_core.ai.transport import FailedExtractionUsage, TransportAttempt
+
+    raise LLMProviderError(
+        "private provider error",
+        details={
+            "body": "private response",
+            "extraction_usage": FailedExtractionUsage(
+                transport_attempts=[
+                    TransportAttempt(status_code=500, request_id="req_1"),
+                    TransportAttempt(exception_type="ReadTimeout"),
+                ]
+            ).model_dump(mode="json"),
+        },
+    )
+
+
+async def _assert_transport_failure(api, response):
+    assert response.status_code == 502
+    detail = response.json()["detail"]
+    assert detail["code"] == "consolidation_extraction_failed"
+    assert len(detail["usage"]["transport_attempts"]) == 2
+    assert detail["usage"]["cost_usd"] is None
+    assert not detail["usage"]["usage_complete"]
+    assert "private" not in response.text
+    from sibyl_core.services.content_client import normalize_records
+
+    assert (
+        normalize_records(await api.store.execute_query("SELECT * FROM eval_consolidations;")) == []
+    )
+
+
+async def _assert_same_consolidation_replay(api, request, response, calls):
+    replay = await api.client.post("/memory/eval/experiments/experiment/consolidate", json=request)
+    assert replay.status_code == 200
+    assert replay.json() == response.json()
+    assert len(calls) == 1

--- a/packages/python/sibyl-core/src/sibyl_core/ai/clients.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/clients.py
@@ -115,6 +115,7 @@ def _config_fingerprint(config: LLMConfig) -> str:
             str(config.temperature),
             str(config.max_tokens),
             str(config.timeout_seconds),
+            str(config.transport_max_retries),
             api_key_hash or "",
         ]
     )

--- a/packages/python/sibyl-core/src/sibyl_core/ai/llm/budget.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/llm/budget.py
@@ -80,10 +80,16 @@ async def reserve_llm_budget(
     surface: str,
     prompt: str,
     output_token_limit: int | None = None,
+    attempt_envelope: int = 1,
 ) -> int:
+    """Reserve a character-based estimate, including the configured retry envelope."""
+    if attempt_envelope < 1:
+        raise ValueError("attempt envelope must be positive")
     enforcer = _budget_enforcer
     context = _budget_context.get()
-    estimated_tokens = estimate_llm_tokens(prompt, output_token_limit=output_token_limit)
+    estimated_tokens = (
+        estimate_llm_tokens(prompt, output_token_limit=output_token_limit) * attempt_envelope
+    )
     if enforcer is None or context is None:
         return estimated_tokens
     await enforcer.reserve(

--- a/packages/python/sibyl-core/src/sibyl_core/ai/llm/config.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/llm/config.py
@@ -29,6 +29,7 @@ class LLMConfig(BaseModel):
     temperature: float = Field(default=0.0, ge=0.0, le=2.0)
     max_tokens: int | None = Field(default=None, gt=0)
     timeout_seconds: float = Field(default=60.0, gt=0.0)
+    transport_max_retries: int = Field(default=2, ge=0, strict=True)
     api_key: SecretStr | None = None
 
 
@@ -47,6 +48,9 @@ class ResolvedLLMConfig(BaseModel):
     max_tokens: ConfigField[int | None]
     timeout_seconds: ConfigField[float]
     api_key: ConfigField[SecretStr | None]
+    transport_max_retries: ConfigField[int] = Field(
+        default_factory=lambda: ConfigField(value=2, source="default")
+    )
     cached_at: datetime | None = None
 
     def to_llm_config(self) -> LLMConfig:
@@ -57,6 +61,7 @@ class ResolvedLLMConfig(BaseModel):
             max_tokens=self.max_tokens.value,
             timeout_seconds=self.timeout_seconds.value,
             api_key=self.api_key.value,
+            transport_max_retries=self.transport_max_retries.value,
         )
 
 
@@ -84,7 +89,14 @@ class EnvConfigSource:
             max_tokens=self._resolve_int(surface, "MAX_TOKENS", default=None),
             timeout_seconds=self._resolve_float(surface, "TIMEOUT_SECONDS", default=60.0),
             api_key=self._resolve_api_key(provider.value),
+            transport_max_retries=self._resolve_transport_retries(surface),
         )
+
+    def _resolve_transport_retries(self, surface: LLMSurface) -> ConfigField[int]:
+        resolved = self._resolve_int(surface, "TRANSPORT_MAX_RETRIES", default=2)
+        if resolved.value is None or resolved.value < 0:
+            raise LLMConfigError("Transport retries must be a nonnegative integer")
+        return ConfigField[int].model_validate(resolved.model_dump())
 
     async def invalidate(self, surface: LLMSurface | None = None) -> None:
         return None

--- a/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py
@@ -3,20 +3,27 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, TypeAdapter
 from pydantic_ai import Agent
 from pydantic_ai.messages import ModelResponse
-from pydantic_ai.models import ModelSettings
+from pydantic_ai.models import Model, ModelSettings
+from pydantic_ai.models.openai import OpenAIResponsesModel
 
 from sibyl_core.ai.clients import get_agent
 from sibyl_core.ai.errors import LLMError, classify_llm_exception
 from sibyl_core.ai.llm.budget import reserve_llm_budget
 from sibyl_core.ai.llm.config import LLMSurface
+from sibyl_core.ai.transport import (
+    FailedExtractionUsage,
+    TransportAttempt,
+    collect_transport_attempts,
+)
 from sibyl_core.observability import elapsed_ms, telemetry_registry
 
 
@@ -29,6 +36,8 @@ class ExtractionUsage(BaseModel):
     total_tokens: int
     cost_usd: float | None = None
     cost_complete: bool = False
+    transport_attempts: list[TransportAttempt] = Field(default_factory=list)
+    transport_usage_complete: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -62,13 +71,27 @@ class Extractor[T]:
 
     async def extract_with_usage(self, prompt: str) -> ExtractionResult[T]:
         started_at = time.perf_counter()
+        with collect_transport_attempts() as attempts:
+            return await self._extract_with_attempts(prompt, started_at, attempts)
+
+    async def _extract_with_attempts(
+        self, prompt: str, started_at: float, attempts: list[TransportAttempt]
+    ) -> ExtractionResult[T]:
         try:
+            agent = await self._get_agent()
+            transport_retries = (
+                agent.model.client.max_retries
+                if isinstance(agent.model, OpenAIResponsesModel)
+                else 0
+            )
+            # An unspecified output retry policy estimates one model request;
+            # dynamic agent settings and provider work are not bounded here.
             await reserve_llm_budget(
                 surface=self.surface.value,
-                prompt=prompt,
-                output_token_limit=self.max_tokens,
+                prompt=self._budget_prompt(prompt),
+                output_token_limit=self._budget_output_limit(agent),
+                attempt_envelope=(transport_retries + 1) * ((self.output_retries or 0) + 1),
             )
-            agent = await self._get_agent()
             result = await agent.run(
                 prompt,
                 model_settings=_model_settings(self.max_tokens),
@@ -82,8 +105,13 @@ class Extractor[T]:
             )
             return ExtractionResult(
                 output=result.output,
-                usage=_extraction_usage(result),
+                usage=_extraction_usage(result, attempts),
             )
+        except asyncio.CancelledError as exc:
+            exc.__dict__["extraction_usage"] = FailedExtractionUsage(
+                transport_attempts=attempts
+            ).model_dump(mode="json")
+            raise
         except Exception as exc:
             telemetry_registry().record_llm_call(
                 surface=self.surface.value,
@@ -92,7 +120,27 @@ class Extractor[T]:
                 status="error",
                 duration_ms=elapsed_ms(started_at),
             )
-            raise self._classify(exc) from exc
+            error = self._classify(exc)
+            error.details["extraction_usage"] = FailedExtractionUsage(
+                transport_attempts=attempts
+            ).model_dump(mode="json")
+            raise error from exc
+
+    def _budget_output_limit(self, agent: Agent[Any, Any]) -> int | None:
+        """Use known static settings; dynamic settings and absent limits stay unknown."""
+        if self.max_tokens is not None:
+            return self.max_tokens
+        settings = dict(agent.model.settings or {}) if isinstance(agent.model, Model) else {}
+        if isinstance(agent.model_settings, dict):
+            settings.update(agent.model_settings)
+        return settings.get("max_tokens")
+
+    def _budget_prompt(self, prompt: str) -> str:
+        instructions = self.system_prompt or ()
+        if isinstance(instructions, str):
+            instructions = (instructions,)
+        schema = TypeAdapter(self.output_type).json_schema()
+        return "\n".join((*instructions, prompt, json.dumps(schema, sort_keys=True)))
 
     async def extract_many(
         self,
@@ -136,7 +184,7 @@ def _model_settings(max_tokens: int | None) -> ModelSettings | None:
     return ModelSettings(max_tokens=max_tokens)
 
 
-def _extraction_usage(result: Any) -> ExtractionUsage:
+def _extraction_usage(result: Any, attempts: list[TransportAttempt]) -> ExtractionUsage:
     run_usage = result.usage
     responses = [message for message in result.new_messages() if isinstance(message, ModelResponse)]
     provider = next(
@@ -155,7 +203,20 @@ def _extraction_usage(result: Any) -> ExtractionUsage:
         except (AssertionError, LookupError):
             continue
         priced_responses += 1
-    cost_complete = bool(responses) and priced_responses == len(responses)
+    successful = [
+        i
+        for i, attempt in enumerate(attempts)
+        if attempt.status_code is not None and 200 <= attempt.status_code < 300
+    ]
+    if len(successful) == len(responses) and all(
+        response.usage.has_values() for response in responses
+    ):
+        for index in successful:
+            attempts[index] = attempts[index].model_copy(update={"usage_known": True})
+    transport_complete = all(attempt.usage_known for attempt in attempts) if attempts else None
+    cost_complete = (
+        bool(responses) and priced_responses == len(responses) and transport_complete is not False
+    )
     return ExtractionUsage(
         provider=provider,
         model=model,
@@ -165,4 +226,6 @@ def _extraction_usage(result: Any) -> ExtractionUsage:
         total_tokens=run_usage.total_tokens,
         cost_usd=total_cost if cost_complete else None,
         cost_complete=cost_complete,
+        transport_attempts=attempts,
+        transport_usage_complete=transport_complete,
     )

--- a/packages/python/sibyl-core/src/sibyl_core/ai/providers.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/providers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import Literal
 
+from openai import AsyncOpenAI
 from pydantic_ai.models import Model
 from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
 from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
@@ -16,6 +17,7 @@ from pydantic_ai.providers.openai import OpenAIProvider
 from sibyl_core.ai.errors import LLMConfigError
 from sibyl_core.ai.llm.config import LLMConfig
 from sibyl_core.ai.registry import ModelKind, model_registry
+from sibyl_core.ai.transport import RecordingOpenAIClient
 
 
 def build_model(config: LLMConfig) -> Model:
@@ -38,7 +40,13 @@ def build_model(config: LLMConfig) -> Model:
         case "openai":
             return OpenAIResponsesModel(
                 provider_model_id,
-                provider=OpenAIProvider(api_key=api_key),
+                provider=OpenAIProvider(
+                    openai_client=AsyncOpenAI(
+                        api_key=api_key,
+                        max_retries=config.transport_max_retries,
+                        http_client=RecordingOpenAIClient(),
+                    )
+                ),
                 settings=OpenAIResponsesModelSettings(**_settings(config)),
             )
 

--- a/packages/python/sibyl-core/src/sibyl_core/ai/transport.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/transport.py
@@ -1,0 +1,85 @@
+"""Safe, context-local receipts for SDK HTTP attempts during extraction."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from importlib.metadata import version
+from typing import Any
+
+from openai import DefaultAsyncHttpxClient
+from pydantic import BaseModel, ConfigDict, Field
+
+from sibyl_core.ai.llm.config import LLMConfig
+
+
+class TransportAttempt(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    status_code: int | None = None
+    exception_type: str | None = None
+    request_id: str | None = None
+    usage_known: bool = False
+
+
+class FailedExtractionUsage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    transport_attempts: list[TransportAttempt] = Field(default_factory=list)
+    usage_complete: bool = False
+    cost_usd: None = None
+    cost_complete: bool = False
+
+
+_attempts: ContextVar[list[TransportAttempt] | None] = ContextVar(
+    "llm_transport_attempts", default=None
+)
+
+
+@contextmanager
+def collect_transport_attempts() -> Iterator[list[TransportAttempt]]:
+    attempts: list[TransportAttempt] = []
+    token = _attempts.set(attempts)
+    try:
+        yield attempts
+    finally:
+        _attempts.reset(token)
+
+
+class RecordingOpenAIClient(DefaultAsyncHttpxClient):
+    async def send(self, request: Any, **kwargs: Any) -> Any:
+        attempts = _attempts.get()
+        try:
+            response = await super().send(request, **kwargs)
+        except (Exception, asyncio.CancelledError) as exc:
+            if attempts is not None:
+                # Exception messages and request/response bodies may contain secrets.
+                attempts.append(TransportAttempt(exception_type=type(exc).__name__))
+            raise
+        if attempts is not None:
+            request_id = response.headers.get("x-request-id")
+            if (
+                request_id is not None
+                and re.fullmatch(r"[a-zA-Z0-9_.:-]{1,200}", request_id) is None
+            ):
+                request_id = None
+            attempts.append(
+                TransportAttempt(status_code=response.status_code, request_id=request_id)
+            )
+        return response
+
+
+def transport_policy(config: LLMConfig) -> dict[str, str | int | None]:
+    """Bind the supported SDK behavior; other providers remain uninstrumented."""
+    return {
+        "provider": config.provider,
+        "sdk_version": version(
+            {"openai": "openai", "anthropic": "anthropic", "gemini": "google-genai"}[
+                config.provider
+            ]
+        ),
+        "pydantic_ai_version": version("pydantic-ai-slim"),
+        "max_retries": config.transport_max_retries if config.provider == "openai" else None,
+        "receipt_version": "sibyl-sdk-attempt-v1" if config.provider == "openai" else None,
+    }

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -12,6 +12,7 @@ from uuid import NAMESPACE_URL, uuid5
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 from sibyl_core.ai.llm.config import LLMSurface, resolve_llm_config
+from sibyl_core.ai.transport import transport_policy
 from sibyl_core.auth.memory_policy import (
     EVAL_ADMISSION_METADATA_KEY,
     EVAL_CONSOLIDATION_METADATA_KEY,
@@ -469,6 +470,7 @@ async def _extractor_policy() -> _ExtractorPolicy:
             "max_input_chars": max_input_chars,
             "max_output_tokens": max_output_tokens,
             "input_budget_unit": "system_user_declared_schema_characters",
+            "transport": transport_policy(config.to_llm_config()),
         }
     )
     return _ExtractorPolicy(config.model.value, revision, max_input_chars, max_output_tokens)

--- a/packages/python/sibyl-core/tests/ai/llm/test_extractor.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_extractor.py
@@ -82,6 +82,8 @@ async def test_extractor_returns_provider_usage_and_complete_cost() -> None:
         "total_tokens": 16,
         "cost_usd": 0.0012,
         "cost_complete": True,
+        "transport_attempts": [],
+        "transport_usage_complete": None,
     }
 
 
@@ -159,7 +161,7 @@ async def test_extractor_reserves_budget_before_provider_call() -> None:
     context, surface, tokens = enforcer.calls[0]
     assert context.user_id == "user-1"
     assert surface == "default"
-    assert tokens == 11
+    assert tokens > 11  # Declared output schema and retry envelope are included.
 
 
 async def _invalid_json_response(_: list[ModelMessage], __: AgentInfo) -> ModelResponse:

--- a/packages/python/sibyl-core/tests/ai/llm/test_transport_accounting.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_transport_accounting.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from decimal import Decimal
+from types import SimpleNamespace
+
+import httpx2 as httpx
+import pytest
+from pydantic import BaseModel, SecretStr
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelResponse
+
+from sibyl_core.ai import providers
+from sibyl_core.ai.clients import _config_fingerprint
+from sibyl_core.ai.errors import LLMError
+from sibyl_core.ai.llm.budget import llm_budget_context, set_budget_enforcer
+from sibyl_core.ai.llm.config import EnvConfigSource, LLMConfig, LLMSurface
+from sibyl_core.ai.llm.extractor import Extractor
+from sibyl_core.ai.transport import RecordingOpenAIClient
+from sibyl_core.services import eval_publication
+
+
+def response() -> dict:
+    return {
+        "id": "resp_mock",
+        "object": "response",
+        "created_at": 0,
+        "model": "qwen/qwen3-coder-next",
+        "status": "completed",
+        "output": [
+            {
+                "id": "msg_mock",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "ok", "annotations": []}],
+            }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 1, "total_tokens": 11},
+    }
+
+
+@pytest.mark.parametrize("failure", [None, "http", "timeout", "invalid_json", "missing_usage"])
+async def test_transport_attempts_preserve_unknown_usage(monkeypatch, failure):
+    calls = []
+
+    def respond(request):
+        calls.append(request)
+        if failure == "timeout":
+            raise httpx.ReadTimeout("private exception body", request=request)
+        if len(calls) < 3 or failure == "http":
+            return httpx.Response(
+                500,
+                headers={"retry-after-ms": "1", "x-request-id": f"request_{len(calls)}"},
+                json={"error": {"message": "private provider body"}},
+            )
+        if failure == "invalid_json":
+            return httpx.Response(200, content=b"not json")
+        payload = response()
+        if failure == "missing_usage":
+            payload.pop("usage")
+        return httpx.Response(200, headers={"x-request-id": "request_3"}, json=payload)
+
+    async with RecordingOpenAIClient(transport=httpx.MockTransport(respond)) as http:
+        monkeypatch.setattr(providers, "RecordingOpenAIClient", lambda: http)
+        model = providers.build_model(
+            LLMConfig(
+                provider="openai", model="qwen/qwen3-coder-next", api_key=SecretStr("private-key")
+            )
+        )
+        assert model.client.max_retries == 2
+        extractor = Extractor(str, agent=Agent(model, retries={"output": 0}), output_retries=0)
+        monkeypatch.setattr(
+            ModelResponse, "cost", lambda _: SimpleNamespace(total_price=Decimal("0.1"))
+        )
+        if failure in {"http", "timeout", "invalid_json"}:
+            with pytest.raises(LLMError) as caught:
+                await extractor.extract_with_usage("private prompt")
+            receipt = caught.value.details["extraction_usage"]
+            assert receipt["usage_complete"] is False
+        else:
+            result = await extractor.extract_with_usage("private prompt")
+            assert result.usage.requests == 1
+            assert result.usage.input_tokens == (0 if failure == "missing_usage" else 10)
+            receipt = result.usage.model_dump()
+            assert receipt["transport_usage_complete"] is False
+        assert len(calls) == 3
+        assert len(receipt["transport_attempts"]) == 3
+        assert not receipt["cost_complete"]
+        assert receipt["cost_usd"] is None
+        assert not receipt["transport_attempts"][0]["usage_known"]
+        serialized = json.dumps(receipt)
+        assert "private" not in serialized and "authorization" not in serialized.lower()
+
+
+async def test_transport_receipts_are_isolated_for_concurrent_extractions(monkeypatch):
+    async def respond(request):
+        await asyncio.sleep(0)
+        prompt = json.loads(request.content)["input"][0]["content"]
+        return httpx.Response(200, headers={"x-request-id": prompt}, json=response())
+
+    async with RecordingOpenAIClient(transport=httpx.MockTransport(respond)) as http:
+        monkeypatch.setattr(providers, "RecordingOpenAIClient", lambda: http)
+        model = providers.build_model(
+            LLMConfig(
+                provider="openai", model="qwen/qwen3-coder-next", api_key=SecretStr("private-key")
+            )
+        )
+        extractor = Extractor(str, agent=Agent(model), output_retries=0)
+        results = await asyncio.gather(
+            *(extractor.extract_with_usage(f"request_{i}") for i in range(8))
+        )
+        for i, result in enumerate(results):
+            assert len(result.usage.transport_attempts) == 1
+            assert result.usage.transport_attempts[0].request_id == f"request_{i}"
+            assert result.usage.transport_usage_complete is True
+
+
+async def test_transport_budget_includes_system_schema_and_retry_envelope(monkeypatch):
+    class Payload(BaseModel):
+        name: str
+
+    reservations = []
+
+    class Budget:
+        async def reserve(self, context, *, surface, estimated_tokens):
+            reservations.append(estimated_tokens)
+            raise LLMError("stop before provider")
+
+    def no_request(request):
+        pytest.fail("budget must precede transport")
+
+    async with RecordingOpenAIClient(transport=httpx.MockTransport(no_request)) as http:
+        monkeypatch.setattr(providers, "RecordingOpenAIClient", lambda: http)
+        model = providers.build_model(
+            LLMConfig(
+                provider="openai", model="qwen/qwen3-coder-next", api_key=SecretStr("private-key")
+            )
+        )
+        extractor = Extractor(
+            Payload,
+            agent=Agent(model, output_type=Payload),
+            system_prompt="system",
+            output_retries=0,
+            max_tokens=7,
+        )
+        set_budget_enforcer(Budget())
+        try:
+            with llm_budget_context(user_id="user", organization_id="org"), pytest.raises(LLMError):
+                await extractor.extract("prompt")
+        finally:
+            set_budget_enforcer(None)
+        expected = (
+            len("system\nprompt\n" + json.dumps(Payload.model_json_schema(), sort_keys=True)) // 4
+            + 7
+        ) * 3
+        assert reservations == [expected]
+
+
+async def test_transport_policy_binds_config_cache_and_dependency_versions(monkeypatch):
+    environment = {"SIBYL_LLM_MEMORY_PROVIDER": "openai", "SIBYL_LLM_MEMORY_MODEL": "test"}
+    source = EnvConfigSource(environment)
+    monkeypatch.setattr(eval_publication, "resolve_llm_config", source.resolve)
+    original = await eval_publication._extractor_policy()
+    config = (await source.resolve(LLMSurface.MEMORY)).to_llm_config()
+    assert config.transport_max_retries == 2
+    environment["SIBYL_LLM_MEMORY_TRANSPORT_MAX_RETRIES"] = "4"
+    assert await eval_publication._extractor_policy() != original
+    changed = (await source.resolve(LLMSurface.MEMORY)).to_llm_config()
+    assert _config_fingerprint(changed) != _config_fingerprint(config)
+    environment.pop("SIBYL_LLM_MEMORY_TRANSPORT_MAX_RETRIES")
+    from sibyl_core.ai import transport
+
+    monkeypatch.setattr(transport, "version", lambda _: "changed-version")
+    assert await eval_publication._extractor_policy() != original
+    environment["SIBYL_LLM_MEMORY_TRANSPORT_MAX_RETRIES"] = "-1"
+    with pytest.raises(LLMError):
+        await source.resolve(LLMSurface.MEMORY)
+
+
+async def test_transport_cancellation_records_ambiguous_attempt_and_reraises(monkeypatch):
+    dispatched = asyncio.Event()
+
+    async def respond(request):
+        dispatched.set()
+        await asyncio.Event().wait()
+
+    async with RecordingOpenAIClient(transport=httpx.MockTransport(respond)) as http:
+        monkeypatch.setattr(providers, "RecordingOpenAIClient", lambda: http)
+        model = providers.build_model(
+            LLMConfig(
+                provider="openai", model="qwen/qwen3-coder-next", api_key=SecretStr("private-key")
+            )
+        )
+        extractor = Extractor(str, agent=Agent(model), output_retries=0)
+        task = asyncio.create_task(extractor.extract_with_usage("private prompt"))
+        await dispatched.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError) as caught:
+            await task
+        usage = caught.value.extraction_usage
+        assert len(usage["transport_attempts"]) == 1
+        assert usage["transport_attempts"][0]["exception_type"] == "CancelledError"
+        assert usage["usage_complete"] is False
+        assert usage["cost_usd"] is None
+
+
+async def test_transport_collection_child_sharing_and_nested_isolation():
+    from sibyl_core.ai.transport import collect_transport_attempts
+
+    async with RecordingOpenAIClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(200))
+    ) as http:
+        with collect_transport_attempts() as parent:
+            await asyncio.create_task(http.get("https://example.invalid"))
+            assert len(parent) == 1
+            with collect_transport_attempts() as nested:
+                await asyncio.create_task(http.get("https://example.invalid"))
+                assert len(nested) == 1
+                assert len(parent) == 1
+            await http.get("https://example.invalid")
+            assert len(parent) == 2
+
+
+async def test_default_extractor_budget_uses_known_agent_output_settings():
+    from pydantic_ai.models.test import TestModel
+
+    reservations = []
+
+    class Budget:
+        async def reserve(self, context, *, surface, estimated_tokens):
+            reservations.append(estimated_tokens)
+
+    extractor = Extractor(
+        str,
+        agent=Agent(TestModel(settings={"max_tokens": 17}), model_settings={"max_tokens": 23}),
+        output_retries=None,
+    )
+    set_budget_enforcer(Budget())
+    try:
+        with llm_budget_context(user_id="user", organization_id="org"):
+            await extractor.extract("abcd")
+    finally:
+        set_budget_enforcer(None)
+    # No explicit output retry policy: this remains a one-request estimate.
+    assert reservations == [
+        len("abcd\n" + json.dumps({"type": "string"}, sort_keys=True)) // 4 + 23
+    ]


### PR DESCRIPTION
An SDK retry can hide behind a successful extraction: two HTTP failures followed by success produce three transport attempts, while the model usage reports one request. Consolidation now retains those attempt receipts and leaves total cost unknown when an earlier attempt has no usage report.

## 🛠️ How it works

The OpenAI provider keeps its default two transport retries and native SDK connection settings. A context-local collector records status, exception type and a restricted request identifier for each SDK send. Request bodies, response bodies and credentials are excluded. Concurrent extractions have separate collectors; child tasks inherit their parent's collector.

Successful extraction receipts retain the final model token usage alongside transport attempts. Failed or ambiguous attempts prevent a complete-cost claim. Terminal extraction failures return an authenticated consolidation HTTP502 response with only the typed accounting receipt. Cancellation carries the receipt and propagates unchanged; a disconnected client cannot be promised delivery.

The existing extractor policy digest now includes the retry count and installed SDK/PydanticAI versions. Budget preflight includes declared system/user/schema text, known output allowance and configured retries. The character-based calculation remains an estimate. Dynamic settings, unspecified output retry defaults, provider-internal work and individual redirect hops are outside its completeness claim. Other providers remain uninstrumented.

## 🧪 Validation

| Check | Result |
| --- | --- |
| Final-base core selection covering extraction, transport, consolidation and projection | 158 passed |
| Final-base API selection covering eval admission and LLM configuration | 43 passed |
| Core/API lint and typecheck | All four passed |
| Native SDK controls on the reviewed implementation | 49 passed, including 11 focused retry/cancellation/concurrency controls |
| Independent native controls and regressions | 6 new controls plus 12 regressions passed |
| Separate root rerun of the independent controls | All 6 passed |
| Operational distillation receipt regression after hosted assertion correction | 4 passed |

The independent checks exercise two failures then success, terminal failure, missing usage, cancellation, context isolation and protected failure responses using local mock transports. The initial fixture mixed legacy httpx with the SDK's httpx2 transport and failed stream assertions; the final fixtures use the native SDK transport. All 12 reviewed file hashes remained identical after integration onto main.

No model calls or live pilot execution were performed. These checks establish local accounting behavior, not provider-reported total spend or learning-transfer results.

The first hosted package run found an exact-dictionary assertion that omitted the two new usage fields in an operational distillation receipt. The follow-up commit adds those expected fields only; all 12 independently reviewed files remain byte-identical. Hosted checks are rerunning for the new head.
