### PR TITLE
fix(web): make memory capture inspection optional

### DIFF
--- a/apps/web/src/app/(main)/dashboard-content.test.tsx
+++ b/apps/web/src/app/(main)/dashboard-content.test.tsx
@@ -273,12 +273,12 @@ describe('DashboardContent', () => {
     expect(openCaptureMemory).toHaveBeenCalledWith('dashboard');
   });
 
-  it('links the dashboard to the memory review queue', () => {
+  it('links the dashboard to optional memory inspection', () => {
     render(<DashboardContent initialStats={initialStats} />);
 
-    expect(screen.getByRole('link', { name: /review memory/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /inspect memory/i })).toHaveAttribute(
       'href',
-      '/memory/captures?link=unlinked'
+      '/memory/captures'
     );
   });
 

--- a/apps/web/src/app/(main)/dashboard-content.tsx
+++ b/apps/web/src/app/(main)/dashboard-content.tsx
@@ -891,7 +891,7 @@ export function DashboardContent({ initialStats }: DashboardContentProps) {
               </button>
 
               <Link
-                href="/memory/captures?link=unlinked"
+                href="/memory/captures"
                 className="flex items-center gap-2 sm:gap-3 p-2.5 sm:p-3 bg-sc-bg-highlight rounded-lg sm:rounded-xl border border-sc-fg-subtle/10 hover:border-sc-yellow/30 hover:bg-sc-bg-surface transition-colors duration-200 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sc-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-sc-bg-elevated"
               >
                 <div className="w-8 h-8 sm:w-9 sm:h-9 rounded-lg bg-sc-yellow/10 flex items-center justify-center shrink-0">
@@ -903,10 +903,10 @@ export function DashboardContent({ initialStats }: DashboardContentProps) {
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="text-xs sm:text-sm font-medium text-sc-fg-primary group-hover:text-sc-yellow transition-colors truncate">
-                    Review Memory
+                    Inspect Memory
                   </div>
                   <div className="text-[10px] sm:text-xs text-sc-fg-muted truncate">
-                    Triage captures waiting on graph linkage
+                    Explore saved captures and their sources
                   </div>
                 </div>
                 <ArrowRight

--- a/apps/web/src/app/(main)/memory/captures/page.tsx
+++ b/apps/web/src/app/(main)/memory/captures/page.tsx
@@ -6,7 +6,7 @@ export default function MemoryCapturesPage() {
     <RawCaptureReview
       basePath="/memory/captures"
       title="Memory Captures"
-      description="Review raw captures, graph linkage, and queued memory actions"
+      description="Inspect saved captures and graph links whenever you need to"
       breadcrumbItems={[
         { label: 'Home', href: '/' },
         { label: 'Memory', href: '/memory', icon: Database },

--- a/apps/web/src/app/(main)/memory/page.test.tsx
+++ b/apps/web/src/app/(main)/memory/page.test.tsx
@@ -226,9 +226,13 @@ describe('MemoryContent', () => {
 
     expect(screen.getByText('Memory Workspace')).toBeInTheDocument();
     expect(screen.getByText('Recent Captures')).toBeInTheDocument();
-    expect(screen.getByText('Review Actions')).toBeInTheDocument();
+    expect(screen.queryByText('Review Actions')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /inspect captures/i })).toHaveAttribute(
+      'href',
+      '/memory/captures'
+    );
     expect(screen.getByText('Recent Imports')).toBeInTheDocument();
-    expect(screen.getByText('Reflection Queue')).toBeInTheDocument();
+    expect(screen.getByText('Reflection Candidates')).toBeInTheDocument();
     expect(screen.getByText('Agent Access')).toBeInTheDocument();
     expect(screen.getByText('Terminal capture')).toBeInTheDocument();
     expect(screen.getByText('Mailbox import')).toBeInTheDocument();

--- a/apps/web/src/app/(main)/memory/page.tsx
+++ b/apps/web/src/app/(main)/memory/page.tsx
@@ -6,7 +6,8 @@ import { MemoryContent } from './memory-content';
 
 export const metadata: Metadata = {
   title: 'Memory',
-  description: 'Memory workspace for captures, review actions, recalls, and agent access',
+  description:
+    'Memory workspace for saved captures, optional inspection, recalls, and agent access',
 };
 
 export default function MemoryPage() {

--- a/apps/web/src/components/memory/memory-home.tsx
+++ b/apps/web/src/components/memory/memory-home.tsx
@@ -139,7 +139,7 @@ function scopeDot(scope: MemoryScope | null): string {
 
 interface HeroProps {
   captureCount: number;
-  pendingCount: number;
+  unlinkedCount: number;
   recallCount: number;
   agentReaders: number;
   scopeChip: string | null;
@@ -147,7 +147,7 @@ interface HeroProps {
 
 function MemoryHero({
   captureCount,
-  pendingCount,
+  unlinkedCount,
   recallCount,
   agentReaders,
   scopeChip,
@@ -172,19 +172,13 @@ function MemoryHero({
               )}
             </div>
             <p className="text-[11px] text-sc-fg-muted">
-              Raw memory, imports, review, recall, and source-grounded synthesis.
+              Saved memory, imports, recall, and source-grounded synthesis.
             </p>
           </div>
         </div>
         <div className="flex flex-wrap gap-x-4 gap-y-1 pl-10 text-[11px] sm:pl-0">
           <HeroStat icon={Database} tone="cyan" value={captureCount} label="captures" />
-          <HeroStat
-            icon={WarningCircle}
-            tone="yellow"
-            value={pendingCount}
-            label="to review"
-            pulse={pendingCount > 0}
-          />
+          <HeroStat icon={WarningCircle} tone="yellow" value={unlinkedCount} label="unlinked" />
           <HeroStat icon={Search} tone="coral" value={recallCount} label="recalls" />
           <HeroStat icon={Key} tone="purple" value={agentReaders} label="readers" />
         </div>
@@ -246,12 +240,6 @@ function MemoryExplainer({ onDismiss }: { onDismiss: () => void }) {
       body: 'Raw memory written from CLI, MCP, the web, or imports. Source of truth.',
     },
     {
-      icon: WarningCircle,
-      tone: 'yellow',
-      title: 'Review',
-      body: 'Captures or reflections waiting for you to confirm, link, or correct.',
-    },
-    {
       icon: Search,
       tone: 'coral',
       title: 'Recalls',
@@ -261,7 +249,7 @@ function MemoryExplainer({ onDismiss }: { onDismiss: () => void }) {
       icon: Eye,
       tone: 'purple',
       title: 'Inspections',
-      body: 'When someone opened a source to see what it is, who wrote it, and why.',
+      body: 'Optional source visits to inspect saved content, history, and correction controls.',
     },
   ];
 
@@ -278,7 +266,7 @@ function MemoryExplainer({ onDismiss }: { onDismiss: () => void }) {
       <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-sc-fg-subtle">
         What you're looking at
       </p>
-      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-2 sm:grid-cols-3">
         {concepts.map(concept => {
           const toneClass = {
             cyan: 'text-sc-cyan',
@@ -611,7 +599,6 @@ export function MemoryHome() {
   }
 
   const capturesQuery = useRawCaptures({ limit: 24 });
-  const pendingQuery = useRawCaptures({ review_state: 'pending', limit: 24 });
   const importsQuery = useRawCaptures({ capture_surface: 'source_import', limit: 8 });
   const reflectionsQuery = useRawCaptures({
     capture_surface: 'reflection_candidate',
@@ -625,11 +612,6 @@ export function MemoryHome() {
     () =>
       (capturesQuery.data?.captures ?? []).filter(capture => matchesCaptureScope(scope, capture)),
     [capturesQuery.data?.captures, scope]
-  );
-  const pending = useMemo(
-    () =>
-      (pendingQuery.data?.captures ?? []).filter(capture => matchesCaptureScope(scope, capture)),
-    [pendingQuery.data?.captures, scope]
   );
   const imports = useMemo(
     () =>
@@ -655,14 +637,9 @@ export function MemoryHome() {
   const recalls = events.filter(eventIsRecall);
   const agentAccess = events.filter(eventIsAgentAccess);
   const synthesisEvents = events.filter(event => event.action.includes('synthesis'));
-  const isLoading =
-    capturesQuery.isLoading &&
-    pendingQuery.isLoading &&
-    auditQuery.isLoading &&
-    spacesQuery.isLoading;
+  const isLoading = capturesQuery.isLoading && auditQuery.isLoading && spacesQuery.isLoading;
   const panelErrors = [
     capturesQuery.error,
-    pendingQuery.error,
     importsQuery.error,
     reflectionsQuery.error,
     auditQuery.error,
@@ -680,7 +657,7 @@ export function MemoryHome() {
     <div className="space-y-4">
       <MemoryHero
         captureCount={captures.length}
-        pendingCount={pending.length}
+        unlinkedCount={captures.filter(capture => !capture.entity_id).length}
         recallCount={recalls.length}
         agentReaders={agentReaders}
         scopeChip={scopeChip}
@@ -712,16 +689,11 @@ export function MemoryHome() {
           tone="cyan"
         />
         <PrimaryActionTile
-          href="/memory/captures?link=unlinked"
-          icon={WarningCircle}
-          label="Review Queue"
-          description={
-            pending.length > 0
-              ? `${pending.length} captures waiting on your review`
-              : 'Triage pending captures and reflections'
-          }
-          tone="coral"
-          badge={pending.length > 0 ? `${pending.length}` : undefined}
+          href="/memory/captures"
+          icon={FileText}
+          label="Inspect Captures"
+          description="Explore saved content or make an optional correction"
+          tone="cyan"
         />
       </div>
 
@@ -758,42 +730,19 @@ export function MemoryHome() {
             <CaptureRows captures={captures.slice(0, 6)} emptyLabel="No captures in this scope" />
           </Panel>
 
-          <Panel
-            title="Review Actions"
-            icon={WarningCircle}
-            iconTone="yellow"
-            count={pending.length}
-            action={
-              pending.length > 0 && (
-                <Link
-                  href="/memory/captures?link=unlinked"
-                  className="rounded text-[11px] font-medium text-sc-yellow transition-colors duration-200 hover:text-sc-yellow/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sc-cyan focus-visible:ring-offset-2 focus-visible:ring-offset-sc-bg-elevated"
-                >
-                  Open Queue →
-                </Link>
-              )
-            }
-          >
-            <CaptureRows
-              captures={pending.slice(0, 5)}
-              emptyLabel="Inbox zero. No pending reviews."
-              linkToReview
-            />
-          </Panel>
-
           <div className="grid gap-4 lg:grid-cols-2">
             <Panel title="Recent Imports" icon={Upload} iconTone="cyan" count={imports.length}>
               <CaptureRows captures={imports.slice(0, 4)} emptyLabel="No source imports yet" />
             </Panel>
             <Panel
-              title="Reflection Queue"
+              title="Reflection Candidates"
               icon={LightBulb}
               iconTone="coral"
               count={reflections.length}
             >
               <CaptureRows
                 captures={reflections.slice(0, 4)}
-                emptyLabel="No reflection candidates waiting"
+                emptyLabel="No reflection candidates in this view"
                 linkToReview
               />
             </Panel>

--- a/apps/web/src/components/memory/raw-capture-review.test.tsx
+++ b/apps/web/src/components/memory/raw-capture-review.test.tsx
@@ -97,7 +97,7 @@ describe('RawCaptureReview', () => {
     expect(screen.getByText('Verbatim Content')).toBeInTheDocument();
     expect(screen.getByText('remember this exact text from the dashboard')).toBeInTheDocument();
     expect(screen.getAllByText('Quick memory').length).toBeGreaterThan(0);
-    expect(screen.getByText('Needs link')).toBeInTheDocument();
+    expect(screen.getAllByText('Unlinked').length).toBeGreaterThan(0);
   });
 
   it('updates the memory captures route when selecting a different capture', async () => {
@@ -121,7 +121,7 @@ describe('RawCaptureReview', () => {
   it('filters captures down to entries that still need linking', async () => {
     const { user } = render(<RawCaptureReview />);
 
-    await user.click(screen.getByRole('button', { name: /needs link1/i }));
+    await user.click(screen.getByRole('button', { name: /unlinked1/i }));
 
     expect(
       screen.getByRole('button', { name: /select capture deep thought/i })
@@ -132,19 +132,19 @@ describe('RawCaptureReview', () => {
     expect(screen.getByText('remember this exact text from the terminal')).toBeInTheDocument();
   });
 
-  it('starts in the needs-link queue when requested in the url', () => {
+  it('starts in the unlinked view when requested in the url', () => {
     navigationState.searchParams = new URLSearchParams('link=unlinked');
 
     render(<RawCaptureReview />);
 
-    expect(screen.getByText('Needs Link Queue')).toBeInTheDocument();
+    expect(screen.getByText('Unlinked Captures')).toBeInTheDocument();
     expect(screen.getByText('remember this exact text from the terminal')).toBeInTheDocument();
     expect(
       screen.queryByText('remember this exact text from the dashboard')
     ).not.toBeInTheDocument();
   });
 
-  it('advances review navigation from the detail pane', async () => {
+  it('advances capture navigation from the detail pane', async () => {
     const { user } = render(<RawCaptureReview />);
 
     await user.click(screen.getByRole('button', { name: 'Next' }));
@@ -152,21 +152,29 @@ describe('RawCaptureReview', () => {
     expect(replace).toHaveBeenCalledWith('/memory/captures?id=raw-2', { scroll: false });
   });
 
-  it('sends a defer action for the selected capture', async () => {
-    const mutateAsync = vi.fn().mockResolvedValue({
-      ...captureList.captures[0],
-      raw_content: 'remember this exact text from the dashboard',
-      review_state: 'deferred',
+  it('does not silently hide deferred unlinked captures', () => {
+    navigationState.searchParams = new URLSearchParams('link=unlinked');
+    hooks.useRawCaptures.mockReturnValue({
+      data: {
+        ...captureList,
+        captures: captureList.captures.map(capture => ({ ...capture, review_state: 'deferred' })),
+      },
+      isLoading: false,
+      error: null,
     });
-    hooks.useUpdateRawCaptureReviewState.mockReturnValue({
-      mutateAsync,
-      isPending: false,
-    });
+    render(<RawCaptureReview />);
+    expect(
+      screen.getByRole('button', { name: /select capture deep thought/i })
+    ).toBeInTheDocument();
+  });
 
-    const { user } = render(<RawCaptureReview />);
-
-    await user.click(screen.getByRole('button', { name: 'Defer' }));
-
-    expect(mutateAsync).toHaveBeenCalledWith({ id: 'raw-1', reviewState: 'deferred' });
+  it('keeps inspection optional and links to existing correction controls', () => {
+    render(<RawCaptureReview />);
+    expect(screen.queryByRole('button', { name: 'Defer' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Return to Queue' })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /inspect source or make a correction/i })
+    ).toHaveAttribute('href', '/memory/sources/raw-1');
+    expect(screen.getByText(/inspection is optional/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/memory/raw-capture-review.tsx
+++ b/apps/web/src/components/memory/raw-capture-review.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { toast } from 'sonner';
 import { useSetBreadcrumb } from '@/components/layout/breadcrumb';
 import { PageHeader } from '@/components/layout/page-header';
 import { EntityBadge } from '@/components/ui/badge';
@@ -30,11 +29,11 @@ import {
 } from '@/components/ui/select';
 import { LoadingState } from '@/components/ui/spinner';
 import { formatDateTime, formatDistanceToNow } from '@/lib/constants/formatting';
-import { useRawCapture, useRawCaptures, useUpdateRawCaptureReviewState } from '@/lib/hooks/memory';
+import { useRawCapture, useRawCaptures } from '@/lib/hooks/memory';
 
 const MAX_CAPTURE_RESULTS = 200;
 const DEFAULT_TITLE = 'Memory Captures';
-const DEFAULT_DESCRIPTION = 'Review raw captures, graph linkage, and queued memory actions';
+const DEFAULT_DESCRIPTION = 'Inspect saved captures and graph links whenever you need to';
 type LinkFilter = 'all' | 'linked' | 'unlinked';
 type ReviewFilter = 'all' | 'pending' | 'deferred' | 'archived';
 
@@ -95,17 +94,17 @@ function normalizeLinkFilter(value: string | null): LinkFilter {
   return value === 'linked' || value === 'unlinked' ? value : 'all';
 }
 
-function normalizeReviewFilter(value: string | null, linkFilter: LinkFilter): ReviewFilter {
+function normalizeReviewFilter(value: string | null): ReviewFilter {
   if (value === 'pending' || value === 'deferred' || value === 'archived') {
     return value;
   }
 
-  return linkFilter === 'unlinked' ? 'pending' : 'all';
+  return 'all';
 }
 
 function reviewStateLabel(value: ReviewFilter | 'pending' | 'deferred' | 'archived'): string {
   if (value === 'all') return 'All states';
-  if (value === 'pending') return 'Open';
+  if (value === 'pending') return 'Stored';
   return titleCase(value);
 }
 
@@ -127,7 +126,7 @@ export function RawCaptureReview({
   const [typeFilter, setTypeFilter] = useState('all');
   const [linkFilter, setLinkFilter] = useState<LinkFilter>(initialLinkFilter);
   const [reviewFilter, setReviewFilter] = useState<ReviewFilter>(() =>
-    normalizeReviewFilter(searchParams.get('review'), initialLinkFilter)
+    normalizeReviewFilter(searchParams.get('review'))
   );
 
   const { data, isLoading, error } = useRawCaptures({
@@ -135,7 +134,6 @@ export function RawCaptureReview({
     entity_type: typeFilter === 'all' ? undefined : typeFilter,
     capture_surface: surfaceFilter === 'all' ? undefined : surfaceFilter,
   });
-  const updateReviewState = useUpdateRawCaptureReviewState();
 
   const captures = data?.captures ?? [];
   const surfaceOptions = useMemo(
@@ -241,14 +239,11 @@ export function RawCaptureReview({
   const updateLinkFilter = useCallback(
     (next: LinkFilter) => {
       setLinkFilter(next);
-      const nextReview = next === 'unlinked' && reviewFilter === 'all' ? 'pending' : reviewFilter;
-      setReviewFilter(nextReview);
       replaceCaptureParams({
         link: next === 'all' ? null : next,
-        review: nextReview === 'all' ? null : nextReview,
       });
     },
-    [replaceCaptureParams, reviewFilter]
+    [replaceCaptureParams]
   );
 
   const updateReviewFilter = useCallback(
@@ -273,8 +268,7 @@ export function RawCaptureReview({
   }, [searchParams]);
 
   useEffect(() => {
-    const nextLink = normalizeLinkFilter(searchParams.get('link'));
-    const nextReview = normalizeReviewFilter(searchParams.get('review'), nextLink);
+    const nextReview = normalizeReviewFilter(searchParams.get('review'));
     setReviewFilter(current => (current === nextReview ? current : nextReview));
   }, [searchParams]);
 
@@ -288,23 +282,6 @@ export function RawCaptureReview({
       archived: captures.filter(capture => capture.review_state === 'archived').length,
     };
   }, [captures]);
-
-  async function handleReviewAction(next: 'pending' | 'deferred' | 'archived') {
-    if (!selectedCapture) return;
-
-    try {
-      await updateReviewState.mutateAsync({ id: selectedCapture.id, reviewState: next });
-      toast.success(
-        next === 'pending'
-          ? 'Capture returned to the review queue'
-          : next === 'deferred'
-            ? 'Capture deferred'
-            : 'Capture archived from the queue'
-      );
-    } catch {
-      toast.error('Failed to update capture review state');
-    }
-  }
 
   if (error) {
     return (
@@ -363,9 +340,9 @@ export function RawCaptureReview({
           <p className="mt-1 text-sm text-sc-fg-muted">Verbatim quick-capture snapshots</p>
         </div>
         <div className="rounded-xl border border-sc-fg-subtle/20 bg-sc-bg-elevated p-4 shadow-card">
-          <p className="text-xs uppercase tracking-[0.12em] text-sc-fg-subtle">Needs Link</p>
+          <p className="text-xs uppercase tracking-[0.12em] text-sc-fg-subtle">Unlinked</p>
           <p className="mt-2 text-2xl font-semibold text-sc-fg-primary">{stats.unlinked}</p>
-          <p className="mt-1 text-sm text-sc-fg-muted">Captures that still need graph linkage</p>
+          <p className="mt-1 text-sm text-sc-fg-muted">Saved captures without graph links</p>
         </div>
         <div className="rounded-xl border border-sc-fg-subtle/20 bg-sc-bg-elevated p-4 shadow-card">
           <p className="text-xs uppercase tracking-[0.12em] text-sc-fg-subtle">Linked Entities</p>
@@ -381,7 +358,7 @@ export function RawCaptureReview({
               {[
                 { value: 'all', label: 'All', count: captures.length },
                 { value: 'linked', label: 'Linked', count: stats.linked },
-                { value: 'unlinked', label: 'Needs Link', count: stats.unlinked },
+                { value: 'unlinked', label: 'Unlinked', count: stats.unlinked },
               ].map(option => {
                 const active = linkFilter === option.value;
                 return (
@@ -409,7 +386,7 @@ export function RawCaptureReview({
                 { value: 'all', label: 'All states', count: captures.length },
                 {
                   value: 'pending',
-                  label: 'Open',
+                  label: 'Stored',
                   count: captures.length - stats.deferred - stats.archived,
                 },
                 { value: 'deferred', label: 'Deferred', count: stats.deferred },
@@ -526,7 +503,7 @@ export function RawCaptureReview({
                       <EntityBadge type={capture.entity_type} />
                       {!capture.entity_id && (
                         <span className="rounded border border-sc-yellow/30 bg-sc-yellow/10 px-2 py-0.5 text-xs font-medium text-sc-yellow">
-                          Needs link
+                          Unlinked
                         </span>
                       )}
                       {capture.review_state !== 'pending' && (
@@ -584,15 +561,15 @@ export function RawCaptureReview({
                   <div>
                     <p className="text-xs uppercase tracking-[0.12em] text-sc-fg-subtle">
                       {linkFilter === 'unlinked'
-                        ? 'Needs Link Queue'
+                        ? 'Unlinked Captures'
                         : linkFilter === 'linked'
-                          ? 'Linked Capture Review'
-                          : 'Capture Review'}
+                          ? 'Linked Captures'
+                          : 'Capture Details'}
                     </p>
                     <p className="mt-1 text-sm text-sc-fg-muted">
-                      Reviewing {activeCaptureIndex + 1} of {filteredCaptures.length}
+                      Viewing {activeCaptureIndex + 1} of {filteredCaptures.length}
                       {linkFilter === 'unlinked'
-                        ? ` | ${stats.unlinked} captures still need graph linkage`
+                        ? ` | ${stats.unlinked} captures have no graph link`
                         : ''}
                     </p>
                   </div>
@@ -617,35 +594,26 @@ export function RawCaptureReview({
                   </div>
                 </div>
 
-                <div className="flex flex-wrap items-center gap-2 border-t border-sc-fg-subtle/15 pt-3">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    loading={updateReviewState.isPending}
-                    disabled={selectedCapture.review_state === 'pending'}
-                    onClick={() => handleReviewAction('pending')}
+                <div className="space-y-2 border-t border-sc-fg-subtle/15 pt-3">
+                  <p className="text-sm text-sc-fg-muted">
+                    Inspection is optional. Captures are saved automatically; a missing graph link
+                    does not mean you need to review an entry.
+                  </p>
+                  <p className="text-xs text-sc-fg-subtle">
+                    {selectedCapture.metadata.autonomy_outcome === 'exception'
+                      ? 'Automation recorded an exception. Inspect the source for its current state.'
+                      : selectedCapture.metadata.autonomy_outcome === 'auto_promote'
+                        ? 'An automatic promotion decision was recorded. Inspect the source for its current state.'
+                        : selectedCapture.metadata.autonomy_outcome === 'skip'
+                          ? 'Automation skipped this capture.'
+                          : 'No automation outcome is recorded for this capture.'}
+                  </p>
+                  <Link
+                    href={`/memory/sources/${encodeURIComponent(selectedCapture.id)}`}
+                    className="inline-flex rounded text-sm font-medium text-sc-cyan hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sc-cyan"
                   >
-                    Return to Queue
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    loading={updateReviewState.isPending}
-                    disabled={selectedCapture.review_state === 'deferred'}
-                    onClick={() => handleReviewAction('deferred')}
-                  >
-                    Defer
-                  </Button>
-                  <span className="h-5 w-px bg-sc-fg-subtle/20" aria-hidden="true" />
-                  <Button
-                    variant="danger"
-                    size="sm"
-                    loading={updateReviewState.isPending}
-                    disabled={selectedCapture.review_state === 'archived'}
-                    onClick={() => handleReviewAction('archived')}
-                  >
-                    Archive
-                  </Button>
+                    Inspect source or make a correction
+                  </Link>
                 </div>
               </div>
 


### PR DESCRIPTION
The captures page presented saved memories as a review queue, implying that users needed to triage entries before memory could work. This change makes captures an optional inspection surface and removes the dashboard's routine triage prompt.

Unlinked captures are described as saved content without graph links. Selecting that filter no longer silently filters out deferred or archived entries. Queue-state mutation buttons are replaced with a link to the existing source inspector, where correction previews, redaction and deletion remain available.

Recorded automation outcomes are described as recorded decisions or exceptions. The UI does not infer successful publication from a promotion decision or pretend an unrecorded outcome has completed. Backend automatic reconsideration remains separate implementation work.

## 🧪 Validation

Independent review and root verification each passed 27 component controls, including navigation across captures, recorded outcome labels, archived entries, and correction/delete access. Web lint and typecheck passed. Desktop and mobile production-component fixtures were visually checked with synthetic data; no original API or browser session was changed.
