### PR TITLE
fix(archives): restore graph companions atomically with exact dates

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/migrate/graph_companion_restore.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/graph_companion_restore.py
@@ -1,0 +1,156 @@
+"""Compose validated graph companions into their source restore transaction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from surrealdb import RecordID
+
+from sibyl_core.migrate.legacy_graph_archive import (
+    _EPISODE_UPSERT_STATEMENTS,
+    _MENTION_UPSERT_STATEMENTS,
+    BackupEpisodeNode,
+    BackupMentionEdge,
+    episode_record,
+)
+from sibyl_core.migrate.source_integrity import native_archive_parameters
+from sibyl_core.models.entities import Relationship
+from sibyl_core.services.graph_common import normalize_graph_records
+from sibyl_core.services.graph_relationships import (
+    _RELATIONSHIP_BULK_UPSERT_STATEMENTS,
+    _relationship_record,
+)
+from sibyl_core.services.source_archive_store import _graph_auxiliary_snapshot_sql
+
+
+@dataclass(frozen=True)
+class CompanionRestorePlan:
+    preconditions: str
+    statements: str
+    parameters: dict[str, Any]
+    episodes_restored: int
+    episodes_skipped: int
+    relationships_restored: int
+    mentions_restored: int
+    mentions_skipped: int
+
+
+async def prepare_companion_restore(
+    client: Any,
+    *,
+    organization_id: str,
+    episodes: list[BackupEpisodeNode],
+    relationships: list[Relationship],
+    mentions: list[BackupMentionEdge],
+    skip_existing: bool,
+    clean: bool,
+) -> CompanionRestorePlan:
+    """Capture skip decisions and fence the exact companion state before any writes."""
+    for item in [*episodes, *mentions]:
+        if item.group_id != organization_id:
+            raise ValueError("graph companion is outside restore organization")
+    snapshot_sql = _graph_auxiliary_snapshot_sql()
+    rows = normalize_graph_records(
+        await client.execute_query(
+            f"RETURN {{ {snapshot_sql} RETURN {{rows: $graph_auxiliary, "
+            "fingerprint: crypto::sha256(type::string($graph_auxiliary))}; };",
+            organizations=[organization_id],
+        )
+    )
+    if len(rows) != 1 or not isinstance(rows[0].get("fingerprint"), str):
+        raise ValueError("graph companion snapshot returned an invalid shape")
+    snapshot = rows[0]["rows"]
+    if not isinstance(snapshot, dict):
+        raise ValueError("graph companion snapshot returned invalid rows")
+    existing_episodes = {row["uuid"] for row in snapshot["episode"]}
+    existing_mentions = {row["uuid"] for row in snapshot["mentions"]}
+    selected_episodes = [
+        row for row in episodes if clean or not skip_existing or row.uuid not in existing_episodes
+    ]
+    selected_mentions = [
+        row for row in mentions if clean or not skip_existing or row.uuid not in existing_mentions
+    ]
+    episode_records = [episode_record(row) for row in selected_episodes]
+    relationship_records = [
+        _relationship_record(row, group_id=organization_id) for row in relationships
+    ]
+    mention_records = [
+        {
+            "uuid": row.uuid,
+            "group_id": row.group_id,
+            "source_node_uuid": row.source_node_uuid,
+            "target_node_uuid": row.target_node_uuid,
+            "created_at": row.created_at,
+            "rel": RecordID("mentions", row.uuid),
+        }
+        for row in selected_mentions
+    ]
+    episode_bindings = "\n".join(
+        f"LET ${name} = $episode.{name};"
+        for name in (episode_records[0] if episode_records else {})
+    )
+    statements = f"""
+        FOR $episode IN $archive_episodes {{
+            {episode_bindings}
+            IF array::len((SELECT uuid FROM episode
+                WHERE uuid=$uuid AND group_id!=$group_id)) > 0 {{
+                THROW 'archive episode identity belongs to another organization';
+            }};
+            {_EPISODE_UPSERT_STATEMENTS}
+        }};
+        LET $rows = $archive_relationships.map(|$edge|
+            object::from_entries(array::concat(object::entries($edge), [
+                ['in', (SELECT VALUE id FROM entity
+                    WHERE uuid=$edge.source_id AND group_id=$edge.group_id LIMIT 1)[0]],
+                ['out', (SELECT VALUE id FROM entity
+                    WHERE uuid=$edge.target_id AND group_id=$edge.group_id LIMIT 1)[0]]
+            ]))
+        );
+        IF array::len($rows[WHERE in=NONE OR out=NONE]) > 0 {{
+            THROW 'archive relationship endpoint is missing from restore organization';
+        }};
+        FOR $edge IN $rows {{
+            IF array::len((SELECT uuid FROM relates_to
+                WHERE uuid=$edge.uuid AND group_id!=$edge.group_id)) > 0 {{
+                THROW 'archive relationship identity belongs to another organization';
+            }};
+        }};
+        LET $edges = $rows.map(|$edge| {{uuid: $edge.uuid, src: $edge.in, tgt: $edge.out}});
+        IF array::len($rows) > 0 {{ {_RELATIONSHIP_BULK_UPSERT_STATEMENTS} }};
+        FOR $mention IN $archive_mentions {{
+            LET $uuid = $mention.uuid;
+            LET $group_id = $mention.group_id;
+            LET $created_at = $mention.created_at;
+            LET $rel = $mention.rel;
+            LET $src = (SELECT VALUE id FROM episode
+                WHERE uuid=$mention.source_node_uuid AND group_id=$group_id LIMIT 1)[0];
+            LET $tgt = (SELECT VALUE id FROM entity
+                WHERE uuid=$mention.target_node_uuid AND group_id=$group_id LIMIT 1)[0];
+            IF $src=NONE OR $tgt=NONE {{
+                THROW 'archive mention endpoint is missing from restore organization';
+            }};
+            IF array::len((SELECT uuid FROM mentions
+                WHERE uuid=$uuid AND group_id!=$group_id)) > 0 {{
+                THROW 'archive mention identity belongs to another organization';
+            }};
+            {_MENTION_UPSERT_STATEMENTS}
+        }};
+    """
+    return CompanionRestorePlan(
+        preconditions=snapshot_sql
+        + "IF crypto::sha256(type::string($graph_auxiliary)) != $archive_companion_fingerprint {"
+        "THROW 'archive companion destination changed before restore'; };",
+        statements=statements,
+        parameters={
+            "archive_companion_fingerprint": rows[0]["fingerprint"],
+            "archive_episodes": native_archive_parameters(episode_records),
+            "archive_relationships": native_archive_parameters(relationship_records),
+            "archive_mentions": native_archive_parameters(mention_records),
+        },
+        episodes_restored=len(selected_episodes),
+        episodes_skipped=len(episodes) - len(selected_episodes),
+        relationships_restored=len(relationships),
+        mentions_restored=len(selected_mentions),
+        mentions_skipped=len(mentions) - len(selected_mentions),
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/graph_companions.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/graph_companions.py
@@ -1,0 +1,69 @@
+"""Typed dates at the public graph companion archive boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sibyl_core.migrate.legacy_graph_archive import (
+    episode_from_payload,
+    episode_payload_from_node,
+    mention_from_payload,
+    mention_payload_from_edge,
+    parse_backup_datetime,
+)
+from sibyl_core.migrate.source_integrity import decode_record, encode_record
+from sibyl_core.models.entities import Relationship
+from sibyl_core.services.graph_records import relationship_from_surreal_row
+
+DATETIME_PATHS = "archive_datetime_paths"
+
+
+def relationship_from_archive(payload: dict[str, Any]) -> Relationship:
+    """Decode declared dates without interpreting ordinary metadata strings."""
+    record = dict(payload)
+    if DATETIME_PATHS in record:
+        paths = record.pop(DATETIME_PATHS)
+        record = decode_record({"record": record, "datetimes": paths})
+    if record.get("created_at"):
+        record["created_at"] = parse_backup_datetime(record["created_at"])
+    return Relationship.model_validate(record)
+
+
+def companion_payloads(
+    snapshot: dict[str, Any], *, organization_id: str
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Serialize companions from the same precise native snapshot as sources."""
+    auxiliary = snapshot["graph_auxiliary"]
+    relationships = []
+    for row in auxiliary["relates_to"]:
+        relationship = relationship_from_surreal_row(
+            {**row, "record_id": row["archive_record_key"]}
+        )
+        encoded = encode_record(relationship.model_dump(mode="python"))
+        relationships.append({**encoded["record"], DATETIME_PATHS: encoded["datetimes"]})
+    episodes = [
+        episode_payload_from_node(
+            episode_from_payload(row, organization_id=organization_id),
+            organization_id=organization_id,
+        )
+        for row in auxiliary["episode"]
+    ]
+    records = {
+        row["archive_record_key"]: row["uuid"]
+        for row in [*snapshot["source_rows"], *auxiliary["episode"]]
+    }
+    mentions = [
+        mention_payload_from_edge(
+            mention_from_payload(
+                {
+                    **row,
+                    "source_id": records[row["source_record_key"]],
+                    "target_id": records[row["target_record_key"]],
+                },
+                organization_id=organization_id,
+            ),
+            organization_id=organization_id,
+        )
+        for row in auxiliary["mentions"]
+    ]
+    return relationships, episodes, mentions

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_graph_archive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_graph_archive.py
@@ -150,9 +150,7 @@ async def mention_exists(client: Any, uuid: str) -> bool:
     return bool(rows)
 
 
-async def save_native_episode(client: Any, episode: BackupEpisodeNode) -> None:
-    await client.execute_query(
-        """
+_EPISODE_UPSERT_STATEMENTS = """
         UPSERT episode SET
             uuid = $uuid,
             name = $name,
@@ -165,17 +163,46 @@ async def save_native_episode(client: Any, episode: BackupEpisodeNode) -> None:
             valid_at = $valid_at,
             entity_edges = $entity_edges
         WHERE uuid = $uuid;
-        """,
-        uuid=episode.uuid,
-        name=episode.name,
-        source=episode.source.value,
-        source_description=episode.source_description,
-        content=episode.content,
-        labels=list(episode.labels),
-        group_id=episode.group_id,
-        created_at=native_archive_parameters(episode.created_at),
-        valid_at=native_archive_parameters(episode.valid_at),
-        entity_edges=list(episode.entity_edges),
+        """
+
+_MENTION_UPSERT_STATEMENTS = """
+        DELETE FROM mentions WHERE uuid = $uuid AND (in != $src OR out != $tgt);
+        LET $updated = (UPDATE mentions SET
+            in = $src,
+            out = $tgt,
+            uuid = $uuid,
+            group_id = $group_id,
+            created_at = $created_at
+        WHERE uuid = $uuid RETURN id);
+        IF array::len($updated) = 0 THEN
+            RELATE $src->$rel->$tgt SET
+                uuid = $uuid,
+                group_id = $group_id,
+                created_at = $created_at;
+        END;
+        """
+
+
+def episode_record(episode: BackupEpisodeNode) -> dict[str, Any]:
+    """Keep ordinary and archive episode writes on the same storage contract."""
+    return {
+        "uuid": episode.uuid,
+        "name": episode.name,
+        "source": episode.source.value,
+        "source_description": episode.source_description,
+        "content": episode.content,
+        "labels": list(episode.labels),
+        "group_id": episode.group_id,
+        "created_at": episode.created_at,
+        "valid_at": episode.valid_at,
+        "entity_edges": list(episode.entity_edges),
+    }
+
+
+async def save_native_episode(client: Any, episode: BackupEpisodeNode) -> None:
+    await client.execute_query(
+        _EPISODE_UPSERT_STATEMENTS,
+        **native_archive_parameters(episode_record(episode)),
     )
 
 
@@ -191,22 +218,7 @@ async def save_native_mention(client: Any, mention: BackupMentionEdge) -> None:
         raise ValueError(msg)
 
     await client.execute_query(
-        """
-        DELETE FROM mentions WHERE uuid = $uuid AND (in != $src OR out != $tgt);
-        LET $updated = (UPDATE mentions SET
-            in = $src,
-            out = $tgt,
-            uuid = $uuid,
-            group_id = $group_id,
-            created_at = $created_at
-        WHERE uuid = $uuid RETURN id);
-        IF array::len($updated) = 0 THEN
-            RELATE $src->$rel->$tgt SET
-                uuid = $uuid,
-                group_id = $group_id,
-                created_at = $created_at;
-        END;
-        """,
+        _MENTION_UPSERT_STATEMENTS,
         rel=RecordID("mentions", mention.uuid),
         src=source_record_id,
         tgt=target_record_id,

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_graph_archive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/legacy_graph_archive.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from surrealdb import RecordID
 
+from sibyl_core.migrate.source_integrity import ArchiveDatetime, native_archive_parameters
 from sibyl_core.services.graph_common import normalize_graph_records as normalize_records
 
 ARCHIVE_GRAPH_TABLES = ("episode",)
@@ -44,6 +45,8 @@ class BackupMentionEdge:
 
 
 def serialize_backup_datetime(value: Any) -> str:
+    if isinstance(value, ArchiveDatetime):
+        return value.native_text
     if isinstance(value, datetime):
         return value.isoformat()
     return str(value or "")
@@ -53,7 +56,7 @@ def parse_backup_datetime(value: Any) -> datetime:
     if isinstance(value, datetime):
         return value
     if isinstance(value, str) and value:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return ArchiveDatetime.parse(value)
     raise ValueError(f"Invalid backup datetime: {value!r}")
 
 
@@ -106,6 +109,7 @@ def episode_from_payload(payload: dict[str, Any], *, organization_id: str) -> Ba
         source_description=str(payload.get("source_description") or ""),
         content=str(payload.get("content") or ""),
         entity_edges=list(payload.get("entity_edges") or []),
+        labels=string_list(payload.get("labels"), default=["Episodic"]),
         created_at=created_at,
         valid_at=valid_at,
     )
@@ -169,8 +173,8 @@ async def save_native_episode(client: Any, episode: BackupEpisodeNode) -> None:
         content=episode.content,
         labels=list(episode.labels),
         group_id=episode.group_id,
-        created_at=episode.created_at,
-        valid_at=episode.valid_at,
+        created_at=native_archive_parameters(episode.created_at),
+        valid_at=native_archive_parameters(episode.valid_at),
         entity_edges=list(episode.entity_edges),
     )
 
@@ -208,7 +212,7 @@ async def save_native_mention(client: Any, mention: BackupMentionEdge) -> None:
         tgt=target_record_id,
         uuid=mention.uuid,
         group_id=mention.group_id,
-        created_at=mention.created_at,
+        created_at=native_archive_parameters(mention.created_at),
     )
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_relationships.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_relationships.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from datetime import datetime
 
 from surrealdb import RecordID
 
 from sibyl_core.backends.surreal.connection import _is_transient_connection_error
 from sibyl_core.embeddings.providers import EmbeddingProvider
 from sibyl_core.memory_pipeline.quality import expand_memory_quality_storage_metadata
+from sibyl_core.migrate.source_integrity import ArchiveDatetime, native_archive_parameters
 from sibyl_core.models.entities import Entity, Relationship, RelationshipType
 from sibyl_core.services.graph_client import (
     SurrealGraphClient,
@@ -595,7 +597,7 @@ async def _replace_relationship(
         src=src,
         tgt=tgt,
         rel=RecordID("relates_to", relationship.id),
-        **payload,
+        **native_archive_parameters(payload),
     )
 
 
@@ -679,7 +681,7 @@ async def _replace_relationships_bulk(
     try:
         await client.execute_query(
             _RELATIONSHIP_BULK_UPSERT_QUERY,
-            rows=rows,
+            rows=native_archive_parameters(rows),
             edges=edges,
         )
     except Exception as exc:
@@ -689,10 +691,18 @@ async def _replace_relationships_bulk(
         await prepare_graph_schema(client)
         await client.execute_query(
             _RELATIONSHIP_BULK_UPSERT_QUERY,
-            rows=rows,
+            rows=native_archive_parameters(rows),
             edges=edges,
         )
     return written_ids
+
+
+def _relationship_datetime(value: object) -> datetime | None:
+    """Preserve column precision without changing the original metadata value."""
+    parsed = _metadata_datetime(value)
+    if parsed is not None and isinstance(value, str):
+        return ArchiveDatetime.parse(value)
+    return parsed
 
 
 def _relationship_record(relationship: Relationship, *, group_id: str) -> SurrealRecord:
@@ -715,9 +725,11 @@ def _relationship_record(relationship: Relationship, *, group_id: str) -> Surrea
         "episodes": _metadata_str_list(metadata.get("episodes")),
         "attributes": attributes,
         "created_at": relationship.created_at,
-        "expired_at": _metadata_datetime(metadata.get("expired_at")),
-        "valid_at": _metadata_datetime(metadata.get("valid_at") or metadata.get("valid_from")),
-        "invalid_at": _metadata_datetime(metadata.get("invalid_at") or metadata.get("valid_to")),
+        "expired_at": _relationship_datetime(metadata.get("expired_at")),
+        "valid_at": _relationship_datetime(metadata.get("valid_at") or metadata.get("valid_from")),
+        "invalid_at": _relationship_datetime(
+            metadata.get("invalid_at") or metadata.get("valid_to")
+        ),
     }
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_relationships.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_relationships.py
@@ -45,8 +45,7 @@ from sibyl_core.services.graph_records import (
     _relationship_from_row,
 )
 
-_RELATIONSHIP_BULK_UPSERT_QUERY = """
-BEGIN TRANSACTION;
+_RELATIONSHIP_BULK_UPSERT_STATEMENTS = """
 -- The planner never serves `uuid IN $list` from idx_relates_uuid (TableScan
 -- for every statement type, seconds per capture batch once the table is
 -- large), so the endpoint-move cleanup iterates the batch and addresses each
@@ -69,8 +68,10 @@ INSERT RELATION INTO relates_to $rows ON DUPLICATE KEY UPDATE
     expired_at = $input.expired_at,
     valid_at = $input.valid_at,
     invalid_at = $input.invalid_at;
-COMMIT TRANSACTION;
 """
+_RELATIONSHIP_BULK_UPSERT_QUERY = (
+    "BEGIN TRANSACTION;\n" + _RELATIONSHIP_BULK_UPSERT_STATEMENTS + "COMMIT TRANSACTION;"
+)
 
 
 class RelationshipManager:

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -150,6 +150,7 @@ async def restore_source_integrity(
     skip_existing: bool = True,
     global_scope: bool = False,
     clean_graph_auxiliary: bool = False,
+    auxiliary_preconditions: str = "",
     auxiliary_statements: str = "",
     auxiliary_parameters: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -301,6 +302,7 @@ async def restore_source_integrity(
         IF crypto::sha256(type::string({{ source_rows: $rows, source_states: $states, derivations: $associations {companion_field} }})) != $expected {{
             THROW 'archive destination changed before restore';
         }};
+        {auxiliary_preconditions}
         {companion_cleanup}
         FOR $key IN $deletes {{ DELETE type::record($key); }};
         FOR $entry IN $writes {{

--- a/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/source_archive_store.py
@@ -24,13 +24,13 @@ def _source_table(kind: SourceKind) -> tuple[str, str]:
 def _graph_auxiliary_snapshot_sql() -> str:
     return """LET $graph_auxiliary = {
         episode: (SELECT *, type::string(id) AS archive_record_key OMIT id
-            FROM episode WHERE group_id IN $organizations ORDER BY uuid, archive_record_key),
+            FROM episode WHERE group_id IN $organizations ORDER BY uuid DESC, archive_record_key),
         relates_to: (SELECT *, type::string(id) AS archive_record_key,
             type::string(in) AS source_record_key, type::string(out) AS target_record_key OMIT id, in, out
-            FROM relates_to WHERE group_id IN $organizations ORDER BY uuid, archive_record_key),
+            FROM relates_to WHERE group_id IN $organizations ORDER BY created_at DESC, uuid DESC, archive_record_key),
         mentions: (SELECT *, type::string(id) AS archive_record_key,
             type::string(in) AS source_record_key, type::string(out) AS target_record_key OMIT id, in, out
-            FROM mentions WHERE group_id IN $organizations ORDER BY uuid, archive_record_key)
+            FROM mentions WHERE group_id IN $organizations ORDER BY uuid DESC, archive_record_key)
     };"""
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
@@ -18,12 +18,6 @@ from sibyl_core.migrate.legacy_graph_archive import (
     episode_from_payload as _episode_from_payload,
 )
 from sibyl_core.migrate.legacy_graph_archive import (
-    list_native_backup_episodes as _list_native_backup_episodes,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
-    list_native_backup_mentions as _list_native_backup_mentions,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
     mention_exists as _mention_exists,
 )
 from sibyl_core.migrate.legacy_graph_archive import (
@@ -430,52 +424,6 @@ def _entity_from_backup_data(entity_data: dict[str, Any]) -> Entity:
         return Entity.model_validate(payload)
 
 
-async def _list_backup_episodes(
-    *,
-    organization_id: str,
-    client: Any,
-) -> list[dict[str, Any]]:
-    return await _list_native_backup_episodes(
-        organization_id=organization_id,
-        client=client,
-        page_size=BACKFILL_PAGE_SIZE,
-    )
-
-
-async def _list_backup_mentions(
-    *,
-    organization_id: str,
-    client: Any,
-) -> list[dict[str, Any]]:
-    return await _list_native_backup_mentions(
-        organization_id=organization_id,
-        client=client,
-        page_size=BACKFILL_PAGE_SIZE,
-    )
-
-
-async def _list_backup_relationships(
-    *,
-    organization_id: str,
-    client: Any,
-    relationship_manager: Any,
-) -> list[Relationship]:
-    relationships: list[Relationship] = []
-    offset = 0
-    while True:
-        batch = await relationship_manager.list_all(
-            limit=BACKFILL_PAGE_SIZE,
-            offset=offset,
-        )
-        if not batch:
-            break
-        relationships.extend(batch)
-        if len(batch) < BACKFILL_PAGE_SIZE:
-            break
-        offset += len(batch)
-    return relationships
-
-
 async def _list_backup_entities(
     *,
     organization_id: str,
@@ -513,16 +461,29 @@ async def create_backup(*, organization_id: str) -> BackupResult:
 
     try:
         runtime = await get_graph_runtime(organization_id)
-        relationship_manager = runtime.relationship_manager
         client = runtime.client
 
         from sibyl_core.memory_pipeline.observations import SourceKind
-        from sibyl_core.migrate.source_integrity import validate_integrity_archive
+        from sibyl_core.migrate.graph_companions import companion_payloads
+        from sibyl_core.migrate.source_integrity import (
+            build_integrity_archive,
+            validate_integrity_archive,
+        )
         from sibyl_core.services.graph_records import entity_from_surreal_row
-        from sibyl_core.services.source_archive_store import export_source_integrity
+        from sibyl_core.services.source_archive_store import read_source_archive_snapshot
 
-        source_integrity = await export_source_integrity(
-            client.execute_query, kind=SourceKind.GRAPH_ENTITY, organizations=[organization_id]
+        snapshot = await read_source_archive_snapshot(
+            client.execute_query,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[organization_id],
+            include_graph_auxiliary=True,
+        )
+        source_integrity = build_integrity_archive(
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[organization_id],
+            source_rows=snapshot["source_rows"],
+            source_states=snapshot["source_states"],
+            derivations=snapshot["derivations"],
         )
         from sibyl_core.migrate.archive_lineage import seal_archive_lineage
 
@@ -536,18 +497,9 @@ async def create_backup(*, organization_id: str) -> BackupResult:
         )
         all_entities = [entity_from_surreal_row(row) for row in source_rows]
 
-        relationships = await _list_backup_relationships(
+        relationships, episodes, mentions = companion_payloads(
+            snapshot,
             organization_id=organization_id,
-            client=client,
-            relationship_manager=relationship_manager,
-        )
-        episodes = await _list_backup_episodes(
-            organization_id=organization_id,
-            client=client,
-        )
-        mentions = await _list_backup_mentions(
-            organization_id=organization_id,
-            client=client,
         )
 
         # Build backup data
@@ -560,7 +512,7 @@ async def create_backup(*, organization_id: str) -> BackupResult:
             entity_count=len(all_entities),
             relationship_count=len(relationships),
             entities=[e.model_dump(mode="json") for e in all_entities],
-            relationships=[r.model_dump(mode="json") for r in relationships],
+            relationships=relationships,
             episode_count=len(episodes),
             mention_count=len(mentions),
             episodes=episodes,
@@ -652,6 +604,12 @@ async def restore_backup(
             normalize_mention_payloads,
             normalize_relationship_payloads,
         )
+        from sibyl_core.migrate.graph_companions import DATETIME_PATHS, relationship_from_archive
+
+        # Reject malformed typed payloads before a clean restore can delete rows.
+        for payload in backup_data.relationships:
+            if DATETIME_PATHS in payload:
+                relationship_from_archive(payload)
 
         runtime = await get_graph_runtime(organization_id)
         relationship_manager = runtime.relationship_manager
@@ -753,7 +711,7 @@ async def restore_backup(
         relationships_to_restore: list[Relationship] = []
         for rel_data in normalize_relationship_payloads(backup_data.relationships):
             try:
-                relationship = Relationship.model_validate(rel_data)
+                relationship = relationship_from_archive(rel_data)
                 relationships_to_restore.append(relationship)
             except Exception as e:
                 error_msg = f"Relationship {rel_data.get('id', 'unknown')}: {e}"

--- a/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/admin.py
@@ -18,19 +18,7 @@ from sibyl_core.migrate.legacy_graph_archive import (
     episode_from_payload as _episode_from_payload,
 )
 from sibyl_core.migrate.legacy_graph_archive import (
-    mention_exists as _mention_exists,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
     mention_from_payload as _mention_from_payload,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
-    record_id as _record_id,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
-    save_native_episode as _save_native_episode,
-)
-from sibyl_core.migrate.legacy_graph_archive import (
-    save_native_mention as _save_native_mention,
 )
 from sibyl_core.models.entities import (
     ConfigFile,
@@ -600,167 +588,93 @@ async def restore_backup(
     quarantined: list[dict[str, str]] = []
 
     try:
+        from dataclasses import asdict
+
+        from sibyl_core.memory_pipeline.observations import SourceKind
         from sibyl_core.migrate.archive import (
             normalize_mention_payloads,
             normalize_relationship_payloads,
         )
-        from sibyl_core.migrate.graph_companions import DATETIME_PATHS, relationship_from_archive
+        from sibyl_core.migrate.archive_lineage import seal_archive_lineage
+        from sibyl_core.migrate.graph_companion_restore import prepare_companion_restore
+        from sibyl_core.migrate.graph_companions import relationship_from_archive
+        from sibyl_core.migrate.legacy_source_archive import build_legacy_source_archive
+        from sibyl_core.services.graph_entity_store import _entity_record
+        from sibyl_core.services.source_archive_store import restore_source_integrity
 
-        # Reject malformed typed payloads before a clean restore can delete rows.
-        for payload in backup_data.relationships:
-            if DATETIME_PATHS in payload:
-                relationship_from_archive(payload)
-
-        runtime = await get_graph_runtime(organization_id)
-        relationship_manager = runtime.relationship_manager
-        driver = runtime.client
-
-        legacy_entities = backup_data.entities
+        # Validate the entire payload before any source or companion can change.
+        episodes = [
+            _episode_from_payload(row, organization_id=organization_id)
+            for row in backup_data.episodes
+        ]
+        relationships = [
+            relationship_from_archive(row)
+            for row in normalize_relationship_payloads(backup_data.relationships)
+        ]
+        mentions = [
+            _mention_from_payload(row, organization_id=organization_id)
+            for row in normalize_mention_payloads(backup_data.mentions)
+        ]
+        unavailable_ids: set[str] = set()
         if backup_data.version == "3.0":
-            from dataclasses import asdict
-
-            from sibyl_core.migrate.archive_lineage import seal_archive_lineage
-
             sealed, _, _ = seal_archive_lineage(asdict(backup_data), None)
             assert sealed is not None
             backup_data = BackupData(**sealed)
-            from sibyl_core.memory_pipeline.observations import SourceKind
-            from sibyl_core.services.source_archive_store import restore_source_integrity
-
-            restored = await restore_source_integrity(
-                driver.execute_query,
-                backup_data.source_integrity,
-                kind=SourceKind.GRAPH_ENTITY,
-                organizations=[organization_id],
-                skip_existing=skip_existing,
-                clean=clean,
-                clean_graph_auxiliary=clean,
-            )
-            entities_restored = len(restored["restored_source_ids"])
-            integrity_conflicts = restored["conflicts"]
+            integrity = backup_data.source_integrity
             quarantined = [
                 row for row in backup_data.lineage_validation if row.get("status") == "quarantined"
             ]
-            entities_skipped = backup_data.entity_count - entities_restored
-            legacy_entities = []
-        elif backup_data.source_integrity is not None:
-            raise ValueError("legacy graph payload cannot carry unrecognized integrity")
-        if legacy_entities or (clean and backup_data.version != "3.0"):
-            from sibyl_core.memory_pipeline.observations import SourceKind
-            from sibyl_core.migrate.legacy_source_archive import build_legacy_source_archive
-            from sibyl_core.services.graph_entity_store import _entity_record
-            from sibyl_core.services.source_archive_store import restore_source_integrity
-
+        else:
+            if backup_data.source_integrity is not None:
+                raise ValueError("legacy graph payload cannot carry unrecognized integrity")
             records = [
                 dict(_entity_record(_entity_from_backup_data(row), group_id=organization_id))
-                for row in legacy_entities
+                for row in backup_data.entities
             ]
-            legacy_integrity, unavailable_ids = build_legacy_source_archive(
+            integrity, unavailable_ids = build_legacy_source_archive(
                 records, kind=SourceKind.GRAPH_ENTITY, organizations=[organization_id]
             )
-            restored = await restore_source_integrity(
-                driver.execute_query,
-                legacy_integrity,
-                kind=SourceKind.GRAPH_ENTITY,
-                organizations=[organization_id],
-                skip_existing=skip_existing,
-                clean=clean,
-                clean_graph_auxiliary=clean,
-            )
-            restored_ids = restored["restored_source_ids"]
-            entities_restored = len(restored_ids)
-            entities_skipped = backup_data.entity_count - entities_restored
-            integrity_conflicts = restored["conflicts"]
-            quarantined = [
-                {
-                    "source_id": identity,
-                    "reason": "unverifiable_legacy_lineage",
-                    "repair": "reauthor_under_new_capture_identity",
-                }
-                for identity in restored_ids
-                if identity in unavailable_ids
-            ]
-
-        episodes_to_restore: list[Any] = []
-        for episode_data in backup_data.episodes:
-            try:
-                episode = _episode_from_payload(episode_data, organization_id=organization_id)
-                if skip_existing:
-                    existing = await _record_id(driver, "episode", episode.uuid)
-                    if existing:
-                        episodes_skipped += 1
-                        continue
-
-                episodes_to_restore.append(episode)
-            except Exception as e:
-                error_msg = f"Episode {episode_data.get('uuid', 'unknown')}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Episode restore failed", error=error_msg)
-
-        for episode in episodes_to_restore:
-            try:
-                await _save_native_episode(driver, episode)
-                episodes_restored += 1
-            except Exception as e:
-                error_msg = f"Episode {episode.uuid}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Episode restore failed", error=error_msg)
-
-        relationships_to_restore: list[Relationship] = []
-        for rel_data in normalize_relationship_payloads(backup_data.relationships):
-            try:
-                relationship = relationship_from_archive(rel_data)
-                relationships_to_restore.append(relationship)
-            except Exception as e:
-                error_msg = f"Relationship {rel_data.get('id', 'unknown')}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Relationship restore failed", error=error_msg)
-
-        create_bulk = getattr(relationship_manager, "create_bulk", None)
-        if relationships_to_restore and callable(create_bulk):
-            created_count, failed_count = await create_bulk(relationships_to_restore)
-            relationships_restored += created_count
-            if failed_count:
-                error_msg = f"Bulk relationship restore failed for {failed_count} relationships"
-                errors.append(error_msg)
-                log.warning("Bulk relationship restore reported failures", failed=failed_count)
-        else:
-            for relationship in relationships_to_restore:
-                try:
-                    await relationship_manager.create(relationship)
-                    relationships_restored += 1
-                except Exception as e:
-                    error_msg = f"Relationship {relationship.id}: {e}"
-                    errors.append(error_msg)
-                    if len(errors) <= 10:
-                        log.warning("Relationship restore failed", error=error_msg)
-
-        mentions_to_restore: list[Any] = []
-        for mention_data in normalize_mention_payloads(backup_data.mentions):
-            try:
-                mention = _mention_from_payload(mention_data, organization_id=organization_id)
-                if skip_existing and await _mention_exists(driver, mention.uuid):
-                    mentions_skipped += 1
-                    continue
-                mentions_to_restore.append(mention)
-            except Exception as e:
-                error_msg = f"Mention {mention_data.get('uuid', 'unknown')}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Mention restore failed", error=error_msg)
-
-        for mention in mentions_to_restore:
-            try:
-                await _save_native_mention(driver, mention)
-                mentions_restored += 1
-            except Exception as e:
-                error_msg = f"Mention {mention.uuid}: {e}"
-                errors.append(error_msg)
-                if len(errors) <= 10:
-                    log.warning("Mention restore failed", error=error_msg)
+        runtime = await get_graph_runtime(organization_id)
+        driver = runtime.client
+        companions = await prepare_companion_restore(
+            driver,
+            organization_id=organization_id,
+            episodes=episodes,
+            relationships=relationships,
+            mentions=mentions,
+            skip_existing=skip_existing,
+            clean=clean,
+        )
+        restored = await restore_source_integrity(
+            driver.execute_query,
+            integrity,
+            kind=SourceKind.GRAPH_ENTITY,
+            organizations=[organization_id],
+            skip_existing=skip_existing,
+            clean=clean,
+            clean_graph_auxiliary=clean,
+            auxiliary_preconditions=companions.preconditions,
+            auxiliary_statements=companions.statements,
+            auxiliary_parameters=companions.parameters,
+        )
+        restored_ids = restored["restored_source_ids"]
+        entities_restored = len(restored_ids)
+        entities_skipped = backup_data.entity_count - entities_restored
+        integrity_conflicts = restored["conflicts"]
+        quarantined.extend(
+            {
+                "source_id": identity,
+                "reason": "unverifiable_legacy_lineage",
+                "repair": "reauthor_under_new_capture_identity",
+            }
+            for identity in restored_ids
+            if identity in unavailable_ids
+        )
+        episodes_restored = companions.episodes_restored
+        episodes_skipped = companions.episodes_skipped
+        relationships_restored = companions.relationships_restored
+        mentions_restored = companions.mentions_restored
+        mentions_skipped = companions.mentions_skipped
 
         duration = time.time() - start_time
         log.info(

--- a/packages/python/sibyl-core/tests/test_graph_archive_atomicity.py
+++ b/packages/python/sibyl-core/tests/test_graph_archive_atomicity.py
@@ -1,0 +1,147 @@
+"""Public graph restore commits sources and every companion as one unit."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.migrate.legacy_graph_archive import episode_from_payload, save_native_episode
+from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.tools.admin import create_backup, restore_backup
+from tests.test_source_integrity_archive import destination as destination
+from tests.test_source_integrity_archive import runtime as runtime
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+
+STAMP = "2026-09-10T02:47:11.572211763Z"
+
+
+async def fingerprint(client):
+    return await client.execute_query(
+        "RETURN crypto::sha256(type::string({"
+        "entities: (SELECT * FROM entity ORDER BY id),"
+        "states: (SELECT * FROM source_states ORDER BY id),"
+        "derivations: (SELECT * FROM memory_derivations ORDER BY id),"
+        "episodes: (SELECT * FROM episode ORDER BY id),"
+        "relationships: (SELECT * FROM relates_to ORDER BY id),"
+        "mentions: (SELECT * FROM mentions ORDER BY id)}));"
+    )
+
+
+async def episode(client, identity):
+    await save_native_episode(
+        client,
+        episode_from_payload(
+            {
+                "uuid": identity,
+                "name": identity,
+                "content": "Evidence",
+                "created_at": STAMP,
+                "valid_at": STAMP,
+            },
+            organization_id=client.group_id,
+        ),
+    )
+
+
+@pytest.mark.parametrize("clean", [False, True])
+async def test_late_mention_failure_rolls_back_all_graph_tables(
+    runtime, destination, monkeypatch, clean
+):
+    await runtime.entity_manager.create_direct(
+        Entity(id="incoming", entity_type=EntityType.SESSION, name="Incoming", content="New")
+    )
+    await runtime.relationship_manager.create_direct_bulk(
+        [
+            Relationship(
+                id="incoming-edge",
+                source_id="incoming",
+                target_id="project_a",
+                relationship_type=RelationshipType.RELATED_TO,
+            )
+        ]
+    )
+    await episode(runtime.client, "incoming-episode")
+    for identity in ("must-survive", "retained-tombstone"):
+        await destination.entity_manager.create_direct(
+            Entity(id=identity, entity_type=EntityType.SESSION, name=identity, content="Old")
+        )
+    await destination.client.execute_query("DELETE entity WHERE uuid='retained-tombstone';")
+    await episode(destination.client, "existing-episode")
+    before = await fingerprint(destination.client)
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success, backup.message
+    backup.backup_data.mentions = [
+        {
+            "uuid": "missing-endpoint",
+            "source_id": "incoming-episode",
+            "target_id": "does-not-exist",
+            "created_at": STAMP,
+        }
+    ]
+    monkeypatch.setattr(
+        "sibyl_core.tools.admin.get_graph_runtime", AsyncMock(return_value=destination)
+    )
+    result = await restore_backup(
+        backup.backup_data, organization_id=runtime.client.group_id, clean=clean
+    )
+    assert not result.success
+    assert any("mention endpoint is missing" in error for error in result.errors)
+    assert (
+        result.entities_restored == result.episodes_restored == result.relationships_restored == 0
+    )
+    assert await fingerprint(destination.client) == before
+
+
+@pytest.mark.parametrize("collection", ["episodes", "relationships", "mentions"])
+async def test_malformed_graph_companion_rejects_before_destination(
+    runtime, monkeypatch, collection
+):
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success, backup.message
+    setattr(backup.backup_data, collection, [{"id": "invalid-companion"}])
+    loader = AsyncMock(side_effect=AssertionError("destination must not be opened"))
+    monkeypatch.setattr("sibyl_core.tools.admin.get_graph_runtime", loader)
+    result = await restore_backup(
+        backup.backup_data, organization_id=runtime.client.group_id, clean=True
+    )
+    assert not result.success
+    loader.assert_not_called()
+
+
+@pytest.mark.parametrize("clean", [False, True])
+async def test_companion_nanosecond_change_fences_source_restore(
+    runtime, destination, monkeypatch, clean
+):
+    await episode(destination.client, "racing-episode")
+    backup = await create_backup(organization_id=runtime.client.group_id)
+    assert backup.success, backup.message
+    monkeypatch.setattr(
+        "sibyl_core.tools.admin.get_graph_runtime", AsyncMock(return_value=destination)
+    )
+    execute = destination.client.execute_query
+    changed = False
+    preserved = None
+
+    async def race(query, **parameters):
+        nonlocal changed, preserved
+        if (
+            "BEGIN TRANSACTION" in query
+            and "archive_companion_fingerprint" in query
+            and not changed
+        ):
+            changed = True
+            await execute(
+                "UPDATE episode SET created_at=d'2026-09-10T02:47:11.572211764Z' WHERE uuid='racing-episode';"
+            )
+            preserved = await fingerprint(destination.client)
+        return await execute(query, **parameters)
+
+    monkeypatch.setattr(destination.client, "execute_query", race)
+    result = await restore_backup(
+        backup.backup_data, organization_id=runtime.client.group_id, clean=clean
+    )
+    assert changed
+    assert not result.success
+    assert any("destination changed" in error for error in result.errors)
+    assert await fingerprint(destination.client) == preserved

--- a/packages/python/sibyl-core/tests/test_graph_companion_precision.py
+++ b/packages/python/sibyl-core/tests/test_graph_companion_precision.py
@@ -1,0 +1,188 @@
+"""Public graph companions preserve native dates across JSON and restore."""
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+from sibyl_core.migrate.graph_companions import DATETIME_PATHS, relationship_from_archive
+from sibyl_core.migrate.legacy_graph_archive import episode_from_payload, save_native_episode
+from sibyl_core.models.entities import Relationship, RelationshipType
+from sibyl_core.tools.admin import BackupData, create_backup, restore_backup
+from tests.test_source_integrity_archive import destination as destination
+from tests.test_source_integrity_archive import runtime as runtime
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+
+STAMP = "2026-09-10T02:47:11.572211763Z"
+
+
+async def test_public_companions_keep_native_dates_through_json_restore(
+    runtime, destination, monkeypatch
+):
+    await runtime.relationship_manager.create_direct_bulk(
+        [
+            Relationship(
+                id="precise-edge",
+                source_id="project_a",
+                target_id="project_b",
+                relationship_type=RelationshipType.RELATED_TO,
+            )
+        ]
+    )
+    await runtime.client.execute_query(
+        "UPDATE relates_to SET created_at=d'2026-09-10T02:47:11.572211763Z', "
+        "valid_at=d'2026-09-10T02:47:11.000000001Z', "
+        "attributes.nested={at: d'2026-09-10T02:47:11.572211763Z', "
+        "literal: '2026-09-10T02:47:11.572211763Z'} WHERE uuid='precise-edge';"
+    )
+    episode = episode_from_payload(
+        {
+            "uuid": "precise-episode",
+            "name": "Episode",
+            "content": "Evidence",
+            "created_at": STAMP,
+            "valid_at": STAMP,
+        },
+        organization_id=runtime.client.group_id,
+    )
+    await save_native_episode(runtime.client, episode)
+    await runtime.client.execute_query(
+        "LET $src=(SELECT VALUE id FROM episode WHERE uuid='precise-episode')[0]; "
+        "LET $tgt=(SELECT VALUE id FROM entity WHERE uuid='project_a')[0]; "
+        "RELATE $src->mentions:precise->$tgt SET uuid='precise-mention', group_id=$org, "
+        "created_at=d'2026-09-10T02:47:11.572211763Z';",
+        org=runtime.client.group_id,
+    )
+    result = await create_backup(organization_id=runtime.client.group_id)
+    assert result.success, result.message
+    payload = json.loads(json.dumps(asdict(result.backup_data)))
+    edge = next(row for row in payload["relationships"] if row["id"] == "precise-edge")
+    assert edge["created_at"] == STAMP
+    assert edge["metadata"]["nested"] == {"at": STAMP, "literal": STAMP}
+    assert ["metadata", "nested", "at"] in edge[DATETIME_PATHS]
+    assert ["metadata", "nested", "literal"] not in edge[DATETIME_PATHS]
+    assert payload["episodes"][0]["created_at"] == STAMP
+    assert payload["mentions"][0]["created_at"] == STAMP
+    monkeypatch.setattr(
+        "sibyl_core.tools.admin.get_graph_runtime", AsyncMock(return_value=destination)
+    )
+    restored = await restore_backup(BackupData(**payload), organization_id=runtime.client.group_id)
+    assert restored.success, restored.message
+    for table, identity in (
+        ("relates_to", "precise-edge"),
+        ("episode", "precise-episode"),
+        ("mentions", "precise-mention"),
+    ):
+        rows = await destination.client.execute_query(
+            f"SELECT type::string(created_at) AS stamp FROM {table} WHERE uuid=$uuid;",
+            uuid=identity,
+        )
+        assert rows[0]["stamp"] == STAMP
+    rows = await destination.client.execute_query(
+        "SELECT type::string(valid_at) AS valid, type::string(attributes.nested.at) AS stamp, "
+        "attributes.nested.at AS typed, "
+        "attributes.nested.literal AS literal FROM relates_to WHERE uuid='precise-edge';"
+    )
+    assert isinstance(rows[0].pop("typed"), datetime)
+    assert rows[0] == {
+        "valid": "2026-09-10T02:47:11.000000001Z",
+        "stamp": STAMP,
+        "literal": STAMP,
+    }
+
+
+def test_relationship_legacy_offset_and_typed_paths_survive_merge():
+    from sibyl_core.migrate.merge import _merge_relationships
+
+    payload = {
+        "id": "edge",
+        "source_id": "old",
+        "target_id": "other",
+        "relationship_type": "RELATED_TO",
+        "created_at": STAMP,
+        "metadata": {"old": STAMP},
+        DATETIME_PATHS: [["metadata", "old"]],
+    }
+    merged = _merge_relationships([{"relationships": [payload]}], replacements={"old": "new"})
+    assert merged[0][DATETIME_PATHS] == [["metadata", "old"]]
+    model = relationship_from_archive(merged[0])
+    assert model.source_id == "new"
+    assert model.created_at.native_text == STAMP
+    assert model.metadata["old"].native_text == STAMP
+
+
+async def test_invalid_companion_date_paths_reject_before_clean(runtime, monkeypatch):
+    result = await create_backup(organization_id=runtime.client.group_id)
+    assert result.success, result.message
+    result.backup_data.relationships = [{"id": "bad", DATETIME_PATHS: [["missing"]]}]
+    execute = AsyncMock(side_effect=AssertionError("must not touch destination"))
+    monkeypatch.setattr(runtime.client, "execute_query", execute)
+    restored = await restore_backup(
+        result.backup_data, organization_id=runtime.client.group_id, clean=True
+    )
+    assert not restored.success
+    execute.assert_not_called()
+
+
+async def test_public_backup_rejects_companion_nanosecond_capture_race(runtime, monkeypatch):
+    await runtime.relationship_manager.create_direct_bulk(
+        [
+            Relationship(
+                id="racing-edge",
+                source_id="project_a",
+                target_id="project_b",
+                relationship_type=RelationshipType.RELATED_TO,
+            )
+        ]
+    )
+    await runtime.client.execute_query(
+        "UPDATE relates_to SET created_at=d'2026-09-10T02:47:11.572211763Z' "
+        "WHERE uuid='racing-edge';"
+    )
+    execute = runtime.client.execute_query
+    changed = False
+
+    async def mutate_before_date_capture(query, **parameters):
+        nonlocal changed
+        if "AS datetimes" in query and not changed:
+            changed = True
+            await execute(
+                "UPDATE relates_to SET created_at=d'2026-09-10T02:47:11.572211764Z' "
+                "WHERE uuid='racing-edge';"
+            )
+        return await execute(query, **parameters)
+
+    monkeypatch.setattr(runtime.client, "execute_query", mutate_before_date_capture)
+    result = await create_backup(organization_id=runtime.client.group_id)
+    assert changed
+    assert not result.success
+    assert "changed during datetime capture" in result.message
+
+
+async def test_legacy_relationship_date_string_keeps_metadata_type(runtime):
+    from sibyl_core.migrate.graph_companions import relationship_from_archive
+
+    value = "2026-09-10T02:47:11.572211763+05:45"
+    relationship = relationship_from_archive(
+        {
+            "id": "legacy-precise",
+            "source_id": "project_a",
+            "target_id": "project_b",
+            "relationship_type": "RELATED_TO",
+            "created_at": value,
+            "metadata": {"valid_at": value},
+        }
+    )
+    assert relationship.metadata["valid_at"] == value
+    await runtime.relationship_manager.create_direct_bulk([relationship])
+    rows = await runtime.client.execute_query(
+        "SELECT type::string(created_at) AS created, type::string(valid_at) AS valid, "
+        "attributes.valid_at AS original FROM relates_to WHERE uuid='legacy-precise';"
+    )
+    assert rows[0] == {
+        "created": "2026-09-09T21:02:11.572211763Z",
+        "valid": "2026-09-09T21:02:11.572211763Z",
+        "original": value,
+    }

--- a/packages/python/sibyl-core/tests/test_tools_admin.py
+++ b/packages/python/sibyl-core/tests/test_tools_admin.py
@@ -49,6 +49,20 @@ def archive_restore(monkeypatch):
     return seam
 
 
+def empty_companion_client():
+    """Serialization-only tests expose an empty checked companion snapshot."""
+    return SimpleNamespace(
+        execute_query=AsyncMock(
+            return_value=[
+                {
+                    "rows": {"episode": [], "relates_to": [], "mentions": []},
+                    "fingerprint": "0" * 64,
+                }
+            ]
+        )
+    )
+
+
 def archived_entities(archive_restore):
     from sibyl_core.migrate.source_integrity import decode_record
     from sibyl_core.services.graph_records import entity_from_surreal_row
@@ -347,7 +361,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -365,7 +379,11 @@ class TestRestoreBackup:
         archive_restore.assert_awaited_once()
         entity_manager.create_direct_bulk.assert_not_awaited()
         entity_manager.create_direct.assert_not_awaited()
-        relationship_manager.create_bulk.assert_awaited_once()
+        relationship_manager.create_bulk.assert_not_awaited()
+        assert (
+            len(archive_restore.await_args.kwargs["auxiliary_parameters"]["archive_relationships"])
+            == 1
+        )
         relationship_manager.create.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -422,7 +440,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -514,7 +532,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -579,7 +597,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -641,7 +659,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -939,7 +957,7 @@ class TestRestoreBackup:
             "sibyl_core.tools.admin.get_graph_runtime",
             AsyncMock(
                 return_value=SimpleNamespace(
-                    client=SimpleNamespace(execute_query=AsyncMock()),
+                    client=empty_companion_client(),
                     entity_manager=entity_manager,
                     relationship_manager=relationship_manager,
                 )
@@ -953,13 +971,15 @@ class TestRestoreBackup:
 
         assert result.success is True
         restored_entities = archived_entities(archive_restore)
-        restored_relationships = relationship_manager.create_bulk.await_args.args[0]
+        restored_relationships = archive_restore.await_args.kwargs["auxiliary_parameters"][
+            "archive_relationships"
+        ]
         assert [entity.id for entity in restored_entities] == ["project-1", "task-1"]
         assert restored_entities[1].metadata["source_ids"] == ["source:task"]
-        assert restored_relationships[0].source_id == "task-1"
-        assert restored_relationships[0].target_id == "project-1"
-        assert restored_relationships[0].relationship_type is RelationshipType.BELONGS_TO
-        assert restored_relationships[0].metadata["source_ids"] == ["source:task"]
+        assert restored_relationships[0]["source_id"] == "task-1"
+        assert restored_relationships[0]["target_id"] == "project-1"
+        assert restored_relationships[0]["name"] == RelationshipType.BELONGS_TO.value
+        assert restored_relationships[0]["attributes"]["source_ids"] == ["source:task"]
 
 
 class TestBackfillDenormalizedFields:

--- a/packages/python/sibyl-core/tests/test_tools_admin.py
+++ b/packages/python/sibyl-core/tests/test_tools_admin.py
@@ -892,7 +892,7 @@ class TestRestoreBackup:
                 "source_id": "episode-legacy",
                 "target_id": "entity-legacy",
                 "group_id": org_id,
-                "created_at": "2026-04-19T00:00:00+00:00",
+                "created_at": "2026-04-19T00:00:00Z",
             }
         ]
 


### PR DESCRIPTION
Graph backups truncated native nanoseconds in relationships, legacy episodes and mentions. Clean restores could also delete destination rows before a later companion write failed. Backup and restore now preserve exact timestamp values, and each graph restore commits source rows and companions together.

The PR is stacked on #540, which supplies the native snapshot, datetime codec and source-fenced transaction owner.

## 🛠️ Archive boundaries

The public backup owner reads source rows and graph companions in one native snapshot. Typed datetime paths preserve nested dates through JSON without interpreting ordinary metadata strings as dates. Source evidence hashes retain their established date formatting.

Restore validates all companion payloads before mutation. The existing transaction owner checks the destination fingerprint before cleanup, writes sources and episodes, resolves relationship endpoints, and writes companions. A late failure rolls back that graph transaction, including its source lifecycle state. Cross-organization identity collisions are rejected, and a one-nanosecond destination change invalidates the restore fence.

Archived relationship embeddings are preserved. A missing embedding remains missing: restore no longer implicitly calls a provider to build it. Vectorless archives need an explicit embedding rebuild before semantic retrieval can use those relationships.

The change removes obsolete admin export passes and preserves companion ordering and episode labels. Auth, content and graph stores still have separate transaction boundaries; this PR does not provide a cross-namespace crash-atomic restore.

## 🧪 Validation

- The integrated archive selection passed 47 core and 37 API tests. Core and API lint, formatting and typecheck passed.
- Independent atomicity verification passed 22 native SurrealDB 3.2.3 controls and four embedded controls. Four root spot checks also passed. Coverage includes late rollback, foreign identity collisions and destination changes before cleanup.
- Before the atomicity addition, independent verification and a root repeat each passed 41 native precision controls. The full core suite at that earlier revision passed 3,861 tests (14 skipped, one expected failure).
- Native runs used isolated databases with verified cleanup. Public end-to-end disaster recovery qualification remains a separate release gate.

## 🎯 Remaining release check

The underlying stack now preserves newer destination visibility and audience decisions. Independent native verification passed 24 cases, including hidden-source restoration and late mutation races. The corrected combined graph selection passed 47 tests and all core/API static checks. Full public disaster-recovery and restart acceptance remain separate release gates.
