### PR TITLE
fix(memory): distinguish provisional candidates from proven transfer

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -43,8 +43,14 @@ SHA256 = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
 RETROSPECTIVE_REQUEST = (
     "Assess whether the contrast across these completed historical episodes supports "
     "a reusable conditional procedure for a future agent facing similar conditions. "
-    "Consider both successful and failed outcomes. If the evidence cannot support "
-    "such a procedure, abstain and identify the missing support or uncertainty."
+    "Consider both successful and failed outcomes. The output is an unverified "
+    "conditional candidate, not a claim of demonstrated transfer. Limit its "
+    "applicability to conditions supported by the evidence. Shared task families "
+    "or environments neither establish nor disqualify a candidate; evidence from "
+    "different domains or environments is not required at this stage. Transfer "
+    "must be evaluated separately, not asserted from these episodes. If the "
+    "contrast cannot support useful conditions, actions and checks, abstain and "
+    "identify the missing support or uncertainty."
 )
 SYSTEM_PROMPT = (
     "You are performing retrospective memory consolidation. You are not the agent "

--- a/packages/python/sibyl-core/tests/ai/llm/test_retrospective_consolidation.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_retrospective_consolidation.py
@@ -26,9 +26,27 @@ async def test_native_retrospective_request_preserves_both_valid_outcomes(
 ):
     monkeypatch.setattr(extraction, "reserve_llm_budget", AsyncMock())
     source = _contrast_group() if projected else group
-    # Both fixtures deliberately use one family and compatible environments.
+    source = c.ConsolidationGroup.model_validate(
+        source.model_copy(
+            update={
+                "episodes": tuple(
+                    episode.model_copy(
+                        update={
+                            "environment": episode.environment | {"execution_label": f"run-{i}"}
+                        }
+                    )
+                    for i, episode in enumerate(source.episodes)
+                )
+            }
+        )
+    )
+    # Compatibility is bounded to declared keys, not every observation.
     assert len({episode.family_id for episode in source.episodes}) == 1
-    assert all(episode.environment == source.episodes[0].environment for episode in source.episodes)
+    assert all(
+        len({episode.environment[key] for episode in source.episodes}) == 1
+        for key in source.environment_compatibility_keys
+    )
+    assert len({episode.environment["execution_label"] for episode in source.episodes}) > 1
     reason = "The evidence does not identify an action and check that distinguish the outcomes."
     if projected:
         output = {

--- a/packages/python/sibyl-core/tests/ai/llm/test_retrospective_consolidation.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_retrospective_consolidation.py
@@ -26,7 +26,10 @@ async def test_native_retrospective_request_preserves_both_valid_outcomes(
 ):
     monkeypatch.setattr(extraction, "reserve_llm_budget", AsyncMock())
     source = _contrast_group() if projected else group
-    reason = "The different outcomes do not isolate which condition caused the difference."
+    # Both fixtures deliberately use one family and compatible environments.
+    assert len({episode.family_id for episode in source.episodes}) == 1
+    assert all(episode.environment == source.episodes[0].environment for episode in source.episodes)
+    reason = "The evidence does not identify an action and check that distinguish the outcomes."
     if projected:
         output = {
             "outcome": {"kind": "procedure", **_proposal()}
@@ -97,6 +100,11 @@ async def test_native_retrospective_request_preserves_both_valid_outcomes(
     assert "retrospective memory consolidation" in wire["instructions"]
     assert "not the agent executing any recorded task" in wire["instructions"]
     assert c.RETROSPECTIVE_REQUEST in wire["instructions"]
+    assert "unverified conditional candidate" in wire["instructions"]
+    assert "neither establish nor disqualify" in wire["instructions"]
+    assert "different domains or environments is not required" in wire["instructions"]
+    assert "Transfer must be evaluated separately" in wire["instructions"]
+    assert "cannot support useful conditions, actions and checks, abstain" in wire["instructions"]
     user_input = next(item["content"] for item in wire["input"] if item.get("role") == "user")
     assert user_input.endswith(c.RETROSPECTIVE_REQUEST)
     assert (
@@ -107,6 +115,8 @@ async def test_native_retrospective_request_preserves_both_valid_outcomes(
     assert result.receipt["usage"]["input_tokens"] == 31
     assert result.receipt["usage"]["output_tokens"] == 17
     assert result.receipt["output_retries"] == 2
+    assert result.receipt["transfer"] == "not_measured"
+    assert result.receipt["entailment"] == "pending"
     if outcome == "abstention":
         assert result.candidate is None and result.receipt["reason"] == reason
         assert result.receipt["status"] == "abstained"


### PR DESCRIPTION
A consolidation run abstained because its evidence came from one task family and environment. The extractor was demanding demonstrated cross-domain transfer before producing an artifact that the system already treats as an unverified conditional candidate.

The shared request now asks for applicability bounded by the evidence and leaves transfer evaluation to the later validation stage. A shared family or environment neither establishes nor disqualifies a candidate. Missing support for useful conditions, actions or checks still calls for abstention. The clarified request reaches both raw and projected evidence paths and changes the existing extraction-policy fingerprint.

## 🧪 Validation

The focused core suite passed 90 tests, the admission API suite passed 26, and core lint/typecheck passed. Native SDK mock controls cover a same-family candidate and an insufficient-evidence abstention on both evidence paths, inspect the actual prompt, and preserve `transfer=not_measured`.

These checks establish prompt propagation and output handling. Model compliance and learning efficacy require a separate live diagnostic; this change does not claim either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Retrospective analysis now clearly distinguishes unverified conditional candidates from demonstrated transfer claims.
  - Shared task families or compatible environments no longer automatically establish or disqualify a candidate.
  - Cross-domain evidence is not required at this stage; transfer is evaluated separately.
  - The system now abstains when available evidence cannot support useful conditions, actions, and checks.
  - Results more clearly indicate when transfer has not been measured and entailment remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->