### PR TITLE
fix(web): allow numeric loopback origins during development

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -42,16 +42,19 @@ function getVersion(): string {
 
 const SIBYL_VERSION = getVersion();
 const buildCpus = Number.parseInt(process.env.SIBYL_NEXT_BUILD_CPUS ?? '', 10);
-const allowedDevOrigins = (process.env.SIBYL_ALLOWED_DEV_ORIGINS ?? '')
-  .split(',')
-  .map(origin => origin.trim())
-  .filter(origin => origin.length > 0);
+const allowedDevOrigins = [
+  '127.0.0.1',
+  ...(process.env.SIBYL_ALLOWED_DEV_ORIGINS ?? '')
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(origin => origin.length > 0),
+];
 
 const nextConfig: NextConfig = {
   // Enable React Compiler for automatic memoization
   reactCompiler: true,
 
-  ...(allowedDevOrigins.length > 0 ? { allowedDevOrigins } : {}),
+  allowedDevOrigins,
 
   // Standalone output for Docker deployment
   output: 'standalone',


### PR DESCRIPTION
Opening the development UI at `http://127.0.0.1:3337` loaded the document, but Next.js rejected its client chunks and HMR requests with HTTP 403. The page stayed on its loading state.

Add the numeric loopback host to the development origin list. Additional hosts still come from `SIBYL_ALLOWED_DEV_ORIGINS`; unrelated origins remain blocked. Next.js applies this guard only during development.

## 🧪 Validation

- Web lint passed (325 files, no fixes).
- Six local controls exercised the installed Next.js 16.3.3 guard against the actual config: loopback changes from denied to allowed for chunks and HMR, configured hosts remain additive, and unrelated hosts, suffix lookalikes, foreign IPs, and opaque origins stay denied.
- Independent review passed. The combined Moon run passed all six controls and the eleven existing capture-showcase tests. Root repeated the two independent controls.

The running local instance was preserved. The config takes effect when the updated development server starts.
