### PR TITLE
fix(memory): preserve and verify compact procedure artifacts

### DIFF
--- a/apps/api/tests/test_procedure_audit_archive.py
+++ b/apps/api/tests/test_procedure_audit_archive.py
@@ -1,0 +1,15 @@
+"""Content archives preserve the lossless audit storage representation."""
+
+import json
+
+from sibyl.persistence.content_archive import _deserialize_value, _serialize_value
+from sibyl_core.memory_pipeline.audit import decode_audit_metadata, encode_audit_metadata
+
+
+def test_procedure_audit_archive_codec_retains_nulls():
+    original = {"conditional_procedure": {"usage": {"cost_usd": None}, "nested": [None]}}
+    storage = encode_audit_metadata(original)
+    archived = json.loads(json.dumps(_serialize_value(storage)))
+    restored = _deserialize_value(archived)
+    assert restored == storage
+    assert decode_audit_metadata(restored) == original

--- a/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/audit.py
+++ b/packages/python/sibyl-core/src/sibyl_core/memory_pipeline/audit.py
@@ -1,0 +1,43 @@
+"""Lossless storage of conditional procedure audit artifacts.
+
+Surreal flexible objects omit null members. Store the audit as one canonical
+JSON value, while keeping model-facing metadata and legacy object rows intact.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+_KEY = "conditional_procedure"
+AUDIT_STORAGE_PREFIX = "sibyl-audit-json-v1:"
+
+
+def _canonical(value: object) -> str:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    )
+
+
+def decode_audit_metadata(metadata: Mapping[str, object]) -> dict[str, object]:
+    result = dict(metadata)
+    value = result.get(_KEY)
+    if isinstance(value, str) and value.startswith(AUDIT_STORAGE_PREFIX):
+        encoded = value[len(AUDIT_STORAGE_PREFIX) :]
+        try:
+            decoded = json.loads(encoded)
+            if not isinstance(decoded, dict) or _canonical(decoded) != encoded:
+                raise ValueError("noncanonical audit object")
+        except (ValueError, TypeError, RecursionError):
+            # Metadata is also user-authored. Preserve malformed values for
+            # artifact validation without making unrelated memory unreadable.
+            return result
+        result[_KEY] = decoded
+    return result
+
+
+def encode_audit_metadata(metadata: Mapping[str, object]) -> dict[str, object]:
+    result = decode_audit_metadata(metadata)
+    if isinstance(result.get(_KEY), dict):
+        result[_KEY] = AUDIT_STORAGE_PREFIX + _canonical(result[_KEY])
+    return result

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_models.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_models.py
@@ -16,6 +16,7 @@ from sibyl_core.embeddings.providers import (
     EmbeddingProvider,
     create_embedding_provider,
 )
+from sibyl_core.memory_pipeline.audit import decode_audit_metadata, encode_audit_metadata
 from sibyl_core.memory_pipeline.lifecycle import raw_memory_lifecycle_recallable
 from sibyl_core.memory_pipeline.quality import (
     expand_memory_quality_storage_metadata,
@@ -602,7 +603,9 @@ def chunk_from_record(record: Mapping[str, object]) -> ContentChunk:
 
 def raw_memory_from_record(record: Mapping[str, object]) -> RawMemory:
     observed_revision = record.get("revision")
-    metadata = normalize_memory_quality_metadata(coerce_dict(record.get("metadata")))
+    metadata = normalize_memory_quality_metadata(
+        decode_audit_metadata(coerce_dict(record.get("metadata")))
+    )
     return RawMemory(
         id=coerce_str(record.get("uuid")),
         organization_id=coerce_str(record.get("organization_id")),
@@ -674,7 +677,7 @@ def source_record(source: ContentSource) -> SurrealRecord:
 
 
 def raw_memory_record(memory: RawMemory) -> SurrealRecord:
-    metadata = expand_memory_quality_storage_metadata(memory.metadata)
+    metadata = encode_audit_metadata(expand_memory_quality_storage_metadata(memory.metadata))
     record: SurrealRecord = {
         "uuid": memory.id,
         "organization_id": memory.organization_id,

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
@@ -848,6 +848,8 @@ async def save_raw_memory(
     source_observations: Sequence[RawMemory] = (),
     publication_operation_id: str | None = None,
 ) -> RawMemory:
+    from sibyl_core.services.procedure_artifact import publication_build_receipt_json
+
     if expected_revision is not None and expected_revision < 1:
         raise ValueError("expected_revision must be at least 1")
     if (source_observations or publication_operation_id) and expected_revision is None:
@@ -917,7 +919,8 @@ async def save_raw_memory(
                                 OR $observed.memory_scope != $source.memory_scope
                                 OR $observed.scope_key != $source.scope_key
                                 OR $observed.review_state != $source.review_state
-                                OR $observed.metadata != $source.metadata {
+                                OR ($observed.metadata != $source.metadata
+                                    AND $observed.metadata != $source.legacy_metadata) {
                                 THROW 'publication_source_observation_changed';
                             };
                         };
@@ -985,6 +988,11 @@ async def save_raw_memory(
                         else None
                     ),
                     publication_principal_id=memory.principal_id,
+                    publication_build_receipt_json=(
+                        publication_build_receipt_json(memory)
+                        if publication_operation_id or source_observations
+                        else None
+                    ),
                     uuid=memory.id,
                     expected_revision=expected_revision,
                     record=update_record,
@@ -992,7 +1000,9 @@ async def save_raw_memory(
                     source_observations=[
                         {
                             **models.raw_memory_record(source),
-                            "metadata": expand_memory_quality_storage_metadata(source.metadata),
+                            "legacy_metadata": expand_memory_quality_storage_metadata(
+                                source.metadata
+                            ),
                         }
                         for source in source_observations
                     ],

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -37,6 +37,7 @@ from sibyl_core.services.memory_source_validation import (
 from sibyl_core.tasks.consolidation import (
     EVIDENCE_SYSTEM_PROMPT,
     OUTPUT_RETRIES,
+    RENDER_VERSION,
     SCHEMA_VERSION,
     SYSTEM_PROMPT,
     AdmittedTaskOutcome,
@@ -524,6 +525,7 @@ async def _extractor_policy() -> _ExtractorPolicy:
     revision = _digest(
         {
             "protocol": SCHEMA_VERSION,
+            "rendering": RENDER_VERSION,
             "evidence_projection": PROJECTION_VERSION,
             "evidence_validation": EVIDENCE_PROPOSAL_VERSION,
             "projection_system_sha256": hashlib.sha256(EVIDENCE_SYSTEM_PROMPT.encode()).hexdigest(),

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication_guards.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication_guards.py
@@ -22,6 +22,8 @@ IF $publication_operation_id != NONE {
     IF $publication = NONE OR $publication.candidate_id != $uuid
         OR $publication.principal_id != $publication_principal_id
         OR $publication.result_kind != 'candidate'
+        OR $publication_build_receipt_json = NONE
+        OR $publication.build_receipt_json != $publication_build_receipt_json
         OR array::len($publication.admission_bindings ?? []) < 2 {
         THROW 'publication_source_observation_changed';
     };
@@ -67,20 +69,44 @@ async def verify_publication_admissions(memory: RawMemory) -> bool:
     operation_id = memory.metadata.get(EVAL_CONSOLIDATION_METADATA_KEY)
     if operation_id is None:
         return True
+    from sibyl_core.services.procedure_artifact import publication_build_receipt_json
+
     async with content_client.surreal_content_client() as client:
         try:
-            await client.execute_query(
-                "RETURN {" + PUBLICATION_ADMISSION_GUARD + "RETURN true; };",
-                publication_operation_id=operation_id,
-                publication_principal_id=memory.principal_id,
-                organization_id=memory.organization_id,
-                uuid=memory.id,
+            snapshots = content_client.normalize_records(
+                await client.execute_query(
+                    "RETURN {"
+                    + PUBLICATION_ADMISSION_GUARD
+                    + """
+                    LET $ledger = (SELECT * FROM eval_consolidations WHERE
+                        organization_id=$organization_id AND uuid=$publication_operation_id LIMIT 1)[0];
+                    RETURN {ledger:$ledger, captures:(SELECT * FROM raw_captures WHERE
+                        organization_id=$organization_id AND uuid IN
+                        $ledger.admission_bindings.map(|$binding| $binding.capture_id))};
+                    };""",
+                    publication_operation_id=operation_id,
+                    publication_build_receipt_json=publication_build_receipt_json(memory),
+                    publication_principal_id=memory.principal_id,
+                    organization_id=memory.organization_id,
+                    uuid=memory.id,
+                )
             )
         except Exception as exc:
             if "publication_source_observation_changed" in str(exc):
                 return False
             raise
-    return True
+    if len(snapshots) != 1:
+        return False
+    ledger = snapshots[0].get("ledger")
+    captures = snapshots[0].get("captures")
+    if not isinstance(ledger, dict) or not isinstance(captures, list):
+        return False
+    if not all(isinstance(row, dict) for row in captures):
+        return False
+    from sibyl_core.services.procedure_artifact import resolve_procedure_artifact
+
+    artifact = await asyncio.to_thread(resolve_procedure_artifact, memory, ledger, captures)
+    return artifact is not None
 
 
 async def unavailable_publication_ids(
@@ -244,7 +270,9 @@ def _publication_snapshot_recallable(publication, captures, attempts) -> bool:
             or _text_digest(admission.get("receipt_base64")) != binding["receipt_artifact_sha256"]
         ):
             return False
-    return True
+    from sibyl_core.services.procedure_artifact import resolve_procedure_artifact
+
+    return resolve_procedure_artifact(memory, publication, list(captures.values())) is not None
 
 
 def _text_digest(value: object) -> str | None:

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_records.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_records.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, cast
 
+from sibyl_core.memory_pipeline.audit import decode_audit_metadata, encode_audit_metadata
 from sibyl_core.memory_pipeline.quality import (
     expand_memory_quality_storage_metadata,
     normalize_memory_quality_metadata,
@@ -157,7 +158,7 @@ def entity_from_surreal_row(row: Mapping[str, object]) -> Entity:
     record_id = _row_record_id(normalized_row)
     if record_id and record_id != entity_id and metadata.get("record_id") is None:
         metadata["record_id"] = record_id
-    metadata = normalize_memory_quality_metadata(metadata)
+    metadata = normalize_memory_quality_metadata(decode_audit_metadata(metadata))
     name = _first_text(normalized_row.get("name"), normalized_row.get("title"), entity_id)
     identity = metadata.get("reflection_identity")
     stored_name = normalized_row.get("name")
@@ -538,7 +539,7 @@ def relationship_from_surreal_row(row: Mapping[str, object]) -> Relationship:
     record_id = _row_record_id(normalized_row)
     if record_id and record_id != relationship_id and metadata.get("record_id") is None:
         metadata["record_id"] = record_id
-    metadata = normalize_memory_quality_metadata(metadata)
+    metadata = normalize_memory_quality_metadata(decode_audit_metadata(metadata))
 
     return Relationship(
         id=relationship_id,
@@ -697,7 +698,7 @@ def _entity_metadata(entity: Entity) -> dict[str, object]:
     for key, value in model_dump.items():
         if value not in (None, "", [], {}):
             metadata[key] = _jsonable(value)
-    return expand_memory_quality_storage_metadata(metadata)
+    return encode_audit_metadata(expand_memory_quality_storage_metadata(metadata))
 
 
 def _jsonable(value: object) -> object:

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
@@ -992,6 +992,12 @@ async def _verify_promotion_sources(
         except Exception as exc:
             log.warning("promotion_source_read_failed", error_type=type(exc).__name__)
             current = None
+        if current is not None and current.id == publication_candidate_id:
+            from sibyl_core.services.eval_publication_guards import verify_publication_admissions
+
+            if not await verify_publication_admissions(current):
+                verified = False
+                continue
         if (
             current is not None
             and _publication_source_recallable(current, publication_candidate_id)

--- a/packages/python/sibyl-core/src/sibyl_core/services/procedure_artifact.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/procedure_artifact.py
@@ -1,0 +1,117 @@
+"""Verify persisted procedure artifacts against their immutable receipt and sources."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.services.content_models import RawMemory
+from sibyl_core.tasks import consolidation as c
+
+
+@dataclass(frozen=True, slots=True)
+class ProcedureArtifact:
+    group: c.ConsolidationGroup
+    candidate: ReflectionCandidate
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate artifact member")
+        result[key] = value
+    return result
+
+
+def _without_object_nulls(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _without_object_nulls(item) for key, item in value.items() if item is not None}
+    if isinstance(value, list):
+        return [_without_object_nulls(item) for item in value]
+    return value
+
+
+def _artifact_payload(memory: RawMemory) -> dict[str, Any]:
+    payload = memory.metadata.get(c.METADATA_KEY)
+    if not isinstance(payload, dict):
+        raise ValueError("procedure audit is not an object")
+    stored_payload = payload
+    if payload.get("render_version") is None:
+        marker = "## Evidence and build receipt\n\n```json\n"
+        if memory.raw_content.count(marker) != 1 or not memory.raw_content.endswith("\n```"):
+            raise ValueError("legacy procedure audit is not uniquely framed")
+        encoded = memory.raw_content.split(marker, 1)[1][:-4]
+        payload = json.loads(encoded, object_pairs_hook=_strict_object)
+        if not isinstance(payload, dict) or "render_version" in payload:
+            raise ValueError("legacy procedure audit has an invalid shape")
+        if stored_payload != payload and stored_payload != _without_object_nulls(payload):
+            raise ValueError("legacy procedure audit differs from stored metadata")
+    return payload
+
+
+def publication_build_receipt_json(memory: RawMemory) -> str | None:
+    """Bind final publication to the exact receipt retained in the candidate audit.
+
+    This extracts an observation, not an artifact validity or authority verdict.
+    Full reconstruction must still precede publication.
+    """
+    try:
+        receipt = _artifact_payload(memory)["build_receipt"]
+        if not isinstance(receipt, dict):
+            return None
+        return json.dumps(
+            receipt, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+        )
+    except (ValueError, TypeError, KeyError, RecursionError):
+        return None
+
+
+def resolve_procedure_artifact(
+    memory: RawMemory, ledger: dict[str, Any], captures: list[dict[str, Any]]
+) -> ProcedureArtifact | None:
+    """Check artifact agreement without granting source or publication authority."""
+    from sibyl_core.services.eval_publication import ConsolidationConflict, _decode_build_receipt
+
+    try:
+        if (
+            ledger.get("candidate_id") != memory.id
+            or ledger.get("organization_id") != memory.organization_id
+            or ledger.get("principal_id") != memory.principal_id
+            or ledger.get("uuid") != memory.metadata.get("eval_consolidation")
+        ):
+            return None
+        payload = _artifact_payload(memory)
+        receipt = _decode_build_receipt(ledger)
+        if receipt is None or payload.get("build_receipt") != receipt:
+            return None
+        group_data = deepcopy(payload["group"])
+        by_id = {row["uuid"]: row for row in captures}
+        for episode in group_data["episodes"]:
+            sources = episode["stored_sources"]
+            if len(sources) != 1:
+                return None
+            row = by_id[sources[0]["source_id"]]
+            episode["artifact"] = row["raw_content"]
+        group = c.ConsolidationGroup.model_validate_json(json.dumps(group_data))
+        if (group.organization_id, group.owner_principal_id) != (
+            memory.organization_id,
+            memory.principal_id,
+        ):
+            return None
+        candidate = c.reconstruct_candidate_artifact(group, payload)
+        matches = (
+            memory.entity_type == candidate.kind
+            and memory.title == candidate.title
+            and memory.raw_content == candidate.content
+            and all(
+                (payload if key == c.METADATA_KEY else memory.metadata.get(key)) == value
+                for key, value in candidate.metadata.items()
+            )
+        )
+        return ProcedureArtifact(group, candidate) if matches else None
+    except (ValueError, TypeError, KeyError, RecursionError, ConsolidationConflict):
+        return None

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -38,6 +38,7 @@ from sibyl_core.tasks.procedure_evidence import (
 SCHEMA_VERSION = "sibyl-conditional-procedure-v1"
 OUTPUT_RETRIES = 2
 METADATA_KEY = "conditional_procedure"
+RENDER_VERSION = "sibyl-conditional-procedure-render-v2"
 Text = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 SHA256 = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
 RETROSPECTIVE_REQUEST = (
@@ -430,17 +431,25 @@ def _spans(
     return [spans[key] for key in sorted(spans)]
 
 
-def _assertion_text(assertion: ConditionalAssertion) -> str:
-    refs = ", ".join(f"{r.episode_id}:{r.start_byte}:{r.end_byte}" for r in assertion.support)
-    return f"{assertion.statement} ({assertion.label}; {refs})"
-
-
 def _candidate(
     group: ConsolidationGroup,
     draft: DraftConditionalProcedure,
     receipt: dict[str, Any],
     evidence: _ExtractionInput | None = None,
+    *,
+    render_version: str | None = RENDER_VERSION,
 ) -> ReflectionCandidate:
+    if render_version not in (None, RENDER_VERSION):
+        raise ValueError("unsupported conditional procedure rendering version")
+
+    def assertion_text(assertion: ConditionalAssertion, path: str) -> str:
+        if render_version is None:
+            refs = ", ".join(
+                f"{ref.episode_id}:{ref.start_byte}:{ref.end_byte}" for ref in assertion.support
+            )
+            return f"{assertion.statement} ({assertion.label}; {refs})"
+        return f"{assertion.statement} ({assertion.label}; evidence: {path})"
+
     payload = {
         "schema_version": SCHEMA_VERSION,
         "group": group.model_dump(mode="json", exclude={"episodes": {"__all__": {"artifact"}}}),
@@ -448,6 +457,8 @@ def _candidate(
         "spans": _spans(group, draft, evidence),
         "build_receipt": deepcopy(receipt),
     }
+    if render_version is not None:
+        payload["render_version"] = render_version
     title = f"Procedure: {draft.goal.statement}"
     lines = [
         f"# {title}",
@@ -456,21 +467,25 @@ def _candidate(
         "and transfer require separate checks.",
         "",
         "## Goal",
-        _assertion_text(draft.goal),
+        assertion_text(draft.goal, "/goal"),
     ]
-    for heading, assertions in (
-        ("Environment", draft.environment),
-        ("Preconditions", draft.preconditions),
-        ("Required tools", draft.required_tools),
+    for heading, field, assertions in (
+        ("Environment", "environment", draft.environment),
+        ("Preconditions", "preconditions", draft.preconditions),
+        ("Required tools", "required_tools", draft.required_tools),
     ):
-        lines.extend(["", f"## {heading}", *[f"- {_assertion_text(a)}" for a in assertions]])
+        lines.extend(["", f"## {heading}"])
+        lines.extend(
+            f"- {assertion_text(assertion, f'/{field}/{index}')}"
+            for index, assertion in enumerate(assertions)
+        )
     lines.extend(["", "## Actions"])
     steps = []
-    for action in draft.actions:
+    for index, action in enumerate(draft.actions):
         lines.extend(
             [
-                f"{action.order}. {_assertion_text(action.action)}",
-                f"   Check: {_assertion_text(action.success_criteria)}",
+                f"{action.order}. {assertion_text(action.action, f'/actions/{index}/action')}",
+                f"   Check: {assertion_text(action.success_criteria, f'/actions/{index}/success_criteria')}",
             ]
         )
         steps.append(
@@ -481,22 +496,40 @@ def _candidate(
                 success_criteria=action.success_criteria.statement,
             ).model_dump(mode="json")
         )
-    for heading, assertions in (
-        ("Expected result", [draft.expected_result]),
-        ("Failure modes", draft.failure_modes),
-        ("Abstain when", draft.abstain_when),
-    ):
-        lines.extend(["", f"## {heading}", *[f"- {_assertion_text(a)}" for a in assertions]])
     lines.extend(
-        [
-            "",
-            "## Evidence and build receipt",
-            "",
-            "```json",
-            json.dumps(payload, sort_keys=True, ensure_ascii=False, indent=2, allow_nan=False),
-            "```",
-        ]
+        ["", "## Expected result", f"- {assertion_text(draft.expected_result, '/expected_result')}"]
     )
+    for heading, field, assertions in (
+        ("Failure modes", "failure_modes", draft.failure_modes),
+        ("Abstain when", "abstain_when", draft.abstain_when),
+    ):
+        lines.extend(["", f"## {heading}"])
+        lines.extend(
+            f"- {assertion_text(assertion, f'/{field}/{index}')}"
+            for index, assertion in enumerate(assertions)
+        )
+    if render_version is None:
+        lines.extend(
+            [
+                "",
+                "## Evidence and build receipt",
+                "",
+                "```json",
+                json.dumps(payload, sort_keys=True, ensure_ascii=False, indent=2, allow_nan=False),
+                "```",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "## Evidence",
+                "Evidence paths identify assertions in conditional_procedure.procedure metadata. "
+                "Complete source spans, outcomes, and the build receipt remain in "
+                "conditional_procedure metadata.",
+                f"Audit SHA-256: {_digest(_canonical(payload))}",
+            ]
+        )
     return ReflectionCandidate(
         kind="procedure",
         title=title,
@@ -517,6 +550,40 @@ def _candidate(
     )
 
 
+class _ReceiptAgreementError(ValueError):
+    """A retained receipt disagrees with the reconstructed source input."""
+
+
+def reconstruct_candidate_artifact(
+    group: ConsolidationGroup, payload: dict[str, Any]
+) -> ReflectionCandidate:
+    """Rebuild once from source bytes and check the retained receipt.
+
+    This validates artifact consistency, not source authorization or entailment.
+    Callers comparing a stored candidate must also compare the returned artifact.
+    """
+    group = _freeze(group)
+    draft = DraftConditionalProcedure.model_validate(payload["procedure"])
+    receipt = payload["build_receipt"]
+    evidence = _extraction_input(group)
+    if receipt.get("projection") != evidence.projection_receipt:
+        raise _ReceiptAgreementError("build receipt projection differs from frozen evidence")
+    for key, value in {
+        "input": group.model_dump(mode="json"),
+        "prompt": {"system": evidence.system, "user": evidence.prompt},
+        "schema": evidence.output_type.model_json_schema(),
+        "output": ProcedureProposal(procedure=draft).model_dump(mode="json"),
+    }.items():
+        if receipt[f"{key}_sha256"] != _digest(_canonical(value)):
+            raise _ReceiptAgreementError(
+                f"build receipt {key} hash differs from the frozen proposal"
+            )
+    render_version = payload.get("render_version")
+    if render_version != receipt.get("render_version"):
+        raise _ReceiptAgreementError("candidate rendering differs from the build receipt")
+    return _candidate(group, draft, receipt, evidence, render_version=render_version)
+
+
 def validate_candidate_content_agreement(
     candidate: ReflectionCandidate, *, group: ConsolidationGroup
 ) -> list[str]:
@@ -526,22 +593,9 @@ def validate_candidate_content_agreement(
     artifact consistency check, not source authorization or publication admission.
     """
     try:
-        group = _freeze(group)
-        payload = candidate.metadata[METADATA_KEY]
-        draft = DraftConditionalProcedure.model_validate(payload["procedure"])
-        receipt = payload["build_receipt"]
-        evidence = _extraction_input(group)
-        if receipt.get("projection") != evidence.projection_receipt:
-            return ["build receipt projection differs from frozen evidence"]
-        for key, value in {
-            "input": group.model_dump(mode="json"),
-            "prompt": {"system": evidence.system, "user": evidence.prompt},
-            "schema": evidence.output_type.model_json_schema(),
-            "output": ProcedureProposal(procedure=draft).model_dump(mode="json"),
-        }.items():
-            if receipt[f"{key}_sha256"] != _digest(_canonical(value)):
-                return [f"build receipt {key} hash differs from the frozen proposal"]
-        expected = _candidate(group, draft, receipt, evidence)
+        expected = reconstruct_candidate_artifact(group, candidate.metadata[METADATA_KEY])
+    except _ReceiptAgreementError as exc:
+        return [str(exc)]
     except (ValueError, TypeError, KeyError) as exc:
         return [f"invalid proposal payload: {exc}"]
     return [] if candidate == expected else ["candidate differs from the untouched proposal"]
@@ -648,6 +702,7 @@ def _finish_proposal(
     prompt = evidence.prompt
     receipt = {
         "schema_version": SCHEMA_VERSION,
+        "render_version": RENDER_VERSION,
         "evidence_validation": EVIDENCE_PROPOSAL_VERSION,
         "outcome_join": "caller_declared",
         "budget_principal": "caller_declared_matching_active_context_when_present",

--- a/packages/python/sibyl-core/tests/test_eval_publication.py
+++ b/packages/python/sibyl-core/tests/test_eval_publication.py
@@ -350,3 +350,10 @@ async def test_retrospective_framing_changes_extractor_revision(monkeypatch):
     assert RETROSPECTIVE_REQUEST in p.SYSTEM_PROMPT
     monkeypatch.setattr(p, "SYSTEM_PROMPT", p.SYSTEM_PROMPT.replace(RETROSPECTIVE_REQUEST, ""))
     assert await p.consolidation_extractor_configuration() != current
+
+
+async def test_procedure_rendering_changes_extractor_revision(monkeypatch):
+    before = await p.consolidation_extractor_configuration()
+    monkeypatch.setattr(p, "RENDER_VERSION", "future-render-version")
+    after = await p.consolidation_extractor_configuration()
+    assert before != after

--- a/packages/python/sibyl-core/tests/test_procedure_audit_storage.py
+++ b/packages/python/sibyl-core/tests/test_procedure_audit_storage.py
@@ -1,0 +1,335 @@
+"""Conditional audit artifacts survive the actual flexible-object boundary."""
+
+import json
+from copy import deepcopy
+
+import pytest
+
+from sibyl_core.memory_pipeline.audit import (
+    AUDIT_STORAGE_PREFIX,
+    decode_audit_metadata,
+    encode_audit_metadata,
+)
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.services import content_client
+from sibyl_core.services import eval_publication as p
+from sibyl_core.services.graph_records import _entity_metadata, entity_from_surreal_row
+from sibyl_core.tasks import consolidation as c
+from tests.test_eval_publication import admitted_pair as admitted_pair
+from tests.test_eval_publication import content_store as content_store
+from tests.test_eval_publication import evidence as evidence
+from tests.test_eval_publication import proposal as proposal
+from tests.test_eval_publication import rows
+from tests.test_eval_publication_promotion import runtime as runtime
+
+
+async def test_procedure_audit_actual_publication_roundtrip(proposal):
+    op, result = proposal
+    expected = deepcopy(result.candidate.metadata[c.METADATA_KEY])
+    assert expected["build_receipt"]["openrouter_provider"] is None
+    stored = await p.store_consolidation(op, result)
+    assert stored.memory.metadata[c.METADATA_KEY] == expected
+    record = next(row for row in await rows("raw_captures") if row["uuid"] == stored.memory.id)
+    assert isinstance(record["metadata"][c.METADATA_KEY], str)
+    assert json.loads(record["metadata"][c.METADATA_KEY][len(AUDIT_STORAGE_PREFIX) :]) == expected
+    assert (await p.get_stored_consolidation(op)).memory.metadata[c.METADATA_KEY] == expected
+    # The original flexible-object representation demonstrably loses this null.
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE raw_captures SET metadata.conditional_procedure=$audit WHERE uuid=$id;",
+            audit=expected,
+            id=stored.memory.id,
+        )
+    legacy = (await p.get_stored_consolidation(op)).memory.metadata[c.METADATA_KEY]
+    assert "openrouter_provider" not in legacy["build_receipt"]
+
+
+async def test_procedure_audit_graph_encoding_roundtrip(content_store):
+    audit = {"receipt": {"cost": None, "requests": [{"id": None}]}, "unicode": "café"}
+    entity = Entity(
+        id="audit-entity",
+        name="Audit",
+        entity_type=EntityType.PATTERN,
+        metadata={c.METADATA_KEY: audit},
+    )
+    metadata = _entity_metadata(entity)
+    assert isinstance(metadata[c.METADATA_KEY], str)
+    # JSON archive transport must retain the encoded storage value exactly.
+    restored = json.loads(json.dumps(metadata))
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "DEFINE TABLE audit_graph SCHEMALESS; CREATE audit_graph CONTENT $row;",
+            row={
+                "uuid": entity.id,
+                "name": entity.name,
+                "entity_type": "pattern",
+                "metadata": restored,
+            },
+        )
+        records = content_client.normalize_records(
+            await client.execute_query("SELECT * FROM audit_graph;")
+        )
+    assert entity_from_surreal_row(records[0]).metadata[c.METADATA_KEY] == audit
+
+
+@pytest.mark.parametrize(
+    "value", ["null", "[]", '{"x":NaN}', '{"x":1,"x":2}', "{", '{ "x": null }', False]
+)
+def test_procedure_audit_legacy_values_preserved(value):
+    original = {c.METADATA_KEY: value}
+    assert decode_audit_metadata(original) == original
+    assert encode_audit_metadata(original) == original
+
+
+@pytest.mark.parametrize(
+    "encoded", ["null", "[]", '{"x":NaN}', '{"x":1,"x":2}', "{", '{ "x": null }']
+)
+async def test_procedure_audit_malformed_tag_preserved_but_untrusted(proposal, encoded):
+    _, result = proposal
+    value = AUDIT_STORAGE_PREFIX + encoded
+    metadata = {c.METADATA_KEY: value}
+    assert decode_audit_metadata(metadata) == metadata
+    assert encode_audit_metadata(metadata) == metadata
+    candidate = deepcopy(result.candidate)
+    candidate.metadata[c.METADATA_KEY] = value
+    assert c.validate_candidate_content_agreement(candidate, group=result.group)
+
+
+def test_procedure_audit_legacy_and_no_mutation():
+    original = {c.METADATA_KEY: {"nested": {"x": None}}, "ordinary": {"y": None}}
+    assert decode_audit_metadata(original) == original
+    encoded = encode_audit_metadata(original)
+    assert decode_audit_metadata(encoded) == original
+    assert original[c.METADATA_KEY]["nested"]["x"] is None
+    assert encoded["ordinary"] == original["ordinary"]
+
+
+async def test_procedure_audit_actual_promotion_retains_nulls(proposal, runtime):
+    from sibyl_core.services.memory_reflection import promote_reflection_candidate_review
+    from sibyl_core.services.surreal_content import get_raw_memory
+
+    op, result = proposal
+    expected = deepcopy(result.candidate.metadata[c.METADATA_KEY])
+    stored = await p.store_consolidation(op, result)
+    promoted = await promote_reflection_candidate_review(
+        candidate_id=stored.memory.id,
+        organization_id=op.organization_id,
+        principal_id=op.principal_id,
+        promote_to_scope="private",
+    )
+    assert promoted.success
+    graph = await runtime.entity_manager.get(promoted.promoted_id)
+    raw = await get_raw_memory(organization_id=op.organization_id, memory_id=stored.memory.id)
+    assert graph.metadata[c.METADATA_KEY] == expected
+    assert raw.metadata[c.METADATA_KEY] == expected
+    again = await promote_reflection_candidate_review(
+        candidate_id=stored.memory.id,
+        organization_id=op.organization_id,
+        principal_id=op.principal_id,
+        promote_to_scope="private",
+    )
+    assert again.success and again.promoted_id == promoted.promoted_id
+
+
+@pytest.mark.parametrize(
+    "value", ["historical user annotation", '{"x":null}', False, AUDIT_STORAGE_PREFIX + "{"]
+)
+async def test_procedure_audit_legacy_does_not_poison_scope_list(content_store, value):
+    from sibyl_core.services.content_raw_persistence import remember_raw_memory
+    from sibyl_core.services.content_raw_recall import list_raw_memories_for_scope
+
+    ordinary = await remember_raw_memory(
+        organization_id="org",
+        principal_id="owner",
+        source_id="ordinary",
+        raw_content="ordinary preserved",
+        embedding_provider=None,
+    )
+    legacy = await remember_raw_memory(
+        organization_id="org",
+        principal_id="owner",
+        source_id="legacy",
+        raw_content="historical metadata",
+        embedding_provider=None,
+    )
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE raw_captures SET metadata.conditional_procedure=$value WHERE uuid=$uuid;",
+            value=value,
+            uuid=legacy.id,
+        )
+    memories = await list_raw_memories_for_scope(
+        organization_id="org", principal_id="owner", include_lifecycle_hidden=True
+    )
+    by_id = {m.id: m for m in memories}
+    assert ordinary.id in by_id
+    assert by_id[legacy.id].metadata[c.METADATA_KEY] == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        AUDIT_STORAGE_PREFIX + "{",
+        AUDIT_STORAGE_PREFIX + "{}",
+        AUDIT_STORAGE_PREFIX + '{"x":1e9999}',
+    ],
+)
+async def test_procedure_audit_invalid_artifact_never_writes_graph(proposal, runtime, value):
+    from sibyl_core.services.memory_reflection import promote_reflection_candidate_review
+
+    op, result = proposal
+    stored = await p.store_consolidation(op, result)
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE raw_captures SET metadata.conditional_procedure=$value WHERE uuid=$uuid;",
+            value=value,
+            uuid=stored.memory.id,
+        )
+    promoted = await promote_reflection_candidate_review(
+        candidate_id=stored.memory.id,
+        organization_id=op.organization_id,
+        principal_id=op.principal_id,
+        promote_to_scope="private",
+    )
+    assert not promoted.success
+    assert await runtime.entity_manager.list_by_type(EntityType.PROCEDURE) == []
+
+
+def test_procedure_audit_deep_invalid_tag_remains_opaque():
+    value = AUDIT_STORAGE_PREFIX + "[" * 2000 + "0" + "]" * 2000
+    assert decode_audit_metadata({c.METADATA_KEY: value}) == {c.METADATA_KEY: value}
+
+
+@pytest.mark.parametrize("tamper", [None, "body", "receipt", "source", "metadata"])
+async def test_procedure_audit_legacy_recovery_requires_complete_agreement(proposal, tamper):
+    from dataclasses import replace
+
+    from sibyl_core.services.procedure_artifact import resolve_procedure_artifact
+
+    op, result = proposal
+    receipt = deepcopy(result.receipt)
+    receipt.pop("render_version")
+    legacy = c._candidate(
+        result.group,
+        result.proposal.procedure,
+        receipt,
+        c._extraction_input(result.group),
+        render_version=None,
+    )
+    stored = await p.store_consolidation(op, replace(result, candidate=legacy, receipt=receipt))
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE raw_captures SET metadata.conditional_procedure=$audit WHERE uuid=$uuid;",
+            audit=legacy.metadata[c.METADATA_KEY],
+            uuid=stored.memory.id,
+        )
+    memory = (await p.get_stored_consolidation(op)).memory
+    ledger = (await rows("eval_consolidations"))[0]
+    captures = await rows("raw_captures")
+    if tamper == "body":
+        memory = replace(
+            memory,
+            raw_content=memory.raw_content.replace(
+                '"schema_version":', '"schema_version":"forged","schema_version":', 1
+            ),
+        )
+    elif tamper == "receipt":
+        changed = json.loads(ledger["build_receipt_json"])
+        changed["output_sha256"] = "0" * 64
+        ledger["build_receipt_json"] = json.dumps(
+            changed, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        )
+    elif tamper == "source":
+        source_id = result.group.episodes[0].stored_sources[0].source_id
+        next(row for row in captures if row["uuid"] == source_id)["raw_content"] = "replaced"
+    elif tamper == "metadata":
+        memory.metadata[c.METADATA_KEY]["procedure"]["goal"]["statement"] = "replaced"
+    artifact = resolve_procedure_artifact(memory, ledger, captures)
+    assert (artifact is not None) == (tamper is None)
+    if artifact is not None:
+        assert artifact.candidate.content == legacy.content
+        assert artifact.candidate.metadata[c.METADATA_KEY] == legacy.metadata[c.METADATA_KEY]
+
+
+async def test_procedure_audit_corruption_after_promotion_denies_recall(proposal, runtime):
+    from sibyl_core.services.content_raw_recall import recall_raw_memory
+    from sibyl_core.services.memory_reflection import promote_reflection_candidate_review
+
+    op, result = proposal
+    stored = await p.store_consolidation(op, result)
+    promoted = await promote_reflection_candidate_review(
+        candidate_id=stored.memory.id,
+        organization_id=op.organization_id,
+        principal_id=op.principal_id,
+        promote_to_scope="private",
+    )
+    assert promoted.success
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query(
+            "UPDATE raw_captures SET metadata.conditional_procedure=$value WHERE uuid=$uuid;",
+            value=AUDIT_STORAGE_PREFIX + "{}",
+            uuid=stored.memory.id,
+        )
+    memories = await recall_raw_memory(
+        organization_id=op.organization_id,
+        principal_id=op.principal_id,
+        query="Check the actual output",
+    )
+    assert stored.memory.id not in {memory.id for memory in memories}
+
+
+async def test_procedure_audit_verification_builds_once_off_event_loop(proposal, monkeypatch):
+    import threading
+
+    from sibyl_core.services.eval_publication_guards import verify_publication_admissions
+
+    op, result = proposal
+    stored = await p.store_consolidation(op, result)
+    main_thread = threading.get_ident()
+    calls = []
+    original = c._extraction_input
+
+    def observed(group):
+        calls.append(threading.get_ident())
+        return original(group)
+
+    monkeypatch.setattr(c, "_extraction_input", observed)
+    assert await verify_publication_admissions(stored.memory)
+    assert len(calls) == 1
+    assert calls[0] != main_thread
+
+
+async def test_procedure_audit_receipt_change_at_commit_denies_promotion(
+    proposal, runtime, monkeypatch
+):
+    from sibyl_core.services.memory_reflection import promote_reflection_candidate_review
+
+    operation, result = proposal
+    stored = await p.store_consolidation(operation, result)
+    mutations = []
+    async with content_client.surreal_content_client() as client:
+        execute = client.execute_query_raw
+
+        async def intercepted(sql, **params):
+            if (
+                params.get("publication_operation_id")
+                and params.get("source_observations")
+                and not mutations
+            ):
+                await client.execute_query(
+                    "UPDATE eval_consolidations SET build_receipt_json=$value WHERE uuid=$uuid;",
+                    value="{}",
+                    uuid=params["publication_operation_id"],
+                )
+                mutations.append(True)
+            return await execute(sql, **params)
+
+        monkeypatch.setattr(client, "execute_query_raw", intercepted)
+        outcome = await promote_reflection_candidate_review(
+            candidate_id=stored.memory.id,
+            organization_id=operation.organization_id,
+            principal_id=operation.principal_id,
+            promote_to_scope="private",
+        )
+    assert mutations == [True]
+    assert not outcome.success

--- a/packages/python/sibyl-core/tests/test_tasks_consolidation.py
+++ b/packages/python/sibyl-core/tests/test_tasks_consolidation.py
@@ -337,7 +337,11 @@ async def test_proposal_preserves_usage_bytes_sources_and_native_steps(group, pr
         )
         assert span["artifact_sha256"] == episode.artifact_sha256
     assert "inferred" in candidate.content
-    assert "capture-success" in candidate.content
+    assert "capture-success" in candidate.raw_source_ids
+    assert "capture-success" not in candidate.content
+    assert "```json" not in candidate.content
+    assert "evidence: /goal" in candidate.content
+    assert payload["render_version"] == c.RENDER_VERSION
     assert str(len(group.episodes[0].artifact)) in result.prompt
     assert c.validate_candidate_content_agreement(candidate, group=group) == []
     entity = Entity(
@@ -572,3 +576,37 @@ async def test_native_build_counts_transformed_schema_and_records_policy(group, 
     assert result.receipt["input_chars"] == actual
     assert result.receipt["output_mode"] == "native_strict"
     assert result.receipt["openrouter_provider"] == "parasail/bf16"
+
+
+async def test_compact_render_keeps_full_audit_without_growing_readable_body(
+    group, procedure, model
+):
+    result = await propose(group, procedure, model)
+    receipt = copy.deepcopy(result.receipt)
+    receipt["diagnostic"] = "retained audit detail " * 10000
+    expanded = c._candidate(group, procedure, receipt)
+    assert len(expanded.content) == len(result.candidate.content)
+    assert expanded.metadata[c.METADATA_KEY]["build_receipt"] == receipt
+    assert expanded.content != result.candidate.content
+    assert "retained audit detail" not in expanded.content
+    assert (
+        expanded.metadata[c.METADATA_KEY]["spans"]
+        == result.candidate.metadata[c.METADATA_KEY]["spans"]
+    )
+
+
+async def test_historical_render_remains_verifiable_and_rejects_version_mismatch(
+    group, procedure, model
+):
+    result = await propose(group, procedure, model)
+    receipt = copy.deepcopy(result.receipt)
+    receipt.pop("render_version")
+    historical = c._candidate(group, procedure, receipt, render_version=None)
+    assert "```json" in historical.content
+    assert c.validate_candidate_content_agreement(historical, group=group) == []
+    historical.metadata[c.METADATA_KEY]["render_version"] = c.RENDER_VERSION
+    assert c.validate_candidate_content_agreement(historical, group=group)
+    current = copy.deepcopy(result.candidate)
+    current.metadata[c.METADATA_KEY]["render_version"] = "unknown"
+    current.metadata[c.METADATA_KEY]["build_receipt"]["render_version"] = "unknown"
+    assert c.validate_candidate_content_agreement(current, group=group)


### PR DESCRIPTION
A conditional procedure could carry hundreds of repeated citations and a full JSON audit in its readable body. Storing that audit as a flexible database object also dropped nested nulls, making the stored artifact disagree with its original receipt. Procedures now use compact evidence pointers in their bodies and retain the complete audit through a tagged canonical JSON representation.

## 🛠️ Artifact agreement at publication

Promotion reconstructs the candidate from its original source bytes and protected build receipt, then compares the exact rendered artifact. The final transaction checks the original source observations and canonical receipt together. Changing candidate evidence or replacing the ledger receipt immediately before commit denies publication. Recall excludes artifacts corrupted after promotion.

Legacy procedures recover their full audit from the original fenced JSON only when the content, receipt and source reconstruction agree. Arbitrary historical metadata remains readable. Unknown or malformed tagged values cannot authorize a procedure promotion. The rendering version participates in extraction identity, preserving legacy replay behavior.

Evidence projection reconstruction runs once off the event loop. Legacy receipt extraction still parses its fenced JSON synchronously. One retained production artifact shrank from 357,865 to 9,938 body characters while preserving all assertions and source spans; that measurement does not establish semantic correctness.

## 🧪 Validation

Independent native SurrealDB 3.2.3 verification passed 42 controls, plus a separate null-omitted legacy promotion check. The cases cover malformed audits, candidate/source/receipt mutations at final commit, post-promotion recall, legacy availability and single off-thread reconstruction. The API archive codec check passed, and all owned verification containers were removed.

After integrating current main, 204 core and 35 API tests passed. Core/API lint, formatting and type checks passed. Three root spot checks passed before integration. No provider calls or original-instance mutations were required.

Artifact validation does not prove factual grounding or learning benefit. The original generated candidate remains rejected on grounding. Full disaster recovery and measured transfer remain separate release gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable preservation of conditional procedure audit details, including null and Unicode values, across storage and retrieval.
  - Introduced versioned procedure rendering with clearer evidence guidance, expected results, failure modes, and abstention conditions.
  - Added support for recovering and validating procedure artifacts from their recorded sources and receipts.

- **Bug Fixes**
  - Publication and promotion checks now reject missing, changed, corrupted, or unverifiable artifacts.
  - Improved compatibility with legacy audit records while preserving malformed values safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->