### PR TITLE
feat(evals): report paired transfer outcomes with frozen identities

### DIFF
--- a/benchmarks/agent_tasks/transfer_report.py
+++ b/benchmarks/agent_tasks/transfer_report.py
@@ -1,0 +1,205 @@
+"""Compare complete, paired schedules using existing trusted task receipts."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from statistics import mean
+from typing import Any, Literal
+
+from benchmarks.agent_tasks.manifest import ManifestError, identity
+from benchmarks.longmemeval_v2_reader_replication_report import cluster_bootstrap
+
+ARMS = ("no_memory", "raw_retrieval", "simple_summary", "sibyl_consolidation")
+
+
+@dataclass(frozen=True)
+class ScheduledAttempt:
+    """Freeze a runner identity before executing any arm."""
+
+    attempt_id: str
+    family: str
+    category: Literal["related_transfer", "applicability_contrast"]
+    repetition: int
+    expected: Mapping[str, Any]
+
+
+IDENTITY_FIELDS = (
+    "experiment_id",
+    "manifest_sha256",
+    "task_id",
+    "task_family_id",
+    "task_sha256",
+    "arm_id",
+    "arm_sha256",
+    "memory_pack_sha256",
+    "seed",
+    "controller_model",
+    "controller_tools",
+    "controller_budget",
+    "runtime",
+    "runner_source_sha256",
+)
+COMMON_FIELDS = (
+    "controller_model",
+    "controller_tools",
+    "controller_budget",
+    "runtime",
+    "runner_source_sha256",
+)
+
+
+def _validate_schedule(schedule: Sequence[ScheduledAttempt]) -> None:
+    if not schedule or len({row.attempt_id for row in schedule}) != len(schedule):
+        raise ManifestError("transfer schedule is empty or repeats an attempt")
+    paired: dict[tuple[str, str, int], list[ScheduledAttempt]] = defaultdict(list)
+    repetitions: dict[tuple[str, str], set[int]] = defaultdict(set)
+    common = None
+    task_identities: dict[str, tuple[Any, ...]] = {}
+    for row in schedule:
+        if (
+            not row.attempt_id
+            or not row.family
+            or type(row.repetition) is not int
+            or row.repetition < 0
+            or row.category not in {"related_transfer", "applicability_contrast"}
+            or set(row.expected) != set(IDENTITY_FIELDS)
+            or row.expected["arm_id"] not in ARMS
+        ):
+            raise ManifestError("invalid scheduled transfer identity")
+        task_key = row.expected["task_id"]
+        task_identity = (
+            row.family,
+            row.category,
+            row.expected["task_sha256"],
+            row.expected["task_family_id"],
+        )
+        if task_key in task_identities and task_identities[task_key] != task_identity:
+            raise ManifestError("transfer task identity differs across repetitions")
+        task_identities[task_key] = task_identity
+        policy = {key: row.expected[key] for key in COMMON_FIELDS}
+        if common is not None and policy != common:
+            raise ManifestError("transfer solver policy differs between arms")
+        common = policy
+        paired[(row.family, row.expected["task_id"], row.repetition)].append(row)
+        repetitions[(row.family, row.expected["task_id"])].add(row.repetition)
+    if len({tuple(sorted(values)) for values in repetitions.values()}) != 1:
+        raise ManifestError("transfer tasks have unequal repetition sets")
+    for rows in paired.values():
+        if Counter(row.expected["arm_id"] for row in rows) != Counter(ARMS):
+            raise ManifestError("every task repetition requires exactly four arms")
+        for key in ("experiment_id", "task_sha256", "task_family_id", "seed", "manifest_sha256"):
+            if len({row.expected[key] for row in rows}) != 1:
+                raise ManifestError("paired task or execution identity differs")
+        if len({row.category for row in rows}) != 1:
+            raise ManifestError("paired task category differs")
+
+
+def _validate_receipt(row: ScheduledAttempt, receipt: Mapping[str, Any]) -> None:
+    unsigned = {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+    if receipt.get("receipt_sha256") != identity(unsigned):
+        raise ManifestError("transfer receipt digest differs")
+    if receipt.get("attempt_id") != row.attempt_id or any(
+        receipt.get(key) != row.expected[key] for key in IDENTITY_FIELDS
+    ):
+        raise ManifestError("transfer receipt is outside its scheduled cell")
+    if (
+        receipt.get("schema_version") != "sibyl-agent-task-receipt-v1"
+        or receipt.get("purpose") != "trusted_development"
+        or receipt.get("task_split") != "development"
+        or receipt.get("sealed_isolation") is not False
+        or not receipt.get("completed_at")
+        or receipt.get("status") == "running"
+        or type(receipt.get("success")) is not bool
+    ):
+        raise ManifestError("transfer receipt is not a terminal development attempt")
+    if receipt["success"] and (
+        receipt.get("status") != "passed"
+        or receipt.get("budget_status") not in {"within_reported_budget", "unknown"}
+        or receipt.get("outcome", {}).get("passed") is not True
+    ):
+        raise ManifestError("transfer success lacks a passing budgeted outcome")
+
+
+def summarize_transfer(
+    schedule: Sequence[ScheduledAttempt], receipts: Mapping[str, Mapping[str, Any]]
+) -> dict[str, Any]:
+    """Keep missing cells in the denominator and resample whole family effects.
+
+    Receipt hashes establish consistency, not hostile-host authentication. The
+    caller retains the frozen manifests and oracle evidence with this report.
+    Preparation costs belong to the separate memory-pack preparation receipts.
+    """
+    _validate_schedule(schedule)
+    if set(receipts) - {row.attempt_id for row in schedule}:
+        raise ManifestError("unscheduled transfer receipts cannot enter the analysis")
+    grouped: dict[tuple[str, str, str], list[float]] = defaultdict(list)
+    statuses: dict[str, Counter[str]] = {arm: Counter() for arm in ARMS}
+    costs = {arm: {"known_usd": 0.0, "unknown_attempts": 0} for arm in ARMS}
+    missing = []
+    unqualified_passes = []
+    budget_statuses: dict[str, Counter[str]] = {arm: Counter() for arm in ARMS}
+    for row in schedule:
+        arm = row.expected["arm_id"]
+        receipt = receipts.get(row.attempt_id)
+        success = False
+        if receipt is None:
+            missing.append(row.attempt_id)
+            statuses[arm]["missing"] += 1
+            costs[arm]["unknown_attempts"] += 1
+        else:
+            _validate_receipt(row, receipt)
+            budget_status = receipt.get("budget_status", "unknown")
+            budget_statuses[arm][budget_status] += 1
+            success = receipt["success"] and budget_status == "within_reported_budget"
+            if receipt["success"] and not success:
+                unqualified_passes.append(row.attempt_id)
+            statuses[arm][receipt["status"]] += 1
+            cost = receipt.get("usage", {}).get("cost_usd")
+            if cost is None:
+                costs[arm]["unknown_attempts"] += 1
+            elif type(cost) not in (int, float) or not math.isfinite(cost) or cost < 0:
+                raise ManifestError("invalid transfer cost")
+            else:
+                costs[arm]["known_usd"] += cost
+        grouped[(row.category, row.family, arm)].append(float(success))
+    categories = {}
+    for category in sorted({row.category for row in schedule}):
+        families = sorted({row.family for row in schedule if row.category == category})
+        family_rates = {
+            family: {arm: mean(grouped[(category, family, arm)]) for arm in ARMS}
+            for family in families
+        }
+        comparisons = {}
+        for control in ARMS[:-1]:
+            effects = {
+                family: rates["sibyl_consolidation"] - rates[control]
+                for family, rates in family_rates.items()
+            }
+            interval = cluster_bootstrap(list(effects.values()))
+            interval["unit"] = "family"
+            comparisons[control] = {"family_effects": effects, "uncertainty": interval}
+        categories[category] = {
+            "family_rates": family_rates,
+            "arm_rates": {arm: mean(rates[arm] for rates in family_rates.values()) for arm in ARMS},
+            "comparisons": comparisons,
+        }
+    return {
+        "schema_version": "sibyl-transfer-diagnostic-report-v1",
+        "schedule_sha256": identity([asdict(row) for row in schedule]),
+        "scheduled_attempts": len(schedule),
+        "recorded_attempts": len(receipts),
+        "receipt_hashes": {key: value["receipt_sha256"] for key, value in receipts.items()},
+        "complete": not missing,
+        "missing_attempt_ids": missing,
+        "unqualified_pass_attempt_ids": unqualified_passes,
+        "budget_statuses": {arm: dict(counts) for arm, counts in budget_statuses.items()},
+        "statuses": {arm: dict(counts) for arm, counts in statuses.items()},
+        "execution_costs": costs,
+        "cost_scope": "execution only; preparation and unknown usage are not zero",
+        "categories": categories,
+        "learning_benefit_established": False,
+        "interpretation": "diagnostic paired family effects; independent confirmation required",
+    }

--- a/tools/tests/test_agent_task_transfer_report.py
+++ b/tools/tests/test_agent_task_transfer_report.py
@@ -1,0 +1,163 @@
+"""Paired transfer diagnostics retain failures and reject mismatched receipts."""
+
+from dataclasses import replace
+
+import pytest
+from benchmarks.agent_tasks.manifest import ManifestError, identity
+from benchmarks.agent_tasks.transfer_report import ARMS, ScheduledAttempt, summarize_transfer
+
+
+def experiment():
+    schedule = []
+    receipts = {}
+    for family in ("first", "second"):
+        for repetition in range(2):
+            for arm in ARMS:
+                attempt = f"{family}-{repetition}-{arm}"
+                expected = {
+                    "experiment_id": "pilot",
+                    "manifest_sha256": identity([family, repetition]),
+                    "task_id": family + "-task",
+                    "task_family_id": family,
+                    "task_sha256": identity(family),
+                    "arm_id": arm,
+                    "arm_sha256": identity([family, arm]),
+                    "memory_pack_sha256": identity([family, arm, "pack"]),
+                    "seed": repetition,
+                    "controller_model": "frozen-model",
+                    "controller_tools": ["shell"],
+                    "controller_budget": {"cost_usd": 1},
+                    "runtime": {"image": "frozen-runtime"},
+                    "runner_source_sha256": {"runner.py": identity("runner")},
+                }
+                schedule.append(
+                    ScheduledAttempt(attempt, family, "related_transfer", repetition, expected)
+                )
+                passed = arm == "sibyl_consolidation" and family == "first"
+                receipt = {
+                    **expected,
+                    "attempt_id": attempt,
+                    "schema_version": "sibyl-agent-task-receipt-v1",
+                    "purpose": "trusted_development",
+                    "task_split": "development",
+                    "sealed_isolation": False,
+                    "completed_at": "2026-09-10T00:00:00Z",
+                    "status": "passed" if passed else "task_failed",
+                    "success": passed,
+                    "budget_status": "within_reported_budget",
+                    "outcome": {"passed": passed},
+                    "usage": {"cost_usd": 0.1},
+                }
+                receipt["receipt_sha256"] = identity(receipt)
+                receipts[attempt] = receipt
+    return schedule, receipts
+
+
+def test_transfer_family_effects_and_missing_denominator():
+    schedule, receipts = experiment()
+    missing = "first-0-sibyl_consolidation"
+    del receipts[missing]
+    report = summarize_transfer(schedule, receipts)
+    related = report["categories"]["related_transfer"]
+    expected_rate = 0.25
+    assert related["arm_rates"]["sibyl_consolidation"] == expected_rate
+    assert related["comparisons"]["no_memory"]["family_effects"] == {"first": 0.5, "second": 0.0}
+    assert related["comparisons"]["no_memory"]["uncertainty"]["unit"] == "family"
+    assert report["scheduled_attempts"] == len(schedule)
+    assert report["missing_attempt_ids"] == [missing]
+    assert report["complete"] is False
+    assert report["execution_costs"]["sibyl_consolidation"]["unknown_attempts"] == 1
+    assert report["learning_benefit_established"] is False
+
+
+@pytest.mark.parametrize("mutation", ["digest", "task", "success", "budget", "running", "cost"])
+def test_transfer_rejects_invalid_receipts(mutation):
+    schedule, receipts = experiment()
+    row = receipts["first-0-sibyl_consolidation"]
+    if mutation == "digest":
+        row["seed"] = 9
+    else:
+        if mutation == "task":
+            row["task_id"] = "another-task"
+        elif mutation == "success":
+            row["outcome"]["passed"] = False
+        elif mutation == "budget":
+            row["budget_status"] = "exceeded"
+        elif mutation == "running":
+            row["status"] = "running"
+        elif mutation == "cost":
+            row["usage"]["cost_usd"] = -1
+        row["receipt_sha256"] = identity({k: v for k, v in row.items() if k != "receipt_sha256"})
+    with pytest.raises(ManifestError):
+        summarize_transfer(schedule, receipts)
+
+
+@pytest.mark.parametrize("mutation", ["missing_arm", "duplicate", "policy", "pair", "repetitions"])
+def test_transfer_rejects_unmatched_schedule(mutation):
+    schedule, _ = experiment()
+    if mutation == "missing_arm":
+        schedule.pop()
+    elif mutation == "duplicate":
+        schedule.append(schedule[0])
+    elif mutation in {"policy", "pair"}:
+        field = "controller_model" if mutation == "policy" else "task_sha256"
+        schedule[0] = replace(schedule[0], expected={**schedule[0].expected, field: "changed"})
+    else:
+        schedule = [row for row in schedule if not (row.family == "first" and row.repetition == 1)]
+    with pytest.raises(ManifestError):
+        summarize_transfer(schedule, {})
+
+
+def test_transfer_unknown_cost_is_retained_and_extra_attempt_is_refused():
+    schedule, receipts = experiment()
+    row = receipts[schedule[0].attempt_id]
+    row["usage"]["cost_usd"] = None
+    row["receipt_sha256"] = identity({k: v for k, v in row.items() if k != "receipt_sha256"})
+    report = summarize_transfer(schedule, receipts)
+    assert report["complete"] is True
+    assert report["execution_costs"]["no_memory"]["unknown_attempts"] == 1
+    assert len(report["receipt_hashes"]) == len(schedule)
+    receipts["unscheduled"] = row
+    with pytest.raises(ManifestError, match="unscheduled"):
+        summarize_transfer(schedule, receipts)
+
+
+def test_transfer_unknown_budget_pass_remains_unqualified():
+    schedule, receipts = experiment()
+    attempt = "first-0-sibyl_consolidation"
+    row = receipts[attempt]
+    row["budget_status"] = "unknown"
+    row["usage"]["cost_usd"] = None
+    row["receipt_sha256"] = identity({k: v for k, v in row.items() if k != "receipt_sha256"})
+    report = summarize_transfer(schedule, receipts)
+    assert report["complete"] is True
+    assert report["unqualified_pass_attempt_ids"] == [attempt]
+    assert report["budget_statuses"]["sibyl_consolidation"]["unknown"] == 1
+    expected_rate = 0.25
+    assert (
+        report["categories"]["related_transfer"]["arm_rates"]["sibyl_consolidation"]
+        == expected_rate
+    )
+
+
+@pytest.mark.parametrize("field", ["task_sha256", "task_family_id", "category"])
+def test_transfer_task_identity_cannot_change_between_repetitions(field):
+    schedule, _ = experiment()
+    for index, row in enumerate(schedule):
+        if row.family == "first" and row.repetition == 1:
+            schedule[index] = (
+                replace(row, category="applicability_contrast")
+                if field == "category"
+                else replace(row, expected={**row.expected, field: "changed"})
+            )
+    with pytest.raises(ManifestError, match="identity differs"):
+        summarize_transfer(schedule, {})
+
+
+def test_transfer_paired_experiment_identity_must_agree():
+    schedule, _ = experiment()
+    schedule[0] = replace(
+        schedule[0], expected={**schedule[0].expected, "experiment_id": "different-experiment"}
+    )
+    with pytest.raises(ManifestError, match="execution identity"):
+        summarize_transfer(schedule, {})


### PR DESCRIPTION
Transfer comparisons need to retain every scheduled attempt, including missing runs and successful answers whose execution budget is unknown. The report now compares four memory conditions using a frozen schedule and the existing task receipts. Unknown-budget passes remain visible but do not count as success within the allowed budget.

The schedule requires four matched arms per task repetition and consistent task identity across repetitions. Results give each family equal weight and reuse the existing bootstrap implementation for paired family effects against each control. Execution costs retain unknown amounts separately; memory preparation costs remain a separate input to the experiment.

## 🧪 Validation

The focused suite passed 18 tests. An independent reviewer reproduced five defects in the initial draft and verified their corrections with six additional controls. Root repeated those controls and an existing runner control (seven passing checks), verified the reviewed file hashes, and passed lint and typecheck.

The helper reports diagnostic evidence only. It does not establish learning benefit, authenticate a hostile host, or replace the caller's frozen task selection and runtime manifests. No model calls or measured learning outcomes are included.

## 🛠️ Stack

This layer adds only the transfer report and its tests above #552. The execution controller and memory-pack preparation remain separate work.
