### PR TITLE
fix(web): finish setup with fresh authenticated navigation

### DIFF
--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -104,7 +104,10 @@ export default function SetupPage() {
       <main className="flex-1 flex items-start justify-center px-4 pb-12">
         <SetupWizard
           initialStatus={status}
-          onComplete={() => router.push('/login?setup=complete')}
+          onComplete={() => {
+            // Start with the signup cookies and discard pre-setup query caches.
+            window.location.assign('/');
+          }}
         />
       </main>
     </div>


### PR DESCRIPTION
Completing first-time setup can send a newly registered owner back to the welcome wizard. The login page reuses the shared setup query's cached pre-signup result for 30 seconds and redirects to setup, even though signup has already issued valid cookies.

The completion button now starts a full navigation to the app root. The new document uses the signup cookies and creates fresh query state. Missing authentication still follows the existing login redirect.

## 🧪 Validation

Web lint and typecheck pass. Independent review confirmed the cache and redirect sequence; all seven login tests pass. The isolated installer reproduced the old behavior in its captured page while authenticated memory save and recall both succeeded.

The corrected isolated installer run passed real browser setup, persisted onboarding completion and an unobstructed authenticated dashboard before and after reload. Independent verification checked the exact source build and confirmed that repeat installation preserved running service identities. Authenticated browser API memory save and exact recall also passed; the visual memory composer and reboot recovery were not exercised.
