### PR TITLE
feat(memory): preserve graph publication source observations

### DIFF
--- a/apps/api/src/sibyl/api/routes/context.py
+++ b/apps/api/src/sibyl/api/routes/context.py
@@ -686,6 +686,7 @@ async def reflect_context(
         )
 
         pack = await reflect_memory(
+            allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
             content=request.content,
             source_title=request.source_title,
             intent=request.intent.value,

--- a/apps/api/src/sibyl/api/routes/memory_promotion.py
+++ b/apps/api/src/sibyl/api/routes/memory_promotion.py
@@ -213,6 +213,7 @@ async def promote_reflection_candidate(
             http_request=http_request,
         )
         result = await promote_reflection_candidate_review(
+            allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
             candidate_id=request.candidate_id,
             organization_id=str(org.id),
             principal_id=principal_id,
@@ -290,6 +291,7 @@ async def promote_memory(
             http_request=http_request,
         )
         result = await promote_reflection_candidate_review(
+            allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
             candidate_id=request.candidate_id,
             organization_id=str(org.id),
             principal_id=principal_id,
@@ -311,6 +313,7 @@ async def promote_memory(
                 surface="memory_promote",
             )
             result = await promote_raw_memory(
+                allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
                 raw_memory_id=request.candidate_id,
                 organization_id=str(org.id),
                 principal_id=principal_id,

--- a/apps/api/src/sibyl/api/routes/memory_review.py
+++ b/apps/api/src/sibyl/api/routes/memory_review.py
@@ -207,6 +207,7 @@ async def _auto_review_reflection_candidate(
     promotion: ReflectionPromotionResult | None = None
     if decision.should_promote:
         promotion = await promote_reflection_candidate_review(
+            allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
             candidate_id=request.candidate_id,
             organization_id=str(org.id),
             principal_id=principal_id,

--- a/apps/api/src/sibyl/api/routes/memory_sharing.py
+++ b/apps/api/src/sibyl/api/routes/memory_sharing.py
@@ -79,6 +79,7 @@ async def preview_memory_share_route(
         surface="memory_share_preview",
     )
     result = await preview_memory_share(
+        allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
         source_ids=request.source_ids,
         organization_id=str(org.id),
         principal_id=principal_id,
@@ -151,6 +152,7 @@ async def share_memory_route(
         request.target_scope_key if request.target_scope == "project" else None
     )
     result = await share_memory(
+        allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
         source_ids=request.source_ids,
         organization_id=str(org.id),
         principal_id=principal_id,

--- a/apps/api/src/sibyl/core_runtime_ports.py
+++ b/apps/api/src/sibyl/core_runtime_ports.py
@@ -311,6 +311,10 @@ class ApiAuditPort:
 
 
 def install_core_runtime_ports() -> None:
+    from sibyl.jobs.lifecycle_repair import resolve_source_authority
+    from sibyl_core.runtime_ports import install_source_authority_resolver
+
+    install_source_authority_resolver(resolve_source_authority)
     install_queue_port(ApiQueuePort())
     install_content_port(ApiContentPort())
     install_graph_link_port(ApiGraphLinkPort())

--- a/apps/api/src/sibyl/mcp_tools/memory.py
+++ b/apps/api/src/sibyl/mcp_tools/memory.py
@@ -344,6 +344,7 @@ async def _reflect_mcp_memory(
             accessible_projects=accessible_projects,
         )
     pack = await reflect_memory(
+        allowed_memory_scope_keys=ctx.api_key_memory_scope_keys,
         content=content,
         source_title=source_title,
         intent=intent,

--- a/apps/api/tests/test_routes_memory.py
+++ b/apps/api/tests/test_routes_memory.py
@@ -2241,6 +2241,7 @@ async def test_preview_memory_share_returns_disabled_contract_and_audit() -> Non
     assert accessible.await_args_list[1].kwargs == {"required_role": ProjectRole.CONTRIBUTOR}
     accessible_teams.assert_awaited_once_with(ctx)
     preview.assert_awaited_once_with(
+        allowed_memory_scope_keys=None,
         source_ids=["memory-1"],
         organization_id=str(org.id),
         principal_id="user-123",
@@ -2404,6 +2405,7 @@ async def test_share_memory_applies_promotions_and_returns_audit_receipt() -> No
 
     accessible_teams.assert_awaited_once_with(ctx)
     share.assert_awaited_once_with(
+        allowed_memory_scope_keys=None,
         source_ids=["memory-1"],
         organization_id=str(org.id),
         principal_id="user-123",
@@ -2505,6 +2507,7 @@ async def test_share_memory_applies_team_promotions_with_membership_scope() -> N
 
     accessible_teams.assert_awaited_once_with(ctx)
     share.assert_awaited_once_with(
+        allowed_memory_scope_keys=None,
         source_ids=["memory-1"],
         organization_id=str(org.id),
         principal_id="user-123",
@@ -2999,6 +3002,7 @@ async def test_auto_review_reflection_candidate_promotes_safe_candidate() -> Non
         writable_projects={"project_123"},
     )
     promote.assert_awaited_once_with(
+        allowed_memory_scope_keys=None,
         candidate_id="candidate-1",
         organization_id=str(org.id),
         principal_id="user-123",
@@ -3417,6 +3421,7 @@ async def test_promote_reflection_candidate_verifies_project_target() -> None:
         require_existing_project=True,
     )
     promote.assert_awaited_once_with(
+        allowed_memory_scope_keys=None,
         candidate_id="candidate-1",
         organization_id=str(org.id),
         principal_id="user-123",
@@ -3516,6 +3521,7 @@ async def test_promote_memory_routes_imported_raw_memory() -> None:
 
     reflection_promote.assert_awaited_once()
     raw_promote.assert_awaited_once_with(
+        allowed_memory_scope_keys=None,
         raw_memory_id="raw-1",
         organization_id=str(org.id),
         principal_id="user-123",

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -73,7 +73,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 32
+CONTENT_SCHEMA_CURRENT_VERSION = 33
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -955,6 +955,17 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
                 source_state_event(SourceKind.RAW_CAPTURE, retire_derivations=True).replace(
                     "DEFINE EVENT IF NOT EXISTS", "DEFINE EVENT OVERWRITE"
                 ),
+            ),
+        ),
+        SchemaMigration(
+            version=33,
+            name="content_source_publication_bookkeeping",
+            statements=(
+                source_state_event(
+                    SourceKind.RAW_CAPTURE,
+                    retire_derivations=True,
+                    publication_bookkeeping=True,
+                ).replace("DEFINE EVENT IF NOT EXISTS", "DEFINE EVENT OVERWRITE"),
             ),
         ),
     )

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, cast
 
 import structlog
 
+from sibyl_core.backends.surreal.schema_derivations import DERIVATION_DEFINITIONS
 from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement, split_statements
 from sibyl_core.backends.surreal.schema_index_recovery import ensure_owned_concurrent_index
 from sibyl_core.backends.surreal.schema_lifecycle_repair import (
@@ -838,6 +839,16 @@ GRAPH_SCHEMA_MIGRATIONS = (
             source_state_event(SourceKind.GRAPH_ENTITY),
         ),
         action=migrate_graph_source_states,
+    ),
+    SchemaMigration(
+        version=25,
+        name="graph_observation_associations",
+        statements=(
+            *split_statements(DERIVATION_DEFINITIONS),
+            source_state_event(SourceKind.GRAPH_ENTITY, retire_derivations=True).replace(
+                "DEFINE EVENT IF NOT EXISTS", "DEFINE EVENT OVERWRITE"
+            ),
+        ),
     ),
 )
 

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_states.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_states.py
@@ -60,7 +60,55 @@ _RAW_EVIDENCE_FIELDS = (
 )
 
 
-def source_state_event(kind: SourceKind, *, retire_derivations: bool = False) -> str:
+def _raw_publication_evidence_changed() -> str:
+    """Compare read-relevant lifecycle fields without promotion audit details."""
+    stable_states = "[NONE, 'pending', 'promoted', 'active']"
+
+    def state(expression: str) -> str:
+        return f"(IF {expression} IN {stable_states} THEN 'active' ELSE {expression} END)"
+
+    def review(prefix: str, field: str) -> str:
+        value = f"{prefix}.{field}"
+        return (
+            f"(IF {prefix}.metadata.eval_consolidation = NONE AND {value} IN "
+            f"[NONE, 'pending', 'promoted'] THEN 'ordinary' ELSE {value} END)"
+        )
+
+    fields = [
+        field
+        for field in _RAW_EVIDENCE_FIELDS
+        if field
+        not in {
+            "review_state",
+            "metadata.review_state",
+            "metadata.lifecycle_state",
+            "metadata.lifecycle_flags",
+            "metadata.memory_lifecycle",
+        }
+    ]
+    fields.extend(("principal_id", "memory_scope", "scope_key", "project_id", "agent_id"))
+    fields.extend(
+        f"metadata.{flag}{suffix}"
+        for flag in ("hidden", "redacted", "sensitive")
+        for suffix in ("", "_at")
+    )
+    comparisons = [f"$before.{field} != $after.{field}" for field in fields]
+    for field in ("review_state", "metadata.review_state"):
+        comparisons.append(f"{review('$before', field)} != {review('$after', field)}")
+    for field in ("metadata.lifecycle_state", "metadata.memory_lifecycle.state"):
+        comparisons.append(f"{state('$before.' + field)} != {state('$after.' + field)}")
+    for field in ("metadata.lifecycle_flags", "metadata.memory_lifecycle.flags"):
+        comparisons.append(f"($before.{field} ?? []) != ($after.{field} ?? [])")
+    for field in ("replacement_source_id", "duplicate_of_source_id"):
+        comparisons.append(
+            f"$before.metadata.memory_lifecycle.{field} != $after.metadata.memory_lifecycle.{field}"
+        )
+    return " OR ".join(comparisons)
+
+
+def source_state_event(
+    kind: SourceKind, *, retire_derivations: bool = False, publication_bookkeeping: bool = False
+) -> str:
     """Generate only fixed, application-owned identifiers and field expressions.
 
     Comparing source fields avoids relying on database JSON formatting for the
@@ -68,7 +116,11 @@ def source_state_event(kind: SourceKind, *, retire_derivations: bool = False) ->
     """
     table, organization_field = _SOURCE_TABLES[kind]
     fields = _GRAPH_EVIDENCE_FIELDS if kind is SourceKind.GRAPH_ENTITY else _RAW_EVIDENCE_FIELDS
-    changed = " OR ".join(f"$before.{field} != $after.{field}" for field in fields)
+    changed = (
+        _raw_publication_evidence_changed()
+        if kind is SourceKind.RAW_CAPTURE and publication_bookkeeping
+        else " OR ".join(f"$before.{field} != $after.{field}" for field in fields)
+    )
     deleted = "$event = 'DELETE'"
     if kind is SourceKind.RAW_CAPTURE:
         deleted += " OR $after.deleted_at != NONE"

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
@@ -14,7 +14,7 @@ from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement,
 if TYPE_CHECKING:
     from sibyl_core.backends.surreal.schema_ownership import SchemaOwnership
 
-GRAPH_SCHEMA_CURRENT_VERSION = 24
+GRAPH_SCHEMA_CURRENT_VERSION = 25
 GRAPH_SCHEMA_NAME = "graph"
 SCHEMA_VERSION_TABLE = "schema_version"
 

--- a/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
+++ b/packages/python/sibyl-core/src/sibyl_core/projection/passages.py
@@ -348,6 +348,18 @@ async def project_entity_passages(
     """
     source_id = created_source_id or source.id
     stored_parent = await parent_lifecycle_as_stored(entity_manager, source, source_id=source_id)
+    projection_source = None
+    load_projection_source = getattr(entity_manager, "load_projection_source", None)
+    if callable(load_projection_source):
+        try:
+            projection_source = await load_projection_source(source_id)
+        except Exception as exc:
+            return PassageProjectionResult(
+                source_id=source_id, reason="source_unavailable", errors=(str(exc),)
+            )
+        if projection_source is not None:
+            stored_parent = projection_source[0].entity
+
     entities, relationships = plan_entity_passages(
         stored_parent,
         source_id=source_id,
@@ -360,12 +372,22 @@ async def project_entity_passages(
             reason="below_threshold" if not should_project_passages(source) else "single_slice",
         )
 
+    if projection_source is not None:
+        from sibyl_core.projection.pending import pending_patch
+
+        # The atomic parent observation protects this bracket before any child
+        # becomes visible. Preserve pending verdicts owned by other sources.
+        for entity in entities:
+            entity.metadata.update(
+                pending_patch(entity.metadata, {}, authority=f"parent:{source_id}")
+            )
     errors: list[str] = []
     try:
         created_passages = await _create_passages(
             entity_manager,
             entities,
             generate_embeddings=generate_embeddings,
+            projection_source=projection_source,
         )
     except Exception as exc:
         # A memory that stored fine must not fail because its passages did.
@@ -707,17 +729,28 @@ async def _create_passages(
     entities: Sequence[Entity],
     *,
     generate_embeddings: bool,
+    projection_source=None,
 ) -> tuple[Entity, ...]:
     create_direct_bulk = getattr(entity_manager, "create_direct_bulk", None)
     if callable(create_direct_bulk):
         created_ids = list(
-            await create_direct_bulk(list(entities), generate_embeddings=generate_embeddings)
+            await create_direct_bulk(
+                list(entities),
+                generate_embeddings=generate_embeddings,
+                **(
+                    {"projection_source": projection_source}
+                    if projection_source is not None
+                    else {}
+                ),
+            )
         )
         return tuple(
             entity.model_copy(update={"id": created_id})
             for entity, created_id in zip(entities, created_ids, strict=False)
         )
 
+    if projection_source is not None:
+        raise TypeError("protected passage projection requires atomic bulk storage")
     create_direct = getattr(entity_manager, "create_direct", None)
     if callable(create_direct):
         created: list[Entity] = []

--- a/packages/python/sibyl-core/src/sibyl_core/runtime_ports.py
+++ b/packages/python/sibyl-core/src/sibyl_core/runtime_ports.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from contextlib import AbstractAsyncContextManager
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from sibyl_core.services.memory_source_validation import SourceAuthorityResolver
 
 
 class RuntimePortUnavailable(RuntimeError):
@@ -143,10 +146,22 @@ class _NoAuditPort:
         return None
 
 
+_source_authority_resolver: SourceAuthorityResolver | None = None
 _queue_port: QueuePort | None = None
 _content_port: ContentPort | None = None
 _graph_link_port: GraphLinkPort | None = None
 _audit_port: AuditPort = _NoAuditPort()
+
+
+def install_source_authority_resolver(resolver: SourceAuthorityResolver) -> None:
+    global _source_authority_resolver
+    _source_authority_resolver = resolver
+
+
+def get_source_authority_resolver() -> SourceAuthorityResolver:
+    if _source_authority_resolver is None:
+        raise RuntimePortUnavailable("Source authority resolver is not installed")
+    return _source_authority_resolver
 
 
 def install_queue_port(port: QueuePort) -> None:
@@ -170,7 +185,8 @@ def install_audit_port(port: AuditPort) -> None:
 
 
 def reset_runtime_ports() -> None:
-    global _audit_port, _content_port, _graph_link_port, _queue_port
+    global _audit_port, _content_port, _graph_link_port, _queue_port, _source_authority_resolver
+    _source_authority_resolver = None
     _queue_port = None
     _content_port = None
     _graph_link_port = None

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication_guards.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication_guards.py
@@ -149,6 +149,10 @@ async def unavailable_publication_ids(
         unavailable.update(
             await unavailable_raw_derivation_ids(organization_id, raw_memories, source_authority)
         )
+    else:
+        from sibyl_core.services.graph_derivations import unavailable_graph_derivation_ids
+
+        unavailable.update(await unavailable_graph_derivation_ids(organization_id, list(rows)))
     return unavailable
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_derivations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_derivations.py
@@ -1,0 +1,161 @@
+"""Validate graph publication ancestry through the existing final read gate."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+
+from sibyl_core.backends.surreal.records import normalize_records
+from sibyl_core.memory_pipeline.observations import SourceIdentity, SourceKind, evidence_hash
+from sibyl_core.runtime_ports import RuntimePortUnavailable, get_source_authority_resolver
+from sibyl_core.services.memory_derivations import observation_from_record, validate_observations
+from sibyl_core.services.memory_source_validation import source_authority_ceiling
+from sibyl_core.services.source_observations import SourceUnavailableError, graph_evidence
+
+
+def graph_target_digest(entity) -> str:
+    """Bind published evidence and audience, excluding publication bookkeeping."""
+    return evidence_hash(
+        {
+            "version": 1,
+            "evidence": graph_evidence(entity),
+            "audience": {
+                key: entity.metadata.get(key)
+                for key in ("memory_scope", "scope_key", "principal_id", "project_id")
+            },
+        }
+    )
+
+
+async def graph_association_current(entity, association, *, ancestors=frozenset()) -> bool:
+    if association is None:
+        return True
+    if association.get("active") is not True or association.get(
+        "body_sha256"
+    ) != graph_target_digest(entity):
+        return False
+    principal_id = association.get("principal_id")
+    if not isinstance(principal_id, str):
+        return False
+    ceiling = source_authority_ceiling(association.get("authority_ceiling"), principal_id)
+    if ceiling is None:
+        return False
+    try:
+        resolver = get_source_authority_resolver()
+    except RuntimePortUnavailable:
+        return False
+    authority = await resolver(entity.organization_id, principal_id)
+    if authority is None or authority.principal_id != principal_id:
+        return False
+    scopes = ceiling.scope_keys
+    if authority.scope_keys is not None:
+        scopes = authority.scope_keys if scopes is None else scopes & authority.scope_keys
+    from dataclasses import replace
+
+    authority = replace(
+        authority,
+        projects=authority.projects & ceiling.projects,
+        teams=authority.teams & ceiling.teams,
+        delegations=authority.delegations & ceiling.delegations,
+        scope_keys=scopes,
+    )
+    values = association.get("observations")
+    if not isinstance(values, list) or not values:
+        return False
+    try:
+        observations = [observation_from_record(value) for value in values]
+    except SourceUnavailableError:
+        return False
+    return await validate_observations(
+        observations, authority, organization_id=entity.organization_id, ancestors=ancestors
+    )
+
+
+async def graph_derivation_current(entity, *, ancestors=frozenset()) -> bool:
+    from sibyl_core.services.graph_runtime import get_surreal_graph_runtime
+
+    runtime = await get_surreal_graph_runtime(entity.organization_id)
+    rows = normalize_records(
+        await runtime.client.execute_query(
+            "SELECT * FROM memory_derivations WHERE organization_id=$org AND target_kind='graph_entity' AND target_id=$id LIMIT 1;",
+            org=entity.organization_id,
+            id=entity.id,
+        )
+    )
+    return await graph_association_current(entity, rows[0] if rows else None, ancestors=ancestors)
+
+
+async def unavailable_graph_derivation_ids(organization_id: str, ids: Sequence[str]) -> set[str]:
+    from sibyl_core.services.graph_records import entity_from_surreal_row
+
+    if not ids:
+        return set()
+    from sibyl_core.services.graph_runtime import get_surreal_graph_runtime
+
+    runtime = await get_surreal_graph_runtime(organization_id)
+    snapshots = normalize_records(
+        await runtime.client.execute_query(
+            """RETURN {
+            RETURN {
+                associations: (SELECT * FROM memory_derivations WHERE organization_id=$org
+                    AND target_kind='graph_entity' AND target_id IN $ids),
+                targets: (SELECT * FROM entity WHERE group_id=$org AND uuid IN $ids)
+            };
+        };""",
+            org=organization_id,
+            ids=list(ids),
+        )
+    )
+    if len(snapshots) != 1:
+        raise RuntimeError("graph derivation snapshot unavailable")
+    target_rows = snapshots[0].get("targets")
+    association_rows = snapshots[0].get("associations")
+    if not isinstance(target_rows, list) or not isinstance(association_rows, list):
+        raise RuntimeError("graph derivation snapshot unavailable")
+    targets = {row["uuid"]: entity_from_surreal_row(row) for row in target_rows}
+
+    async def current(association):
+        target_id = association["target_id"]
+        entity = targets.get(target_id)
+        identity = SourceIdentity(organization_id, SourceKind.GRAPH_ENTITY, target_id)
+        if entity is None or not await graph_association_current(
+            entity, association, ancestors=frozenset({identity})
+        ):
+            return target_id
+        return None
+
+    return {
+        value
+        for value in await asyncio.gather(*(current(row) for row in association_rows))
+        if value is not None
+    }
+
+
+async def load_graph_projection_source(client, *, organization_id: str, source_id: str):
+    """Capture the protected parent snapshot before the projection cuts text."""
+    from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+    from sibyl_core.services.source_observations import GraphSourceSnapshot
+    from sibyl_core.services.source_state_store import load_source_snapshot
+
+    associations = normalize_records(
+        await client.execute_query(
+            "SELECT * FROM memory_derivations WHERE organization_id=$org AND target_kind='graph_entity' AND target_id=$id LIMIT 1;",
+            org=organization_id,
+            id=source_id,
+        )
+    )
+    if not associations:
+        return None
+    association = associations[0]
+    snapshot = await load_source_snapshot(
+        SourceIdentity(organization_id, SourceKind.GRAPH_ENTITY, source_id),
+        organization_id=organization_id,
+        execute_query=client.execute_query,
+    )
+    if (
+        not isinstance(snapshot, GraphSourceSnapshot)
+        or not graph_metadata_recallable(snapshot.entity.metadata)
+        or not await graph_association_current(snapshot.entity, association)
+    ):
+        raise SourceUnavailableError()
+    return snapshot, association

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entities.py
@@ -34,12 +34,15 @@ class EntityManager(_EntityWorkItemManager):
     supports_bounded_entity_list = True
     supports_lightweight_entity_list = True
 
-    async def create_direct_if_absent(self, entity: Entity) -> tuple[Entity, bool]:
+    async def create_direct_if_absent(
+        self, entity: Entity, *, derivation: Mapping[str, object] | None = None
+    ) -> tuple[Entity, bool]:
         """Insert once, returning the stored row and whether this call created it."""
         row, created = await _insert_entity_if_absent(
             self._client,
             entity,
             group_id=self._group_id,
+            derivation=derivation,
         )
         return _entity_from_row(row), created
 
@@ -49,6 +52,13 @@ class EntityManager(_EntityWorkItemManager):
         await _replace_entity(self._client, entity, group_id=self._group_id)
         return entity.id
 
+    async def load_projection_source(self, source_id: str):
+        from sibyl_core.services.graph_derivations import load_graph_projection_source
+
+        return await load_graph_projection_source(
+            self._client, organization_id=self._group_id, source_id=source_id
+        )
+
     async def create_direct_bulk(
         self,
         entities: Sequence[Entity],
@@ -56,6 +66,7 @@ class EntityManager(_EntityWorkItemManager):
         generate_embeddings: bool = False,
         embedding_batch_size: int = 64,
         write_batch_size: int = 128,
+        projection_source=None,
     ) -> list[str]:
         prepared_entities = await self.prepare_entities_for_write(
             entities,
@@ -69,7 +80,9 @@ class EntityManager(_EntityWorkItemManager):
         batch_size = max(int(write_batch_size), 1)
         for index in range(0, len(prepared_entities), batch_size):
             batch = prepared_entities[index : index + batch_size]
-            await _replace_entities_bulk(self._client, batch, group_id=self._group_id)
+            await _replace_entities_bulk(
+                self._client, batch, group_id=self._group_id, projection_source=projection_source
+            )
             created_ids.extend(entity.id for entity in batch)
         return created_ids
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
@@ -218,11 +218,69 @@ async def _insert_entity_if_absent(
     entity: Entity,
     *,
     group_id: str,
+    derivation: Mapping[str, object] | None = None,
 ) -> tuple[SurrealRecord, bool]:
     """Arbitrate creation by physical record ID without rewriting a retry."""
     _enforce_entity_content_limit([entity])
     record = _entity_record(entity, group_id=group_id)
     record["id"] = entity.id
+    if derivation is not None:
+        from sibyl_core.services.graph_derivations import graph_target_digest
+        from sibyl_core.services.graph_records import entity_from_surreal_row
+
+        association = dict(derivation)
+        if (
+            association.get("organization_id") != group_id
+            or association.get("target_id") != entity.id
+            or association.get("target_kind") != "graph_entity"
+        ):
+            raise ValueError("derivation does not match graph target")
+        association["body_sha256"] = graph_target_digest(entity_from_surreal_row(record))
+        result = normalize_records(
+            await client.execute_query(
+                """RETURN {
+                LET $inserted = INSERT IGNORE INTO entity $rows;
+                IF array::len($inserted) > 0 {
+                    CREATE memory_derivations CONTENT $association;
+                    RETURN {row: $inserted[0], created: true};
+                };
+                LET $existing = (SELECT * FROM memory_derivations WHERE organization_id=$org
+                    AND target_kind='graph_entity' AND target_id=$uuid LIMIT 1)[0];
+                RETURN {row: (SELECT * FROM entity WHERE uuid=$uuid LIMIT 1)[0], created: false, association: $existing};
+            };""",
+                rows=[record],
+                association=association,
+                org=group_id,
+                uuid=entity.id,
+            )
+        )
+        stored = result[0].get("row") if len(result) == 1 else None
+        if not isinstance(stored, dict):
+            raise RuntimeError("graph derivation publication returned no target")
+        created = result[0]["created"] is True
+        if not created:
+            from sibyl_core.services.memory_derivations import observation_from_record
+
+            existing = result[0].get("association")
+            if not isinstance(existing, dict) or any(
+                existing.get(key) != association.get(key)
+                for key in ("active", "body_sha256", "principal_id", "authority_ceiling")
+            ):
+                raise ValueError("graph derivation replay mismatch")
+            saved_observations = existing.get("observations")
+            expected_observations = association.get("observations")
+            if (
+                not isinstance(saved_observations, list)
+                or not isinstance(expected_observations, list)
+                or len(saved_observations) != len(expected_observations)
+            ):
+                raise ValueError("graph derivation replay mismatch")
+            if any(
+                not observation_from_record(saved).same_evidence(observation_from_record(expected))
+                for saved, expected in zip(saved_observations, expected_observations, strict=True)
+            ):
+                raise ValueError("graph derivation replay mismatch")
+        return stored, created
     query = "INSERT IGNORE INTO entity $rows;"
     try:
         result = await client.execute_query(query, rows=[record])
@@ -250,12 +308,17 @@ async def _replace_entities_bulk(
     entities: Sequence[Entity],
     *,
     group_id: str,
+    projection_source=None,
 ) -> list[SurrealRecord]:
     _enforce_entity_content_limit(entities)
     records = [_entity_record(entity, group_id=group_id) for entity in entities]
     if not records:
         return []
     await heal_entity_metadata_snapshots(client, records, group_id=group_id)
+    if projection_source is not None:
+        return await _replace_projected_entities(
+            client, records, group_id=group_id, projection_source=projection_source
+        )
     try:
         result = await _execute_replace_entities_with_schema_retry(client, records)
     except Exception as exc:
@@ -834,3 +897,91 @@ def _entity_update_metadata_patch(updates: Mapping[str, Any]) -> dict[str, objec
 
 
 __all__ = ["CLEAR_MEMORY_SCOPE", "MAX_ENTITY_CONTENT_CHARS", "heal_entity_metadata_snapshots"]
+
+
+async def _replace_projected_entities(client, records, *, group_id, projection_source):
+    """Write passages and their protected parent observations in one transaction."""
+    from dataclasses import asdict
+
+    from sibyl_core.services.graph_derivations import graph_target_digest
+    from sibyl_core.services.graph_records import entity_from_surreal_row
+
+    snapshot, parent_association = projection_source
+    observation = snapshot.observation
+    if observation.source.organization_id != group_id or not observation.durable:
+        raise ValueError("projection source does not match organization")
+    associations = []
+    for record in records:
+        entity = entity_from_surreal_row(record)
+        if (
+            entity.entity_type is not EntityType.PASSAGE
+            or entity.metadata.get("source_entity_id") != observation.source.id
+        ):
+            raise ValueError("projection target does not match parent")
+        associations.append(
+            {
+                "organization_id": group_id,
+                "target_kind": "graph_entity",
+                "target_id": entity.id,
+                "body_sha256": graph_target_digest(entity),
+                "principal_id": parent_association["principal_id"],
+                "authority_ceiling": parent_association["authority_ceiling"],
+                "observations": [asdict(observation)],
+                "active": True,
+            }
+        )
+    upsert = (
+        render_surreal_compatible_sql(_ENTITY_BULK_UPSERT_QUERY, url=client._url)
+        .strip()
+        .rstrip(";")
+    )
+    query = (
+        """RETURN {
+        LET $parent = (SELECT * FROM entity WHERE group_id=$org AND uuid=$parent_id LIMIT 1)[0];
+        LET $state = (SELECT * FROM source_states WHERE organization_id=$org AND source_kind='graph_entity' AND source_id=$parent_id LIMIT 1)[0];
+        LET $parent_derivation = (SELECT * FROM memory_derivations WHERE organization_id=$org AND target_kind='graph_entity' AND target_id=$parent_id LIMIT 1)[0];
+        IF $parent = NONE OR $state = NONE OR $parent.revision != $revision
+            OR $state.revision != $revision OR $state.generation != $generation OR $state.deleted
+            OR $parent_derivation.active != true
+            OR $parent_derivation.body_sha256 != $parent_association.body_sha256
+            OR $parent_derivation.observations != $parent_association.observations
+            OR $parent_derivation.authority_ceiling != $parent_association.authority_ceiling {
+            THROW 'projection parent observation changed';
+        };
+        LET $previous_targets = SELECT uuid FROM entity WHERE group_id=$org AND uuid IN $ids;
+        LET $written = ("""
+        + upsert
+        + """);
+        FOR $association IN $associations {
+            LET $old = (SELECT * FROM memory_derivations WHERE organization_id=$org AND target_kind='graph_entity' AND target_id=$association.target_id LIMIT 1)[0];
+            IF $old != NONE AND (array::len($old.observations) != 1
+                OR $old.observations[0].source != $association.observations[0].source) {
+                THROW 'projection association belongs to another source';
+            };
+            LET $was_present = array::len($previous_targets[WHERE uuid=$association.target_id]) > 0;
+            IF $was_present AND ($old = NONE
+                OR $old.observations[0].generation != $association.observations[0].generation
+                OR $old.observations[0].content_sha256 != $association.observations[0].content_sha256
+                OR $old.active != true) {
+                UPDATE source_states SET generation += 1
+                    WHERE organization_id=$org AND source_kind='graph_entity' AND source_id=$association.target_id;
+            };
+            IF $old = NONE { CREATE memory_derivations CONTENT $association; }
+            ELSE { UPDATE $old.id CONTENT $association; };
+        };
+        RETURN $written;
+    };"""
+    )
+    return normalize_records(
+        await client.execute_query(
+            query,
+            rows=records,
+            ids=[record["uuid"] for record in records],
+            associations=associations,
+            org=group_id,
+            parent_id=observation.source.id,
+            revision=observation.revision,
+            generation=observation.generation,
+            parent_association=parent_association,
+        )
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_contract.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_contract.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sibyl_core.auth.memory_policy import MemoryPolicyDecision
+from sibyl_core.memory_pipeline.observations import SourceObservation
 from sibyl_core.models.reflection import ReflectionCandidate
 from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 from sibyl_core.tools.responses import AddResponse
+
+if TYPE_CHECKING:
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
 
 
 class WriteMode(StrEnum):
@@ -151,3 +155,5 @@ class _ReflectionPromotionPlan:
     target_project: str | None
     raw_source_ids: list[str]
     input_memories: list[RawMemory]
+    source_observations: tuple[SourceObservation, ...] = ()
+    source_authority: SourceReadAuthority | None = None

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_derivations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_derivations.py
@@ -87,7 +87,11 @@ async def validate_observations(
             return await raw_derivation_current(
                 snapshot.memory, authority, ancestors=ancestors | {observation.source}
             )
-        return True
+        from sibyl_core.services.graph_derivations import graph_derivation_current
+
+        return await graph_derivation_current(
+            snapshot.entity, ancestors=ancestors | {observation.source}
+        )
 
     return all(await asyncio.gather(*(current(observation) for observation in observations)))
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
 import re
 from collections.abc import Iterable, Sequence
 from dataclasses import replace
@@ -21,6 +26,7 @@ from sibyl_core.memory_pipeline.lifecycle import (
     graph_lifecycle_stamp,
     graph_metadata_recallable,
 )
+from sibyl_core.memory_pipeline.observations import SourceObservation
 from sibyl_core.memory_pipeline.source_lifecycle import (
     CORRECTION_BLOCKERS_KEY,
     SOURCE_BINDINGS_KEY,
@@ -86,6 +92,7 @@ from sibyl_core.services.memory_promotion import (
     _scope_metadata,
     _source_scope_denial,
 )
+from sibyl_core.services.promotion_observations import load_promotion_source
 from sibyl_core.services.surreal_content import (
     MemoryScope,
     RawMemory,
@@ -140,10 +147,16 @@ async def _load_raw_sources(
 
 async def _load_promotion_inputs(
     memory: RawMemory, *, organization_id: str
-) -> tuple[list[RawMemory], bool]:
+) -> tuple[list[RawMemory], bool, tuple[SourceObservation, ...]]:
     """Resolve every declared retained capture for promotion and sharing."""
     source_ids = _raw_source_ids(memory)
-    sources = await _load_raw_sources(organization_id=organization_id, raw_source_ids=source_ids)
+    import asyncio
+
+    snapshots = await asyncio.gather(
+        *(load_promotion_source(organization_id, source_id) for source_id in source_ids)
+    )
+    sources = [snapshot.memory for snapshot in snapshots if snapshot is not None]
+    observations = tuple(snapshot.observation for snapshot in snapshots if snapshot is not None)
     required = set(source_ids)
     loaded = {source.id for source in sources}
     if memory.source_id in required and re.fullmatch(
@@ -153,7 +166,7 @@ async def _load_promotion_inputs(
         # rows still participate in authorization and lifecycle checks.
         required.remove(memory.source_id)
         loaded.discard(memory.source_id)
-    return [memory, *sources], required == loaded
+    return [memory, *sources], required == loaded, observations
 
 
 async def persist_reflection_source(
@@ -219,6 +232,8 @@ async def persist_reflection_candidate(
     scope_key: str | None = None,
     link_source_entity: bool = True,
     source_memories: Sequence[RawMemory] = (),
+    source_observations: Sequence[SourceObservation] = (),
+    source_authority: SourceReadAuthority | None = None,
     reserved_entity_id: str | None = None,
     publication_candidate_id: str | None = None,
 ) -> ReflectionWriteResult:
@@ -250,6 +265,31 @@ async def persist_reflection_candidate(
             metadata=policy_metadata,
         )
 
+    if source_observations:
+        from sibyl_core.services.memory_source_validation import SourceReadAuthority
+        from sibyl_core.services.promotion_observations import promotion_observations_current
+
+        current_authority = SourceReadAuthority(
+            principal_id=str(principal_id or ""),
+            projects=frozenset(accessible_projects or ()),
+            teams=frozenset(accessible_teams or ()),
+            delegations=frozenset(accessible_delegations or ()),
+        )
+        if source_authority is not None:
+            if source_authority.principal_id != current_authority.principal_id:
+                return _retired_reflection_result(reserved_entity_id or "")
+            source_authority = replace(
+                source_authority,
+                projects=source_authority.projects & current_authority.projects,
+                teams=source_authority.teams & current_authority.teams,
+                delegations=source_authority.delegations & current_authority.delegations,
+            )
+        else:
+            source_authority = current_authority
+        if not await promotion_observations_current(
+            source_observations, source_authority, organization_id
+        ):
+            return _retired_reflection_result(reserved_entity_id or "")
     runtime = await get_surreal_graph_runtime(organization_id)
     source_ids = _candidate_source_ids(candidate, source_id)
     superseded_ids = await _authorized_superseded_entity_ids(
@@ -292,6 +332,10 @@ async def persist_reflection_candidate(
     legacy_reservation = (
         reserved_entity_id is not None and entity.metadata[IDENTITY_KEY]["version"] == 2
     )
+    if legacy_reservation:
+        # The reserved output predates durable source observations. Its existing
+        # unknown-revision reconciliation must not acquire newly observed trust.
+        source_observations = ()
     if source_memories:
         bindings = source_revision_bindings(source_memories)
         if legacy_reservation:
@@ -353,10 +397,34 @@ async def persist_reflection_candidate(
         "request": publication_request,
     }
     if not await _verify_promotion_sources(
-        runtime, source_memories, publication_candidate_id=publication_candidate_id
+        runtime,
+        source_memories,
+        publication_candidate_id=publication_candidate_id,
+        source_observations=source_observations,
+        source_authority=source_authority,
     ):
         return _retired_reflection_result(entity.id)
-    stored, created = await runtime.entity_manager.create_direct_if_absent(entity)
+    derivation = None
+    if source_observations:
+        from dataclasses import asdict
+
+        if source_authority is None:
+            raise ValueError("source authority is required for graph derivation")
+        derivation = {
+            "organization_id": organization_id,
+            "target_kind": "graph_entity",
+            "target_id": entity.id,
+            "principal_id": source_authority.principal_id,
+            "authority_ceiling": source_authority.ceiling_metadata(),
+            "observations": [asdict(observation) for observation in source_observations],
+            "active": True,
+        }
+    if derivation is None:
+        stored, created = await runtime.entity_manager.create_direct_if_absent(entity)
+    else:
+        stored, created = await runtime.entity_manager.create_direct_if_absent(
+            entity, derivation=derivation
+        )
     verify_reflection_identity(entity, stored)
     if legacy_reservation:
         for memory in source_memories:
@@ -371,6 +439,8 @@ async def persist_reflection_candidate(
     if not await _verify_promotion_sources(
         runtime,
         source_memories,
+        source_observations=source_observations,
+        source_authority=source_authority,
         publication_candidate_id=publication_candidate_id,
         entity_id=stored.id,
     ):
@@ -441,6 +511,8 @@ async def persist_reflection_candidate(
         if not await _verify_promotion_sources(
             runtime,
             source_memories,
+            source_observations=source_observations,
+            source_authority=source_authority,
             publication_candidate_id=publication_candidate_id,
             entity_id=current.id,
         ):
@@ -464,6 +536,8 @@ async def persist_reflection_candidate(
     if not await _verify_promotion_sources(
         runtime,
         source_memories,
+        source_observations=source_observations,
+        source_authority=source_authority,
         publication_candidate_id=publication_candidate_id,
         entity_id=stored.id,
     ):
@@ -578,12 +652,14 @@ async def promote_reflection_candidate_review(
     writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> ReflectionPromotionResult:
     accessible_projects = (
         frozenset(accessible_projects) if accessible_projects is not None else None
     )
     writable_projects = frozenset(writable_projects) if writable_projects is not None else None
     plan = await _resolve_reflection_promotion_plan(
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
         candidate_id=candidate_id,
         organization_id=organization_id,
         principal_id=principal_id,
@@ -628,12 +704,14 @@ async def promote_raw_memory(
     writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> ReflectionPromotionResult:
     accessible_projects = (
         frozenset(accessible_projects) if accessible_projects is not None else None
     )
     writable_projects = frozenset(writable_projects) if writable_projects is not None else None
     plan = await _resolve_raw_memory_promotion_plan(
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
         raw_memory_id=raw_memory_id,
         organization_id=organization_id,
         principal_id=principal_id,
@@ -870,6 +948,8 @@ async def _apply_promotion_plan(
         scope_key=plan.target_scope_key,
         link_source_entity=False,
         source_memories=plan.input_memories,
+        source_observations=plan.source_observations,
+        source_authority=plan.source_authority,
         reserved_entity_id=_metadata_str(plan.candidate_memory.metadata, "promoted_entity_id"),
         publication_candidate_id=plan.candidate_memory.id
         if plan.candidate_memory.metadata.get(EVAL_CONSOLIDATION_METADATA_KEY)
@@ -889,11 +969,20 @@ async def _verify_promotion_sources(
     runtime: Any,
     memories: Sequence[RawMemory],
     *,
+    source_observations: Sequence[SourceObservation] = (),
+    source_authority: SourceReadAuthority | None = None,
     entity_id: str | None = None,
     publication_candidate_id: str | None = None,
 ) -> bool:
     """Close correction's read-before-insert gap without restoring retired rows."""
     verified = True
+    if source_observations:
+        from sibyl_core.services.promotion_observations import promotion_observations_current
+
+        if source_authority is None or not await promotion_observations_current(
+            source_observations, source_authority, runtime.client.group_id
+        ):
+            verified = False
     for expected in memories:
         signature = raw_memory_source_fingerprint(expected)
         try:
@@ -1151,11 +1240,12 @@ async def _resolve_reflection_promotion_plan(
     accessible_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> _ReflectionPromotionPlan | ReflectionPromotionResult:
-    candidate_memory = await get_raw_memory(
-        organization_id=organization_id,
-        memory_id=candidate_id,
-    )
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
+    snapshot = await load_promotion_source(organization_id, candidate_id)
+    candidate_memory = snapshot.memory if snapshot is not None else None
     if candidate_memory is None:
         return _promotion_denied(
             candidate_id=candidate_id,
@@ -1187,7 +1277,7 @@ async def _resolve_reflection_promotion_plan(
         )
 
     raw_source_ids = _raw_source_ids(candidate_memory) or [candidate_memory.id]
-    input_memories, sources_complete = await _load_promotion_inputs(
+    input_memories, sources_complete, input_observations = await _load_promotion_inputs(
         candidate_memory, organization_id=organization_id
     )
 
@@ -1221,6 +1311,21 @@ async def _resolve_reflection_promotion_plan(
             accessible_teams=accessible_teams,
             accessible_delegations=accessible_delegations,
         )
+        snapshot = await load_promotion_source(organization_id, candidate_memory.id)
+        if (
+            snapshot is None
+            or snapshot.memory.revision != candidate_memory.revision
+            or snapshot.memory.raw_content != candidate_memory.raw_content
+        ):
+            return _promotion_denied(
+                candidate_id=candidate_memory.id,
+                reason="source_changed",
+                review_state=candidate_memory.review_state,
+                memory_scope=candidate_memory.memory_scope,
+                scope_key=candidate_memory.scope_key,
+                raw_source_ids=raw_source_ids,
+            )
+        candidate_memory = snapshot.memory
         input_memories[0] = candidate_memory
 
     from sibyl_core.services.eval_publication_guards import verify_publication_admissions
@@ -1297,6 +1402,15 @@ async def _resolve_reflection_promotion_plan(
         )
     )
     return _ReflectionPromotionPlan(
+        source_authority=SourceReadAuthority(
+            str(principal_id or ""),
+            projects=frozenset(accessible_projects or ()),
+            teams=frozenset(accessible_teams or ()),
+            delegations=frozenset(accessible_delegations or ()),
+            scope_keys=frozenset(allowed_memory_scope_keys)
+            if allowed_memory_scope_keys is not None
+            else None,
+        ),
         candidate_memory=candidate_memory,
         promotion_candidate=promotion_candidate,
         target_scope=target_scope,
@@ -1304,6 +1418,13 @@ async def _resolve_reflection_promotion_plan(
         target_project=target_project,
         raw_source_ids=raw_source_ids,
         input_memories=input_memories,
+        source_observations=(
+            (snapshot.observation,)
+            if snapshot is not None
+            and not candidate_memory.metadata.get(EVAL_CONSOLIDATION_METADATA_KEY)
+            else ()
+        )
+        + input_observations,
     )
 
 
@@ -1319,11 +1440,12 @@ async def _resolve_raw_memory_promotion_plan(
     accessible_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> _ReflectionPromotionPlan | ReflectionPromotionResult:
-    memory = await get_raw_memory(
-        organization_id=organization_id,
-        memory_id=raw_memory_id,
-    )
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
+    snapshot = await load_promotion_source(organization_id, raw_memory_id)
+    memory = snapshot.memory if snapshot is not None else None
     if memory is None:
         return _promotion_denied(
             candidate_id=raw_memory_id,
@@ -1405,6 +1527,15 @@ async def _resolve_raw_memory_promotion_plan(
         else _metadata_str(memory.metadata, "project_id")
     )
     return _ReflectionPromotionPlan(
+        source_authority=SourceReadAuthority(
+            str(principal_id or ""),
+            projects=frozenset(accessible_projects or ()),
+            teams=frozenset(accessible_teams or ()),
+            delegations=frozenset(accessible_delegations or ()),
+            scope_keys=frozenset(allowed_memory_scope_keys)
+            if allowed_memory_scope_keys is not None
+            else None,
+        ),
         candidate_memory=memory,
         promotion_candidate=promotion_candidate,
         target_scope=target_scope,
@@ -1412,4 +1543,5 @@ async def _resolve_raw_memory_promotion_plan(
         target_project=target_project,
         raw_source_ids=raw_source_ids,
         input_memories=input_memories,
+        source_observations=(snapshot.observation,) if snapshot is not None else (),
     )

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_sharing.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_sharing.py
@@ -40,6 +40,7 @@ from sibyl_core.services.memory_reflection import (
     _promotion_write_denied,
     persist_reflection_candidate,
 )
+from sibyl_core.services.promotion_observations import load_promotion_source
 from sibyl_core.services.surreal_content import (
     MemoryScope,
     RawMemory,
@@ -74,6 +75,7 @@ async def preview_memory_share(
     writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> MemorySharePreview:
     accessible_projects = (
         frozenset(accessible_projects) if accessible_projects is not None else None
@@ -159,7 +161,25 @@ async def preview_memory_share(
             accessible_projects=accessible_projects,
             accessible_teams=accessible_teams,
             accessible_delegations=accessible_delegations,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
         )
+        if read_decision.allowed:
+            from sibyl_core.services.memory_derivations import raw_derivation_current
+            from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
+            authority = SourceReadAuthority(
+                str(principal_id or ""),
+                projects=frozenset(accessible_projects or ()),
+                teams=frozenset(accessible_teams or ()),
+                delegations=frozenset(accessible_delegations or ()),
+                scope_keys=frozenset(allowed_memory_scope_keys)
+                if allowed_memory_scope_keys is not None
+                else None,
+            )
+            if not await raw_derivation_current(memory, authority):
+                read_decision = replace(
+                    read_decision, allowed=False, reason="source_not_recallable"
+                )
         decisions.append(read_decision)
         if read_decision.allowed:
             visible_source_ids.append(memory.id)
@@ -217,12 +237,14 @@ async def share_memory(
     writable_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> MemoryShareResult:
     accessible_projects = (
         frozenset(accessible_projects) if accessible_projects is not None else None
     )
     writable_projects = frozenset(writable_projects or ())
     preview = await preview_memory_share(
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
         source_ids=source_ids,
         organization_id=organization_id,
         principal_id=principal_id,
@@ -252,6 +274,7 @@ async def share_memory(
     promotions: list[ReflectionPromotionResult] = []
     for source_id in preview.visible_source_ids:
         plan = await _resolve_raw_memory_share_plan(
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
             raw_memory_id=source_id,
             organization_id=organization_id,
             principal_id=principal_id,
@@ -521,11 +544,12 @@ async def _resolve_raw_memory_share_plan(
     accessible_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
     accessible_delegations: Iterable[str] | None = None,
+    allowed_memory_scope_keys: Iterable[str] | None = None,
 ) -> _ReflectionPromotionPlan | ReflectionPromotionResult:
-    memory = await get_raw_memory(
-        organization_id=organization_id,
-        memory_id=raw_memory_id,
-    )
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
+    snapshot = await load_promotion_source(organization_id, raw_memory_id)
+    memory = snapshot.memory if snapshot is not None else None
     if memory is None:
         return _promotion_denied(
             candidate_id=raw_memory_id,
@@ -548,7 +572,7 @@ async def _resolve_raw_memory_share_plan(
             raw_source_ids=raw_source_ids,
         )
 
-    input_memories, sources_complete = await _load_promotion_inputs(
+    input_memories, sources_complete, input_observations = await _load_promotion_inputs(
         memory, organization_id=organization_id
     )
     source_denial = _principal_denial(
@@ -617,6 +641,15 @@ async def _resolve_raw_memory_share_plan(
         else _metadata_str(memory.metadata, "project_id")
     )
     return _ReflectionPromotionPlan(
+        source_authority=SourceReadAuthority(
+            str(principal_id or ""),
+            projects=frozenset(accessible_projects or ()),
+            teams=frozenset(accessible_teams or ()),
+            delegations=frozenset(accessible_delegations or ()),
+            scope_keys=frozenset(allowed_memory_scope_keys)
+            if allowed_memory_scope_keys is not None
+            else None,
+        ),
         candidate_memory=memory,
         promotion_candidate=promotion_candidate,
         target_scope=target_scope,
@@ -624,6 +657,8 @@ async def _resolve_raw_memory_share_plan(
         target_project=target_project,
         raw_source_ids=raw_source_ids,
         input_memories=input_memories,
+        source_observations=((snapshot.observation,) if snapshot is not None else ())
+        + input_observations,
     )
 
 
@@ -659,6 +694,8 @@ async def _apply_share_plan(
         scope_key=plan.target_scope_key,
         link_source_entity=False,
         source_memories=plan.input_memories,
+        source_observations=plan.source_observations,
+        source_authority=plan.source_authority,
     )
     if not result.response.success or result.metadata.get("promotion_state") == "partial":
         return _promotion_write_denied(plan=plan, result=result)

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_source_validation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_source_validation.py
@@ -50,12 +50,17 @@ type SourceAuthorityResolver = Callable[[str, str], Awaitable[SourceReadAuthorit
 
 
 def _saved_ceiling(memory: content_models.RawMemory) -> SourceReadAuthority | None:
-    value = memory.metadata.get(SOURCE_VALIDATION_CONTEXT_KEY)
+    return source_authority_ceiling(
+        memory.metadata.get(SOURCE_VALIDATION_CONTEXT_KEY), memory.principal_id
+    )
+
+
+def source_authority_ceiling(value: object, principal_id: str) -> SourceReadAuthority | None:
     if not isinstance(value, Mapping):
         return None
     if type(value.get("version")) is not int or value["version"] != 1:
         return None
-    if value.get("principal_id") != memory.principal_id or not memory.principal_id:
+    if value.get("principal_id") != principal_id or not principal_id:
         return None
     if type(value.get("scope_restricted")) is not bool:
         return None
@@ -66,7 +71,7 @@ def _saved_ceiling(memory: content_models.RawMemory) -> SourceReadAuthority | No
     if not value["scope_restricted"] and value["scope_keys"]:
         return None
     return SourceReadAuthority(
-        principal_id=memory.principal_id,
+        principal_id=principal_id,
         projects=frozenset(value["projects"]),
         teams=frozenset(value["teams"]),
         delegations=frozenset(value["delegations"]),

--- a/packages/python/sibyl-core/src/sibyl_core/services/promotion_observations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/promotion_observations.py
@@ -1,0 +1,23 @@
+"""Capture source-local observations at promotion input materialization."""
+
+from sibyl_core.memory_pipeline.observations import SourceIdentity, SourceKind
+from sibyl_core.services import content_client
+from sibyl_core.services.source_state_store import RawSourceSnapshot, load_source_snapshot
+
+
+async def load_promotion_source(organization_id: str, memory_id: str) -> RawSourceSnapshot | None:
+    async with content_client.surreal_content_client() as client:
+        snapshot = await load_source_snapshot(
+            SourceIdentity(organization_id, SourceKind.RAW_CAPTURE, memory_id),
+            organization_id=organization_id,
+            execute_query=client.execute_query,
+        )
+    return snapshot if isinstance(snapshot, RawSourceSnapshot) else None
+
+
+async def promotion_observations_current(observations, authority, organization_id: str) -> bool:
+    from sibyl_core.services.memory_derivations import validate_observations
+
+    return bool(observations) and await validate_observations(
+        observations, authority, organization_id=organization_id
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/synthesis.py
@@ -733,6 +733,13 @@ async def materialize_synthesis_section_packs(
                     source_name = snapshot.memory.title or "Untitled raw memory"
                     source_content = snapshot.memory.raw_content
                 elif isinstance(snapshot, GraphSourceSnapshot):
+                    from sibyl_core.services.graph_derivations import graph_derivation_current
+
+                    if not await graph_derivation_current(
+                        snapshot.entity, ancestors=frozenset({identity})
+                    ):
+                        hidden_count += 1
+                        continue
                     source_name = snapshot.entity.name
                     source_content = snapshot.entity.content or snapshot.entity.description
             sources.append(

--- a/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/reflect.py
@@ -54,6 +54,7 @@ async def reflect_memory(
     principal_id: str | None = None,
     accessible_projects: set[str] | None = None,
     writable_projects: set[str] | None = None,
+    allowed_memory_scope_keys: frozenset[str] | None = None,
     memory_scope: str | MemoryScope | None = None,
     scope_key: str | None = None,
     suggested_memory_scope: str | MemoryScope | None = None,
@@ -108,17 +109,24 @@ async def reflect_memory(
         limit=limit,
     )
     active_extractor = extractor or HeuristicReflectionExtractor()
-    candidates = await active_extractor.extract(
-        ReflectionExtractionRequest(
-            content=content,
-            source_title=source_title,
-            intent=intent,
-            domain=domain,
-            project=project,
-            limit=limit,
+
+    async def extract_candidates():
+        extracted = await active_extractor.extract(
+            ReflectionExtractionRequest(
+                content=content,
+                source_title=source_title,
+                intent=intent,
+                domain=domain,
+                project=project,
+                limit=limit,
+            )
         )
-    )
-    validate_reflection_candidates(candidates, require_source_ids=False)
+        validate_reflection_candidates(extracted, require_source_ids=False)
+        return extracted
+
+    candidates = await extract_candidates() if not persist or persist_review else None
+    source_observations = ()
+    source_authority = None
 
     persist_policy_metadata: dict[str, Any] = {}
     if persist:
@@ -132,6 +140,8 @@ async def reflect_memory(
         )
         persist_policy_metadata = _reflect_policy_metadata(persist_decisions)
         if any(not decision.allowed for decision in persist_decisions):
+            if candidates is None:
+                candidates = await extract_candidates()
             denied_candidates = [
                 ground_reflection_candidate(
                     replace(candidate, metadata={**candidate.metadata, **persist_policy_metadata}),
@@ -189,6 +199,8 @@ async def reflect_memory(
         else:
             # A requested source is an evidence prerequisite. Never publish a
             # candidate after its source was denied or retired.
+            if candidates is None:
+                candidates = await extract_candidates()
             return ReflectionPack(
                 source_title=source_title,
                 source_id=source.id,
@@ -217,6 +229,45 @@ async def reflect_memory(
                 total_candidates=len(candidates),
                 persisted_count=0,
             )
+
+    if persist and not persist_review and source_id is not None:
+        from sibyl_core.memory_pipeline.observations import SourceIdentity, SourceKind
+        from sibyl_core.services.memory_derivations import validate_observations
+        from sibyl_core.services.memory_source_validation import SourceReadAuthority
+        from sibyl_core.services.observed_sources import load_authorized_source_snapshot
+        from sibyl_core.services.source_observations import (
+            GraphSourceSnapshot,
+            SourceUnavailableError,
+        )
+
+        authority = SourceReadAuthority(
+            str(principal_id or ""),
+            projects=frozenset(accessible_projects or ()),
+            scope_keys=(
+                frozenset(allowed_memory_scope_keys)
+                if allowed_memory_scope_keys is not None
+                else None
+            ),
+        )
+        snapshot = await load_authorized_source_snapshot(
+            SourceIdentity(str(organization_id), SourceKind.GRAPH_ENTITY, source_id),
+            authority,
+            organization_id=str(organization_id),
+        )
+        if (
+            not isinstance(snapshot, GraphSourceSnapshot)
+            or not snapshot.observation.durable
+            or (snapshot.entity.content or snapshot.entity.description).strip() != content
+            or not await validate_observations(
+                [snapshot.observation], authority, organization_id=str(organization_id)
+            )
+        ):
+            raise SourceUnavailableError()
+        content = snapshot.entity.content or snapshot.entity.description
+        source_observations = (snapshot.observation,)
+        source_authority = authority
+    if candidates is None:
+        candidates = await extract_candidates()
 
     source_anchor_id = source_id
     if persist and source_anchor_id is None and not persist_source:
@@ -293,6 +344,8 @@ async def reflect_memory(
             )
             continue
         candidate_result = await _persist_reflection_candidate(
+            source_observations=source_observations,
+            source_authority=source_authority,
             candidate=replace(candidate, metadata=metadata),
             organization_id=str(organization_id),
             principal_id=principal_id,

--- a/packages/python/sibyl-core/tests/test_default_memory_loop.py
+++ b/packages/python/sibyl-core/tests/test_default_memory_loop.py
@@ -27,7 +27,12 @@ def _subprocess_env() -> dict[str, str]:
         )
     )
     return {
-        **os.environ,
+        **{
+            key: value
+            for key, value in os.environ.items()
+            if not any(marker in key.upper() for marker in ("KEY", "TOKEN", "SECRET", "PASSWORD"))
+        },
+        "UV_NO_ENV_FILE": "1",
         "PYTHONPATH": pythonpath,
         "SIBYL_REPO_ROOT": str(_REPO_ROOT),
     }
@@ -61,6 +66,9 @@ async def main():
     )
     import sibyl_core.retrieval._search_database as retrieval_database
     import sibyl_core.services.memory_reflection as memory_module
+    import sibyl_core.services.graph_runtime as core_graph_runtime
+    import sibyl_core.services.content_models as content_models
+    content_models.configured_raw_memory_embedding_provider = lambda: None
     import sibyl_core.tools.add as add_module
     import sibyl_core.tools.context as context_module
     import sibyl_core.tools.core as core_module
@@ -95,6 +103,7 @@ async def main():
     async def empty_raw_recall(**_kwargs):
         return []
 
+    core_graph_runtime.get_surreal_graph_runtime = runtime_factory
     add_module.get_surreal_graph_runtime = runtime_factory
     context_module.get_surreal_graph_runtime = runtime_factory
     explore_module.get_graph_runtime = runtime_factory

--- a/packages/python/sibyl-core/tests/test_eval_publication_promotion.py
+++ b/packages/python/sibyl-core/tests/test_eval_publication_promotion.py
@@ -40,6 +40,18 @@ async def runtime(monkeypatch):
     monkeypatch.setattr(
         memory_reflection, "get_surreal_graph_runtime", AsyncMock(return_value=runtime)
     )
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
+    async def authority(_organization_id, principal_id):
+        return SourceReadAuthority(principal_id)
+
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_derivations.get_source_authority_resolver", lambda: authority
+    )
     try:
         yield runtime
     finally:
@@ -51,6 +63,9 @@ async def test_designated_candidate_promotes_and_replays_without_early_recall(
 ):
     op, result = proposal
     stored = await p.store_consolidation(op, result)
+    from tests.test_source_publication_epochs import source_snapshot
+
+    before_admission = await source_snapshot(stored.memory)
     recall_params = dict(
         organization_id=op.organization_id,
         principal_id=op.principal_id,
@@ -62,9 +77,9 @@ async def test_designated_candidate_promotes_and_replays_without_early_recall(
     observed = []
     create = runtime.entity_manager.create_direct_if_absent
 
-    async def watched(entity):
+    async def watched(entity, **kwargs):
         observed.append(graph_metadata_recallable(entity.metadata))
-        return await create(entity)
+        return await create(entity, **kwargs)
 
     monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", watched)
     first = await memory_reflection.promote_reflection_candidate_review(
@@ -77,6 +92,8 @@ async def test_designated_candidate_promotes_and_replays_without_early_recall(
     assert observed == [False]
     current = await get_raw_memory(organization_id=op.organization_id, memory_id=stored.memory.id)
     assert current.review_state == "promoted"
+    after_admission = await source_snapshot(current)
+    assert after_admission.observation.generation > before_admission.observation.generation
     assert content_models.raw_memory_recallable(current)
     assert current.id in {memory.id for memory in await recall_raw_memory(**recall_params)}
     assert graph_metadata_recallable((await runtime.entity_manager.get(first.promoted_id)).metadata)

--- a/packages/python/sibyl-core/tests/test_graph_derivation_publication.py
+++ b/packages/python/sibyl-core/tests/test_graph_derivation_publication.py
@@ -1,0 +1,488 @@
+"""Graph publication must keep the source observations used by its plan."""
+
+from sibyl_core.models.entities import EntityType
+from sibyl_core.services import content_client
+from sibyl_core.services.memory_sharing import _apply_share_plan, _resolve_raw_memory_share_plan
+from sibyl_core.services.surreal_content import remember_raw_memory
+from tests.test_synthesis_source_observations import (
+    content_store as content_store,
+)
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+from tests.test_synthesis_source_observations import (
+    runtime as runtime,
+)
+
+
+async def share_plan(runtime, memory_id):
+    return await _resolve_raw_memory_share_plan(
+        raw_memory_id=memory_id,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        promote_to_scope="project",
+        promote_to_scope_key="project_a",
+        accessible_projects={"project_a"},
+    )
+
+
+async def publish(runtime, plan):
+    return await _apply_share_plan(
+        plan=plan,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        domain=None,
+        related_to=None,
+        accessible_projects={"project_a"},
+        writable_projects={"project_a"},
+        accessible_teams=set(),
+        accessible_delegations=set(),
+    )
+
+
+async def test_share_plan_captures_durable_source_observation(runtime, content_store):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="share-observation",
+        raw_content="The deployment rule is blue approval.",
+        embedding_provider=None,
+    )
+    plan = await share_plan(runtime, source.id)
+    assert plan.source_observations
+    observation = plan.source_observations[0]
+    assert observation.durable
+    assert observation.source.id == source.id
+    assert observation.source.organization_id == runtime.client.group_id
+    result = await publish(runtime, plan)
+    assert result.success
+
+
+async def test_share_plan_cannot_adopt_identical_recreated_source(runtime, content_store):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="share-recreation",
+        raw_content="The deployment rule is blue approval.",
+        embedding_provider=None,
+    )
+    plan = await share_plan(runtime, source.id)
+    async with content_client.surreal_content_client() as client:
+        rows = await client.execute_query(
+            "SELECT * FROM raw_captures WHERE uuid=$uuid;", uuid=source.id
+        )
+        saved = {key: value for key, value in rows[0].items() if key != "id"}
+        await client.execute_query("DELETE raw_captures WHERE uuid=$uuid;", uuid=source.id)
+        await client.execute_query("CREATE raw_captures CONTENT $saved;", saved=saved)
+    result = await publish(runtime, plan)
+    assert not result.success
+    assert not await runtime.entity_manager.list_by_type(EntityType.EPISODE, limit=20)
+
+
+async def test_graph_derivation_replay_preserves_bookkeeping_and_rejects_recreation(
+    runtime, content_store
+):
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="graph-replay",
+        raw_content="The deployment rule is blue approval.",
+        embedding_provider=None,
+    )
+    first = await publish(runtime, await share_plan(runtime, source.id))
+    assert first.success
+    rows = await runtime.client.execute_query(
+        "SELECT * FROM memory_derivations WHERE target_id=$id;",
+        id=first.promoted_id,
+    )
+    assert len(rows) == 1 and rows[0]["active"] is True
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE raw_captures SET revision += 1, retrieval_count += 1 WHERE uuid=$id;",
+            id=source.id,
+        )
+    repeated = await publish(runtime, await share_plan(runtime, source.id))
+    assert repeated.success and repeated.promoted_id == first.promoted_id
+    assert (
+        await runtime.client.execute_query(
+            "SELECT * FROM memory_derivations WHERE target_id=$id;", id=first.promoted_id
+        )
+        == rows
+    )
+    await runtime.entity_manager.delete(first.promoted_id)
+    import pytest
+
+    with pytest.raises(Exception, match=r"already|index|duplicate"):
+        await publish(runtime, await share_plan(runtime, source.id))
+    assert not await runtime.client.execute_query(
+        "SELECT * FROM entity WHERE uuid=$id;", id=first.promoted_id
+    )
+    retired = await runtime.client.execute_query(
+        "SELECT * FROM memory_derivations WHERE target_id=$id;", id=first.promoted_id
+    )
+    assert len(retired) == 1 and retired[0]["active"] is False
+
+
+async def test_shared_graph_validates_publisher_ancestry_without_private_reader_access(
+    runtime, content_store, monkeypatch
+):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.auth.memory_policy import memory_metadata_read_allowed
+    from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+    from sibyl_core.services.memory_correction import apply_memory_correction
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+    from tests.test_synthesis_source_observations import remember_observed_synthesis
+
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="shared-ancestry",
+        raw_content="Deployment requires blue approval.",
+        embedding_provider=None,
+    )
+    synthesis = await remember_observed_synthesis(
+        runtime, source.id, "raw_memory", source.revision, source.raw_content
+    )
+    published = await publish(runtime, await share_plan(runtime, synthesis.remembered_memory_id))
+    assert published.success
+    target = await runtime.entity_manager.get(published.promoted_id)
+    assert memory_metadata_read_allowed(
+        target.metadata,
+        principal_id="user_b",
+        private_scope_granted=True,
+        accessible_projects={"project_a"},
+        row_project_id="project_a",
+    )
+    resolver = AsyncMock(
+        return_value=SourceReadAuthority("user_a", projects=frozenset({"project_a"}))
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_derivations.get_source_authority_resolver", lambda: resolver
+    )
+    assert not await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: target.metadata}
+    )
+    resolver.assert_awaited_with(runtime.client.group_id, "user_a")
+    await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id=source.id,
+        action="hide",
+    )
+    assert target.id in await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: target.metadata}
+    )
+
+
+async def test_direct_reflection_captures_graph_before_extractor_mutates_source(
+    runtime, content_store
+):
+    from sibyl_core.models.entities import Entity
+    from sibyl_core.models.reflection import ReflectionCandidate
+    from sibyl_core.tools.reflect import reflect_memory
+
+    source = Entity(
+        id="direct-source",
+        entity_type=EntityType.SESSION,
+        name="Source",
+        content="Deployment requires blue approval.",
+        metadata={"memory_scope": "private", "principal_id": "user_a"},
+    )
+    await runtime.entity_manager.create_direct(source)
+
+    class RacingExtractor:
+        async def extract(self, request):
+            assert request.content == source.content
+            await runtime.entity_manager.update(
+                source.id, {"content": "Deployment now requires red approval."}
+            )
+            return [
+                ReflectionCandidate(
+                    kind="decision",
+                    title="Deployment approval",
+                    content=request.content,
+                    reason="preserve deployment rule",
+                    confidence=1.0,
+                    tags=[],
+                )
+            ]
+
+    pack = await reflect_memory(
+        source.content,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        existing_source_id=source.id,
+        persist=True,
+        persist_source=False,
+        extractor=RacingExtractor(),
+    )
+    assert pack.persisted_count == 0
+    assert pack.candidates[0].persisted_id is None
+
+
+async def test_direct_reflection_binds_new_graph_source_before_extraction(runtime, content_store):
+    from sibyl_core.backends.surreal.records import normalize_records
+    from sibyl_core.models.reflection import ReflectionCandidate
+    from sibyl_core.tools.reflect import reflect_memory
+
+    class Extractor:
+        async def extract(self, request):
+            rows = normalize_records(
+                await runtime.client.execute_query(
+                    "SELECT * FROM entity WHERE name='New reflection source'"
+                )
+            )
+            assert len(rows) == 1
+            assert rows[0]["content"] == request.content
+            return [
+                ReflectionCandidate(
+                    kind="decision",
+                    title="Deployment approval",
+                    content=request.content,
+                    reason="preserve deployment rule",
+                    confidence=1.0,
+                    tags=[],
+                )
+            ]
+
+    pack = await reflect_memory(
+        "Deployment requires blue approval.",
+        source_title="New reflection source",
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        persist=True,
+        extractor=Extractor(),
+    )
+    assert pack.persisted_count == 1
+    rows = normalize_records(
+        await runtime.client.execute_query(
+            "SELECT * FROM memory_derivations WHERE target_id=$id",
+            id=pack.candidates[0].persisted_id,
+        )
+    )
+    assert rows[0]["active"] is True
+    assert rows[0]["observations"][0]["source"]["id"] == pack.source_id
+    assert rows[0]["observations"][0]["source"]["kind"] == "graph_entity"
+
+
+async def test_graph_target_scope_change_after_discovery_retires_same_content(
+    runtime, content_store, monkeypatch
+):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.auth.memory_policy import memory_metadata_read_allowed
+    from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="rule",
+        raw_content="Deployment requires blue approval.",
+        embedding_provider=None,
+    )
+    published = await publish(runtime, await share_plan(runtime, source.id))
+    assert published.success
+    target = await runtime.entity_manager.get(published.promoted_id)
+    assert memory_metadata_read_allowed(
+        target.metadata,
+        principal_id="user_b",
+        private_scope_granted=True,
+        accessible_projects={"project_a"},
+        row_project_id="project_a",
+    )
+    resolver = AsyncMock(
+        return_value=SourceReadAuthority("user_a", projects=frozenset({"project_a"}))
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_derivations.get_source_authority_resolver", lambda: resolver
+    )
+    assert not await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: target.metadata}
+    )
+    updated = await runtime.entity_manager.update(
+        target.id,
+        {"metadata": {"memory_scope": "private", "principal_id": "user_a", "scope_key": None}},
+    )
+    assert updated.content == target.content
+    assert target.id in await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: target.metadata}
+    )
+
+
+async def test_share_rejects_project_ancestor_outside_key_grant(runtime, content_store):
+    from sibyl_core.auth.memory_policy import memory_scope_policy_key
+    from sibyl_core.services.memory_sharing import share_memory
+    from sibyl_core.services.surreal_content import MemoryScope
+    from sibyl_core.services.synthesis import draft_synthesis_artifact, remember_synthesis_artifact
+    from tests.test_synthesis_source_observations import materialized_synthesis
+
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="project-rule",
+        raw_content="Deployment requires blue approval.",
+        memory_scope=MemoryScope.PROJECT,
+        scope_key="project_a",
+        embedding_provider=None,
+    )
+    run = await materialized_synthesis(
+        runtime,
+        source.id,
+        "raw_memory",
+        source.revision,
+        source.raw_content,
+        accessible_projects={"project_a", "project_b"},
+    )
+    artifact = await remember_synthesis_artifact(
+        draft_synthesis_artifact(run),
+        run,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+    )
+    common = dict(
+        source_ids=[artifact.remembered_memory_id],
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        target_scope="project",
+        target_scope_key="project_b",
+        accessible_projects={"project_a", "project_b"},
+        writable_projects={"project_b"},
+    )
+    keys = frozenset(
+        {
+            memory_scope_policy_key(MemoryScope.PRIVATE, "user_a"),
+            memory_scope_policy_key(MemoryScope.PROJECT, "project_b"),
+        }
+    )
+    denied = await share_memory(**common, allowed_memory_scope_keys=keys)
+    assert not denied.applied
+    assert denied.preview.visible_source_ids == []
+    allowed = await share_memory(
+        **common,
+        allowed_memory_scope_keys=keys
+        | {memory_scope_policy_key(MemoryScope.PROJECT, "project_a")},
+    )
+    assert allowed.applied
+    assert allowed.promotions[0].success
+
+
+async def test_direct_reflection_source_change_during_insert_denies_publication(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.models.entities import Entity
+    from sibyl_core.models.reflection import ReflectionCandidate
+    from sibyl_core.tools.reflect import reflect_memory
+
+    source = Entity(
+        id="insert-race-source",
+        entity_type=EntityType.SESSION,
+        name="Source",
+        content="Deployment requires blue approval.",
+        metadata={"memory_scope": "private", "principal_id": "user_a"},
+    )
+    await runtime.entity_manager.create_direct(source)
+    original_create = runtime.entity_manager.create_direct_if_absent
+    inserted_ids = []
+
+    async def create_then_revoke(entity, **kwargs):
+        result = await original_create(entity, **kwargs)
+        inserted_ids.append(result[0].id)
+        await runtime.entity_manager.update(
+            source.id, {"content": "Deployment now requires red approval."}
+        )
+        return result
+
+    monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", create_then_revoke)
+
+    class Extractor:
+        async def extract(self, request):
+            return [
+                ReflectionCandidate(
+                    kind="decision",
+                    title="Deployment approval",
+                    content=request.content,
+                    reason="preserve deployment rule",
+                    confidence=1.0,
+                    tags=[],
+                )
+            ]
+
+    pack = await reflect_memory(
+        source.content,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        existing_source_id=source.id,
+        persist=True,
+        persist_source=False,
+        extractor=Extractor(),
+    )
+    assert pack.persisted_count == 0
+    assert len(inserted_ids) == 1
+    target = await runtime.entity_manager.get(inserted_ids[0])
+    assert target.metadata["reflection_publication"]["state"] == "pending"
+
+
+async def test_graph_descendant_retains_original_raw_ancestry(runtime, content_store, monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.models.reflection import ReflectionCandidate
+    from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+    from sibyl_core.services.memory_correction import apply_memory_correction
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+    from sibyl_core.tools.reflect import reflect_memory
+
+    resolver = AsyncMock(
+        return_value=SourceReadAuthority("user_a", projects=frozenset({"project_a"}))
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_derivations.get_source_authority_resolver", lambda: resolver
+    )
+    source = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="ancestor",
+        raw_content="Deployment requires blue approval.",
+        embedding_provider=None,
+    )
+    first = await publish(runtime, await share_plan(runtime, source.id))
+    assert first.success
+    published = await runtime.entity_manager.get(first.promoted_id)
+
+    class Extractor:
+        async def extract(self, request):
+            return [
+                ReflectionCandidate(
+                    kind="decision",
+                    title="Descendant approval",
+                    content=request.content,
+                    reason="preserve approval",
+                    confidence=1.0,
+                    tags=[],
+                )
+            ]
+
+    pack = await reflect_memory(
+        published.content,
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        project="project_a",
+        accessible_projects={"project_a"},
+        writable_projects={"project_a"},
+        existing_source_id=published.id,
+        persist=True,
+        persist_source=False,
+        extractor=Extractor(),
+    )
+    assert pack.persisted_count == 1
+    descendant = await runtime.entity_manager.get(pack.candidates[0].persisted_id)
+    rows = {descendant.id: descendant.metadata}
+    assert not await unavailable_publication_ids(runtime.client.group_id, rows)
+    await apply_memory_correction(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id=source.id,
+        action="hide",
+    )
+    assert descendant.id in await unavailable_publication_ids(runtime.client.group_id, rows)

--- a/packages/python/sibyl-core/tests/test_graph_passage_derivations.py
+++ b/packages/python/sibyl-core/tests/test_graph_passage_derivations.py
@@ -1,0 +1,209 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.projection.passages import project_entity_passages
+from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+from sibyl_core.services.memory_source_validation import SourceReadAuthority
+from sibyl_core.tools.reflect import reflect_memory
+from tests.test_synthesis_source_observations import content_store as content_store
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+from tests.test_synthesis_source_observations import materialized_synthesis
+from tests.test_synthesis_source_observations import runtime as runtime
+
+
+async def published_passages(runtime, content_store, monkeypatch):
+    org = runtime.client.group_id
+    resolver = AsyncMock(return_value=SourceReadAuthority("user_a"))
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_derivations.get_source_authority_resolver", lambda: resolver
+    )
+    body = "\n\n".join(
+        f"Rule {i}: Deployment requires blue approval. "
+        + ("Preserve the deployment evidence. " * 30)
+        for i in range(12)
+    )
+    source = Entity(
+        id="projection-source",
+        entity_type=EntityType.SESSION,
+        name="Original source",
+        content=body,
+        metadata={"memory_scope": "private", "principal_id": "user_a"},
+    )
+    await runtime.entity_manager.create_direct(source)
+
+    class Extractor:
+        async def extract(self, request):
+            return [
+                ReflectionCandidate(
+                    kind="decision",
+                    title="Derived long rule",
+                    content=request.content,
+                    reason="retain rule",
+                    confidence=1.0,
+                    tags=[],
+                )
+            ]
+
+    pack = await reflect_memory(
+        body,
+        organization_id=org,
+        principal_id="user_a",
+        existing_source_id=source.id,
+        persist=True,
+        persist_source=False,
+        extractor=Extractor(),
+    )
+    assert pack.persisted_count == 1
+    target = await runtime.entity_manager.get(pack.candidates[0].persisted_id)
+    projection = await project_entity_passages(
+        entity_manager=runtime.entity_manager,
+        relationship_manager=runtime.relationship_manager,
+        source=target,
+        group_id=org,
+        generate_embeddings=False,
+    )
+    assert projection.passages > 1 and not projection.errors
+    passage = await runtime.entity_manager.get(projection.created_passages[0].id)
+    return source, target, projection, passage
+
+
+async def test_projected_passage_retains_graph_ancestry(runtime, content_store, monkeypatch):
+    org = runtime.client.group_id
+    source, target, projection, passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+    assert not await unavailable_publication_ids(
+        org, {target.id: target.metadata, passage.id: passage.metadata}
+    )
+    await runtime.entity_manager.update(
+        source.id, {"content": "The approval requirement was revoked."}
+    )
+    denied = await unavailable_publication_ids(
+        org, {target.id: target.metadata, passage.id: passage.metadata}
+    )
+    assert target.id in denied
+    materialized = await materialized_synthesis(
+        runtime, passage.id, "passage", passage.revision, passage.content
+    )
+    retained = sum(len(pack.sources) for pack in materialized.source_packs)
+    print(
+        "INDEPENDENT_PROJECTION",
+        {
+            "passages": projection.passages,
+            "target_denied": target.id in denied,
+            "passage_denied": passage.id in denied,
+            "materialized_source_count": retained,
+        },
+    )
+    assert passage.id in denied and retained == 0, (
+        "projected passage bypassed protected graph ancestor revocation and materialization"
+    )
+
+
+@pytest.mark.parametrize("mutation", ["remove_markers", "recreate_parent"])
+async def test_passage_protected_parent_survives_mutable_marker_removal_and_recreation(
+    runtime, content_store, monkeypatch, mutation
+):
+    source, target, _projection, passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+    if mutation == "remove_markers":
+        await runtime.client.execute_query(
+            "UPDATE entity UNSET attributes.source_entity_id, attributes.parent_entity_id, attributes.projection_kind WHERE uuid=$id;",
+            id=passage.id,
+        )
+        await runtime.entity_manager.update(source.id, {"content": "Revoked original evidence."})
+    else:
+        rows = await runtime.client.execute_query(
+            "SELECT * FROM entity WHERE uuid=$id;", id=target.id
+        )
+        saved = {key: value for key, value in rows[0].items() if key != "id"}
+        await runtime.client.execute_query(
+            "DELETE entity WHERE uuid=$id; CREATE entity CONTENT $row;", id=target.id, row=saved
+        )
+    assert passage.id in await unavailable_publication_ids(
+        runtime.client.group_id, {passage.id: passage.metadata}
+    )
+    materialized = await materialized_synthesis(
+        runtime, passage.id, "passage", passage.revision, passage.content
+    )
+    assert not any(pack.sources for pack in materialized.source_packs)
+
+
+async def test_projection_parent_race_rolls_back_children_and_associations(
+    runtime, content_store, monkeypatch
+):
+    _source, target, _projection, passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+    original = runtime.entity_manager.create_direct_bulk
+
+    async def race(entities, **kwargs):
+        await runtime.entity_manager.update(
+            target.id, {"content": "Changed after passage planning."}
+        )
+        return await original(entities, **kwargs)
+
+    monkeypatch.setattr(runtime.entity_manager, "create_direct_bulk", race)
+    before = await runtime.client.execute_query(
+        "SELECT * FROM memory_derivations WHERE target_id=$id;", id=passage.id
+    )
+    result = await project_entity_passages(
+        entity_manager=runtime.entity_manager,
+        relationship_manager=runtime.relationship_manager,
+        source=target,
+        group_id=runtime.client.group_id,
+        generate_embeddings=False,
+    )
+    assert result.errors and result.passages == 0
+    after = await runtime.client.execute_query(
+        "SELECT * FROM memory_derivations WHERE target_id=$id;", id=passage.id
+    )
+    assert after == before
+    assert (await runtime.entity_manager.get(passage.id)).content == passage.content
+
+
+async def test_passage_reprojection_advances_changed_parent_epoch_only(
+    runtime, content_store, monkeypatch
+):
+    from sibyl_core.memory_pipeline.observations import SourceIdentity, SourceKind
+    from sibyl_core.services.source_state_store import load_source_snapshot
+
+    _source, target, _projection, passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+
+    async def observe():
+        return await load_source_snapshot(
+            SourceIdentity(runtime.client.group_id, SourceKind.GRAPH_ENTITY, passage.id),
+            organization_id=runtime.client.group_id,
+            execute_query=runtime.client.execute_query,
+        )
+
+    first = await observe()
+
+    async def reproject():
+        result = await project_entity_passages(
+            entity_manager=runtime.entity_manager,
+            relationship_manager=runtime.relationship_manager,
+            source=target,
+            group_id=runtime.client.group_id,
+            generate_embeddings=False,
+        )
+        assert result.passages and not result.errors
+
+    await reproject()
+    replay = await observe()
+    assert replay.observation.same_evidence(first.observation)
+    await runtime.client.execute_query(
+        "UPDATE entity SET attributes.excluded_from_recall=true WHERE uuid=$id; UPDATE entity SET attributes.excluded_from_recall=false WHERE uuid=$id;",
+        id=target.id,
+    )
+    assert (await observe()).observation.same_evidence(first.observation)
+    await reproject()
+    assert (await observe()).observation.generation > first.observation.generation

--- a/packages/python/sibyl-core/tests/test_memory.py
+++ b/packages/python/sibyl-core/tests/test_memory.py
@@ -33,6 +33,52 @@ from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 from sibyl_core.tools.responses import AddResponse
 
 
+@pytest.fixture(autouse=True)
+def promotion_snapshots(monkeypatch):
+    """Adapt this module's mocked content rows to its mocked source ledger."""
+    from sibyl_core.memory_pipeline.observations import (
+        SourceIdentity,
+        SourceKind,
+        SourceObservation,
+        evidence_hash,
+    )
+    from sibyl_core.services.source_state_store import RawSourceSnapshot
+
+    async def snapshot(organization_id, memory_id, module=reflection_module):
+        memory = await module.get_raw_memory(organization_id=organization_id, memory_id=memory_id)
+        if memory is None:
+            return None
+        return RawSourceSnapshot(
+            memory,
+            SourceObservation(
+                SourceIdentity(organization_id, SourceKind.RAW_CAPTURE, memory.id),
+                1,
+                evidence_hash(memory.raw_content),
+                memory.revision,
+                True,
+            ),
+        )
+
+    monkeypatch.setattr(reflection_module, "load_promotion_source", snapshot)
+    monkeypatch.setattr(
+        sharing_module,
+        "load_promotion_source",
+        lambda org, memory_id: snapshot(org, memory_id, sharing_module),
+    )
+    from sibyl_core.services import memory_derivations
+    from sibyl_core.services.source_observations import SourceUnavailableError, observe_raw_capture
+
+    async def authorized_snapshot(source, authority, *, organization_id):
+        result = await snapshot(organization_id, source.id)
+        if result is None:
+            raise SourceUnavailableError()
+        observe_raw_capture(result.memory, authority)
+        return result
+
+    monkeypatch.setattr(memory_derivations, "load_authorized_source_snapshot", authorized_snapshot)
+    monkeypatch.setattr(memory_derivations, "load_raw_derivation", AsyncMock(return_value=None))
+
+
 def _raw_review_candidate(**overrides: object) -> RawMemory:
     values = {
         "id": "candidate-1",
@@ -1482,7 +1528,7 @@ async def test_persist_reflection_candidate_reports_partial_relationship_writes(
         )
 
     entity_manager = SimpleNamespace(
-        create_direct_if_absent=AsyncMock(side_effect=lambda entity: (entity, True)),
+        create_direct_if_absent=AsyncMock(side_effect=lambda entity, **kwargs: (entity, True)),
         update=AsyncMock(
             return_value=Entity(id="receipt", entity_type=EntityType.DECISION, name="Receipt")
         ),
@@ -1494,6 +1540,7 @@ async def test_persist_reflection_candidate_reports_partial_relationship_writes(
 
     relationship_manager = SimpleNamespace(create_bulk=AsyncMock(side_effect=create_relationships))
     runtime = SimpleNamespace(
+        client=SimpleNamespace(group_id="org-1"),
         entity_manager=entity_manager,
         relationship_manager=relationship_manager,
     )
@@ -1549,7 +1596,7 @@ async def test_promote_review_candidate_bounds_contradicted_source_for_as_of_rea
         def __init__(self) -> None:
             self.updated: list[tuple[str, dict[str, object]]] = []
 
-        async def create_direct_if_absent(self, entity):
+        async def create_direct_if_absent(self, entity, **kwargs):
             self.created_entity = entity
             return entity, True
 
@@ -1578,6 +1625,7 @@ async def test_promote_review_candidate_bounds_contradicted_source_for_as_of_rea
 
     entity_manager = FakeEntityManager()
     runtime = SimpleNamespace(
+        client=SimpleNamespace(group_id="org-1"),
         entity_manager=entity_manager,
         relationship_manager=SimpleNamespace(
             create_bulk=AsyncMock(return_value=(0, 0)),
@@ -1661,7 +1709,7 @@ async def test_promote_review_candidate_skips_other_private_principal_invalidati
         def __init__(self) -> None:
             self.updated: list[tuple[str, dict[str, object]]] = []
 
-        async def create_direct_if_absent(self, entity):
+        async def create_direct_if_absent(self, entity, **kwargs):
             self.created_entity = entity
             return entity, True
 
@@ -1685,6 +1733,7 @@ async def test_promote_review_candidate_skips_other_private_principal_invalidati
 
     entity_manager = FakeEntityManager()
     runtime = SimpleNamespace(
+        client=SimpleNamespace(group_id="org-1"),
         entity_manager=entity_manager,
         relationship_manager=SimpleNamespace(
             create_bulk=AsyncMock(return_value=(0, 0)),
@@ -1747,7 +1796,7 @@ async def test_promote_review_candidate_skips_foreign_private_superseded_entity(
             self.created_metadata: dict[str, object] | None = None
             self.updated: list[tuple[str, dict[str, object]]] = []
 
-        async def create_direct_if_absent(self, entity):
+        async def create_direct_if_absent(self, entity, **kwargs):
             self.created_metadata = entity.metadata
             self.created_entity = entity
             return entity, True
@@ -1777,6 +1826,7 @@ async def test_promote_review_candidate_skips_foreign_private_superseded_entity(
 
     entity_manager = FakeEntityManager()
     runtime = SimpleNamespace(
+        client=SimpleNamespace(group_id="org-1"),
         entity_manager=entity_manager,
         relationship_manager=SimpleNamespace(
             create_bulk=AsyncMock(return_value=(0, 0)),

--- a/packages/python/sibyl-core/tests/test_promotion_reservation_upgrade.py
+++ b/packages/python/sibyl-core/tests/test_promotion_reservation_upgrade.py
@@ -129,17 +129,21 @@ async def test_v2_reservation_old_and_new_publishers_converge(
         await runtime.entity_manager.create_direct_if_absent(legacy)
     real_insert = runtime.entity_manager.create_direct_if_absent
 
-    async def checked_insert(entity):
+    async def checked_insert(entity, **kwargs):
         assert entity.id == legacy.id
         assert not graph_metadata_recallable(entity.metadata)
         assert all(value == 0 for value in entity.metadata["source_bindings"].values())
-        return await real_insert(entity)
+        assert "derivation" not in kwargs
+        return await real_insert(entity, **kwargs)
 
     monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", checked_insert)
     result = await publish(args)
     monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", real_insert)
     assert result.success
     assert result.promoted_id == legacy.id
+    assert not await runtime.client.execute_query(
+        "SELECT * FROM memory_derivations WHERE target_id=$id;", id=legacy.id
+    )
     stored, created = await runtime.entity_manager.create_direct_if_absent(legacy)
     assert not created
     verify_reflection_identity(legacy, stored)

--- a/packages/python/sibyl-core/tests/test_reflect.py
+++ b/packages/python/sibyl-core/tests/test_reflect.py
@@ -26,9 +26,12 @@ def native_reflection_runtime(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespac
     """Keep the native orchestration real while recording its storage boundary."""
     entities: list[Entity] = []
     relationships = []
+    stored: dict[str, Entity] = {}
 
-    async def create_direct_if_absent(entity):
+    async def create_direct_if_absent(entity, **kwargs):
         entities.append(entity)
+        entity.observed_revision = entity.revision
+        stored[entity.id] = entity
         return entity, True
 
     async def update(entity_id, updates, **kwargs):
@@ -44,10 +47,12 @@ def native_reflection_runtime(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespac
         entity_manager=SimpleNamespace(
             create_direct_if_absent=AsyncMock(side_effect=create_direct_if_absent),
             update=AsyncMock(side_effect=update),
-            get=AsyncMock(return_value=None),
+            get=AsyncMock(side_effect=lambda entity_id: stored.get(entity_id)),
         ),
         relationship_manager=SimpleNamespace(create_bulk=AsyncMock(side_effect=create_bulk)),
+        client=SimpleNamespace(group_id="org_123", execute_query=AsyncMock(return_value=[])),
         entities=entities,
+        stored=stored,
         relationships=relationships,
     )
     monkeypatch.setattr(
@@ -56,6 +61,23 @@ def native_reflection_runtime(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespac
     )
     monkeypatch.setattr(
         "sibyl_core.tools.reflect._load_reflection_decision_memories", AsyncMock(return_value=[])
+    )
+    from sibyl_core.memory_pipeline.observations import SourceObservation
+    from sibyl_core.services.source_observations import GraphSourceSnapshot, graph_evidence
+
+    async def snapshot(source, **kwargs):
+        entity = stored.get(source.id)
+        if entity is None:
+            return None
+        return GraphSourceSnapshot(
+            entity.model_copy(update={"observed_revision": entity.revision}),
+            SourceObservation(source, 1, graph_evidence(entity), entity.revision, True),
+        )
+
+    monkeypatch.setattr("sibyl_core.services.observed_sources.load_source_snapshot", snapshot)
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
     )
     return runtime
 
@@ -123,6 +145,20 @@ async def test_native_reflection_keeps_scope_and_provenance(
 
     content = "We decided to preserve source evidence before publishing decisions."
     project = "project_123" if scope == "project" else None
+    if existing_source_id is not None:
+        native_reflection_runtime.stored[existing_source_id] = Entity(
+            id=existing_source_id,
+            organization_id="org_123",
+            entity_type=EntityType.SESSION,
+            name="Existing source",
+            content=content,
+            metadata={
+                "memory_scope": scope,
+                "scope_key": project,
+                "principal_id": "user_123",
+                "project_id": project,
+            },
+        )
     pack = await reflect_memory(
         content,
         organization_id="org_123",
@@ -395,51 +431,15 @@ async def test_reflect_memory_review_persistence_denies_unverified_project(
 
 @pytest.mark.asyncio
 async def test_reflect_memory_native_write_uses_policy_and_direct_graph(
-    monkeypatch: pytest.MonkeyPatch,
+    native_reflection_runtime: SimpleNamespace,
 ) -> None:
-    created_entities = []
-    created_relationships = []
-
-    class FakeEntityManager:
-        async def create_direct_if_absent(self, entity):
-            created_entities.append(entity)
-            return entity, True
-
-        async def update(self, entity_id, updates, **kwargs):
-            entity = next(entity for entity in created_entities if entity.id == entity_id)
-            entity.metadata.update(updates["metadata"])
-            return entity
-
-        # Promotion links only targets it can resolve and the writer can see,
-        # so the declared link has to exist for the RELATED_TO edge to appear.
-        async def get(self, entity_id):
-            return Entity(
-                id=entity_id,
-                entity_type=EntityType.TASK,
-                name="Linked task",
-                description="",
-                content="",
-                metadata={"project_id": "project_123"},
-            )
-
-    class FakeRelationshipManager:
-        async def create_bulk(self, relationships):
-            created_relationships.extend(relationships)
-            return len(relationships), 0
-
-    async def fake_get_graph_runtime(_organization_id: str):
-        return type(
-            "Runtime",
-            (),
-            {
-                "entity_manager": FakeEntityManager(),
-                "relationship_manager": FakeRelationshipManager(),
-            },
-        )()
-
-    monkeypatch.setattr(
-        "sibyl_core.services.memory_reflection.get_surreal_graph_runtime",
-        fake_get_graph_runtime,
+    created_entities = native_reflection_runtime.entities
+    created_relationships = native_reflection_runtime.relationships
+    native_reflection_runtime.stored["task_123"] = Entity(
+        id="task_123",
+        entity_type=EntityType.TASK,
+        name="Linked task",
+        metadata={"project_id": "project_123"},
     )
 
     pack = await reflect_memory(

--- a/packages/python/sibyl-core/tests/test_reflection_identity.py
+++ b/packages/python/sibyl-core/tests/test_reflection_identity.py
@@ -58,6 +58,10 @@ async def runtime(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[GraphRuntime
             AsyncMock(return_value=runtime),
         )
         monkeypatch.setattr(
+            "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+            AsyncMock(return_value=runtime),
+        )
+        monkeypatch.setattr(
             "sibyl_core.tools.reflect._load_reflection_decision_memories",
             AsyncMock(return_value=[]),
         )
@@ -963,9 +967,9 @@ async def test_source_correction_during_promotion_cannot_publish_live_evidence(
     else:
         insert = runtime.entity_manager.create_direct_if_absent
 
-        async def correcting_insert(entity):
+        async def correcting_insert(entity, **kwargs):
             await correct()
-            return await insert(entity)
+            return await insert(entity, **kwargs)
 
         monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", correcting_insert)
     common = dict(

--- a/packages/python/sibyl-core/tests/test_source_publication_epochs.py
+++ b/packages/python/sibyl-core/tests/test_source_publication_epochs.py
@@ -1,0 +1,132 @@
+"""Publication bookkeeping preserves source identity without hiding lifecycle changes."""
+
+from dataclasses import replace
+from uuid import uuid4
+
+import pytest
+
+from sibyl_core.memory_pipeline.observations import SourceIdentity, SourceKind
+from sibyl_core.services import content_client
+from sibyl_core.services.source_state_store import load_source_snapshot
+from sibyl_core.services.surreal_content import remember_raw_memory, save_raw_memory
+from tests.test_reflection_identity import content_store as content_store
+
+
+async def source_snapshot(memory):
+    async with content_client.surreal_content_client() as client:
+        return await load_source_snapshot(
+            SourceIdentity(memory.organization_id, SourceKind.RAW_CAPTURE, memory.id),
+            organization_id=memory.organization_id,
+            execute_query=client.execute_query,
+        )
+
+
+async def test_ordinary_publication_bookkeeping_preserves_source_epoch(content_store):
+    memory = await remember_raw_memory(
+        organization_id=str(uuid4()),
+        principal_id="owner",
+        source_id="source",
+        raw_content="Keep the blue approval.",
+        embedding_provider=None,
+    )
+    before = await source_snapshot(memory)
+    promoted = await save_raw_memory(
+        replace(
+            memory,
+            review_state="promoted",
+            metadata={
+                **memory.metadata,
+                "review_state": "promoted",
+                "lifecycle_state": "active",
+                "lifecycle_flags": [],
+                "memory_lifecycle": {
+                    "state": "active",
+                    "flags": [],
+                    "action": "promote",
+                    "reason": "published",
+                    "source_id": memory.id,
+                    "derived_ids": ["target"],
+                },
+            },
+        ),
+        expected_revision=memory.revision,
+    )
+    after = await source_snapshot(promoted)
+    assert after.observation.same_evidence(before.observation)
+    assert after.observation.revision > before.observation.revision
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"review_state": "archived"},
+        {"review_state": "deferred"},
+        {"metadata": {"review_state": "rejected"}},
+        {"metadata": {"lifecycle_state": "archived"}},
+        {"metadata": {"memory_lifecycle": {"state": "active", "flags": ["hidden"]}}},
+        {"principal_id": "other"},
+    ],
+)
+async def test_nonbookkeeping_transition_advances_source_epoch(content_store, updates):
+    memory = await remember_raw_memory(
+        organization_id=str(uuid4()),
+        principal_id="owner",
+        source_id="source",
+        raw_content="Keep the blue approval.",
+        embedding_provider=None,
+    )
+    before = await source_snapshot(memory)
+    changed = await save_raw_memory(replace(memory, **updates), expected_revision=memory.revision)
+    after = await source_snapshot(changed)
+    assert after.observation.generation > before.observation.generation
+
+
+async def test_upgrade_preserves_existing_source_and_high_water(monkeypatch):
+    from contextlib import asynccontextmanager
+
+    from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
+    from sibyl_core.backends.surreal.content_schema import (
+        CONTENT_SCHEMA_NAME,
+        _content_schema_migrations,
+    )
+    from sibyl_core.backends.surreal.schema_version import (
+        apply_schema_migrations,
+        get_schema_version,
+    )
+
+    client = SurrealContentClient(url="memory://")
+    try:
+        await apply_schema_migrations(
+            client.execute_query,
+            [
+                migration
+                for migration in _content_schema_migrations(url=client._url)
+                if migration.version <= 32
+            ],
+            name=CONTENT_SCHEMA_NAME,
+        )
+
+        @asynccontextmanager
+        async def session():
+            yield client
+
+        monkeypatch.setattr(content_client, "surreal_content_client", session)
+        memory = await remember_raw_memory(
+            organization_id=str(uuid4()),
+            principal_id="owner",
+            source_id="source",
+            raw_content="Keep the original signed content.",
+            metadata={"note": "unchanged"},
+            embedding_provider=None,
+        )
+        before = await source_snapshot(memory)
+        await bootstrap_content_schema(client)
+        assert await get_schema_version(client.execute_query, name=CONTENT_SCHEMA_NAME) == 33
+        after = await source_snapshot(memory)
+        assert after == before
+        promoted = await save_raw_memory(
+            replace(memory, review_state="promoted"), expected_revision=memory.revision
+        )
+        assert (await source_snapshot(promoted)).observation.same_evidence(before.observation)
+    finally:
+        await client.close()


### PR DESCRIPTION
## 🧠 Preserve evidence through graph publication

A reflection or shared synthesis could remain available after its original evidence changed or its publisher lost access. Graph publication now carries the observations captured before extraction into a protected association written atomically with the target. Final retrieval and synthesis materialization validate that association recursively against current source state and publisher authority.

Protected passage projection retains the same ancestry. For example, changing the original source of a reflected decision now makes its projected passages and further graph descendants unavailable, even if mutable lineage markers are removed.

## 🛠️ Design and compatibility

The existing publication owner captures typed raw or graph observations before drafting, retains the original grant ceiling, and revalidates those observations at its existing write and finalization boundaries. The association includes the target's evidence and audience, so changing visibility cannot preserve an old publication identity. Current reads resolve publisher memberships again; publication does not claim a global membership snapshot through extraction.

The graph writer stores the target and its protected association in one transaction. Source events retire associations on physical deletion. Protected passage batches check their captured parent's revision, generation, and association before writing children. Explicit reprojection advances a child's source generation when parent evidence changes, while same-evidence replay remains stable. Each batch is atomic; the whole projection is not a cross-batch transaction.

The upgrade adds graph schema 25 and content schema 33. The new raw-source event distinguishes ordinary promotion bookkeeping from admission or visibility changes. Eval consolidation candidates retain strict admission transitions. Applied historical migrations stay intact. Existing v2 reservations keep unknown-revision reconciliation and never acquire fresh observations for historical evidence.

## 🧪 Validation

- The credential-free full core suite passed 3,729 tests (14 skipped, one expected failure). Focused API coverage passed 131 tests, and all four core/API lint and typecheck gates passed.
- An isolated, pinned SurrealDB 3.2.3 SDK run passed 101 cases. Disposable containers were removed after execution.
- Independent review reproduced the original passage bypass, then verified its correction with five native SDK controls, including descendant content changes, hiding, identical recreation, and authority revocation. Four legacy reservation regressions passed separately. Root spot checks repeated those controls.
- Integration with the consolidation validation fix preserved all 34 reviewed file hashes. The integrated head passed 97 focused tests and all four static gates.

An earlier local smoke subprocess inherited provider credentials and made incidental embedding requests. Usage and cost were not recoverable from the retained failure output. The smoke fixture now installs its missing offline embedding stub, and subsequent local gates use a credential-free environment. No provider calls were part of the isolated SDK qualification.

## 📌 Remaining 1.4 gates

This slice covers reflection, sharing, and passage descendants. The separate prose-memory projection producer still needs protected lineage for extracted graph handles; a project-session reproduction is retained for the next slice. Archive/IMPORT restoration, lost ledgers or associations, and historical derived targets without protected associations remain release qualification work. These limits prevent treating this PR as complete lifecycle or 1.4 release acceptance.
