### PR TITLE
feat(archives): preserve source lineage and permanent restore history

### DIFF
--- a/apps/api/src/sibyl/api/routes/admin.py
+++ b/apps/api/src/sibyl/api/routes/admin.py
@@ -451,6 +451,12 @@ async def create_backup(
         relationship_count=result.backup_data.relationship_count,
         entities=result.backup_data.entities,
         relationships=result.backup_data.relationships,
+        episode_count=result.backup_data.episode_count,
+        mention_count=result.backup_data.mention_count,
+        episodes=result.backup_data.episodes,
+        mentions=result.backup_data.mentions,
+        source_integrity=result.backup_data.source_integrity,
+        lineage_validation=result.backup_data.lineage_validation,
     )
 
     return BackupResponse(
@@ -489,6 +495,12 @@ async def restore_backup_endpoint(
         relationship_count=request.backup_data.relationship_count,
         entities=request.backup_data.entities,
         relationships=request.backup_data.relationships,
+        episode_count=request.backup_data.episode_count,
+        mention_count=request.backup_data.mention_count,
+        episodes=request.backup_data.episodes,
+        mentions=request.backup_data.mentions,
+        source_integrity=request.backup_data.source_integrity,
+        lineage_validation=request.backup_data.lineage_validation,
     )
 
     result = await do_restore(
@@ -505,6 +517,8 @@ async def restore_backup_endpoint(
         relationships_skipped=result.relationships_skipped,
         errors=result.errors,
         duration_seconds=result.duration_seconds,
+        integrity_conflicts=result.integrity_conflicts,
+        quarantined=result.quarantined,
     )
 
 

--- a/apps/api/src/sibyl/api/schemas/admin.py
+++ b/apps/api/src/sibyl/api/schemas/admin.py
@@ -133,6 +133,12 @@ class BackupDataSchema(BaseModel):
     relationship_count: int
     entities: list[dict]
     relationships: list[dict]
+    episode_count: int = 0
+    mention_count: int = 0
+    episodes: list[dict] = Field(default_factory=list)
+    mentions: list[dict] = Field(default_factory=list)
+    source_integrity: dict[str, Any] | None = None
+    lineage_validation: list[dict[str, str]] = Field(default_factory=list)
 
 
 class BackupResponse(BaseModel):
@@ -163,6 +169,8 @@ class RestoreResponse(BaseModel):
     relationships_skipped: int
     errors: list[str]
     duration_seconds: float
+    integrity_conflicts: list[dict[str, str]] = Field(default_factory=list)
+    quarantined: list[dict[str, str]] = Field(default_factory=list)
 
 
 class BackfillRequest(BaseModel):

--- a/apps/api/src/sibyl/cli/db.py
+++ b/apps/api/src/sibyl/cli/db.py
@@ -514,6 +514,8 @@ def _coerce_graph_backup_data(payload: dict[str, object], org_id: str):
         mention_count=_count("mention_count", len(mentions)),
         episodes=episodes,
         mentions=mentions,
+        source_integrity=payload.get("source_integrity"),
+        lineage_validation=payload.get("lineage_validation", []),
     )
 
 
@@ -616,6 +618,17 @@ def restore_db(
                 skip_existing=skip_existing,
             )
 
+            if result.quarantined:
+                warn(
+                    f"Quarantined {len(result.quarantined)} memories with unverifiable lineage; content is retained."
+                )
+                info(
+                    "Reauthor reviewed content through POST /api/memory/raw with a new source_id; the original remains quarantined."
+                )
+            if result.integrity_conflicts:
+                warn(
+                    f"Preserved {len(result.integrity_conflicts)} destination source histories that conflict with the archive."
+                )
             if result.success:
                 success("Restore complete!")
             else:

--- a/apps/api/src/sibyl/cli/migrate.py
+++ b/apps/api/src/sibyl/cli/migrate.py
@@ -792,6 +792,8 @@ def _report_restore_integrity(
     reasons = {
         "retained_tombstone": "retained deletion history",
         "retained_high_water": "retained source generation",
+        "retained_source_revocation": "retained source visibility restriction",
+        "retained_source_authority": "retained source audience",
         "existing_source_preserved": "existing source preserved",
         "incoming_lineage_not_adopted": "incoming lineage not adopted",
         "captured_dependency_mismatch": "source evidence changed",

--- a/apps/api/src/sibyl/cli/migrate.py
+++ b/apps/api/src/sibyl/cli/migrate.py
@@ -7,6 +7,7 @@ import secrets
 import shlex
 import shutil
 import subprocess
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
@@ -784,6 +785,38 @@ def _restore_auth_payload(payload: dict[str, object], *, clean: bool) -> bool:
     return _restore()
 
 
+def _report_restore_integrity(
+    *, integrity_conflicts: list[dict[str, str]], quarantined: list[dict[str, str]]
+) -> None:
+    """Summarize restore decisions without echoing archive-controlled text or identities."""
+    reasons = {
+        "retained_tombstone": "retained deletion history",
+        "retained_high_water": "retained source generation",
+        "existing_source_preserved": "existing source preserved",
+        "incoming_lineage_not_adopted": "incoming lineage not adopted",
+        "captured_dependency_mismatch": "source evidence changed",
+        "external_dependency_omitted": "source dependency absent",
+        "unverifiable_legacy_lineage": "unverifiable legacy lineage",
+    }
+    for records, summary in (
+        (integrity_conflicts, "destination source histories preserved instead of replaced"),
+        (quarantined, "memories quarantined with content retained"),
+    ):
+        if not records:
+            continue
+        warn(f"  {summary.capitalize()}: {len(records)}.")
+        counts = Counter(
+            reasons.get(row.get("reason", ""), "unspecified reason") for row in records
+        )
+        for reason, count in sorted(counts.items()):
+            info(f"    {reason}: {count}")
+    if quarantined:
+        info(
+            "  Reauthor reviewed content through POST /api/memory/raw with a new source_id; "
+            "the original remains quarantined."
+        )
+
+
 def _restore_content_payload(
     payload: dict[str, object], *, clean: bool, global_scope: bool = False
 ) -> bool:
@@ -793,9 +826,12 @@ def _restore_content_payload(
             result = await restore_content_archive_payload(
                 payload, clean=clean, global_scope=global_scope
             )
+            _report_restore_integrity(
+                integrity_conflicts=result.integrity_conflicts, quarantined=result.quarantined
+            )
             if result.success:
                 success(
-                    "  Content restored: "
+                    "  Content writes applied: "
                     f"{result.rows_restored} rows across {result.tables_restored} tables"
                 )
             else:
@@ -829,9 +865,12 @@ def _restore_graph_payload(backup_dict: dict[str, object], org_id: str, *, clean
                 clean=clean,
             )
 
+            _report_restore_integrity(
+                integrity_conflicts=result.integrity_conflicts, quarantined=result.quarantined
+            )
             if result.success:
                 success(
-                    f"  Graph restored: {result.entities_restored} entities, "
+                    f"  Graph writes applied: {result.entities_restored} entities, "
                     f"{result.relationships_restored} relationships"
                 )
             else:

--- a/apps/api/src/sibyl/cli/migrate.py
+++ b/apps/api/src/sibyl/cli/migrate.py
@@ -784,11 +784,15 @@ def _restore_auth_payload(payload: dict[str, object], *, clean: bool) -> bool:
     return _restore()
 
 
-def _restore_content_payload(payload: dict[str, object], *, clean: bool) -> bool:
+def _restore_content_payload(
+    payload: dict[str, object], *, clean: bool, global_scope: bool = False
+) -> bool:
     @run_async
     async def _restore() -> bool:
         try:
-            result = await restore_content_archive_payload(payload, clean=clean)
+            result = await restore_content_archive_payload(
+                payload, clean=clean, global_scope=global_scope
+            )
             if result.success:
                 success(
                     "  Content restored: "
@@ -816,12 +820,13 @@ def _restore_graph_payload(backup_dict: dict[str, object], org_id: str, *, clean
 
         try:
             backup_data = _coerce_graph_backup_data(backup_dict, org_id)
-            await _prepare_graph_runtime_async(org_id, clean=clean)
+            await _prepare_graph_runtime_async(org_id, clean=False)
 
             result = await restore_backup(
                 backup_data,
                 organization_id=org_id,
                 skip_existing=not clean,
+                clean=clean,
             )
 
             if result.success:
@@ -840,7 +845,7 @@ def _restore_graph_payload(backup_dict: dict[str, object], org_id: str, *, clean
     return _restore()
 
 
-def _bootstrap_surreal_runtimes(*, clean: bool) -> None:
+def _bootstrap_surreal_runtimes() -> None:
     """Bootstrap SCHEMAFULL tables + indexes in surreal auth and content namespaces.
 
     Runs unconditionally during import so namespaces are queryable even when the
@@ -855,10 +860,10 @@ def _bootstrap_surreal_runtimes(*, clean: bool) -> None:
     @run_async
     async def _bootstrap() -> None:
         info("Bootstrapping Surreal auth schema...")
-        await bootstrap_auth_schema(build_surreal_auth_client(), reset=clean)
+        await bootstrap_auth_schema(build_surreal_auth_client(), reset=False)
         if settings.store == "surreal":
             info("Bootstrapping Surreal content schema...")
-            await bootstrap_content_schema(build_surreal_content_client(), reset=clean)
+            await bootstrap_content_schema(build_surreal_content_client(), reset=False)
 
     _bootstrap()
 
@@ -1696,6 +1701,20 @@ def export_archive(
         )
         raise typer.Exit(code=1)
 
+    from sibyl_core.migrate.archive_lineage import seal_archive_lineage
+
+    sealed_graph, sealed_content, lineage_report = seal_archive_lineage(
+        json.loads(files[GRAPH_FILENAME]) if GRAPH_FILENAME in files else None,
+        json.loads(files[CONTENT_FILENAME]) if CONTENT_FILENAME in files else None,
+    )
+    for name, sealed_payload in (
+        (GRAPH_FILENAME, sealed_graph),
+        (CONTENT_FILENAME, sealed_content),
+    ):
+        if sealed_payload is not None:
+            files[name] = (json.dumps(sealed_payload, indent=2, default=str) + "\n").encode()
+    archive_metadata["lineage_validation"] = lineage_report
+
     manifest = build_manifest(
         organization_id=org_id,
         source_store=settings.store,
@@ -1749,6 +1768,13 @@ def import_archive(
             help="Restore content payload into Surreal content storage",
         ),
     ] = True,
+    global_content_scope: Annotated[
+        bool,
+        typer.Option(
+            "--global-content-scope",
+            help="Explicitly permit restoring all organizations in the content namespace",
+        ),
+    ] = False,
 ) -> None:
     """Import a manifest archive into the active store."""
     archive = _load_valid_archive(source)
@@ -1780,7 +1806,7 @@ def import_archive(
             info("Cancelled")
             return
 
-    _bootstrap_surreal_runtimes(clean=clean)
+    _bootstrap_surreal_runtimes()
 
     if restore_auth and AUTH_FILENAME in archive.files:
         info("Restoring auth payload into Surreal auth storage...")
@@ -1792,7 +1818,9 @@ def import_archive(
     if restore_content and CONTENT_FILENAME in archive.files and settings.store == "surreal":
         info("Restoring content payload into Surreal content storage...")
         payload = content_payload_from_archive(archive)
-        if payload is None or not _restore_content_payload(payload, clean=clean):
+        if payload is None or not _restore_content_payload(
+            payload, clean=clean, global_scope=global_content_scope
+        ):
             error("Content import failed")
             raise typer.Exit(code=1)
 
@@ -2043,6 +2071,13 @@ def rehearse_archive(
         int,
         typer.Option("--sample-size", help="How many entity IDs to spot-check during verify"),
     ] = 10,
+    global_content_scope: Annotated[
+        bool,
+        typer.Option(
+            "--global-content-scope",
+            help="Explicitly permit restoring all organizations in the content namespace",
+        ),
+    ] = False,
 ) -> None:
     """Run an import + verify + baseline smoke rehearsal against the active store."""
     archive = _load_valid_archive(source)
@@ -2075,7 +2110,7 @@ def rehearse_archive(
             info("Cancelled")
             return
 
-    _bootstrap_surreal_runtimes(clean=clean)
+    _bootstrap_surreal_runtimes()
 
     if restore_auth and AUTH_FILENAME in archive.files:
         info("Restoring auth payload into Surreal auth storage...")
@@ -2087,7 +2122,9 @@ def rehearse_archive(
     if restore_content and CONTENT_FILENAME in archive.files and settings.store == "surreal":
         info("Restoring content payload into Surreal content storage...")
         payload = content_payload_from_archive(archive)
-        if payload is None or not _restore_content_payload(payload, clean=clean):
+        if payload is None or not _restore_content_payload(
+            payload, clean=clean, global_scope=global_content_scope
+        ):
             error("Content import failed")
             raise typer.Exit(code=1)
 
@@ -2263,6 +2300,13 @@ def cutover_archive(
             help="Acknowledge that rollback is no longer promised once writes reopen on SurrealDB",
         ),
     ] = False,
+    global_content_scope: Annotated[
+        bool,
+        typer.Option(
+            "--global-content-scope",
+            help="Explicitly permit restoring all organizations in the content namespace",
+        ),
+    ] = False,
 ) -> None:
     """Run the explicit Surreal cutover acceptance gate on a validated archive."""
     _require_cutover_surreal_runtime()
@@ -2312,7 +2356,7 @@ def cutover_archive(
             info("Cancelled")
             return
 
-    _bootstrap_surreal_runtimes(clean=clean)
+    _bootstrap_surreal_runtimes()
 
     if restore_auth and AUTH_FILENAME in archive.files:
         info("Importing auth payload into the Surreal auth runtime...")
@@ -2324,7 +2368,9 @@ def cutover_archive(
     if restore_content and CONTENT_FILENAME in archive.files and settings.store == "surreal":
         info("Importing content payload into the Surreal content runtime...")
         payload = content_payload_from_archive(archive)
-        if payload is None or not _restore_content_payload(payload, clean=clean):
+        if payload is None or not _restore_content_payload(
+            payload, clean=clean, global_scope=global_content_scope
+        ):
             error("Content import failed")
             raise typer.Exit(code=1)
 

--- a/apps/api/src/sibyl/jobs/backup.py
+++ b/apps/api/src/sibyl/jobs/backup.py
@@ -60,6 +60,7 @@ class BackupMetadata:
     graph_entities: int
     graph_relationships: int
     files: dict[str, str] = field(default_factory=dict)  # filename -> sha256
+    lineage_validation: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -352,6 +353,30 @@ async def run_backup(  # noqa: PLR0915
                     log.exception("backup_graph_failed", backup_id=backup_id, error=str(e))
                     raise
 
+            from sibyl_core.migrate.archive_lineage import seal_archive_lineage
+
+            captured_graph = (
+                await asyncio.to_thread(lambda: json.loads(graph_file.read_text()))
+                if graph_file.exists()
+                else None
+            )
+            captured_content = (
+                await asyncio.to_thread(lambda: json.loads(content_file.read_text()))
+                if content_file.exists()
+                else None
+            )
+            sealed_graph, sealed_content, lineage_report = seal_archive_lineage(
+                captured_graph, captured_content
+            )
+            if sealed_graph is not None:
+                graph_size = await _write_json_file_async(graph_file, sealed_graph, default=str)
+                file_checksums["graph.json"] = await _sha256_file_async(graph_file)
+            if sealed_content is not None:
+                content_size = await _write_json_file_async(
+                    content_file, sealed_content, default=str
+                )
+                file_checksums["content.json"] = await _sha256_file_async(content_file)
+
             # Step 4: Create metadata
             metadata = BackupMetadata(
                 version=BACKUP_VERSION,
@@ -362,6 +387,7 @@ async def run_backup(  # noqa: PLR0915
                 graph_entities=entity_count,
                 graph_relationships=relationship_count,
                 files=file_checksums,
+                lineage_validation=lineage_report,
             )
             await _write_json_file_async(metadata_file, asdict(metadata))
 

--- a/apps/api/src/sibyl/persistence/content_archive.py
+++ b/apps/api/src/sibyl/persistence/content_archive.py
@@ -710,9 +710,7 @@ async def _prepare_auxiliary_content_restore(client, tables, organization_id, *,
             index = rows_restored
             parameters[f"archive_record_{index}"] = record
             parameters[f"archive_identity_{index}"] = identity
-            statement = _auxiliary_restore_statement(
-                spec, organization_id, record, legacy=legacy
-            )
+            statement = _auxiliary_restore_statement(spec, organization_id, record, legacy=legacy)
             statements.append(
                 f"FOR $archive_once IN [true] {{ LET $record = $archive_record_{index}; "
                 f"LET $identity = $archive_identity_{index}; {statement} }};"

--- a/apps/api/src/sibyl/persistence/content_archive.py
+++ b/apps/api/src/sibyl/persistence/content_archive.py
@@ -24,7 +24,7 @@ from sibyl_core.backends.surreal.schema_invariants import (
 
 log = structlog.get_logger()
 
-CONTENT_ARCHIVE_VERSION = "1.0"
+CONTENT_ARCHIVE_VERSION = "2.0"
 
 
 @dataclass(frozen=True)
@@ -205,12 +205,11 @@ _CONTENT_ARCHIVE_TABLE_SPECS = (
 
 CONTENT_ARCHIVE_TABLES = tuple(spec.name for spec in _CONTENT_ARCHIVE_TABLE_SPECS)
 _CONTENT_ARCHIVE_TABLES_BY_NAME = {spec.name: spec for spec in _CONTENT_ARCHIVE_TABLE_SPECS}
-_SELECT_SURREAL_TABLE_ROWS = {
-    spec.name: f"SELECT * FROM {spec.name};"  # noqa: S608 - table names are fixed constants
-    for spec in _CONTENT_ARCHIVE_TABLE_SPECS
-}
 _BACKUP_ARCHIVE_TABLES = frozenset({"backup_settings", "backups"})
 _GLOBAL_CONTENT_ARCHIVE_TABLES = frozenset({"system_settings", "telemetry_rollups"})
+_RETAINED_OPERATION_TABLES = frozenset(
+    {"eval_attempts", "eval_consolidations", "api_idempotency_records"}
+)
 _CONTENT_RELATION_ARCHIVE_TABLES = frozenset(
     {"derived_from", "chunk_of", "supersedes", "extracted_into"}
 )
@@ -225,6 +224,8 @@ class ContentArchiveRestoreResult:
     rows_restored: int
     errors: list[str] = field(default_factory=list)
     dropped_fields: dict[str, list[str]] = field(default_factory=dict)
+    integrity_conflicts: list[dict[str, str]] = field(default_factory=list)
+    quarantined: list[dict[str, str]] = field(default_factory=list)
 
 
 def build_surreal_content_client() -> SurrealContentClient:
@@ -360,12 +361,21 @@ def _content_archive_export_query(
     spec: ContentArchiveTableSpec,
     organization_id: str | None,
 ) -> tuple[str, dict[str, object]] | None:
+    projection = "*"
+    if spec.name in _RETAINED_OPERATION_TABLES:
+        projection += ", type::string(created_at) AS created_at"
+        if spec.name == "eval_attempts":
+            projection += (
+                ", IF admitted_at != NONE { type::string(admitted_at) } "
+                "ELSE { NONE } AS admitted_at"
+            )
+    query = f"SELECT {projection} FROM {spec.name}"  # noqa: S608
     if organization_id is None:
-        return _SELECT_SURREAL_TABLE_ROWS[spec.name], {}
+        return query + ";", {}
     if spec.name in _GLOBAL_CONTENT_ARCHIVE_TABLES:
         return None
     return (
-        f"SELECT * FROM {spec.name} WHERE organization_id = $organization_id;",  # noqa: S608
+        query + " WHERE organization_id = $organization_id;",
         {"organization_id": organization_id},
     )
 
@@ -375,7 +385,11 @@ async def _clean_content_archive_rows(
     organization_id: str | None,
 ) -> None:
     wipe_specs = sorted(
-        _CONTENT_ARCHIVE_TABLE_SPECS,
+        [
+            spec
+            for spec in _CONTENT_ARCHIVE_TABLE_SPECS
+            if spec.name != "raw_captures" and spec.name not in _RETAINED_OPERATION_TABLES
+        ],
         key=lambda spec: spec.name not in _CONTENT_RELATION_ARCHIVE_TABLES,
     )
     if organization_id is None:
@@ -430,11 +444,33 @@ async def _export_surreal_content_archive_payload(
             )
             tables[spec.name] = rows
             row_counts[spec.name] = len(rows)
+        from sibyl_core.memory_pipeline.observations import SourceKind
+        from sibyl_core.migrate.source_integrity import validate_integrity_archive
+        from sibyl_core.services.source_archive_store import export_source_integrity
+
+        integrity = await export_source_integrity(
+            client.execute_query,
+            kind=SourceKind.RAW_CAPTURE,
+            organizations=[org_id] if org_id is not None else None,
+        )
+        raw_rows, _, _ = validate_integrity_archive(
+            integrity, kind=SourceKind.RAW_CAPTURE, organizations=integrity["organizations"]
+        )
+        tables["raw_captures"] = [
+            {
+                key: _serialize_value(value)
+                for key, value in row.items()
+                if key != "archive_record_key"
+            }
+            for row in raw_rows
+        ]
+        row_counts["raw_captures"] = len(raw_rows)
     finally:
         await client.close()
 
     return {
         "version": CONTENT_ARCHIVE_VERSION,
+        "source_integrity": integrity,
         "created_at": datetime.now(UTC).isoformat(),
         "organization_id": str(organization_id) if organization_id is not None else None,
         "tables": tables,
@@ -451,10 +487,223 @@ async def export_content_archive_payload(
     return await _export_surreal_content_archive_payload(organization_id)
 
 
+def _prepare_content_source_integrity(payload, tables, organization_id):
+    """Validate source scope and translate legacy content before cleanup starts."""
+    from sibyl_core.memory_pipeline.observations import SourceKind
+    from sibyl_core.migrate.source_integrity import validate_integrity_archive
+
+    version = payload.get("version", "1.0")
+    if version == CONTENT_ARCHIVE_VERSION and set(CONTENT_ARCHIVE_TABLES) - set(tables):
+        raise ValueError("current content archive is missing required tables")
+    for table, rows in tables.items():
+        if table not in CONTENT_ARCHIVE_TABLES or not isinstance(rows, list):
+            raise ValueError("content archive has an unknown or malformed table")
+        if organization_id is not None and table in _GLOBAL_CONTENT_ARCHIVE_TABLES and rows:
+            raise ValueError("organization-scoped archive cannot restore global tables")
+        for row in rows:
+            if not isinstance(row, dict):
+                raise TypeError("content archive row must be an object")
+            if (
+                organization_id is not None
+                and table not in _GLOBAL_CONTENT_ARCHIVE_TABLES
+                and str(row.get("organization_id")) != organization_id
+            ):
+                raise ValueError("content archive row is outside restore organization")
+    if version not in {"1.0", CONTENT_ARCHIVE_VERSION}:
+        raise ValueError("unsupported content archive version")
+    integrity = payload.get("source_integrity")
+    if version == CONTENT_ARCHIVE_VERSION:
+        scope = (
+            [organization_id]
+            if organization_id is not None
+            else (integrity.get("organizations") if isinstance(integrity, dict) else None)
+        )
+        if not isinstance(scope, list):
+            raise ValueError("content archive integrity scope is missing")
+        validate_integrity_archive(integrity, kind=SourceKind.RAW_CAPTURE, organizations=scope)
+    elif integrity is not None:
+        raise ValueError("legacy content archive cannot carry unrecognized integrity")
+
+    unavailable_ids: set[str] = set()
+    if version != CONTENT_ARCHIVE_VERSION:
+        from sibyl_core.migrate.legacy_source_archive import build_legacy_source_archive
+
+        legacy_rows = tables.get("raw_captures", [])
+        if not isinstance(legacy_rows, list) or any(
+            not isinstance(row, dict) for row in legacy_rows
+        ):
+            raise ValueError("legacy raw capture collection is malformed")
+        records = []
+        for row in legacy_rows:
+            record = {str(key): value for key, value in row.items() if key != "id"}
+            record["uuid"] = str(row.get("uuid") or row.get("id") or "").strip()
+            for field in (
+                "created_at",
+                "updated_at",
+                "captured_at",
+                "deleted_at",
+                "purge_after",
+                "last_recalled_at",
+                "last_used_at",
+            ):
+                if field in record:
+                    record[field] = _deserialize_value(record[field])
+            records.append(record)
+        scope = (
+            [organization_id]
+            if organization_id is not None
+            else sorted({str(row.get("organization_id") or "") for row in records})
+        )
+        integrity, unavailable_ids = build_legacy_source_archive(
+            records,
+            kind=SourceKind.RAW_CAPTURE,
+            organizations=scope,
+        )
+
+    return integrity, scope, unavailable_ids
+
+
+async def _filter_legacy_source_fields(client, integrity, scope):
+    from sibyl_core.memory_pipeline.observations import SourceKind
+    from sibyl_core.migrate.source_integrity import (
+        build_integrity_archive,
+        validate_integrity_archive,
+    )
+
+    rows, states, associations = validate_integrity_archive(
+        integrity, kind=SourceKind.RAW_CAPTURE, organizations=scope
+    )
+    declared = await fetch_declared_fields(client.execute_query, "raw_captures")
+    dropped_fields: set[str] = set()
+    filtered = []
+    for row in rows:
+        record_key = row.pop("archive_record_key")
+        record, dropped = _drop_undeclared_fields(row, declared)
+        record["archive_record_key"] = record_key
+        dropped_fields.update(dropped)
+        filtered.append(record)
+    return build_integrity_archive(
+        kind=SourceKind.RAW_CAPTURE,
+        organizations=scope,
+        source_rows=filtered,
+        source_states=states,
+        derivations=associations,
+    ), dropped_fields
+
+
+def _auxiliary_restore_statement(
+    spec: ContentArchiveTableSpec, organization_id: str | None, record: dict[str, object]
+) -> str:
+    """Preserve operation history and reject foreign identities in the same transaction."""
+    existing = (
+        f"LET $existing = SELECT * OMIT id FROM {spec.name} "  # noqa: S608
+        f"WHERE {spec.target_identity_field} = $identity;\n"
+    )
+    ownership_guard = ""
+    if organization_id is not None:
+        ownership_guard = (
+            "IF array::len($existing[WHERE organization_id = $organization_id]) "
+            "!= array::len($existing) { "
+            "THROW 'archive identity belongs to another organization'; };\n"
+        )
+    conversion = ""
+    if spec.name in _RETAINED_OPERATION_TABLES:
+        fields = ["created_at"] + (
+            ["admitted_at"] if spec.name == "eval_attempts" and "admitted_at" in record else []
+        )
+        converted = ", ".join(
+            f"IF $record.{field} != NONE AND $record.{field} != NULL "
+            f"{{ type::datetime($record.{field}) }} "
+            f"ELSE {{ NONE }} AS {field}"
+            for field in fields
+        )
+        conversion = f"LET $record = (SELECT *, {converted} FROM ONLY $record);\n"  # noqa: S608
+        write = (
+            f"IF array::len($existing) = 0 {{ {spec.create_sql} }} ELSE {{ "
+            "IF $existing != [$record] { "
+            "THROW 'archive conflicts with retained operation history'; }; };\n"
+        )
+    else:
+        write = f"{spec.delete_by_identity_sql}\n{spec.create_sql}\n"
+    return f"BEGIN TRANSACTION;\n{conversion}{existing}{ownership_guard}{write}COMMIT TRANSACTION;"
+
+
+async def _restore_auxiliary_content_tables(client, tables, organization_id):
+    """Restore non-source tables using their existing per-record transactions."""
+    tables_restored = rows_restored = 0
+    errors: list[str] = []
+    dropped_fields: dict[str, set[str]] = {}
+    for spec in _CONTENT_ARCHIVE_TABLE_SPECS:
+        if spec.name == "raw_captures":
+            continue
+        rows = tables.get(spec.name)
+        if rows is None:
+            rows = []
+        if not isinstance(rows, list):
+            errors.append(f"{spec.name} payload must be a list")
+            continue
+        if not rows:
+            continue
+
+        declared = await fetch_declared_fields(client.execute_query, spec.name)
+        tables_restored += 1
+        for row in rows:
+            if not isinstance(row, dict):
+                errors.append(f"{spec.name} row payload must be an object")
+                continue
+            normalized_row = _normalize_content_archive_restore_row(
+                spec,
+                {str(key): value for key, value in row.items()},
+            )
+            identity = str(
+                normalized_row.get(spec.source_identity_field)
+                or normalized_row.get(spec.target_identity_field)
+                or ""
+            ).strip()
+            if not identity:
+                errors.append(f"{spec.name} row is missing {spec.source_identity_field}")
+                continue
+
+            record = {
+                key: (
+                    value if spec.name in _RETAINED_OPERATION_TABLES else _deserialize_value(value)
+                )
+                for key, value in normalized_row.items()
+                if not (
+                    spec.source_identity_field != spec.target_identity_field
+                    and key == spec.source_identity_field
+                )
+            }
+            if spec.name == "document_chunks":
+                record["embedding"] = _deserialize_vector(record.get("embedding"))
+            record[spec.target_identity_field] = identity
+            record, dropped = _drop_undeclared_fields(record, declared)
+            if dropped:
+                dropped_fields.setdefault(spec.name, set()).update(dropped)
+
+            if spec.name == "eval_attempts" and record.get("admitted_at") is None:
+                record.pop("admitted_at", None)
+            restore_row_sql = _auxiliary_restore_statement(spec, organization_id, record)
+            try:
+                result = await client.execute_query_raw(
+                    restore_row_sql,
+                    identity=identity,
+                    record=record,
+                    organization_id=organization_id,
+                )
+                _raise_on_error(result, query=restore_row_sql)
+                rows_restored += 1
+            except Exception as exc:
+                errors.append(f"{spec.name}:{identity}: {exc}")
+
+    return tables_restored, rows_restored, errors, dropped_fields
+
+
 async def restore_content_archive_payload(
     payload: dict[str, object],
     *,
     clean: bool = False,
+    global_scope: bool = False,
 ) -> ContentArchiveRestoreResult:
     """Restore a content payload into the Surreal content namespace."""
 
@@ -466,82 +715,76 @@ async def restore_content_archive_payload(
     organization_id = str(payload_org_id).strip() if payload_org_id is not None else None
     if organization_id == "":
         organization_id = None
+    if organization_id is None and not global_scope:
+        raise ValueError("global content restore requires explicit operator scope")
+    if organization_id is not None and global_scope:
+        raise ValueError("global content scope cannot be applied to an organization-scoped archive")
+
+    from sibyl_core.memory_pipeline.observations import SourceKind
+    from sibyl_core.migrate.archive_lineage import seal_archive_lineage
+
+    _, sealed, _ = seal_archive_lineage(None, payload)
+    assert sealed is not None
+    payload = sealed
+    integrity, scope, unavailable_ids = _prepare_content_source_integrity(
+        payload, tables, organization_id
+    )
 
     client = build_surreal_content_client()
     tables_restored = 0
     rows_restored = 0
     errors: list[str] = []
     dropped_fields: dict[str, set[str]] = {}
+    integrity_conflicts: list[dict[str, str]] = []
+    quarantined: list[dict[str, str]] = []
 
     try:
         await bootstrap_content_schema(client, reset=False)
+        if payload.get("version", "1.0") != CONTENT_ARCHIVE_VERSION:
+            integrity, legacy_dropped = await _filter_legacy_source_fields(client, integrity, scope)
+            if legacy_dropped:
+                dropped_fields["raw_captures"] = legacy_dropped
+        from sibyl_core.services.source_archive_store import restore_source_integrity
+
+        restored = await restore_source_integrity(
+            client.execute_query,
+            integrity,
+            kind=SourceKind.RAW_CAPTURE,
+            organizations=scope,
+            clean=clean,
+            skip_existing=False,
+            global_scope=global_scope,
+        )
+        restored_ids = restored["restored_source_ids"]
+        rows_restored += len(restored_ids)
+        tables_restored += 1
+        integrity_conflicts = restored["conflicts"]
+        quarantined = [
+            {
+                "source_id": identity,
+                "reason": "unverifiable_legacy_lineage",
+                "repair": "reauthor_under_new_capture_identity",
+            }
+            for identity in restored_ids
+            if identity in unavailable_ids
+        ]
+        quarantined.extend(
+            dict(row)
+            for row in payload.get("lineage_validation", [])
+            if isinstance(row, dict) and row.get("status") == "quarantined"
+        )
         if clean:
             await _clean_content_archive_rows(client, organization_id)
 
-        for spec in _CONTENT_ARCHIVE_TABLE_SPECS:
-            rows = tables.get(spec.name)
-            if rows is None:
-                rows = []
-            if not isinstance(rows, list):
-                errors.append(f"{spec.name} payload must be a list")
-                continue
-            if not rows:
-                continue
-
-            declared = await fetch_declared_fields(client.execute_query, spec.name)
-            tables_restored += 1
-            for row in rows:
-                if not isinstance(row, dict):
-                    errors.append(f"{spec.name} row payload must be an object")
-                    continue
-                normalized_row = _normalize_content_archive_restore_row(
-                    spec,
-                    {str(key): value for key, value in row.items()},
-                )
-                identity = str(
-                    normalized_row.get(spec.source_identity_field)
-                    or normalized_row.get(spec.target_identity_field)
-                    or ""
-                ).strip()
-                if not identity:
-                    errors.append(f"{spec.name} row is missing {spec.source_identity_field}")
-                    continue
-
-                record = {
-                    key: _deserialize_value(value)
-                    for key, value in normalized_row.items()
-                    if not (
-                        spec.source_identity_field != spec.target_identity_field
-                        and key == spec.source_identity_field
-                    )
-                }
-                if spec.name == "document_chunks":
-                    record["embedding"] = _deserialize_vector(record.get("embedding"))
-                record[spec.target_identity_field] = identity
-                record, dropped = _drop_undeclared_fields(record, declared)
-                if dropped:
-                    dropped_fields.setdefault(spec.name, set()).update(dropped)
-
-                # Delete+create must be atomic: a create that fails after the
-                # delete would otherwise drop the existing row on a restore, the
-                # worst outcome on the DR path. The transaction rolls the delete
-                # back so the prior row survives a failed replace.
-                restore_row_sql = (
-                    f"BEGIN TRANSACTION;\n"
-                    f"{spec.delete_by_identity_sql}\n"
-                    f"{spec.create_sql}\n"
-                    f"COMMIT TRANSACTION;"
-                )
-                try:
-                    result = await client.execute_query_raw(
-                        restore_row_sql,
-                        identity=identity,
-                        record=record,
-                    )
-                    _raise_on_error(result, query=restore_row_sql)
-                    rows_restored += 1
-                except Exception as exc:
-                    errors.append(f"{spec.name}:{identity}: {exc}")
+        (
+            auxiliary_tables,
+            auxiliary_rows,
+            errors,
+            auxiliary_dropped,
+        ) = await _restore_auxiliary_content_tables(client, tables, organization_id)
+        dropped_fields.update(auxiliary_dropped)
+        tables_restored += auxiliary_tables
+        rows_restored += auxiliary_rows
 
         if dropped_fields:
             log.warning(
@@ -555,6 +798,8 @@ async def restore_content_archive_payload(
             tables_restored=tables_restored,
             rows_restored=rows_restored,
             errors=errors[:50],
+            integrity_conflicts=integrity_conflicts,
+            quarantined=quarantined,
             dropped_fields={
                 table: sorted(names) for table, names in sorted(dropped_fields.items())
             },

--- a/apps/api/src/sibyl/persistence/content_archive.py
+++ b/apps/api/src/sibyl/persistence/content_archive.py
@@ -535,7 +535,27 @@ def _prepare_content_source_integrity(payload, tables, organization_id):
             raise ValueError("legacy raw capture collection is malformed")
         records = []
         for row in legacy_rows:
-            record = {str(key): value for key, value in row.items() if key != "id"}
+            # Legacy rows may omit fields whose defaults only run on CREATE.
+            # Complete those fields before a checked restore updates an existing row.
+            now = datetime.now(UTC)
+            record = {
+                "source_id": "",
+                "principal_id": "",
+                "memory_scope": "private",
+                "review_state": "pending",
+                "title": "",
+                "raw_content": "",
+                "entity_type": "",
+                "tags": [],
+                "metadata": {},
+                "provenance": {},
+                "captured_at": now,
+                "created_at": now,
+                "retrieval_count": 0,
+                "citation_count": 0,
+                "misled_count": 0,
+                **{str(key): value for key, value in row.items() if key != "id"},
+            }
             record["uuid"] = str(row.get("uuid") or row.get("id") or "").strip()
             for field in (
                 "created_at",

--- a/apps/api/src/sibyl/persistence/content_archive.py
+++ b/apps/api/src/sibyl/persistence/content_archive.py
@@ -15,7 +15,6 @@ from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_
 from sibyl_core.backends.surreal.records import (
     normalize_records as _normalize_records,
     query_error as _query_error,
-    raise_on_error as _raise_on_error,
 )
 from sibyl_core.backends.surreal.schema_invariants import (
     drop_undeclared_fields as _drop_undeclared_fields,
@@ -380,10 +379,7 @@ def _content_archive_export_query(
     )
 
 
-async def _clean_content_archive_rows(
-    client: SurrealContentClient,
-    organization_id: str | None,
-) -> None:
+def _clean_content_archive_statements(organization_id: str | None) -> str:
     wipe_specs = sorted(
         [
             spec
@@ -393,23 +389,12 @@ async def _clean_content_archive_rows(
         key=lambda spec: spec.name not in _CONTENT_RELATION_ARCHIVE_TABLES,
     )
     if organization_id is None:
-        wipe_sql = "\n".join(spec.delete_all_sql for spec in wipe_specs)
-        wipe_result = await client.execute_query_raw(
-            f"BEGIN TRANSACTION;\n{wipe_sql}\nCOMMIT TRANSACTION;",
-        )
-        _raise_on_error(wipe_result, query="restore_content_archive_payload:clean")
-        return
-
-    wipe_sql = "\n".join(
+        return "\n".join(spec.delete_all_sql for spec in wipe_specs)
+    return "\n".join(
         f"DELETE FROM {spec.name} WHERE organization_id = $organization_id;"  # noqa: S608
         for spec in wipe_specs
         if spec.name not in _GLOBAL_CONTENT_ARCHIVE_TABLES
     )
-    wipe_result = await client.execute_query_raw(
-        f"BEGIN TRANSACTION;\n{wipe_sql}\nCOMMIT TRANSACTION;",
-        organization_id=organization_id,
-    )
-    _raise_on_error(wipe_result, query="restore_content_archive_payload:clean_org")
 
 
 async def _export_surreal_content_archive_payload(
@@ -556,6 +541,9 @@ def _prepare_content_source_integrity(payload, tables, organization_id):
                 "misled_count": 0,
                 **{str(key): value for key, value in row.items() if key != "id"},
             }
+            for field in ("created_at", "captured_at"):
+                if record[field] is None:
+                    record[field] = now
             record["uuid"] = str(row.get("uuid") or row.get("id") or "").strip()
             for field in (
                 "created_at",
@@ -612,7 +600,11 @@ async def _filter_legacy_source_fields(client, integrity, scope):
 
 
 def _auxiliary_restore_statement(
-    spec: ContentArchiveTableSpec, organization_id: str | None, record: dict[str, object]
+    spec: ContentArchiveTableSpec,
+    organization_id: str | None,
+    record: dict[str, object],
+    *,
+    legacy: bool = False,
 ) -> str:
     """Preserve operation history and reject foreign identities in the same transaction."""
     existing = (
@@ -638,18 +630,26 @@ def _auxiliary_restore_statement(
             for field in fields
         )
         conversion = f"LET $record = (SELECT *, {converted} FROM ONLY $record);\n"  # noqa: S608
+        comparison = "$existing != [$record]"
+        if legacy and "created_at" not in record:
+            comparison = (
+                "(SELECT * OMIT created_at FROM $existing) "
+                "!= (SELECT * OMIT created_at FROM [$record])"
+            )
         write = (
             f"IF array::len($existing) = 0 {{ {spec.create_sql} }} ELSE {{ "
-            "IF $existing != [$record] { "
+            f"IF {comparison} {{ "
             "THROW 'archive conflicts with retained operation history'; }; };\n"
         )
     else:
         write = f"{spec.delete_by_identity_sql}\n{spec.create_sql}\n"
-    return f"BEGIN TRANSACTION;\n{conversion}{existing}{ownership_guard}{write}COMMIT TRANSACTION;"
+    return f"{conversion}{existing}{ownership_guard}{write}"
 
 
-async def _restore_auxiliary_content_tables(client, tables, organization_id):
-    """Restore non-source tables using their existing per-record transactions."""
+async def _prepare_auxiliary_content_restore(client, tables, organization_id, *, legacy=False):
+    """Validate and compile non-source writes for the source-local transaction."""
+    statements: list[str] = []
+    parameters: dict[str, object] = {"organization_id": organization_id}
     tables_restored = rows_restored = 0
     errors: list[str] = []
     dropped_fields: dict[str, set[str]] = {}
@@ -694,6 +694,10 @@ async def _restore_auxiliary_content_tables(client, tables, organization_id):
                     and key == spec.source_identity_field
                 )
             }
+            if legacy and spec.name == "eval_consolidations":
+                record.setdefault("admission_bindings", [])
+            elif legacy and spec.name == "api_idempotency_records":
+                record.setdefault("response_body", {})
             if spec.name == "document_chunks":
                 record["embedding"] = _deserialize_vector(record.get("embedding"))
             record[spec.target_identity_field] = identity
@@ -703,20 +707,19 @@ async def _restore_auxiliary_content_tables(client, tables, organization_id):
 
             if spec.name == "eval_attempts" and record.get("admitted_at") is None:
                 record.pop("admitted_at", None)
-            restore_row_sql = _auxiliary_restore_statement(spec, organization_id, record)
-            try:
-                result = await client.execute_query_raw(
-                    restore_row_sql,
-                    identity=identity,
-                    record=record,
-                    organization_id=organization_id,
-                )
-                _raise_on_error(result, query=restore_row_sql)
-                rows_restored += 1
-            except Exception as exc:
-                errors.append(f"{spec.name}:{identity}: {exc}")
+            index = rows_restored
+            parameters[f"archive_record_{index}"] = record
+            parameters[f"archive_identity_{index}"] = identity
+            statement = _auxiliary_restore_statement(
+                spec, organization_id, record, legacy=legacy
+            )
+            statements.append(
+                f"FOR $archive_once IN [true] {{ LET $record = $archive_record_{index}; "
+                f"LET $identity = $archive_identity_{index}; {statement} }};"
+            )
+            rows_restored += 1
 
-    return tables_restored, rows_restored, errors, dropped_fields
+    return tables_restored, rows_restored, errors, dropped_fields, "\n".join(statements), parameters
 
 
 async def restore_content_archive_payload(
@@ -766,15 +769,60 @@ async def restore_content_archive_payload(
                 dropped_fields["raw_captures"] = legacy_dropped
         from sibyl_core.services.source_archive_store import restore_source_integrity
 
-        restored = await restore_source_integrity(
-            client.execute_query,
-            integrity,
-            kind=SourceKind.RAW_CAPTURE,
-            organizations=scope,
-            clean=clean,
-            skip_existing=False,
-            global_scope=global_scope,
+        (
+            auxiliary_tables,
+            auxiliary_rows,
+            errors,
+            auxiliary_dropped,
+            auxiliary_sql,
+            auxiliary_parameters,
+        ) = await _prepare_auxiliary_content_restore(
+            client, tables, organization_id, legacy=payload.get("version", "1.0") == "1.0"
         )
+        if errors:
+            return ContentArchiveRestoreResult(
+                success=False, tables_restored=0, rows_restored=0, errors=errors[:50]
+            )
+        specs = [
+            spec
+            for spec in _CONTENT_ARCHIVE_TABLE_SPECS
+            if spec.name != "raw_captures"
+            and (organization_id is None or spec.name not in _GLOBAL_CONTENT_ARCHIVE_TABLES)
+        ]
+        predicate = "" if organization_id is None else " WHERE organization_id = $organization_id"
+        snapshot_fields = ", ".join(
+            f"{spec.name}: (SELECT * FROM {spec.name}{predicate} ORDER BY id)"  # noqa: S608
+            for spec in specs
+        )
+        snapshot = f"crypto::sha256(type::string({{{snapshot_fields}}}))"
+        fingerprints = await client.execute_query(
+            f"RETURN {{ fingerprint: {snapshot} }};", organization_id=organization_id
+        )
+        auxiliary_parameters["archive_auxiliary_fingerprint"] = _normalize_records(fingerprints)[0][
+            "fingerprint"
+        ]
+        auxiliary_sql = (
+            f"IF {snapshot} != $archive_auxiliary_fingerprint {{ "
+            "THROW 'archive auxiliary destination changed before restore'; };\n"
+            + (_clean_content_archive_statements(organization_id) if clean else "")
+            + auxiliary_sql
+        )
+        try:
+            restored = await restore_source_integrity(
+                client.execute_query,
+                integrity,
+                kind=SourceKind.RAW_CAPTURE,
+                organizations=scope,
+                clean=clean,
+                skip_existing=False,
+                global_scope=global_scope,
+                auxiliary_statements=auxiliary_sql,
+                auxiliary_parameters=auxiliary_parameters,
+            )
+        except Exception as exc:
+            return ContentArchiveRestoreResult(
+                success=False, tables_restored=0, rows_restored=0, errors=[str(exc)]
+            )
         restored_ids = restored["restored_source_ids"]
         rows_restored += len(restored_ids)
         tables_restored += 1
@@ -793,15 +841,6 @@ async def restore_content_archive_payload(
             for row in payload.get("lineage_validation", [])
             if isinstance(row, dict) and row.get("status") == "quarantined"
         )
-        if clean:
-            await _clean_content_archive_rows(client, organization_id)
-
-        (
-            auxiliary_tables,
-            auxiliary_rows,
-            errors,
-            auxiliary_dropped,
-        ) = await _restore_auxiliary_content_tables(client, tables, organization_id)
         dropped_fields.update(auxiliary_dropped)
         tables_restored += auxiliary_tables
         rows_restored += auxiliary_rows

--- a/apps/api/tests/test_archive_operation_history.py
+++ b/apps/api/tests/test_archive_operation_history.py
@@ -1,0 +1,172 @@
+"""Restoration retains forward operation history and restores absent history."""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl.persistence import content_archive
+from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
+from tests.test_memory_eval_admission import eval_api as eval_api  # noqa: PLC0414
+
+
+@pytest.mark.parametrize(
+    "table", ["eval_attempts", "eval_consolidations", "api_idempotency_records"]
+)
+@pytest.mark.parametrize("clean", [False, True])
+@pytest.mark.parametrize("global_scope", [False, True])
+async def test_archive_retains_operation_history(table, clean, global_scope, monkeypatch):
+    store = SurrealContentClient(url="memory://")
+    close = store.close
+    await bootstrap_content_schema(store)
+    monkeypatch.setattr(store, "close", AsyncMock())
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: store)
+    org, identity = str(uuid4()), str(uuid4())
+    records = {
+        "eval_attempts": {
+            "experiment_id": "experiment",
+            "attempt_id": "attempt",
+            "assignment_sha256": "a" * 64,
+            "assignment_json": "{}",
+        },
+        "eval_consolidations": {
+            "principal_id": "owner",
+            "request_sha256": "b" * 64,
+            "result_kind": "abstained",
+        },
+        "api_idempotency_records": {
+            "principal_id": "owner",
+            "idempotency_key": "key",
+            "method": "POST",
+            "path": "/fixture",
+            "request_hash": "hash",
+            "response_status_code": 200,
+            "response_body": {"timestamp_text": "2026-09-10T02:47:11.572211763Z"},
+        },
+    }
+    select = f"SELECT * FROM {table};"  # noqa: S608
+    try:
+        empty = await content_archive.export_content_archive_payload(None if global_scope else org)
+        await store.execute_query(
+            f"CREATE {table} CONTENT $record;",
+            record={"uuid": identity, "organization_id": org, **records[table]},
+        )
+        await store.execute_query(
+            f"UPDATE {table} SET created_at = <datetime>'2026-09-10T02:47:11.572211763Z';"  # noqa: S608
+        )
+        before = await store.execute_query(select)
+        # An archive predating completion cannot erase the permanent operation.
+        result = await content_archive.restore_content_archive_payload(
+            empty,
+            clean=clean,
+            global_scope=global_scope,
+        )
+        assert result.success, result.errors
+        assert await store.execute_query(select) == before
+
+        archived = await content_archive.export_content_archive_payload(
+            None if global_scope else org
+        )
+        assert archived["tables"][table][0]["created_at"] == "2026-09-10T02:47:11.572211763Z"
+        result = await content_archive.restore_content_archive_payload(
+            archived,
+            clean=clean,
+            global_scope=global_scope,
+        )
+        assert result.success, result.errors
+        assert await store.execute_query(select) == before
+
+        # An older collision must not replace a newer terminal or admission field.
+        mutation = {
+            "eval_attempts": "admitted_at = <datetime>'2026-09-10T02:49:11.572211763Z'",
+            "eval_consolidations": "promoted_entity_id = 'retained-publication'",
+            "api_idempotency_records": "response_body = {current: true}",
+        }[table]
+        await store.execute_query(f"UPDATE {table} SET {mutation};")  # noqa: S608
+        advanced = await store.execute_query(select)
+        result = await content_archive.restore_content_archive_payload(
+            archived,
+            clean=clean,
+            global_scope=global_scope,
+        )
+        assert not result.success
+        assert await store.execute_query(select) == advanced
+
+        current = await content_archive.export_content_archive_payload(
+            None if global_scope else org
+        )
+        if table == "eval_attempts":
+            assert current["tables"][table][0]["admitted_at"] == "2026-09-10T02:49:11.572211763Z"
+        # Absent-row DR remains supported in a genuinely empty destination.
+        destination = SurrealContentClient(url="memory://")
+        await bootstrap_content_schema(destination)
+        destination_close = destination.close
+        monkeypatch.setattr(destination, "close", AsyncMock())
+        monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+        try:
+            result = await content_archive.restore_content_archive_payload(
+                current,
+                clean=clean,
+                global_scope=global_scope,
+            )
+            assert result.success, result.errors
+            restored = await destination.execute_query(select)
+            assert [{k: v for k, v in row.items() if k != "id"} for row in restored] == [
+                {k: v for k, v in row.items() if k != "id"} for row in advanced
+            ]
+        finally:
+            await destination_close()
+    finally:
+        await close()
+
+
+async def test_restore_keeps_terminal_consolidation_out_of_extraction(eval_api, monkeypatch):
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from sibyl_core.services import eval_consolidation, eval_publication
+    from tests.test_memory_eval_admission import _register
+
+    api = eval_api
+    assert (await _register(api)).status_code == 200
+    assert (await api.client.post(api.path, json=api.body)).status_code == 200
+    monkeypatch.setattr(api.store, "close", AsyncMock())
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: api.store)
+    org = api.assignment.organization_id
+    old = await content_archive.export_content_archive_payload(org)
+    raw = await api.store.execute_query("SELECT * FROM raw_captures ORDER BY uuid;")
+    operation = eval_publication.ConsolidationOperation(
+        organization_id=org,
+        principal_id="owner",
+        experiment_id="experiment",
+        experiment_revision="1",
+        arm_id="raw",
+        checkpoint=0,
+        group_id="contrast",
+        attempt_ids=("a", "b"),
+        mechanism="check output",
+        controller_policy_sha256="c" * 64,
+        extractor_revision="frozen-v1",
+    )
+    await api.store.execute_query(
+        "CREATE eval_consolidations CONTENT $record;",
+        record={
+            "uuid": operation.key,
+            "organization_id": org,
+            "principal_id": "owner",
+            "request_sha256": operation.request_sha256,
+            "result_kind": "abstained",
+        },
+    )
+    result = await content_archive.restore_content_archive_payload(old, clean=True)
+    assert result.success, result.errors
+    assert await api.store.execute_query("SELECT * FROM raw_captures ORDER BY uuid;") == raw
+    extractor = AsyncMock(side_effect=AssertionError("terminal operation reached extraction"))
+    monkeypatch.setattr(eval_consolidation, "propose_admitted_procedure", extractor)
+    retained = await eval_publication.consolidate_admitted_procedure(
+        operation,
+        trusted_issuer_id="oracle",
+        trusted_public_key=Ed25519PrivateKey.generate().public_key(),
+        model_override="unused",
+    )
+    assert retained.status == "abstained"
+    extractor.assert_not_awaited()

--- a/apps/api/tests/test_archive_schema_drift.py
+++ b/apps/api/tests/test_archive_schema_drift.py
@@ -10,7 +10,6 @@ import pytest
 import pytest_asyncio
 from surrealdb import AsyncSurreal
 
-from sibyl.persistence import content_archive
 from sibyl.persistence.auth_archive import restore_auth_archive_payload
 from sibyl.persistence.content_archive import restore_content_archive_payload
 from sibyl.persistence.surreal import auth as surreal_auth, content as surreal_content
@@ -111,7 +110,7 @@ async def test_content_restore_drops_undeclared_fields_and_reports_them(
     """
     capture_id = uuid4()
     payload = {
-        "version": content_archive.CONTENT_ARCHIVE_VERSION,
+        "version": "1.0",
         "organization_id": "org-123",
         "tables": {
             "raw_captures": [

--- a/apps/api/tests/test_archive_source_revocation.py
+++ b/apps/api/tests/test_archive_source_revocation.py
@@ -1,0 +1,217 @@
+"""Older public archives cannot undo newer source visibility decisions."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl.persistence import content_archive
+from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
+from sibyl_core.services.graph_client import SurrealGraphClient, prepare_graph_schema
+from sibyl_core.services.graph_entities import EntityManager
+from sibyl_core.services.graph_relationships import RelationshipManager
+from sibyl_core.services.graph_runtime import GraphRuntime
+from sibyl_core.services.memory_correction import apply_memory_correction
+from sibyl_core.services.surreal_content import recall_raw_memory, remember_raw_memory
+
+
+@pytest.fixture
+async def revocation_store(monkeypatch):
+    org = str(uuid4())
+    client = SurrealContentClient(url="memory://")
+    graph = SurrealGraphClient(group_id=org, url="memory://")
+    close = client.close
+    try:
+        await bootstrap_content_schema(client)
+        await prepare_graph_schema(graph)
+        runtime = GraphRuntime(
+            client=graph,
+            entity_manager=EntityManager(graph, group_id=org),
+            relationship_manager=RelationshipManager(graph, group_id=org),
+        )
+        for path in (
+            "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+            "sibyl_core.services.memory_lifecycle.get_surreal_graph_runtime",
+        ):
+            monkeypatch.setattr(path, AsyncMock(return_value=runtime))
+        monkeypatch.setattr(client, "close", AsyncMock())
+        monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: client)
+        monkeypatch.setattr(
+            "sibyl_core.services.content_models.configured_raw_memory_embedding_provider",
+            lambda: None,
+        )
+
+        @asynccontextmanager
+        async def session():
+            yield client
+
+        monkeypatch.setattr("sibyl_core.services.content_client.surreal_content_client", session)
+        yield client, org
+    finally:
+        await close()
+        await graph.close()
+
+
+async def capture(org, source_id="original"):
+    return await remember_raw_memory(
+        organization_id=org,
+        principal_id="owner",
+        source_id=source_id,
+        raw_content="amethyst deployment evidence",
+        embedding_provider=None,
+    )
+
+
+async def visible(org):
+    return {
+        row.id
+        for row in await recall_raw_memory(
+            organization_id=org,
+            principal_id="owner",
+            query="amethyst",
+        )
+    }
+
+
+async def source_fingerprint(client, source_id):
+    return await client.execute_query(
+        "RETURN crypto::sha256(type::string({"
+        "row: (SELECT * FROM raw_captures WHERE uuid=$source_id),"
+        "state: (SELECT * FROM source_states WHERE source_id=$source_id)}));",
+        source_id=source_id,
+    )
+
+
+@pytest.mark.parametrize("clean", [False, True])
+@pytest.mark.parametrize("action", ["hide", "delete", "supersede"])
+async def test_public_restore_retains_newer_raw_revocation(revocation_store, clean, action):
+    client, org = revocation_store
+    source = await capture(org)
+    replacement = await capture(org, "replacement")
+    archive = await content_archive.export_content_archive_payload(org)
+    await apply_memory_correction(
+        organization_id=org,
+        principal_id="owner",
+        source_id=source.id,
+        action=action,
+        **({"replacement_source_id": replacement.id} if action == "supersede" else {}),
+    )
+    assert source.id not in await visible(org)
+    before = await source_fingerprint(client, source.id)
+    result = await content_archive.restore_content_archive_payload(archive, clean=clean)
+    assert result.success, result.errors
+    assert source.id not in await visible(org)
+    assert await source_fingerprint(client, source.id) == before
+    assert any(
+        row["source_id"] == source.id and row["reason"] == "retained_source_revocation"
+        for row in result.integrity_conflicts
+    )
+
+
+async def test_clean_omission_retains_tombstone_before_later_restore(revocation_store):
+    client, org = revocation_store
+    empty = await content_archive.export_content_archive_payload(org)
+    source = await capture(org)
+    archive = await content_archive.export_content_archive_payload(org)
+    await apply_memory_correction(
+        organization_id=org,
+        principal_id="owner",
+        source_id=source.id,
+        action="hide",
+    )
+    result = await content_archive.restore_content_archive_payload(empty, clean=True)
+    assert result.success, result.errors
+    assert not await client.execute_query(
+        "SELECT * FROM raw_captures WHERE uuid=$id;", id=source.id
+    )
+    state = await client.execute_query(
+        "SELECT * FROM source_states WHERE source_id=$id;", id=source.id
+    )
+    assert state[0]["deleted"] is True
+    before = await source_fingerprint(client, source.id)
+    result = await content_archive.restore_content_archive_payload(archive, clean=True)
+    assert result.success, result.errors
+    assert source.id not in await visible(org)
+    assert await source_fingerprint(client, source.id) == before
+    assert any(row["reason"] == "retained_tombstone" for row in result.integrity_conflicts)
+
+
+async def test_forward_archive_restores_explicitly_unhidden_source(revocation_store, monkeypatch):
+    _, org = revocation_store
+    source = await capture(org)
+    await apply_memory_correction(
+        organization_id=org,
+        principal_id="owner",
+        source_id=source.id,
+        action="hide",
+    )
+    hidden = await content_archive.export_content_archive_payload(org)
+    await apply_memory_correction(
+        organization_id=org,
+        principal_id="owner",
+        source_id=source.id,
+        action="restore",
+    )
+    active = await content_archive.export_content_archive_payload(org)
+    destination = SurrealContentClient(url="memory://")
+    close = destination.close
+    try:
+        await bootstrap_content_schema(destination)
+        monkeypatch.setattr(destination, "close", AsyncMock())
+        monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+
+        @asynccontextmanager
+        async def session():
+            yield destination
+
+        monkeypatch.setattr("sibyl_core.services.content_client.surreal_content_client", session)
+        result = await content_archive.restore_content_archive_payload(hidden, clean=True)
+        assert result.success, result.errors
+        assert source.id not in await visible(org)
+        result = await content_archive.restore_content_archive_payload(active, clean=True)
+        assert result.success, result.errors
+        assert not result.integrity_conflicts
+        assert source.id in await visible(org)
+    finally:
+        await close()
+
+
+async def test_older_active_content_remains_restorable_with_same_audience(revocation_store):
+    from sibyl_core.services.surreal_content import get_raw_memory
+
+    _, org = revocation_store
+    source = await capture(org)
+    archive = await content_archive.export_content_archive_payload(org)
+    await apply_memory_correction(
+        organization_id=org,
+        principal_id="owner",
+        source_id=source.id,
+        action="revise",
+        revised_content="amethyst changed deployment",
+    )
+    result = await content_archive.restore_content_archive_payload(archive, clean=True)
+    assert result.success, result.errors
+    restored = await get_raw_memory(memory_id=source.id, organization_id=org)
+    assert restored.raw_content == source.raw_content
+    assert source.id in await visible(org)
+
+
+async def test_older_archive_cannot_change_current_raw_owner(revocation_store):
+    from dataclasses import replace
+
+    from sibyl_core.services.content_raw_persistence import save_raw_memory
+    from sibyl_core.services.surreal_content import get_raw_memory
+
+    client, org = revocation_store
+    source = await capture(org)
+    archive = await content_archive.export_content_archive_payload(org)
+    await save_raw_memory(replace(source, principal_id="other-owner"), embedding_provider=None)
+    before = await source_fingerprint(client, source.id)
+    result = await content_archive.restore_content_archive_payload(archive, clean=True)
+    assert result.success, result.errors
+    assert await source_fingerprint(client, source.id) == before
+    assert source.id not in await visible(org)
+    restored = await get_raw_memory(memory_id=source.id, organization_id=org)
+    assert restored.principal_id == "other-owner"
+    assert any(row["reason"] == "retained_source_authority" for row in result.integrity_conflicts)

--- a/apps/api/tests/test_cli_migrate.py
+++ b/apps/api/tests/test_cli_migrate.py
@@ -1337,3 +1337,72 @@ def test_migrate_collapse_epics_dry_run_then_apply(tmp_path: Path) -> None:
         assert "Converted 1" in applied.output
         # Apply flipped the epic into a task in place.
         assert run_async(_epic_type)() is EntityType.TASK
+
+
+def test_content_restore_reports_preservation_and_quarantine_without_failing(capsys):
+    result = SimpleNamespace(
+        success=True,
+        rows_restored=2,
+        tables_restored=1,
+        errors=[],
+        integrity_conflicts=[{"reason": "retained_tombstone"}, {"reason": "retained_tombstone"}],
+        quarantined=[{"reason": "unverifiable_legacy_lineage"}],
+    )
+    with patch("sibyl.cli.migrate.restore_content_archive_payload", AsyncMock(return_value=result)):
+        assert migrate_cli._restore_content_payload({}, clean=True)
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "Destination source histories preserved instead of replaced: 2" in output
+    assert "retained deletion history: 2" in output
+    assert "Memories quarantined with content retained: 1" in output
+    assert "unverifiable legacy lineage: 1" in output
+    assert "Content writes applied: 2 rows across 1 tables" in output
+    assert "new source_id" in output
+
+
+def test_graph_restore_reports_integrity_even_when_other_writes_fail(capsys):
+    result = SimpleNamespace(
+        success=False,
+        entities_restored=1,
+        relationships_restored=0,
+        errors=["write failure"],
+        integrity_conflicts=[{"reason": "existing_source_preserved"}],
+        quarantined=[{"reason": "captured_dependency_mismatch"}],
+    )
+    with (
+        patch("sibyl.cli.db._coerce_graph_backup_data", return_value=object()),
+        patch("sibyl.cli.db._prepare_graph_runtime_async", AsyncMock()),
+        patch("sibyl_core.tools.admin.restore_backup", AsyncMock(return_value=result)),
+    ):
+        assert not migrate_cli._restore_graph_payload({}, "org", clean=True)
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "existing source preserved: 1" in output
+    assert "source evidence changed: 1" in output
+    assert "Graph restore completed with errors: 1" in output
+
+
+def test_restore_integrity_summary_does_not_echo_archive_text(capsys):
+    migrate_cli._report_restore_integrity(
+        integrity_conflicts=[{"reason": "[red]private\\nsecret", "source_id": "private-id"}],
+        quarantined=[],
+    )
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "unspecified reason: 1" in output
+    assert "private" not in output
+    assert "secret" not in output
+
+
+def test_content_restore_without_integrity_decisions_keeps_success_summary(capsys):
+    result = SimpleNamespace(
+        success=True,
+        rows_restored=4,
+        tables_restored=2,
+        errors=[],
+        integrity_conflicts=[],
+        quarantined=[],
+    )
+    with patch("sibyl.cli.migrate.restore_content_archive_payload", AsyncMock(return_value=result)):
+        assert migrate_cli._restore_content_payload({}, clean=False)
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "Content writes applied: 4 rows across 2 tables" in output
+    assert "quarantined" not in output
+    assert "histories" not in output

--- a/apps/api/tests/test_cli_migrate.py
+++ b/apps/api/tests/test_cli_migrate.py
@@ -1406,3 +1406,17 @@ def test_content_restore_without_integrity_decisions_keeps_success_summary(capsy
     assert "Content writes applied: 4 rows across 2 tables" in output
     assert "quarantined" not in output
     assert "histories" not in output
+
+
+def test_restore_reports_source_visibility_and_audience_retention(capsys):
+    migrate_cli._report_restore_integrity(
+        integrity_conflicts=[
+            {"reason": "retained_source_revocation", "source_id": "private-source"},
+            {"reason": "retained_source_authority", "source_id": "private-source"},
+        ],
+        quarantined=[],
+    )
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "retained source visibility restriction: 1" in output
+    assert "retained source audience: 1" in output
+    assert "private-source" not in output

--- a/apps/api/tests/test_cli_migrate.py
+++ b/apps/api/tests/test_cli_migrate.py
@@ -810,7 +810,7 @@ def test_migrate_import_restores_content_when_surreal_store_is_enabled(tmp_path:
     assert result.exit_code == 0
     payload = restore_content.call_args.args[0]
     assert payload["row_counts"]["document_chunks"] == 1
-    assert restore_content.call_args.kwargs == {"clean": False}
+    assert restore_content.call_args.kwargs == {"clean": False, "global_scope": False}
 
 
 def test_migrate_verify_uses_runtime_verifier(tmp_path: Path) -> None:

--- a/apps/api/tests/test_content_archive_atomicity.py
+++ b/apps/api/tests/test_content_archive_atomicity.py
@@ -1,0 +1,235 @@
+"""Failed source-local restore cannot commit cleanup or earlier auxiliary writes."""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl.persistence import content_archive
+from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
+
+
+@pytest.fixture
+async def archive_stores(monkeypatch):
+    source = SurrealContentClient(url="memory://")
+    destination = SurrealContentClient(url="memory://")
+    closes = (source.close, destination.close)
+    try:
+        for client in (source, destination):
+            await bootstrap_content_schema(client)
+            monkeypatch.setattr(client, "close", AsyncMock())
+        yield source, destination
+    finally:
+        for close in closes:
+            await close()
+
+
+async def fingerprint(client):
+    return await client.execute_query(
+        "RETURN crypto::sha256(type::string({"
+        "raw: (SELECT * FROM raw_captures ORDER BY id),"
+        "states: (SELECT * FROM source_states ORDER BY id),"
+        "derivations: (SELECT * FROM memory_derivations ORDER BY id),"
+        "attempts: (SELECT * FROM eval_attempts ORDER BY id),"
+        "cursors: (SELECT * FROM content_changefeed_cursors ORDER BY id) }));"
+    )
+
+
+async def raw(client, org, identity):
+    await client.execute_query(
+        "CREATE raw_captures CONTENT $record;",
+        record={
+            "uuid": identity,
+            "organization_id": org,
+            "principal_id": "owner",
+            "raw_content": identity,
+        },
+    )
+
+
+@pytest.mark.parametrize("clean", [False, True])
+async def test_auxiliary_conflict_rolls_back_sources_cleanup_and_prior_writes(
+    archive_stores, monkeypatch, clean
+):
+    source, destination = archive_stores
+    org, foreign, collision = str(uuid4()), str(uuid4()), str(uuid4())
+    await raw(source, org, "incoming")
+    await raw(destination, org, "must-survive")
+    await source.execute_query(
+        "CREATE eval_attempts CONTENT $record;",
+        record={
+            "uuid": str(uuid4()),
+            "organization_id": org,
+            "experiment_id": "experiment",
+            "attempt_id": "attempt",
+            "assignment_sha256": "a" * 64,
+            "assignment_json": "{}",
+        },
+    )
+    for client, organization in ((source, org), (destination, foreign)):
+        await client.execute_query(
+            "CREATE content_changefeed_cursors CONTENT $record;",
+            record={
+                "uuid": collision,
+                "organization_id": organization,
+                "table_name": "raw_captures",
+                "consumer_name": "fixture",
+                "versionstamp": 7,
+            },
+        )
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: source)
+    payload = await content_archive.export_content_archive_payload(org)
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+    before = await fingerprint(destination)
+    result = await content_archive.restore_content_archive_payload(payload, clean=clean)
+    assert not result.success
+    assert any("another organization" in error for error in result.errors)
+    assert result.rows_restored == 0
+    assert await fingerprint(destination) == before
+
+
+async def test_auxiliary_snapshot_change_denies_source_commit(archive_stores, monkeypatch):
+    source, destination = archive_stores
+    org, cursor = str(uuid4()), str(uuid4())
+    await raw(source, org, "incoming")
+    await raw(destination, org, "must-survive")
+    await destination.execute_query(
+        "CREATE content_changefeed_cursors CONTENT $record;",
+        record={
+            "uuid": cursor,
+            "organization_id": org,
+            "table_name": "raw_captures",
+            "consumer_name": "fixture",
+            "versionstamp": 7,
+        },
+    )
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: source)
+    payload = await content_archive.export_content_archive_payload(org)
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+    execute = destination.execute_query
+    changed = False
+    preserved = None
+
+    async def race(query, **parameters):
+        nonlocal changed, preserved
+        if (
+            "BEGIN TRANSACTION" in query
+            and "archive auxiliary destination changed" in query
+            and not changed
+        ):
+            changed = True
+            await execute(
+                "UPDATE content_changefeed_cursors SET versionstamp=8 WHERE uuid=$uuid;",
+                uuid=cursor,
+            )
+            preserved = await fingerprint(destination)
+        return await execute(query, **parameters)
+
+    monkeypatch.setattr(destination, "execute_query", race)
+    result = await content_archive.restore_content_archive_payload(payload, clean=True)
+    assert changed
+    assert not result.success
+    assert any("auxiliary destination changed" in error for error in result.errors)
+    assert await fingerprint(destination) == preserved
+
+
+async def test_invalid_auxiliary_payload_denies_before_clean(archive_stores, monkeypatch):
+    source, destination = archive_stores
+    org = str(uuid4())
+    await raw(source, org, "incoming")
+    await raw(destination, org, "must-survive")
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: source)
+    payload = await content_archive.export_content_archive_payload(org)
+    payload["tables"]["eval_attempts"] = [{"organization_id": org}]
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+    before = await fingerprint(destination)
+    result = await content_archive.restore_content_archive_payload(payload, clean=True)
+    assert not result.success
+    assert any("missing" in error for error in result.errors)
+    assert await fingerprint(destination) == before
+
+
+@pytest.mark.parametrize("null_field", ["created_at", "captured_at"])
+async def test_legacy_null_required_date_uses_import_default(
+    archive_stores, monkeypatch, null_field
+):
+    _, destination = archive_stores
+    org = str(uuid4())
+    supplied = "2020-01-02T03:04:05Z"
+    record = {
+        "uuid": "legacy-null-date",
+        "organization_id": org,
+        "raw_content": "legacy evidence",
+        "created_at": supplied,
+        "captured_at": supplied,
+        null_field: None,
+    }
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+    payload = {"organization_id": org, "tables": {"raw_captures": [record]}}
+    for _ in range(2):
+        result = await content_archive.restore_content_archive_payload(payload)
+        assert result.success, result.errors
+        rows = content_archive._normalize_records(
+            await destination.execute_query("SELECT * FROM raw_captures;")
+        )
+        assert len(rows) == 1
+        assert rows[0][null_field] is not None
+        preserved = "captured_at" if null_field == "created_at" else "created_at"
+        assert rows[0][preserved].isoformat().startswith("2020-01-02T03:04:05")
+        assert rows[0]["raw_content"] == "legacy evidence"
+        assert rows[0]["derivation_required"] is True
+
+
+@pytest.mark.parametrize(
+    "table", ["eval_attempts", "eval_consolidations", "api_idempotency_records"]
+)
+async def test_legacy_operation_without_generated_date_repeats_without_rewrite(
+    archive_stores, monkeypatch, table
+):
+    _, destination = archive_stores
+    org = str(uuid4())
+    record = {
+        "uuid": str(uuid4()),
+        "organization_id": org,
+        "experiment_id": "experiment",
+        "attempt_id": "attempt",
+        "assignment_sha256": "a" * 64,
+        "assignment_json": "{}",
+    }
+    if table == "eval_consolidations":
+        record = {
+            "uuid": record["uuid"],
+            "organization_id": org,
+            "principal_id": "owner",
+            "request_sha256": "b" * 64,
+            "result_kind": "abstained",
+        }
+    elif table == "api_idempotency_records":
+        record = {
+            "uuid": record["uuid"],
+            "organization_id": org,
+            "principal_id": "owner",
+            "idempotency_key": "key",
+            "method": "POST",
+            "path": "/fixture",
+            "request_hash": "hash",
+            "response_status_code": 200,
+        }
+    payload = {"organization_id": org, "tables": {table: [record]}}
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+    first = await content_archive.restore_content_archive_payload(payload)
+    assert first.success, first.errors
+    before = await fingerprint(destination)
+    repeated = await content_archive.restore_content_archive_payload(payload, clean=True)
+    assert repeated.success, repeated.errors
+    assert await fingerprint(destination) == before
+    changed_field = {
+        "eval_attempts": "assignment_json",
+        "eval_consolidations": "request_sha256",
+        "api_idempotency_records": "request_hash",
+    }[table]
+    record[changed_field] = "changed"
+    conflicting = await content_archive.restore_content_archive_payload(payload)
+    assert not conflicting.success
+    assert any("retained operation history" in error for error in conflicting.errors)
+    assert await fingerprint(destination) == before

--- a/apps/api/tests/test_legacy_checkpoint_persistence.py
+++ b/apps/api/tests/test_legacy_checkpoint_persistence.py
@@ -1,6 +1,7 @@
 """Archive and review writes retain storage-owned legacy content epochs."""
 
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -28,7 +29,11 @@ async def checkpoint_client(monkeypatch):
         await client.close()
 
 
-async def test_checkpoint_archive_restore_after_bootstrap(checkpoint_client):
+@pytest.mark.parametrize("supplied_timestamps", [False, True])
+@pytest.mark.parametrize("checkpoint_revision", [None, 7])
+async def test_checkpoint_archive_restore_after_bootstrap(
+    checkpoint_client, supplied_timestamps, checkpoint_revision
+):
     history = [{"action": "revise", "reason": "legacy corrected text"}]
     record = {
         "id": str(uuid4()),
@@ -37,6 +42,15 @@ async def test_checkpoint_archive_restore_after_bootstrap(checkpoint_client):
         "raw_content": "restored evidence",
         "metadata": {"correction_history": history},
     }
+    if checkpoint_revision is not None:
+        record["legacy_content_checkpoint"] = {
+            "entries": history,
+            "observed_revision": checkpoint_revision,
+        }
+    expected_checkpoint = checkpoint_revision or 9
+    supplied = datetime(2020, 1, 2, tzinfo=UTC)
+    if supplied_timestamps:
+        record.update(created_at=supplied.isoformat(), captured_at=supplied.isoformat())
     with (
         patch.object(
             content_archive, "build_surreal_content_client", return_value=checkpoint_client
@@ -45,6 +59,7 @@ async def test_checkpoint_archive_restore_after_bootstrap(checkpoint_client):
     ):
         result = await content_archive.restore_content_archive_payload(
             {
+                "organization_id": record["organization_id"],
                 "tables": {"raw_captures": [record]},
             }
         )
@@ -56,8 +71,12 @@ async def test_checkpoint_archive_restore_after_bootstrap(checkpoint_client):
     )[0]
     assert stored["revision"] == 9
     assert stored["metadata"]["correction_history"] == history
-    assert stored["legacy_content_checkpoint"] == {"entries": history, "observed_revision": 9}
-    record["legacy_content_checkpoint"] = {"entries": history, "observed_revision": 7}
+    assert stored["legacy_content_checkpoint"] == {
+        "entries": history,
+        "observed_revision": expected_checkpoint,
+    }
+    first_captured_at = stored["captured_at"]
+    record["legacy_content_checkpoint"] = {"entries": history, "observed_revision": 5}
     with (
         patch.object(
             content_archive, "build_surreal_content_client", return_value=checkpoint_client
@@ -66,6 +85,7 @@ async def test_checkpoint_archive_restore_after_bootstrap(checkpoint_client):
     ):
         result = await content_archive.restore_content_archive_payload(
             {
+                "organization_id": record["organization_id"],
                 "tables": {"raw_captures": [record]},
             }
         )
@@ -75,7 +95,17 @@ async def test_checkpoint_archive_restore_after_bootstrap(checkpoint_client):
             checkpoint_client, "SELECT * FROM raw_captures WHERE uuid = $uuid;", uuid=record["id"]
         )
     )[0]
-    assert stored["legacy_content_checkpoint"]["observed_revision"] == 7
+    assert stored["legacy_content_checkpoint"]["observed_revision"] == expected_checkpoint
+    assert stored["revision"] == 10
+    assert stored["derivation_required"] is True
+    assert stored["captured_at"] is not None
+    assert stored["created_at"] is not None
+    assert stored["metadata"]["correction_history"] == history
+    assert result.quarantined[0]["source_id"] == record["id"]
+    if supplied_timestamps:
+        assert stored["created_at"] == stored["captured_at"] == supplied
+    else:
+        assert stored["captured_at"] > first_captured_at
 
 
 async def test_checkpoint_stale_review_preserves_concurrent_history(checkpoint_client, monkeypatch):

--- a/apps/api/tests/test_source_archive_integrity.py
+++ b/apps/api/tests/test_source_archive_integrity.py
@@ -104,7 +104,6 @@ async def test_global_restore_requires_explicit_operator_scope_before_client(mon
 
 
 async def test_explicit_global_clean_retains_omitted_org_highwater_and_fences_new_org(monkeypatch):
-    import pytest
 
     client = SurrealContentClient(url="memory://")
     await bootstrap_content_schema(client)
@@ -155,10 +154,12 @@ async def test_explicit_global_clean_retains_omitted_org_highwater_and_fences_ne
             return await execute(statement, **params)
 
         monkeypatch.setattr(client, "execute_query", race)
-        with pytest.raises(Exception, match="destination changed"):
-            await content_archive.restore_content_archive_payload(
-                payload, clean=True, global_scope=True
-            )
+        failed = await content_archive.restore_content_archive_payload(
+            payload, clean=True, global_scope=True
+        )
+        assert not failed.success
+        assert failed.rows_restored == 0
+        assert any("destination changed" in error for error in failed.errors)
         assert injected
         assert new_source is not None
         rows = await execute("SELECT * FROM raw_captures;")

--- a/apps/api/tests/test_source_archive_integrity.py
+++ b/apps/api/tests/test_source_archive_integrity.py
@@ -1,0 +1,229 @@
+"""Application content archive imports preserve content without granting old trust."""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sibyl.persistence import content_archive
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.services import content_client
+from sibyl_core.services.content_raw_persistence import remember_raw_memory
+
+
+async def test_legacy_content_archive_quarantines_imported_memory_with_exact_metadata(monkeypatch):
+    source = SurrealContentClient(url="memory://")
+    destination = SurrealContentClient(url="memory://")
+    await bootstrap_content_schema(source)
+    await bootstrap_content_schema(destination)
+    source_close, destination_close = source.close, destination.close
+    monkeypatch.setattr(source, "close", AsyncMock())
+    monkeypatch.setattr(destination, "close", AsyncMock())
+
+    @asynccontextmanager
+    async def session():
+        yield source
+
+    monkeypatch.setattr(content_client, "surreal_content_client", session)
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: source)
+    org = str(uuid4())
+    try:
+        raw = await remember_raw_memory(
+            organization_id=org,
+            principal_id="owner",
+            source_id="legacy",
+            raw_content="Do not lose these words",
+            metadata={"literal": "2026-09-09T00:00:00Z"},
+            embedding_provider=None,
+        )
+        payload = await content_archive.export_content_archive_payload(org)
+        payload["version"] = "1.0"
+        payload.pop("source_integrity")
+        monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+        result = await content_archive.restore_content_archive_payload(payload, clean=True)
+        assert not result.errors, result.errors
+        assert result.quarantined == [
+            {
+                "source_id": raw.id,
+                "reason": "unverifiable_legacy_lineage",
+                "repair": "reauthor_under_new_capture_identity",
+            }
+        ]
+        rows = await destination.execute_query(
+            "SELECT * FROM raw_captures WHERE uuid=$uuid;", uuid=raw.id
+        )
+        assert len(rows) == 1
+        assert rows[0]["raw_content"] == raw.raw_content
+        assert rows[0]["metadata"]["literal"] == "2026-09-09T00:00:00Z"
+        assert rows[0]["derivation_required"] is True
+        assert not await destination.execute_query("SELECT * FROM memory_derivations;")
+
+        from sibyl_core.services.content_models import raw_memory_from_record
+        from sibyl_core.services.memory_derivations import raw_derivation_current
+        from sibyl_core.services.memory_source_validation import SourceReadAuthority
+
+        @asynccontextmanager
+        async def restored_session():
+            yield destination
+
+        monkeypatch.setattr(content_client, "surreal_content_client", restored_session)
+        authority = SourceReadAuthority(principal_id="owner", projects=frozenset())
+        quarantined_memory = raw_memory_from_record(rows[0])
+        assert not await raw_derivation_current(quarantined_memory, authority)
+        reauthored = await remember_raw_memory(
+            organization_id=org,
+            principal_id="owner",
+            source_id="reviewed-new-identity",
+            raw_content=quarantined_memory.raw_content,
+            embedding_provider=None,
+        )
+        assert reauthored.id != quarantined_memory.id
+        assert await raw_derivation_current(reauthored, authority)
+        assert not await raw_derivation_current(quarantined_memory, authority)
+
+    finally:
+        await source_close()
+        await destination_close()
+
+
+async def test_global_restore_requires_explicit_operator_scope_before_client(monkeypatch):
+    from unittest.mock import Mock
+
+    import pytest
+
+    factory = Mock(side_effect=AssertionError("database must not be opened"))
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", factory)
+    with pytest.raises(ValueError, match="explicit operator scope"):
+        await content_archive.restore_content_archive_payload(
+            {"version": "1.0", "tables": {}}, clean=True
+        )
+    factory.assert_not_called()
+
+
+async def test_explicit_global_clean_retains_omitted_org_highwater_and_fences_new_org(monkeypatch):
+    import pytest
+
+    client = SurrealContentClient(url="memory://")
+    await bootstrap_content_schema(client)
+    close = client.close
+    monkeypatch.setattr(client, "close", AsyncMock())
+
+    @asynccontextmanager
+    async def session():
+        yield client
+
+    monkeypatch.setattr(content_client, "surreal_content_client", session)
+    monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: client)
+
+    async def remember(org, source):
+        return await remember_raw_memory(
+            organization_id=org,
+            principal_id="owner",
+            source_id=source,
+            raw_content=source,
+            embedding_provider=None,
+        )
+
+    try:
+        original = await remember("retained-org", "Original")
+        payload = await content_archive.export_content_archive_payload()
+        omitted = await remember("omitted-org", "Added after archive")
+        result = await content_archive.restore_content_archive_payload(
+            payload, clean=True, global_scope=True
+        )
+        assert not result.errors
+        rows = await client.execute_query("SELECT * FROM raw_captures;")
+        assert {row["uuid"] for row in rows} == {original.id}
+        states = await client.execute_query(
+            "SELECT * FROM source_states WHERE source_id=$uuid;", uuid=omitted.id
+        )
+        assert len(states) == 1
+        assert states[0]["deleted"] is True
+        highwater = states[0]
+        execute = client.execute_query
+        injected = False
+        new_source = None
+
+        async def race(statement, **params):
+            nonlocal injected, new_source
+            if "archive destination changed before restore" in statement and not injected:
+                injected = True
+                new_source = await remember("new-concurrent-org", "Concurrent source")
+            return await execute(statement, **params)
+
+        monkeypatch.setattr(client, "execute_query", race)
+        with pytest.raises(Exception, match="destination changed"):
+            await content_archive.restore_content_archive_payload(
+                payload, clean=True, global_scope=True
+            )
+        assert injected
+        assert new_source is not None
+        rows = await execute("SELECT * FROM raw_captures;")
+        assert {row["uuid"] for row in rows} == {original.id, new_source.id}
+        states = await execute(
+            "SELECT * FROM source_states WHERE source_id=$uuid;", uuid=omitted.id
+        )
+        assert states == [highwater]
+    finally:
+        await close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "table", ["content_changefeed_cursors", "source_imports", "api_idempotency_records"]
+)
+@pytest.mark.parametrize("clean", [False, True])
+@pytest.mark.parametrize("foreign", [False, True])
+async def test_scoped_archive_does_not_replace_foreign_auxiliary_identity(
+    monkeypatch, clean, foreign, table
+):
+    source = SurrealContentClient(url="memory://")
+    destination = SurrealContentClient(url="memory://")
+    source_close, destination_close = source.close, destination.close
+    try:
+        await bootstrap_content_schema(source)
+        await bootstrap_content_schema(destination)
+        monkeypatch.setattr(source, "close", AsyncMock())
+        monkeypatch.setattr(destination, "close", AsyncMock())
+        org_a, org_b, identity = str(uuid4()), str(uuid4()), str(uuid4())
+        fields = {
+            "content_changefeed_cursors": {
+                "table_name": "raw_captures",
+                "consumer_name": "fixture",
+                "versionstamp": 7,
+            },
+            "source_imports": {"principal_id": "owner"},
+            "api_idempotency_records": {
+                "principal_id": "owner",
+                "idempotency_key": "fixture",
+                "method": "POST",
+                "path": "/fixture",
+                "request_hash": "fixture",
+                "response_status_code": 200,
+                "created_at": datetime.now(UTC),
+            },
+        }[table]
+        for client, org in [(source, org_a), (destination, org_b if foreign else org_a)]:
+            await client.execute_query(
+                f"CREATE {table} CONTENT $record;",
+                record={"uuid": identity, "organization_id": org, **fields},
+            )
+        before = await destination.execute_query(f"SELECT * FROM {table};")  # noqa: S608
+        monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: source)
+        payload = await content_archive.export_content_archive_payload(org_a)
+        monkeypatch.setattr(content_archive, "build_surreal_content_client", lambda: destination)
+        result = await content_archive.restore_content_archive_payload(payload, clean=clean)
+        after = await destination.execute_query(f"SELECT * FROM {table};")  # noqa: S608
+        if foreign:
+            assert not result.success
+            assert after == before, result.errors
+        else:
+            assert result.success, result.errors
+            assert len(after) == 1
+            assert after[0]["organization_id"] == org_a
+    finally:
+        await source_close()
+        await destination_close()

--- a/apps/api/tests/test_source_state_restore.py
+++ b/apps/api/tests/test_source_state_restore.py
@@ -81,14 +81,17 @@ async def test_raw_source_generation_survives_actual_purge_and_archive_restore(m
         assert retired[0]["deleted"] is True
         result = await content_archive.restore_content_archive_payload(archive)
         assert not result.errors
-        restored = await snapshot()
-        assert isinstance(restored, RawSourceSnapshot)
-        assert restored.observation.generation > retired[0]["generation"]
-        assert restored.observation.content_sha256 == original.observation.content_sha256
+        assert await snapshot() is None
+        assert any(
+            row["source_id"] == raw.id and row["reason"] == "retained_tombstone"
+            for row in result.integrity_conflicts
+        )
         result = await content_archive.restore_content_archive_payload(archive, clean=True)
         assert not result.errors
-        replaced = await snapshot()
-        assert isinstance(replaced, RawSourceSnapshot)
-        assert replaced.observation.generation > restored.observation.generation
+        assert await snapshot() is None
+        retained = await client.execute_query(
+            "SELECT * FROM source_states WHERE source_id=$uuid;", uuid=raw.id
+        )
+        assert retained == retired
     finally:
         await close()

--- a/apps/api/tests/test_surreal_content_persistence.py
+++ b/apps/api/tests/test_surreal_content_persistence.py
@@ -1848,7 +1848,7 @@ async def test_content_archive_restore_preserves_embeddings_and_metadata(
             return_value=surreal_content_client,
         ),
     ):
-        result = await restore_content_archive_payload(payload, clean=True)
+        result = await restore_content_archive_payload(payload, clean=True, global_scope=True)
 
     assert result.success is True
     assert result.tables_restored == 8
@@ -1983,7 +1983,7 @@ async def test_content_archive_restore_parses_pgvector_text_embeddings(
             return_value=surreal_content_client,
         ),
     ):
-        result = await restore_content_archive_payload(payload, clean=True)
+        result = await restore_content_archive_payload(payload, clean=True, global_scope=True)
 
     assert result.success is True
     chunk_rows = _normalize_records(

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/archive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/archive.py
@@ -327,14 +327,28 @@ def validate_archive(archive: LoadedArchive) -> list[str]:
                 errors=errors,
             )
 
+    if not errors:
+        try:
+            _sealed_memory_payloads(archive)
+        except (ValueError, TypeError, KeyError, RuntimeError) as exc:
+            errors.append(f"archive source integrity validation failed: {exc}")
     return errors
 
 
+def _sealed_memory_payloads(archive: LoadedArchive):
+    from sibyl_core.migrate.archive_lineage import seal_archive_lineage
+
+    graph = archive.files.get(GRAPH_FILENAME)
+    content = archive.files.get(CONTENT_FILENAME)
+    return seal_archive_lineage(
+        json.loads(graph.decode("utf-8")) if graph is not None else None,
+        json.loads(content.decode("utf-8")) if content is not None else None,
+    )
+
+
 def graph_payload_from_archive(archive: LoadedArchive) -> dict[str, Any] | None:
-    payload = archive.files.get(GRAPH_FILENAME)
-    if payload is None:
-        return None
-    return json.loads(payload.decode("utf-8"))
+    graph, _, _ = _sealed_memory_payloads(archive)
+    return graph
 
 
 def auth_payload_from_archive(archive: LoadedArchive) -> dict[str, Any] | None:
@@ -345,10 +359,8 @@ def auth_payload_from_archive(archive: LoadedArchive) -> dict[str, Any] | None:
 
 
 def content_payload_from_archive(archive: LoadedArchive) -> dict[str, Any] | None:
-    payload = archive.files.get(CONTENT_FILENAME)
-    if payload is None:
-        return None
-    return json.loads(payload.decode("utf-8"))
+    _, content, _ = _sealed_memory_payloads(archive)
+    return content
 
 
 def normalize_relationship_payloads(

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/archive_lineage.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/archive_lineage.py
@@ -1,0 +1,125 @@
+"""Check captured source dependencies without claiming a global archive snapshot."""
+
+import hashlib
+from copy import deepcopy
+from typing import Any
+
+from sibyl_core.memory_pipeline.observations import (
+    SourceIdentity,
+    SourceKind,
+    SourceObservation,
+    evidence_hash,
+)
+from sibyl_core.migrate.source_integrity import build_integrity_archive, validate_integrity_archive
+from sibyl_core.services.graph_derivations import graph_target_digest
+from sibyl_core.services.graph_records import entity_from_surreal_row
+from sibyl_core.services.memory_derivations import observation_from_record
+from sibyl_core.services.source_observations import graph_evidence
+
+
+def seal_archive_lineage(
+    graph_payload: dict[str, Any] | None,
+    content_payload: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, list[dict[str, str]]]:
+    """Quarantine mismatched captured dependencies before publishing the archive.
+
+    Each namespace supplies its own coherent capture. Sources omitted from a
+    standalone archive remain unresolved and protected, so a later coherent
+    content restore may satisfy them. Present but contradictory source evidence
+    retires the archived target association without rewriting its observations.
+    """
+    graph, content = deepcopy(graph_payload), deepcopy(content_payload)
+    sections = {}
+    observed = {}
+    for kind, payload, current_version in (
+        (SourceKind.GRAPH_ENTITY, graph, "3.0"),
+        (SourceKind.RAW_CAPTURE, content, "2.0"),
+    ):
+        if payload is None or payload.get("version") != current_version:
+            continue
+        section = payload.get("source_integrity")
+        organizations = section.get("organizations") if isinstance(section, dict) else None
+        if not isinstance(organizations, list):
+            raise ValueError("current archive has no complete source integrity section")
+        rows, states, associations = validate_integrity_archive(
+            section, kind=kind, organizations=organizations
+        )
+        sections[kind] = (payload, organizations, rows, states, associations)
+        org_field = "group_id" if kind is SourceKind.GRAPH_ENTITY else "organization_id"
+        state_map = {(state["organization_id"], state["source_id"]): state for state in states}
+        for row in rows:
+            source = SourceIdentity(row[org_field], kind, row["uuid"])
+            state = state_map[(source.organization_id, source.id)]
+            if state["deleted"]:
+                continue
+            digest = (
+                graph_evidence(entity_from_surreal_row(row))
+                if kind is SourceKind.GRAPH_ENTITY
+                else evidence_hash({"version": 1, "raw_content": row["raw_content"]})
+            )
+            observed[source] = SourceObservation(
+                source=source,
+                generation=state["generation"],
+                revision=state["revision"],
+                incarnation=state["incarnation"],
+                content_sha256=digest,
+                durable=True,
+            )
+    report = [
+        dict(row)
+        for payload in (graph, content)
+        if payload is not None
+        for row in payload.get("lineage_validation", [])
+        if isinstance(row, dict) and row.get("status") == "quarantined"
+    ]
+    for kind, (payload, organizations, rows, states, associations) in sections.items():
+        org_field = "group_id" if kind is SourceKind.GRAPH_ENTITY else "organization_id"
+        row_map = {(row[org_field], row["uuid"]): row for row in rows}
+        for association in associations:
+            if not association["active"]:
+                continue
+            target = row_map.get((association["organization_id"], association["target_id"]))
+            target_digest = None
+            if target is not None:
+                target_digest = (
+                    graph_target_digest(entity_from_surreal_row(target))
+                    if kind is SourceKind.GRAPH_ENTITY
+                    else hashlib.sha256(target["raw_content"].encode()).hexdigest()
+                )
+            mismatch = target_digest != association["body_sha256"]
+            unresolved = False
+            for value in association["observations"]:
+                original = observation_from_record(value)
+                if original.source.kind not in sections:
+                    unresolved = True
+                    continue
+                current = observed.get(original.source)
+                if current is None or not original.same_evidence(current):
+                    mismatch = True
+            if mismatch or unresolved:
+                identity = association["target_id"]
+                row = row_map.get((association["organization_id"], identity))
+                if row is not None:
+                    row["derivation_required"] = True
+                if mismatch:
+                    association["active"] = False
+                report.append(
+                    {
+                        "organization_id": association["organization_id"],
+                        "source_kind": kind.value,
+                        "source_id": identity,
+                        "status": "quarantined" if mismatch else "unresolved",
+                        "reason": "captured_dependency_mismatch"
+                        if mismatch
+                        else "external_dependency_omitted",
+                    }
+                )
+        payload["source_integrity"] = build_integrity_archive(
+            kind=kind,
+            organizations=organizations,
+            source_rows=rows,
+            source_states=states,
+            derivations=associations,
+        )
+        payload["lineage_validation"] = [row for row in report if row["source_kind"] == kind.value]
+    return graph, content, report

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/graph_companion_restore.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/graph_companion_restore.py
@@ -1,0 +1,156 @@
+"""Compose validated graph companions into their source restore transaction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from surrealdb import RecordID
+
+from sibyl_core.migrate.legacy_graph_archive import (
+    _EPISODE_UPSERT_STATEMENTS,
+    _MENTION_UPSERT_STATEMENTS,
+    BackupEpisodeNode,
+    BackupMentionEdge,
+    episode_record,
+)
+from sibyl_core.migrate.source_integrity import native_archive_parameters
+from sibyl_core.models.entities import Relationship
+from sibyl_core.services.graph_common import normalize_graph_records
+from sibyl_core.services.graph_relationships import (
+    _RELATIONSHIP_BULK_UPSERT_STATEMENTS,
+    _relationship_record,
+)
+from sibyl_core.services.source_archive_store import _graph_auxiliary_snapshot_sql
+
+
+@dataclass(frozen=True)
+class CompanionRestorePlan:
+    preconditions: str
+    statements: str
+    parameters: dict[str, Any]
+    episodes_restored: int
+    episodes_skipped: int
+    relationships_restored: int
+    mentions_restored: int
+    mentions_skipped: int
+
+
+async def prepare_companion_restore(
+    client: Any,
+    *,
+    organization_id: str,
+    episodes: list[BackupEpisodeNode],
+    relationships: list[Relationship],
+    mentions: list[BackupMentionEdge],
+    skip_existing: bool,
+    clean: bool,
+) -> CompanionRestorePlan:
+    """Capture skip decisions and fence the exact companion state before any writes."""
+    for item in [*episodes, *mentions]:
+        if item.group_id != organization_id:
+            raise ValueError("graph companion is outside restore organization")
+    snapshot_sql = _graph_auxiliary_snapshot_sql()
+    rows = normalize_graph_records(
+        await client.execute_query(
+            f"RETURN {{ {snapshot_sql} RETURN {{rows: $graph_auxiliary, "
+            "fingerprint: crypto::sha256(type::string($graph_auxiliary))}; };",
+            organizations=[organization_id],
+        )
+    )
+    if len(rows) != 1 or not isinstance(rows[0].get("fingerprint"), str):
+        raise ValueError("graph companion snapshot returned an invalid shape")
+    snapshot = rows[0]["rows"]
+    if not isinstance(snapshot, dict):
+        raise ValueError("graph companion snapshot returned invalid rows")
+    existing_episodes = {row["uuid"] for row in snapshot["episode"]}
+    existing_mentions = {row["uuid"] for row in snapshot["mentions"]}
+    selected_episodes = [
+        row for row in episodes if clean or not skip_existing or row.uuid not in existing_episodes
+    ]
+    selected_mentions = [
+        row for row in mentions if clean or not skip_existing or row.uuid not in existing_mentions
+    ]
+    episode_records = [episode_record(row) for row in selected_episodes]
+    relationship_records = [
+        _relationship_record(row, group_id=organization_id) for row in relationships
+    ]
+    mention_records = [
+        {
+            "uuid": row.uuid,
+            "group_id": row.group_id,
+            "source_node_uuid": row.source_node_uuid,
+            "target_node_uuid": row.target_node_uuid,
+            "created_at": row.created_at,
+            "rel": RecordID("mentions", row.uuid),
+        }
+        for row in selected_mentions
+    ]
+    episode_bindings = "\n".join(
+        f"LET ${name} = $episode.{name};"
+        for name in (episode_records[0] if episode_records else {})
+    )
+    statements = f"""
+        FOR $episode IN $archive_episodes {{
+            {episode_bindings}
+            IF array::len((SELECT uuid FROM episode
+                WHERE uuid=$uuid AND group_id!=$group_id)) > 0 {{
+                THROW 'archive episode identity belongs to another organization';
+            }};
+            {_EPISODE_UPSERT_STATEMENTS}
+        }};
+        LET $rows = $archive_relationships.map(|$edge|
+            object::from_entries(array::concat(object::entries($edge), [
+                ['in', (SELECT VALUE id FROM entity
+                    WHERE uuid=$edge.source_id AND group_id=$edge.group_id LIMIT 1)[0]],
+                ['out', (SELECT VALUE id FROM entity
+                    WHERE uuid=$edge.target_id AND group_id=$edge.group_id LIMIT 1)[0]]
+            ]))
+        );
+        IF array::len($rows[WHERE in=NONE OR out=NONE]) > 0 {{
+            THROW 'archive relationship endpoint is missing from restore organization';
+        }};
+        FOR $edge IN $rows {{
+            IF array::len((SELECT uuid FROM relates_to
+                WHERE uuid=$edge.uuid AND group_id!=$edge.group_id)) > 0 {{
+                THROW 'archive relationship identity belongs to another organization';
+            }};
+        }};
+        LET $edges = $rows.map(|$edge| {{uuid: $edge.uuid, src: $edge.in, tgt: $edge.out}});
+        IF array::len($rows) > 0 {{ {_RELATIONSHIP_BULK_UPSERT_STATEMENTS} }};
+        FOR $mention IN $archive_mentions {{
+            LET $uuid = $mention.uuid;
+            LET $group_id = $mention.group_id;
+            LET $created_at = $mention.created_at;
+            LET $rel = $mention.rel;
+            LET $src = (SELECT VALUE id FROM episode
+                WHERE uuid=$mention.source_node_uuid AND group_id=$group_id LIMIT 1)[0];
+            LET $tgt = (SELECT VALUE id FROM entity
+                WHERE uuid=$mention.target_node_uuid AND group_id=$group_id LIMIT 1)[0];
+            IF $src=NONE OR $tgt=NONE {{
+                THROW 'archive mention endpoint is missing from restore organization';
+            }};
+            IF array::len((SELECT uuid FROM mentions
+                WHERE uuid=$uuid AND group_id!=$group_id)) > 0 {{
+                THROW 'archive mention identity belongs to another organization';
+            }};
+            {_MENTION_UPSERT_STATEMENTS}
+        }};
+    """
+    return CompanionRestorePlan(
+        preconditions=snapshot_sql
+        + "IF crypto::sha256(type::string($graph_auxiliary)) != $archive_companion_fingerprint {"
+        "THROW 'archive companion destination changed before restore'; };",
+        statements=statements,
+        parameters={
+            "archive_companion_fingerprint": rows[0]["fingerprint"],
+            "archive_episodes": native_archive_parameters(episode_records),
+            "archive_relationships": native_archive_parameters(relationship_records),
+            "archive_mentions": native_archive_parameters(mention_records),
+        },
+        episodes_restored=len(selected_episodes),
+        episodes_skipped=len(episodes) - len(selected_episodes),
+        relationships_restored=len(relationships),
+        mentions_restored=len(selected_mentions),
+        mentions_skipped=len(mentions) - len(selected_mentions),
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/graph_companions.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/graph_companions.py
@@ -1,0 +1,69 @@
+"""Typed dates at the public graph companion archive boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sibyl_core.migrate.legacy_graph_archive import (
+    episode_from_payload,
+    episode_payload_from_node,
+    mention_from_payload,
+    mention_payload_from_edge,
+    parse_backup_datetime,
+)
+from sibyl_core.migrate.source_integrity import decode_record, encode_record
+from sibyl_core.models.entities import Relationship
+from sibyl_core.services.graph_records import relationship_from_surreal_row
+
+DATETIME_PATHS = "archive_datetime_paths"
+
+
+def relationship_from_archive(payload: dict[str, Any]) -> Relationship:
+    """Decode declared dates without interpreting ordinary metadata strings."""
+    record = dict(payload)
+    if DATETIME_PATHS in record:
+        paths = record.pop(DATETIME_PATHS)
+        record = decode_record({"record": record, "datetimes": paths})
+    if record.get("created_at"):
+        record["created_at"] = parse_backup_datetime(record["created_at"])
+    return Relationship.model_validate(record)
+
+
+def companion_payloads(
+    snapshot: dict[str, Any], *, organization_id: str
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Serialize companions from the same precise native snapshot as sources."""
+    auxiliary = snapshot["graph_auxiliary"]
+    relationships = []
+    for row in auxiliary["relates_to"]:
+        relationship = relationship_from_surreal_row(
+            {**row, "record_id": row["archive_record_key"]}
+        )
+        encoded = encode_record(relationship.model_dump(mode="python"))
+        relationships.append({**encoded["record"], DATETIME_PATHS: encoded["datetimes"]})
+    episodes = [
+        episode_payload_from_node(
+            episode_from_payload(row, organization_id=organization_id),
+            organization_id=organization_id,
+        )
+        for row in auxiliary["episode"]
+    ]
+    records = {
+        row["archive_record_key"]: row["uuid"]
+        for row in [*snapshot["source_rows"], *auxiliary["episode"]]
+    }
+    mentions = [
+        mention_payload_from_edge(
+            mention_from_payload(
+                {
+                    **row,
+                    "source_id": records[row["source_record_key"]],
+                    "target_id": records[row["target_record_key"]],
+                },
+                organization_id=organization_id,
+            ),
+            organization_id=organization_id,
+        )
+        for row in auxiliary["mentions"]
+    ]
+    return relationships, episodes, mentions

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_graph_archive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_graph_archive.py
@@ -150,9 +150,7 @@ async def mention_exists(client: Any, uuid: str) -> bool:
     return bool(rows)
 
 
-async def save_native_episode(client: Any, episode: BackupEpisodeNode) -> None:
-    await client.execute_query(
-        """
+_EPISODE_UPSERT_STATEMENTS = """
         UPSERT episode SET
             uuid = $uuid,
             name = $name,
@@ -165,17 +163,46 @@ async def save_native_episode(client: Any, episode: BackupEpisodeNode) -> None:
             valid_at = $valid_at,
             entity_edges = $entity_edges
         WHERE uuid = $uuid;
-        """,
-        uuid=episode.uuid,
-        name=episode.name,
-        source=episode.source.value,
-        source_description=episode.source_description,
-        content=episode.content,
-        labels=list(episode.labels),
-        group_id=episode.group_id,
-        created_at=native_archive_parameters(episode.created_at),
-        valid_at=native_archive_parameters(episode.valid_at),
-        entity_edges=list(episode.entity_edges),
+        """
+
+_MENTION_UPSERT_STATEMENTS = """
+        DELETE FROM mentions WHERE uuid = $uuid AND (in != $src OR out != $tgt);
+        LET $updated = (UPDATE mentions SET
+            in = $src,
+            out = $tgt,
+            uuid = $uuid,
+            group_id = $group_id,
+            created_at = $created_at
+        WHERE uuid = $uuid RETURN id);
+        IF array::len($updated) = 0 THEN
+            RELATE $src->$rel->$tgt SET
+                uuid = $uuid,
+                group_id = $group_id,
+                created_at = $created_at;
+        END;
+        """
+
+
+def episode_record(episode: BackupEpisodeNode) -> dict[str, Any]:
+    """Keep ordinary and archive episode writes on the same storage contract."""
+    return {
+        "uuid": episode.uuid,
+        "name": episode.name,
+        "source": episode.source.value,
+        "source_description": episode.source_description,
+        "content": episode.content,
+        "labels": list(episode.labels),
+        "group_id": episode.group_id,
+        "created_at": episode.created_at,
+        "valid_at": episode.valid_at,
+        "entity_edges": list(episode.entity_edges),
+    }
+
+
+async def save_native_episode(client: Any, episode: BackupEpisodeNode) -> None:
+    await client.execute_query(
+        _EPISODE_UPSERT_STATEMENTS,
+        **native_archive_parameters(episode_record(episode)),
     )
 
 
@@ -191,22 +218,7 @@ async def save_native_mention(client: Any, mention: BackupMentionEdge) -> None:
         raise ValueError(msg)
 
     await client.execute_query(
-        """
-        DELETE FROM mentions WHERE uuid = $uuid AND (in != $src OR out != $tgt);
-        LET $updated = (UPDATE mentions SET
-            in = $src,
-            out = $tgt,
-            uuid = $uuid,
-            group_id = $group_id,
-            created_at = $created_at
-        WHERE uuid = $uuid RETURN id);
-        IF array::len($updated) = 0 THEN
-            RELATE $src->$rel->$tgt SET
-                uuid = $uuid,
-                group_id = $group_id,
-                created_at = $created_at;
-        END;
-        """,
+        _MENTION_UPSERT_STATEMENTS,
         rel=RecordID("mentions", mention.uuid),
         src=source_record_id,
         tgt=target_record_id,

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_graph_archive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_graph_archive.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from surrealdb import RecordID
 
+from sibyl_core.migrate.source_integrity import ArchiveDatetime, native_archive_parameters
 from sibyl_core.services.graph_common import normalize_graph_records as normalize_records
 
 ARCHIVE_GRAPH_TABLES = ("episode",)
@@ -44,6 +45,8 @@ class BackupMentionEdge:
 
 
 def serialize_backup_datetime(value: Any) -> str:
+    if isinstance(value, ArchiveDatetime):
+        return value.native_text
     if isinstance(value, datetime):
         return value.isoformat()
     return str(value or "")
@@ -53,7 +56,7 @@ def parse_backup_datetime(value: Any) -> datetime:
     if isinstance(value, datetime):
         return value
     if isinstance(value, str) and value:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return ArchiveDatetime.parse(value)
     raise ValueError(f"Invalid backup datetime: {value!r}")
 
 
@@ -106,6 +109,7 @@ def episode_from_payload(payload: dict[str, Any], *, organization_id: str) -> Ba
         source_description=str(payload.get("source_description") or ""),
         content=str(payload.get("content") or ""),
         entity_edges=list(payload.get("entity_edges") or []),
+        labels=string_list(payload.get("labels"), default=["Episodic"]),
         created_at=created_at,
         valid_at=valid_at,
     )
@@ -169,8 +173,8 @@ async def save_native_episode(client: Any, episode: BackupEpisodeNode) -> None:
         content=episode.content,
         labels=list(episode.labels),
         group_id=episode.group_id,
-        created_at=episode.created_at,
-        valid_at=episode.valid_at,
+        created_at=native_archive_parameters(episode.created_at),
+        valid_at=native_archive_parameters(episode.valid_at),
         entity_edges=list(episode.entity_edges),
     )
 
@@ -208,7 +212,7 @@ async def save_native_mention(client: Any, mention: BackupMentionEdge) -> None:
         tgt=target_record_id,
         uuid=mention.uuid,
         group_id=mention.group_id,
-        created_at=mention.created_at,
+        created_at=native_archive_parameters(mention.created_at),
     )
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_source_archive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_source_archive.py
@@ -1,0 +1,69 @@
+"""Translate incomplete legacy rows without inventing trusted historical lineage."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+from uuid import uuid4
+
+from sibyl_core.memory_pipeline.observations import SourceKind
+from sibyl_core.migrate.source_integrity import build_integrity_archive
+
+_WORK_ITEM_TYPES = frozenset({"project", "task", "epic", "team", "milestone"})
+
+
+def legacy_memory_requires_quarantine(row: dict[str, Any], kind: SourceKind) -> bool:
+    return (
+        kind is SourceKind.RAW_CAPTURE
+        or row.get("derivation_required") is True
+        or row.get("entity_type") not in _WORK_ITEM_TYPES
+    )
+
+
+def build_legacy_source_archive(
+    rows: list[dict[str, Any]], *, kind: SourceKind, organizations: list[str]
+) -> tuple[dict[str, Any], set[str]]:
+    """Preserve incoming content with fresh state and unavailable memory lineage.
+
+    Legacy archives cannot prove whether an ordinary-looking memory previously
+    had a protected association. The storage-owned marker preserves that
+    uncertainty; an operator can reauthor content under a new capture identity.
+    Existing destination rows are still governed by checked restore policy.
+    """
+    org_field = "group_id" if kind is SourceKind.GRAPH_ENTITY else "organization_id"
+    table = "entity" if kind is SourceKind.GRAPH_ENTITY else "raw_captures"
+    records = deepcopy(rows)
+    states = []
+    quarantined: set[str] = set()
+    for row in records:
+        identity = row.get("uuid")
+        org = row.get(org_field)
+        if not isinstance(identity, str) or not identity or org not in organizations:
+            raise ValueError("legacy source identity is outside restore scope")
+        revision = row.get("revision", 1)
+        if type(revision) is not int or revision < 1:
+            raise ValueError("legacy source revision is invalid")
+        row["revision"] = revision
+        row["archive_record_key"] = f"{table}:{uuid4().hex}"
+        is_memory = kind is SourceKind.RAW_CAPTURE or row.get("entity_type") not in _WORK_ITEM_TYPES
+        if is_memory or row.get("derivation_required") is True:
+            row["derivation_required"] = True
+            quarantined.add(identity)
+        states.append(
+            {
+                "organization_id": org,
+                "source_kind": kind.value,
+                "source_id": identity,
+                "generation": 1,
+                "revision": revision,
+                "deleted": kind is SourceKind.RAW_CAPTURE and row.get("deleted_at") is not None,
+                "incarnation": str(uuid4()),
+            }
+        )
+    return build_integrity_archive(
+        kind=kind,
+        organizations=organizations,
+        source_rows=records,
+        source_states=states,
+        derivations=[],
+    ), quarantined

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/merge.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/merge.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from sibyl_core.memory_pipeline.observations import SourceKind
 from sibyl_core.migrate.archive import (
     AUTH_FILENAME,
     CONTENT_FILENAME,
@@ -21,6 +24,7 @@ from sibyl_core.migrate.archive import (
     normalize_mention_payloads,
     normalize_relationship_payloads,
 )
+from sibyl_core.migrate.legacy_source_archive import legacy_memory_requires_quarantine
 
 REFERENCE_FIELDS = {
     "api_key_id",
@@ -181,6 +185,7 @@ def merge_archives(
             force_canonical_org=False,
             force_row_organization_id=True,
         )
+        content_payload["organization_id"] = options.canonical_org_id
         content_row_counts = dict(content_payload["row_counts"])
         files[CONTENT_FILENAME] = _json_bytes(content_payload)
         file_metadata[CONTENT_FILENAME] = {
@@ -192,6 +197,18 @@ def merge_archives(
     if not files:
         msg = "No mergeable graph, auth, or content payloads found"
         raise ValueError(msg)
+
+    provenance_files = []
+    for source_archive in archives:
+        for original_name in (GRAPH_FILENAME, CONTENT_FILENAME):
+            original = source_archive.files.get(original_name)
+            if original is None:
+                continue
+            digest = hashlib.sha256(original).hexdigest()
+            name = f"provenance/{digest}/{original_name}"
+            files[name] = original
+            file_metadata[name] = {"kind": "source_provenance", "sha256": digest}
+            provenance_files.append(name)
 
     manifest = build_manifest(
         organization_id=options.canonical_org_id,
@@ -209,6 +226,8 @@ def merge_archives(
                 "entity_alias_count": entity_alias_count,
                 "user_alias_count": user_alias_count,
                 "drop_volatile_auth": options.drop_volatile_auth,
+                "memory_lineage_policy": "quarantine_transformed_memory",
+                "original_provenance_files": sorted(set(provenance_files)),
             }
         },
     )
@@ -384,6 +403,11 @@ def _merge_graph_payloads(
             if not isinstance(raw_entity, dict):
                 continue
             entity = _rewrite_value(dict(raw_entity), replacements)
+            if legacy_memory_requires_quarantine(raw_entity, SourceKind.GRAPH_ENTITY):
+                for field in ("metadata", "provenance", "content", "description", "name"):
+                    if field in raw_entity:
+                        entity[field] = deepcopy(raw_entity[field])
+                entity["derivation_required"] = True
             entity["organization_id"] = options.canonical_org_id
             if "group_id" in entity:
                 entity["group_id"] = options.canonical_org_id
@@ -600,6 +624,11 @@ def _merge_tabular_payloads(
             for raw_row in raw_rows:
                 if isinstance(raw_row, dict):
                     row = _rewrite_value(dict(raw_row), replacements)
+                    if table_name == "raw_captures":
+                        for field in ("metadata", "provenance", "raw_content", "title"):
+                            if field in raw_row:
+                                row[field] = deepcopy(raw_row[field])
+                        row["derivation_required"] = True
                     if force_row_organization_id:
                         _force_row_organization_id(row, canonical_org_id)
                     rows.append(row)

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/source_integrity.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/source_integrity.py
@@ -6,12 +6,61 @@ import hashlib
 import json
 import re
 from copy import deepcopy
-from datetime import datetime
-from typing import Any
+from datetime import UTC, datetime
+from typing import Any, SupportsIndex
 
 from sibyl_core.memory_pipeline.observations import SourceKind
 
 INTEGRITY_ARCHIVE_VERSION = 1
+
+
+class ArchiveDatetime(datetime):
+    """Keep native archive precision without changing evidence hash date formatting."""
+
+    native_text: str
+
+    @classmethod
+    def parse(cls, text: str) -> ArchiveDatetime:
+        parsed = datetime.fromisoformat(text)
+        value = cls(
+            parsed.year,
+            parsed.month,
+            parsed.day,
+            parsed.hour,
+            parsed.minute,
+            parsed.second,
+            parsed.microsecond,
+            tzinfo=parsed.tzinfo,
+            fold=parsed.fold,
+        )
+        value.native_text = text
+        return value
+
+    def __reduce_ex__(self, protocol: SupportsIndex, /):
+        return self.parse, (self.native_text,)
+
+
+def native_archive_parameters(value: Any) -> Any:
+    """Pass archive dates through the SDK's lossless native datetime encoder."""
+    from surrealdb.data.types.datetime import Datetime
+
+    if isinstance(value, ArchiveDatetime):
+        # The native CBOR datetime string requires UTC Z notation. Keep the
+        # fractional remainder that Python's microsecond datetime cannot hold.
+        fraction = re.match(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}[.,](\d+)", value.native_text)
+        digits = fraction.group(1) if fraction else ""
+        if len(digits) > 9:
+            raise ValueError("archive datetime exceeds native nanosecond precision")
+        parsed = datetime.fromisoformat(value.native_text)
+        utc = parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+        nanoseconds = utc.microsecond * 1000 + int((digits[6:] + "000")[:3])
+        seconds = utc.replace(microsecond=0).isoformat(timespec="seconds").removesuffix("+00:00")
+        return Datetime(f"{seconds}.{nanoseconds:09d}Z")
+    if isinstance(value, dict):
+        return {key: native_archive_parameters(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [native_archive_parameters(item) for item in value]
+    return value
 
 
 def encode_record(record: dict[str, Any]) -> dict[str, Any]:
@@ -21,7 +70,7 @@ def encode_record(record: dict[str, Any]) -> dict[str, Any]:
     def encode(value: Any, path: list[str | int]) -> Any:
         if isinstance(value, datetime):
             datetimes.append(path)
-            return value.isoformat()
+            return value.native_text if isinstance(value, ArchiveDatetime) else value.isoformat()
         if isinstance(value, dict):
             if any(not isinstance(key, str) for key in value):
                 raise ValueError("archive record keys must be strings")
@@ -52,7 +101,7 @@ def decode_record(payload: object) -> dict[str, Any]:
         key = path[-1]
         if type(key) not in (str, int) or not isinstance(parent[key], str):
             raise ValueError("archive datetime path must identify a string")
-        parent[key] = datetime.fromisoformat(parent[key])
+        parent[key] = ArchiveDatetime.parse(parent[key])
     return record
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/source_integrity.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/source_integrity.py
@@ -94,14 +94,21 @@ def decode_record(payload: object) -> dict[str, Any]:
         if not isinstance(path, list) or not path:
             raise ValueError("invalid archive datetime path")
         parent: Any = record
-        for key in path[:-1]:
-            if type(key) not in (str, int):
+        for index, key in enumerate(path):
+            if isinstance(parent, dict):
+                valid = type(key) is str and key in parent
+            elif isinstance(parent, list):
+                valid = type(key) is int and 0 <= key < len(parent)
+            else:
+                valid = False
+            if not valid:
                 raise ValueError("invalid archive datetime path component")
-            parent = parent[key]
-        key = path[-1]
-        if type(key) not in (str, int) or not isinstance(parent[key], str):
-            raise ValueError("archive datetime path must identify a string")
-        parent[key] = ArchiveDatetime.parse(parent[key])
+            if index == len(path) - 1:
+                if not isinstance(parent[key], str):
+                    raise ValueError("archive datetime path must identify a string")
+                parent[key] = ArchiveDatetime.parse(parent[key])
+            else:
+                parent = parent[key]
     return record
 
 
@@ -174,6 +181,8 @@ def validate_integrity_archive(
         org, identity = row.get(org_field), row.get("uuid")
         if org not in orgs or not isinstance(identity, str) or not identity:
             raise ValueError("archive source identity mismatch")
+        if kind is SourceKind.RAW_CAPTURE and not isinstance(row.get("raw_content"), str):
+            raise ValueError("archive raw source content must be a string")
         key = (org, identity)
         if key in row_keys:
             raise ValueError("duplicate archive source identity")

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/source_integrity.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/source_integrity.py
@@ -1,0 +1,199 @@
+"""Complete, typed source provenance sections for privileged application archives."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from datetime import datetime
+from typing import Any
+
+from sibyl_core.memory_pipeline.observations import SourceKind
+
+INTEGRITY_ARCHIVE_VERSION = 1
+
+
+def encode_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Preserve database datetimes without interpreting user strings as dates."""
+    datetimes: list[list[str | int]] = []
+
+    def encode(value: Any, path: list[str | int]) -> Any:
+        if isinstance(value, datetime):
+            datetimes.append(path)
+            return value.isoformat()
+        if isinstance(value, dict):
+            if any(not isinstance(key, str) for key in value):
+                raise ValueError("archive record keys must be strings")
+            return {key: encode(item, [*path, key]) for key, item in value.items()}
+        if isinstance(value, list | tuple):
+            return [encode(item, [*path, index]) for index, item in enumerate(value)]
+        if value is None or isinstance(value, str | int | float | bool):
+            return value
+        raise ValueError(f"unsupported archive value type: {type(value).__name__}")
+
+    return {"record": encode(record, []), "datetimes": datetimes}
+
+
+def decode_record(payload: object) -> dict[str, Any]:
+    if not isinstance(payload, dict) or set(payload) != {"record", "datetimes"}:
+        raise ValueError("archive source row requires record and datetimes")
+    if not isinstance(payload["record"], dict) or not isinstance(payload["datetimes"], list):
+        raise ValueError("invalid typed archive record")
+    record = deepcopy(payload["record"])
+    for path in payload["datetimes"]:
+        if not isinstance(path, list) or not path:
+            raise ValueError("invalid archive datetime path")
+        parent: Any = record
+        for key in path[:-1]:
+            if type(key) not in (str, int):
+                raise ValueError("invalid archive datetime path component")
+            parent = parent[key]
+        key = path[-1]
+        if type(key) not in (str, int) or not isinstance(parent[key], str):
+            raise ValueError("archive datetime path must identify a string")
+        parent[key] = datetime.fromisoformat(parent[key])
+    return record
+
+
+def _digest(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def build_integrity_archive(
+    *,
+    kind: SourceKind,
+    organizations: list[str],
+    source_rows: list[dict[str, Any]],
+    source_states: list[dict[str, Any]],
+    derivations: list[dict[str, Any]],
+) -> dict[str, Any]:
+    payload = {
+        "version": INTEGRITY_ARCHIVE_VERSION,
+        "kind": kind.value,
+        "organizations": sorted(organizations),
+        "source_rows": [encode_record(row) for row in source_rows],
+        "source_states": source_states,
+        "derivations": derivations,
+    }
+    payload["sha256"] = _digest(payload)
+    validate_integrity_archive(payload, kind=kind, organizations=organizations)
+    return payload
+
+
+def validate_integrity_archive(
+    payload: object, *, kind: SourceKind, organizations: list[str]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Reject incomplete or foreign provenance before any destination mutation."""
+    required = {
+        "version",
+        "kind",
+        "organizations",
+        "source_rows",
+        "source_states",
+        "derivations",
+        "sha256",
+    }
+    if not isinstance(payload, dict) or set(payload) != required:
+        raise ValueError("archive integrity section is incomplete")
+    if (
+        type(payload["version"]) is not int
+        or payload["version"] != INTEGRITY_ARCHIVE_VERSION
+        or payload["kind"] != kind.value
+    ):
+        raise ValueError("unsupported archive integrity contract")
+    if any(not isinstance(org, str) or not org.strip() for org in organizations):
+        raise ValueError("archive organization scope must be explicit")
+    if payload["organizations"] != sorted(set(organizations)):
+        raise ValueError("archive integrity organization mismatch")
+    if payload["sha256"] != _digest({k: v for k, v in payload.items() if k != "sha256"}):
+        raise ValueError("archive integrity digest mismatch")
+    if any(
+        not isinstance(payload[key], list)
+        for key in ("source_rows", "source_states", "derivations")
+    ):
+        raise ValueError("archive integrity collections must be arrays")
+    rows = [decode_record(row) for row in payload["source_rows"]]
+    states = deepcopy(payload["source_states"])
+    derivations = deepcopy(payload["derivations"])
+    orgs = set(organizations)
+    org_field = "group_id" if kind is SourceKind.GRAPH_ENTITY else "organization_id"
+    row_keys: set[tuple[str, str]] = set()
+    state_keys: set[tuple[str, str]] = set()
+    for row in rows:
+        org, identity = row.get(org_field), row.get("uuid")
+        if org not in orgs or not isinstance(identity, str) or not identity:
+            raise ValueError("archive source identity mismatch")
+        key = (org, identity)
+        if key in row_keys:
+            raise ValueError("duplicate archive source identity")
+        row_keys.add(key)
+        if (
+            row.get("derivation_required") is not None
+            and type(row["derivation_required"]) is not bool
+        ):
+            raise ValueError("invalid archive source marker")
+    for state in states:
+        if not isinstance(state, dict):
+            raise ValueError("invalid archive source state")
+        org, identity = state.get("organization_id"), state.get("source_id")
+        if org not in orgs or not isinstance(identity, str) or not identity:
+            raise ValueError("archive ledger identity mismatch")
+        if state.get("source_kind") != kind.value:
+            raise ValueError("archive ledger source kind mismatch")
+        key = (org, identity)
+        if key in state_keys:
+            raise ValueError("duplicate archive source ledger")
+        state_keys.add(key)
+        if (
+            type(state.get("generation")) is not int
+            or state["generation"] <= 0
+            or type(state.get("revision")) is not int
+            or state["revision"] < 0
+            or type(state.get("deleted")) is not bool
+            or not isinstance(state.get("incarnation"), str)
+            or not state["incarnation"].strip()
+        ):
+            raise ValueError("invalid archive source incarnation or high-water")
+    if not row_keys <= state_keys:
+        raise ValueError("archive source has no retained ledger")
+    ledger_by_key = {(state["organization_id"], state["source_id"]): state for state in states}
+    for row in rows:
+        state = ledger_by_key[(row[org_field], row["uuid"])]
+        if type(row.get("revision")) is not int or row["revision"] != state["revision"]:
+            raise ValueError("archive source revision does not match retained ledger")
+    if any(
+        not state["deleted"] and (state["organization_id"], state["source_id"]) not in row_keys
+        for state in states
+    ):
+        raise ValueError("archive live ledger has no source row")
+    association_keys: set[tuple[str, str]] = set()
+    for association in derivations:
+        if not isinstance(association, dict):
+            raise ValueError("invalid archive derivation")
+        key = (association.get("organization_id"), association.get("target_id"))
+        if key not in state_keys or association.get("target_kind") != kind.value:
+            raise ValueError("archive derivation target has no scoped ledger")
+        if key in association_keys:
+            raise ValueError("duplicate archive target association")
+        association_keys.add(key)
+        if type(association.get("active")) is not bool:
+            raise ValueError("archive derivation requires explicit retirement state")
+        if not isinstance(association.get("observations"), list) or not association["observations"]:
+            raise ValueError("archive derivation has no captured observations")
+        if (
+            not isinstance(association.get("body_sha256"), str)
+            or re.fullmatch(r"[0-9a-f]{64}", association["body_sha256"]) is None
+            or not isinstance(association.get("principal_id"), str)
+            or not association["principal_id"].strip()
+            or not isinstance(association.get("authority_ceiling"), dict)
+        ):
+            raise ValueError("archive derivation body or authority is malformed")
+        from sibyl_core.services.memory_derivations import observation_from_record
+
+        for value in association["observations"]:
+            observation = observation_from_record(value)
+            if not observation.durable or observation.source.organization_id != key[0]:
+                raise ValueError("archive derivation source is not scoped durable evidence")
+    return rows, states, derivations

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_relationships.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_relationships.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from datetime import datetime
 
 from surrealdb import RecordID
 
 from sibyl_core.backends.surreal.connection import _is_transient_connection_error
 from sibyl_core.embeddings.providers import EmbeddingProvider
 from sibyl_core.memory_pipeline.quality import expand_memory_quality_storage_metadata
+from sibyl_core.migrate.source_integrity import ArchiveDatetime, native_archive_parameters
 from sibyl_core.models.entities import Entity, Relationship, RelationshipType
 from sibyl_core.services.graph_client import (
     SurrealGraphClient,
@@ -595,7 +597,7 @@ async def _replace_relationship(
         src=src,
         tgt=tgt,
         rel=RecordID("relates_to", relationship.id),
-        **payload,
+        **native_archive_parameters(payload),
     )
 
 
@@ -679,7 +681,7 @@ async def _replace_relationships_bulk(
     try:
         await client.execute_query(
             _RELATIONSHIP_BULK_UPSERT_QUERY,
-            rows=rows,
+            rows=native_archive_parameters(rows),
             edges=edges,
         )
     except Exception as exc:
@@ -689,10 +691,18 @@ async def _replace_relationships_bulk(
         await prepare_graph_schema(client)
         await client.execute_query(
             _RELATIONSHIP_BULK_UPSERT_QUERY,
-            rows=rows,
+            rows=native_archive_parameters(rows),
             edges=edges,
         )
     return written_ids
+
+
+def _relationship_datetime(value: object) -> datetime | None:
+    """Preserve column precision without changing the original metadata value."""
+    parsed = _metadata_datetime(value)
+    if parsed is not None and isinstance(value, str):
+        return ArchiveDatetime.parse(value)
+    return parsed
 
 
 def _relationship_record(relationship: Relationship, *, group_id: str) -> SurrealRecord:
@@ -715,9 +725,11 @@ def _relationship_record(relationship: Relationship, *, group_id: str) -> Surrea
         "episodes": _metadata_str_list(metadata.get("episodes")),
         "attributes": attributes,
         "created_at": relationship.created_at,
-        "expired_at": _metadata_datetime(metadata.get("expired_at")),
-        "valid_at": _metadata_datetime(metadata.get("valid_at") or metadata.get("valid_from")),
-        "invalid_at": _metadata_datetime(metadata.get("invalid_at") or metadata.get("valid_to")),
+        "expired_at": _relationship_datetime(metadata.get("expired_at")),
+        "valid_at": _relationship_datetime(metadata.get("valid_at") or metadata.get("valid_from")),
+        "invalid_at": _relationship_datetime(
+            metadata.get("invalid_at") or metadata.get("valid_to")
+        ),
     }
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_relationships.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_relationships.py
@@ -45,8 +45,7 @@ from sibyl_core.services.graph_records import (
     _relationship_from_row,
 )
 
-_RELATIONSHIP_BULK_UPSERT_QUERY = """
-BEGIN TRANSACTION;
+_RELATIONSHIP_BULK_UPSERT_STATEMENTS = """
 -- The planner never serves `uuid IN $list` from idx_relates_uuid (TableScan
 -- for every statement type, seconds per capture batch once the table is
 -- large), so the endpoint-move cleanup iterates the batch and addresses each
@@ -69,8 +68,10 @@ INSERT RELATION INTO relates_to $rows ON DUPLICATE KEY UPDATE
     expired_at = $input.expired_at,
     valid_at = $input.valid_at,
     invalid_at = $input.invalid_at;
-COMMIT TRANSACTION;
 """
+_RELATIONSHIP_BULK_UPSERT_QUERY = (
+    "BEGIN TRANSACTION;\n" + _RELATIONSHIP_BULK_UPSERT_STATEMENTS + "COMMIT TRANSACTION;"
+)
 
 
 class RelationshipManager:

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -140,6 +140,34 @@ async def export_source_integrity(
     )
 
 
+def _source_visibility(row: dict[str, Any], kind: SourceKind) -> tuple[bool, tuple[object, ...]]:
+    """Read lifecycle and audience through the same adapters used by source reads."""
+    from sibyl_core.memory_pipeline.lifecycle import (
+        graph_metadata_recallable,
+        raw_memory_lifecycle_recallable,
+    )
+    from sibyl_core.services.content_models import raw_memory_from_record
+    from sibyl_core.services.graph_records import _entity_from_row
+
+    if kind is SourceKind.RAW_CAPTURE:
+        memory = raw_memory_from_record(row)
+        return (
+            memory.deleted_at is None and raw_memory_lifecycle_recallable(memory),
+            (
+                memory.principal_id,
+                memory.memory_scope.value,
+                memory.scope_key,
+                memory.project_id,
+                memory.agent_id,
+            ),
+        )
+    entity = _entity_from_row(row)
+    return graph_metadata_recallable(entity.metadata), tuple(
+        entity.metadata.get(key) or None
+        for key in ("principal_id", "memory_scope", "scope_key", "project_id", "agent_id")
+    )
+
+
 async def restore_source_integrity(
     execute_query: SurrealExecute,
     payload: object,
@@ -218,6 +246,20 @@ async def restore_source_integrity(
                 {"organization_id": key[0], "source_id": key[1], "reason": "retained_tombstone"}
             )
             continue
+        if row is not None and previous_row is not None and not trusted:
+            recallable, audience = _source_visibility(previous_row, kind)
+            _, incoming_audience = _source_visibility(row, kind)
+            if not recallable or audience != incoming_audience:
+                conflicts.append(
+                    {
+                        "organization_id": key[0],
+                        "source_id": key[1],
+                        "reason": "retained_source_revocation"
+                        if not recallable
+                        else "retained_source_authority",
+                    }
+                )
+                continue
         if row is None:
             if fresh or forward:
                 if previous_row is not None:

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from sibyl_core.backends.surreal.records import normalize_records
 from sibyl_core.backends.surreal.schema_version import SurrealExecute
 from sibyl_core.memory_pipeline.observations import SourceKind
-from sibyl_core.migrate.source_integrity import build_integrity_archive
+from sibyl_core.migrate.source_integrity import (
+    ArchiveDatetime,
+    build_integrity_archive,
+    native_archive_parameters,
+)
 
 
 def _source_table(kind: SourceKind) -> tuple[str, str]:
@@ -44,31 +49,78 @@ async def read_source_archive_snapshot(
         raise ValueError("graph companion inventory requires explicit organization scope")
     companion_sql = _graph_auxiliary_snapshot_sql() if include_graph_auxiliary else ""
     companion_field = ", graph_auxiliary: $graph_auxiliary" if include_graph_auxiliary else ""
+    snapshot_sql = f"""LET $rows = SELECT *, type::string(id) AS archive_record_key OMIT id
+        FROM {table} WHERE {row_scope} ORDER BY {org_field}, uuid;
+        LET $states = SELECT * OMIT id FROM source_states
+            WHERE {ledger_scope} AND source_kind=$kind ORDER BY organization_id, source_id;
+        LET $derivations = SELECT * OMIT id FROM memory_derivations
+            WHERE {ledger_scope} AND target_kind=$kind ORDER BY organization_id, target_id;
+        {companion_sql}
+        LET $snapshot = {{ source_rows: $rows, source_states: $states,
+            derivations: $derivations {companion_field} }};"""
     result = normalize_records(
         await execute_query(
-            f"""RETURN {{
-            LET $rows = SELECT *, type::string(id) AS archive_record_key OMIT id
-                FROM {table} WHERE {row_scope}
-                ORDER BY {org_field}, uuid;
-            LET $states = SELECT * OMIT id FROM source_states
-                WHERE {ledger_scope} AND source_kind=$kind
-                ORDER BY organization_id, source_id;
-            LET $derivations = SELECT * OMIT id FROM memory_derivations
-                WHERE {ledger_scope} AND target_kind=$kind
-                ORDER BY organization_id, target_id;
-            {companion_sql}
-            RETURN {{ source_rows: $rows, source_states: $states, derivations: $derivations {companion_field} }};
-        }};""",
+            f"RETURN {{ {snapshot_sql} RETURN {{snapshot: $snapshot, fingerprint: crypto::sha256(type::string($snapshot))}}; }};",
             organizations=organizations,
             kind=kind.value,
         )
     )
-    if len(result) != 1 or any(
-        not isinstance(result[0].get(key), list)
-        for key in ("source_rows", "source_states", "derivations")
+    if len(result) != 1:
+        raise ValueError("source archive snapshot returned an invalid shape")
+    snapshot = result[0].get("snapshot")
+    fingerprint = result[0].get("fingerprint")
+    if (
+        not isinstance(snapshot, dict)
+        or not isinstance(fingerprint, str)
+        or any(
+            not isinstance(snapshot.get(key), list)
+            for key in ("source_rows", "source_states", "derivations")
+        )
     ):
         raise ValueError("source archive snapshot returned an invalid shape")
-    return result[0]
+
+    # The SDK truncates native nanoseconds. Capture typed datetime text only
+    # after proving the second source-local read matches the original snapshot.
+    dates: list[tuple[Any, str | int, str]] = []
+
+    def collect(value: Any, path: str) -> None:
+        if isinstance(value, dict | list):
+            items = value.items() if isinstance(value, dict) else enumerate(value)
+            for key, item in items:
+                if isinstance(key, int):
+                    child = f"{path}[{key}]"
+                else:
+                    escaped = key.replace("\\", "\\\\").replace("`", "\\`")
+                    child = f"{path}.`{escaped}`" if path else f"`{escaped}`"
+                if isinstance(item, datetime):
+                    dates.append((value, key, child))
+                else:
+                    collect(item, child)
+
+    collect(snapshot, "")
+    if dates:
+        captured = normalize_records(
+            await execute_query(
+                f"""RETURN {{ {snapshot_sql}
+                IF crypto::sha256(type::string($snapshot)) != $fingerprint {{
+                    THROW 'archive source changed during datetime capture';
+                }};
+                RETURN SELECT array::map($paths, |$path| type::string(type::field($path))) AS datetimes
+                    FROM ONLY $snapshot;
+            }};""",
+                organizations=organizations,
+                kind=kind.value,
+                fingerprint=fingerprint,
+                paths=[path for _, _, path in dates],
+            )
+        )
+        texts = captured[0].get("datetimes") if len(captured) == 1 else None
+        if not isinstance(texts, list) or len(texts) != len(dates):
+            raise ValueError("source archive datetime capture returned an invalid shape")
+        for (parent, key, _), text in zip(dates, texts, strict=True):
+            parent[key] = ArchiveDatetime.parse(text)
+    snapshot["fingerprint"] = fingerprint
+    return snapshot
 
 
 async def export_source_integrity(
@@ -79,7 +131,13 @@ async def export_source_integrity(
     )
     if organizations is None:
         organizations = sorted({state["organization_id"] for state in snapshot["source_states"]})
-    return build_integrity_archive(kind=kind, organizations=organizations, **snapshot)
+    return build_integrity_archive(
+        kind=kind,
+        organizations=organizations,
+        source_rows=snapshot["source_rows"],
+        source_states=snapshot["source_states"],
+        derivations=snapshot["derivations"],
+    )
 
 
 async def restore_source_integrity(
@@ -238,7 +296,7 @@ async def restore_source_integrity(
             WHERE {ledger_scope} AND target_kind=$kind
             ORDER BY organization_id, target_id;
         {companion_sql}
-        IF {{ source_rows: $rows, source_states: $states, derivations: $associations {companion_field} }} != $expected {{
+        IF crypto::sha256(type::string({{ source_rows: $rows, source_states: $states, derivations: $associations {companion_field} }})) != $expected {{
             THROW 'archive destination changed before restore';
         }};
         {companion_cleanup}
@@ -269,9 +327,9 @@ async def restore_source_integrity(
         query,
         organizations=organizations,
         kind=kind.value,
-        expected=before,
+        expected=before["fingerprint"],
         deletes=deletes,
-        writes=writes,
+        writes=native_archive_parameters(writes),
         ledger_writes=ledger_writes,
         association_writes=association_writes,
     )

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -16,13 +16,34 @@ def _source_table(kind: SourceKind) -> tuple[str, str]:
     return "raw_captures", "organization_id"
 
 
+def _graph_auxiliary_snapshot_sql() -> str:
+    return """LET $graph_auxiliary = {
+        episode: (SELECT *, type::string(id) AS archive_record_key OMIT id
+            FROM episode WHERE group_id IN $organizations ORDER BY uuid, archive_record_key),
+        relates_to: (SELECT *, type::string(id) AS archive_record_key,
+            type::string(in) AS source_record_key, type::string(out) AS target_record_key OMIT id, in, out
+            FROM relates_to WHERE group_id IN $organizations ORDER BY uuid, archive_record_key),
+        mentions: (SELECT *, type::string(id) AS archive_record_key,
+            type::string(in) AS source_record_key, type::string(out) AS target_record_key OMIT id, in, out
+            FROM mentions WHERE group_id IN $organizations ORDER BY uuid, archive_record_key)
+    };"""
+
+
 async def read_source_archive_snapshot(
-    execute_query: SurrealExecute, *, kind: SourceKind, organizations: list[str] | None
+    execute_query: SurrealExecute,
+    *,
+    kind: SourceKind,
+    organizations: list[str] | None,
+    include_graph_auxiliary: bool = False,
 ) -> dict[str, Any]:
     """Read live sources, absent-source history, and target associations together."""
     table, org_field = _source_table(kind)
     row_scope = f"{org_field} IN $organizations" if organizations is not None else "true"
     ledger_scope = "organization_id IN $organizations" if organizations is not None else "true"
+    if include_graph_auxiliary and (kind is not SourceKind.GRAPH_ENTITY or organizations is None):
+        raise ValueError("graph companion inventory requires explicit organization scope")
+    companion_sql = _graph_auxiliary_snapshot_sql() if include_graph_auxiliary else ""
+    companion_field = ", graph_auxiliary: $graph_auxiliary" if include_graph_auxiliary else ""
     result = normalize_records(
         await execute_query(
             f"""RETURN {{
@@ -35,7 +56,8 @@ async def read_source_archive_snapshot(
             LET $derivations = SELECT * OMIT id FROM memory_derivations
                 WHERE {ledger_scope} AND target_kind=$kind
                 ORDER BY organization_id, target_id;
-            RETURN {{ source_rows: $rows, source_states: $states, derivations: $derivations }};
+            {companion_sql}
+            RETURN {{ source_rows: $rows, source_states: $states, derivations: $derivations {companion_field} }};
         }};""",
             organizations=organizations,
             kind=kind.value,
@@ -68,19 +90,30 @@ async def restore_source_integrity(
     organizations: list[str],
     clean: bool = False,
     skip_existing: bool = True,
+    global_scope: bool = False,
+    clean_graph_auxiliary: bool = False,
 ) -> dict[str, Any]:
     """Restore complete source units without lowering destination trust history."""
     from copy import deepcopy
 
     from sibyl_core.migrate.source_integrity import validate_integrity_archive
 
+    if clean_graph_auxiliary and (not clean or kind is not SourceKind.GRAPH_ENTITY):
+        raise ValueError("graph companion cleanup requires a scoped clean graph restore")
+    if global_scope and kind is not SourceKind.RAW_CAPTURE:
+        raise ValueError("global restore scope is only supported for the shared raw source store")
     rows, states, associations = validate_integrity_archive(
         payload, kind=kind, organizations=organizations
     )
     before = await read_source_archive_snapshot(
-        execute_query, kind=kind, organizations=organizations
+        execute_query,
+        kind=kind,
+        organizations=None if global_scope else organizations,
+        include_graph_auxiliary=clean_graph_auxiliary,
     )
     table, org_field = _source_table(kind)
+    row_scope = "true" if global_scope else f"{org_field} IN $organizations"
+    ledger_scope = "true" if global_scope else "organization_id IN $organizations"
 
     def row_key(row):
         return row[org_field], row["uuid"]
@@ -187,18 +220,28 @@ async def restore_source_integrity(
         deletes.extend(
             row["archive_record_key"] for key, row in old_rows.items() if key not in incoming_states
         )
+    companion_sql = _graph_auxiliary_snapshot_sql() if clean_graph_auxiliary else ""
+    companion_field = ", graph_auxiliary: $graph_auxiliary" if clean_graph_auxiliary else ""
+    companion_cleanup = (
+        """FOR $row IN array::concat($graph_auxiliary.relates_to,
+        $graph_auxiliary.mentions, $graph_auxiliary.episode) { DELETE type::record($row.archive_record_key); };"""
+        if clean_graph_auxiliary
+        else ""
+    )
     query = f"""BEGIN TRANSACTION;
         LET $rows = SELECT *, type::string(id) AS archive_record_key OMIT id
-            FROM {table} WHERE {org_field} IN $organizations ORDER BY {org_field}, uuid;
+            FROM {table} WHERE {row_scope} ORDER BY {org_field}, uuid;
         LET $states = SELECT * OMIT id FROM source_states
-            WHERE organization_id IN $organizations AND source_kind=$kind
+            WHERE {ledger_scope} AND source_kind=$kind
             ORDER BY organization_id, source_id;
         LET $associations = SELECT * OMIT id FROM memory_derivations
-            WHERE organization_id IN $organizations AND target_kind=$kind
+            WHERE {ledger_scope} AND target_kind=$kind
             ORDER BY organization_id, target_id;
-        IF {{ source_rows: $rows, source_states: $states, derivations: $associations }} != $expected {{
+        {companion_sql}
+        IF {{ source_rows: $rows, source_states: $states, derivations: $associations {companion_field} }} != $expected {{
             THROW 'archive destination changed before restore';
         }};
+        {companion_cleanup}
         FOR $key IN $deletes {{ DELETE type::record($key); }};
         FOR $entry IN $writes {{
             LET $existing = (SELECT * FROM type::record($entry.key))[0];

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -150,6 +150,7 @@ async def restore_source_integrity(
     skip_existing: bool = True,
     global_scope: bool = False,
     clean_graph_auxiliary: bool = False,
+    auxiliary_preconditions: str = "",
     auxiliary_statements: str = "",
     auxiliary_parameters: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -301,6 +302,7 @@ async def restore_source_integrity(
         IF crypto::sha256(type::string({{ source_rows: $rows, source_states: $states, derivations: $associations {companion_field} }})) != $expected {{
             THROW 'archive destination changed before restore';
         }};
+        {auxiliary_preconditions}
         {companion_cleanup}
         FOR $key IN $deletes {{ DELETE type::record($key); }};
         FOR $entry IN $writes {{

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -24,13 +24,13 @@ def _source_table(kind: SourceKind) -> tuple[str, str]:
 def _graph_auxiliary_snapshot_sql() -> str:
     return """LET $graph_auxiliary = {
         episode: (SELECT *, type::string(id) AS archive_record_key OMIT id
-            FROM episode WHERE group_id IN $organizations ORDER BY uuid, archive_record_key),
+            FROM episode WHERE group_id IN $organizations ORDER BY uuid DESC, archive_record_key),
         relates_to: (SELECT *, type::string(id) AS archive_record_key,
             type::string(in) AS source_record_key, type::string(out) AS target_record_key OMIT id, in, out
-            FROM relates_to WHERE group_id IN $organizations ORDER BY uuid, archive_record_key),
+            FROM relates_to WHERE group_id IN $organizations ORDER BY created_at DESC, uuid DESC, archive_record_key),
         mentions: (SELECT *, type::string(id) AS archive_record_key,
             type::string(in) AS source_record_key, type::string(out) AS target_record_key OMIT id, in, out
-            FROM mentions WHERE group_id IN $organizations ORDER BY uuid, archive_record_key)
+            FROM mentions WHERE group_id IN $organizations ORDER BY uuid DESC, archive_record_key)
     };"""
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -1,0 +1,235 @@
+"""Source-local archive snapshots and checked restoration through existing stores."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sibyl_core.backends.surreal.records import normalize_records
+from sibyl_core.backends.surreal.schema_version import SurrealExecute
+from sibyl_core.memory_pipeline.observations import SourceKind
+from sibyl_core.migrate.source_integrity import build_integrity_archive
+
+
+def _source_table(kind: SourceKind) -> tuple[str, str]:
+    if kind is SourceKind.GRAPH_ENTITY:
+        return "entity", "group_id"
+    return "raw_captures", "organization_id"
+
+
+async def read_source_archive_snapshot(
+    execute_query: SurrealExecute, *, kind: SourceKind, organizations: list[str] | None
+) -> dict[str, Any]:
+    """Read live sources, absent-source history, and target associations together."""
+    table, org_field = _source_table(kind)
+    row_scope = f"{org_field} IN $organizations" if organizations is not None else "true"
+    ledger_scope = "organization_id IN $organizations" if organizations is not None else "true"
+    result = normalize_records(
+        await execute_query(
+            f"""RETURN {{
+            LET $rows = SELECT *, type::string(id) AS archive_record_key OMIT id
+                FROM {table} WHERE {row_scope}
+                ORDER BY {org_field}, uuid;
+            LET $states = SELECT * OMIT id FROM source_states
+                WHERE {ledger_scope} AND source_kind=$kind
+                ORDER BY organization_id, source_id;
+            LET $derivations = SELECT * OMIT id FROM memory_derivations
+                WHERE {ledger_scope} AND target_kind=$kind
+                ORDER BY organization_id, target_id;
+            RETURN {{ source_rows: $rows, source_states: $states, derivations: $derivations }};
+        }};""",
+            organizations=organizations,
+            kind=kind.value,
+        )
+    )
+    if len(result) != 1 or any(
+        not isinstance(result[0].get(key), list)
+        for key in ("source_rows", "source_states", "derivations")
+    ):
+        raise ValueError("source archive snapshot returned an invalid shape")
+    return result[0]
+
+
+async def export_source_integrity(
+    execute_query: SurrealExecute, *, kind: SourceKind, organizations: list[str] | None
+) -> dict[str, Any]:
+    snapshot = await read_source_archive_snapshot(
+        execute_query, kind=kind, organizations=organizations
+    )
+    if organizations is None:
+        organizations = sorted({state["organization_id"] for state in snapshot["source_states"]})
+    return build_integrity_archive(kind=kind, organizations=organizations, **snapshot)
+
+
+async def restore_source_integrity(
+    execute_query: SurrealExecute,
+    payload: object,
+    *,
+    kind: SourceKind,
+    organizations: list[str],
+    clean: bool = False,
+    skip_existing: bool = True,
+) -> dict[str, Any]:
+    """Restore complete source units without lowering destination trust history."""
+    from copy import deepcopy
+
+    from sibyl_core.migrate.source_integrity import validate_integrity_archive
+
+    rows, states, associations = validate_integrity_archive(
+        payload, kind=kind, organizations=organizations
+    )
+    before = await read_source_archive_snapshot(
+        execute_query, kind=kind, organizations=organizations
+    )
+    table, org_field = _source_table(kind)
+
+    def row_key(row):
+        return row[org_field], row["uuid"]
+
+    def state_key(state):
+        return state["organization_id"], state["source_id"]
+
+    def association_key(association):
+        return association["organization_id"], association["target_id"]
+
+    old_rows = {row_key(row): row for row in before["source_rows"]}
+    old_states = {state_key(state): state for state in before["source_states"]}
+    old_associations = {association_key(row): row for row in before["derivations"]}
+    incoming_rows = {row_key(row): row for row in rows}
+    incoming_states = {state_key(state): state for state in states}
+    incoming_associations = {association_key(row): row for row in associations}
+    writes: list[dict[str, Any]] = []
+    ledger_writes: list[dict[str, Any]] = []
+    association_writes: list[dict[str, Any]] = []
+    deletes: list[str] = []
+    conflicts: list[dict[str, str]] = []
+    restored: list[str] = []
+
+    for key, incoming_state in incoming_states.items():
+        row = incoming_rows.get(key)
+        previous = old_states.get(key)
+        previous_row = old_rows.get(key)
+        prior_association = old_associations.get(key)
+        fresh = previous is None and previous_row is None and prior_association is None
+        same_state = previous is not None and all(
+            previous.get(field) == incoming_state.get(field)
+            for field in ("incarnation", "generation", "deleted")
+        )
+        forward = previous is not None and (
+            previous["incarnation"] == incoming_state["incarnation"]
+            and previous["generation"] < incoming_state["generation"]
+            and not previous["deleted"]
+        )
+        trusted = fresh or ((same_state or forward) and (row is None or previous_row is not None))
+        if previous is not None and previous["deleted"] and row is not None:
+            conflicts.append(
+                {"organization_id": key[0], "source_id": key[1], "reason": "retained_tombstone"}
+            )
+            continue
+        if row is None:
+            if fresh or forward:
+                if previous_row is not None:
+                    deletes.append(previous_row["archive_record_key"])
+                ledger_writes.append(incoming_state)
+            elif not same_state:
+                conflicts.append(
+                    {
+                        "organization_id": key[0],
+                        "source_id": key[1],
+                        "reason": "retained_high_water",
+                    }
+                )
+                continue
+        elif previous_row is not None and (skip_existing or same_state):
+            if not same_state:
+                conflicts.append(
+                    {
+                        "organization_id": key[0],
+                        "source_id": key[1],
+                        "reason": "existing_source_preserved",
+                    }
+                )
+                continue
+        else:
+            record = deepcopy(row)
+            record_key = record.pop("archive_record_key", None)
+            if not isinstance(record_key, str) or not record_key.startswith(table + ":"):
+                raise ValueError("archive source record key does not match its table")
+            if previous_row is not None:
+                record_key = previous_row["archive_record_key"]
+                record["revision"] = max(record["revision"], previous_row["revision"] + 1)
+            if (
+                key in incoming_associations
+                or prior_association is not None
+                or (previous_row or {}).get("derivation_required") is True
+            ):
+                record["derivation_required"] = True
+            writes.append({"key": record_key, "record": record})
+            restored.append(key[1])
+            if trusted:
+                ledger_writes.append({**incoming_state, "revision": record["revision"]})
+            else:
+                if prior_association is not None:
+                    association_writes.append({**prior_association, "active": False})
+                conflicts.append(
+                    {
+                        "organization_id": key[0],
+                        "source_id": key[1],
+                        "reason": "incoming_lineage_not_adopted",
+                    }
+                )
+        association = incoming_associations.get(key)
+        if association is not None and trusted:
+            if prior_association is not None and prior_association["active"] is False:
+                continue
+            association_writes.append(association)
+
+    if clean:
+        deletes.extend(
+            row["archive_record_key"] for key, row in old_rows.items() if key not in incoming_states
+        )
+    query = f"""BEGIN TRANSACTION;
+        LET $rows = SELECT *, type::string(id) AS archive_record_key OMIT id
+            FROM {table} WHERE {org_field} IN $organizations ORDER BY {org_field}, uuid;
+        LET $states = SELECT * OMIT id FROM source_states
+            WHERE organization_id IN $organizations AND source_kind=$kind
+            ORDER BY organization_id, source_id;
+        LET $associations = SELECT * OMIT id FROM memory_derivations
+            WHERE organization_id IN $organizations AND target_kind=$kind
+            ORDER BY organization_id, target_id;
+        IF {{ source_rows: $rows, source_states: $states, derivations: $associations }} != $expected {{
+            THROW 'archive destination changed before restore';
+        }};
+        FOR $key IN $deletes {{ DELETE type::record($key); }};
+        FOR $entry IN $writes {{
+            LET $existing = (SELECT * FROM type::record($entry.key))[0];
+            IF $existing != NONE AND ($existing.{org_field} != $entry.record.{org_field}
+                OR $existing.uuid != $entry.record.uuid) {{
+                THROW 'archive physical record identity conflicts with destination';
+            }};
+            UPSERT type::record($entry.key) CONTENT $entry.record;
+        }};
+        FOR $state IN $ledger_writes {{
+            LET $key = type::record(string::concat('source_states:',
+                crypto::sha256(type::string([$state.organization_id, $kind, $state.source_id]))));
+            UPSERT $key CONTENT $state;
+        }};
+        FOR $association IN $association_writes {{
+            LET $existing = (SELECT id FROM memory_derivations
+                WHERE organization_id=$association.organization_id AND target_kind=$kind
+                    AND target_id=$association.target_id LIMIT 1)[0];
+            IF $existing = NONE {{ CREATE memory_derivations CONTENT $association; }}
+            ELSE {{ UPDATE $existing.id CONTENT $association; }};
+        }};
+        COMMIT TRANSACTION;
+    """
+    await execute_query(
+        query,
+        organizations=organizations,
+        kind=kind.value,
+        expected=before,
+        deletes=deletes,
+        writes=writes,
+        ledger_writes=ledger_writes,
+        association_writes=association_writes,
+    )
+    return {"restored_source_ids": restored, "conflicts": conflicts}

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -150,6 +150,8 @@ async def restore_source_integrity(
     skip_existing: bool = True,
     global_scope: bool = False,
     clean_graph_auxiliary: bool = False,
+    auxiliary_statements: str = "",
+    auxiliary_parameters: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Restore complete source units without lowering destination trust history."""
     from copy import deepcopy
@@ -321,8 +323,20 @@ async def restore_source_integrity(
             IF $existing = NONE {{ CREATE memory_derivations CONTENT $association; }}
             ELSE {{ UPDATE $existing.id CONTENT $association; }};
         }};
+        {auxiliary_statements}
         COMMIT TRANSACTION;
     """
+    extra = auxiliary_parameters or {}
+    if set(extra) & {
+        "organizations",
+        "kind",
+        "expected",
+        "deletes",
+        "writes",
+        "ledger_writes",
+        "association_writes",
+    }:
+        raise ValueError("archive auxiliary parameters conflict with source bindings")
     await execute_query(
         query,
         organizations=organizations,
@@ -332,5 +346,6 @@ async def restore_source_integrity(
         writes=native_archive_parameters(writes),
         ledger_writes=ledger_writes,
         association_writes=association_writes,
+        **extra,
     )
     return {"restored_source_ids": restored, "conflicts": conflicts}

--- a/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
@@ -304,6 +304,8 @@ class BackupData:
     mention_count: int = 0
     episodes: list[dict] = field(default_factory=list)
     mentions: list[dict] = field(default_factory=list)
+    source_integrity: dict[str, Any] | None = None
+    lineage_validation: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -335,6 +337,8 @@ class RestoreResult:
     episodes_skipped: int = 0
     mentions_restored: int = 0
     mentions_skipped: int = 0
+    integrity_conflicts: list[dict[str, str]] = field(default_factory=list)
+    quarantined: list[dict[str, str]] = field(default_factory=list)
 
 
 # Export every entity type that can participate in graph edges.
@@ -509,15 +513,28 @@ async def create_backup(*, organization_id: str) -> BackupResult:
 
     try:
         runtime = await get_graph_runtime(organization_id)
-        entity_manager = runtime.entity_manager
         relationship_manager = runtime.relationship_manager
         client = runtime.client
 
-        all_entities = await _list_backup_entities(
-            organization_id=organization_id,
-            client=client,
-            entity_manager=entity_manager,
+        from sibyl_core.memory_pipeline.observations import SourceKind
+        from sibyl_core.migrate.source_integrity import validate_integrity_archive
+        from sibyl_core.services.graph_records import entity_from_surreal_row
+        from sibyl_core.services.source_archive_store import export_source_integrity
+
+        source_integrity = await export_source_integrity(
+            client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[organization_id]
         )
+        from sibyl_core.migrate.archive_lineage import seal_archive_lineage
+
+        sealed, _, lineage_validation = seal_archive_lineage(
+            {"version": "3.0", "source_integrity": source_integrity}, None
+        )
+        assert sealed is not None
+        source_integrity = sealed["source_integrity"]
+        source_rows, _, _ = validate_integrity_archive(
+            source_integrity, kind=SourceKind.GRAPH_ENTITY, organizations=[organization_id]
+        )
+        all_entities = [entity_from_surreal_row(row) for row in source_rows]
 
         relationships = await _list_backup_relationships(
             organization_id=organization_id,
@@ -535,7 +552,9 @@ async def create_backup(*, organization_id: str) -> BackupResult:
 
         # Build backup data
         backup_data = BackupData(
-            version="2.0",
+            version="3.0",
+            source_integrity=source_integrity,
+            lineage_validation=lineage_validation,
             created_at=datetime.now(UTC).isoformat(),
             organization_id=organization_id,
             entity_count=len(all_entities),
@@ -594,6 +613,7 @@ async def restore_backup(
     *,
     organization_id: str,
     skip_existing: bool = True,
+    clean: bool = False,
 ) -> RestoreResult:
     """Restore graph data from a backup.
 
@@ -624,6 +644,8 @@ async def restore_backup(
     episodes_skipped = 0
     mentions_restored = 0
     mentions_skipped = 0
+    integrity_conflicts: list[dict[str, str]] = []
+    quarantined: list[dict[str, str]] = []
 
     try:
         from sibyl_core.migrate.archive import (
@@ -632,58 +654,74 @@ async def restore_backup(
         )
 
         runtime = await get_graph_runtime(organization_id)
-        entity_manager = runtime.entity_manager
         relationship_manager = runtime.relationship_manager
         driver = runtime.client
 
-        entities_to_restore: list[Entity] = []
-        for entity_data in backup_data.entities:
-            try:
-                entity = _entity_from_backup_data(entity_data)
-                # Check if entity exists (get() raises on missing)
-                if skip_existing:
-                    try:
-                        existing = await entity_manager.get(entity.id)
-                        if existing:
-                            entities_skipped += 1
-                            continue
-                    except Exception:
-                        pass  # Entity doesn't exist — proceed to create
+        legacy_entities = backup_data.entities
+        if backup_data.version == "3.0":
+            from dataclasses import asdict
 
-                entities_to_restore.append(entity)
-            except Exception as e:
-                error_msg = f"Entity {entity_data.get('id', 'unknown')}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Entity restore failed", error=error_msg)
+            from sibyl_core.migrate.archive_lineage import seal_archive_lineage
 
-        create_direct_bulk = getattr(entity_manager, "create_direct_bulk", None)
-        create_direct = getattr(entity_manager, "create_direct", None)
+            sealed, _, _ = seal_archive_lineage(asdict(backup_data), None)
+            assert sealed is not None
+            backup_data = BackupData(**sealed)
+            from sibyl_core.memory_pipeline.observations import SourceKind
+            from sibyl_core.services.source_archive_store import restore_source_integrity
 
-        if entities_to_restore and callable(create_direct_bulk):
-            created_ids = await create_direct_bulk(
-                entities_to_restore,
-                generate_embeddings=False,
+            restored = await restore_source_integrity(
+                driver.execute_query,
+                backup_data.source_integrity,
+                kind=SourceKind.GRAPH_ENTITY,
+                organizations=[organization_id],
+                skip_existing=skip_existing,
+                clean=clean,
+                clean_graph_auxiliary=clean,
             )
-            entities_restored += len(created_ids)
-            failed_count = len(entities_to_restore) - len(created_ids)
-            if failed_count:
-                error_msg = f"Bulk entity restore failed for {failed_count} entities"
-                errors.append(error_msg)
-                log.warning("Bulk entity restore reported failures", failed=failed_count)
-        else:
-            for entity in entities_to_restore:
-                try:
-                    if callable(create_direct):
-                        await create_direct(entity, generate_embedding=False)
-                    else:
-                        await entity_manager.create(entity)
-                    entities_restored += 1
-                except Exception as e:
-                    error_msg = f"Entity {entity.id}: {e}"
-                    errors.append(error_msg)
-                    if len(errors) <= 10:
-                        log.warning("Entity restore failed", error=error_msg)
+            entities_restored = len(restored["restored_source_ids"])
+            integrity_conflicts = restored["conflicts"]
+            quarantined = [
+                row for row in backup_data.lineage_validation if row.get("status") == "quarantined"
+            ]
+            entities_skipped = backup_data.entity_count - entities_restored
+            legacy_entities = []
+        elif backup_data.source_integrity is not None:
+            raise ValueError("legacy graph payload cannot carry unrecognized integrity")
+        if legacy_entities or (clean and backup_data.version != "3.0"):
+            from sibyl_core.memory_pipeline.observations import SourceKind
+            from sibyl_core.migrate.legacy_source_archive import build_legacy_source_archive
+            from sibyl_core.services.graph_entity_store import _entity_record
+            from sibyl_core.services.source_archive_store import restore_source_integrity
+
+            records = [
+                dict(_entity_record(_entity_from_backup_data(row), group_id=organization_id))
+                for row in legacy_entities
+            ]
+            legacy_integrity, unavailable_ids = build_legacy_source_archive(
+                records, kind=SourceKind.GRAPH_ENTITY, organizations=[organization_id]
+            )
+            restored = await restore_source_integrity(
+                driver.execute_query,
+                legacy_integrity,
+                kind=SourceKind.GRAPH_ENTITY,
+                organizations=[organization_id],
+                skip_existing=skip_existing,
+                clean=clean,
+                clean_graph_auxiliary=clean,
+            )
+            restored_ids = restored["restored_source_ids"]
+            entities_restored = len(restored_ids)
+            entities_skipped = backup_data.entity_count - entities_restored
+            integrity_conflicts = restored["conflicts"]
+            quarantined = [
+                {
+                    "source_id": identity,
+                    "reason": "unverifiable_legacy_lineage",
+                    "repair": "reauthor_under_new_capture_identity",
+                }
+                for identity in restored_ids
+                if identity in unavailable_ids
+            ]
 
         episodes_to_restore: list[Any] = []
         for episode_data in backup_data.episodes:
@@ -793,6 +831,8 @@ async def restore_backup(
             episodes_skipped=episodes_skipped,
             mentions_restored=mentions_restored,
             mentions_skipped=mentions_skipped,
+            integrity_conflicts=integrity_conflicts,
+            quarantined=quarantined,
         )
 
     except Exception as e:
@@ -809,6 +849,8 @@ async def restore_backup(
             episodes_skipped=episodes_skipped,
             mentions_restored=mentions_restored,
             mentions_skipped=mentions_skipped,
+            integrity_conflicts=integrity_conflicts,
+            quarantined=quarantined,
         )
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
@@ -18,12 +18,6 @@ from sibyl_core.migrate.legacy_graph_archive import (
     episode_from_payload as _episode_from_payload,
 )
 from sibyl_core.migrate.legacy_graph_archive import (
-    list_native_backup_episodes as _list_native_backup_episodes,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
-    list_native_backup_mentions as _list_native_backup_mentions,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
     mention_exists as _mention_exists,
 )
 from sibyl_core.migrate.legacy_graph_archive import (
@@ -430,52 +424,6 @@ def _entity_from_backup_data(entity_data: dict[str, Any]) -> Entity:
         return Entity.model_validate(payload)
 
 
-async def _list_backup_episodes(
-    *,
-    organization_id: str,
-    client: Any,
-) -> list[dict[str, Any]]:
-    return await _list_native_backup_episodes(
-        organization_id=organization_id,
-        client=client,
-        page_size=BACKFILL_PAGE_SIZE,
-    )
-
-
-async def _list_backup_mentions(
-    *,
-    organization_id: str,
-    client: Any,
-) -> list[dict[str, Any]]:
-    return await _list_native_backup_mentions(
-        organization_id=organization_id,
-        client=client,
-        page_size=BACKFILL_PAGE_SIZE,
-    )
-
-
-async def _list_backup_relationships(
-    *,
-    organization_id: str,
-    client: Any,
-    relationship_manager: Any,
-) -> list[Relationship]:
-    relationships: list[Relationship] = []
-    offset = 0
-    while True:
-        batch = await relationship_manager.list_all(
-            limit=BACKFILL_PAGE_SIZE,
-            offset=offset,
-        )
-        if not batch:
-            break
-        relationships.extend(batch)
-        if len(batch) < BACKFILL_PAGE_SIZE:
-            break
-        offset += len(batch)
-    return relationships
-
-
 async def _list_backup_entities(
     *,
     organization_id: str,
@@ -513,16 +461,29 @@ async def create_backup(*, organization_id: str) -> BackupResult:
 
     try:
         runtime = await get_graph_runtime(organization_id)
-        relationship_manager = runtime.relationship_manager
         client = runtime.client
 
         from sibyl_core.memory_pipeline.observations import SourceKind
-        from sibyl_core.migrate.source_integrity import validate_integrity_archive
+        from sibyl_core.migrate.graph_companions import companion_payloads
+        from sibyl_core.migrate.source_integrity import (
+            build_integrity_archive,
+            validate_integrity_archive,
+        )
         from sibyl_core.services.graph_records import entity_from_surreal_row
-        from sibyl_core.services.source_archive_store import export_source_integrity
+        from sibyl_core.services.source_archive_store import read_source_archive_snapshot
 
-        source_integrity = await export_source_integrity(
-            client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[organization_id]
+        snapshot = await read_source_archive_snapshot(
+            client.execute_query,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[organization_id],
+            include_graph_auxiliary=True,
+        )
+        source_integrity = build_integrity_archive(
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[organization_id],
+            source_rows=snapshot["source_rows"],
+            source_states=snapshot["source_states"],
+            derivations=snapshot["derivations"],
         )
         from sibyl_core.migrate.archive_lineage import seal_archive_lineage
 
@@ -536,18 +497,9 @@ async def create_backup(*, organization_id: str) -> BackupResult:
         )
         all_entities = [entity_from_surreal_row(row) for row in source_rows]
 
-        relationships = await _list_backup_relationships(
+        relationships, episodes, mentions = companion_payloads(
+            snapshot,
             organization_id=organization_id,
-            client=client,
-            relationship_manager=relationship_manager,
-        )
-        episodes = await _list_backup_episodes(
-            organization_id=organization_id,
-            client=client,
-        )
-        mentions = await _list_backup_mentions(
-            organization_id=organization_id,
-            client=client,
         )
 
         # Build backup data
@@ -560,7 +512,7 @@ async def create_backup(*, organization_id: str) -> BackupResult:
             entity_count=len(all_entities),
             relationship_count=len(relationships),
             entities=[e.model_dump(mode="json") for e in all_entities],
-            relationships=[r.model_dump(mode="json") for r in relationships],
+            relationships=relationships,
             episode_count=len(episodes),
             mention_count=len(mentions),
             episodes=episodes,
@@ -652,6 +604,12 @@ async def restore_backup(
             normalize_mention_payloads,
             normalize_relationship_payloads,
         )
+        from sibyl_core.migrate.graph_companions import DATETIME_PATHS, relationship_from_archive
+
+        # Reject malformed typed payloads before a clean restore can delete rows.
+        for payload in backup_data.relationships:
+            if DATETIME_PATHS in payload:
+                relationship_from_archive(payload)
 
         runtime = await get_graph_runtime(organization_id)
         relationship_manager = runtime.relationship_manager
@@ -753,7 +711,7 @@ async def restore_backup(
         relationships_to_restore: list[Relationship] = []
         for rel_data in normalize_relationship_payloads(backup_data.relationships):
             try:
-                relationship = Relationship.model_validate(rel_data)
+                relationship = relationship_from_archive(rel_data)
                 relationships_to_restore.append(relationship)
             except Exception as e:
                 error_msg = f"Relationship {rel_data.get('id', 'unknown')}: {e}"

--- a/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
@@ -18,19 +18,7 @@ from sibyl_core.migrate.legacy_graph_archive import (
     episode_from_payload as _episode_from_payload,
 )
 from sibyl_core.migrate.legacy_graph_archive import (
-    mention_exists as _mention_exists,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
     mention_from_payload as _mention_from_payload,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
-    record_id as _record_id,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
-    save_native_episode as _save_native_episode,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
-    save_native_mention as _save_native_mention,
 )
 from sibyl_core.models.entities import (
     ConfigFile,
@@ -600,167 +588,93 @@ async def restore_backup(
     quarantined: list[dict[str, str]] = []
 
     try:
+        from dataclasses import asdict
+
+        from sibyl_core.memory_pipeline.observations import SourceKind
         from sibyl_core.migrate.archive import (
             normalize_mention_payloads,
             normalize_relationship_payloads,
         )
-        from sibyl_core.migrate.graph_companions import DATETIME_PATHS, relationship_from_archive
+        from sibyl_core.migrate.archive_lineage import seal_archive_lineage
+        from sibyl_core.migrate.graph_companion_restore import prepare_companion_restore
+        from sibyl_core.migrate.graph_companions import relationship_from_archive
+        from sibyl_core.migrate.legacy_source_archive import build_legacy_source_archive
+        from sibyl_core.services.graph_entity_store import _entity_record
+        from sibyl_core.services.source_archive_store import restore_source_integrity
 
-        # Reject malformed typed payloads before a clean restore can delete rows.
-        for payload in backup_data.relationships:
-            if DATETIME_PATHS in payload:
-                relationship_from_archive(payload)
-
-        runtime = await get_graph_runtime(organization_id)
-        relationship_manager = runtime.relationship_manager
-        driver = runtime.client
-
-        legacy_entities = backup_data.entities
+        # Validate the entire payload before any source or companion can change.
+        episodes = [
+            _episode_from_payload(row, organization_id=organization_id)
+            for row in backup_data.episodes
+        ]
+        relationships = [
+            relationship_from_archive(row)
+            for row in normalize_relationship_payloads(backup_data.relationships)
+        ]
+        mentions = [
+            _mention_from_payload(row, organization_id=organization_id)
+            for row in normalize_mention_payloads(backup_data.mentions)
+        ]
+        unavailable_ids: set[str] = set()
         if backup_data.version == "3.0":
-            from dataclasses import asdict
-
-            from sibyl_core.migrate.archive_lineage import seal_archive_lineage
-
             sealed, _, _ = seal_archive_lineage(asdict(backup_data), None)
             assert sealed is not None
             backup_data = BackupData(**sealed)
-            from sibyl_core.memory_pipeline.observations import SourceKind
-            from sibyl_core.services.source_archive_store import restore_source_integrity
-
-            restored = await restore_source_integrity(
-                driver.execute_query,
-                backup_data.source_integrity,
-                kind=SourceKind.GRAPH_ENTITY,
-                organizations=[organization_id],
-                skip_existing=skip_existing,
-                clean=clean,
-                clean_graph_auxiliary=clean,
-            )
-            entities_restored = len(restored["restored_source_ids"])
-            integrity_conflicts = restored["conflicts"]
+            integrity = backup_data.source_integrity
             quarantined = [
                 row for row in backup_data.lineage_validation if row.get("status") == "quarantined"
             ]
-            entities_skipped = backup_data.entity_count - entities_restored
-            legacy_entities = []
-        elif backup_data.source_integrity is not None:
-            raise ValueError("legacy graph payload cannot carry unrecognized integrity")
-        if legacy_entities or (clean and backup_data.version != "3.0"):
-            from sibyl_core.memory_pipeline.observations import SourceKind
-            from sibyl_core.migrate.legacy_source_archive import build_legacy_source_archive
-            from sibyl_core.services.graph_entity_store import _entity_record
-            from sibyl_core.services.source_archive_store import restore_source_integrity
-
+        else:
+            if backup_data.source_integrity is not None:
+                raise ValueError("legacy graph payload cannot carry unrecognized integrity")
             records = [
                 dict(_entity_record(_entity_from_backup_data(row), group_id=organization_id))
-                for row in legacy_entities
+                for row in backup_data.entities
             ]
-            legacy_integrity, unavailable_ids = build_legacy_source_archive(
+            integrity, unavailable_ids = build_legacy_source_archive(
                 records, kind=SourceKind.GRAPH_ENTITY, organizations=[organization_id]
             )
-            restored = await restore_source_integrity(
-                driver.execute_query,
-                legacy_integrity,
-                kind=SourceKind.GRAPH_ENTITY,
-                organizations=[organization_id],
-                skip_existing=skip_existing,
-                clean=clean,
-                clean_graph_auxiliary=clean,
-            )
-            restored_ids = restored["restored_source_ids"]
-            entities_restored = len(restored_ids)
-            entities_skipped = backup_data.entity_count - entities_restored
-            integrity_conflicts = restored["conflicts"]
-            quarantined = [
-                {
-                    "source_id": identity,
-                    "reason": "unverifiable_legacy_lineage",
-                    "repair": "reauthor_under_new_capture_identity",
-                }
-                for identity in restored_ids
-                if identity in unavailable_ids
-            ]
-
-        episodes_to_restore: list[Any] = []
-        for episode_data in backup_data.episodes:
-            try:
-                episode = _episode_from_payload(episode_data, organization_id=organization_id)
-                if skip_existing:
-                    existing = await _record_id(driver, "episode", episode.uuid)
-                    if existing:
-                        episodes_skipped += 1
-                        continue
-
-                episodes_to_restore.append(episode)
-            except Exception as e:
-                error_msg = f"Episode {episode_data.get('uuid', 'unknown')}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Episode restore failed", error=error_msg)
-
-        for episode in episodes_to_restore:
-            try:
-                await _save_native_episode(driver, episode)
-                episodes_restored += 1
-            except Exception as e:
-                error_msg = f"Episode {episode.uuid}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Episode restore failed", error=error_msg)
-
-        relationships_to_restore: list[Relationship] = []
-        for rel_data in normalize_relationship_payloads(backup_data.relationships):
-            try:
-                relationship = relationship_from_archive(rel_data)
-                relationships_to_restore.append(relationship)
-            except Exception as e:
-                error_msg = f"Relationship {rel_data.get('id', 'unknown')}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Relationship restore failed", error=error_msg)
-
-        create_bulk = getattr(relationship_manager, "create_bulk", None)
-        if relationships_to_restore and callable(create_bulk):
-            created_count, failed_count = await create_bulk(relationships_to_restore)
-            relationships_restored += created_count
-            if failed_count:
-                error_msg = f"Bulk relationship restore failed for {failed_count} relationships"
-                errors.append(error_msg)
-                log.warning("Bulk relationship restore reported failures", failed=failed_count)
-        else:
-            for relationship in relationships_to_restore:
-                try:
-                    await relationship_manager.create(relationship)
-                    relationships_restored += 1
-                except Exception as e:
-                    error_msg = f"Relationship {relationship.id}: {e}"
-                    errors.append(error_msg)
-                    if len(errors) <= 10:
-                        log.warning("Relationship restore failed", error=error_msg)
-
-        mentions_to_restore: list[Any] = []
-        for mention_data in normalize_mention_payloads(backup_data.mentions):
-            try:
-                mention = _mention_from_payload(mention_data, organization_id=organization_id)
-                if skip_existing and await _mention_exists(driver, mention.uuid):
-                    mentions_skipped += 1
-                    continue
-                mentions_to_restore.append(mention)
-            except Exception as e:
-                error_msg = f"Mention {mention_data.get('uuid', 'unknown')}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Mention restore failed", error=error_msg)
-
-        for mention in mentions_to_restore:
-            try:
-                await _save_native_mention(driver, mention)
-                mentions_restored += 1
-            except Exception as e:
-                error_msg = f"Mention {mention.uuid}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Mention restore failed", error=error_msg)
+        runtime = await get_graph_runtime(organization_id)
+        driver = runtime.client
+        companions = await prepare_companion_restore(
+            driver,
+            organization_id=organization_id,
+            episodes=episodes,
+            relationships=relationships,
+            mentions=mentions,
+            skip_existing=skip_existing,
+            clean=clean,
+        )
+        restored = await restore_source_integrity(
+            driver.execute_query,
+            integrity,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[organization_id],
+            skip_existing=skip_existing,
+            clean=clean,
+            clean_graph_auxiliary=clean,
+            auxiliary_preconditions=companions.preconditions,
+            auxiliary_statements=companions.statements,
+            auxiliary_parameters=companions.parameters,
+        )
+        restored_ids = restored["restored_source_ids"]
+        entities_restored = len(restored_ids)
+        entities_skipped = backup_data.entity_count - entities_restored
+        integrity_conflicts = restored["conflicts"]
+        quarantined.extend(
+            {
+                "source_id": identity,
+                "reason": "unverifiable_legacy_lineage",
+                "repair": "reauthor_under_new_capture_identity",
+            }
+            for identity in restored_ids
+            if identity in unavailable_ids
+        )
+        episodes_restored = companions.episodes_restored
+        episodes_skipped = companions.episodes_skipped
+        relationships_restored = companions.relationships_restored
+        mentions_restored = companions.mentions_restored
+        mentions_skipped = companions.mentions_skipped
 
         duration = time.time() - start_time
         log.info(

--- a/packages/python/sibyl-core/tests/test_archive_lineage.py
+++ b/packages/python/sibyl-core/tests/test_archive_lineage.py
@@ -1,0 +1,158 @@
+"""Cross-store export drift preserves content while retiring mismatched trust."""
+
+from copy import deepcopy
+
+from sibyl_core.memory_pipeline.observations import SourceKind
+from sibyl_core.migrate.archive_lineage import seal_archive_lineage
+from sibyl_core.migrate.source_integrity import validate_integrity_archive
+from sibyl_core.services import content_client
+from sibyl_core.services.source_archive_store import export_source_integrity
+from sibyl_core.services.surreal_content import remember_raw_memory
+from tests.test_graph_derivation_publication import publish, share_plan
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+
+
+async def test_export_drift_quarantines_actual_shared_graph_without_rebinding(
+    runtime, content_store
+):
+    org = runtime.client.group_id
+    source = await remember_raw_memory(
+        organization_id=org,
+        principal_id="user_a",
+        source_id="archive-cross-store",
+        raw_content="Approved deployment rule",
+        embedding_provider=None,
+    )
+    published = await publish(runtime, await share_plan(runtime, source.id))
+    assert published.success
+    graph = {
+        "version": "3.0",
+        "source_integrity": await export_source_integrity(
+            runtime.client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[org]
+        ),
+    }
+    original = deepcopy(graph)
+    standalone, _, pending = seal_archive_lineage(graph, None)
+    assert any(
+        row["source_id"] == published.promoted_id and row["status"] == "unresolved"
+        for row in pending
+    )
+    assert (
+        next(
+            row
+            for row in standalone["source_integrity"]["derivations"]
+            if row["target_id"] == published.promoted_id
+        )["active"]
+        is True
+    )
+    async with content_client.surreal_content_client() as client:
+        complete = {
+            "version": "2.0",
+            "source_integrity": await export_source_integrity(
+                client.execute_query, kind=SourceKind.RAW_CAPTURE, organizations=[org]
+            ),
+        }
+        _, _, good = seal_archive_lineage(graph, complete)
+        assert not good
+        await client.execute_query(
+            "UPDATE raw_captures SET raw_content='Revoked rule', revision+=1 WHERE uuid=$uuid;",
+            uuid=source.id,
+        )
+        later = {
+            "version": "2.0",
+            "source_integrity": await export_source_integrity(
+                client.execute_query, kind=SourceKind.RAW_CAPTURE, organizations=[org]
+            ),
+        }
+    sealed, _, report = seal_archive_lineage(graph, later)
+    assert graph == original
+    assert any(
+        row["source_id"] == published.promoted_id and row["status"] == "quarantined"
+        for row in report
+    )
+    rows, _, associations = validate_integrity_archive(
+        sealed["source_integrity"], kind=SourceKind.GRAPH_ENTITY, organizations=[org]
+    )
+    archived = next(row for row in associations if row["target_id"] == published.promoted_id)
+    previous = next(
+        row
+        for row in original["source_integrity"]["derivations"]
+        if row["target_id"] == published.promoted_id
+    )
+    assert archived["active"] is False
+    assert archived["observations"] == previous["observations"]
+    assert (
+        next(row for row in rows if row["uuid"] == published.promoted_id)["derivation_required"]
+        is True
+    )
+
+
+async def test_actual_merge_retains_original_provenance_and_quarantines_memory(
+    runtime, monkeypatch
+):
+    import json
+    from dataclasses import asdict
+    from pathlib import Path
+    from unittest.mock import AsyncMock
+    from uuid import uuid4
+
+    from sibyl_core.backends.surreal.schema import bootstrap_schema
+    from sibyl_core.migrate.archive import (
+        GRAPH_FILENAME,
+        LoadedArchive,
+        build_manifest,
+        graph_payload_from_archive,
+    )
+    from sibyl_core.migrate.merge import ArchiveMergeOptions, merge_archives
+    from sibyl_core.services.graph_client import SurrealGraphClient
+    from sibyl_core.services.graph_entities import EntityManager
+    from sibyl_core.services.graph_relationships import RelationshipManager
+    from sibyl_core.services.graph_runtime import GraphRuntime
+    from sibyl_core.tools.admin import BackupData, create_backup, restore_backup
+    from tests.test_memory_projection_derivations import protected_session
+
+    source, target, _ = await protected_session(runtime, monkeypatch)
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success
+    original = json.dumps(asdict(backup.backup_data), sort_keys=True).encode()
+    files = {GRAPH_FILENAME: original}
+    archive = LoadedArchive(
+        source=Path("owned-archive"),
+        files=files,
+        manifest=build_manifest(
+            organization_id=runtime.client.group_id, source_store="surreal", files=files
+        ),
+    )
+    org = "merged-" + uuid4().hex
+    result = merge_archives([archive], options=ArchiveMergeOptions(canonical_org_id=org))
+    provenance = result.archive.manifest.metadata["merge"]["original_provenance_files"]
+    assert len(provenance) == 1
+    assert result.archive.files[provenance[0]] == original
+    merged = graph_payload_from_archive(result.archive)
+    assert merged is not None
+    client = SurrealGraphClient(group_id=org, url="memory://")
+    try:
+        await bootstrap_schema(client)
+        destination = GraphRuntime(
+            client=client,
+            entity_manager=EntityManager(client, group_id=org),
+            relationship_manager=RelationshipManager(client, group_id=org),
+        )
+        monkeypatch.setattr(
+            "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+            AsyncMock(return_value=destination),
+        )
+        restored = await restore_backup(BackupData(**merged), organization_id=org)
+        assert restored.success, restored.errors
+        quarantined = {row["source_id"] for row in restored.quarantined}
+        assert {source.id, target.id} <= quarantined
+        target_row = await destination.entity_manager.get(target.id)
+        assert target_row.content == target.content
+        assert target_row.derivation_required is True
+        assert not await client.execute_query("SELECT * FROM memory_derivations;")
+    finally:
+        await client.close()

--- a/packages/python/sibyl-core/tests/test_graph_archive_atomicity.py
+++ b/packages/python/sibyl-core/tests/test_graph_archive_atomicity.py
@@ -1,0 +1,147 @@
+"""Public graph restore commits sources and every companion as one unit."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.migrate.legacy_graph_archive import episode_from_payload, save_native_episode
+from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.tools.admin import create_backup, restore_backup
+from tests.test_source_integrity_archive import destination as destination
+from tests.test_source_integrity_archive import runtime as runtime
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+
+STAMP = "2026-09-10T02:47:11.572211763Z"
+
+
+async def fingerprint(client):
+    return await client.execute_query(
+        "RETURN crypto::sha256(type::string({"
+        "entities: (SELECT * FROM entity ORDER BY id),"
+        "states: (SELECT * FROM source_states ORDER BY id),"
+        "derivations: (SELECT * FROM memory_derivations ORDER BY id),"
+        "episodes: (SELECT * FROM episode ORDER BY id),"
+        "relationships: (SELECT * FROM relates_to ORDER BY id),"
+        "mentions: (SELECT * FROM mentions ORDER BY id)}));"
+    )
+
+
+async def episode(client, identity):
+    await save_native_episode(
+        client,
+        episode_from_payload(
+            {
+                "uuid": identity,
+                "name": identity,
+                "content": "Evidence",
+                "created_at": STAMP,
+                "valid_at": STAMP,
+            },
+            organization_id=client.group_id,
+        ),
+    )
+
+
+@pytest.mark.parametrize("clean", [False, True])
+async def test_late_mention_failure_rolls_back_all_graph_tables(
+    runtime, destination, monkeypatch, clean
+):
+    await runtime.entity_manager.create_direct(
+        Entity(id="incoming", entity_type=EntityType.SESSION, name="Incoming", content="New")
+    )
+    await runtime.relationship_manager.create_direct_bulk(
+        [
+            Relationship(
+                id="incoming-edge",
+                source_id="incoming",
+                target_id="project_a",
+                relationship_type=RelationshipType.RELATED_TO,
+            )
+        ]
+    )
+    await episode(runtime.client, "incoming-episode")
+    for identity in ("must-survive", "retained-tombstone"):
+        await destination.entity_manager.create_direct(
+            Entity(id=identity, entity_type=EntityType.SESSION, name=identity, content="Old")
+        )
+    await destination.client.execute_query("DELETE entity WHERE uuid='retained-tombstone';")
+    await episode(destination.client, "existing-episode")
+    before = await fingerprint(destination.client)
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success, backup.message
+    backup.backup_data.mentions = [
+        {
+            "uuid": "missing-endpoint",
+            "source_id": "incoming-episode",
+            "target_id": "does-not-exist",
+            "created_at": STAMP,
+        }
+    ]
+    monkeypatch.setattr(
+        "sibyl_core.tools.admin.get_graph_runtime", AsyncMock(return_value=destination)
+    )
+    result = await restore_backup(
+        backup.backup_data, organization_id=runtime.client.group_id, clean=clean
+    )
+    assert not result.success
+    assert any("mention endpoint is missing" in error for error in result.errors)
+    assert (
+        result.entities_restored == result.episodes_restored == result.relationships_restored == 0
+    )
+    assert await fingerprint(destination.client) == before
+
+
+@pytest.mark.parametrize("collection", ["episodes", "relationships", "mentions"])
+async def test_malformed_graph_companion_rejects_before_destination(
+    runtime, monkeypatch, collection
+):
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success, backup.message
+    setattr(backup.backup_data, collection, [{"id": "invalid-companion"}])
+    loader = AsyncMock(side_effect=AssertionError("destination must not be opened"))
+    monkeypatch.setattr("sibyl_core.tools.admin.get_graph_runtime", loader)
+    result = await restore_backup(
+        backup.backup_data, organization_id=runtime.client.group_id, clean=True
+    )
+    assert not result.success
+    loader.assert_not_called()
+
+
+@pytest.mark.parametrize("clean", [False, True])
+async def test_companion_nanosecond_change_fences_source_restore(
+    runtime, destination, monkeypatch, clean
+):
+    await episode(destination.client, "racing-episode")
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success, backup.message
+    monkeypatch.setattr(
+        "sibyl_core.tools.admin.get_graph_runtime", AsyncMock(return_value=destination)
+    )
+    execute = destination.client.execute_query
+    changed = False
+    preserved = None
+
+    async def race(query, **parameters):
+        nonlocal changed, preserved
+        if (
+            "BEGIN TRANSACTION" in query
+            and "archive_companion_fingerprint" in query
+            and not changed
+        ):
+            changed = True
+            await execute(
+                "UPDATE episode SET created_at=d'2026-09-10T02:47:11.572211764Z' WHERE uuid='racing-episode';"
+            )
+            preserved = await fingerprint(destination.client)
+        return await execute(query, **parameters)
+
+    monkeypatch.setattr(destination.client, "execute_query", race)
+    result = await restore_backup(
+        backup.backup_data, organization_id=runtime.client.group_id, clean=clean
+    )
+    assert changed
+    assert not result.success
+    assert any("destination changed" in error for error in result.errors)
+    assert await fingerprint(destination.client) == preserved

--- a/packages/python/sibyl-core/tests/test_graph_archive_revocation.py
+++ b/packages/python/sibyl-core/tests/test_graph_archive_revocation.py
@@ -1,0 +1,62 @@
+"""Graph archive replacement respects later lifecycle and audience decisions."""
+
+import pytest
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.tools.admin import create_backup, restore_backup
+from tests.test_source_integrity_archive import runtime as runtime
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+
+
+@pytest.mark.parametrize("clean", [False, True])
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {"excluded_from_recall": True},
+        {"lifecycle_state": "deleted"},
+        {"superseded_by_source_id": "new-source"},
+        {"principal_id": "new-owner", "memory_scope": "private"},
+    ],
+)
+async def test_graph_restore_preserves_current_visibility(runtime, clean, patch):
+    source = Entity(
+        id="revoked-source",
+        entity_type=EntityType.SESSION,
+        name="Evidence",
+        content="Amethyst evidence",
+    )
+    await runtime.entity_manager.create_direct(source)
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success, backup.message
+    await runtime.entity_manager.update(source.id, {"metadata": patch})
+    changed = await runtime.entity_manager.get(source.id)
+    if "principal_id" not in patch:
+        assert not graph_metadata_recallable(changed.metadata)
+    before = await runtime.client.execute_query(
+        "RETURN crypto::sha256(type::string({"
+        "row: (SELECT * FROM entity WHERE uuid=$id),"
+        "state: (SELECT * FROM source_states WHERE source_id=$id)}));",
+        id=source.id,
+    )
+    result = await restore_backup(
+        backup.backup_data,
+        organization_id=runtime.client.group_id,
+        clean=clean,
+        skip_existing=False,
+    )
+    assert result.success, result.message
+    after = await runtime.client.execute_query(
+        "RETURN crypto::sha256(type::string({"
+        "row: (SELECT * FROM entity WHERE uuid=$id),"
+        "state: (SELECT * FROM source_states WHERE source_id=$id)}));",
+        id=source.id,
+    )
+    assert after == before
+    restored = await runtime.entity_manager.get(source.id)
+    for key, value in patch.items():
+        assert restored.metadata[key] == value
+    if "principal_id" not in patch:
+        assert not graph_metadata_recallable(restored.metadata)

--- a/packages/python/sibyl-core/tests/test_graph_companion_precision.py
+++ b/packages/python/sibyl-core/tests/test_graph_companion_precision.py
@@ -1,0 +1,188 @@
+"""Public graph companions preserve native dates across JSON and restore."""
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+from sibyl_core.migrate.graph_companions import DATETIME_PATHS, relationship_from_archive
+from sibyl_core.migrate.legacy_graph_archive import episode_from_payload, save_native_episode
+from sibyl_core.models.entities import Relationship, RelationshipType
+from sibyl_core.tools.admin import BackupData, create_backup, restore_backup
+from tests.test_source_integrity_archive import destination as destination
+from tests.test_source_integrity_archive import runtime as runtime
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+
+STAMP = "2026-09-10T02:47:11.572211763Z"
+
+
+async def test_public_companions_keep_native_dates_through_json_restore(
+    runtime, destination, monkeypatch
+):
+    await runtime.relationship_manager.create_direct_bulk(
+        [
+            Relationship(
+                id="precise-edge",
+                source_id="project_a",
+                target_id="project_b",
+                relationship_type=RelationshipType.RELATED_TO,
+            )
+        ]
+    )
+    await runtime.client.execute_query(
+        "UPDATE relates_to SET created_at=d'2026-09-10T02:47:11.572211763Z', "
+        "valid_at=d'2026-09-10T02:47:11.000000001Z', "
+        "attributes.nested={at: d'2026-09-10T02:47:11.572211763Z', "
+        "literal: '2026-09-10T02:47:11.572211763Z'} WHERE uuid='precise-edge';"
+    )
+    episode = episode_from_payload(
+        {
+            "uuid": "precise-episode",
+            "name": "Episode",
+            "content": "Evidence",
+            "created_at": STAMP,
+            "valid_at": STAMP,
+        },
+        organization_id=runtime.client.group_id,
+    )
+    await save_native_episode(runtime.client, episode)
+    await runtime.client.execute_query(
+        "LET $src=(SELECT VALUE id FROM episode WHERE uuid='precise-episode')[0]; "
+        "LET $tgt=(SELECT VALUE id FROM entity WHERE uuid='project_a')[0]; "
+        "RELATE $src->mentions:precise->$tgt SET uuid='precise-mention', group_id=$org, "
+        "created_at=d'2026-09-10T02:47:11.572211763Z';",
+        org=runtime.client.group_id,
+    )
+    result = await create_backup(organization_id=runtime.client.group_id)
+    assert result.success, result.message
+    payload = json.loads(json.dumps(asdict(result.backup_data)))
+    edge = next(row for row in payload["relationships"] if row["id"] == "precise-edge")
+    assert edge["created_at"] == STAMP
+    assert edge["metadata"]["nested"] == {"at": STAMP, "literal": STAMP}
+    assert ["metadata", "nested", "at"] in edge[DATETIME_PATHS]
+    assert ["metadata", "nested", "literal"] not in edge[DATETIME_PATHS]
+    assert payload["episodes"][0]["created_at"] == STAMP
+    assert payload["mentions"][0]["created_at"] == STAMP
+    monkeypatch.setattr(
+        "sibyl_core.tools.admin.get_graph_runtime", AsyncMock(return_value=destination)
+    )
+    restored = await restore_backup(BackupData(**payload), organization_id=runtime.client.group_id)
+    assert restored.success, restored.message
+    for table, identity in (
+        ("relates_to", "precise-edge"),
+        ("episode", "precise-episode"),
+        ("mentions", "precise-mention"),
+    ):
+        rows = await destination.client.execute_query(
+            f"SELECT type::string(created_at) AS stamp FROM {table} WHERE uuid=$uuid;",
+            uuid=identity,
+        )
+        assert rows[0]["stamp"] == STAMP
+    rows = await destination.client.execute_query(
+        "SELECT type::string(valid_at) AS valid, type::string(attributes.nested.at) AS stamp, "
+        "attributes.nested.at AS typed, "
+        "attributes.nested.literal AS literal FROM relates_to WHERE uuid='precise-edge';"
+    )
+    assert isinstance(rows[0].pop("typed"), datetime)
+    assert rows[0] == {
+        "valid": "2026-09-10T02:47:11.000000001Z",
+        "stamp": STAMP,
+        "literal": STAMP,
+    }
+
+
+def test_relationship_legacy_offset_and_typed_paths_survive_merge():
+    from sibyl_core.migrate.merge import _merge_relationships
+
+    payload = {
+        "id": "edge",
+        "source_id": "old",
+        "target_id": "other",
+        "relationship_type": "RELATED_TO",
+        "created_at": STAMP,
+        "metadata": {"old": STAMP},
+        DATETIME_PATHS: [["metadata", "old"]],
+    }
+    merged = _merge_relationships([{"relationships": [payload]}], replacements={"old": "new"})
+    assert merged[0][DATETIME_PATHS] == [["metadata", "old"]]
+    model = relationship_from_archive(merged[0])
+    assert model.source_id == "new"
+    assert model.created_at.native_text == STAMP
+    assert model.metadata["old"].native_text == STAMP
+
+
+async def test_invalid_companion_date_paths_reject_before_clean(runtime, monkeypatch):
+    result = await create_backup(organization_id=runtime.client.group_id)
+    assert result.success, result.message
+    result.backup_data.relationships = [{"id": "bad", DATETIME_PATHS: [["missing"]]}]
+    execute = AsyncMock(side_effect=AssertionError("must not touch destination"))
+    monkeypatch.setattr(runtime.client, "execute_query", execute)
+    restored = await restore_backup(
+        result.backup_data, organization_id=runtime.client.group_id, clean=True
+    )
+    assert not restored.success
+    execute.assert_not_called()
+
+
+async def test_public_backup_rejects_companion_nanosecond_capture_race(runtime, monkeypatch):
+    await runtime.relationship_manager.create_direct_bulk(
+        [
+            Relationship(
+                id="racing-edge",
+                source_id="project_a",
+                target_id="project_b",
+                relationship_type=RelationshipType.RELATED_TO,
+            )
+        ]
+    )
+    await runtime.client.execute_query(
+        "UPDATE relates_to SET created_at=d'2026-09-10T02:47:11.572211763Z' "
+        "WHERE uuid='racing-edge';"
+    )
+    execute = runtime.client.execute_query
+    changed = False
+
+    async def mutate_before_date_capture(query, **parameters):
+        nonlocal changed
+        if "AS datetimes" in query and not changed:
+            changed = True
+            await execute(
+                "UPDATE relates_to SET created_at=d'2026-09-10T02:47:11.572211764Z' "
+                "WHERE uuid='racing-edge';"
+            )
+        return await execute(query, **parameters)
+
+    monkeypatch.setattr(runtime.client, "execute_query", mutate_before_date_capture)
+    result = await create_backup(organization_id=runtime.client.group_id)
+    assert changed
+    assert not result.success
+    assert "changed during datetime capture" in result.message
+
+
+async def test_legacy_relationship_date_string_keeps_metadata_type(runtime):
+    from sibyl_core.migrate.graph_companions import relationship_from_archive
+
+    value = "2026-09-10T02:47:11.572211763+05:45"
+    relationship = relationship_from_archive(
+        {
+            "id": "legacy-precise",
+            "source_id": "project_a",
+            "target_id": "project_b",
+            "relationship_type": "RELATED_TO",
+            "created_at": value,
+            "metadata": {"valid_at": value},
+        }
+    )
+    assert relationship.metadata["valid_at"] == value
+    await runtime.relationship_manager.create_direct_bulk([relationship])
+    rows = await runtime.client.execute_query(
+        "SELECT type::string(created_at) AS created, type::string(valid_at) AS valid, "
+        "attributes.valid_at AS original FROM relates_to WHERE uuid='legacy-precise';"
+    )
+    assert rows[0] == {
+        "created": "2026-09-09T21:02:11.572211763Z",
+        "valid": "2026-09-09T21:02:11.572211763Z",
+        "original": value,
+    }

--- a/packages/python/sibyl-core/tests/test_source_archive_owners.py
+++ b/packages/python/sibyl-core/tests/test_source_archive_owners.py
@@ -1,0 +1,207 @@
+"""Public archive owners retain the complete protected source contract."""
+
+import json
+
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+from tests.test_source_integrity_archive import destination as destination
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+
+
+async def test_application_graph_backup_roundtrips_protected_target(
+    runtime, destination, content_store, monkeypatch
+):
+    from dataclasses import asdict
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+    from sibyl_core.tools.admin import BackupData, create_backup, restore_backup
+    from tests.test_memory_projection_derivations import protected_session
+
+    source, target, _ = await protected_session(runtime, monkeypatch)
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success, backup.message
+    transported = BackupData(**json.loads(json.dumps(asdict(backup.backup_data))))
+    assert transported.version == "3.0"
+    assert transported.source_integrity is not None
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+        AsyncMock(return_value=destination),
+    )
+    result = await restore_backup(transported, organization_id=runtime.client.group_id)
+    assert result.success, result.errors
+    restored = await destination.entity_manager.get(target.id)
+    assert target.id not in await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: restored.metadata}
+    )
+    await destination.entity_manager.update(source.id, {"content": "Changed after restore"})
+    assert target.id in await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: restored.metadata}
+    )
+
+
+async def test_legacy_graph_import_preserves_content_but_quarantines_memory(
+    runtime, destination, content_store, monkeypatch
+):
+    from dataclasses import asdict
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+    from sibyl_core.tools.admin import BackupData, create_backup, restore_backup
+
+    memory = Entity(
+        id="old-memory",
+        entity_type=EntityType.SESSION,
+        name="Unverifiable memory",
+        content="Keep these exact source bytes",
+    )
+    await runtime.entity_manager.create_direct(memory)
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success
+    payload = asdict(backup.backup_data)
+    payload.update(version="2.0", source_integrity=None)
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+        AsyncMock(return_value=destination),
+    )
+    result = await restore_backup(BackupData(**payload), organization_id=runtime.client.group_id)
+    assert result.success, result.errors
+    assert any(row["source_id"] == memory.id for row in result.quarantined)
+    restored = await destination.entity_manager.get(memory.id)
+    assert restored.content == memory.content
+    assert restored.derivation_required is True
+    denied = await unavailable_publication_ids(
+        runtime.client.group_id, {memory.id: restored.metadata}
+    )
+    assert memory.id in denied
+    for row in payload["entities"]:
+        if row["entity_type"] == "project":
+            project = await destination.entity_manager.get(row["id"])
+            assert not project.derivation_required
+            assert project.id not in await unavailable_publication_ids(
+                runtime.client.group_id, {project.id: project.metadata}
+            )
+
+
+async def test_legacy_skip_preserves_existing_ordinary_memory(runtime, monkeypatch):
+    from dataclasses import asdict
+
+    from sibyl_core.memory_pipeline.observations import SourceKind
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.services.source_archive_store import read_source_archive_snapshot
+    from sibyl_core.tools.admin import BackupData, create_backup, restore_backup
+
+    memory = Entity(
+        id="ordinary-in-place",
+        entity_type=EntityType.SESSION,
+        name="Owned original",
+        content="Original",
+    )
+    await runtime.entity_manager.create_direct(memory)
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    payload = asdict(backup.backup_data)
+    payload.update(version="2.0", source_integrity=None)
+    before = await read_source_archive_snapshot(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    result = await restore_backup(
+        BackupData(**payload), organization_id=runtime.client.group_id, skip_existing=True
+    )
+    assert result.success, result.errors
+    assert not result.quarantined
+    after = await read_source_archive_snapshot(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    assert after == before
+
+
+async def test_full_graph_clean_replaces_episode_inventory_without_resetting_source_history(
+    runtime,
+):
+    from sibyl_core.memory_pipeline.observations import SourceKind
+    from sibyl_core.models.entities import Relationship, RelationshipType
+    from sibyl_core.services.source_archive_store import read_source_archive_snapshot
+    from sibyl_core.tools.admin import BackupData, create_backup, restore_backup
+
+    org = runtime.client.group_id
+    await runtime.relationship_manager.create(
+        Relationship(
+            id="original-link",
+            source_id="project_a",
+            target_id="project_b",
+            relationship_type=RelationshipType.RELATED_TO,
+        )
+    )
+    backup = await create_backup(organization_id=org)
+    assert backup.success
+    extra = BackupData(
+        version="2.0",
+        created_at="2026-09-09T00:00:00Z",
+        organization_id=org,
+        entity_count=0,
+        relationship_count=0,
+        entities=[],
+        relationships=[],
+        episode_count=1,
+        episodes=[
+            {
+                "uuid": "post-archive-episode",
+                "name": "New episode",
+                "source": "message",
+                "source_description": "chat",
+                "content": "Post archive content",
+                "created_at": "2026-09-09T00:00:00Z",
+                "valid_at": "2026-09-09T00:00:00Z",
+                "entity_edges": [],
+            }
+        ],
+    )
+    added = await restore_backup(extra, organization_id=org)
+    assert added.success, added.errors
+    assert await runtime.client.execute_query(
+        "SELECT * FROM episode WHERE uuid='post-archive-episode';"
+    )
+    before = await read_source_archive_snapshot(
+        runtime.client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[org]
+    )
+    result = await restore_backup(
+        backup.backup_data, organization_id=org, clean=True, skip_existing=False
+    )
+    assert result.success, result.errors
+    assert not await runtime.client.execute_query(
+        "SELECT * FROM episode WHERE uuid='post-archive-episode';"
+    )
+    after = await read_source_archive_snapshot(
+        runtime.client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[org]
+    )
+    assert after == before
+
+    execute = runtime.client.execute_query
+    injected = False
+
+    async def race(statement, **params):
+        nonlocal injected
+        if "archive destination changed before restore" in statement and not injected:
+            injected = True
+            added = await restore_backup(extra, organization_id=org)
+            assert added.success, added.errors
+        return await execute(statement, **params)
+
+    from unittest.mock import patch
+
+    with patch.object(runtime.client, "execute_query", race):
+        conflicted = await restore_backup(
+            backup.backup_data, organization_id=org, clean=True, skip_existing=False
+        )
+    assert injected
+    assert not conflicted.success
+    assert any("destination changed" in error for error in conflicted.errors)
+    assert await execute("SELECT * FROM episode WHERE uuid='post-archive-episode';")
+    assert await execute("SELECT * FROM relates_to WHERE uuid='original-link';")

--- a/packages/python/sibyl-core/tests/test_source_archive_precision.py
+++ b/packages/python/sibyl-core/tests/test_source_archive_precision.py
@@ -1,0 +1,266 @@
+"""Archive snapshots retain native nanoseconds and reject sub-microsecond races."""
+
+import json
+from copy import deepcopy
+
+import pytest
+
+from sibyl_core.memory_pipeline.observations import SourceKind
+from sibyl_core.migrate.source_integrity import ArchiveDatetime, decode_record, encode_record
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.services.source_archive_store import (
+    export_source_integrity,
+    read_source_archive_snapshot,
+    restore_source_integrity,
+)
+from tests.test_source_integrity_archive import destination as destination
+from tests.test_source_integrity_archive import runtime as runtime
+
+FIRST = "2026-09-10T02:47:11.572211763Z"
+SECOND = "2026-09-10T02:47:11.572211764Z"
+
+
+def test_archive_codec_keeps_native_precision_through_copy_and_json():
+    value = {"created_at": ArchiveDatetime.parse(FIRST), "literal": FIRST}
+    restored = decode_record(json.loads(json.dumps(encode_record(deepcopy(value)))))
+    assert encode_record(restored)["record"] == {"created_at": FIRST, "literal": FIRST}
+    assert restored["created_at"].isoformat() == "2026-09-10T02:47:11.572211+00:00"
+
+
+async def seed(runtime):
+    await runtime.entity_manager.create_direct(
+        Entity(id="precision", entity_type=EntityType.SESSION, name="Precision", content="Evidence")
+    )
+    await runtime.client.execute_query(
+        """UPDATE entity SET created_at=d'2026-09-10T02:47:11.572211763Z',
+        attributes.metadata = {literal: $literal, 'literal.key': [d'2026-09-10T02:47:11.572211764Z']}
+        WHERE uuid='precision';""",
+        literal=FIRST,
+    )
+
+
+async def exact_dates(client):
+    return await client.execute_query(
+        """SELECT type::string(created_at) AS created_at,
+        type::string(attributes.metadata.`literal.key`[0]) AS nested,
+        attributes.metadata.literal AS literal FROM entity WHERE uuid='precision';"""
+    )
+
+
+async def test_native_archive_dates_survive_same_store_and_fresh_restore(runtime, destination):
+    await seed(runtime)
+    before = await exact_dates(runtime.client)
+    payload = json.loads(
+        json.dumps(
+            await export_source_integrity(
+                runtime.client.execute_query,
+                kind=SourceKind.GRAPH_ENTITY,
+                organizations=[runtime.client.group_id],
+            )
+        )
+    )
+    for target in (runtime, destination):
+        result = await restore_source_integrity(
+            target.client.execute_query,
+            payload,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[runtime.client.group_id],
+        )
+        assert not result["conflicts"]
+        assert await exact_dates(target.client) == before
+    row = next(row for row in payload["source_rows"] if row["record"]["uuid"] == "precision")
+    assert row["record"]["created_at"] == FIRST
+    assert row["record"]["attributes"]["metadata"]["literal.key"] == [SECOND]
+
+
+async def test_native_one_nanosecond_capture_race_is_rejected(runtime):
+    await seed(runtime)
+    original = runtime.client.execute_query
+    mutated = False
+
+    async def change(statement, **params):
+        nonlocal mutated
+        if "paths" in params and not mutated:
+            mutated = True
+            await original(
+                "UPDATE entity SET created_at=d'2026-09-10T02:47:11.572211764Z' WHERE uuid='precision';"
+            )
+        return await original(statement, **params)
+
+    with pytest.raises(Exception, match="source changed during datetime capture"):
+        await read_source_archive_snapshot(
+            change,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[runtime.client.group_id],
+        )
+    assert mutated
+
+
+async def test_native_one_nanosecond_restore_race_is_rejected(runtime):
+    await seed(runtime)
+    payload = await export_source_integrity(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    original = runtime.client.execute_query
+    mutated = False
+
+    async def change(statement, **params):
+        nonlocal mutated
+        if statement.startswith("BEGIN TRANSACTION;") and not mutated:
+            mutated = True
+            await original(
+                "UPDATE entity SET created_at=d'2026-09-10T02:47:11.572211764Z' WHERE uuid='precision';"
+            )
+        return await original(statement, **params)
+
+    with pytest.raises(Exception, match="destination changed"):
+        await restore_source_integrity(
+            change,
+            payload,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[runtime.client.group_id],
+            clean=True,
+        )
+    assert mutated
+    from sibyl_core.backends.surreal.records import normalize_records
+
+    assert normalize_records(await exact_dates(runtime.client))[0]["created_at"] == SECOND
+
+
+@pytest.mark.parametrize("key", ["literal.key", "back`tick", "back\\slash", "Ω", "[0]"])
+async def test_native_datetime_paths_preserve_literal_metadata_keys(runtime, key):
+    from surrealdb.data.types.datetime import Datetime
+
+    await seed(runtime)
+    await runtime.client.execute_query(
+        "UPDATE entity SET attributes.metadata=$metadata WHERE uuid='precision';",
+        metadata={key: [Datetime(FIRST)], "literal": FIRST},
+    )
+    payload = await export_source_integrity(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    row = next(row for row in payload["source_rows"] if row["record"]["uuid"] == "precision")
+    assert row["record"]["attributes"]["metadata"][key] == [FIRST]
+    assert row["record"]["attributes"]["metadata"]["literal"] == FIRST
+
+
+async def test_native_raw_source_archive_retains_nanoseconds_on_empty_destination():
+    from uuid import uuid4
+
+    from sibyl_core.backends.surreal import SurrealContentClient, bootstrap_content_schema
+
+    source = SurrealContentClient(url="memory://", database="source_" + uuid4().hex)
+    target = SurrealContentClient(url="memory://", database="target_" + uuid4().hex)
+    try:
+        for client in (source, target):
+            await bootstrap_content_schema(client)
+        await source.execute_query(
+            """CREATE raw_captures CONTENT {
+                uuid: 'precision', organization_id: 'org', source_id: 'source',
+                raw_content: 'Evidence', principal_id: 'owner',
+                created_at: d'2026-09-10T02:47:11.572211763Z',
+                captured_at: d'2026-09-10T02:47:11.572211764Z',
+                metadata: {date: d'2026-09-10T02:47:11.572211765Z', literal: $literal}
+            };""",
+            literal=FIRST,
+        )
+        payload = json.loads(
+            json.dumps(
+                await export_source_integrity(
+                    source.execute_query,
+                    kind=SourceKind.RAW_CAPTURE,
+                    organizations=["org"],
+                )
+            )
+        )
+        result = await restore_source_integrity(
+            target.execute_query,
+            payload,
+            kind=SourceKind.RAW_CAPTURE,
+            organizations=["org"],
+        )
+        assert not result["conflicts"]
+        query = """SELECT type::string(created_at) AS created_at,
+            type::string(captured_at) AS captured_at, type::string(metadata.date) AS nested,
+            metadata.literal AS literal FROM raw_captures WHERE uuid='precision';"""
+        assert await target.execute_query(query) == await source.execute_query(query)
+        assert payload["source_rows"][0]["record"]["captured_at"] == SECOND
+    finally:
+        await source.close()
+        await target.close()
+
+
+async def test_native_companion_one_nanosecond_change_prevents_graph_cleanup(runtime):
+    from sibyl_core.models.entities import Relationship, RelationshipType
+
+    await runtime.relationship_manager.create(
+        Relationship(
+            id="precise-link",
+            source_id="project_a",
+            target_id="project_b",
+            relationship_type=RelationshipType.RELATED_TO,
+        )
+    )
+    await runtime.client.execute_query(
+        "UPDATE relates_to SET created_at=d'2026-09-10T02:47:11.572211763Z' WHERE uuid='precise-link';"
+    )
+    payload = await export_source_integrity(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    execute = runtime.client.execute_query
+    mutated = False
+
+    async def race(statement, **params):
+        nonlocal mutated
+        if statement.startswith("BEGIN TRANSACTION;") and not mutated:
+            mutated = True
+            await execute(
+                "UPDATE relates_to SET created_at=d'2026-09-10T02:47:11.572211764Z' WHERE uuid='precise-link';"
+            )
+        return await execute(statement, **params)
+
+    with pytest.raises(Exception, match="destination changed"):
+        await restore_source_integrity(
+            race,
+            payload,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[runtime.client.group_id],
+            clean=True,
+            clean_graph_auxiliary=True,
+        )
+    assert mutated
+    from sibyl_core.backends.surreal.records import normalize_records
+
+    rows = normalize_records(
+        await execute(
+            "SELECT type::string(created_at) AS created_at FROM relates_to WHERE uuid='precise-link';"
+        )
+    )
+    assert rows == [{"created_at": SECOND}]
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("2020-01-02T00:00:00+00:00", "2020-01-02T00:00:00Z"),
+        ("2020-01-02T00:00:00", "2020-01-02T00:00:00Z"),
+        ("2020-01-02T01:00:00.123456789+01:00", "2020-01-02T00:00:00.123456789Z"),
+        ("2020-01-01T23:00:00.000000001-01:00", "2020-01-02T00:00:00.000000001Z"),
+    ],
+)
+async def test_native_archive_parameters_keep_legacy_offsets_and_fraction(runtime, text, expected):
+    from sibyl_core.migrate.source_integrity import native_archive_parameters
+
+    record = {"date": ArchiveDatetime.parse(text)}
+    result = await runtime.client.execute_query(
+        "RETURN type::string($record.date);",
+        record=native_archive_parameters(record),
+    )
+    assert result == expected
+    assert encode_record(record)["record"]["date"] == text

--- a/packages/python/sibyl-core/tests/test_source_archive_precision.py
+++ b/packages/python/sibyl-core/tests/test_source_archive_precision.py
@@ -27,6 +27,41 @@ def test_archive_codec_keeps_native_precision_through_copy_and_json():
     assert restored["created_at"].isoformat() == "2026-09-10T02:47:11.572211+00:00"
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        ["missing"],
+        ["missing", "date"],
+        ["items", 2],
+        ["items", -1],
+        ["items", "0"],
+        ["items", True],
+        ["scalar", "date"],
+        ["scalar", 0],
+        ["mapping", 0],
+        ["mapping", "missing"],
+        ["nothing", "date"],
+    ],
+)
+def test_archive_codec_rejects_invalid_datetime_paths(path):
+    payload = {
+        "record": {"items": [FIRST], "scalar": FIRST, "mapping": {"0": FIRST}, "nothing": None},
+        "datetimes": [path],
+    }
+    before = deepcopy(payload)
+    with pytest.raises(ValueError, match="archive datetime path"):
+        decode_record(payload)
+    assert payload == before
+
+
+def test_archive_codec_nested_datetime_paths_preserve_literal_strings():
+    original = {"items": [{"0": ArchiveDatetime.parse(FIRST)}, FIRST]}
+    restored = decode_record(encode_record(original))
+    assert isinstance(restored["items"][0]["0"], ArchiveDatetime)
+    assert type(restored["items"][1]) is str
+    assert encode_record(restored) == encode_record(original)
+
+
 async def seed(runtime):
     await runtime.entity_manager.create_direct(
         Entity(id="precision", entity_type=EntityType.SESSION, name="Precision", content="Evidence")

--- a/packages/python/sibyl-core/tests/test_source_integrity_archive.py
+++ b/packages/python/sibyl-core/tests/test_source_integrity_archive.py
@@ -1,8 +1,10 @@
 """Archive completeness and typed evidence must survive JSON transport."""
 
+import hashlib
 import json
 from copy import deepcopy
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
@@ -418,3 +420,28 @@ async def test_foreign_physical_record_collision_rolls_back_scoped_cleanup(runti
         )
         assert after == before
         assert selected.id in {row["uuid"] for row in after["source_rows"]}
+
+
+@pytest.mark.parametrize("raw_content", [None, 7, False, [], {}])
+def test_archive_validation_reports_invalid_raw_content(raw_content):
+    from sibyl_core.migrate.archive import LoadedArchive, build_manifest, validate_archive
+
+    section = archive()
+    section["source_rows"][0]["record"]["raw_content"] = raw_content
+    unsigned = {key: value for key, value in section.items() if key != "sha256"}
+    section["sha256"] = hashlib.sha256(
+        json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    files = {
+        "content.json": json.dumps(
+            {"version": "2.0", "tables": {}, "source_integrity": section}
+        ).encode()
+    }
+    loaded = LoadedArchive(
+        source=Path("invalid-raw-content"),
+        files=files,
+        manifest=build_manifest(organization_id="org", source_store="surreal", files=files),
+    )
+    assert validate_archive(loaded) == [
+        "archive source integrity validation failed: archive raw source content must be a string"
+    ]

--- a/packages/python/sibyl-core/tests/test_source_integrity_archive.py
+++ b/packages/python/sibyl-core/tests/test_source_integrity_archive.py
@@ -1,0 +1,420 @@
+"""Archive completeness and typed evidence must survive JSON transport."""
+
+import json
+from copy import deepcopy
+from datetime import UTC, datetime
+
+import pytest
+
+from sibyl_core.memory_pipeline.observations import SourceKind
+from sibyl_core.migrate.source_integrity import (
+    build_integrity_archive,
+    decode_record,
+    encode_record,
+    validate_integrity_archive,
+)
+from tests.test_reflection_identity import content_store as content_store
+from tests.test_reflection_identity import runtime as runtime
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+
+
+def archive():
+    return build_integrity_archive(
+        kind=SourceKind.RAW_CAPTURE,
+        organizations=["org"],
+        source_rows=[
+            {
+                "uuid": "memory",
+                "organization_id": "org",
+                "revision": 1,
+                "raw_content": "signed bytes",
+                "metadata": {"literal": "2026-09-09T00:00:00Z"},
+                "created_at": datetime(2026, 9, 9, tzinfo=UTC),
+            }
+        ],
+        source_states=[
+            {
+                "organization_id": "org",
+                "source_kind": "raw_capture",
+                "source_id": "memory",
+                "generation": 9,
+                "revision": 1,
+                "deleted": False,
+                "incarnation": "retained",
+            },
+            {
+                "organization_id": "org",
+                "source_kind": "raw_capture",
+                "source_id": "deleted",
+                "generation": 14,
+                "revision": 8,
+                "deleted": True,
+                "incarnation": "tombstone",
+            },
+        ],
+        derivations=[],
+    )
+
+
+def test_archive_preserves_typed_dates_and_literal_signed_metadata():
+    payload = json.loads(json.dumps(archive()))
+    rows, states, associations = validate_integrity_archive(
+        payload, kind=SourceKind.RAW_CAPTURE, organizations=["org"]
+    )
+    assert rows[0]["created_at"] == datetime(2026, 9, 9, tzinfo=UTC)
+    assert rows[0]["metadata"]["literal"] == "2026-09-09T00:00:00Z"
+    assert states[1]["deleted"] is True
+    assert states[1]["generation"] == 14
+    assert not associations
+
+
+@pytest.mark.parametrize("section", ["source_states", "derivations", "source_rows"])
+def test_current_archive_rejects_omitted_collection(section):
+    payload = archive()
+    del payload[section]
+    with pytest.raises(ValueError, match="incomplete"):
+        validate_integrity_archive(payload, kind=SourceKind.RAW_CAPTURE, organizations=["org"])
+
+
+def test_archive_rejects_tampered_ledger_before_restore():
+    payload = deepcopy(archive())
+    payload["source_states"][0]["generation"] = 1
+    with pytest.raises(ValueError, match="digest"):
+        validate_integrity_archive(payload, kind=SourceKind.RAW_CAPTURE, organizations=["org"])
+
+
+def test_archive_scope_is_trusted_by_caller_not_payload():
+    with pytest.raises(ValueError, match="organization"):
+        validate_integrity_archive(archive(), kind=SourceKind.RAW_CAPTURE, organizations=["other"])
+
+
+def test_typed_record_does_not_confuse_user_object_with_codec_marker():
+    value = {"metadata": {"record": {"datetimes": []}}, "values": [None, False, 4, "2026-01-01"]}
+    assert decode_record(json.loads(json.dumps(encode_record(value)))) == value
+
+
+@pytest.mark.asyncio
+async def test_source_export_reads_real_rows_and_retained_tombstones(runtime):
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.services.source_archive_store import export_source_integrity
+
+    for identity in ("live-archive", "deleted-archive"):
+        await runtime.entity_manager.create_direct(
+            Entity(id=identity, entity_type=EntityType.SESSION, name=identity, content="Evidence")
+        )
+    await runtime.entity_manager.delete("deleted-archive")
+    payload = await export_source_integrity(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    rows, states, _ = validate_integrity_archive(
+        json.loads(json.dumps(payload)),
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    assert any(row["uuid"] == "live-archive" for row in rows)
+    assert not any(row["uuid"] == "deleted-archive" for row in rows)
+    assert next(state for state in states if state["source_id"] == "deleted-archive")["deleted"]
+
+
+@pytest.fixture
+async def destination(runtime):
+    from uuid import uuid4
+
+    from sibyl_core.backends.surreal.schema import bootstrap_schema
+    from sibyl_core.services.graph_client import SurrealGraphClient
+    from sibyl_core.services.graph_entities import EntityManager
+    from sibyl_core.services.graph_relationships import RelationshipManager
+    from sibyl_core.services.graph_runtime import GraphRuntime
+
+    client = SurrealGraphClient(
+        group_id=runtime.client.group_id, url="memory://", database="archive_" + uuid4().hex
+    )
+    try:
+        await bootstrap_schema(client)
+        yield GraphRuntime(
+            client=client,
+            entity_manager=EntityManager(client, group_id=client.group_id),
+            relationship_manager=RelationshipManager(client, group_id=client.group_id),
+        )
+    finally:
+        await client.close()
+
+
+async def test_complete_fresh_restore_preserves_protected_graph_ancestry(
+    runtime, destination, content_store, monkeypatch
+):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+    from sibyl_core.services.source_archive_store import (
+        export_source_integrity,
+        restore_source_integrity,
+    )
+    from tests.test_memory_projection_derivations import protected_session
+
+    source, target, _ = await protected_session(runtime, monkeypatch)
+    payload = await export_source_integrity(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    result = await restore_source_integrity(
+        destination.client.execute_query,
+        json.loads(json.dumps(payload)),
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    assert not result["conflicts"]
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+        AsyncMock(return_value=destination),
+    )
+    restored = await destination.entity_manager.get(target.id)
+    assert restored.derivation_required
+    assert target.id not in await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: restored.metadata}
+    )
+    await destination.entity_manager.update(source.id, {"content": "Changed evidence"})
+    assert target.id in await unavailable_publication_ids(
+        runtime.client.group_id, {target.id: restored.metadata}
+    )
+
+
+async def test_restore_cannot_revive_destination_source_tombstone(runtime, destination):
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.services.source_archive_store import (
+        export_source_integrity,
+        read_source_archive_snapshot,
+        restore_source_integrity,
+    )
+
+    entity = Entity(
+        id="tombstone", entity_type=EntityType.SESSION, name="Source", content="Original"
+    )
+    await runtime.entity_manager.create_direct(entity)
+    payload = await export_source_integrity(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    await restore_source_integrity(
+        destination.client.execute_query,
+        payload,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    assert await destination.entity_manager.delete(entity.id)
+    before = await read_source_archive_snapshot(
+        destination.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    assert any(
+        row["source_id"] == entity.id and row["deleted"] for row in before["source_states"]
+    ), before
+    result = await restore_source_integrity(
+        destination.client.execute_query,
+        payload,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+        clean=True,
+        skip_existing=False,
+    )
+    assert any(row["reason"] == "retained_tombstone" for row in result["conflicts"])
+    after = await read_source_archive_snapshot(
+        destination.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    assert after == before
+
+
+async def test_scoped_clean_keeps_other_org_and_retains_deleted_high_water(runtime, content_store):
+    from sibyl_core.services import content_client
+    from sibyl_core.services.source_archive_store import (
+        export_source_integrity,
+        read_source_archive_snapshot,
+        restore_source_integrity,
+    )
+    from sibyl_core.services.surreal_content import remember_raw_memory
+
+    async def remember(org, text):
+        return await remember_raw_memory(
+            organization_id=org,
+            principal_id="owner",
+            source_id=text,
+            raw_content=text,
+            embedding_provider=None,
+        )
+
+    org = runtime.client.group_id
+    original = await remember(org, "Original")
+    other = await remember("unrelated-org", "Unrelated")
+    async with content_client.surreal_content_client() as client:
+        payload = await export_source_integrity(
+            client.execute_query, kind=SourceKind.RAW_CAPTURE, organizations=[org]
+        )
+        extra = await remember(org, "Added after archive")
+        result = await restore_source_integrity(
+            client.execute_query,
+            payload,
+            kind=SourceKind.RAW_CAPTURE,
+            organizations=[org],
+            clean=True,
+        )
+        assert not result["conflicts"]
+        snapshot = await read_source_archive_snapshot(
+            client.execute_query,
+            kind=SourceKind.RAW_CAPTURE,
+            organizations=None,
+        )
+        assert {row["uuid"] for row in snapshot["source_rows"]} == {original.id, other.id}
+        tombstone = next(row for row in snapshot["source_states"] if row["source_id"] == extra.id)
+        assert tombstone["deleted"] is True
+        assert tombstone["generation"] >= 2
+
+
+async def test_destination_mutation_between_snapshot_and_commit_aborts_restore(
+    runtime, destination
+):
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.services.source_archive_store import (
+        export_source_integrity,
+        restore_source_integrity,
+    )
+
+    entity = Entity(id="cas", entity_type=EntityType.SESSION, name="Source", content="Original")
+    await runtime.entity_manager.create_direct(entity)
+    payload = await export_source_integrity(
+        runtime.client.execute_query,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[runtime.client.group_id],
+    )
+    original = destination.client.execute_query
+    injected = False
+
+    async def mutate_before_commit(statement, **params):
+        nonlocal injected
+        if statement.startswith("BEGIN TRANSACTION;") and not injected:
+            injected = True
+            await destination.entity_manager.create_direct(entity)
+            await destination.entity_manager.update(entity.id, {"content": "Concurrent evidence"})
+        return await original(statement, **params)
+
+    with pytest.raises(Exception, match="destination changed"):
+        await restore_source_integrity(
+            mutate_before_commit,
+            payload,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[runtime.client.group_id],
+            clean=True,
+            skip_existing=False,
+        )
+    assert injected
+    assert (await destination.entity_manager.get(entity.id)).content == "Concurrent evidence"
+
+
+async def test_restore_preserves_inactive_target_association(runtime, destination, monkeypatch):
+    from sibyl_core.services.source_archive_store import (
+        export_source_integrity,
+        read_source_archive_snapshot,
+        restore_source_integrity,
+    )
+    from tests.test_memory_projection_derivations import protected_session
+
+    _, target, _ = await protected_session(runtime, monkeypatch)
+    org = runtime.client.group_id
+    payload = await export_source_integrity(
+        runtime.client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[org]
+    )
+    await restore_source_integrity(
+        destination.client.execute_query, payload, kind=SourceKind.GRAPH_ENTITY, organizations=[org]
+    )
+    assert await destination.entity_manager.delete(target.id)
+    before = await read_source_archive_snapshot(
+        destination.client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[org]
+    )
+    assert (
+        next(row for row in before["derivations"] if row["target_id"] == target.id)["active"]
+        is False
+    )
+    result = await restore_source_integrity(
+        destination.client.execute_query,
+        payload,
+        kind=SourceKind.GRAPH_ENTITY,
+        organizations=[org],
+        clean=True,
+        skip_existing=False,
+    )
+    assert any(
+        row["source_id"] == target.id and row["reason"] == "retained_tombstone"
+        for row in result["conflicts"]
+    )
+    after = await read_source_archive_snapshot(
+        destination.client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[org]
+    )
+    assert after == before
+
+
+async def test_foreign_physical_record_collision_rolls_back_scoped_cleanup(runtime, content_store):
+    from sibyl_core.services import content_client
+    from sibyl_core.services.source_archive_store import (
+        export_source_integrity,
+        read_source_archive_snapshot,
+        restore_source_integrity,
+    )
+    from sibyl_core.services.surreal_content import remember_raw_memory
+
+    org = runtime.client.group_id
+    selected = await remember_raw_memory(
+        organization_id=org,
+        principal_id="owner",
+        source_id="selected",
+        raw_content="Selected",
+        embedding_provider=None,
+    )
+    other = await remember_raw_memory(
+        organization_id="other-org",
+        principal_id="owner",
+        source_id="other",
+        raw_content="Other",
+        embedding_provider=None,
+    )
+    async with content_client.surreal_content_client() as client:
+        payload = await export_source_integrity(
+            client.execute_query, kind=SourceKind.RAW_CAPTURE, organizations=[org]
+        )
+        before = await read_source_archive_snapshot(
+            client.execute_query, kind=SourceKind.RAW_CAPTURE, organizations=None
+        )
+        rows, states, associations = validate_integrity_archive(
+            payload, kind=SourceKind.RAW_CAPTURE, organizations=[org]
+        )
+        foreign = next(row for row in before["source_rows"] if row["uuid"] == other.id)
+        rows[0]["archive_record_key"] = foreign["archive_record_key"]
+        rows[0]["uuid"] = "new-source-identity"
+        states[0]["source_id"] = "new-source-identity"
+        forged = build_integrity_archive(
+            kind=SourceKind.RAW_CAPTURE,
+            organizations=[org],
+            source_rows=rows,
+            source_states=states,
+            derivations=associations,
+        )
+        with pytest.raises(Exception, match="physical record identity conflicts"):
+            await restore_source_integrity(
+                client.execute_query,
+                forged,
+                kind=SourceKind.RAW_CAPTURE,
+                organizations=[org],
+                clean=True,
+            )
+        after = await read_source_archive_snapshot(
+            client.execute_query, kind=SourceKind.RAW_CAPTURE, organizations=None
+        )
+        assert after == before
+        assert selected.id in {row["uuid"] for row in after["source_rows"]}

--- a/packages/python/sibyl-core/tests/test_tools_admin.py
+++ b/packages/python/sibyl-core/tests/test_tools_admin.py
@@ -49,6 +49,20 @@ def archive_restore(monkeypatch):
     return seam
 
 
+def empty_companion_client():
+    """Serialization-only tests expose an empty checked companion snapshot."""
+    return SimpleNamespace(
+        execute_query=AsyncMock(
+            return_value=[
+                {
+                    "rows": {"episode": [], "relates_to": [], "mentions": []},
+                    "fingerprint": "0" * 64,
+                }
+            ]
+        )
+    )
+
+
 def archived_entities(archive_restore):
     from sibyl_core.migrate.source_integrity import decode_record
     from sibyl_core.services.graph_records import entity_from_surreal_row
@@ -347,7 +361,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -365,7 +379,11 @@ class TestRestoreBackup:
         archive_restore.assert_awaited_once()
         entity_manager.create_direct_bulk.assert_not_awaited()
         entity_manager.create_direct.assert_not_awaited()
-        relationship_manager.create_bulk.assert_awaited_once()
+        relationship_manager.create_bulk.assert_not_awaited()
+        assert (
+            len(archive_restore.await_args.kwargs["auxiliary_parameters"]["archive_relationships"])
+            == 1
+        )
         relationship_manager.create.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -422,7 +440,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -514,7 +532,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -579,7 +597,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -641,7 +659,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -939,7 +957,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -953,13 +971,15 @@ class TestRestoreBackup:
 
         assert result.success is True
         restored_entities = archived_entities(archive_restore)
-        restored_relationships = relationship_manager.create_bulk.await_args.args[0]
+        restored_relationships = archive_restore.await_args.kwargs["auxiliary_parameters"][
+            "archive_relationships"
+        ]
         assert [entity.id for entity in restored_entities] == ["project-1", "task-1"]
         assert restored_entities[1].metadata["source_ids"] == ["source:task"]
-        assert restored_relationships[0].source_id == "task-1"
-        assert restored_relationships[0].target_id == "project-1"
-        assert restored_relationships[0].relationship_type is RelationshipType.BELONGS_TO
-        assert restored_relationships[0].metadata["source_ids"] == ["source:task"]
+        assert restored_relationships[0]["source_id"] == "task-1"
+        assert restored_relationships[0]["target_id"] == "project-1"
+        assert restored_relationships[0]["name"] == RelationshipType.BELONGS_TO.value
+        assert restored_relationships[0]["attributes"]["source_ids"] == ["source:task"]
 
 
 class TestBackfillDenormalizedFields:

--- a/packages/python/sibyl-core/tests/test_tools_admin.py
+++ b/packages/python/sibyl-core/tests/test_tools_admin.py
@@ -35,6 +35,30 @@ from sibyl_core.tools.admin import (
 )
 
 
+@pytest.fixture
+def archive_restore(monkeypatch):
+    """Expose serialized source units; real transactional behavior has SDK controls."""
+    from sibyl_core.migrate.source_integrity import validate_integrity_archive
+
+    async def restored(_execute, payload, *, kind, organizations, **_policy):
+        rows, _, _ = validate_integrity_archive(payload, kind=kind, organizations=organizations)
+        return {"restored_source_ids": [row["uuid"] for row in rows], "conflicts": []}
+
+    seam = AsyncMock(side_effect=restored)
+    monkeypatch.setattr("sibyl_core.services.source_archive_store.restore_source_integrity", seam)
+    return seam
+
+
+def archived_entities(archive_restore):
+    from sibyl_core.migrate.source_integrity import decode_record
+    from sibyl_core.services.graph_records import entity_from_surreal_row
+
+    return [
+        entity_from_surreal_row(decode_record(row))
+        for row in archive_restore.await_args.args[1]["source_rows"]
+    ]
+
+
 class TestRebuildIndices:
     """Admin index rebuilds should report real behavior, not placeholder success."""
 
@@ -282,14 +306,15 @@ class TestHealthAndStats:
 
 
 class TestRestoreBackup:
-    """Graph restores should use the fast direct entity seams."""
+    """Graph restore serialization must preserve values at the checked owner."""
 
     @pytest.mark.asyncio
-    async def test_clean_restore_uses_bulk_direct_entity_insert(self) -> None:
+    async def test_restore_submits_checked_source_unit_without_embedding_writes(
+        self, archive_restore
+    ) -> None:
         org_id = "00000000-0000-0000-0000-000000000111"
         entity_manager = AsyncMock()
         relationship_manager = AsyncMock()
-        driver = SimpleNamespace()
         entity_manager.create_direct_bulk = AsyncMock(return_value=["entity-1", "entity-2"])
         entity_manager.create_direct = AsyncMock()
         relationship_manager.create_bulk = AsyncMock(return_value=(1, 0))
@@ -322,7 +347,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(get_org_driver=lambda group_id: driver),
+                    client=SimpleNamespace(execute_query=AsyncMock()),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -337,16 +362,16 @@ class TestRestoreBackup:
         assert result.success is True
         assert result.entities_restored == 2
         assert result.entities_skipped == 0
-        entity_manager.create_direct_bulk.assert_awaited_once_with(
-            ANY,
-            generate_embeddings=False,
-        )
+        archive_restore.assert_awaited_once()
+        entity_manager.create_direct_bulk.assert_not_awaited()
         entity_manager.create_direct.assert_not_awaited()
         relationship_manager.create_bulk.assert_awaited_once()
         relationship_manager.create.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_restore_normalizes_owner_metadata_it_cannot_authorize(self) -> None:
+    async def test_restore_normalizes_owner_metadata_it_cannot_authorize(
+        self, archive_restore
+    ) -> None:
         """A restore rebuilds rows from a request body, not from a caller.
 
         It keeps the ownership the backup recorded, but must not introduce
@@ -397,7 +422,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(get_org_driver=lambda group_id: None),
+                    client=SimpleNamespace(execute_query=AsyncMock()),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -410,10 +435,7 @@ class TestRestoreBackup:
             )
 
         assert result.success is True
-        restored = {
-            entity.id: entity.metadata
-            for entity in entity_manager.create_direct_bulk.await_args.args[0]
-        }
+        restored = {entity.id: entity.metadata for entity in archived_entities(archive_restore)}
         # Recorded ownership survives; the extra owner channel does not.
         assert restored["episode_planted"]["memory_scope"] == "private"
         assert restored["episode_planted"]["principal_id"] == "victim"
@@ -441,7 +463,7 @@ class TestRestoreBackup:
         )
 
     @pytest.mark.asyncio
-    async def test_restore_rehydrates_typed_entities_losslessly(self) -> None:
+    async def test_restore_rehydrates_typed_entities_losslessly(self, archive_restore) -> None:
         org_id = "00000000-0000-0000-0000-000000000111"
         entity_manager = AsyncMock()
         relationship_manager = AsyncMock()
@@ -492,7 +514,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(get_org_driver=lambda group_id: SimpleNamespace()),
+                    client=SimpleNamespace(execute_query=AsyncMock()),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -505,18 +527,24 @@ class TestRestoreBackup:
             )
 
         assert result.success is True
-        restored = entity_manager.create_direct_bulk.await_args.args[0]
-        assert [type(entity) for entity in restored] == [Task, Project, Epic]
-        assert restored[0].status is TaskStatus.DOING
-        assert restored[0].priority is TaskPriority.CRITICAL
-        assert restored[0].project_id == "project-1"
-        assert restored[0].assignees == ["nova"]
-        assert restored[1].repository_url == "https://github.com/hyperb1iss/sibyl"
-        assert restored[1].tech_stack == ["python", "surrealdb"]
-        assert restored[2].project_id == "project-1"
+        restored = archived_entities(archive_restore)
+        assert [entity.entity_type for entity in restored] == [
+            EntityType.TASK,
+            EntityType.PROJECT,
+            EntityType.EPIC,
+        ]
+        assert restored[0].metadata["status"] == TaskStatus.DOING.value
+        assert restored[0].metadata["priority"] == TaskPriority.CRITICAL.value
+        assert restored[0].metadata["project_id"] == "project-1"
+        assert restored[0].metadata["assignees"] == ["nova"]
+        assert restored[1].metadata["repository_url"] == "https://github.com/hyperb1iss/sibyl"
+        assert restored[1].metadata["tech_stack"] == ["python", "surrealdb"]
+        assert restored[2].metadata["project_id"] == "project-1"
 
     @pytest.mark.asyncio
-    async def test_restore_preserves_legacy_typed_entities_as_generic(self) -> None:
+    async def test_restore_preserves_legacy_typed_entities_as_generic(
+        self, archive_restore
+    ) -> None:
         org_id = "00000000-0000-0000-0000-000000000111"
         entity_manager = AsyncMock()
         relationship_manager = AsyncMock()
@@ -551,7 +579,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(get_org_driver=lambda group_id: SimpleNamespace()),
+                    client=SimpleNamespace(execute_query=AsyncMock()),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -564,7 +592,7 @@ class TestRestoreBackup:
             )
 
         assert result.success is True
-        restored = entity_manager.create_direct_bulk.await_args.args[0]
+        restored = archived_entities(archive_restore)
         assert [type(entity) for entity in restored] == [Entity, Entity]
         assert [entity.entity_type for entity in restored] == [
             EntityType.NOTE,
@@ -574,11 +602,14 @@ class TestRestoreBackup:
         assert restored[1].content == "Old error pattern before structured fields"
 
     @pytest.mark.asyncio
-    async def test_skip_existing_restore_uses_bulk_create_without_embeddings(self) -> None:
+    async def test_skip_existing_restore_preserves_checked_owner_policy(
+        self, archive_restore
+    ) -> None:
+        archive_restore.side_effect = None
+        archive_restore.return_value = {"restored_source_ids": ["entity-2"], "conflicts": []}
         org_id = "00000000-0000-0000-0000-000000000111"
         entity_manager = AsyncMock()
         relationship_manager = AsyncMock()
-        driver = SimpleNamespace()
         entity_manager.get = AsyncMock(
             side_effect=[SimpleNamespace(id="entity-1"), Exception("missing")]
         )
@@ -610,7 +641,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(get_org_driver=lambda group_id: driver),
+                    client=SimpleNamespace(execute_query=AsyncMock()),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -625,14 +656,15 @@ class TestRestoreBackup:
         assert result.success is True
         assert result.entities_restored == 1
         assert result.entities_skipped == 1
-        entity_manager.create_direct_bulk.assert_awaited_once_with(
-            ANY,
-            generate_embeddings=False,
-        )
+        archive_restore.assert_awaited_once()
+        entity_manager.create_direct_bulk.assert_not_awaited()
         entity_manager.create_direct.assert_not_awaited()
         relationship_manager.create_bulk.assert_not_awaited()
-        create_args = entity_manager.create_direct_bulk.await_args
-        assert [entity.id for entity in create_args.args[0]] == ["entity-2"]
+        assert archive_restore.await_args.kwargs["skip_existing"] is True
+        assert [entity.id for entity in archived_entities(archive_restore)] == [
+            "entity-1",
+            "entity-2",
+        ]
 
     @pytest.mark.asyncio
     async def test_restore_rehydrates_episodes_and_mentions(self) -> None:
@@ -865,7 +897,7 @@ class TestRestoreBackup:
         ]
 
     @pytest.mark.asyncio
-    async def test_restore_preserves_task_link_source_metadata(self) -> None:
+    async def test_restore_preserves_task_link_source_metadata(self, archive_restore) -> None:
         org_id = "00000000-0000-0000-0000-000000000111"
         entity_manager = AsyncMock()
         relationship_manager = AsyncMock()
@@ -907,7 +939,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(get_org_driver=lambda group_id: SimpleNamespace()),
+                    client=SimpleNamespace(execute_query=AsyncMock()),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -920,7 +952,7 @@ class TestRestoreBackup:
             )
 
         assert result.success is True
-        restored_entities = entity_manager.create_direct_bulk.await_args.args[0]
+        restored_entities = archived_entities(archive_restore)
         restored_relationships = relationship_manager.create_bulk.await_args.args[0]
         assert [entity.id for entity in restored_entities] == ["project-1", "task-1"]
         assert restored_entities[1].metadata["source_ids"] == ["source:task"]

--- a/packages/python/sibyl-core/tests/test_tools_admin.py
+++ b/packages/python/sibyl-core/tests/test_tools_admin.py
@@ -892,7 +892,7 @@ class TestRestoreBackup:
                 "source_id": "episode-legacy",
                 "target_id": "entity-legacy",
                 "group_id": org_id,
-                "created_at": "2026-04-19T00:00:00+00:00",
+                "created_at": "2026-04-19T00:00:00Z",
             }
         ]
 


### PR DESCRIPTION
Restoring an older archive could revive stale derived memory, undo a newer visibility decision, or erase a completed consolidation and allow extraction to run again. Archive owners now preserve source identities and permanent operation history, validate captured lineage, and retain newer destination restrictions.

## 🛠️ Restore contract

Graph and content archives carry source state, protected associations, tombstones and inactive lineage. Source restore checks a database-computed destination fingerprint before writes. Scoped cleanup applies only to the selected organization; global cleanup requires explicit operator scope and checks concurrently introduced organizations.

Content cleanup, source writes and auxiliary operation history share one transaction. A late auxiliary failure rolls back the content restore. Existing evaluation attempts, consolidation operations and API idempotency records cannot be silently replaced or erased. Identical records replay; conflicting records fail. Foreign organization identities remain protected.

An older or incomparable archive cannot replace an existing hidden, deleted or superseded source, or change its audience. The whole destination row and its history are retained with an explicit conflict reason. A demonstrably newer archive from the same source incarnation can restore an explicit unhide. Older active content with unchanged audience remains restorable. Clean omission preserves deletion history before a later old import.

Cross-namespace export checks captured dependencies for protected targets. A mismatch quarantines the target without rewriting its original observations. Matching dependencies do not establish a globally atomic snapshot. Legacy memory with unverifiable lineage remains available for explicit quarantine reporting and repair through a new capture identity. Sparse legacy raw imports receive supported defaults without changing provided timestamps; repeated imports preserve existing operation history.

The typed archive codec preserves native nanoseconds through SDK and JSON boundaries, including nested dates and legacy UTC offsets. Ordinary strings retain their bytes. Malformed typed paths and invalid raw-content shapes fail validation. A one-nanosecond concurrent change invalidates the restore fingerprint before cleanup.

CLI restore output reports applied writes, retained history and quarantine reasons without printing arbitrary archive IDs or text. The graph companion changes from #543 are included here so source and companion restoration land together. Graph restore validates episodes, relationships and mentions before mutation, then applies them in the same transaction as its source rows. Native companion timestamps retain all nine fractional digits. Auth, content and graph stores retain separate transaction boundaries.

Archived relationship embeddings are preserved. Missing embeddings remain missing; restore does not implicitly call a provider. Vectorless archives need an explicit embedding rebuild before semantic retrieval can use those relationships.

## 🧪 Validation

- The current integrated selection passed 77 API and 54 core tests. Core and API lint, formatting and typecheck passed.
- Independent revocation verification passed 24 native SurrealDB 3.2.3 cases, including the original hide resurrection, forward unhide, omission followed by old import, audience changes and late-hide races. CLI reporting and three root spot checks passed.
- The content transaction correction passed 50 independent native controls. Root checks and integrated regressions verified rollback, retained operation history and legacy replay.
- Graph atomicity passed 22 independent native controls and four embedded controls. The combined graph selection passed 47 tests and all core/API static checks. Earlier native qualification covered source timestamps, one-nanosecond races, foreign auxiliary identities and protected lineage. All native runs used isolated owned databases with verified cleanup.

Full public disaster-recovery acceptance, restart recovery and cross-store consistency remain separate release gates. No provider calls or original-instance changes were required for these restore tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backups and restores now include episode and mention data.
  * Archives include source-integrity and lineage validation details.
  * Restore results report integrity conflicts and quarantined records.
  * Added a global content-scope option for archive import, rehearsal, and cutover.
  * Legacy archives preserve available content while identifying unverifiable lineage.
* **Bug Fixes**
  * Prevented overwriting newer destination history or conflicting source records.
  * Preserved source provenance, operation history, tombstones, and high-precision timestamps during archive workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->