### PR TITLE
perf(schema): seed source ledgers without rewriting indexed entities

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_states.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_states.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import time
+
+import structlog
+
 from sibyl_core.backends.surreal.schema_ownership import SchemaOwnership
 from sibyl_core.backends.surreal.schema_version import SurrealExecute
 from sibyl_core.memory_pipeline.observations import SourceKind
+
+log = structlog.get_logger()
 
 SOURCE_STATE_DEFINITIONS = """
 DEFINE TABLE IF NOT EXISTS source_states SCHEMAFULL PERMISSIONS NONE;
@@ -165,14 +171,19 @@ async def migrate_source_states(
 ) -> None:
     """Backfill in restartable pages after the source event has been installed.
 
-    An untracked source gets one bookkeeping revision bump to trigger its
-    event. Repeated pages skip existing generations. Concurrent new writes
-    maintain their own state.
+    Seed the small ledger directly without rewriting indexed source records.
+    Read each source inside the same transaction that creates its ledger. The
+    installed event uses the same record key, so concurrent source mutations
+    contend on that key rather than publishing an obsolete generation.
+    Repeated pages preserve existing generations and retained tombstones.
     """
     mutate = ownership.mutate if ownership is not None else execute_query
     table, organization_field = _SOURCE_TABLES[kind]
+    deleted = "$source.deleted_at != NONE" if kind is SourceKind.RAW_CAPTURE else "false"
     cursor = ""
+    checked = 0
     while True:
+        started = time.monotonic()
         rows = await execute_query(
             f"SELECT id, uuid FROM {table} WHERE uuid > $cursor ORDER BY uuid LIMIT $limit;",
             cursor=cursor,
@@ -185,12 +196,22 @@ async def migrate_source_states(
         await mutate(
             f"""RETURN {{
                 FOR $record IN $rows {{
-                    LET $source = (SELECT * FROM $record)[0];
-                    LET $state = (SELECT * FROM source_states
-                        WHERE organization_id = $source.{organization_field}
-                            AND source_kind = $kind AND source_id = $source.uuid LIMIT 1)[0];
-                    IF $source != NONE AND $state = NONE {{
-                        UPDATE $record SET revision = (revision ?? 0) + 1 RETURN NONE;
+                    LET $source = (SELECT uuid, {organization_field}, revision, deleted_at
+                        FROM $record)[0];
+                    IF $source != NONE {{
+                        IF $source.uuid = NONE OR $source.{organization_field} = NONE {{
+                            THROW 'source identity is required';
+                        }};
+                        LET $org = type::string($source.{organization_field});
+                        LET $uuid = type::string($source.uuid);
+                        LET $key = type::record(string::concat('source_states:',
+                            crypto::sha256(type::string([$org, $kind, $uuid]))));
+                        IF record::exists($key) = false {{
+                            CREATE $key SET organization_id = $org, source_kind = $kind,
+                                source_id = $uuid, generation = 1,
+                                revision = $source.revision ?? 0, deleted = {deleted}
+                                RETURN NONE;
+                        }};
                     }};
                 }};
                 RETURN NONE;
@@ -199,6 +220,14 @@ async def migrate_source_states(
             kind=kind.value,
         )
         cursor = str(rows[-1]["uuid"])
+        checked += len(rows)
+        log.info(
+            "source_state_backfill_page",
+            source_kind=kind.value,
+            rows_checked=checked,
+            page_rows=len(rows),
+            elapsed_ms=round((time.monotonic() - started) * 1000, 2),
+        )
 
 
 async def migrate_graph_source_states(

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_states.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_states.py
@@ -180,12 +180,14 @@ async def migrate_source_states(
     mutate = ownership.mutate if ownership is not None else execute_query
     table, organization_field = _SOURCE_TABLES[kind]
     deleted = "$source.deleted_at != NONE" if kind is SourceKind.RAW_CAPTURE else "false"
-    cursor = ""
+    cursor = None
     checked = 0
     while True:
         started = time.monotonic()
+        # Walk primary records so secondary-index scan boundaries cannot skip sources.
+        after = "WHERE id > $cursor" if cursor is not None else ""
         rows = await execute_query(
-            f"SELECT id, uuid FROM {table} WHERE uuid > $cursor ORDER BY uuid LIMIT $limit;",
+            f"SELECT id, uuid FROM {table} {after} ORDER BY id LIMIT $limit;",
             cursor=cursor,
             limit=512,
         )
@@ -219,7 +221,7 @@ async def migrate_source_states(
             rows=[r["id"] for r in rows],
             kind=kind.value,
         )
-        cursor = str(rows[-1]["uuid"])
+        cursor = rows[-1]["id"]
         checked += len(rows)
         log.info(
             "source_state_backfill_page",

--- a/packages/python/sibyl-core/tests/test_graph.py
+++ b/packages/python/sibyl-core/tests/test_graph.py
@@ -3082,7 +3082,7 @@ async def test_graph_bootstrap_backfills_unversioned_legacy_required_fields() ->
         )
         assert rows == [
             {
-                "revision": 2,
+                "revision": 1,
                 "retrieval_count": 11,
                 "citation_count": 7,
                 "misled_count": 2,

--- a/packages/python/sibyl-core/tests/test_source_state_store.py
+++ b/packages/python/sibyl-core/tests/test_source_state_store.py
@@ -97,12 +97,14 @@ async def test_graph_epoch_backfill_is_restartable_and_preserves_high_water(
     await runtime.client.execute_query(
         "REMOVE EVENT maintain_source_state ON entity; DELETE source_states;"
     )
+    source_rows = await runtime.client.execute_query("SELECT * FROM entity ORDER BY uuid;")
     from sibyl_core.backends.surreal.schema import bootstrap_schema
 
     await runtime.client.execute_query("UPDATE schema_version SET version=23 WHERE name='graph';")
     await bootstrap_schema(runtime.client, force=True)
     first = await runtime.client.execute_query("SELECT * FROM source_states ORDER BY source_id;")
     assert len(first) == 3
+    assert await runtime.client.execute_query("SELECT * FROM entity ORDER BY uuid;") == source_rows
     await migrate_source_states(runtime.client.execute_query, kind=SourceKind.GRAPH_ENTITY)
     assert (
         await runtime.client.execute_query("SELECT * FROM source_states ORDER BY source_id;")
@@ -137,3 +139,41 @@ async def test_graph_epoch_reset_retires_retained_state(runtime: GraphRuntime) -
     )
     assert isinstance(recreated, GraphSourceSnapshot)
     assert recreated.observation.generation > original.observation.generation
+
+
+async def test_raw_epoch_backfill_preserves_source_rows_and_deletion_state() -> None:
+    from sibyl_core.backends.surreal import SurrealContentClient
+    from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+    from sibyl_core.backends.surreal.schema_source_states import (
+        migrate_source_states,
+        source_state_event,
+    )
+
+    client = SurrealContentClient(url="memory://")
+    try:
+        await bootstrap_content_schema(client, reset=True)
+        await client.execute_query("REMOVE EVENT maintain_source_state ON raw_captures;")
+        await client.execute_query(
+            "CREATE raw_captures:live SET uuid='live', organization_id='org-backfill', "
+            "raw_content='Original evidence', revision=7; "
+            "CREATE raw_captures:deleted SET uuid='deleted', organization_id='org-backfill', "
+            "raw_content='Deleted evidence', revision=9, deleted_at=time::now();"
+        )
+        before = await client.execute_query("SELECT * FROM raw_captures ORDER BY uuid;")
+        await client.execute_query(source_state_event(SourceKind.RAW_CAPTURE))
+        await migrate_source_states(client.execute_query, kind=SourceKind.RAW_CAPTURE)
+        assert await client.execute_query("SELECT * FROM raw_captures ORDER BY uuid;") == before
+        states = await client.execute_query("SELECT * FROM source_states ORDER BY source_id;")
+        assert [(row["source_id"], row["revision"], row["deleted"]) for row in states] == [
+            ("deleted", 9, True),
+            ("live", 7, False),
+        ]
+        await migrate_source_states(client.execute_query, kind=SourceKind.RAW_CAPTURE)
+        assert (
+            await client.execute_query("SELECT * FROM source_states ORDER BY source_id;") == states
+        )
+        await client.execute_query("UPDATE raw_captures:live SET raw_content='Changed evidence';")
+        changed = await client.execute_query("SELECT * FROM source_states WHERE source_id='live';")
+        assert changed[0]["generation"] == 2
+    finally:
+        await client.close()

--- a/packages/python/sibyl-core/tests/test_source_state_store.py
+++ b/packages/python/sibyl-core/tests/test_source_state_store.py
@@ -177,3 +177,28 @@ async def test_raw_epoch_backfill_preserves_source_rows_and_deletion_state() -> 
         assert changed[0]["generation"] == 2
     finally:
         await client.close()
+
+
+async def test_graph_backfill_covers_multiple_index_pages(runtime: GraphRuntime) -> None:
+    from sibyl_core.backends.surreal.schema_source_states import (
+        migrate_source_states,
+        source_state_event,
+    )
+
+    client = runtime.client
+    base = (await client.execute_query("SELECT * FROM entity LIMIT 1;"))[0]
+    await client.execute_query(
+        "REMOVE EVENT maintain_source_state ON entity; DELETE source_states;"
+    )
+    rows = [
+        {**{key: value for key, value in base.items() if key != "id"}, "uuid": f"backfill-{i:05}"}
+        for i in range(1025)
+    ]
+    await client.execute_query("INSERT INTO entity $rows RETURN NONE;", rows=rows)
+    await client.execute_query(source_state_event(SourceKind.GRAPH_ENTITY))
+    before = await client.execute_query("SELECT * FROM entity ORDER BY id;")
+    await migrate_source_states(client.execute_query, kind=SourceKind.GRAPH_ENTITY)
+    states = await client.execute_query("SELECT * FROM source_states;")
+    assert len(states) == len(before) == 1027
+    assert {row["source_id"] for row in states} == {row["uuid"] for row in before}
+    assert await client.execute_query("SELECT * FROM entity ORDER BY id;") == before


### PR DESCRIPTION
Graph-backed pages can hang on their first request after an upgrade because source-state migration rewrites every untracked entity. A live migration transaction took 72 seconds; each page can rewrite up to 512 indexed source records. Auth and content readiness still return quickly because organization graph schemas are prepared lazily.

The migration now creates the small source ledger directly. It reads source identity, revision and deletion state inside the existing fenced transaction and uses the same deterministic ledger key as the installed mutation event. Existing ledger rows and tombstones remain intact. Source contents, embeddings and revisions are preserved. Each completed page reports its checked-row count and elapsed time. Primary-record-ID pagination replaces UUID index ranges (the latter omitted a source at an internal 500-row boundary in the reproduction). Batch size remains 512.

## 🧪 Validation

The graph regression failed before the change because migration altered source revisions. The final correction passes 59 source lifecycle and schema-ownership controls, including exact coverage of 1,027 sources across three pages. Raw-source coverage includes soft deletion, preserved revisions, restartability and the next mutation's generation. Core lint and typecheck passed.

An isolated embedded-database comparison with 258 indexed source records and full embedding vectors measured 3.377 seconds before and 0.081 seconds after (41.9x faster). The otherwise identical comparison without vectors measured 0.179 seconds before and 0.047 seconds after. Both comparisons retained every source field after the new backfill. These are synthetic measurements, not live-instance timings.

Independent embedded verification passed six controls covering complete 514-source backfill, concurrent updates, deletion and recreation, event collisions, and concurrent replays. The final pagination version measured 0.116 seconds versus 3.524 seconds for 258 vector-indexed sources, and 0.288 seconds versus 7.091 seconds for 514 sources. The old 514-source run omitted one ledger entry; the corrected run retained all 514. Native-server verification passed on 514 vector-indexed sources, including source preservation, complete coverage, restartability and mutation/deletion controls. Root repeated four independent race controls; fourteen upgrade and source-state controls passed after correcting the legacy upgrade expectation to retain revision one.

The reviewed production file was applied to the local checkout and the API autoreloader restarted its child process. Authenticated browser verification then showed 9,847 entities, populated projects and tasks, and a completed session snapshot. Previously failing graph-backed endpoints returned HTTP 200. The database and configuration were preserved. Hosted CI for the final head remains pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved schema migration and backfill reliability for source-state records.
  - Existing generations, revisions, deletion markers, and source records are now preserved during migration.
  - Repeated migrations no longer create unnecessary changes and remain consistent across large datasets.
  - Legacy records now receive the correct initial revision value.
  - Large graphs are fully processed across multiple migration pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->