### PR TITLE
fix(memory): retain receipts for every consolidation outcome

### DIFF
--- a/apps/api/src/sibyl/api/routes/memory_evals.py
+++ b/apps/api/src/sibyl/api/routes/memory_evals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 from dataclasses import replace
+from typing import Literal
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -212,6 +213,8 @@ class EvalConsolidationResponse(BaseModel):
     memory_id: str | None
     candidate: ReflectionCandidate | None
     abstention_reason: str | None
+    rejection_reason: str | None
+    receipt_status: Literal["available", "unavailable"]
     build_receipt: dict[str, object]
     source_join: str
     source_freshness: str
@@ -289,7 +292,7 @@ async def consolidate_admitted_attempts(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     memory = result.memory
     candidate = None
-    receipt = {}
+    receipt = result.build_receipt
     if memory is not None:
         memory = await reconcile_raw_source_lifecycle(
             memory,
@@ -318,14 +321,22 @@ async def consolidate_admitted_attempts(
         payload = memory.metadata.get(METADATA_KEY)
         if not isinstance(payload, dict) or not isinstance(payload.get("build_receipt"), dict):
             raise HTTPException(status_code=409, detail="Stored consolidation receipt is invalid")
-        receipt = payload["build_receipt"]
+        if receipt is None:
+            receipt = payload["build_receipt"]
     return EvalConsolidationResponse(
         operation_id=result.operation_id,
         status=result.status,
         memory_id=memory.id if memory else None,
         candidate=candidate,
-        abstention_reason="insufficient_support" if result.status == "abstained" else None,
-        build_receipt=receipt,
+        abstention_reason=receipt.get("reason")
+        if receipt and result.status == "abstained"
+        else None,
+        rejection_reason=receipt.get("reason") if receipt and result.status == "rejected" else None,
+        receipt_status="available" if receipt is not None else "unavailable",
+        build_receipt=receipt if receipt is not None else {},
         source_join="authenticated_admission_ledger",
-        source_freshness="checked_at_persistence; current_lifecycle_required_for_publication",
+        source_freshness=(
+            "checked_at_persistence; receipt_replay_is_historical; "
+            "current_lifecycle_required_for_publication"
+        ),
     )

--- a/apps/api/tests/test_memory_eval_admission.py
+++ b/apps/api/tests/test_memory_eval_admission.py
@@ -250,6 +250,7 @@ async def test_archive_restore_preserves_consumed_attempt(eval_api, monkeypatch,
         "blank",
         "input_budget",
         "transport_failure",
+        "structural_rejection",
     ],
 )
 async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, change):
@@ -295,7 +296,12 @@ async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, 
         "mechanism": "compare output",
     }
     calls = []
-    candidate_changes = {"candidate", "source_deleted_replay", "stamp_changed_replay"}
+    candidate_changes = {
+        "candidate",
+        "source_deleted_replay",
+        "stamp_changed_replay",
+        "structural_rejection",
+    }
 
     async def extract(_self, prompt):
         calls.append(prompt)
@@ -311,6 +317,7 @@ async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, 
         )
 
     monkeypatch.setattr(consolidation.Extractor, "extract_with_usage", extract)
+    _configure_structural_rejection(monkeypatch, change)
     if change == "owner":
         api.ctx.user_id = "other"
     elif change == "role":
@@ -343,13 +350,12 @@ async def test_http_consolidation_reads_admitted_sources(eval_api, monkeypatch, 
         return
     assert response.status_code == expected, response.text
     assert len(calls) == (1 if change in {None, *candidate_changes} else 0)
-    if change is None:
-        assert response.json()["candidate"] is None
-        assert response.json()["source_join"] == "authenticated_admission_ledger"
-        assert "sibyl-signed-eval-outcome-v1" in calls[0]
 
+    _assert_outcome_receipt(change, response, calls)
     if change in {None, *candidate_changes}:
         await _assert_same_consolidation_replay(api, request, response, calls)
+    if change is None:
+        await _assert_legacy_receipt_unavailable(api, request, calls)
     if change in {"source_deleted_replay", "stamp_changed_replay"}:
         await _assert_unavailable_consolidation_replay(api, request, change)
     if change == "candidate":
@@ -469,4 +475,40 @@ async def _assert_same_consolidation_replay(api, request, response, calls):
     replay = await api.client.post("/memory/eval/experiments/experiment/consolidate", json=request)
     assert replay.status_code == 200
     assert replay.json() == response.json()
+    assert len(calls) == 1
+
+
+def _configure_structural_rejection(monkeypatch, change):
+    if change == "structural_rejection":
+
+        def reject(*_args):
+            raise ValueError("Missing failure support")
+
+        monkeypatch.setattr(consolidation, "_candidate", reject)
+
+
+def _assert_outcome_receipt(change, response, calls):
+    if change is None:
+        assert response.json()["candidate"] is None
+        assert response.json()["source_join"] == "authenticated_admission_ledger"
+        assert "sibyl-signed-eval-outcome-v1" in calls[0]
+        assert response.json()["receipt_status"] == "available"
+        assert response.json()["abstention_reason"] == "Insufficient transferable evidence"
+        assert response.json()["build_receipt"]["reason"] == "Insufficient transferable evidence"
+        assert response.json()["rejection_reason"] is None
+    elif change == "structural_rejection":
+        assert response.json()["status"] == "rejected"
+        assert response.json()["rejection_reason"] == "Missing failure support"
+        assert response.json()["abstention_reason"] is None
+        assert response.json()["build_receipt"]["status"] == "rejected"
+        assert response.json()["receipt_status"] == "available"
+
+
+async def _assert_legacy_receipt_unavailable(api, request, calls):
+    await api.store.execute_query("UPDATE eval_consolidations UNSET build_receipt_json;")
+    legacy = await api.client.post("/memory/eval/experiments/experiment/consolidate", json=request)
+    assert legacy.status_code == 200
+    assert legacy.json()["receipt_status"] == "unavailable"
+    assert legacy.json()["abstention_reason"] is None
+    assert legacy.json()["build_receipt"] == {}
     assert len(calls) == 1

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -77,7 +77,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 34
+CONTENT_SCHEMA_CURRENT_VERSION = 35
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -976,6 +976,14 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             version=34,
             name="content_source_integrity",
             action=partial(migrate_source_integrity, kind=SourceKind.RAW_CAPTURE),
+        ),
+        SchemaMigration(
+            version=35,
+            name="content_consolidation_receipts",
+            statements=(
+                "DEFINE FIELD IF NOT EXISTS build_receipt_json ON eval_consolidations "
+                "TYPE option<string>",
+            ),
         ),
     )
 

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schemas/content/10_tables.surql
@@ -433,6 +433,7 @@ DEFINE FIELD IF NOT EXISTS organization_id ON eval_consolidations TYPE string;
 DEFINE FIELD IF NOT EXISTS principal_id ON eval_consolidations TYPE string;
 DEFINE FIELD IF NOT EXISTS request_sha256 ON eval_consolidations TYPE string;
 DEFINE FIELD IF NOT EXISTS admission_bindings ON eval_consolidations TYPE array<object> FLEXIBLE DEFAULT [];
+DEFINE FIELD IF NOT EXISTS build_receipt_json ON eval_consolidations TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS candidate_id ON eval_consolidations TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS promoted_entity_id ON eval_consolidations TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS result_kind ON eval_consolidations TYPE string ASSERT $value IN ['candidate', 'abstained'];

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -182,10 +182,13 @@ RETURN { ledger: $stored, memory: $memory };
 def _decode_build_receipt(ledger: dict) -> dict[str, Any] | None:
     encoded_receipt = ledger.get("build_receipt_json")
     try:
+        result_kind = ledger.get("result_kind")
+        if result_kind not in {"candidate", "abstained"}:
+            raise ValueError("receipt has an invalid outcome kind")
         receipt = json.loads(encoded_receipt) if encoded_receipt is not None else None
         if encoded_receipt is not None:
             allowed_statuses = (
-                {"abstained", "rejected"} if ledger["result_kind"] == "abstained" else {"proposed"}
+                {"abstained", "rejected"} if result_kind == "abstained" else {"proposed"}
             )
             if (
                 not isinstance(receipt, dict)

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from typing import Any, Literal
 from uuid import NAMESPACE_URL, uuid5
@@ -125,8 +126,9 @@ class ConsolidationOperation:
 @dataclass(frozen=True)
 class StoredConsolidation:
     operation_id: str
-    status: Literal["candidate", "abstained", "gone"]
+    status: Literal["candidate", "abstained", "rejected", "gone"]
     memory: content_models.RawMemory | None
+    build_receipt: dict[str, Any] | None = None
 
 
 # One RETURN statement is an implicit atomic transaction on both SDK transports.
@@ -177,6 +179,40 @@ RETURN { ledger: $stored, memory: $memory };
 """
 
 
+def _decode_build_receipt(ledger: dict) -> dict[str, Any] | None:
+    encoded_receipt = ledger.get("build_receipt_json")
+    try:
+        receipt = json.loads(encoded_receipt) if encoded_receipt is not None else None
+        if encoded_receipt is not None:
+            allowed_statuses = (
+                {"abstained", "rejected"} if ledger["result_kind"] == "abstained" else {"proposed"}
+            )
+            if (
+                not isinstance(receipt, dict)
+                or receipt.get("schema_version") != SCHEMA_VERSION
+                or receipt.get("status") not in allowed_statuses
+                or not isinstance(receipt.get("usage"), dict)
+                or (
+                    ledger["result_kind"] == "abstained"
+                    and (
+                        not isinstance(receipt.get("reason"), str) or not receipt["reason"].strip()
+                    )
+                )
+                or json.dumps(
+                    receipt,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                    allow_nan=False,
+                )
+                != encoded_receipt
+            ):
+                raise ValueError("receipt has an invalid schema or outcome")
+    except (TypeError, ValueError) as exc:
+        raise ConsolidationConflict("stored consolidation receipt is invalid") from exc
+    return receipt
+
+
 def _decode(operation: ConsolidationOperation, row: dict) -> StoredConsolidation:
     ledger = row["ledger"]
     if (
@@ -184,19 +220,23 @@ def _decode(operation: ConsolidationOperation, row: dict) -> StoredConsolidation
         or ledger["request_sha256"] != operation.request_sha256
     ):
         raise ConsolidationConflict("immutable consolidation request differs")
+    receipt = _decode_build_receipt(ledger)
     if ledger["result_kind"] == "abstained":
-        return StoredConsolidation(operation.key, "abstained", None)
+        status: Literal["abstained", "rejected"] = (
+            "rejected" if receipt and receipt.get("status") == "rejected" else "abstained"
+        )
+        return StoredConsolidation(operation.key, status, None, receipt)
     record = row.get("memory")
     memory = content_models.raw_memory_from_record(record) if record else None
     if memory is None or memory.deleted_at is not None:
-        return StoredConsolidation(operation.key, "gone", None)
+        return StoredConsolidation(operation.key, "gone", None, receipt)
     if (
         memory.principal_id != operation.principal_id
         or memory.memory_scope != "private"
         or memory.metadata.get(CONSOLIDATION_METADATA_KEY) != operation.key
     ):
         raise ConsolidationConflict("stored consolidation candidate was replaced")
-    return StoredConsolidation(operation.key, "candidate", memory)
+    return StoredConsolidation(operation.key, "candidate", memory, receipt)
 
 
 async def get_stored_consolidation(operation: ConsolidationOperation) -> StoredConsolidation | None:
@@ -233,6 +273,23 @@ async def store_consolidation(
     existing = await get_stored_consolidation(operation)
     if existing is not None:
         return existing
+    build_receipt = deepcopy(result.receipt)
+    status = build_receipt.get("status")
+    if (
+        (result.candidate is not None and status != "proposed")
+        or (result.candidate is None and status not in {"abstained", "rejected"})
+        or (
+            status == "abstained"
+            and build_receipt.get("reason") != result.proposal.abstention_reason
+        )
+        or (status in {"abstained", "rejected"} and not build_receipt.get("reason"))
+    ):
+        raise ConsolidationConflict("consolidation receipt disagrees with its outcome")
+    result_kind = "candidate" if result.candidate is not None else "abstained"
+    encoded_receipt = json.dumps(
+        build_receipt, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    )
+    _decode_build_receipt({"result_kind": result_kind, "build_receipt_json": encoded_receipt})
     group = result.group
     if result.candidate is not None and validate_candidate_content_agreement(
         result.candidate, group=group
@@ -412,11 +469,10 @@ async def store_consolidation(
                 ).hexdigest(),
             }
             for source in sources
-        ]
-        if candidate
-        else [],
+        ],
+        "build_receipt_json": encoded_receipt,
         "candidate_id": candidate_id,
-        "result_kind": "candidate" if candidate else "abstained",
+        "result_kind": result_kind,
     }
     async with content_client.surreal_content_client() as client:
         try:

--- a/packages/python/sibyl-core/tests/test_consolidation_receipts.py
+++ b/packages/python/sibyl-core/tests/test_consolidation_receipts.py
@@ -1,0 +1,154 @@
+"""Every terminal consolidation preserves the evidence of its own outcome."""
+
+import json
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.services import content_client
+from sibyl_core.services import eval_publication as p
+from sibyl_core.tasks import consolidation as c
+from tests.test_eval_publication import (
+    admitted_pair as admitted_pair,
+)
+from tests.test_eval_publication import (
+    content_store as content_store,
+)
+from tests.test_eval_publication import (
+    evidence as evidence,
+)
+from tests.test_eval_publication import (
+    proposal as proposal,
+)
+from tests.test_eval_publication import (
+    rows,
+)
+
+
+def negative(result, status):
+    reason = "Evidence is too narrow" if status == "abstained" else "Missing failure support"
+    receipt = deepcopy(result.receipt)
+    receipt.update(
+        status=status,
+        reason=reason,
+        usage={
+            "requests": 2,
+            "input_tokens": 81,
+            "output_tokens": 12,
+            "cost_usd": None,
+            "cost_complete": False,
+            "transport_attempts": [
+                {"status_code": 200, "usage_known": True},
+                {"status_code": 502, "usage_known": False},
+            ],
+            "transport_usage_complete": False,
+        },
+    )
+    return replace(
+        result,
+        candidate=None,
+        receipt=receipt,
+        proposal=c.ProcedureProposal(abstention_reason=reason)
+        if status == "abstained"
+        else result.proposal,
+    )
+
+
+@pytest.mark.parametrize("status", ["abstained", "rejected"])
+async def test_negative_receipt_roundtrip_is_exact_and_terminal(proposal, status):
+    op, result = proposal
+    result = negative(result, status)
+    original = deepcopy(result.receipt)
+    stored = await p.store_consolidation(op, result)
+    assert stored.status == status and stored.memory is None
+    assert stored.build_receipt == original
+    ledger = (await rows("eval_consolidations"))[0]
+    assert json.loads(ledger["build_receipt_json"]) == original
+    assert len(ledger["admission_bindings"]) == len(result.group.episodes) == 2
+    assert len(await rows("raw_captures")) == 2
+    result.receipt["reason"] = "caller changed after storage"
+    # Immutable audit survives later deletion; it is not publication authority.
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query("DELETE raw_captures;")
+    assert await p.store_consolidation(op, result) == stored
+    assert await p.get_stored_consolidation(op) == stored
+    assert stored.build_receipt["usage"]["cost_usd"] is None
+
+
+async def test_candidate_receipt_survives_candidate_purge(proposal):
+    op, result = proposal
+    stored = await p.store_consolidation(op, result)
+    assert stored.build_receipt == result.receipt
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query("DELETE raw_captures WHERE uuid=$id;", id=stored.memory.id)
+    gone = await p.get_stored_consolidation(op)
+    assert gone.status == "gone" and gone.build_receipt == result.receipt
+
+
+@pytest.mark.parametrize("status", ["abstained", "rejected"])
+async def test_negative_receipt_source_race_rolls_back(proposal, monkeypatch, status):
+    op, result = proposal
+    result = negative(result, status)
+    original = content_client.select_many
+
+    async def changing(client, query, **kwargs):
+        records = await original(client, query, **kwargs)
+        if "FROM eval_attempts" in query:
+            await client.execute_query("UPDATE raw_captures SET revision += 1;")
+        return records
+
+    monkeypatch.setattr(content_client, "select_many", changing)
+    with pytest.raises(p.ConsolidationConflict, match="source changed"):
+        await p.store_consolidation(op, result)
+    assert await rows("eval_consolidations") == []
+
+
+async def test_missing_legacy_receipt_stays_unknown_after_upgrade(proposal):
+    op, result = proposal
+    await p.store_consolidation(op, negative(result, "abstained"))
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE eval_consolidations UNSET build_receipt_json; "
+            "REMOVE FIELD build_receipt_json ON eval_consolidations; "
+            "UPDATE schema_version SET version=34 WHERE name='content';"
+        )
+        before = await rows("eval_consolidations")
+        await bootstrap_content_schema(client)
+        after = await rows("eval_consolidations")
+        assert before == after
+        await bootstrap_content_schema(client)
+        assert await rows("eval_consolidations") == after
+    legacy = await p.get_stored_consolidation(op)
+    assert legacy.status == "abstained" and legacy.build_receipt is None
+    assert (await p.store_consolidation(op, result)).build_receipt is None
+
+
+@pytest.mark.parametrize("field,value", [("principal_id", "other"), ("organization_id", "other")])
+async def test_negative_receipt_cannot_cross_authority(proposal, field, value):
+    op, result = proposal
+    await p.store_consolidation(op, negative(result, "abstained"))
+    changed = replace(op, **{field: value})
+    assert await p.get_stored_consolidation(changed) is None
+
+
+@pytest.mark.parametrize("encoded", ["not-json", "null", "[]", "{}", '{"status":"rejected"}'])
+async def test_corrupt_receipt_is_not_legacy_unknown(proposal, encoded):
+    op, result = proposal
+    await p.store_consolidation(op, negative(result, "abstained"))
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE eval_consolidations SET build_receipt_json=$encoded;", encoded=encoded
+        )
+    with pytest.raises(p.ConsolidationConflict, match="receipt is invalid"):
+        await p.get_stored_consolidation(op)
+
+
+async def test_invalid_receipt_cannot_create_terminal_record(proposal):
+    op, result = proposal
+    invalid = negative(result, "abstained")
+    invalid.receipt["schema_version"] = "unknown"
+    with pytest.raises(p.ConsolidationConflict, match="receipt is invalid"):
+        await p.store_consolidation(op, invalid)
+    assert await rows("eval_consolidations") == []

--- a/packages/python/sibyl-core/tests/test_consolidation_receipts.py
+++ b/packages/python/sibyl-core/tests/test_consolidation_receipts.py
@@ -152,3 +152,22 @@ async def test_invalid_receipt_cannot_create_terminal_record(proposal):
     with pytest.raises(p.ConsolidationConflict, match="receipt is invalid"):
         await p.store_consolidation(op, invalid)
     assert await rows("eval_consolidations") == []
+
+
+@pytest.mark.parametrize("kind", ["invalid", "", None, [], {}, "missing"])
+@pytest.mark.parametrize("receipt_present", [False, True])
+def test_receipt_decode_rejects_invalid_or_missing_outcome_kind(kind, receipt_present):
+    ledger = {} if kind == "missing" else {"result_kind": kind}
+    if receipt_present:
+        ledger["build_receipt_json"] = json.dumps(
+            {"schema_version": p.SCHEMA_VERSION, "status": "proposed", "usage": {}},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    with pytest.raises(p.ConsolidationConflict, match="stored consolidation receipt is invalid"):
+        p._decode_build_receipt(ledger)
+
+
+@pytest.mark.parametrize("kind", ["candidate", "abstained"])
+def test_receipt_decode_keeps_valid_legacy_outcome_unavailable(kind):
+    assert p._decode_build_receipt({"result_kind": kind}) is None

--- a/packages/python/sibyl-core/tests/test_eval_publication.py
+++ b/packages/python/sibyl-core/tests/test_eval_publication.py
@@ -149,6 +149,7 @@ async def test_abstention_is_terminal_and_contains_no_source_text(proposal):
     abstention = replace(
         result,
         candidate=None,
+        receipt=result.receipt | {"status": "abstained", "reason": "insufficient support"},
         proposal=c.ProcedureProposal(abstention_reason="insufficient support"),
     )
     assert (await p.store_consolidation(op, abstention)).status == "abstained"

--- a/packages/python/sibyl-core/tests/test_source_integrity.py
+++ b/packages/python/sibyl-core/tests/test_source_integrity.py
@@ -186,7 +186,7 @@ async def test_content_upgrade_from_33_preserves_retained_identity(runtime, cont
         current = (
             await client.execute_query("SELECT version FROM schema_version WHERE name='content';")
         )[0]["version"]
-        assert current == CONTENT_SCHEMA_CURRENT_VERSION == 34
+        assert current == CONTENT_SCHEMA_CURRENT_VERSION
         after = await load_source_snapshot(
             source, organization_id=source.organization_id, execute_query=client.execute_query
         )


### PR DESCRIPTION
A completed consolidation could return a generic abstention with an empty receipt even though extraction produced a specific reason and recorded usage. Structural candidate rejection followed the same path, so callers could not distinguish it from a model abstention.

Persist the existing build receipt for every outcome in the protected consolidation ledger. Canonical JSON preserves explicit nulls (including unknown cost) that Surreal object writes otherwise omit. The ledger also retains the original admission bindings for negative outcomes. Replay returns the original receipt without extracting again, and a purged candidate keeps its audit receipt.

The API reports the actual abstention or rejection reason and marks receipt availability explicitly. Historical rows without retained receipts remain unknown. Invalid stored JSON, schema or outcome data produces an integrity error. Missing and malformed outcome kinds are rejected even when a legacy row has no receipt. Historical receipt replay does not establish current source validity or authorize publication.

## 🛠️ Migration

The additive content migration 35 adds one optional string field after the storage-integrity checkpoint's content 34. The existing protected table permissions, operation identity and atomic source checks remain in place. No historical receipt is reconstructed.

## 🧪 Validation

- The storage/publication selection passed 88 tests, including promotion and source-mutation controls.
- The final receipt selection passed 28 tests covering null preservation, replay, candidate purge, source races, migration, corruption and authority boundaries. An independent run repeated all 28 after the outcome-kind guard was added.
- The API admission suite passed 26 tests, including real reasons, structural rejection and legacy receipt unavailability.
- After integrating the storage checkpoint and current main, the core selection passed 108 cases and exposed one stale fixture asserting schema 34. Removing only the obsolete literal retained its exact current-version and identity checks; the corrected upgrade plus 14 receipt controls passed. Independent review accepted that one-line correction.
- The integrated API suite passed 26 tests. Core and API lint checks and typechecks passed.
- After #535 merged, the branch was rebased onto main. The complete source tree and eight-file change stayed byte-identical; the receipt/upgrade selection passed 15 tests and the API suite passed 26 tests again.

Independent review passed 17 native SDK controls and 26 API tests. The native controls verify exact null preservation, schema upgrade, rollback and replay; the owned test container was removed afterward. The original paid result remains an unknown model-versus-structural outcome; this change does not retroactively recover its reason or cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Consolidation results now include build receipt availability and detailed rejection reasons.
  - Rejected outcomes are explicitly represented alongside candidate, abstained, and unavailable outcomes.
  - Build receipts are retained with consolidation records for audit and status tracking.
  - Receipt-based abstention reasons and historical source-freshness information are now surfaced.

- **Bug Fixes**
  - Consolidation responses now consistently use the most accurate available build receipt, including stored receipts when needed.
  - Invalid or corrupted receipt data is rejected instead of being treated as missing legacy data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->