### PR TITLE
test(installer): qualify unpublished wheels in fresh containers

### DIFF
--- a/moon.yml
+++ b/moon.yml
@@ -1972,3 +1972,31 @@ tasks:
   e2e-down:
     command: docker compose --env-file /dev/null -f compose.e2e.yml down -v
     preset: server
+
+  installer-clean-machine:
+    command: python tools/installer/driver.py
+    inputs:
+      - install.sh
+      - tools/installer/**/*
+      - dist/*.whl
+    options:
+      cache: false
+
+  installer-harness-format:
+    script: |
+      set -eu
+      uv run --no-sync ruff check tools/installer --fix
+      uv run --no-sync ruff format tools/installer
+    options:
+      cache: false
+
+  installer-harness-check:
+    script: |
+      set -eu
+      uv run --no-sync ruff check tools/installer
+      uv run --no-sync ruff format --check tools/installer
+      uv run --no-sync ty check tools/installer
+    inputs:
+      - tools/installer/**/*.py
+    options:
+      cache: false

--- a/moon.yml
+++ b/moon.yml
@@ -759,7 +759,7 @@ tasks:
     command:
       uv run pytest tools/tests/test_runtime_surface.py tools/tests/test_retrieval_mode_history.py
       tools/tests/test_longmemeval_v2_reader_replay.py
-      tools/tests/test_usage_rerank_harness.py -v
+      tools/tests/test_usage_rerank_harness.py tools/tests/test_installer_qualification.py -v
     inputs:
       - tools/**/*.py
       - benchmarks/git_provenance.py

--- a/tools/installer/Dockerfile
+++ b/tools/installer/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.13-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285
+RUN apt-get update && apt-get install --no-install-recommends -y curl procps && rm -rf /var/lib/apt/lists/*
+COPY uv /usr/local/bin/uv
+RUN uv --version && curl --version && ps --version && dpkg-query -W > /bootstrap-packages.txt

--- a/tools/installer/driver.py
+++ b/tools/installer/driver.py
@@ -1,0 +1,77 @@
+"""Prepare and qualify unpublished wheels only in newly owned remote containers."""
+
+import io
+import shlex
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+from uuid import uuid4
+
+root = Path(__file__).resolve().parents[2]
+run_id = "sibyl14-installer-" + uuid4().hex
+remote_root = "/home/dev/dev/eval-runs/" + run_id
+ssh = ["ssh", "-o", "BatchMode=yes", "devbox-stef-gradial-com-main"]
+archive = io.BytesIO()
+with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+    for source, target in [
+        (root / "install.sh", "install.sh"),
+        (root / "tools/installer/qualify.py", "qualify.py"),
+        (root / "tools/installer/Dockerfile", "Dockerfile"),
+    ]:
+        tar.add(source, arcname=target)
+    for wheel in (root / "dist").glob("*.whl"):
+        tar.add(wheel, arcname="wheels/" + wheel.name)
+extract = f'import os,sys,tarfile; os.makedirs({remote_root!r},exist_ok=False);tarfile.open(fileobj=sys.stdin.buffer,mode="r|gz").extractall({remote_root!r},filter="data")'
+subprocess.run(  # noqa: S603 - fixed SSH host and owned payload
+    [*ssh, "env -i PATH=/usr/bin:/bin python3 -c " + shlex.quote(extract)],
+    input=archive.getvalue(),
+    check=True,
+)
+remote = r"""
+import hashlib,json,os,pathlib,shutil,subprocess
+r=pathlib.Path(ROOT)
+name=NAME
+base=pathlib.Path('/home/dev/dev/eval-runs/sibyl14-official-api-67a3b43ea7f44f2a804fc1165a975c44')
+shutil.copyfile('/home/dev/.proto/tools/uv/0.12.5/uv',r/'uv');(r/'uv').chmod(0o755)
+inputs=r/'inputs';inputs.mkdir()
+for item in ('install.sh','qualify.py','wheels'):
+    shutil.move(str(r/item),str(inputs/item))
+results=r/'results';results.mkdir()
+# Freeze input bytes before any installer process exists.
+(r/'inputs.json').write_text(json.dumps({str(p.relative_to(r)):hashlib.sha256(p.read_bytes()).hexdigest() for p in r.rglob('*') if p.is_file()},indent=2))
+env={'PATH':'/usr/bin:/bin','DOCKER_HOST':'unix:///run/devbox-docker/docker.sock'}
+def docker(*args,**kw):return subprocess.run(['/usr/bin/docker',*args],env=env,text=True,**kw)
+with (r/'build.log').open('w') as log:
+    docker('build','--label','sibyl.qualification='+name,'-t',name,str(r),stdout=log,stderr=subprocess.STDOUT).check_returncode()
+image=json.loads(subprocess.check_output(['/usr/bin/docker','image','inspect',name],env=env))[0]
+(r/'image.json').write_text(json.dumps(image,indent=2))
+assert image['Config']['Labels']['sibyl.qualification']==name
+for mode in ('remote','daemon','bootstrap'):
+    cname=name+'-'+mode
+    try:
+        with (r/(mode+'.log')).open('w') as log:
+            result=docker('run','--name',cname,'--hostname',cname,'--env','SIBYL_INSTALLER_RUN_ID='+name,'--env','SIBYL_INSTALLER_ROLE='+mode,'--label','sibyl.qualification='+name,'--cap-drop=ALL','--security-opt=no-new-privileges','--mount','type=bind,source='+str(inputs)+',target=/input,readonly','--mount','type=bind,source='+str(results)+',target=/output','--entrypoint','python',image['Id'],'/input/qualify.py',('remote' if mode=='bootstrap' else mode),'--inputs','/input','--output','/output/'+mode,*(['--bootstrap'] if mode=='bootstrap' else []),stdout=log,stderr=subprocess.STDOUT)
+        result.check_returncode()
+    finally:
+        check=docker('inspect',cname,capture_output=True)
+        if check.returncode==0:
+            data=json.loads(check.stdout)[0]
+            assert data['Config']['Labels']['sibyl.qualification']==name and data['Image']==image['Id']
+            (r/(mode+'-container.json')).write_text(json.dumps(data,indent=2))
+            removed=docker('rm','-f','-v',cname,capture_output=True)
+            absent=docker('inspect',cname,capture_output=True).returncode != 0
+            (r/(mode+'-cleanup.json')).write_text(json.dumps({'container_id':data['Id'],'remove_exit':removed.returncode,'container_absent':absent,'host_ports':data['HostConfig'].get('PortBindings')},indent=2))
+            removed.check_returncode()
+            assert absent
+        expected=json.loads((r/'inputs.json').read_text())
+        assert all(hashlib.sha256((r/path).read_bytes()).hexdigest()==digest for path,digest in expected.items())
+        (r/(mode+'-input-verification.json')).write_text(json.dumps({'verified_files':len(expected),'unchanged':True}))
+print('QUALIFIED',str(r),flush=True)
+""".replace("ROOT", repr(remote_root)).replace("NAME", repr(run_id))
+sys.stdout.write(f"OWNED_ROOT {remote_root}\n")
+sys.stdout.flush()
+result = subprocess.run(  # noqa: S603 - fixed SSH host and owned payload
+    [*ssh, "env -i PATH=/usr/bin:/bin python3 -"], input=remote, text=True, check=False
+)
+raise SystemExit(result.returncode)

--- a/tools/installer/qualify.py
+++ b/tools/installer/qualify.py
@@ -1,0 +1,197 @@
+"""Run the actual installer against an isolated index inside an owned container."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.server
+import json
+import os
+import re
+import socket
+import subprocess
+import threading
+import urllib.request
+import zipfile
+from functools import partial
+from pathlib import Path
+
+
+def require_owned_container(inputs: Path, output: Path, run_id: str, role: str) -> None:
+    """Refuse host execution and writable aliases before bootstrap mutations."""
+    if not Path("/.dockerenv").is_file():
+        raise RuntimeError("owned Docker container required")
+    if not re.fullmatch(r"sibyl14-installer-[0-9a-f]{32}", run_id):
+        raise RuntimeError("explicit owned run identity required")
+    if role not in {"remote", "daemon", "bootstrap"} or socket.gethostname() != f"{run_id}-{role}":
+        raise RuntimeError("owned container hostname mismatch")
+    if inputs != Path("/input") or output != Path("/output") / role:
+        raise RuntimeError("canonical isolated paths required")
+    mounts = {}
+    for line in Path("/proc/self/mountinfo").read_text().splitlines():
+        fields = line.split()
+        if fields[4] in {"/input", "/output"}:
+            mounts[fields[4]] = (Path(fields[3]), set(fields[5].split(",")))
+    if set(mounts) != {"/input", "/output"}:
+        raise RuntimeError("dedicated input and output mounts required")
+    source, flags = mounts["/input"]
+    results, _ = mounts["/output"]
+    if "ro" not in flags or run_id not in source.parts or run_id not in results.parts:
+        raise RuntimeError("owned read-only input mount required")
+    if source.is_relative_to(results) or results.is_relative_to(source):
+        raise RuntimeError("input and output mounts overlap")
+
+
+def prepare_index(inputs: Path, output: Path):
+    index = output / "index"
+    index.mkdir()
+    artifacts = {}
+    for wheel in sorted((inputs / "wheels").glob("*.whl")):
+        name = wheel.name.split("-")[0].replace("_", "-")
+        if name in artifacts or name not in {"sibyl-core", "sibyl-dev", "sibyld"}:
+            raise RuntimeError("unexpected or duplicate wheel: " + name)
+        package = index / "simple" / name
+        package.mkdir(parents=True)
+        data = wheel.read_bytes()
+        digest = hashlib.sha256(data).hexdigest()
+        (package / wheel.name).write_bytes(data)
+        (package / "index.html").write_text(
+            f'<a href="{wheel.name}#sha256={digest}">{wheel.name}</a>\n'
+        )
+        artifacts[name] = {"wheel": wheel.name, "sha256": digest}
+    if not {"sibyl-core", "sibyl-dev", "sibyld"} <= artifacts.keys():
+        raise RuntimeError("all unpublished Sibyl wheels are mandatory")
+    handler = partial(http.server.SimpleHTTPRequestHandler, directory=str(index))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return artifacts, server
+
+
+def verify_installation(home, inputs, artifacts, env, mode):
+    receipt = {}
+    tools = ["sibyl-dev"] + (["sibyld"] if mode == "daemon" else [])
+    verified = {}
+    for tool in tools:
+        venv = home / ".local/share/uv/tools" / tool
+        for name in ["sibyl-core", tool]:
+            wheel = inputs / "wheels" / artifacts[name]["wheel"]
+            script = 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
+            site = Path(
+                subprocess.check_output(  # noqa: S603 - interpreter under fresh owned tool environment
+                    [str(venv / "bin/python"), "-c", script], env=env, text=True
+                ).strip()
+            )
+            with zipfile.ZipFile(wheel) as archive:
+                files = [
+                    p
+                    for p in archive.namelist()
+                    if not p.endswith("/") and not p.endswith(".dist-info/RECORD")
+                ]
+                for path in files:
+                    if (site / path).read_bytes() != archive.read(path):
+                        raise RuntimeError(f"installed wheel mismatch: {name}:{path}")
+                verified[f"{tool}:{name}"] = len(files)
+    receipt["verified_wheel_files"] = verified
+    inventory_script = 'import importlib.metadata,json; print(json.dumps({d.metadata["Name"]:d.version for d in importlib.metadata.distributions()},sort_keys=True))'
+    receipt["installed_distributions"] = {
+        tool: json.loads(
+            subprocess.check_output(  # noqa: S603 - interpreter under fresh owned tool environment
+                [
+                    str(home / ".local/share/uv/tools" / tool / "bin/python"),
+                    "-c",
+                    inventory_script,
+                ],
+                env=env,
+                text=True,
+            )
+        )
+        for tool in tools
+    }
+    if mode == "daemon":
+        with urllib.request.urlopen(
+            "http://127.0.0.1:3334/api/health/ready", timeout=5
+        ) as response:
+            receipt["api_readiness"] = {
+                "status": response.status,
+                "body": json.loads(response.read()),
+            }
+        receipt["daemon_pid"] = int((home / ".sibyl/run/sibyld.pid").read_text())
+    return receipt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("remote", "daemon"))
+    parser.add_argument("--bootstrap", action="store_true")
+    parser.add_argument("--inputs", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if Path("/var/run/docker.sock").exists():
+        raise RuntimeError("qualification must not have a Docker socket")
+    output = args.output.resolve()
+    inputs = args.inputs.resolve()
+    require_owned_container(
+        inputs,
+        output,
+        os.environ.get("SIBYL_INSTALLER_RUN_ID", ""),
+        os.environ.get("SIBYL_INSTALLER_ROLE", ""),
+    )
+    output.mkdir(parents=True, exist_ok=False)
+    inputs = args.inputs.resolve()
+    home = output / "home"
+    home.mkdir()
+    if args.bootstrap:
+        Path("/usr/local/bin/uv").rename("/usr/local/bin/uv-unused")
+    receipt = {
+        "mode": args.mode,
+        "provider_credentials": False,
+        "dependency_resolution": "installer_default_unconstrained",
+    }
+    server = None
+    try:
+        artifacts, server = prepare_index(inputs, output)
+        env = {
+            "HOME": str(home),
+            "PATH": "/usr/local/bin:/usr/bin:/bin",
+            "NO_COLOR": "1",
+            "UV_INDEX": f"http://127.0.0.1:{server.server_port}/simple",
+            "UV_DEFAULT_INDEX": "https://pypi.org/simple",
+            "UV_INDEX_STRATEGY": "first-index",
+            "UV_CACHE_DIR": str(output / "cache"),
+            "UV_NO_ENV_FILE": "1",
+        }
+        receipt["artifacts"] = artifacts
+        with (output / "installer.log").open("wb") as log:
+            result = subprocess.run(  # noqa: S603 - owned installer and fixed argument choices
+                [
+                    "/bin/sh",
+                    str(inputs / "install.sh"),
+                    "--" + args.mode,
+                    "--version",
+                    "1.3.2",
+                    "--no-open",
+                ],
+                env=env,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+        receipt["installer_exit"] = result.returncode
+        receipt["bootstrap_without_uv"] = args.bootstrap
+        uv_binary = home / ".local/bin/uv" if args.bootstrap else Path("/usr/local/bin/uv")
+        if uv_binary.exists():
+            receipt["uv_binary_sha256"] = hashlib.sha256(uv_binary.read_bytes()).hexdigest()
+        result.check_returncode()
+        receipt.update(verify_installation(home, inputs, artifacts, env, args.mode))
+        receipt["status"] = "passed"
+    except Exception as exc:
+        receipt.update(status="failed", error_category=type(exc).__name__, error=str(exc))
+        raise
+    finally:
+        if server is not None:
+            server.shutdown()
+        (output / "receipt.json").write_text(json.dumps(receipt, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/installer/qualify.py
+++ b/tools/installer/qualify.py
@@ -13,6 +13,7 @@ import subprocess
 import threading
 import urllib.request
 import zipfile
+from email.parser import Parser
 from functools import partial
 from pathlib import Path
 
@@ -40,6 +41,28 @@ def require_owned_container(inputs: Path, output: Path, run_id: str, role: str) 
         raise RuntimeError("owned read-only input mount required")
     if source.is_relative_to(results) or results.is_relative_to(source):
         raise RuntimeError("input and output mounts overlap")
+
+
+def wheel_release(wheels: list[Path]) -> str:
+    """Require one coherent release before serving any unpublished artifact."""
+    expected = {"sibyl-core", "sibyl-dev", "sibyld"}
+    releases = {}
+    for wheel in wheels:
+        with zipfile.ZipFile(wheel) as archive:
+            metadata = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+            if len(metadata) != 1:
+                raise RuntimeError("wheel requires exactly one METADATA record")
+            record = Parser().parsestr(archive.read(metadata[0]).decode())
+        name = str(record.get("Name", "")).lower().replace("_", "-")
+        version = str(record.get("Version", "")).strip()
+        if name not in expected or name in releases or not version:
+            raise RuntimeError("unexpected, duplicate, or unversioned wheel metadata")
+        if wheel.name.split("-")[0].replace("_", "-") != name:
+            raise RuntimeError("wheel filename disagrees with metadata identity")
+        releases[name] = version
+    if set(releases) != expected or len(set(releases.values())) != 1:
+        raise RuntimeError("all three wheel releases must agree")
+    return releases["sibyl-core"]
 
 
 def prepare_index(inputs: Path, output: Path):
@@ -149,6 +172,8 @@ def main() -> None:
     }
     server = None
     try:
+        version = wheel_release(sorted((inputs / "wheels").glob("*.whl")))
+        receipt["artifact_version"] = version
         artifacts, server = prepare_index(inputs, output)
         env = {
             "HOME": str(home),
@@ -168,7 +193,7 @@ def main() -> None:
                     str(inputs / "install.sh"),
                     "--" + args.mode,
                     "--version",
-                    "1.3.2",
+                    version,
                     "--no-open",
                 ],
                 env=env,

--- a/tools/tests/test_installer_qualification.py
+++ b/tools/tests/test_installer_qualification.py
@@ -1,0 +1,37 @@
+"""Reject mixed unpublished releases before starting the private index."""
+
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+from tools.installer.qualify import wheel_release
+
+
+def wheels(root: Path, versions: tuple[str, str, str]) -> list[Path]:
+    paths = []
+    for name, version in zip(("sibyl_core", "sibyl_dev", "sibyld"), versions, strict=True):
+        path = root / f"{name}-{version}-py3-none-any.whl"
+        with ZipFile(path, "w") as archive:
+            archive.writestr(
+                f"{name}-{version}.dist-info/METADATA",
+                f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n",
+            )
+        paths.append(path)
+    return paths
+
+
+def test_release_uses_wheel_metadata(tmp_path):
+    assert wheel_release(wheels(tmp_path, ("1.4.0", "1.4.0", "1.4.0"))) == "1.4.0"
+
+
+def test_mixed_releases_rejected(tmp_path):
+    with pytest.raises(RuntimeError, match="releases must agree"):
+        wheel_release(wheels(tmp_path, ("1.4.0", "1.3.2", "1.4.0")))
+
+
+def test_missing_and_duplicate_project_wheels_rejected(tmp_path):
+    artifacts = wheels(tmp_path, ("1.4.0", "1.4.0", "1.4.0"))
+    with pytest.raises(RuntimeError, match="releases must agree"):
+        wheel_release(artifacts[:2])
+    with pytest.raises(RuntimeError, match="duplicate"):
+        wheel_release([*artifacts, artifacts[0]])


### PR DESCRIPTION
The existing installer tests use command stubs, so they cannot establish that unpublished Sibyl packages install and start on a fresh machine. This change adds an opt-in remote qualification task that runs the actual installer in disposable containers against a private index containing exactly the three locally built wheels.

The harness checks every installed Sibyl wheel file against the input artifact, records resolved dependency versions, and exercises remote, daemon, and missing-uv bootstrap modes. Wheel metadata must declare one matching release before the index starts. Each run gets fresh homes and caches, separate read-only inputs, explicit container identity checks, and cleanup receipts. The operational driver currently targets the configured Gradial development box; it does not run as part of ordinary CI.

## 🧪 Validation

- Built the three unpublished package wheels from the captured source commit (`e1ee331e`), whose package metadata is still version 1.3.2. No release or registry publication occurred.
- Ran all three modes with default dependency resolution and no dependency constraints. Independent repetition passed in 37.9 seconds; the guarded run passed in 43.0 seconds. Remote/bootstrap verified 325 installed files each, and daemon verified 824 files plus native API readiness HTTP 200.
- Verified seven input hashes unchanged after each mode and confirmed owned containers removed with no host ports published.
- Passed independent container-boundary controls and metadata-selection controls, the 185-test inventory suite, and focused lint/type checks. The later metadata-selection change was checked against the actual built wheels and offline fixtures; the native installation receipts precede that small change.

Full default-server/UI installation, first-memory behavior, and qualification against the eventual release source remain separate open gates. Dependency versions are retained, but upstream transitive download artifact hashes are not yet a complete receipt. This PR adds the remote/daemon qualification surface and does not claim those remaining release gates passed.
