### PR TITLE
fix(memory): restore consolidation validation feedback

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -33,6 +33,7 @@ from sibyl_core.services.memory_source_validation import (
 )
 from sibyl_core.tasks.consolidation import (
     EVIDENCE_SYSTEM_PROMPT,
+    OUTPUT_RETRIES,
     SCHEMA_VERSION,
     SYSTEM_PROMPT,
     AdmittedTaskOutcome,
@@ -469,6 +470,7 @@ async def _extractor_policy() -> _ExtractorPolicy:
             "temperature": config.temperature.value,
             "max_input_chars": max_input_chars,
             "max_output_tokens": max_output_tokens,
+            "output_retries": OUTPUT_RETRIES,
             "input_budget_unit": "system_user_declared_schema_characters",
             "transport": transport_policy(config.to_llm_config()),
         }

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -31,6 +31,7 @@ from sibyl_core.tasks.episode_evidence import (
 from sibyl_core.tasks.procedure_evidence import EvidenceProposal, resolve_evidence_proposal
 
 SCHEMA_VERSION = "sibyl-conditional-procedure-v1"
+OUTPUT_RETRIES = 2
 METADATA_KEY = "conditional_procedure"
 Text = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 SHA256 = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
@@ -572,7 +573,7 @@ async def propose_conditional_procedure(
         surface=LLMSurface.MEMORY,
         system_prompt=evidence.system,
         model_override=model_override,
-        output_retries=0,
+        output_retries=OUTPUT_RETRIES,
         max_tokens=max_tokens,
     )
     with llm_budget_context(
@@ -622,7 +623,7 @@ def _finish_proposal(
         "input_chars": input_chars,
         "input_budget_unit": "system_user_declared_schema_characters",
         "max_output_tokens": max_tokens,
-        "output_retries": 0,
+        "output_retries": OUTPUT_RETRIES,
         "input_sha256": _digest(_canonical(group.model_dump(mode="json"))),
         "prompt_sha256": _digest(_canonical({"system": evidence.system, "user": prompt})),
         "schema_sha256": _digest(_canonical(evidence.output_type.model_json_schema())),

--- a/packages/python/sibyl-core/tests/ai/llm/test_consolidation_validation_feedback.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_consolidation_validation_feedback.py
@@ -1,0 +1,116 @@
+"""Consolidation keeps normal schema feedback separate from transport retries."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelResponse
+from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from sibyl_core.ai.errors import LLMValidationError
+from sibyl_core.ai.llm import Extractor
+from sibyl_core.ai.llm import extractor as extraction
+from sibyl_core.ai.transport import RecordingOpenAIClient
+from sibyl_core.tasks.consolidation import OUTPUT_RETRIES
+from sibyl_core.tasks.procedure_evidence import EvidenceProposal
+
+
+@pytest.mark.parametrize("recover", [False, True])
+@pytest.mark.parametrize("transport_retry", [False, True])
+async def test_validation_feedback_retains_attempts(monkeypatch, recover, transport_retry):
+    reserve = AsyncMock()
+    monkeypatch.setattr(extraction, "reserve_llm_budget", reserve)
+    monkeypatch.setattr(ModelResponse, "cost", lambda _: SimpleNamespace(total_price=0.01))
+    requests = []
+    responses = 0
+    malformed = json.dumps({"procedure": '{"goal": "unterminated}'})
+
+    def respond(request):
+        nonlocal responses
+        requests.append(json.loads(request.content))
+        if transport_retry and len(requests) == 1:
+            return httpx2.Response(
+                500,
+                json={"error": {"message": "temporary provider failure"}},
+                headers={"retry-after-ms": "1"},
+            )
+        responses += 1
+        arguments = (
+            json.dumps({"abstention_reason": "Insufficient supported evidence"})
+            if recover and responses > 1
+            else malformed
+        )
+        return httpx2.Response(
+            200,
+            json={
+                "id": f"resp_{responses}",
+                "object": "response",
+                "created_at": 0,
+                "model": "qwen/qwen3-coder-next",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "id": f"fc_{responses}",
+                        "call_id": f"call_{responses}",
+                        "name": "final_result",
+                        "arguments": arguments,
+                    }
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+            },
+        )
+
+    async with RecordingOpenAIClient(transport=httpx2.MockTransport(respond)) as http:
+        client = AsyncOpenAI(
+            api_key="fixture",
+            base_url="https://example.invalid/v1",
+            http_client=http,
+            max_retries=2,
+        )
+        model = OpenAIResponsesModel(
+            "qwen/qwen3-coder-next", provider=OpenAIProvider(openai_client=client)
+        )
+        agent = Agent(model, output_type=EvidenceProposal, retries={"output": OUTPUT_RETRIES})
+        extractor = Extractor(
+            EvidenceProposal, agent=agent, output_retries=OUTPUT_RETRIES, max_tokens=2048
+        )
+        if recover:
+            result = await extractor.extract_with_usage("Contrast the supplied evidence")
+            assert result.output.procedure is None
+            assert result.output.abstention_reason == "Insufficient supported evidence"
+            assert result.usage.requests == 2
+            assert result.usage.input_tokens == 20
+            assert result.usage.output_tokens == 4
+            attempts = result.usage.transport_attempts
+            assert all(attempt.usage_known for attempt in attempts[int(transport_retry) :])
+            if transport_retry:
+                assert not attempts[0].usage_known
+                assert result.usage.cost_usd is None
+                assert result.usage.transport_usage_complete is False
+        else:
+            with pytest.raises(LLMValidationError) as error:
+                await extractor.extract_with_usage("Contrast the supplied evidence")
+            failed = error.value.details["extraction_usage"]
+            assert failed["cost_usd"] is None
+            assert failed["usage_complete"] is False
+            attempts = failed["transport_attempts"]
+            assert all(not attempt["usage_known"] for attempt in attempts)
+
+    assert reserve.await_args.kwargs["attempt_envelope"] == 9
+    assert reserve.await_args.kwargs["output_token_limit"] == 2048
+    assert len(attempts) == len(requests) == (2 if recover else 3) + int(transport_retry)
+    feedback_request = requests[1 + int(transport_retry)]
+    feedback = [
+        item["output"]
+        for item in feedback_request["input"]
+        if item.get("type") == "function_call_output"
+    ]
+    assert len(feedback) == 1
+    assert "procedure" in feedback[0] and "model_type" in feedback[0]
+    assert all(request["tools"][0]["strict"] is False for request in requests)

--- a/packages/python/sibyl-core/tests/test_eval_publication.py
+++ b/packages/python/sibyl-core/tests/test_eval_publication.py
@@ -304,3 +304,13 @@ async def test_frozen_input_and_output_budgets_reach_actual_proposal(proposal, m
     monkeypatch.setattr(p.core_config, "consolidation_max_input_chars", 120_000)
     environment["SIBYL_LLM_MEMORY_MAX_TOKENS"] = "3073"
     assert (await p.consolidation_extractor_configuration())[1] != revision
+
+
+async def test_output_validation_policy_changes_extractor_revision(monkeypatch):
+    from sibyl_core.ai.llm.config import EnvConfigSource
+
+    monkeypatch.setattr(p, "resolve_llm_config", EnvConfigSource({}).resolve)
+    assert p.OUTPUT_RETRIES == 2
+    current = await p.consolidation_extractor_configuration()
+    monkeypatch.setattr(p, "OUTPUT_RETRIES", 0)
+    assert await p.consolidation_extractor_configuration() != current

--- a/packages/python/sibyl-core/tests/test_tasks_consolidation.py
+++ b/packages/python/sibyl-core/tests/test_tasks_consolidation.py
@@ -126,7 +126,7 @@ def model(monkeypatch):
 
     async def local_agent(extractor):
         assert extractor.surface is LLMSurface.MEMORY
-        assert extractor.output_retries == 0
+        assert extractor.output_retries == c.OUTPUT_RETRIES == 2
         return Agent(
             FunctionModel(respond),
             output_type=c.ProcedureProposal,
@@ -523,3 +523,8 @@ async def test_complete_input_budget_includes_schema_and_accepts_exact_boundary(
     assert len(model[1]) == 1
     assert result.receipt["input_chars"] == actual
     assert result.receipt["max_input_chars"] == actual
+
+
+async def test_build_receipt_records_output_validation_policy(group, procedure, model):
+    result = await propose(group, procedure, model)
+    assert result.receipt["output_retries"] == c.OUTPUT_RETRIES == 2


### PR DESCRIPTION
Consolidation currently aborts on the first malformed model response, even though the shared extractor normally allows two rounds of validation feedback. A real response returned `procedure` as a string containing malformed JSON instead of an object. The response finished normally at 855 output tokens, below its 2,048-token limit.

Use the extractor's normal two output-validation retries for consolidation. Pydantic sends the schema error back to the model; every returned proposal still passes the original validators. The shared retry count also enters the extractor revision and build receipt, so a result built under the previous policy cannot be reused as a new-policy result.

The existing transport accounting covers the additional model calls. With two SDK retries per call, the preflight reservation estimates a nine-send envelope. Failed or ambiguous attempts retain unknown usage and cost. Validation exhaustion still returns an error without publishing a candidate.

## 🧪 Validation

| Check | Result |
| --- | --- |
| Scoped consolidation, publication and transport regressions | 174 passed |
| API admission and archive tests | 26 passed |
| Core lint and typecheck | Passed |
| Independent SDK review | 8 checks passed, including recovery and exhaustion across all nine sends |
| Root verification | 4 checks passed for the full retry envelope, revision and receipt |
| Private replay of the observed malformed response through a local SDK transport | Passed; validation feedback reached the next request and both responses' usage was retained |

The native SDK regressions cover recovery, exhausted validation, an additional transport retry, and the reservation estimate. The private replay uses a fixture response after the observed failure; it does not establish live model recovery. A new provider run remains separate qualification work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Failed extraction results are now retried up to two times, improving recovery from invalid outputs.
  * Validation feedback remains separate from transport-level retry handling.

* **Transparency**
  * Processing receipts now record the configured output-retry count.
  * Changes to the retry policy are reflected in the extraction policy revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->