### PR TITLE
feat(memory): support native strict consolidation output

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py
@@ -7,13 +7,14 @@ import json
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, TypeAdapter
-from pydantic_ai import Agent
+from pydantic_ai import Agent, NativeOutput
 from pydantic_ai.messages import ModelResponse
 from pydantic_ai.models import Model, ModelSettings
 from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 
 from sibyl_core.ai.clients import get_agent
 from sibyl_core.ai.errors import LLMError, classify_llm_exception
@@ -46,6 +47,16 @@ class ExtractionResult[T]:
     usage: ExtractionUsage
 
 
+OutputMode = Literal["tool", "native_strict"]
+
+
+def extraction_schema(output_type: Any, output_mode: OutputMode = "tool") -> dict[str, Any]:
+    schema = TypeAdapter(output_type).json_schema()
+    if output_mode == "native_strict":
+        return OpenAIJsonSchemaTransformer(schema, strict=True).walk()
+    return schema
+
+
 class Extractor[T]:
     def __init__(
         self,
@@ -57,7 +68,15 @@ class Extractor[T]:
         output_retries: int | None = 2,
         max_tokens: int | None = None,
         agent: Agent[Any, Any] | None = None,
+        output_mode: OutputMode = "tool",
+        openrouter_provider: str | None = None,
     ) -> None:
+        if output_mode not in ("tool", "native_strict"):
+            raise ValueError("unsupported extraction output mode")
+        if openrouter_provider is not None and not openrouter_provider.strip():
+            raise ValueError("provider endpoint must be nonempty")
+        self.output_mode = output_mode
+        self.openrouter_provider = openrouter_provider
         self.output_type = output_type
         self.surface = surface
         self.system_prompt = system_prompt
@@ -79,6 +98,15 @@ class Extractor[T]:
     ) -> ExtractionResult[T]:
         try:
             agent = await self._get_agent()
+            if self.output_mode == "native_strict" and not isinstance(
+                agent.model, OpenAIResponsesModel
+            ):
+                raise ValueError("native strict extraction requires OpenAI Responses")
+            if self.openrouter_provider is not None and (
+                not isinstance(agent.model, OpenAIResponsesModel)
+                or agent.model.client.base_url.host != "openrouter.ai"
+            ):
+                raise ValueError("OpenRouter routing requires the OpenRouter API origin")
             transport_retries = (
                 agent.model.client.max_retries
                 if isinstance(agent.model, OpenAIResponsesModel)
@@ -94,7 +122,7 @@ class Extractor[T]:
             )
             result = await agent.run(
                 prompt,
-                model_settings=_model_settings(self.max_tokens),
+                model_settings=self._model_settings(),
             )
             telemetry_registry().record_llm_call(
                 surface=self.surface.value,
@@ -139,7 +167,7 @@ class Extractor[T]:
         instructions = self.system_prompt or ()
         if isinstance(instructions, str):
             instructions = (instructions,)
-        schema = TypeAdapter(self.output_type).json_schema()
+        schema = extraction_schema(self.output_type, self.output_mode)
         return "\n".join((*instructions, prompt, json.dumps(schema, sort_keys=True)))
 
     async def extract_many(
@@ -162,13 +190,31 @@ class Extractor[T]:
     async def _get_agent(self) -> Agent[Any, Any]:
         if self._agent is not None:
             return self._agent
+        output_type: Any = self.output_type
         return await get_agent(
             self.surface,
-            output_type=self.output_type,
+            output_type=(
+                NativeOutput(output_type, strict=True)
+                if self.output_mode == "native_strict"
+                else self.output_type
+            ),
             system_prompt=self.system_prompt,
             model_override=self.model_override,
             output_retries=self.output_retries,
         )
+
+    def _model_settings(self) -> ModelSettings | None:
+        settings = _model_settings(self.max_tokens)
+        if self.openrouter_provider is not None:
+            settings = settings or ModelSettings()
+            settings["extra_body"] = {
+                "provider": {
+                    "only": [self.openrouter_provider],
+                    "require_parameters": True,
+                    "allow_fallbacks": False,
+                }
+            }
+        return settings
 
     def _classify(self, exc: Exception) -> LLMError:
         return classify_llm_exception(

--- a/packages/python/sibyl-core/src/sibyl_core/config.py
+++ b/packages/python/sibyl-core/src/sibyl_core/config.py
@@ -131,6 +131,9 @@ class CoreConfig(BaseSettings):
         description="LLM model for entity extraction",
     )
 
+    consolidation_output_mode: Literal["tool", "native_strict"] = "tool"
+    consolidation_openrouter_provider: str | None = None
+
     consolidation_max_input_chars: int = Field(
         default=40_000,
         gt=0,

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_consolidation.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import hashlib
 from dataclasses import dataclass
+from typing import Literal
 from uuid import NAMESPACE_URL, uuid5
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
@@ -255,6 +256,8 @@ async def propose_admitted_procedure(
     expected_controller_policy_sha256: str,
     max_input_chars: int = 40_000,
     max_tokens: int = 2_048,
+    output_mode: Literal["tool", "native_strict"] = "tool",
+    openrouter_provider: str | None = None,
     model_override: str | None = None,
 ) -> AdmittedConsolidationResult:
     """Authorize externally, join stored evidence, extract, then check the sources again."""
@@ -280,6 +283,8 @@ async def propose_admitted_procedure(
         group,
         max_input_chars=max_input_chars,
         max_tokens=max_tokens,
+        output_mode=output_mode,
+        openrouter_provider=openrouter_provider,
         model_override=model_override,
     )
     if await load() != group:

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -33,6 +33,7 @@ from sibyl_core.services.memory_source_validation import (
 )
 from sibyl_core.tasks.consolidation import (
     EVIDENCE_SYSTEM_PROMPT,
+    OUTPUT_RETRIES,
     SCHEMA_VERSION,
     SYSTEM_PROMPT,
     AdmittedTaskOutcome,
@@ -469,6 +470,7 @@ async def _extractor_policy() -> _ExtractorPolicy:
             "temperature": config.temperature.value,
             "max_input_chars": max_input_chars,
             "max_output_tokens": max_output_tokens,
+            "output_retries": OUTPUT_RETRIES,
             "input_budget_unit": "system_user_declared_schema_characters",
             "transport": transport_policy(config.to_llm_config()),
         }

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -12,6 +12,7 @@ from uuid import NAMESPACE_URL, uuid5
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 from sibyl_core.ai.llm.config import LLMSurface, resolve_llm_config
+from sibyl_core.ai.llm.extractor import extraction_schema
 from sibyl_core.ai.transport import transport_policy
 from sibyl_core.auth.memory_policy import (
     EVAL_ADMISSION_METADATA_KEY,
@@ -447,6 +448,8 @@ class _ExtractorPolicy:
     revision: str
     max_input_chars: int
     max_output_tokens: int
+    output_mode: Literal["tool", "native_strict"]
+    openrouter_provider: str | None
 
 
 async def _extractor_policy() -> _ExtractorPolicy:
@@ -471,11 +474,23 @@ async def _extractor_policy() -> _ExtractorPolicy:
             "max_input_chars": max_input_chars,
             "max_output_tokens": max_output_tokens,
             "output_retries": OUTPUT_RETRIES,
+            "output_mode": core_config.consolidation_output_mode,
+            "wire_schema_sha256": _digest(
+                extraction_schema(EvidenceProposal, core_config.consolidation_output_mode)
+            ),
+            "openrouter_provider": core_config.consolidation_openrouter_provider,
             "input_budget_unit": "system_user_declared_schema_characters",
             "transport": transport_policy(config.to_llm_config()),
         }
     )
-    return _ExtractorPolicy(config.model.value, revision, max_input_chars, max_output_tokens)
+    return _ExtractorPolicy(
+        config.model.value,
+        revision,
+        max_input_chars,
+        max_output_tokens,
+        core_config.consolidation_output_mode,
+        core_config.consolidation_openrouter_provider,
+    )
 
 
 async def consolidation_extractor_configuration() -> tuple[str, str]:
@@ -516,6 +531,8 @@ async def consolidate_admitted_procedure(
         model_override=model_override,
         max_input_chars=policy.max_input_chars,
         max_tokens=policy.max_output_tokens,
+        output_mode=policy.output_mode,
+        openrouter_provider=policy.openrouter_provider,
     )
     if await _extractor_policy() != policy:
         raise ConsolidationConflict("extraction configuration changed during consolidation")

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -31,6 +31,7 @@ from sibyl_core.tasks.episode_evidence import (
 from sibyl_core.tasks.procedure_evidence import EvidenceProposal, resolve_evidence_proposal
 
 SCHEMA_VERSION = "sibyl-conditional-procedure-v1"
+OUTPUT_RETRIES = 2
 METADATA_KEY = "conditional_procedure"
 Text = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 SHA256 = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
@@ -572,7 +573,7 @@ async def propose_conditional_procedure(
         surface=LLMSurface.MEMORY,
         system_prompt=evidence.system,
         model_override=model_override,
-        output_retries=0,
+        output_retries=OUTPUT_RETRIES,
         max_tokens=max_tokens,
     )
     with llm_budget_context(
@@ -622,7 +623,7 @@ def _finish_proposal(
         "input_chars": input_chars,
         "input_budget_unit": "system_user_declared_schema_characters",
         "max_output_tokens": max_tokens,
-        "output_retries": 0,
+        "output_retries": OUTPUT_RETRIES,
         "input_sha256": _digest(_canonical(group.model_dump(mode="json"))),
         "prompt_sha256": _digest(_canonical({"system": evidence.system, "user": prompt})),
         "schema_sha256": _digest(_canonical(evidence.output_type.model_json_schema())),

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_vali
 
 from sibyl_core.ai.llm import Extractor, LLMSurface
 from sibyl_core.ai.llm.budget import get_llm_budget_context, llm_budget_context
+from sibyl_core.ai.llm.extractor import OutputMode, extraction_schema
 from sibyl_core.models.entities import ProcedureStep
 from sibyl_core.models.memory_scope import MemoryScope
 from sibyl_core.models.reflection import ReflectionCandidate
@@ -540,6 +541,8 @@ async def propose_conditional_procedure(
     max_input_chars: int = 40_000,
     max_tokens: int = 2_048,
     model_override: str | None = None,
+    output_mode: OutputMode = "tool",
+    openrouter_provider: str | None = None,
 ) -> ConsolidationResult:
     """Make one extraction attempt and return a proposal, rejection, or abstention.
 
@@ -564,7 +567,7 @@ async def propose_conditional_procedure(
         raise ValueError("build budgets must be positive integers")
     evidence = await asyncio.to_thread(_extraction_input, group)
     prompt = evidence.prompt
-    schema = evidence.output_type.model_json_schema()
+    schema = extraction_schema(evidence.output_type, output_mode)
     input_chars = len(prompt) + len(evidence.system) + len(_canonical(schema).decode("utf-8"))
     if input_chars > max_input_chars:
         raise ConsolidationInputBudgetExceeded(input_chars, max_input_chars)
@@ -575,6 +578,8 @@ async def propose_conditional_procedure(
         model_override=model_override,
         output_retries=OUTPUT_RETRIES,
         max_tokens=max_tokens,
+        output_mode=output_mode,
+        openrouter_provider=openrouter_provider,
     )
     with llm_budget_context(
         user_id=group.owner_principal_id, organization_id=group.organization_id
@@ -596,6 +601,8 @@ async def propose_conditional_procedure(
         max_input_chars,
         input_chars,
         max_tokens,
+        output_mode,
+        openrouter_provider,
     )
 
 
@@ -608,6 +615,8 @@ def _finish_proposal(
     max_input_chars: int,
     input_chars: int,
     max_tokens: int,
+    output_mode: OutputMode = "tool",
+    openrouter_provider: str | None = None,
 ) -> ConsolidationResult:
     prompt = evidence.prompt
     receipt = {
@@ -624,6 +633,11 @@ def _finish_proposal(
         "input_budget_unit": "system_user_declared_schema_characters",
         "max_output_tokens": max_tokens,
         "output_retries": OUTPUT_RETRIES,
+        "output_mode": output_mode,
+        "openrouter_provider": openrouter_provider,
+        "wire_schema_sha256": _digest(
+            _canonical(extraction_schema(evidence.output_type, output_mode))
+        ),
         "input_sha256": _digest(_canonical(group.model_dump(mode="json"))),
         "prompt_sha256": _digest(_canonical({"system": evidence.system, "user": prompt})),
         "schema_sha256": _digest(_canonical(evidence.output_type.model_json_schema())),

--- a/packages/python/sibyl-core/tests/ai/llm/test_consolidation_validation_feedback.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_consolidation_validation_feedback.py
@@ -1,0 +1,116 @@
+"""Consolidation keeps normal schema feedback separate from transport retries."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelResponse
+from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from sibyl_core.ai.errors import LLMValidationError
+from sibyl_core.ai.llm import Extractor
+from sibyl_core.ai.llm import extractor as extraction
+from sibyl_core.ai.transport import RecordingOpenAIClient
+from sibyl_core.tasks.consolidation import OUTPUT_RETRIES
+from sibyl_core.tasks.procedure_evidence import EvidenceProposal
+
+
+@pytest.mark.parametrize("recover", [False, True])
+@pytest.mark.parametrize("transport_retry", [False, True])
+async def test_validation_feedback_retains_attempts(monkeypatch, recover, transport_retry):
+    reserve = AsyncMock()
+    monkeypatch.setattr(extraction, "reserve_llm_budget", reserve)
+    monkeypatch.setattr(ModelResponse, "cost", lambda _: SimpleNamespace(total_price=0.01))
+    requests = []
+    responses = 0
+    malformed = json.dumps({"procedure": '{"goal": "unterminated}'})
+
+    def respond(request):
+        nonlocal responses
+        requests.append(json.loads(request.content))
+        if transport_retry and len(requests) == 1:
+            return httpx2.Response(
+                500,
+                json={"error": {"message": "temporary provider failure"}},
+                headers={"retry-after-ms": "1"},
+            )
+        responses += 1
+        arguments = (
+            json.dumps({"abstention_reason": "Insufficient supported evidence"})
+            if recover and responses > 1
+            else malformed
+        )
+        return httpx2.Response(
+            200,
+            json={
+                "id": f"resp_{responses}",
+                "object": "response",
+                "created_at": 0,
+                "model": "qwen/qwen3-coder-next",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "id": f"fc_{responses}",
+                        "call_id": f"call_{responses}",
+                        "name": "final_result",
+                        "arguments": arguments,
+                    }
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+            },
+        )
+
+    async with RecordingOpenAIClient(transport=httpx2.MockTransport(respond)) as http:
+        client = AsyncOpenAI(
+            api_key="fixture",
+            base_url="https://example.invalid/v1",
+            http_client=http,
+            max_retries=2,
+        )
+        model = OpenAIResponsesModel(
+            "qwen/qwen3-coder-next", provider=OpenAIProvider(openai_client=client)
+        )
+        agent = Agent(model, output_type=EvidenceProposal, retries={"output": OUTPUT_RETRIES})
+        extractor = Extractor(
+            EvidenceProposal, agent=agent, output_retries=OUTPUT_RETRIES, max_tokens=2048
+        )
+        if recover:
+            result = await extractor.extract_with_usage("Contrast the supplied evidence")
+            assert result.output.procedure is None
+            assert result.output.abstention_reason == "Insufficient supported evidence"
+            assert result.usage.requests == 2
+            assert result.usage.input_tokens == 20
+            assert result.usage.output_tokens == 4
+            attempts = result.usage.transport_attempts
+            assert all(attempt.usage_known for attempt in attempts[int(transport_retry) :])
+            if transport_retry:
+                assert not attempts[0].usage_known
+                assert result.usage.cost_usd is None
+                assert result.usage.transport_usage_complete is False
+        else:
+            with pytest.raises(LLMValidationError) as error:
+                await extractor.extract_with_usage("Contrast the supplied evidence")
+            failed = error.value.details["extraction_usage"]
+            assert failed["cost_usd"] is None
+            assert failed["usage_complete"] is False
+            attempts = failed["transport_attempts"]
+            assert all(not attempt["usage_known"] for attempt in attempts)
+
+    assert reserve.await_args.kwargs["attempt_envelope"] == 9
+    assert reserve.await_args.kwargs["output_token_limit"] == 2048
+    assert len(attempts) == len(requests) == (2 if recover else 3) + int(transport_retry)
+    feedback_request = requests[1 + int(transport_retry)]
+    feedback = [
+        item["output"]
+        for item in feedback_request["input"]
+        if item.get("type") == "function_call_output"
+    ]
+    assert len(feedback) == 1
+    assert "procedure" in feedback[0] and "model_type" in feedback[0]
+    assert all(request["tools"][0]["strict"] is False for request in requests)

--- a/packages/python/sibyl-core/tests/ai/llm/test_native_extraction.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_native_extraction.py
@@ -1,0 +1,150 @@
+"""Native extraction preserves validation and explicit endpoint policy."""
+
+import json
+from unittest.mock import AsyncMock
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+from pydantic_ai import Agent, NativeOutput
+from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from sibyl_core.ai.errors import LLMValidationError
+from sibyl_core.ai.llm import Extractor
+from sibyl_core.ai.llm import extractor as extraction
+from sibyl_core.ai.transport import RecordingOpenAIClient
+from sibyl_core.tasks.procedure_evidence import EvidenceProposal
+
+
+@pytest.mark.parametrize("recover", [False, True])
+@pytest.mark.parametrize("output_kind", ["procedure", "abstention"])
+async def test_native_extraction_wire_feedback_and_routing(monkeypatch, recover, output_kind):
+    reserve = AsyncMock()
+    monkeypatch.setattr(extraction, "reserve_llm_budget", reserve)
+    requests = []
+
+    def respond(request):
+        wire = json.loads(request.content)
+        requests.append(wire)
+        content = {"procedure": '{"goal":{}}', "abstention_reason": None}
+        if recover and len(requests) > 1:
+            content = {"procedure": None, "abstention_reason": "Insufficient evidence"}
+            if output_kind == "procedure":
+                assertion = {
+                    "statement": "Synthetic observation",
+                    "label": "observed",
+                    "support": [{"evidence_id": "synthetic"}],
+                }
+                content = {
+                    "procedure": {
+                        "goal": assertion,
+                        "environment": [assertion],
+                        "preconditions": [assertion],
+                        "required_tools": [],
+                        "actions": [
+                            {"order": 1, "action": assertion, "success_criteria": assertion}
+                        ],
+                        "expected_result": assertion,
+                        "failure_modes": [assertion],
+                        "abstain_when": [assertion],
+                    },
+                    "abstention_reason": None,
+                }
+        return httpx2.Response(
+            200,
+            json={
+                "id": f"resp_{len(requests)}",
+                "object": "response",
+                "created_at": 0,
+                "model": "qwen/qwen3-coder-next",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "id": f"msg_{len(requests)}",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [
+                            {"type": "output_text", "text": json.dumps(content), "annotations": []}
+                        ],
+                    }
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+            },
+        )
+
+    async with RecordingOpenAIClient(transport=httpx2.MockTransport(respond)) as http:
+        client = AsyncOpenAI(
+            api_key="fixture",
+            base_url="https://openrouter.ai/api/v1",
+            http_client=http,
+            max_retries=2,
+        )
+        model = OpenAIResponsesModel(
+            "qwen/qwen3-coder-next", provider=OpenAIProvider(openai_client=client)
+        )
+        agent = Agent(
+            model, output_type=NativeOutput(EvidenceProposal, strict=True), retries={"output": 2}
+        )
+        extractor = Extractor(
+            EvidenceProposal,
+            agent=agent,
+            output_mode="native_strict",
+            openrouter_provider="parasail/bf16",
+            max_tokens=2048,
+        )
+        if recover:
+            result = await extractor.extract_with_usage("Synthetic contrast")
+            assert (result.output.procedure is not None) == (output_kind == "procedure")
+            assert (result.output.abstention_reason is not None) == (output_kind == "abstention")
+            assert result.usage.input_tokens == 20
+            assert len(result.usage.transport_attempts) == 2
+        else:
+            with pytest.raises(LLMValidationError) as error:
+                await extractor.extract_with_usage("Synthetic contrast")
+            assert len(error.value.details["extraction_usage"]["transport_attempts"]) == 3
+    assert reserve.await_args.kwargs["attempt_envelope"] == 9
+    schema = extraction.extraction_schema(EvidenceProposal, "native_strict")
+    for request in requests:
+        assert request["text"]["format"]["schema"] == schema
+        assert request["text"]["format"]["strict"] is True
+        assert request.get("tools", []) == []
+        assert request["provider"] == {
+            "only": ["parasail/bf16"],
+            "require_parameters": True,
+            "allow_fallbacks": False,
+        }
+    assert "model_type" in json.dumps(requests[1]["input"])
+
+
+def test_native_extraction_schema_keeps_nullable_abstention():
+    declared = extraction.extraction_schema(EvidenceProposal)
+    strict = extraction.extraction_schema(EvidenceProposal, "native_strict")
+    assert not declared.get("required")
+    assert set(strict["required"]) == {"procedure", "abstention_reason"}
+    assert strict["properties"]["procedure"]["anyOf"][1] == {"type": "null"}
+    assert strict["properties"]["abstention_reason"]["anyOf"][1] == {"type": "null"}
+
+
+async def test_native_extraction_agent_cache_separates_output_modes(monkeypatch):
+    from sibyl_core.ai import clients
+    from sibyl_core.ai.llm.config import EnvConfigSource
+
+    monkeypatch.setattr(
+        clients, "resolve_llm_config", EnvConfigSource({"SIBYL_LLM_PROVIDER": "openai"}).resolve
+    )
+    clients.invalidate_agent_cache()
+    async with httpx2.AsyncClient(
+        transport=httpx2.MockTransport(lambda _: httpx2.Response(400))
+    ) as http:
+        client = AsyncOpenAI(api_key="fixture", http_client=http)
+        model = OpenAIResponsesModel(
+            "qwen/qwen3-coder-next", provider=OpenAIProvider(openai_client=client)
+        )
+        monkeypatch.setattr(clients, "build_model", lambda _: model)
+        tool = await Extractor(EvidenceProposal)._get_agent()
+        native = await Extractor(EvidenceProposal, output_mode="native_strict")._get_agent()
+        native_again = await Extractor(EvidenceProposal, output_mode="native_strict")._get_agent()
+        assert native is native_again and native is not tool
+    clients.invalidate_agent_cache()

--- a/packages/python/sibyl-core/tests/test_eval_publication.py
+++ b/packages/python/sibyl-core/tests/test_eval_publication.py
@@ -304,3 +304,13 @@ async def test_frozen_input_and_output_budgets_reach_actual_proposal(proposal, m
     monkeypatch.setattr(p.core_config, "consolidation_max_input_chars", 120_000)
     environment["SIBYL_LLM_MEMORY_MAX_TOKENS"] = "3073"
     assert (await p.consolidation_extractor_configuration())[1] != revision
+
+
+async def test_output_validation_policy_changes_extractor_revision(monkeypatch):
+    from sibyl_core.ai.llm.config import EnvConfigSource
+
+    monkeypatch.setattr(p, "resolve_llm_config", EnvConfigSource({}).resolve)
+    assert p.OUTPUT_RETRIES == 2
+    current = await p.consolidation_extractor_configuration()
+    monkeypatch.setattr(p, "OUTPUT_RETRIES", 0)
+    assert await p.consolidation_extractor_configuration() != current

--- a/packages/python/sibyl-core/tests/test_eval_publication.py
+++ b/packages/python/sibyl-core/tests/test_eval_publication.py
@@ -299,6 +299,8 @@ async def test_frozen_input_and_output_budgets_reach_actual_proposal(proposal, m
     assert stored.memory is not None
     assert calls[0]["max_input_chars"] == 120_000
     assert calls[0]["max_tokens"] == 3072
+    assert calls[0]["output_mode"] == p.core_config.consolidation_output_mode
+    assert calls[0]["openrouter_provider"] == p.core_config.consolidation_openrouter_provider
     monkeypatch.setattr(p.core_config, "consolidation_max_input_chars", 120_001)
     assert (await p.consolidation_extractor_configuration())[1] != revision
     monkeypatch.setattr(p.core_config, "consolidation_max_input_chars", 120_000)
@@ -314,3 +316,16 @@ async def test_output_validation_policy_changes_extractor_revision(monkeypatch):
     current = await p.consolidation_extractor_configuration()
     monkeypatch.setattr(p, "OUTPUT_RETRIES", 0)
     assert await p.consolidation_extractor_configuration() != current
+
+
+async def test_native_mode_and_endpoint_change_extractor_revision(monkeypatch):
+    from sibyl_core.ai.llm.config import EnvConfigSource
+
+    monkeypatch.setattr(p, "resolve_llm_config", EnvConfigSource({}).resolve)
+    original = await p.consolidation_extractor_configuration()
+    monkeypatch.setattr(p.core_config, "consolidation_output_mode", "native_strict")
+    native = await p.consolidation_extractor_configuration()
+    assert native != original
+    monkeypatch.setattr(p.core_config, "consolidation_openrouter_provider", "parasail/bf16")
+    routed = await p.consolidation_extractor_configuration()
+    assert routed not in (original, native)

--- a/packages/python/sibyl-core/tests/test_tasks_consolidation.py
+++ b/packages/python/sibyl-core/tests/test_tasks_consolidation.py
@@ -126,7 +126,7 @@ def model(monkeypatch):
 
     async def local_agent(extractor):
         assert extractor.surface is LLMSurface.MEMORY
-        assert extractor.output_retries == 0
+        assert extractor.output_retries == c.OUTPUT_RETRIES == 2
         return Agent(
             FunctionModel(respond),
             output_type=c.ProcedureProposal,
@@ -523,3 +523,8 @@ async def test_complete_input_budget_includes_schema_and_accepts_exact_boundary(
     assert len(model[1]) == 1
     assert result.receipt["input_chars"] == actual
     assert result.receipt["max_input_chars"] == actual
+
+
+async def test_build_receipt_records_output_validation_policy(group, procedure, model):
+    result = await propose(group, procedure, model)
+    assert result.receipt["output_retries"] == c.OUTPUT_RETRIES == 2

--- a/packages/python/sibyl-core/tests/test_tasks_consolidation.py
+++ b/packages/python/sibyl-core/tests/test_tasks_consolidation.py
@@ -528,3 +528,42 @@ async def test_complete_input_budget_includes_schema_and_accepts_exact_boundary(
 async def test_build_receipt_records_output_validation_policy(group, procedure, model):
     result = await propose(group, procedure, model)
     assert result.receipt["output_retries"] == c.OUTPUT_RETRIES == 2
+
+
+async def test_native_build_counts_transformed_schema_and_records_policy(group, monkeypatch):
+    from types import SimpleNamespace
+
+    from sibyl_core.ai.llm.extractor import extraction_schema
+
+    calls = []
+
+    class NativeFixture:
+        def __init__(self, output_type, **kwargs):
+            calls.append(kwargs)
+
+        async def extract_with_usage(self, prompt):
+            return SimpleNamespace(
+                output=c.ProcedureProposal(abstention_reason="No supported procedure"),
+                usage=SimpleNamespace(model_dump=lambda **_: {}),
+            )
+
+    monkeypatch.setattr(c, "Extractor", NativeFixture)
+    schema = extraction_schema(c.ProcedureProposal, "native_strict")
+    actual = len(c.SYSTEM_PROMPT) + len(c._prompt(group)) + len(c._canonical(schema).decode())
+    with pytest.raises(c.ConsolidationInputBudgetExceeded):
+        await c.propose_conditional_procedure(
+            group, output_mode="native_strict", max_input_chars=actual - 1
+        )
+    assert calls == []
+    result = await c.propose_conditional_procedure(
+        group,
+        output_mode="native_strict",
+        openrouter_provider="parasail/bf16",
+        max_input_chars=actual,
+    )
+    assert calls[0]["output_mode"] == "native_strict"
+    assert calls[0]["openrouter_provider"] == "parasail/bf16"
+    assert result.receipt["wire_schema_sha256"] == c._digest(c._canonical(schema))
+    assert result.receipt["input_chars"] == actual
+    assert result.receipt["output_mode"] == "native_strict"
+    assert result.receipt["openrouter_provider"] == "parasail/bf16"


### PR DESCRIPTION
Consolidation can receive a JSON string where its schema requires a nested procedure object, even after validation feedback. Add an opt-in native strict JSON output mode so an experiment can request schema-constrained text without going through tool-argument decoding. Ordinary extraction keeps its current output mode.

## 🛠️ Output and routing policy

The existing extractor wraps its output model with PydanticAI `NativeOutput(strict=True)` and sends an optional explicit OpenRouter endpoint preference. Endpoint routing requires supported parameters and disables substitution outside the selected endpoint. A mismatched API origin fails before dispatch.

Consolidation threads the configured mode and endpoint through admitted-source extraction. Both values and the transformed schema enter the extractor revision; build receipts retain the mode, endpoint and wire-schema hash. Input preflight and shared budget estimates include the transformed schema. The output cap, validation retries and SDK transport retries retain their existing behavior, including unknown usage for ambiguous attempts.

Set `SIBYL_CONSOLIDATION_OUTPUT_MODE=native_strict` and `SIBYL_CONSOLIDATION_OPENROUTER_PROVIDER=parasail/bf16` for the reviewed experiment. Both settings are opt-in. Nullable procedure and abstention fields remain valid, while native strict output requires their explicit presence. Returned JSON strings are rejected without repair.

## 🧪 Validation

Native SDK MockTransport tests exercise nested procedure success, abstention, malformed output rejection, validation feedback and exhaustion. Independent controls additionally exercise all nine possible transport sends, endpoint rejection before dispatch and agent-cache separation. Receipt and revision tests verify that policy changes cannot reuse the previous extraction identity.

The earlier tool-output pilot returned three identical encoded objects despite feedback. Upstream vLLM converter tests reproduce that behavior for this schema, but the deployed serving engine was not identified. Native output acceptance by the live provider remains a separate runtime gate; these offline checks do not establish it.

The integrated branch passed 191 scoped core tests, 25 API admission tests, and core/API lint and typecheck. An independent reviewer passed four additional adversarial controls; a second review reran those controls and two receipt/policy cases. The eight reviewed files remain byte-identical after integrating main.
