### PR TITLE
fix(memory): preserve source identity across ledger loss

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -17,6 +17,10 @@ from sibyl_core.backends.surreal.schema_invariants import (
     SchemaInvariantPlan,
     expected_unique_indexes,
 )
+from sibyl_core.backends.surreal.schema_source_integrity import (
+    migrate_source_integrity,
+    prepare_source_integrity_upgrade,
+)
 from sibyl_core.backends.surreal.schema_source_states import (
     SOURCE_STATE_DEFINITIONS,
     migrate_source_states,
@@ -73,7 +77,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 33
+CONTENT_SCHEMA_CURRENT_VERSION = 34
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -968,6 +972,11 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
                 ).replace("DEFINE EVENT IF NOT EXISTS", "DEFINE EVENT OVERWRITE"),
             ),
         ),
+        SchemaMigration(
+            version=34,
+            name="content_source_integrity",
+            action=partial(migrate_source_integrity, kind=SourceKind.RAW_CAPTURE),
+        ),
     )
 
 
@@ -980,6 +989,7 @@ def content_schema_invariant_plan(*, url: str = "") -> SchemaInvariantPlan:
 
 
 async def bootstrap_content_schema(client: SurrealContentClient, *, reset: bool = False) -> None:
+    await prepare_source_integrity_upgrade(client.execute_query)
     if reset:
         await retire_source_states(client.execute_query, kind=SourceKind.RAW_CAPTURE)
         for table in (*CONTENT_TABLES, SCHEMA_VERSION_TABLE):

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema.py
@@ -22,6 +22,10 @@ from sibyl_core.backends.surreal.schema_ownership import (
     SchemaOwnership,
     try_acquire_schema_ownership,
 )
+from sibyl_core.backends.surreal.schema_source_integrity import (
+    migrate_graph_source_integrity,
+    prepare_source_integrity_upgrade,
+)
 from sibyl_core.backends.surreal.schema_source_states import (
     SOURCE_STATE_DEFINITIONS,
     migrate_graph_source_states,
@@ -850,6 +854,9 @@ GRAPH_SCHEMA_MIGRATIONS = (
             ),
         ),
     ),
+    SchemaMigration(
+        version=26, name="graph_source_integrity", action=migrate_graph_source_integrity
+    ),
 )
 
 
@@ -873,6 +880,8 @@ def _graph_schema_migrations(
                 if migration.action is migrate_lifecycle_repair
                 else partial(migrate_graph_source_states, ownership=ownership)
                 if migration.action is migrate_graph_source_states
+                else partial(migrate_graph_source_integrity, ownership=ownership)
+                if migration.action is migrate_graph_source_integrity
                 else migration.action
             ),
         )
@@ -1278,6 +1287,7 @@ async def _bootstrap_owned_schema(
     reset: bool,
     force: bool,
 ) -> None:
+    await prepare_source_integrity_upgrade(ownership.read, ownership=ownership)
     current_version = 0
     if reset:
         await retire_source_states(ownership.mutate, kind=SourceKind.GRAPH_ENTITY)

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_integrity.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_integrity.py
@@ -1,0 +1,84 @@
+"""Upgrade retained ledgers before any repair can create a new incarnation."""
+
+from functools import partial
+
+from sibyl_core.backends.surreal.schema_invariants import fetch_declared_fields
+from sibyl_core.backends.surreal.schema_ownership import SchemaOwnership
+from sibyl_core.backends.surreal.schema_source_states import (
+    SOURCE_STATE_DEFINITIONS,
+    source_state_event,
+)
+from sibyl_core.backends.surreal.schema_version import SurrealExecute
+from sibyl_core.memory_pipeline.observations import SourceKind
+
+
+async def prepare_source_integrity_upgrade(
+    execute_query: SurrealExecute, *, ownership: SchemaOwnership | None = None
+) -> None:
+    """Fence legacy identity assignment before historical source backfills.
+
+    The field declaration is the durable completion marker. Later bootstraps
+    never assign legacy identities to missing or corrupt incarnation values.
+    """
+    mutate = ownership.mutate if ownership is not None else execute_query
+    await mutate(SOURCE_STATE_DEFINITIONS)
+    fields = await fetch_declared_fields(execute_query, "source_states")
+    if "incarnation" in fields:
+        return
+    body = """
+        DEFINE FIELD incarnation ON source_states TYPE option<string>
+            DEFAULT type::string(rand::uuid());
+        UPDATE source_states SET incarnation = string::concat('legacy-v1:',
+            crypto::sha256(organization_id), ':', source_kind, ':', crypto::sha256(source_id))
+            WHERE incarnation = NONE RETURN NONE;
+    """
+    if ownership is not None:
+        await ownership.mutate(body)
+    else:
+        await execute_query("BEGIN TRANSACTION; " + body + " COMMIT TRANSACTION;")
+
+
+async def migrate_source_integrity(
+    execute_query: SurrealExecute,
+    *,
+    kind: SourceKind,
+    ownership: SchemaOwnership | None = None,
+) -> None:
+    table = "entity" if kind is SourceKind.GRAPH_ENTITY else "raw_captures"
+    organization_field = "group_id" if kind is SourceKind.GRAPH_ENTITY else "organization_id"
+    event = source_state_event(
+        kind,
+        retire_derivations=True,
+        publication_bookkeeping=kind is SourceKind.RAW_CAPTURE,
+        integrity=True,
+    ).replace("DEFINE EVENT IF NOT EXISTS", "DEFINE EVENT OVERWRITE")
+    body = f"""
+        DEFINE FIELD IF NOT EXISTS incarnation ON source_states TYPE option<string>;
+        DEFINE FIELD IF NOT EXISTS derivation_required ON {table} TYPE option<bool> DEFAULT false;
+        {event}
+        DEFINE EVENT OVERWRITE require_target_derivation ON memory_derivations
+            WHEN $event IN ['CREATE', 'UPDATE'] THEN {{
+                IF $after.target_kind != '{kind.value}' {{ THROW 'derivation target kind mismatch'; }};
+                UPDATE {table} SET derivation_required = true
+                    WHERE uuid = $after.target_id AND {organization_field} = $after.organization_id
+                        AND derivation_required != true;
+            }};
+        RETURN {{
+            LET $associations = SELECT organization_id, target_id FROM memory_derivations
+                WHERE target_kind = '{kind.value}';
+            FOR $association IN $associations {{
+                UPDATE {table} SET derivation_required = true
+                    WHERE uuid = $association.target_id
+                        AND {organization_field} = $association.organization_id
+                        AND derivation_required != true;
+            }};
+            RETURN NONE;
+        }};
+    """
+    if ownership is not None:
+        await ownership.mutate(body)
+    else:
+        await execute_query("BEGIN TRANSACTION; " + body + " COMMIT TRANSACTION;")
+
+
+migrate_graph_source_integrity = partial(migrate_source_integrity, kind=SourceKind.GRAPH_ENTITY)

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_states.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_source_states.py
@@ -113,7 +113,11 @@ def _raw_publication_evidence_changed() -> str:
 
 
 def source_state_event(
-    kind: SourceKind, *, retire_derivations: bool = False, publication_bookkeeping: bool = False
+    kind: SourceKind,
+    *,
+    retire_derivations: bool = False,
+    publication_bookkeeping: bool = False,
+    integrity: bool = False,
 ) -> str:
     """Generate only fixed, application-owned identifiers and field expressions.
 
@@ -138,6 +142,15 @@ def source_state_event(
         if retire_derivations
         else ""
     )
+    incarnation = (
+        "incarnation = $state.incarnation ?? type::string(rand::uuid())," if integrity else ""
+    )
+    marker_guard = (
+        "IF $event = 'UPDATE' AND $before.derivation_required = true "
+        "AND $after.derivation_required != true { THROW 'protected target cannot lose lineage'; };"
+        if integrity
+        else ""
+    )
     return f"""
 DEFINE EVENT IF NOT EXISTS maintain_source_state ON {table} WHEN true THEN {{
     LET $source = IF $event = 'DELETE' THEN $before ELSE $after END;
@@ -148,12 +161,14 @@ DEFINE EVENT IF NOT EXISTS maintain_source_state ON {table} WHEN true THEN {{
         OR $before.{organization_field} != $after.{organization_field}) {{
         THROW 'source identity is immutable';
     }};
+    {marker_guard}
     LET $org = type::string($source.{organization_field});
     LET $uuid = type::string($source.uuid);
     LET $key = type::record(string::concat('source_states:', crypto::sha256(type::string([$org, '{kind.value}', $uuid]))));
     LET $state = (SELECT * FROM $key)[0];
     LET $changed = $event != 'UPDATE' OR {changed};
     UPSERT $key SET organization_id = $org, source_kind = '{kind.value}', source_id = $uuid,
+        {incarnation}
         generation = ($state.generation ?? 0) + IF $state = NONE OR $changed
             OR ($state.deleted AND NOT ({deleted})) THEN 1 ELSE 0 END,
         revision = $source.revision ?? 0,

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_version.py
@@ -14,7 +14,7 @@ from sibyl_core.backends.surreal.schema_helpers import execute_schema_statement,
 if TYPE_CHECKING:
     from sibyl_core.backends.surreal.schema_ownership import SchemaOwnership
 
-GRAPH_SCHEMA_CURRENT_VERSION = 25
+GRAPH_SCHEMA_CURRENT_VERSION = 26
 GRAPH_SCHEMA_NAME = "graph"
 SCHEMA_VERSION_TABLE = "schema_version"
 

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/observations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/observations.py
@@ -40,6 +40,7 @@ class SourceObservation:
     content_sha256: str
     revision: int
     durable: bool
+    incarnation: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.source, SourceIdentity):
@@ -52,13 +53,23 @@ class SourceObservation:
             r"[0-9a-f]{64}", self.content_sha256
         ):
             raise ValueError("source content hash must be a lowercase SHA-256 digest")
+        if self.incarnation is not None and (
+            not isinstance(self.incarnation, str) or not self.incarnation.strip()
+        ):
+            raise ValueError("source incarnation must be a nonempty string")
         if type(self.durable) is not bool:
             raise ValueError("observation durability must be explicit")
+
+    @property
+    def effective_incarnation(self) -> str:
+        """Translate legacy observations without refreshing their evidence."""
+        return self.incarnation or legacy_source_incarnation(self.source)
 
     def same_evidence(self, other: SourceObservation) -> bool:
         """Bookkeeping revisions do not manufacture a new source observation."""
         return (
             self.source == other.source
+            and self.effective_incarnation == other.effective_incarnation
             and self.generation == other.generation
             and self.content_sha256 == other.content_sha256
             and self.durable == other.durable
@@ -69,3 +80,10 @@ def evidence_hash(value: object) -> str:
     """Hash the versioned materialized representation, not arbitrary metadata."""
     encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def legacy_source_incarnation(source: SourceIdentity) -> str:
+    """Identity assigned only to a ledger retained through the upgrade."""
+    organization = hashlib.sha256(source.organization_id.encode()).hexdigest()
+    identity = hashlib.sha256(source.id.encode()).hexdigest()
+    return f"legacy-v1:{organization}:{source.kind.value}:{identity}"

--- a/packages/python/sibyl-core/src/sibyl_core/models/entities.py
+++ b/packages/python/sibyl-core/src/sibyl_core/models/entities.py
@@ -137,6 +137,7 @@ class Entity(BaseModel):
         description="Last modifier identity (user id/email) when known",
     )
     revision: int = Field(default=1, ge=1, description="Monotonic mutation revision")
+    derivation_required: bool = Field(default=False, exclude=True)
     observed_revision: int | None = Field(
         default=None,
         exclude=True,

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_models.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_models.py
@@ -139,6 +139,7 @@ class RawMemory:
     snippet: str | None = None
 
     legacy_content_checkpoint: dict[str, object] | None = field(default=None, repr=False)
+    derivation_required: bool = field(default=False, repr=False, compare=False)
     observed_revision: int | None = field(default=None, repr=False, compare=False)
 
 
@@ -627,6 +628,7 @@ def raw_memory_from_record(record: Mapping[str, object]) -> RawMemory:
         capture_surface=coerce_optional_str(record.get("capture_surface")),
         created_by_user_id=coerce_optional_str(record.get("created_by_user_id")),
         revision=max(coerce_int(record.get("revision")), 1),
+        derivation_required=record.get("derivation_required") is True,
         legacy_content_checkpoint=coerce_dict(record.get("legacy_content_checkpoint")) or None,
         observed_revision=observed_revision
         if type(observed_revision) is int and observed_revision > 0

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
@@ -122,10 +122,18 @@ async def replace_raw_memory_records_bulk(
         from sibyl_core.backends.surreal.schema_derivations import STORE_RAW_DERIVATIONS
 
         query = query.replace("COMMIT TRANSACTION;", STORE_RAW_DERIVATIONS + "COMMIT TRANSACTION;")
+    protected_targets = {derivation["target_id"] for derivation in derivations}
     rows = await content_client.select_many_raw(
         client,
         query,
-        rows=[{**record, "revision": 1} for record in records],
+        rows=[
+            {
+                **record,
+                "revision": 1,
+                **({"derivation_required": True} if record["uuid"] in protected_targets else {}),
+            }
+            for record in records
+        ],
         derivations=list(derivations),
     )
     if len(rows) != len(records):

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_derivations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_derivations.py
@@ -29,7 +29,7 @@ def graph_target_digest(entity) -> str:
 
 async def graph_association_current(entity, association, *, ancestors=frozenset()) -> bool:
     if association is None:
-        return True
+        return not entity.derivation_required
     if association.get("active") is not True or association.get(
         "body_sha256"
     ) != graph_target_digest(entity):
@@ -114,8 +114,10 @@ async def unavailable_graph_derivation_ids(organization_id: str, ids: Sequence[s
         raise RuntimeError("graph derivation snapshot unavailable")
     targets = {row["uuid"]: entity_from_surreal_row(row) for row in target_rows}
 
-    async def current(association):
-        target_id = association["target_id"]
+    associations = {row["target_id"]: row for row in association_rows}
+
+    async def current(target_id):
+        association = associations.get(target_id)
         entity = targets.get(target_id)
         identity = SourceIdentity(organization_id, SourceKind.GRAPH_ENTITY, target_id)
         if entity is None or not await graph_association_current(
@@ -126,7 +128,9 @@ async def unavailable_graph_derivation_ids(organization_id: str, ids: Sequence[s
 
     return {
         value
-        for value in await asyncio.gather(*(current(row) for row in association_rows))
+        for value in await asyncio.gather(
+            *(current(target_id) for target_id in targets.keys() | associations.keys())
+        )
         if value is not None
     }
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
@@ -225,6 +225,7 @@ async def _insert_entity_if_absent(
     record = _entity_record(entity, group_id=group_id)
     record["id"] = entity.id
     if derivation is not None:
+        record["derivation_required"] = True
         from sibyl_core.services.graph_derivations import graph_target_digest
         from sibyl_core.services.graph_records import entity_from_surreal_row
 
@@ -903,6 +904,7 @@ async def _replace_projected_entities(client, records, *, group_id, projection_s
     """Write projections and their protected parent observations atomically."""
     from dataclasses import asdict
 
+    from sibyl_core.memory_pipeline.observations import legacy_source_incarnation
     from sibyl_core.services.graph_derivations import graph_target_digest
     from sibyl_core.services.graph_records import entity_from_surreal_row
 
@@ -943,6 +945,7 @@ async def _replace_projected_entities(client, records, *, group_id, projection_s
         LET $parent_derivation = (SELECT * FROM memory_derivations WHERE organization_id=$org AND target_kind='graph_entity' AND target_id=$parent_id LIMIT 1)[0];
         IF $parent = NONE OR $state = NONE OR $parent.revision != $revision
             OR $state.revision != $revision OR $state.generation != $generation OR $state.deleted
+            OR $state.incarnation != $incarnation
             OR $parent_derivation.active != true
             OR $parent_derivation.body_sha256 != $parent_association.body_sha256
             OR $parent_derivation.observations != $parent_association.observations
@@ -962,6 +965,8 @@ async def _replace_projected_entities(client, records, *, group_id, projection_s
             LET $was_present = array::len($previous_targets[WHERE uuid=$association.target_id]) > 0;
             IF $was_present AND ($old = NONE
                 OR $old.observations[0].generation != $association.observations[0].generation
+                OR ($old.observations[0].incarnation ?? $legacy_incarnation)
+                    != ($association.observations[0].incarnation ?? $legacy_incarnation)
                 OR $old.observations[0].content_sha256 != $association.observations[0].content_sha256
                 OR $old.active != true) {
                 UPDATE source_states SET generation += 1
@@ -976,13 +981,15 @@ async def _replace_projected_entities(client, records, *, group_id, projection_s
     return normalize_records(
         await client.execute_query(
             query,
-            rows=records,
+            rows=[{**record, "derivation_required": True} for record in records],
             ids=[record["uuid"] for record in records],
             associations=associations,
             org=group_id,
             parent_id=observation.source.id,
             revision=observation.revision,
             generation=observation.generation,
+            incarnation=observation.effective_incarnation,
+            legacy_incarnation=legacy_source_incarnation(observation.source),
             parent_association=parent_association,
         )
     )

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_records.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_records.py
@@ -42,6 +42,7 @@ _RELATED_ENTITY_PROJECTION_FIELDS = (
     ("created_at", "created_at"),
     ("updated_at", "updated_at"),
     ("revision", "revision"),
+    ("derivation_required", "derivation_required"),
     ("project_id", "project_id"),
     ("epic_id", "epic_id"),
     ("parent_task_id", "parent_task_id"),
@@ -208,6 +209,7 @@ def entity_from_surreal_row(row: Mapping[str, object]) -> Entity:
     )
     entity = _coerce_native_entity(entity)
     observed_revision = normalized_row.get("revision")
+    entity.derivation_required = normalized_row.get("derivation_required") is True
     entity.observed_revision = (
         observed_revision if type(observed_revision) is int and observed_revision > 0 else None
     )

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_derivations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_derivations.py
@@ -30,6 +30,7 @@ def observation_from_record(value: object) -> SourceObservation:
             content_sha256=value["content_sha256"],
             revision=value["revision"],
             durable=value["durable"],
+            incarnation=value.get("incarnation"),
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise SourceUnavailableError() from exc
@@ -107,7 +108,7 @@ async def _raw_association_current(
     memory, association, authority: SourceReadAuthority, *, ancestors: frozenset[SourceIdentity]
 ) -> bool:
     if association is None:
-        return memory.capture_surface != "synthesis_artifact"
+        return not memory.derivation_required and memory.capture_surface != "synthesis_artifact"
     if (
         association.get("active") is not True
         or association.get("body_sha256") != hashlib.sha256(memory.raw_content.encode()).hexdigest()
@@ -215,7 +216,11 @@ async def unavailable_raw_derivation_ids(
                 if not raw_memory_lifecycle_recallable(memory):
                     return memory_id
                 # Ordinary authored captures require no source traversal.
-                if memory_id not in associations and memory.capture_surface != "synthesis_artifact":
+                if (
+                    memory_id not in associations
+                    and not memory.derivation_required
+                    and memory.capture_surface != "synthesis_artifact"
+                ):
                     return None
                 if not await _raw_association_current(
                     memory, associations.get(memory_id), authority, ancestors=frozenset()

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_state_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_state_store.py
@@ -73,6 +73,8 @@ async def load_source_snapshot(
         or state["revision"] != row["revision"]
         or type(state.get("generation")) is not int
         or state["generation"] <= 0
+        or not isinstance(state.get("incarnation"), str)
+        or not state["incarnation"]
     ):
         return None
     if source.kind is SourceKind.GRAPH_ENTITY:
@@ -82,6 +84,7 @@ async def load_source_snapshot(
             SourceObservation(
                 source=source,
                 generation=state["generation"],
+                incarnation=state["incarnation"],
                 revision=state["revision"],
                 content_sha256=graph_evidence(entity),
                 durable=True,
@@ -93,6 +96,7 @@ async def load_source_snapshot(
         SourceObservation(
             source=source,
             generation=state["generation"],
+            incarnation=state["incarnation"],
             revision=state["revision"],
             content_sha256=evidence_hash({"version": 1, "raw_content": memory.raw_content}),
             durable=True,

--- a/packages/python/sibyl-core/tests/test_source_integrity.py
+++ b/packages/python/sibyl-core/tests/test_source_integrity.py
@@ -1,0 +1,208 @@
+"""Restore loss must not recreate the identity of previously observed evidence."""
+
+from dataclasses import replace
+from uuid import UUID
+
+import pytest
+
+from sibyl_core.backends.surreal.schema import bootstrap_schema
+from sibyl_core.memory_pipeline.observations import SourceIdentity, SourceKind
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.services.source_state_store import load_source_snapshot
+from tests.test_synthesis_source_observations import (
+    content_store as content_store,
+)
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+from tests.test_synthesis_source_observations import (
+    runtime as runtime,
+)
+
+
+async def snapshot(runtime, identity):
+    source = SourceIdentity(runtime.client.group_id, SourceKind.GRAPH_ENTITY, identity)
+    return await load_source_snapshot(
+        source, organization_id=source.organization_id, execute_query=runtime.client.execute_query
+    )
+
+
+async def seed(runtime, identity):
+    await runtime.entity_manager.create_direct(
+        Entity(id=identity, entity_type=EntityType.SESSION, name="Evidence", content="Blue")
+    )
+    return await snapshot(runtime, identity)
+
+
+@pytest.mark.parametrize("version", [23, 25])
+async def test_integrity_upgrade_missing_state_never_receives_legacy_identity(runtime, version):
+    first = await seed(runtime, "missing")
+    old = replace(first.observation, incarnation=None)
+    await runtime.client.execute_query(
+        "UPDATE source_states UNSET incarnation; REMOVE FIELD incarnation ON source_states; "
+        "DELETE source_states WHERE source_id='missing'; "
+        "UPDATE schema_version SET version=$version WHERE name='graph';",
+        version=version,
+    )
+    await bootstrap_schema(runtime.client)
+    await runtime.client.execute_query(
+        "UPDATE entity SET retrieval_count += 1 WHERE uuid='missing';"
+    )
+    repaired = await snapshot(runtime, "missing")
+    assert UUID(repaired.observation.incarnation)
+    assert not old.same_evidence(repaired.observation)
+    entity = await runtime.entity_manager.get("missing")
+    await runtime.entity_manager.delete(entity.id)
+    await runtime.entity_manager.create_direct(entity)
+    assert not old.same_evidence((await snapshot(runtime, entity.id)).observation)
+
+
+async def test_integrity_upgrade_keeps_valid_and_stale_old_observations(runtime):
+    valid = replace((await seed(runtime, "valid")).observation, incarnation=None)
+    stale = replace((await seed(runtime, "stale")).observation, incarnation=None)
+    await runtime.entity_manager.update("stale", {"content": "Green"})
+    await runtime.client.execute_query(
+        "UPDATE source_states UNSET incarnation; REMOVE FIELD incarnation ON source_states; "
+        "UPDATE schema_version SET version=25 WHERE name='graph';"
+    )
+    await bootstrap_schema(runtime.client)
+    assert valid.same_evidence((await snapshot(runtime, "valid")).observation)
+    assert not stale.same_evidence((await snapshot(runtime, "stale")).observation)
+
+
+async def test_lost_ledger_bookkeeping_cannot_revive_old_incarnation(runtime):
+    first = await seed(runtime, "lost")
+    entity = await runtime.entity_manager.get("lost")
+    await runtime.entity_manager.delete(entity.id)
+    await runtime.entity_manager.create_direct(entity)
+    await runtime.client.execute_query("DELETE source_states WHERE source_id='lost';")
+    assert await snapshot(runtime, entity.id) is None
+    await runtime.client.execute_query("UPDATE entity SET retrieval_count += 1 WHERE uuid='lost';")
+    repaired = await snapshot(runtime, entity.id)
+    assert repaired.observation.generation == first.observation.generation
+    assert repaired.observation.incarnation != first.observation.incarnation
+    assert not repaired.observation.same_evidence(first.observation)
+
+
+async def test_graph_protected_marker_survives_association_loss(runtime, content_store):
+    from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+    from sibyl_core.services.surreal_content import remember_raw_memory
+    from tests.test_graph_derivation_publication import publish, share_plan
+
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="marker",
+        raw_content="Deployment requires blue approval.",
+        embedding_provider=None,
+    )
+    result = await publish(runtime, await share_plan(runtime, raw.id))
+    assert result.success
+    target = await runtime.entity_manager.get(result.promoted_id)
+    assert target.derivation_required
+    before = await snapshot(runtime, target.id)
+    await runtime.client.execute_query(
+        "UPDATE entity SET retrieval_count += 1 WHERE uuid=$id;", id=target.id
+    )
+    assert before.observation.same_evidence((await snapshot(runtime, target.id)).observation)
+    await runtime.client.execute_query(
+        "DELETE memory_derivations WHERE target_id=$id;", id=target.id
+    )
+    assert target.id in await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: target.metadata}
+    )
+    for value in (False, None):
+        with pytest.raises(Exception, match="cannot lose lineage"):
+            await runtime.client.execute_query(
+                "UPDATE entity SET derivation_required=$value WHERE uuid=$id;",
+                id=target.id,
+                value=value,
+            )
+
+
+async def test_raw_protected_marker_denies_missing_association_after_marker_metadata_edit(
+    runtime, content_store
+):
+    from sibyl_core.services.memory_derivations import raw_derivation_current
+    from sibyl_core.services.memory_source_validation import SourceReadAuthority
+    from sibyl_core.services.surreal_content import get_raw_memory, remember_raw_memory
+    from tests.test_synthesis_source_observations import remember_observed_synthesis
+
+    raw = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="raw-marker",
+        raw_content="Deployment requires blue approval.",
+        embedding_provider=None,
+    )
+    result = await remember_observed_synthesis(
+        runtime, raw.id, "raw_memory", raw.revision, raw.raw_content
+    )
+    memory = await get_raw_memory(
+        organization_id=runtime.client.group_id, memory_id=result.remembered_memory_id
+    )
+    assert memory.derivation_required
+    from sibyl_core.services import content_client
+
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "DELETE memory_derivations WHERE target_id=$id; "
+            "UPDATE raw_captures SET capture_surface='ordinary', metadata={} WHERE uuid=$id;",
+            id=memory.id,
+        )
+    memory = await get_raw_memory(organization_id=runtime.client.group_id, memory_id=memory.id)
+    assert memory.derivation_required
+    assert not await raw_derivation_current(
+        memory, SourceReadAuthority("user_a", projects=frozenset({"project_a"}))
+    )
+
+
+async def test_content_upgrade_from_33_preserves_retained_identity(runtime, content_store):
+    from sibyl_core.backends.surreal.content_schema import (
+        CONTENT_SCHEMA_CURRENT_VERSION,
+        bootstrap_content_schema,
+    )
+    from sibyl_core.services import content_client
+    from sibyl_core.services.surreal_content import remember_raw_memory
+
+    memory = await remember_raw_memory(
+        organization_id=runtime.client.group_id,
+        principal_id="user_a",
+        source_id="content-upgrade",
+        raw_content="Retained source evidence",
+        embedding_provider=None,
+    )
+    source = SourceIdentity(runtime.client.group_id, SourceKind.RAW_CAPTURE, memory.id)
+    async with content_client.surreal_content_client() as client:
+        before = await load_source_snapshot(
+            source, organization_id=source.organization_id, execute_query=client.execute_query
+        )
+        legacy = replace(before.observation, incarnation=None)
+        await client.execute_query(
+            "UPDATE source_states UNSET incarnation; REMOVE FIELD incarnation ON source_states; "
+            "UPDATE schema_version SET version=33 WHERE name='content';"
+        )
+        await bootstrap_content_schema(client)
+        current = (
+            await client.execute_query("SELECT version FROM schema_version WHERE name='content';")
+        )[0]["version"]
+        assert current == CONTENT_SCHEMA_CURRENT_VERSION == 34
+        after = await load_source_snapshot(
+            source, organization_id=source.organization_id, execute_query=client.execute_query
+        )
+        assert legacy.same_evidence(after.observation)
+
+
+async def test_graph_upgrade_allows_existing_ordinary_row_update(runtime):
+    before = await seed(runtime, "ordinary-upgrade")
+    await runtime.client.execute_query(
+        "UPDATE entity UNSET derivation_required; REMOVE FIELD derivation_required ON entity; "
+        "UPDATE schema_version SET version=25 WHERE name='graph';"
+    )
+    await bootstrap_schema(runtime.client)
+    await runtime.entity_manager.update("ordinary-upgrade", {"name": "Updated evidence"})
+    after = await snapshot(runtime, "ordinary-upgrade")
+    assert after.entity.name == "Updated evidence"
+    assert not after.entity.derivation_required
+    assert after.observation.incarnation == before.observation.incarnation
+    assert after.observation.generation > before.observation.generation

--- a/packages/python/sibyl-core/tests/test_source_publication_epochs.py
+++ b/packages/python/sibyl-core/tests/test_source_publication_epochs.py
@@ -86,6 +86,7 @@ async def test_upgrade_preserves_existing_source_and_high_water(monkeypatch):
 
     from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
     from sibyl_core.backends.surreal.content_schema import (
+        CONTENT_SCHEMA_CURRENT_VERSION,
         CONTENT_SCHEMA_NAME,
         _content_schema_migrations,
     )
@@ -119,14 +120,34 @@ async def test_upgrade_preserves_existing_source_and_high_water(monkeypatch):
             metadata={"note": "unchanged"},
             embedding_provider=None,
         )
-        before = await source_snapshot(memory)
+        from sibyl_core.memory_pipeline.observations import SourceObservation, evidence_hash
+
+        before_row = (await client.execute_query("SELECT * FROM raw_captures;"))[0]
+        before_state = (await client.execute_query("SELECT * FROM source_states;"))[0]
+        before = SourceObservation(
+            source=SourceIdentity(memory.organization_id, SourceKind.RAW_CAPTURE, memory.id),
+            generation=before_state["generation"],
+            revision=before_state["revision"],
+            content_sha256=evidence_hash({"version": 1, "raw_content": memory.raw_content}),
+            durable=True,
+        )
+        assert await source_snapshot(memory) is None
         await bootstrap_content_schema(client)
-        assert await get_schema_version(client.execute_query, name=CONTENT_SCHEMA_NAME) == 33
+        assert (
+            await get_schema_version(client.execute_query, name=CONTENT_SCHEMA_NAME)
+            == CONTENT_SCHEMA_CURRENT_VERSION
+        )
         after = await source_snapshot(memory)
-        assert after == before
+        assert after.observation.same_evidence(before)
+        after_row = (await client.execute_query("SELECT * FROM raw_captures;"))[0]
+        assert after_row.pop("derivation_required", False) is False
+        assert after_row == before_row
+        after_state = (await client.execute_query("SELECT * FROM source_states;"))[0]
+        assert after_state.pop("incarnation") == before.effective_incarnation
+        assert after_state == before_state
         promoted = await save_raw_memory(
             replace(memory, review_state="promoted"), expected_revision=memory.revision
         )
-        assert (await source_snapshot(promoted)).observation.same_evidence(before.observation)
+        assert (await source_snapshot(promoted)).observation.same_evidence(before)
     finally:
         await client.close()


### PR DESCRIPTION
Losing a source ledger could recreate generation 1 and make an old observation appear current. Losing a derivation association could also make a protected graph target look ordinary. This change gives each source incarnation a durable identity and stores protected-target status independently of the association.

## 🛠️ Storage and upgrade contract

Graph migration 26 and content migration 34 preserve existing ledger identities before historical backfills can create new state. Existing observations translate to the retained legacy identity without refreshing their evidence. A repaired or recreated ledger receives a new incarnation, so the old observation stays stale even if its generation and content match.

Protected publication writes an internal target marker in the existing transaction. Final read gates deny marked targets whose associations are missing. Source events reject clearing a true marker, including rollback when an association deletion preceded the attempted clear. The marker is optional for preexisting ordinary rows, allowing their next save without rewriting all indexed sources.

Normal startup uses the new graph/content version declarations. Upgrade regressions cover both source preservation and ordinary writes after migration. The initial full suite exposed mismatched version declarations; the historical raw fixture then exposed a required-bool default that did not populate existing rows. Both defects are corrected, with the original failures retained in the review receipts.

## 🧪 Validation

The reviewed storage checkpoint (`3443dda7`) passed:

- The full core suite: 3,751 passed, 14 skipped, one expected failure.
- The API integration selection: 15 passed; one schema-drift case requires a real server and was skipped locally.
- Actual pinned SurrealDB 3.2.3 storage and publication checks: 43 passed, with owned test resources removed afterward.
- Independent adversarial review: 20 native database cases passed, including lost-ledger identity, legacy raw/graph writes, and false/NONE marker rollback. A separate root repeat also passed all 20.
- Core lint and typecheck.

The integrated head (`ac2df9a5`) includes current main and #534. Its source patch is unchanged by the rebase. Upstream changes broaden the protected projection writer to named memory projections and seed source ledgers directly without rewriting indexed rows. The integrated gate passed 37 local migration/projection cases and 59 actual SurrealDB 3.2.3 cases, including protected named projections and concurrent backfill controls. Core lint and typecheck also passed. Hosted checks for this head remain the merge gate.

## 🎯 Release boundary

This PR establishes the storage contract. Complete application backup/archive preservation remains a required follow-up. Current archives still need source ledgers, associations, tombstones, protected markers, and destination high-water handling. This PR does not claim that arbitrary IMPORT or administrative schema loss is safe.
