### PR TITLE
fix(cli): initialize SurrealDB volumes before local startup

### DIFF
--- a/apps/cli/src/sibyl_cli/docker.py
+++ b/apps/cli/src/sibyl_cli/docker.py
@@ -14,6 +14,7 @@ import yaml
 
 from sibyl_cli import config_store
 from sibyl_cli.common import NEON_CYAN, console, error, info, success
+from sibyl_cli.docker_storage import surreal_data_mount, surreal_volume_initializer
 from sibyl_cli.local import DEFAULT_IMAGE_TAG, check_docker, check_docker_compose
 
 app = typer.Typer(
@@ -79,9 +80,11 @@ def compose_config(
             },
             "restart": "unless-stopped",
         },
+        "surreal-init": surreal_volume_initializer(),
         "surrealdb": {
             "image": "${SIBYL_SURREAL_IMAGE:-surrealdb/surrealdb:v3.2.3}",
             "container_name": "sibyl-surrealdb",
+            "depends_on": {"surreal-init": {"condition": "service_completed_successfully"}},
             "command": [
                 "start",
                 "--log",
@@ -93,7 +96,7 @@ def compose_config(
                 "rocksdb:///data/sibyl.db",
             ],
             "ports": [f"127.0.0.1:{surreal_port}:8000"],
-            "volumes": ["sibyl_surreal:/data"],
+            "volumes": [surreal_data_mount()],
             "healthcheck": {
                 "test": ["CMD", "/surreal", "is-ready", "--endpoint", "http://localhost:8000"],
                 "interval": "5s",

--- a/apps/cli/src/sibyl_cli/docker_storage.py
+++ b/apps/cli/src/sibyl_cli/docker_storage.py
@@ -1,0 +1,31 @@
+"""Shared volume initialization for the non-root SurrealDB image."""
+
+from typing import Any
+
+
+def surreal_data_mount() -> dict[str, Any]:
+    """Prevent image copy-up from replacing initialized volume ownership."""
+    return {
+        "type": "volume",
+        "source": "sibyl_surreal",
+        "target": "/data",
+        "volume": {"nocopy": True},
+    }
+
+
+def surreal_volume_initializer() -> dict[str, Any]:
+    """Initialize only the mount root; preserve existing database file metadata."""
+    return {
+        "image": "busybox:1.37",
+        "container_name": "sibyl-surreal-init",
+        "user": "0:0",
+        # The official SurrealDB image uses distroless nonroot (65532:65532).
+        "command": ["chown", "65532:65532", "/data"],
+        "volumes": [surreal_data_mount()],
+        "network_mode": "none",
+        "read_only": True,
+        "cap_drop": ["ALL"],
+        "cap_add": ["CHOWN"],
+        "security_opt": ["no-new-privileges:true"],
+        "restart": "no",
+    }

--- a/apps/cli/src/sibyl_cli/local.py
+++ b/apps/cli/src/sibyl_cli/local.py
@@ -34,6 +34,7 @@ from sibyl_cli.common import (
     success,
     warn,
 )
+from sibyl_cli.docker_storage import surreal_data_mount, surreal_volume_initializer
 
 app = typer.Typer(
     name="local",
@@ -134,9 +135,11 @@ COMPOSE_CONFIG = {
             },
             "restart": "unless-stopped",
         },
+        "surreal-init": surreal_volume_initializer(),
         "surrealdb": {
             "image": "${SIBYL_SURREAL_IMAGE:-surrealdb/surrealdb:v3.2.3}",
             "container_name": "sibyl-surrealdb",
+            "depends_on": {"surreal-init": {"condition": "service_completed_successfully"}},
             "command": [
                 "start",
                 "--log",
@@ -148,7 +151,7 @@ COMPOSE_CONFIG = {
                 "rocksdb:///data/sibyl.db",
             ],
             "ports": ["127.0.0.1:8000:8000"],
-            "volumes": ["sibyl_surreal:/data"],
+            "volumes": [surreal_data_mount()],
             "healthcheck": {
                 "test": ["CMD", "/surreal", "is-ready", "--endpoint", "http://localhost:8000"],
                 "interval": "5s",

--- a/apps/cli/tests/test_docker_runtime.py
+++ b/apps/cli/tests/test_docker_runtime.py
@@ -264,3 +264,42 @@ def test_up_starts_local_runtime_without_agent_setup(
     assert (local_dir / "docker-compose.yml").exists()
     assert "sibyl local setup" not in result.output
     assert "Connect page" in result.output
+
+
+@pytest.mark.parametrize("runtime", ["local", "docker"])
+def test_surreal_volume_initialization_preserves_nonroot_and_existing_files(runtime: str) -> None:
+    config = (
+        local_module.COMPOSE_CONFIG
+        if runtime == "local"
+        else docker_module.compose_config(
+            image_tag="test",
+            api_port=3334,
+            web_port=3337,
+            surreal_port=8000,
+            with_worker=False,
+            with_crawler=False,
+        )
+    )
+    services = config["services"]
+    initializer = services["surreal-init"]
+    database = services["surrealdb"]
+    assert initializer["command"] == ["chown", "65532:65532", "/data"]
+    assert initializer["user"] == "0:0"
+    assert initializer["network_mode"] == "none"
+    assert initializer["cap_drop"] == ["ALL"]
+    assert initializer["cap_add"] == ["CHOWN"]
+    assert initializer["read_only"] is True
+    assert "user" not in database
+    assert database["depends_on"]["surreal-init"] == {"condition": "service_completed_successfully"}
+    assert (
+        database["volumes"]
+        == initializer["volumes"]
+        == [
+            {
+                "type": "volume",
+                "source": "sibyl_surreal",
+                "target": "/data",
+                "volume": {"nocopy": True},
+            }
+        ]
+    )


### PR DESCRIPTION
Fresh `sibyl up` and `sibyl docker` deployments can stop before the API starts because SurrealDB cannot create its RocksDB directory on a root-owned named volume. Both CLI-generated stacks now initialize the volume before starting the database.

A shared BusyBox service changes only the `/data` mount root to the official image's non-root UID/GID (65532). The initializer has no network, a read-only root filesystem, and only the CHOWN capability. Both volume mounts disable Docker copy-up so the database image cannot reset the initialized ownership. Existing database file ownership and permissions remain intact.

## 🧪 Validation

- The original native reproduction retained the database's permission-denied error and unhealthy state.
- Independent native verification confirms fresh readiness as UID 65532, a retained SQL record after restart, and unchanged existing file ownership and modes after repeated initialization. All isolated resources were removed.
- All 713 CLI tests pass. CLI lint and type checks pass; root independently repeated both deployment configuration controls.

The complete installer/browser setup run with rebuilt artifacts remains a separate acceptance gate. No release artifacts have been published.
