### PR TITLE
feat(evals): retain durable reader and judge accounting

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -32,6 +32,7 @@ on:
       - "tools/tests/test_compare_eval_reports.py"
       - "tools/tests/test_context_pack_eval_script.py"
       - "tools/tests/test_longmemeval_live.py"
+      - "tools/tests/test_longmemeval_qa_accounting.py"
       - "uv.lock"
   workflow_dispatch:
     inputs:

--- a/benchmarks/longmemeval_live.py
+++ b/benchmarks/longmemeval_live.py
@@ -1028,6 +1028,10 @@ def _qa_config(
     timeout_seconds: float,
     context_arm: str = DEFAULT_QA_CONTEXT_ARM,
     max_context_tokens: int = DEFAULT_QA_CONTEXT_TOKENS,
+    reader_max_output_tokens: int | None = None,
+    judge_max_output_tokens: int | None = None,
+    output_retries: int = 1,
+    transport_max_retries: int = 2,
 ) -> LongMemEvalQAConfig:
     if mode not in LONGMEMEVAL_QA_MODES:
         msg = f"Unsupported LongMemEval QA mode: {mode}"
@@ -1062,6 +1066,10 @@ def _qa_config(
         max_context_sessions=max_context_sessions,
         max_session_chars=max_session_chars,
         timeout_seconds=timeout_seconds,
+        reader_max_output_tokens=reader_max_output_tokens,
+        judge_max_output_tokens=judge_max_output_tokens,
+        output_retries=output_retries,
+        transport_max_retries=transport_max_retries,
     )
 
 
@@ -1083,6 +1091,7 @@ async def _run_case(
     qa_config: LongMemEvalQAConfig,
     transport: httpx.AsyncBaseTransport | None = None,
     active_case: dict[str, Any] | None = None,
+    on_qa_stage: Callable[[int, dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     started = time.perf_counter()
     timings_ms: dict[str, float] = {}
@@ -1187,6 +1196,7 @@ async def _run_case(
         corpus_text_policy=corpus_text_policy,
         config=qa_config,
         native_markdown=native_pack["markdown"] if native_pack is not None else None,
+        on_stage=(lambda stage: on_qa_stage(case_index, stage)) if on_qa_stage else None,
     )
     if native_pack is not None:
         qa_result["native_context"] = native_pack
@@ -1258,6 +1268,7 @@ async def _run_cases(
     memory_extraction_timeout_seconds: float,
     qa_config: LongMemEvalQAConfig,
     on_progress: Callable[[list[dict[str, Any]]], Awaitable[None]] | None = None,
+    on_qa_stage: Callable[[int, dict[str, Any]], None] | None = None,
 ) -> list[dict[str, Any]]:
     worker_count = max(1, concurrency)
     queue: asyncio.Queue[tuple[int, dict[str, Any]]] = asyncio.Queue()
@@ -1303,6 +1314,7 @@ async def _run_cases(
                     qa_config=qa_config,
                     transport=transport,
                     active_case=active_cases[case_index],
+                    on_qa_stage=on_qa_stage,
                 )
             finally:
                 async with lock:
@@ -1522,6 +1534,30 @@ def _aggregate(results: list[dict[str, Any]], k_values: list[int]) -> tuple[dict
     overall["embedding_estimated_input_tokens"] = sum(
         float(result.get("embedding_estimated_input_tokens", 0.0)) for result in results
     )
+    qa_all = [result["qa"] for result in results if isinstance(result.get("qa"), dict)]
+    overall["qa_attempted_count"] = float(
+        sum(row.get("evaluated") is True or row.get("status") == "failed" for row in qa_all)
+    )
+    overall["qa_failed_count"] = float(sum(row.get("status") == "failed" for row in qa_all))
+    for role in ("reader", "judge"):
+        stages = [
+            stage
+            for row in qa_all
+            for stage in row.get("execution_stages", [])
+            if stage["stage"] == role
+        ]
+        overall[f"{role}_reported_input_tokens"] = sum(
+            stage.get("reported_input_tokens") or 0 for stage in stages
+        )
+        overall[f"{role}_reported_output_tokens"] = sum(
+            stage.get("reported_output_tokens") or 0 for stage in stages
+        )
+        overall[f"{role}_usage_unknown_stage_count"] = float(
+            sum(not stage.get("usage_complete", False) for stage in stages)
+        )
+        overall[f"{role}_physical_attempt_count"] = float(
+            sum(len(stage.get("transport_attempts", [])) for stage in stages)
+        )
     qa_results: list[dict[str, Any]] = [
         qa_result
         for result in results
@@ -1575,8 +1611,20 @@ def _aggregate(results: list[dict[str, Any]], k_values: list[int]) -> tuple[dict
 def _write_report(path: Path, report: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_name(f"{path.name}.tmp")
-    tmp_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
-    tmp_path.replace(path)
+    try:
+        with tmp_path.open("w", encoding="utf-8") as output:
+            os.chmod(tmp_path, 0o600)
+            json.dump(report, output, indent=2)
+            output.flush()
+            os.fsync(output.fileno())
+        tmp_path.replace(path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def _build_live_accounting(
@@ -1631,12 +1679,20 @@ def _build_live_accounting(
             "cost_basis": embedding_cost_basis,
         },
         "reader": {
+            "reported_input_tokens": overall.get("reader_reported_input_tokens", 0.0),
+            "reported_output_tokens": overall.get("reader_reported_output_tokens", 0.0),
+            "usage_unknown_stage_count": overall.get("reader_usage_unknown_stage_count", 0.0),
+            "physical_attempt_count": overall.get("reader_physical_attempt_count", 0.0),
             "estimated_input_tokens": overall.get("reader_estimated_input_tokens", 0.0),
             "estimated_output_tokens": overall.get("reader_estimated_output_tokens", 0.0),
             "estimated_cost_usd": reader_cost,
             "cost_basis": qa_cost_basis,
         },
         "judge": {
+            "reported_input_tokens": overall.get("judge_reported_input_tokens", 0.0),
+            "reported_output_tokens": overall.get("judge_reported_output_tokens", 0.0),
+            "usage_unknown_stage_count": overall.get("judge_usage_unknown_stage_count", 0.0),
+            "physical_attempt_count": overall.get("judge_physical_attempt_count", 0.0),
             "estimated_input_tokens": overall.get("judge_estimated_input_tokens", 0.0),
             "estimated_output_tokens": overall.get("judge_estimated_output_tokens", 0.0),
             "estimated_cost_usd": judge_cost,
@@ -1831,6 +1887,10 @@ async def run_benchmark(
     qa_max_context_sessions: int = DEFAULT_QA_MAX_CONTEXT_SESSIONS,
     qa_max_session_chars: int = DEFAULT_QA_MAX_SESSION_CHARS,
     qa_timeout_seconds: float = DEFAULT_QA_TIMEOUT_SECONDS,
+    qa_reader_max_output_tokens: int | None = None,
+    qa_judge_max_output_tokens: int | None = None,
+    qa_output_retries: int = 1,
+    qa_transport_max_retries: int = 2,
     qa_context_arm: str = DEFAULT_QA_CONTEXT_ARM,
     qa_max_context_tokens: int = DEFAULT_QA_CONTEXT_TOKENS,
     verify_sha256: bool = True,
@@ -1869,6 +1929,10 @@ async def run_benchmark(
         max_context_sessions=qa_max_context_sessions,
         max_session_chars=qa_max_session_chars,
         timeout_seconds=qa_timeout_seconds,
+        reader_max_output_tokens=qa_reader_max_output_tokens,
+        judge_max_output_tokens=qa_judge_max_output_tokens,
+        output_retries=qa_output_retries,
+        transport_max_retries=qa_transport_max_retries,
         context_arm=qa_context_arm,
         max_context_tokens=qa_max_context_tokens,
     )
@@ -1921,7 +1985,53 @@ async def run_benchmark(
     )
     print("============================================================\n", flush=True)
 
+    qa_receipts: dict[int, dict[str, Any]] = {}
+    receipt_directory = output_path.with_name(output_path.name + ".qa") if output_path else None
+
+    def retain_qa_stage(case_index: int, stage: dict[str, Any]) -> None:
+        receipt = qa_receipts.setdefault(
+            case_index,
+            {
+                "case_index": case_index,
+                "run_id": run_id,
+                "question_id": entries_by_case_index[case_index]["question_id"],
+                "dataset_sha256": dataset_sha,
+                "policy": qa_report_metadata(qa_config),
+                "stages": {},
+            },
+        )
+        receipt["stages"][stage["stage"]] = stage
+        if receipt_directory is not None:
+            _write_report(receipt_directory / f"{case_index}.json", receipt)
+
+    def receipt_references() -> dict[str, Any]:
+        return {
+            str(index): {
+                "path": str(receipt_directory / f"{index}.json") if receipt_directory else None,
+                "stages": {role: stage["status"] for role, stage in receipt["stages"].items()},
+            }
+            for index, _entry in selected_cases
+            for receipt in [qa_receipts.get(index, {"stages": {}})]
+        }
+
+    def receipt_summary() -> dict[str, int]:
+        return {
+            "attempted_cases": len(qa_receipts),
+            "failed_cases": sum(
+                any(stage["status"] == "failed" for stage in receipt["stages"].values())
+                for receipt in qa_receipts.values()
+            ),
+            "cancelled_cases": sum(
+                any(stage["status"] == "cancelled" for stage in receipt["stages"].values())
+                for receipt in qa_receipts.values()
+            ),
+        }
+
+    completed_results: list[dict[str, Any]] = []
+
     async def checkpoint(partial_results: list[dict[str, Any]]) -> None:
+        nonlocal completed_results
+        completed_results = partial_results
         if output_path is None:
             return
         report = _build_live_report(
@@ -1948,30 +2058,37 @@ async def run_benchmark(
             completion_status="partial",
             qa_config=qa_config,
         )
+        report["qa_stage_receipts"] = receipt_references()
+        report["qa_execution_summary"] = receipt_summary()
         _write_report(output_path, report)
 
     await checkpoint([])
 
-    case_results = await _run_cases(
-        selected_cases,
-        api_url=api_url,
-        run_id=run_id,
-        concurrency=concurrency,
-        k_values=k_values,
-        readiness_timeout_seconds=readiness_timeout_seconds,
-        timeout_seconds=timeout_seconds,
-        corpus_text_policy=corpus_text_policy,
-        transport=transport,
-        heartbeat_interval_seconds=heartbeat_interval_seconds,
-        stall_timeout_seconds=stall_timeout_seconds,
-        diagnostic_search_limit=diagnostic_search_limit,
-        wait_for_memory_projection=wait_for_memory_projection,
-        wait_for_memory_extraction=wait_for_memory_extraction,
-        memory_projection_timeout_seconds=memory_projection_timeout_seconds,
-        memory_extraction_timeout_seconds=memory_extraction_timeout_seconds,
-        qa_config=qa_config,
-        on_progress=checkpoint,
-    )
+    try:
+        case_results = await _run_cases(
+            selected_cases,
+            api_url=api_url,
+            run_id=run_id,
+            concurrency=concurrency,
+            k_values=k_values,
+            readiness_timeout_seconds=readiness_timeout_seconds,
+            timeout_seconds=timeout_seconds,
+            corpus_text_policy=corpus_text_policy,
+            transport=transport,
+            heartbeat_interval_seconds=heartbeat_interval_seconds,
+            stall_timeout_seconds=stall_timeout_seconds,
+            diagnostic_search_limit=diagnostic_search_limit,
+            wait_for_memory_projection=wait_for_memory_projection,
+            wait_for_memory_extraction=wait_for_memory_extraction,
+            memory_projection_timeout_seconds=memory_projection_timeout_seconds,
+            memory_extraction_timeout_seconds=memory_extraction_timeout_seconds,
+            qa_config=qa_config,
+            on_progress=checkpoint,
+            on_qa_stage=retain_qa_stage,
+        )
+    except (Exception, asyncio.CancelledError):
+        await checkpoint(completed_results)
+        raise
     elapsed = time.perf_counter() - started
     report = _build_live_report(
         dataset_path=dataset_path,
@@ -1997,6 +2114,8 @@ async def run_benchmark(
         completion_status="complete",
         qa_config=qa_config,
     )
+    report["qa_stage_receipts"] = receipt_references()
+    report["qa_execution_summary"] = receipt_summary()
     if output_path is not None:
         _write_report(output_path, report)
     overall = report["overall"]
@@ -2108,6 +2227,10 @@ def main() -> None:
     )
     parser.add_argument("--qa-max-session-chars", type=int, default=DEFAULT_QA_MAX_SESSION_CHARS)
     parser.add_argument("--qa-timeout", type=float, default=DEFAULT_QA_TIMEOUT_SECONDS)
+    parser.add_argument("--qa-reader-max-output-tokens", type=int, default=None)
+    parser.add_argument("--qa-judge-max-output-tokens", type=int, default=None)
+    parser.add_argument("--qa-output-retries", type=int, default=1)
+    parser.add_argument("--qa-transport-max-retries", type=int, default=2)
     parser.add_argument("--skip-sha256-check", action="store_true")
     args = parser.parse_args()
 
@@ -2151,6 +2274,10 @@ def main() -> None:
                 qa_max_context_sessions=args.qa_max_context_sessions,
                 qa_max_session_chars=args.qa_max_session_chars,
                 qa_timeout_seconds=args.qa_timeout,
+                qa_reader_max_output_tokens=args.qa_reader_max_output_tokens,
+                qa_judge_max_output_tokens=args.qa_judge_max_output_tokens,
+                qa_output_retries=args.qa_output_retries,
+                qa_transport_max_retries=args.qa_transport_max_retries,
                 verify_sha256=not args.skip_sha256_check,
                 output_path=out_path,
             )

--- a/benchmarks/longmemeval_qa.py
+++ b/benchmarks/longmemeval_qa.py
@@ -2,20 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import json
 import os
 import re
 import time
-from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from decimal import Decimal
+from http import HTTPStatus
 from typing import Any, Literal
 
 import tiktoken
 from pydantic import BaseModel, Field, SecretStr
-from pydantic_ai import Agent
+from pydantic_ai import Agent, AgentRunResult, capture_run_messages
+from pydantic_ai.messages import ModelResponse
+from pydantic_ai.models import Model
 
 from sibyl_core.ai.llm.config import LLMConfig, LLMProviderName
 from sibyl_core.ai.providers import build_model, resolve_provider_model_id
+from sibyl_core.ai.transport import collect_transport_attempts, transport_policy
 from sibyl_core.config import settings
 from sibyl_core.evals.longmemeval import LongMemEvalCorpusDocument, build_longmemeval_corpus
 
@@ -92,8 +99,29 @@ class LongMemEvalQAConfig:
     timeout_seconds: float = DEFAULT_QA_TIMEOUT_SECONDS
     context_arm: LongMemEvalContextArm = DEFAULT_QA_CONTEXT_ARM
     max_context_tokens: int = DEFAULT_QA_CONTEXT_TOKENS
+    reader_max_output_tokens: int | None = None
+    judge_max_output_tokens: int | None = None
+    output_retries: int = 1
+    transport_max_retries: int = 2
+    resolved_reader_model: str = field(init=False)
+    resolved_judge_model: str = field(init=False)
 
     def __post_init__(self) -> None:
+        for role in ("reader", "judge"):
+            model = resolve_provider_model_id(
+                LLMConfig(
+                    provider=getattr(self, f"{role}_provider"), model=getattr(self, f"{role}_model")
+                )
+            )
+            object.__setattr__(self, f"resolved_{role}_model", model)
+        for maximum in (self.reader_max_output_tokens, self.judge_max_output_tokens):
+            if maximum is not None and (type(maximum) is not int or maximum <= 0):
+                raise ValueError("QA output limits must be positive integers or None")
+        if any(
+            type(count) is not int or count < 0
+            for count in (self.output_retries, self.transport_max_retries)
+        ):
+            raise ValueError("QA retry counts must be nonnegative")
         if self.mode == "fixture" and self.context_arm == "native-context-v1":
             raise ValueError("Native QA requires model mode; fixture scoring uses dataset sessions")
         if self.context_arm not in LONGMEMEVAL_CONTEXT_ARMS:
@@ -108,10 +136,14 @@ def qa_report_metadata(config: LongMemEvalQAConfig) -> dict[str, Any]:
         "mode": config.mode,
         "enabled": config.mode != "disabled",
         "reader_provider": config.reader_provider,
-        "reader_model": config.reader_model if config.mode != "disabled" else "not-applicable",
+        "reader_model": config.resolved_reader_model
+        if config.mode != "disabled"
+        else "not-applicable",
         "reader_prompt_id": QA_READER_PROMPT_ID if config.mode != "disabled" else "not-applicable",
         "judge_provider": config.judge_provider,
-        "judge_model": config.judge_model if config.mode != "disabled" else "not-applicable",
+        "judge_model": config.resolved_judge_model
+        if config.mode != "disabled"
+        else "not-applicable",
         "judge_prompt_id": QA_JUDGE_PROMPT_ID if config.mode != "disabled" else "not-applicable",
         "rubric_id": QA_RUBRIC_ID if config.mode != "disabled" else "not-applicable",
         "context_arm": config.context_arm,
@@ -123,7 +155,28 @@ def qa_report_metadata(config: LongMemEvalQAConfig) -> dict[str, Any]:
         "max_session_chars": config.max_session_chars,
         "timeout_seconds": config.timeout_seconds,
         "claim_boundary": _claim_boundary(config),
+        "execution_policy": {
+            "reader_model": config.resolved_reader_model,
+            "judge_model": config.resolved_judge_model,
+            "reader_max_output_tokens": config.reader_max_output_tokens,
+            "judge_max_output_tokens": config.judge_max_output_tokens,
+            "unspecified_output_limit": "provider_default",
+            "output_retries": config.output_retries,
+            "transport_max_retries": config.transport_max_retries,
+            "temperature": 0.0,
+            "reader_system_prompt_sha256": hashlib.sha256(
+                READER_SYSTEM_PROMPT.encode()
+            ).hexdigest(),
+            "judge_system_prompt_sha256": hashlib.sha256(JUDGE_SYSTEM_PROMPT.encode()).hexdigest(),
+            "judge_schema_sha256": hashlib.sha256(
+                json.dumps(LongMemEvalQAJudgment.model_json_schema(), sort_keys=True).encode()
+            ).hexdigest(),
+        },
     }
+
+
+class QAReceiptError(RuntimeError):
+    """Stop execution when a stage cannot be durably retained."""
 
 
 async def evaluate_longmemeval_case_qa(
@@ -133,6 +186,7 @@ async def evaluate_longmemeval_case_qa(
     corpus_text_policy: str,
     config: LongMemEvalQAConfig,
     native_markdown: str | None = None,
+    on_stage: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     if config.mode == "disabled":
         return _disabled_result(config)
@@ -187,14 +241,37 @@ async def evaluate_longmemeval_case_qa(
             reader_prompt=reader_prompt,
         )
     else:
-        result = await _model_result(
-            entry,
-            config=config,
-            context_sessions=context_sessions,
-            reference_answer=reference_answer,
-            answer_session_ids=answer_session_ids,
-            reader_prompt=reader_prompt,
-        )
+        stages: dict[str, dict[str, Any]] = {}
+
+        def retain_stage(receipt: dict[str, Any]) -> None:
+            stages[receipt["stage"]] = receipt
+            if on_stage is not None:
+                try:
+                    on_stage(receipt)
+                except Exception as error:
+                    raise QAReceiptError("QA stage receipt could not be persisted") from error
+
+        try:
+            result = await _model_result(
+                entry,
+                config=config,
+                context_sessions=context_sessions,
+                reference_answer=reference_answer,
+                answer_session_ids=answer_session_ids,
+                reader_prompt=reader_prompt,
+                on_stage=retain_stage,
+            )
+        except QAReceiptError:
+            raise
+        except Exception as error:
+            result = {
+                **qa_report_metadata(config),
+                "evaluated": False,
+                "status": "failed",
+                "exception_type": type(error).__name__,
+                "execution_stages": list(stages.values()),
+                "generated_answer": stages.get("reader", {}).get("output"),
+            }
 
     result["context_receipt"] = {
         "arm": config.context_arm,
@@ -280,18 +357,30 @@ async def _model_result(
     reference_answer: str,
     answer_session_ids: list[str],
     reader_prompt: str,
+    on_stage: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     reader_config = _llm_config(
         provider=config.reader_provider,
-        model=config.reader_model,
+        model=config.resolved_reader_model,
         config=config,
     )
     reader_agent = Agent(
         build_model(reader_config),
         output_type=str,
         instructions=READER_SYSTEM_PROMPT,
+        retries={"output": config.output_retries},
     )
-    reader_response = await reader_agent.run(reader_prompt)
+    stages = []
+    reader_response = await _run_qa_stage(
+        "reader",
+        reader_agent,
+        reader_prompt,
+        reader_config,
+        config.reader_max_output_tokens,
+        config.output_retries,
+        stages,
+        on_stage,
+    )
     generated_answer = str(reader_response.output).strip()
 
     judge_prompt = _judge_prompt(
@@ -302,21 +391,30 @@ async def _model_result(
     )
     judge_config = _llm_config(
         provider=config.judge_provider,
-        model=config.judge_model,
+        model=config.resolved_judge_model,
         config=config,
     )
     judge_agent = Agent(
         build_model(judge_config),
         output_type=LongMemEvalQAJudgment,
         instructions=JUDGE_SYSTEM_PROMPT,
+        retries={"output": config.output_retries},
     )
-    judge_response = await judge_agent.run(judge_prompt)
+    judge_response = await _run_qa_stage(
+        "judge",
+        judge_agent,
+        judge_prompt,
+        judge_config,
+        config.judge_max_output_tokens,
+        config.output_retries,
+        stages,
+        on_stage,
+    )
     judgment = judge_response.output
-    reader_model = resolve_provider_model_id(reader_config)
-    judge_model = resolve_provider_model_id(judge_config)
 
     return {
-        **qa_report_metadata(replace(config, reader_model=reader_model, judge_model=judge_model)),
+        **qa_report_metadata(config),
+        "execution_stages": stages,
         "evaluated": True,
         "correct": judgment.correct,
         "score": float(judgment.score),
@@ -330,6 +428,109 @@ async def _model_result(
         "judge_estimated_input_tokens": _estimate_tokens(judge_prompt),
         "judge_estimated_output_tokens": _estimate_tokens(judgment.model_dump_json()),
     }
+
+
+async def _run_qa_stage[OutputT](
+    role: Literal["reader", "judge"],
+    agent: Agent[None, OutputT],
+    prompt: str,
+    config: LLMConfig,
+    max_tokens: int | None,
+    output_retries: int,
+    stages: list[dict[str, Any]],
+    on_stage: Callable[[dict[str, Any]], None] | None,
+) -> AgentRunResult[OutputT]:
+    if not isinstance(agent.model, Model) or agent.model.model_name != config.model:
+        raise RuntimeError("QA model resolution changed after policy freeze")
+    receipt: dict[str, Any] = {
+        "stage": role,
+        "status": "started",
+        "model": config.model,
+        "prompt_sha256": hashlib.sha256(prompt.encode()).hexdigest(),
+        "max_output_tokens": max_tokens,
+        "output_retries": output_retries,
+        "transport_policy": transport_policy(config),
+        "system_prompt_sha256": hashlib.sha256(
+            (READER_SYSTEM_PROMPT if role == "reader" else JUDGE_SYSTEM_PROMPT).encode()
+        ).hexdigest(),
+        "output_schema_sha256": hashlib.sha256(
+            json.dumps(
+                {"type": "string"}
+                if role == "reader"
+                else LongMemEvalQAJudgment.model_json_schema(),
+                sort_keys=True,
+            ).encode()
+        ).hexdigest(),
+    }
+
+    stages.append(receipt)
+    if on_stage is not None:
+        on_stage(dict(receipt))
+    with collect_transport_attempts() as attempts, capture_run_messages() as messages:
+        try:
+            result = await agent.run(
+                prompt,
+                model_settings={"max_tokens": max_tokens} if max_tokens is not None else None,
+            )
+        except (Exception, asyncio.CancelledError) as error:
+            receipt.update(
+                status="cancelled" if isinstance(error, asyncio.CancelledError) else "failed",
+                exception_type=type(error).__name__,
+            )
+            raise
+        else:
+            receipt["status"] = "completed"
+            receipt["output"] = (
+                result.output.model_dump(mode="json")
+                if isinstance(result.output, BaseModel)
+                else result.output
+            )
+            return result
+        finally:
+            responses = [message for message in messages if isinstance(message, ModelResponse)]
+            successful = [
+                index
+                for index, attempt in enumerate(attempts)
+                if attempt.status_code is not None
+                and HTTPStatus.OK <= attempt.status_code < HTTPStatus.MULTIPLE_CHOICES
+            ]
+            if len(successful) == len(responses) and all(
+                response.usage.has_values() for response in responses
+            ):
+                for index in successful:
+                    attempts[index] = attempts[index].model_copy(update={"usage_known": True})
+            complete = (
+                bool(responses)
+                and bool(attempts)
+                and all(attempt.usage_known for attempt in attempts)
+            )
+            known_responses = [response for response in responses if response.usage.has_values()]
+            costs = [
+                response.usage.cost for response in responses if response.usage.cost is not None
+            ]
+            known_cost = sum(costs, Decimal(0)) if costs else None
+            receipt.update(
+                transport_attempts=[attempt.model_dump(mode="json") for attempt in attempts],
+                reported_input_tokens=sum(
+                    response.usage.input_tokens for response in known_responses
+                )
+                if known_responses
+                else None,
+                reported_output_tokens=sum(
+                    response.usage.output_tokens for response in known_responses
+                )
+                if known_responses
+                else None,
+                known_reported_cost_usd=str(known_cost) if known_cost is not None else None,
+                reported_cost_usd=str(known_cost)
+                if complete and len(costs) == len(responses)
+                else None,
+                usage_complete=complete,
+                response_count=len(responses),
+                response_models=[response.model_name for response in responses],
+            )
+            if on_stage is not None:
+                on_stage(dict(receipt))
 
 
 def _llm_config(
@@ -347,6 +548,7 @@ def _llm_config(
         model=model,
         temperature=0.0,
         timeout_seconds=config.timeout_seconds,
+        transport_max_retries=config.transport_max_retries,
         api_key=SecretStr(api_key),
     )
 

--- a/moon.yml
+++ b/moon.yml
@@ -1096,6 +1096,7 @@ tasks:
       tools/tests/test_compare_eval_reports.py tools/tests/test_context_pack_eval_script.py
       tools/tests/test_longmemeval_agentic_traversal.py
       tools/tests/test_longmemeval_bench.py tools/tests/test_longmemeval_live.py
+      tools/tests/test_longmemeval_qa_accounting.py
       tools/tests/test_longmemeval_replay.py
       tools/tests/test_longmemeval_v2_probe.py tools/tests/test_longmemeval_v2_official.py
       tools/tests/test_longmemeval_v2_official_source.py

--- a/tools/tests/test_longmemeval_qa_accounting.py
+++ b/tools/tests/test_longmemeval_qa_accounting.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx2
+import pytest
+from openai import AsyncOpenAI
+from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.providers.openai import OpenAIProvider
+from tools.tests.test_longmemeval_live import _load_live_module
+
+from sibyl_core.ai.transport import RecordingOpenAIClient
+
+READER_LIMIT = 128
+JUDGE_LIMIT = 64
+REPORTED_INPUT = 10
+FIRST_JUDGE_CALL = 2
+
+
+@pytest.mark.parametrize(
+    "outcome", ["success", "judge_failure", "cancelled", "retry", "validation_retry"]
+)
+async def test_native_qa_stage_receipts_survive_terminal_outcome(  # noqa: PLR0915
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, outcome: str
+) -> None:
+    live = _load_live_module()
+    qa = importlib.import_module("longmemeval_qa")
+    monkeypatch.setenv("OPENAI_API_KEY", "offline-fixture")
+    requests: list[dict[str, Any]] = []
+    receipts: dict[str, Any] = {}
+    path = tmp_path / "case.json"
+
+    def retain(stage: dict[str, Any]) -> None:
+        receipts[stage["stage"]] = stage
+        live._write_report(path, receipts)
+
+    def respond(request: httpx2.Request) -> httpx2.Response:
+        wire = json.loads(request.content)
+        requests.append(wire)
+        judge = bool(wire.get("tools"))
+        if judge:
+            prior = json.loads(path.read_text())
+            assert prior["reader"]["status"] == "completed"
+            assert prior["reader"]["output"] == "Blue"
+            if outcome == "cancelled":
+                raise asyncio.CancelledError
+            if outcome == "judge_failure" or (
+                outcome == "retry" and len(requests) == FIRST_JUDGE_CALL
+            ):
+                return httpx2.Response(
+                    500, json={"error": {"message": "controlled"}}, headers={"retry-after-ms": "1"}
+                )
+            output = [
+                {
+                    "type": "function_call",
+                    "id": "fc_fixture",
+                    "call_id": "call_fixture",
+                    "name": wire["tools"][0]["name"],
+                    "arguments": json.dumps(
+                        {
+                            "correct": True,
+                            "score": "invalid"
+                            if outcome == "validation_retry" and len(requests) == FIRST_JUDGE_CALL
+                            else 1,
+                            "rationale": "Supported",
+                        }
+                    ),
+                }
+            ]
+        else:
+            output = [
+                {
+                    "type": "message",
+                    "id": "msg_fixture",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "Blue", "annotations": []}],
+                }
+            ]
+        return httpx2.Response(
+            200,
+            json={
+                "id": f"resp_{len(requests)}",
+                "object": "response",
+                "created_at": 0,
+                "model": wire["model"],
+                "status": "completed",
+                "output": output,
+                "usage": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+            },
+        )
+
+    async with RecordingOpenAIClient(transport=httpx2.MockTransport(respond)) as http:
+        client = AsyncOpenAI(api_key="offline-fixture", http_client=http, max_retries=1)
+        monkeypatch.setattr(
+            qa,
+            "build_model",
+            lambda config: OpenAIResponsesModel(
+                config.model, provider=OpenAIProvider(openai_client=client)
+            ),
+        )
+        config = qa.LongMemEvalQAConfig(
+            mode="model",
+            reader_max_output_tokens=128,
+            judge_max_output_tokens=64,
+            transport_max_retries=1,
+        )
+        entry = {
+            "question": "Color?",
+            "answer": "Blue",
+            "answer_session_ids": ["s1"],
+            "haystack_session_ids": ["s1"],
+            "haystack_dates": ["2025/01/01"],
+            "haystack_sessions": [[{"role": "user", "content": "Blue"}]],
+        }
+        call = qa.evaluate_longmemeval_case_qa(
+            entry,
+            ranked_session_ids=["s1"],
+            corpus_text_policy="user-and-assistant-turns-v1",
+            config=config,
+            on_stage=retain,
+        )
+        if outcome == "cancelled":
+            with pytest.raises(asyncio.CancelledError):
+                await call
+        else:
+            result = await call
+            assert result["evaluated"] is (outcome != "judge_failure")
+            if outcome == "judge_failure":
+                assert result["generated_answer"] == "Blue"
+                aggregate, _ = live._aggregate(
+                    [
+                        {
+                            "question_type": "single-session-user",
+                            "qa": result,
+                            "cross_question_result_count": 0,
+                            "created_entity_count": 0,
+                            "chunked_session_count": 0,
+                            **{
+                                f"{name}@5": 0
+                                for name in ("hit", "legacy_recall", "recall", "ndcg")
+                            },
+                        }
+                    ],
+                    [5],
+                )
+                assert aggregate["qa_evaluated_count"] == 0
+                assert aggregate["qa_attempted_count"] == aggregate["qa_failed_count"] == 1
+        await client.close()
+    if outcome == "validation_retry":
+        assert len(requests) == FIRST_JUDGE_CALL + 1
+        assert "score" in json.dumps(requests[-1]["input"])
+    retained = json.loads(path.read_text())
+    assert retained["reader"]["reported_input_tokens"] == REPORTED_INPUT
+    assert retained["reader"]["usage_complete"] is True
+    assert retained["reader"]["output"] == "Blue"
+    assert requests[0]["max_output_tokens"] == READER_LIMIT
+    assert all(wire["max_output_tokens"] == JUDGE_LIMIT for wire in requests[1:])
+    assert retained["judge"]["status"] == {"cancelled": "cancelled", "judge_failure": "failed"}.get(
+        outcome, "completed"
+    )
+    if outcome in {"cancelled", "judge_failure", "retry"}:
+        assert retained["judge"]["usage_complete"] is False
+        assert retained["judge"]["reported_cost_usd"] is None
+    assert retained["judge"]["prompt_sha256"] != retained["reader"]["prompt_sha256"]
+    assert retained["reader"]["system_prompt_sha256"]
+    assert retained["judge"]["output_schema_sha256"]
+
+
+def test_atomic_report_preserves_prior_receipt_on_serialization_error(tmp_path: Path) -> None:
+    live = _load_live_module()
+    path = tmp_path / "case.json"
+    live._write_report(path, {"reader": "completed"})
+    with pytest.raises(TypeError):
+        live._write_report(path, {"reader": object()})
+    assert json.loads(path.read_text()) == {"reader": "completed"}
+    assert not path.with_name("case.json.tmp").exists()
+
+
+@pytest.mark.parametrize("maximum", [0, -1, True])
+def test_output_policy_rejects_invalid_limits(maximum: int) -> None:
+    _load_live_module()
+    qa = importlib.import_module("longmemeval_qa")
+    with pytest.raises(ValueError, match="output limits"):
+        qa.LongMemEvalQAConfig(reader_max_output_tokens=maximum)
+
+
+async def test_live_cancel_checkpoint_references_completed_reader(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    live = _load_live_module()
+    data = tmp_path / "input.json"
+    report = tmp_path / "report.json"
+    data.write_text(
+        json.dumps([{"question_id": "fixture", "question_type": "single-session-user"}])
+    )
+
+    async def cancel_case(entry: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        callback = kwargs["on_qa_stage"]
+        callback(
+            kwargs["case_index"], {"stage": "reader", "status": "completed", "output": "retained"}
+        )
+        callback(kwargs["case_index"], {"stage": "judge", "status": "cancelled"})
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(live, "_run_case", cancel_case)
+    with pytest.raises(asyncio.CancelledError):
+        await live.run_benchmark(
+            data, api_url="http://fixture/api", verify_sha256=False, output_path=report
+        )
+    checkpoint = json.loads(report.read_text())
+    reference = checkpoint["qa_stage_receipts"]["0"]["path"]
+    stored = json.loads(await asyncio.to_thread(Path(reference).read_text))
+    assert stored["stages"]["reader"]["output"] == "retained"
+    assert stored["stages"]["judge"]["status"] == "cancelled"
+    assert checkpoint["completion_status"] == "partial"
+    assert checkpoint["qa_execution_summary"] == {
+        "attempted_cases": 1,
+        "failed_cases": 0,
+        "cancelled_cases": 1,
+    }


### PR DESCRIPTION
LongMemEval previously discarded a successful reader response when the judge failed, and its reports kept text-based token estimates without the provider's actual usage. QA now writes a durable receipt for each reader and judge stage before advancing, so failures and cancellation preserve completed work.

## 🛠️ Accounting and execution policy

Each case records its dataset identity, resolved models, prompt/schema hashes, output limits and retry policy. Reports retain physical OpenAI SDK attempts and reported usage separately from character estimates. Failed or ambiguous requests keep unknown usage; a successful retry does not turn the entire stage into known cost. Other provider transports remain explicitly uninstrumented.

Stage files use private temporary files, fsync and atomic replacement. A reader receipt must persist before the judge starts. Cancellation updates the partial report and propagates through the worker owner. Failed QA cases remain in attempt/failure accounting but do not enter the accuracy denominator. Concurrency is unchanged.

Reader/judge output caps and retry counts are configurable. Existing defaults remain provider-default output limits, one output-validation retry and two OpenAI SDK transport retries. A paid comparison still needs its own frozen budgets and acceptance criteria.

## 🧪 Validation

The integrated branch passes 66 focused tests, including four independent adversarial controls, plus inventory lint and type checks. Actual SDK MockTransport cases cover serialized output limits, transport and validation retries, missing usage, concurrent case isolation, judge failure, cancellation and receipt-write failure. The new regression file is registered in the benchmark gate and the evaluation workflow path filter.

No paid provider run or benchmark score is claimed by this change.
