### PR TITLE
feat(ai): support native Anthropic extraction with attempt accounting

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/llm/extractor.py
@@ -8,12 +8,15 @@ import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
+from weakref import WeakKeyDictionary
 
 from pydantic import BaseModel, Field, TypeAdapter
 from pydantic_ai import Agent, NativeOutput
 from pydantic_ai.messages import ModelResponse
 from pydantic_ai.models import Model, ModelSettings
+from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.profiles.openai import OpenAIJsonSchemaTransformer
 
 from sibyl_core.ai.clients import get_agent
@@ -24,6 +27,7 @@ from sibyl_core.ai.transport import (
     FailedExtractionUsage,
     TransportAttempt,
     collect_transport_attempts,
+    reserve_uncovered_transport_attempts,
 )
 from sibyl_core.observability import elapsed_ms, telemetry_registry
 
@@ -50,10 +54,13 @@ class ExtractionResult[T]:
 OutputMode = Literal["tool", "native_strict"]
 
 
-def extraction_schema(output_type: Any, output_mode: OutputMode = "tool") -> dict[str, Any]:
+def extraction_schema(
+    output_type: Any, output_mode: OutputMode = "tool", *, profile: ModelProfile | None = None
+) -> dict[str, Any]:
     schema = TypeAdapter(output_type).json_schema()
     if output_mode == "native_strict":
-        return OpenAIJsonSchemaTransformer(schema, strict=True).walk()
+        transformer = (profile or {}).get("json_schema_transformer") or OpenAIJsonSchemaTransformer
+        return transformer(schema, strict=True).walk()
     return schema
 
 
@@ -84,6 +91,9 @@ class Extractor[T]:
         self.output_retries = output_retries
         self.max_tokens = max_tokens
         self._agent = agent
+        self._prepared_agents: WeakKeyDictionary[asyncio.AbstractEventLoop, Agent[Any, Any]] = (
+            WeakKeyDictionary()
+        )
 
     async def extract(self, prompt: str) -> T:
         return (await self.extract_with_usage(prompt)).output
@@ -99,9 +109,15 @@ class Extractor[T]:
         try:
             agent = await self._get_agent()
             if self.output_mode == "native_strict" and not isinstance(
-                agent.model, OpenAIResponsesModel
+                agent.model, OpenAIResponsesModel | AnthropicModel
             ):
-                raise ValueError("native strict extraction requires OpenAI Responses")
+                raise ValueError("native strict extraction requires OpenAI Responses or Anthropic")
+            if (
+                self.output_mode == "native_strict"
+                and isinstance(agent.model, AnthropicModel)
+                and not agent.model.profile.get("supports_json_schema_output", False)
+            ):
+                raise ValueError("Anthropic model does not support native strict extraction")
             if self.openrouter_provider is not None and (
                 not isinstance(agent.model, OpenAIResponsesModel)
                 or agent.model.client.base_url.host != "openrouter.ai"
@@ -111,21 +127,29 @@ class Extractor[T]:
                 raise ValueError("OpenRouter routing requires the OpenRouter API origin")
             transport_retries = (
                 agent.model.client.max_retries
-                if isinstance(agent.model, OpenAIResponsesModel)
+                if isinstance(agent.model, OpenAIResponsesModel | AnthropicModel)
                 else 0
             )
             # An unspecified output retry policy estimates one model request;
             # dynamic agent settings and provider work are not bounded here.
-            await reserve_llm_budget(
-                surface=self.surface.value,
-                prompt=self._budget_prompt(prompt),
-                output_token_limit=self._budget_output_limit(agent),
-                attempt_envelope=(transport_retries + 1) * ((self.output_retries or 0) + 1),
-            )
-            result = await agent.run(
-                prompt,
-                model_settings=self._model_settings(),
-            )
+            budget_prompt = self._budget_prompt(prompt, agent)
+            output_limit = self._budget_output_limit(agent)
+            envelope = (transport_retries + 1) * ((self.output_retries or 0) + 1)
+
+            async def reserve(envelope: int = 1) -> None:
+                await reserve_llm_budget(
+                    surface=self.surface.value,
+                    prompt=budget_prompt,
+                    output_token_limit=output_limit,
+                    attempt_envelope=envelope,
+                )
+
+            await reserve(envelope)
+            with reserve_uncovered_transport_attempts(envelope, reserve):
+                result = await agent.run(
+                    prompt,
+                    model_settings=self._model_settings(),
+                )
             telemetry_registry().record_llm_call(
                 surface=self.surface.value,
                 provider="runtime",
@@ -165,11 +189,15 @@ class Extractor[T]:
             settings.update(agent.model_settings)
         return settings.get("max_tokens")
 
-    def _budget_prompt(self, prompt: str) -> str:
+    def _budget_prompt(self, prompt: str, agent: Agent[Any, Any]) -> str:
         instructions = self.system_prompt or ()
         if isinstance(instructions, str):
             instructions = (instructions,)
-        schema = extraction_schema(self.output_type, self.output_mode)
+        schema = extraction_schema(
+            self.output_type,
+            self.output_mode,
+            profile=agent.model.profile if isinstance(agent.model, Model) else None,
+        )
         return "\n".join((*instructions, prompt, json.dumps(schema, sort_keys=True)))
 
     async def extract_many(
@@ -189,9 +217,24 @@ class Extractor[T]:
 
         return await asyncio.gather(*(run_one(prompt) for prompt in prompts))
 
+    async def output_schema(self) -> dict[str, Any]:
+        """Resolve the schema from the same model used for this extraction."""
+        if self.output_mode == "tool":
+            return extraction_schema(self.output_type)
+        agent = await self._get_agent()
+        self._prepared_agents[asyncio.get_running_loop()] = agent
+        return extraction_schema(
+            self.output_type,
+            self.output_mode,
+            profile=agent.model.profile if isinstance(agent.model, Model) else None,
+        )
+
     async def _get_agent(self) -> Agent[Any, Any]:
         if self._agent is not None:
             return self._agent
+        prepared = self._prepared_agents.get(asyncio.get_running_loop())
+        if prepared is not None:
+            return prepared
         output_type: Any = self.output_type
         return await get_agent(
             self.surface,

--- a/packages/python/sibyl-core/src/sibyl_core/ai/providers.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/providers.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import os
 from typing import Literal
 
+from anthropic import AsyncAnthropic
 from openai import AsyncOpenAI
 from pydantic_ai.models import Model
 from pydantic_ai.models.anthropic import AnthropicModel, AnthropicModelSettings
 from pydantic_ai.models.google import GoogleModel, GoogleModelSettings
 from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
+from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers.anthropic import AnthropicProvider
 from pydantic_ai.providers.google import GoogleProvider
 from pydantic_ai.providers.openai import OpenAIProvider
@@ -17,7 +19,7 @@ from pydantic_ai.providers.openai import OpenAIProvider
 from sibyl_core.ai.errors import LLMConfigError
 from sibyl_core.ai.llm.config import LLMConfig
 from sibyl_core.ai.registry import ModelKind, model_registry
-from sibyl_core.ai.transport import RecordingOpenAIClient
+from sibyl_core.ai.transport import RecordingAnthropicClient, RecordingOpenAIClient
 
 
 def build_model(config: LLMConfig) -> Model:
@@ -26,10 +28,19 @@ def build_model(config: LLMConfig) -> Model:
 
     match config.provider:
         case "anthropic":
+            settings = _settings(config)
+            if resolved_model_profile(config).get("anthropic_disallows_sampling_settings", False):
+                settings.pop("temperature", None)
             return AnthropicModel(
                 provider_model_id,
-                provider=AnthropicProvider(api_key=api_key),
-                settings=AnthropicModelSettings(**_settings(config)),
+                provider=AnthropicProvider(
+                    anthropic_client=AsyncAnthropic(
+                        api_key=api_key,
+                        max_retries=config.transport_max_retries,
+                        http_client=RecordingAnthropicClient(),
+                    )
+                ),
+                settings=AnthropicModelSettings(**settings),
             )
         case "gemini":
             return GoogleModel(
@@ -49,6 +60,14 @@ def build_model(config: LLMConfig) -> Model:
                 ),
                 settings=OpenAIResponsesModelSettings(**_settings(config)),
             )
+
+
+def resolved_model_profile(config: LLMConfig) -> ModelProfile:
+    """Resolve provider schema capabilities without creating a network client."""
+    provider = {"anthropic": AnthropicProvider, "openai": OpenAIProvider, "gemini": GoogleProvider}[
+        config.provider
+    ]
+    return provider.model_profile(resolve_provider_model_id(config)) or {}
 
 
 def resolve_provider_model_id(config: LLMConfig) -> str:

--- a/packages/python/sibyl-core/src/sibyl_core/ai/registry.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/registry.py
@@ -145,6 +145,29 @@ _DEFAULT_ENTRIES = [
         last_verified_at=_VERIFIED_AT,
     ),
     ModelEntry(
+        alias="claude-opus-5",
+        snapshot="claude-opus-5",
+        kind=ModelKind.LLM,
+        provider="anthropic",
+        provider_model_id="claude-opus-5",
+        pydantic_ai_model_class="AnthropicModel",
+        use_cases=("native-structured-quality",),
+        capabilities=frozenset(
+            {
+                ModelCapability.STRUCTURED_OUTPUT,
+                ModelCapability.STREAMING,
+                ModelCapability.TOOL_USE,
+                ModelCapability.THINKING,
+            }
+        ),
+        max_output_tokens=128_000,
+        default_temperature=None,
+        input_cost_per_mtok_usd=5.0,
+        output_cost_per_mtok_usd=25.0,
+        cost_source_url="https://platform.claude.com/docs/en/models/opus-5/overview",
+        last_verified_at=datetime(2026, 9, 9, tzinfo=UTC),
+    ),
+    ModelEntry(
         alias="claude-sonnet-4-6",
         snapshot="claude-sonnet-4-6",
         kind=ModelKind.LLM,

--- a/packages/python/sibyl-core/src/sibyl_core/ai/transport.py
+++ b/packages/python/sibyl-core/src/sibyl_core/ai/transport.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import re
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from importlib.metadata import version
 from typing import Any
 
+from anthropic import DefaultAsyncHttpxClient as AnthropicHttpClient
 from openai import DefaultAsyncHttpxClient
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -36,6 +37,43 @@ _attempts: ContextVar[list[TransportAttempt] | None] = ContextVar(
     "llm_transport_attempts", default=None
 )
 
+_reserve_attempt: ContextVar[Callable[[], Awaitable[None]] | None] = ContextVar(
+    "llm_reserve_physical_attempt", default=None
+)
+
+
+@contextmanager
+def reserve_uncovered_transport_attempts(
+    covered: int, reserve_extra: Callable[[], Awaitable[None]]
+) -> Iterator[None]:
+    """Reserve unexpected HTTP hops before dispatch beyond the initial envelope."""
+    claimed = 0
+    denied: Exception | None = None
+
+    async def claim() -> None:
+        nonlocal claimed, denied
+        if denied is not None:
+            raise denied
+        claimed += 1
+        if claimed > covered:
+            try:
+                await reserve_extra()
+            except Exception as exc:
+                denied = exc
+                raise
+
+    token = _reserve_attempt.set(claim)
+    try:
+        yield
+    except Exception:
+        # SDKs wrap client-hook exceptions as connection errors. Preserve the
+        # trusted local budget decision and prevent retries from reserving again.
+        if denied is not None:
+            raise denied from None
+        raise
+    finally:
+        _reserve_attempt.reset(token)
+
 
 @contextmanager
 def collect_transport_attempts() -> Iterator[list[TransportAttempt]]:
@@ -47,31 +85,70 @@ def collect_transport_attempts() -> Iterator[list[TransportAttempt]]:
         _attempts.reset(token)
 
 
-class RecordingOpenAIClient(DefaultAsyncHttpxClient):
-    async def send(self, request: Any, **kwargs: Any) -> Any:
-        attempts = _attempts.get()
-        try:
-            response = await super().send(request, **kwargs)
-        except (Exception, asyncio.CancelledError) as exc:
-            if attempts is not None:
-                # Exception messages and request/response bodies may contain secrets.
-                attempts.append(TransportAttempt(exception_type=type(exc).__name__))
-            raise
+async def _record_send(
+    send: Callable[..., Awaitable[Any]], request: Any, *, request_id_header: str, **kwargs: Any
+) -> Any:
+    attempts = _attempts.get()
+    if reserve := _reserve_attempt.get():
+        await reserve()
+    try:
+        response = await send(request, **kwargs)
+    except (Exception, asyncio.CancelledError) as exc:
         if attempts is not None:
-            request_id = response.headers.get("x-request-id")
-            if (
-                request_id is not None
-                and re.fullmatch(r"[a-zA-Z0-9_.:-]{1,200}", request_id) is None
-            ):
-                request_id = None
-            attempts.append(
-                TransportAttempt(status_code=response.status_code, request_id=request_id)
-            )
+            # Exception messages and request/response bodies may contain secrets.
+            attempts.append(TransportAttempt(exception_type=type(exc).__name__))
+        raise
+    if attempts is not None:
+        request_id = response.headers.get(request_id_header)
+        if request_id is not None and re.fullmatch(r"[a-zA-Z0-9_.:-]{1,200}", request_id) is None:
+            request_id = None
+        attempts.append(TransportAttempt(status_code=response.status_code, request_id=request_id))
+    return response
+
+
+class RecordingOpenAIClient(DefaultAsyncHttpxClient):
+    async def _send_single_request(self, request: Any) -> Any:
+        return await _record_send(
+            super()._send_single_request, request, request_id_header="x-request-id"
+        )
+
+
+class RecordingAnthropicClient(AnthropicHttpClient):
+    async def _send_single_request(self, request: Any) -> Any:
+        return await _record_send(
+            super()._send_single_request, request, request_id_header="request-id"
+        )
+
+    async def send(self, request: Any, **kwargs: Any) -> Any:
+        response = await super().send(request, **kwargs)
+        if _attempts.get() is not None and response.is_success and not kwargs.get("stream", False):
+            _validate_anthropic_usage(response.json())
         return response
 
 
+def _validate_anthropic_usage(payload: Any) -> None:
+    """Reject malformed token counts before SDK usage normalization can erase them."""
+    usage = payload.get("usage") if isinstance(payload, dict) else None
+    if not isinstance(usage, dict):
+        raise ValueError("Anthropic response requires usage")
+    for field in ("input_tokens", "output_tokens"):
+        if type(usage.get(field)) is not int or usage[field] < 0:
+            raise ValueError("Anthropic response has invalid token usage")
+    for field in ("cache_creation_input_tokens", "cache_read_input_tokens"):
+        if field in usage and (type(usage[field]) is not int or usage[field] < 0):
+            raise ValueError("Anthropic response has invalid cache token usage")
+    cache = usage.get("cache_creation")
+    if cache is not None:
+        if not isinstance(cache, dict):
+            raise ValueError("Anthropic response has invalid cache usage")
+        for field in ("ephemeral_5m_input_tokens", "ephemeral_1h_input_tokens"):
+            if field in cache and (type(cache[field]) is not int or cache[field] < 0):
+                raise ValueError("Anthropic response has invalid cache token usage")
+
+
 def transport_policy(config: LLMConfig) -> dict[str, str | int | None]:
-    """Bind the supported SDK behavior; other providers remain uninstrumented."""
+    """Bind supported SDK retries and physical HTTP attempt recording."""
+    recorded = config.provider in {"openai", "anthropic"}
     return {
         "provider": config.provider,
         "sdk_version": version(
@@ -80,6 +157,6 @@ def transport_policy(config: LLMConfig) -> dict[str, str | int | None]:
             ]
         ),
         "pydantic_ai_version": version("pydantic-ai-slim"),
-        "max_retries": config.transport_max_retries if config.provider == "openai" else None,
-        "receipt_version": "sibyl-sdk-attempt-v1" if config.provider == "openai" else None,
+        "max_retries": config.transport_max_retries if recorded else None,
+        "receipt_version": "sibyl-sdk-attempt-v2" if recorded else None,
     }

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -14,6 +14,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 from sibyl_core.ai.llm.config import LLMSurface, resolve_llm_config
 from sibyl_core.ai.llm.extractor import extraction_schema
+from sibyl_core.ai.providers import resolved_model_profile
 from sibyl_core.ai.transport import transport_policy
 from sibyl_core.auth.memory_policy import (
     EVAL_ADMISSION_METADATA_KEY,
@@ -536,7 +537,11 @@ async def _extractor_policy() -> _ExtractorPolicy:
             "output_retries": OUTPUT_RETRIES,
             "output_mode": core_config.consolidation_output_mode,
             "wire_schema_sha256": _digest(
-                extraction_schema(EvidenceProposal, core_config.consolidation_output_mode)
+                extraction_schema(
+                    EvidenceProposal,
+                    core_config.consolidation_output_mode,
+                    profile=resolved_model_profile(config.to_llm_config()),
+                )
             ),
             "openrouter_provider": core_config.consolidation_openrouter_provider,
             "input_budget_unit": "system_user_declared_schema_characters",

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_vali
 
 from sibyl_core.ai.llm import Extractor, LLMSurface
 from sibyl_core.ai.llm.budget import get_llm_budget_context, llm_budget_context
-from sibyl_core.ai.llm.extractor import OutputMode, extraction_schema
+from sibyl_core.ai.llm.extractor import OutputMode
 from sibyl_core.models.entities import ProcedureStep
 from sibyl_core.models.memory_scope import MemoryScope
 from sibyl_core.models.reflection import ReflectionCandidate
@@ -591,10 +591,6 @@ async def propose_conditional_procedure(
         raise ValueError("build budgets must be positive integers")
     evidence = await asyncio.to_thread(_extraction_input, group)
     prompt = evidence.prompt
-    schema = extraction_schema(evidence.output_type, output_mode)
-    input_chars = len(prompt) + len(evidence.system) + len(_canonical(schema).decode("utf-8"))
-    if input_chars > max_input_chars:
-        raise ConsolidationInputBudgetExceeded(input_chars, max_input_chars)
     extractor = Extractor(
         evidence.output_type,
         surface=LLMSurface.MEMORY,
@@ -605,6 +601,10 @@ async def propose_conditional_procedure(
         output_mode=output_mode,
         openrouter_provider=openrouter_provider,
     )
+    schema = await extractor.output_schema()
+    input_chars = len(prompt) + len(evidence.system) + len(_canonical(schema).decode("utf-8"))
+    if input_chars > max_input_chars:
+        raise ConsolidationInputBudgetExceeded(input_chars, max_input_chars)
     with llm_budget_context(
         user_id=group.owner_principal_id, organization_id=group.organization_id
     ):
@@ -627,6 +627,7 @@ async def propose_conditional_procedure(
         max_tokens,
         output_mode,
         openrouter_provider,
+        wire_schema_sha256=_digest(_canonical(schema)),
     )
 
 
@@ -641,6 +642,8 @@ def _finish_proposal(
     max_tokens: int,
     output_mode: OutputMode = "tool",
     openrouter_provider: str | None = None,
+    *,
+    wire_schema_sha256: str,
 ) -> ConsolidationResult:
     prompt = evidence.prompt
     receipt = {
@@ -660,9 +663,7 @@ def _finish_proposal(
         "output_retries": OUTPUT_RETRIES,
         "output_mode": output_mode,
         "openrouter_provider": openrouter_provider,
-        "wire_schema_sha256": _digest(
-            _canonical(extraction_schema(evidence.output_type, output_mode))
-        ),
+        "wire_schema_sha256": wire_schema_sha256,
         "input_sha256": _digest(_canonical(group.model_dump(mode="json"))),
         "prompt_sha256": _digest(_canonical({"system": evidence.system, "user": prompt})),
         "schema_sha256": _digest(_canonical(evidence.output_type.model_json_schema())),

--- a/packages/python/sibyl-core/tests/ai/llm/test_anthropic_native_extraction.py
+++ b/packages/python/sibyl-core/tests/ai/llm/test_anthropic_native_extraction.py
@@ -1,0 +1,667 @@
+"""Native Anthropic extraction uses the production factory and strict validation."""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from tests.ai.llm.test_evidence_proposal_validation import procedure
+
+from sibyl_core.ai import clients, providers
+from sibyl_core.ai.errors import LLMError, LLMValidationError
+from sibyl_core.ai.llm import Extractor
+from sibyl_core.ai.llm import extractor as extraction
+from sibyl_core.ai.llm.config import EnvConfigSource, LLMSurface
+from sibyl_core.ai.transport import RecordingAnthropicClient, transport_policy
+from sibyl_core.tasks.procedure_evidence import EvidenceProposal
+
+ABSTENTION = {"outcome": {"kind": "abstention", "reason": "Insufficient synthetic evidence"}}
+
+
+def response(output=ABSTENTION, *, usage=True, model="claude-opus-5"):
+    payload = {
+        "id": "msg_fixture",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": json.dumps(output)}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+    }
+    if usage:
+        payload["usage"] = {
+            "input_tokens": 10,
+            "output_tokens": 2,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }
+    return payload
+
+
+@asynccontextmanager
+async def configured(monkeypatch, respond, *, model="claude-opus-5", retries=2, output_retries=1):
+    source = EnvConfigSource(
+        {
+            "SIBYL_LLM_MEMORY_PROVIDER": "anthropic",
+            "SIBYL_LLM_MEMORY_MODEL": model,
+            "SIBYL_LLM_MEMORY_TRANSPORT_MAX_RETRIES": str(retries),
+            "ANTHROPIC_API_KEY": "fixture-key",
+        }
+    )
+    monkeypatch.setattr(clients, "resolve_llm_config", source.resolve)
+    reserve = AsyncMock()
+    monkeypatch.setattr(extraction, "reserve_llm_budget", reserve)
+    clients.invalidate_agent_cache()
+    async with RecordingAnthropicClient(transport=httpx.MockTransport(respond)) as http:
+        monkeypatch.setattr(providers, "RecordingAnthropicClient", lambda: http)
+        try:
+            yield (
+                Extractor(
+                    EvidenceProposal,
+                    surface=LLMSurface.MEMORY,
+                    output_mode="native_strict",
+                    max_tokens=8192,
+                    output_retries=output_retries,
+                    system_prompt="Synthetic policy",
+                ),
+                reserve,
+                source,
+            )
+        finally:
+            clients.invalidate_agent_cache()
+
+
+def keys(value):
+    if isinstance(value, dict):
+        return set(value).union(*(keys(item) for item in value.values()))
+    if isinstance(value, list):
+        return set().union(*(keys(item) for item in value))
+    return set()
+
+
+@pytest.mark.parametrize("model, sampling", [("claude-opus-5", False), ("claude-haiku-4-5", True)])
+async def test_anthropic_native_factory_emits_profile_schema_and_settings(
+    monkeypatch, model, sampling
+):
+    wires = []
+
+    def respond(request):
+        assert request.url.scheme == "https" and request.url.host == "api.anthropic.com"
+        assert request.url.path == "/v1/messages"
+        wires.append(json.loads(request.content))
+        return httpx.Response(200, headers={"request-id": "req_native"}, json=response(model=model))
+
+    async with configured(monkeypatch, respond, model=model) as (extractor, reserve, source):
+        declared = await extractor.output_schema()
+        result = await extractor.extract_with_usage("Synthetic evidence")
+        wire = wires[0]
+        assert wire["output_config"]["format"] == {"type": "json_schema", "schema": declared}
+        assert "minimum" in keys(EvidenceProposal.model_json_schema())
+        assert "minimum" not in keys(declared)
+        assert "anyOf" in keys(declared)
+        assert "tools" not in wire
+        assert ("temperature" in wire) is sampling
+        assert wire["max_tokens"] == 8192
+        assert result.output.outcome.kind == "abstention"
+        assert result.usage.provider == "anthropic"
+        assert result.usage.input_tokens == 10 and result.usage.output_tokens == 2
+        assert result.usage.transport_usage_complete is True
+        assert result.usage.transport_attempts[0].request_id == "req_native"
+        assert reserve.await_args.kwargs["attempt_envelope"] == 6
+        assert json.dumps(declared, sort_keys=True) in reserve.await_args.kwargs["prompt"]
+        config = (await source.resolve(LLMSurface.MEMORY)).to_llm_config()
+        assert transport_policy(config)["max_retries"] == 2
+        assert transport_policy(config)["receipt_version"] == "sibyl-sdk-attempt-v2"
+
+
+@pytest.mark.parametrize("recover", [False, True])
+async def test_anthropic_native_original_constraints_retry_or_fail(monkeypatch, recover):
+    wires = []
+
+    def respond(request):
+        wires.append(json.loads(request.content))
+        output = {"outcome": {"kind": "procedure", "procedure": procedure()}}
+        output["outcome"]["procedure"]["actions"][0]["order"] = 0
+        if recover and len(wires) > 1:
+            output = ABSTENTION
+        return httpx.Response(200, json=response(output))
+
+    async with configured(monkeypatch, respond) as (extractor, _, _):
+        if recover:
+            result = await extractor.extract_with_usage("Synthetic evidence")
+            assert result.output.outcome.kind == "abstention"
+            assert result.usage.input_tokens == 20
+            assert len(result.usage.transport_attempts) == 2
+        else:
+            with pytest.raises(LLMValidationError) as caught:
+                await extractor.extract_with_usage("Synthetic evidence")
+            receipt = caught.value.details["extraction_usage"]
+            assert len(receipt["transport_attempts"]) == 2
+            assert receipt["cost_usd"] is None and not receipt["cost_complete"]
+        assert len(wires) == 2
+        assert "greater_than_equal" in json.dumps(wires[1]["messages"])
+
+
+@pytest.mark.parametrize("failure", [None, "http", "timeout", "invalid_json", "missing_usage"])
+async def test_anthropic_native_physical_attempts_preserve_unknown_cost(monkeypatch, failure):
+    calls = []
+
+    def respond(request):
+        calls.append(request)
+        if failure == "timeout":
+            raise httpx.ReadTimeout("private exception", request=request)
+        if len(calls) < 3 or failure == "http":
+            return httpx.Response(
+                500,
+                headers={"retry-after-ms": "1", "request-id": f"retry_{len(calls)}"},
+                json={"type": "error", "error": {"type": "api_error", "message": "private body"}},
+            )
+        if failure == "invalid_json":
+            return httpx.Response(200, content=b"not json")
+        return httpx.Response(
+            200,
+            headers={"request-id": "req_final"},
+            json=response(usage=failure != "missing_usage"),
+        )
+
+    async with configured(monkeypatch, respond, output_retries=0) as (extractor, _, _):
+        if failure:
+            with pytest.raises(LLMError) as caught:
+                await extractor.extract_with_usage("private prompt")
+            receipt = caught.value.details["extraction_usage"]
+        else:
+            receipt = (await extractor.extract_with_usage("private prompt")).usage.model_dump()
+        assert len(calls) == 3
+        assert len(receipt["transport_attempts"]) == 3
+        assert not receipt["cost_complete"] and receipt["cost_usd"] is None
+        assert not receipt["transport_attempts"][0]["usage_known"]
+        if failure == "timeout":
+            assert [a["exception_type"] for a in receipt["transport_attempts"]] == [
+                "ReadTimeout"
+            ] * 3
+            assert all(a["status_code"] is None for a in receipt["transport_attempts"])
+        else:
+            assert [a["status_code"] for a in receipt["transport_attempts"]] == [
+                500,
+                500,
+                500 if failure == "http" else 200,
+            ]
+            assert all(a["exception_type"] is None for a in receipt["transport_attempts"])
+            assert [a["request_id"] for a in receipt["transport_attempts"][:2]] == [
+                "retry_1",
+                "retry_2",
+            ]
+        assert "private" not in json.dumps(receipt)
+
+
+async def test_anthropic_unsupported_native_model_and_openrouter_route_fail_before_budget(
+    monkeypatch,
+):
+    def respond(request):
+        pytest.fail("unsupported native policy must not dispatch")
+
+    async with configured(monkeypatch, respond, model="claude-3-haiku-20240307") as (
+        extractor,
+        reserve,
+        _,
+    ):
+        with pytest.raises(LLMError):
+            await extractor.extract("synthetic")
+        reserve.assert_not_awaited()
+    async with configured(monkeypatch, respond) as (extractor, reserve, _):
+        extractor.openrouter_provider = "fixture-route"
+        with pytest.raises(LLMError):
+            await extractor.extract("synthetic")
+        reserve.assert_not_awaited()
+
+
+async def test_anthropic_concurrent_attempts_remain_request_local(monkeypatch):
+    async def respond(request):
+        wire = json.loads(request.content)
+        identity = wire["messages"][0]["content"][0]["text"]
+        await asyncio.sleep(0)
+        return httpx.Response(200, headers={"request-id": identity}, json=response())
+
+    async with configured(monkeypatch, respond) as (extractor, _, _):
+        results = await asyncio.gather(
+            *(extractor.extract_with_usage(f"req_{i}") for i in range(8))
+        )
+        assert [r.usage.transport_attempts[0].request_id for r in results] == [
+            f"req_{i}" for i in range(8)
+        ]
+        assert all(len(r.usage.transport_attempts) == 1 for r in results)
+
+
+async def test_anthropic_native_budget_uses_transformed_schema_and_sdk_envelope(monkeypatch):
+    from sibyl_core.ai.llm.budget import llm_budget_context, reserve_llm_budget, set_budget_enforcer
+
+    reservations = []
+
+    class Budget:
+        async def reserve(self, context, *, estimated_tokens, **kwargs):
+            reservations.append(estimated_tokens)
+            raise RuntimeError("synthetic budget denial")
+
+    def respond(request):
+        pytest.fail("budget denial must precede physical dispatch")
+
+    async with configured(monkeypatch, respond, retries=3, output_retries=2) as (extractor, _, _):
+        monkeypatch.setattr(extraction, "reserve_llm_budget", reserve_llm_budget)
+        schema = await extractor.output_schema()
+        set_budget_enforcer(Budget())
+        try:
+            with (
+                llm_budget_context(user_id="owner", organization_id="org"),
+                pytest.raises(LLMError) as caught,
+            ):
+                await extractor.extract("Synthetic evidence")
+        finally:
+            set_budget_enforcer(None)
+        prompt = "Synthetic policy\nSynthetic evidence\n" + json.dumps(schema, sort_keys=True)
+        assert reservations == [(len(prompt) // 4 + 8192) * 12]
+        assert caught.value.details["extraction_usage"]["transport_attempts"] == []
+
+
+async def test_anthropic_prepared_schema_keeps_same_model_after_config_change(monkeypatch):
+    wires = []
+
+    def respond(request):
+        wires.append(json.loads(request.content))
+        return httpx.Response(200, json=response())
+
+    async with configured(monkeypatch, respond) as (extractor, _, _):
+        schema = await extractor.output_schema()
+        changed = AsyncMock(side_effect=AssertionError("prepared extraction must retain its model"))
+        monkeypatch.setattr(clients, "resolve_llm_config", changed)
+        await extractor.extract("Synthetic evidence")
+        changed.assert_not_awaited()
+        assert wires[0]["model"] == "claude-opus-5"
+        assert wires[0]["output_config"]["format"]["schema"] == schema
+
+
+def test_prepared_extractor_does_not_reuse_agent_across_event_loops(monkeypatch):
+    from pydantic_ai import Agent
+    from pydantic_ai.models.test import TestModel
+
+    made = []
+
+    async def agent(*args, **kwargs):
+        made.append(Agent(TestModel()))
+        return made[-1]
+
+    monkeypatch.setattr(extraction, "get_agent", agent)
+    extractor = Extractor(EvidenceProposal, output_mode="native_strict")
+    asyncio.run(extractor.output_schema())
+    asyncio.run(extractor.output_schema())
+    assert len(made) == 2
+
+
+async def test_anthropic_cancellation_retains_unknown_attempt(monkeypatch):
+    async def respond(request):
+        raise asyncio.CancelledError("private cancellation")
+
+    async with configured(monkeypatch, respond) as (extractor, _, _):
+        with pytest.raises(asyncio.CancelledError) as caught:
+            await extractor.extract("private prompt")
+        receipt = caught.value.extraction_usage
+        assert receipt["transport_attempts"] == [
+            {
+                "status_code": None,
+                "exception_type": "CancelledError",
+                "request_id": None,
+                "usage_known": False,
+            }
+        ]
+        assert receipt["cost_usd"] is None and not receipt["cost_complete"]
+        assert "private" not in json.dumps(receipt)
+
+
+async def test_anthropic_request_id_receipt_rejects_unsafe_header(monkeypatch):
+    def respond(request):
+        return httpx.Response(
+            200, headers={"request-id": "private payload?secret"}, json=response()
+        )
+
+    async with configured(monkeypatch, respond) as (extractor, _, _):
+        result = await extractor.extract_with_usage("synthetic")
+        assert result.usage.transport_attempts[0].request_id is None
+
+
+def test_anthropic_registered_model_resolves_provider_and_snapshot_without_defaults():
+    from pydantic import SecretStr
+
+    from sibyl_core.ai.llm.config import LLMConfig
+    from sibyl_core.ai.registry import model_registry
+
+    entry = model_registry.require("claude-opus-5")
+    assert entry.provider == "anthropic" and entry.default_temperature is None
+    config = LLMConfig(provider="anthropic", model=entry.alias, api_key=SecretStr("fixture"))
+    assert providers.resolve_provider_model_id(config) == "claude-opus-5"
+    with pytest.raises(LLMError):
+        providers.resolve_provider_model_id(config.model_copy(update={"provider": "openai"}))
+    assert model_registry.recommended_for("default").alias == "claude-haiku-4-5"
+
+
+async def test_anthropic_build_receipt_hashes_actual_transformed_schema(monkeypatch):
+    import hashlib
+
+    from tests.test_episode_evidence import _contrast_group
+
+    from sibyl_core.tasks import consolidation as c
+
+    wires = []
+
+    def respond(request):
+        wires.append(json.loads(request.content))
+        return httpx.Response(200, json=response())
+
+    async with configured(monkeypatch, respond):
+        result = await c.propose_conditional_procedure(
+            _contrast_group(),
+            max_input_chars=800_000,
+            max_tokens=8192,
+            output_mode="native_strict",
+            model_override="claude-opus-5",
+        )
+        wire_schema = wires[0]["output_config"]["format"]["schema"]
+        assert (
+            result.receipt["wire_schema_sha256"]
+            == hashlib.sha256(c._canonical(wire_schema)).hexdigest()
+        )
+        assert result.receipt["status"] == "abstained"
+        assert result.receipt["usage"]["provider"] == "anthropic"
+        assert result.receipt["usage"]["transport_attempts"][0]["usage_known"] is True
+        with pytest.raises(c.ConsolidationInputBudgetExceeded):
+            await c.propose_conditional_procedure(
+                _contrast_group(),
+                max_input_chars=1,
+                output_mode="native_strict",
+                model_override="claude-opus-5",
+            )
+        assert len(wires) == 1
+
+
+async def test_anthropic_revision_binds_native_schema_profile_and_transport(monkeypatch):
+    from sibyl_core.services import eval_publication as publication
+
+    source = EnvConfigSource(
+        {"SIBYL_LLM_MEMORY_PROVIDER": "anthropic", "SIBYL_LLM_MEMORY_MODEL": "claude-opus-5"}
+    )
+    monkeypatch.setattr(publication, "resolve_llm_config", source.resolve)
+    monkeypatch.setattr(publication.core_config, "consolidation_output_mode", "native_strict")
+    captured = []
+    digest = publication._digest
+
+    def capture(value):
+        if isinstance(value, dict) and "wire_schema_sha256" in value:
+            captured.append(value)
+        return digest(value)
+
+    monkeypatch.setattr(publication, "_digest", capture)
+    await publication._extractor_policy()
+    config = (await source.resolve(LLMSurface.MEMORY)).to_llm_config()
+    expected = extraction.extraction_schema(
+        EvidenceProposal,
+        "native_strict",
+        profile=providers.resolved_model_profile(config),
+    )
+    assert captured[0]["provider"] == "anthropic"
+    assert captured[0]["wire_schema_sha256"] == digest(expected)
+    assert captured[0]["transport"]["max_retries"] == 2
+
+
+@pytest.mark.parametrize("read_failure", [False, True])
+async def test_anthropic_redirect_hops_survive_buffered_body_failure(monkeypatch, read_failure):
+    calls = []
+
+    class BrokenBody(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            raise httpx.ReadError("private body failure")
+            yield b""
+
+    def respond(request):
+        calls.append(request)
+        if len(calls) == 1:
+            return httpx.Response(
+                307,
+                headers={
+                    "location": "https://api.anthropic.com/v1/messages?hop=1",
+                    "request-id": "req_hop",
+                },
+            )
+        if read_failure:
+            return httpx.Response(200, headers={"request-id": "req_final"}, stream=BrokenBody())
+        return httpx.Response(200, headers={"request-id": "req_final"}, json=response())
+
+    async with configured(monkeypatch, respond, retries=0) as (extractor, _, _):
+        if read_failure:
+            with pytest.raises(LLMError) as caught:
+                await extractor.extract("Synthetic evidence")
+            receipt = caught.value.details["extraction_usage"]
+        else:
+            receipt = (await extractor.extract_with_usage("Synthetic evidence")).usage.model_dump()
+        assert len(calls) == 2
+        assert [attempt["status_code"] for attempt in receipt["transport_attempts"]] == [307, 200]
+        assert [attempt["request_id"] for attempt in receipt["transport_attempts"]] == [
+            "req_hop",
+            "req_final",
+        ]
+        assert receipt["cost_complete"] is False and receipt["cost_usd"] is None
+        assert "private" not in json.dumps(receipt)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("input_tokens", -1),
+        ("output_tokens", True),
+        ("input_tokens", 1.5),
+        ("output_tokens", "2"),
+        ("cache_read_input_tokens", -1),
+        ("cache_creation_input_tokens", False),
+        ("cache_creation", {"ephemeral_5m_input_tokens": -1}),
+    ],
+)
+async def test_anthropic_malformed_usage_rejects_before_normalization(monkeypatch, field, value):
+    calls = []
+
+    def respond(request):
+        calls.append(request)
+        payload = response()
+        payload["usage"][field] = value
+        return httpx.Response(200, headers={"request-id": "req_invalid_usage"}, json=payload)
+
+    async with configured(monkeypatch, respond, retries=0) as (extractor, _, _):
+        with pytest.raises(LLMError) as caught:
+            await extractor.extract("Synthetic evidence")
+        receipt = caught.value.details["extraction_usage"]
+        assert len(calls) == 1
+        assert len(receipt["transport_attempts"]) == 1
+        assert receipt["transport_attempts"][0]["status_code"] == 200
+        assert not receipt["cost_complete"] and receipt["cost_usd"] is None
+        assert not receipt["usage_complete"]
+
+
+async def test_openai_client_retains_each_redirect_hop():
+    import httpx2
+
+    from sibyl_core.ai.transport import RecordingOpenAIClient, collect_transport_attempts
+
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx2.Response(
+                307,
+                headers={
+                    "location": "https://api.openai.com/v1/responses?hop=1",
+                    "x-request-id": "openai_hop",
+                },
+            )
+        return httpx2.Response(200, headers={"x-request-id": "openai_final"}, json={})
+
+    async with RecordingOpenAIClient(transport=httpx2.MockTransport(respond)) as client:
+        with collect_transport_attempts() as attempts:
+            await client.post("https://api.openai.com/v1/responses", json={})
+        assert [attempt.status_code for attempt in attempts] == [307, 200]
+        assert [attempt.request_id for attempt in attempts] == ["openai_hop", "openai_final"]
+
+
+async def test_anthropic_recording_does_not_buffer_streaming_consumers():
+    from sibyl_core.ai.transport import collect_transport_attempts
+
+    reads = []
+
+    class Body(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            reads.append("read")
+            yield b"data: synthetic\n\n"
+
+    async with RecordingAnthropicClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, stream=Body()))
+    ) as client:
+        with collect_transport_attempts() as attempts:
+            async with client.stream("POST", "https://api.anthropic.com/v1/messages") as streamed:
+                assert reads == []
+                assert len(attempts) == 1 and attempts[0].status_code == 200
+                assert await streamed.aread() == b"data: synthetic\n\n"
+                assert reads == ["read"]
+
+
+@pytest.mark.parametrize("deny", [False, True])
+async def test_anthropic_uncovered_redirect_reserves_before_dispatch(monkeypatch, deny):
+    sent = []
+    reservations = []
+
+    def respond(request):
+        sent.append(request)
+        assert len(reservations) >= len(sent)
+        if len(sent) == 1:
+            return httpx.Response(
+                307, headers={"location": "https://api.anthropic.com/v1/messages?hop=1"}
+            )
+        return httpx.Response(200, json=response())
+
+    async def reserve(**kwargs):
+        reservations.append(kwargs)
+        if deny and len(reservations) > 1:
+            raise RuntimeError("synthetic extra reservation denied")
+
+    async with configured(monkeypatch, respond, retries=0, output_retries=0) as (
+        extractor,
+        budget,
+        _,
+    ):
+        budget.side_effect = reserve
+        if deny:
+            with pytest.raises(LLMError) as caught:
+                await extractor.extract("Synthetic evidence")
+            assert len(sent) == 1
+            assert [
+                a["status_code"]
+                for a in caught.value.details["extraction_usage"]["transport_attempts"]
+            ] == [307]
+        else:
+            await extractor.extract("Synthetic evidence")
+            assert len(sent) == 2
+        assert len(reservations) == 2
+        assert reservations[0] == reservations[1]
+        assert reservations[1]["attempt_envelope"] == 1
+
+
+async def test_anthropic_redirect_reservations_are_request_local(monkeypatch):
+    calls = {}
+
+    async def respond(request):
+        identity = json.loads(request.content)["messages"][0]["content"][0]["text"]
+        calls[identity] = calls.get(identity, 0) + 1
+        await asyncio.sleep(0)
+        if identity == "redirect" and calls[identity] == 1:
+            return httpx.Response(
+                307, headers={"location": "https://api.anthropic.com/v1/messages?hop=1"}
+            )
+        return httpx.Response(200, json=response())
+
+    async with configured(monkeypatch, respond, retries=0, output_retries=0) as (
+        extractor,
+        budget,
+        _,
+    ):
+        await asyncio.gather(extractor.extract("redirect"), extractor.extract("direct"))
+        prompts = [c.kwargs["prompt"] for c in budget.await_args_list]
+        assert len(prompts) == 3
+        assert sum("\nredirect\n" in p for p in prompts) == 2
+        assert sum("\ndirect\n" in p for p in prompts) == 1
+        assert calls == {"redirect": 2, "direct": 1}
+
+
+async def test_anthropic_cancelled_extra_reservation_keeps_prior_attempt(monkeypatch):
+    sent = []
+    waiting = asyncio.Event()
+    claims = []
+
+    def respond(request):
+        sent.append(request)
+        return httpx.Response(
+            307, headers={"location": "https://api.anthropic.com/v1/messages?hop=1"}
+        )
+
+    async def reserve(**kwargs):
+        claims.append(kwargs)
+        if len(claims) == 2:
+            waiting.set()
+            await asyncio.Future()
+
+    async with configured(monkeypatch, respond, retries=0, output_retries=0) as (
+        extractor,
+        budget,
+        _,
+    ):
+        budget.side_effect = reserve
+        task = asyncio.create_task(extractor.extract("Synthetic evidence"))
+        await waiting.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError) as caught:
+            await task
+        receipt = caught.value.extraction_usage
+        assert len(sent) == 1 and len(claims) == 2
+        assert [a["status_code"] for a in receipt["transport_attempts"]] == [307]
+        assert not receipt["cost_complete"] and receipt["cost_usd"] is None
+
+
+async def test_anthropic_sdk_wrapping_preserves_terminal_budget_denial(monkeypatch):
+    from sibyl_core.ai.errors import LLMBudgetExceededError
+
+    sent = []
+    reservations = []
+    denial = LLMBudgetExceededError("Synthetic budget exhausted")
+
+    def respond(request):
+        sent.append(request)
+        return httpx.Response(
+            307, headers={"location": f"https://api.anthropic.com/v1/messages?hop={len(sent)}"}
+        )
+
+    async def reserve(**kwargs):
+        reservations.append(kwargs)
+        if len(reservations) > 1:
+            raise denial
+
+    async with configured(monkeypatch, respond, retries=1, output_retries=0) as (
+        extractor,
+        budget,
+        _,
+    ):
+        budget.side_effect = reserve
+        with pytest.raises(LLMBudgetExceededError) as caught:
+            await extractor.extract("Synthetic evidence")
+        assert caught.value is denial
+        assert len(sent) == 2
+        assert [r["attempt_envelope"] for r in reservations] == [2, 1]
+        assert [
+            a["status_code"] for a in denial.details["extraction_usage"]["transport_attempts"]
+        ] == [307, 307]
+        assert denial.details["extraction_usage"]["cost_complete"] is False

--- a/packages/python/sibyl-core/tests/ai/test_registry.py
+++ b/packages/python/sibyl-core/tests/ai/test_registry.py
@@ -10,6 +10,7 @@ def test_registry_has_initial_llm_entries() -> None:
 
     assert [entry.alias for entry in entries] == [
         "claude-haiku-4-5",
+        "claude-opus-5",
         "claude-sonnet-4-6",
         "gemini-3-flash",
         "gemini-3-1-flash-lite",

--- a/packages/python/sibyl-core/tests/test_episode_evidence.py
+++ b/packages/python/sibyl-core/tests/test_episode_evidence.py
@@ -201,6 +201,9 @@ async def test_projected_proposal_resolves_and_revalidates_original_ranges(monke
             self.output_type = output_type
             assert "evidence_id" in kwargs["system_prompt"]
 
+        async def output_schema(self):
+            return self.output_type.model_json_schema()
+
         async def extract_with_usage(self, prompt):
             assert "Evidence view:" in prompt
             return SimpleNamespace(

--- a/packages/python/sibyl-core/tests/test_tasks_consolidation.py
+++ b/packages/python/sibyl-core/tests/test_tasks_consolidation.py
@@ -539,9 +539,14 @@ async def test_native_build_counts_transformed_schema_and_records_policy(group, 
 
     class NativeFixture:
         def __init__(self, output_type, **kwargs):
-            calls.append(kwargs)
+            self.output_type = output_type
+            self.kwargs = kwargs
+
+        async def output_schema(self):
+            return extraction_schema(self.output_type, "native_strict")
 
         async def extract_with_usage(self, prompt):
+            calls.append(self.kwargs)
             return SimpleNamespace(
                 output=c.ProcedureProposal(abstention_reason="No supported procedure"),
                 usage=SimpleNamespace(model_dump=lambda **_: {}),


### PR DESCRIPTION
Native strict consolidation currently accepts only OpenAI Responses. Anthropic's native schema also rejects some constraints in the proposal schema, and Opus 5 rejects the default temperature setting. This change enables Anthropic through the existing PydanticAI model profile, while preserving the original typed proposal validation and its bounded semantic retries.

## 🛠️ Provider and schema behavior

The provider factory creates the Anthropic SDK client with configured transport retries and request-local attempt recording. The existing Anthropic schema transformer produces the native wire schema; the original Python model still rejects invalid action order and other semantic constraints. The model profile omits unsupported sampling settings for Opus 5, while Haiku retains temperature. The registry adds explicit Opus 5 selection without changing the default model.

Consolidation prepares the schema from the actual model before checking its input budget. The prepared model stays bound to that extraction's event loop, and the build receipt stores the schema digest that was sent. The replay policy derives the matching provider schema without creating a network client. OpenRouter routing remains restricted to its HTTPS OpenAI Responses endpoint.

## 🎯 Physical accounting and reservations

The recording clients observe individual HTTP sends, including redirects and a hop followed by a response-body failure. Anthropic token counters are checked before SDK normalization can turn malformed usage into a false zero-cost success. Failed or ambiguous attempts retain unknown cost. Streaming responses are not buffered by the recording layer.

The initial SDK/output-retry envelope still reserves through the existing budget owner. An unexpected physical send beyond that envelope requires an additional reservation before dispatch, using the captured system/schema prompt and output limit. A denied reservation prevents that send and remains a budget error after SDK wrapping. Concurrent extractions have separate counters. The recording contract advances to `sibyl-sdk-attempt-v2`, which changes the consolidation policy identity.

## 🧪 Validation

The focused production-factory tests use the real Anthropic SDK and PydanticAI adapter with MockTransport. The final 50 accounting and budget controls pass, including the independently reproduced redirect and negative-usage failures. The controls also cover semantic retries, native schema emission, malformed usage, concurrent receipt isolation, extra-hop reservation denial, cancellation, and OpenAI redirect recording. Formatting and typechecking pass.

The preceding integration checks passed 122 core consolidation/policy tests and 34 API tests. The earlier broad core selection passed 766 tests with one expected failure; the subsequent changes are confined to physical accounting and its budget hook. No paid provider call has run from this implementation. Independent final review passed 14 additional adversarial controls and 46 existing cases. Root repeated three reservation controls successfully. After rebasing onto current main, all ten reviewed source hashes remained identical and 35 integrated native controls passed. Hosted CI remains pending.
