### PR TITLE
feat(memory): reconsider stored procedures through durable validation

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/automatic_procedure.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/automatic_procedure.py
@@ -1,0 +1,235 @@
+"""Reconsider stored signed procedures through the existing extraction owner."""
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass
+
+from pydantic import TypeAdapter
+
+from sibyl_core.ai.llm.extractor import ExtractionUsage
+from sibyl_core.backends.surreal.schema_source_witness import SOURCE_STATE_WRITE_WITNESS
+from sibyl_core.services.eval_publication import (
+    ConsolidationOperation,
+    StoredConsolidation,
+    _extractor_policy,
+    store_consolidation,
+)
+from sibyl_core.services.procedure_validation import (
+    _SNAPSHOT,
+    prepare_stored_procedure_validation,
+    validate_stored_procedure,
+)
+from sibyl_core.services.validation_candidate import ValidationCandidateWrite
+from sibyl_core.services.validation_execution import (
+    ValidationExecution,
+    ValidationExecutionUnavailable,
+)
+from sibyl_core.services.validation_stages import run_validation_stage
+from sibyl_core.tasks._evidence_json import canonical
+from sibyl_core.tasks.consolidation import (
+    METADATA_KEY,
+    _extraction_input,
+    _review_input,
+    propose_conditional_procedure,
+)
+from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
+from sibyl_core.tasks.procedure_review import ReviewSubmission, review_digest
+
+
+@dataclass(frozen=True)
+class AutomaticProcedureResult:
+    status: str
+    candidate_id: str | None
+    executions: tuple[str, ...]
+    reason: str | None = None
+    stored: StoredConsolidation | None = None
+
+
+async def automatically_reconsider_procedure(
+    *,
+    organization_id: str,
+    principal_id: str,
+    parent_id: str,
+    authorize: Callable[[], Awaitable[None]],
+) -> AutomaticProcedureResult:
+    """Critique, correct and recheck; publication still requires its existing guards."""
+    critique = await validate_stored_procedure(
+        organization_id=organization_id,
+        principal_id=principal_id,
+        parent_id=parent_id,
+        authorize=authorize,
+    )
+    executions = [str(critique["execution_id"])]
+    if critique["status"] != "reconsider":
+        return AutomaticProcedureResult(
+            "validated" if critique["status"] == "no_findings" else "abstained",
+            parent_id if critique["status"] == "no_findings" else None,
+            tuple(executions),
+            critique.get("reason"),
+        )
+    await authorize()
+    original = await prepare_stored_procedure_validation(organization_id, principal_id, parent_id)
+    review = ReviewSubmission.model_validate(critique["submission"])
+    prepared = json.loads(original.prepared.payload_json)
+    if (
+        review.parent_operation_id != prepared["parent_operation_id"]
+        or review.parent_candidate_sha256 != prepared["parent_candidate_sha256"]
+    ):
+        raise ValidationExecutionUnavailable("Stored critique parent changed")
+    resolved = await _extractor_policy()
+    evidence = await asyncio.to_thread(_extraction_input, original.artifact.group)
+    evidence = await asyncio.to_thread(
+        _review_input,
+        original.artifact.group,
+        evidence,
+        {
+            "submission": review.model_dump(mode="json"),
+            "parent_procedure": original.artifact.candidate.metadata[METADATA_KEY]["procedure"],
+        },
+    )
+    policy = canonical(
+        {
+            "kind": "signed_procedure_correction-v1",
+            **asdict(resolved),
+            "system_sha256": review_digest(evidence.system),
+            "prompt_sha256": review_digest(evidence.prompt),
+            "declared_schema_sha256": review_digest(evidence.output_type.model_json_schema()),
+        }
+    )
+    request = {
+        "kind": "signed_procedure_correction",
+        "org": organization_id,
+        "principal": principal_id,
+        "parent": parent_id,
+        "review_execution": executions[0],
+        "review": review.model_dump(mode="json"),
+        "snapshot": original.snapshot_sha256,
+        "source_bindings": original.source_bindings,
+        "policy": policy,
+    }
+
+    async def current():
+        await authorize()
+        refreshed = await prepare_stored_procedure_validation(
+            organization_id, principal_id, parent_id
+        )
+        if (
+            refreshed.snapshot_sha256 != original.snapshot_sha256
+            or await _extractor_policy() != resolved
+        ):
+            raise ValidationExecutionUnavailable("Correction authority or policy changed")
+        prior = ValidationExecution(executions[0], organization_id, principal_id)
+        if await prior.result() != critique:
+            raise ValidationExecutionUnavailable("Stored critique changed")
+
+    guard = (
+        _SNAPSHOT
+        + "IF $snapshot_digest!=$expected { THROW 'Correction sources changed'; };"
+        + "LET $source_states_to_fence=$states;"
+        + SOURCE_STATE_WRITE_WITNESS
+    )
+    params = {"parent": parent_id, "expected": original.snapshot_sha256}
+    execution = ValidationExecution(
+        review_digest(request),
+        organization_id,
+        principal_id,
+        authorize=current,
+        dispatch_guard=guard,
+        guard_params=params,
+    )
+
+    async def run():
+        result = await propose_conditional_procedure(
+            original.artifact.group,
+            review=review,
+            parent_artifact=original.artifact.candidate.metadata[METADATA_KEY],
+            model_override=resolved.model,
+            max_input_chars=resolved.max_input_chars,
+            max_tokens=resolved.max_output_tokens,
+            output_mode=resolved.output_mode,
+            openrouter_provider=resolved.openrouter_provider,
+        )
+        usage = ExtractionUsage.model_validate(result.receipt["usage"])
+        try:
+            return ProcedureCorrectionResult(
+                "procedure_correction",
+                review.parent_operation_id,
+                review.parent_candidate_sha256,
+                executions[0],
+                result,
+                usage,
+            )
+        except BaseException as error:
+            error.__dict__["extraction_usage"] = usage
+            raise
+
+    await run_validation_stage(
+        execution=execution,
+        parent_id=parent_id,
+        source_ids=original.source_ids,
+        request=request,
+        policy=policy,
+        check_current=current,
+        run=run,
+    )
+    executions.append(execution.id)
+    # Decode the persisted output, not a caller-provided proposal or critique.
+    row = await execution.load()
+    if row is None or row.get("state") != "returned" or row.get("purged"):
+        raise ValidationExecutionUnavailable("Correction result unavailable")
+    correction = TypeAdapter(ProcedureCorrectionResult).validate_json(row["result_json"])
+    if correction.review_execution_id != executions[0]:
+        raise ValidationExecutionUnavailable("Correction review changed")
+    await current()
+    assignment = original.assignments[0]
+    operation = ConsolidationOperation(
+        organization_id,
+        principal_id,
+        assignment["experiment_id"],
+        assignment["experiment_revision"],
+        assignment["arm_id"],
+        max(item["checkpoint"] for item in original.assignments),
+        original.artifact.group.group_id,
+        tuple(episode.session_id for episode in original.artifact.group.episodes),
+        original.artifact.group.mechanism,
+        assignment["controller_policy_sha256"],
+        review_digest(policy),
+        execution.id,
+        review.parent_operation_id,
+        review.parent_candidate_sha256,
+    )
+    stored = await store_consolidation(
+        operation,
+        correction.result,
+        validation_write=ValidationCandidateWrite(
+            execution.id,
+            row["result_json"],
+            guard,
+            {**params, "org": organization_id, "principal": principal_id},
+        ),
+    )
+    if stored.memory is None:
+        return AutomaticProcedureResult(
+            "abstained",
+            None,
+            tuple(executions),
+            (stored.build_receipt or {}).get("reason"),
+            stored,
+        )
+    recheck = await validate_stored_procedure(
+        organization_id=organization_id,
+        principal_id=principal_id,
+        parent_id=stored.memory.id,
+        authorize=authorize,
+    )
+    executions.append(str(recheck["execution_id"]))
+    return AutomaticProcedureResult(
+        "corrected" if recheck["status"] == "no_findings" else "abstained",
+        stored.memory.id if recheck["status"] == "no_findings" else None,
+        tuple(executions),
+        None
+        if recheck["status"] == "no_findings"
+        else str(recheck.get("reason") or "corrected_claims_remain_unsupported"),
+        stored,
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication.py
@@ -20,6 +20,7 @@ from sibyl_core.auth.memory_policy import (
     EVAL_ADMISSION_METADATA_KEY,
     EVAL_CONSOLIDATION_METADATA_KEY,
 )
+from sibyl_core.backends.surreal.schema_source_witness import SOURCE_STATE_WRITE_WITNESS
 from sibyl_core.config import core_config
 from sibyl_core.memory_pipeline.source_lifecycle import (
     SOURCE_BINDINGS_KEY,
@@ -34,6 +35,7 @@ from sibyl_core.services.memory_source_validation import (
     SOURCE_VALIDATION_CONTEXT_KEY,
     SourceReadAuthority,
 )
+from sibyl_core.services.validation_candidate import ValidationCandidateWrite
 from sibyl_core.tasks.consolidation import (
     EVIDENCE_SYSTEM_PROMPT,
     OUTPUT_RETRIES,
@@ -74,8 +76,23 @@ class ConsolidationOperation:
     mechanism: str
     controller_policy_sha256: str
     extractor_revision: str
+    correction_execution_id: str | None = None
+    parent_operation_id: str | None = None
+    parent_candidate_sha256: str | None = None
 
     def __post_init__(self) -> None:
+        lineage = (
+            self.correction_execution_id,
+            self.parent_operation_id,
+            self.parent_candidate_sha256,
+        )
+        if any(value is not None for value in lineage) and not all(
+            isinstance(value, str)
+            and len(value) == 64
+            and all(c in "0123456789abcdef" for c in value)
+            for value in lineage
+        ):
+            raise ValueError("complete correction lineage is required")
         if (
             any(
                 not value.strip()
@@ -110,6 +127,15 @@ class ConsolidationOperation:
                 self.checkpoint,
                 self.group_id,
             ]
+            + (
+                [
+                    self.correction_execution_id,
+                    self.parent_operation_id,
+                    self.parent_candidate_sha256,
+                ]
+                if self.correction_execution_id is not None
+                else []
+            )
         )
 
     @property
@@ -169,6 +195,13 @@ IF $existing != NONE {
             THROW 'consolidation conflict: original admitted source changed';
         };
     };
+    LET $source_ids=$sources.map(|$source| $source.capture_id);
+    LET $source_states_to_fence=(SELECT * FROM source_states WHERE organization_id=$organization_id
+        AND source_kind='raw_capture' AND source_id IN $source_ids);
+    IF array::len($source_states_to_fence)!=array::len(array::distinct($source_ids)) {
+        THROW 'consolidation conflict: source state unavailable';
+    };
+    __SOURCE_STATE_WRITE_WITNESS__
     IF $candidate != NONE { CREATE raw_captures CONTENT $candidate; };
     CREATE eval_consolidations CONTENT $ledger;
 };
@@ -178,7 +211,7 @@ LET $memory = (SELECT * FROM raw_captures WHERE organization_id = $organization_
     AND uuid = $stored.candidate_id LIMIT 1)[0];
 RETURN { ledger: $stored, memory: $memory };
 };
-"""
+""".replace("__SOURCE_STATE_WRITE_WITNESS__", SOURCE_STATE_WRITE_WITNESS)
 
 
 def _decode_build_receipt(ledger: dict) -> dict[str, Any] | None:
@@ -269,12 +302,52 @@ RETURN { ledger: $ledger, memory: (SELECT * FROM raw_captures
 async def store_consolidation(
     operation: ConsolidationOperation,
     result: ConsolidationResult,
+    *,
+    validation_write: ValidationCandidateWrite | None = None,
 ) -> StoredConsolidation:
     """Persist a server-verified proposal under its original source observations.
 
     The caller authenticates and revalidates the admitted group before invoking
     this writer. The transaction closes the last read-to-write revision gap.
     """
+    from pydantic import TypeAdapter
+
+    from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
+
+    guard = ""
+    guard_params = {}
+    if operation.correction_execution_id is not None:
+        if (
+            validation_write is None
+            or validation_write.execution_id != operation.correction_execution_id
+        ):
+            raise ConsolidationConflict("stored correction authority is required")
+        corrected = TypeAdapter(ProcedureCorrectionResult).validate_json(
+            validation_write.result_json
+        )
+        if (
+            corrected.parent_operation_id != operation.parent_operation_id
+            or corrected.parent_candidate_sha256 != operation.parent_candidate_sha256
+            or TypeAdapter(ConsolidationResult).dump_python(corrected.result, mode="json")
+            != TypeAdapter(ConsolidationResult).dump_python(result, mode="json")
+        ):
+            raise ConsolidationConflict("stored correction result differs")
+        guard = (
+            validation_write.source_guard
+            + """
+        LET $stage=(SELECT * FROM memory_validation_executions WHERE uuid=$correction_execution
+            AND organization_id=$organization_id AND principal_id=$principal_id)[0];
+        IF $stage=NONE OR $stage.state!='returned' OR $stage.purged
+            OR $stage.result_json!=$correction_result { THROW 'consolidation conflict: correction changed'; };
+        """
+        )
+        guard_params = {
+            **validation_write.guard_params,
+            "correction_execution": validation_write.execution_id,
+            "correction_result": validation_write.result_json,
+        }
+    elif validation_write is not None:
+        raise ConsolidationConflict("correction operation identity is required")
     existing = await get_stored_consolidation(operation)
     if existing is not None:
         return existing
@@ -483,7 +556,8 @@ async def store_consolidation(
         try:
             rows = content_client.normalize_records(
                 await client.execute_query(
-                    _STORE,
+                    _STORE.replace("RETURN {\n", "RETURN {\n" + guard, 1) if guard else _STORE,
+                    **guard_params,
                     operation_id=operation.key,
                     organization_id=operation.organization_id,
                     principal_id=operation.principal_id,

--- a/packages/python/sibyl-core/src/sibyl_core/services/procedure_validation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/procedure_validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from typing import Any
@@ -12,7 +13,7 @@ from pydantic_ai import Agent, NativeOutput
 from sibyl_core.ai.llm.config import LLMSurface, resolve_llm_config
 from sibyl_core.ai.llm.extractor import Extractor
 from sibyl_core.ai.providers import build_model
-from sibyl_core.ai.transport import observe_transport_attempts, transport_policy
+from sibyl_core.ai.transport import transport_policy
 from sibyl_core.backends.surreal.schema_source_witness import SOURCE_STATE_WRITE_WITNESS
 from sibyl_core.config import settings
 from sibyl_core.services.content_models import (
@@ -21,7 +22,7 @@ from sibyl_core.services.content_models import (
 )
 from sibyl_core.services.eval_publication_guards import verify_publication_admissions
 from sibyl_core.services.memory_policy import _authorize_share_source_read
-from sibyl_core.services.procedure_artifact import resolve_procedure_artifact
+from sibyl_core.services.procedure_artifact import ProcedureArtifact, resolve_procedure_artifact
 from sibyl_core.services.validation_execution import (
     ValidationExecution,
     ValidationExecutionUnavailable,
@@ -32,8 +33,8 @@ from sibyl_core.tasks.consolidation import (
     METADATA_KEY,
     ConsolidationInputBudgetExceeded,
     DraftConditionalProcedure,
+    procedure_review_citations,
 )
-from sibyl_core.tasks.episode_evidence import EvidenceCitation
 from sibyl_core.tasks.memory_validation import (
     CriticOutput,
     OriginalValidationEvidence,
@@ -46,15 +47,15 @@ from sibyl_core.tasks.procedure_review import review_digest
 # Hash the server's representation before SDK datetime/null normalization. The
 # same selection closes the final write race without persisting source bodies.
 _SNAPSHOT = """
-LET $ledger = (SELECT * FROM eval_consolidations WHERE organization_id = $org
+LET $validation_ledger = (SELECT * FROM eval_consolidations WHERE organization_id = $org
     AND candidate_id = $parent LIMIT 1)[0];
-LET $ids = array::distinct(array::concat([$parent], ($ledger.admission_bindings ?? []).map(|$b| $b.capture_id)));
+LET $ids = array::distinct(array::concat([$parent], ($validation_ledger.admission_bindings ?? []).map(|$b| $b.capture_id)));
 LET $captures = (SELECT * FROM raw_captures WHERE organization_id = $org AND uuid IN $ids ORDER BY uuid);
 LET $states = (SELECT * OMIT validation_write_witness FROM source_states WHERE organization_id = $org AND source_kind = 'raw_capture'
     AND source_id IN $ids ORDER BY source_id);
 LET $attempts = (SELECT * FROM eval_attempts WHERE organization_id = $org
     AND capture_id IN $ids ORDER BY uuid);
-LET $snapshot = {ledger: $ledger, captures: $captures, states: $states, attempts: $attempts};
+LET $snapshot = {ledger: $validation_ledger, captures: $captures, states: $states, attempts: $attempts};
 LET $snapshot_digest = crypto::sha256(type::string($snapshot));
 """
 
@@ -65,6 +66,8 @@ class AuthorizedProcedureValidation:
     snapshot_sha256: str
     source_ids: list[str]
     source_bindings: list[dict[str, Any]]
+    artifact: ProcedureArtifact
+    assignments: tuple[dict[str, Any], ...]
 
 
 async def prepare_stored_procedure_validation(
@@ -133,8 +136,8 @@ async def prepare_stored_procedure_validation(
     audit = artifact.candidate.metadata[METADATA_KEY]
     procedure = DraftConditionalProcedure.model_validate(audit["procedure"])
     evidence = []
-    citations = {}
-    for index, episode in enumerate(artifact.group.episodes):
+    citations = await asyncio.to_thread(procedure_review_citations, artifact.group)
+    for episode in artifact.group.episodes:
         source_id = episode.stored_sources[0].source_id
         evidence.append(
             OriginalValidationEvidence(
@@ -156,7 +159,6 @@ async def prepare_stored_procedure_validation(
                 "signed",
             )
         )
-        citations[f"s{index}"] = EvidenceCitation(episode.episode_id, ((0, len(episode.artifact)),))
     prepared = prepare_procedure_validation(
         procedure,
         parent_operation_id=ledger["uuid"],
@@ -172,6 +174,8 @@ async def prepare_stored_procedure_validation(
             {key: states[identifier][key] for key in ("source_id", "incarnation", "generation")}
             for identifier in sorted(by_id)
         ],
+        artifact,
+        tuple(json.loads(row["assignment_json"]) for row in data["attempts"]),
     )
 
 
@@ -258,73 +262,22 @@ async def validate_stored_procedure(
         + SOURCE_STATE_WRITE_WITNESS,
         guard_params={"parent": parent_id, "expected": original.snapshot_sha256},
     )
-    claimed = await execution.begin(
-        parent_id=parent_id, source_ids=original.source_ids, policy=policy, request=request
-    )
-    if not claimed:
-        existing = await execution.load()
-        if existing is None or existing.get("state") not in {"recorded", "returned"}:
-            return await execution.result()
-    if claimed:
-        try:
-            await authorize()
-            current = await prepare_stored_procedure_validation(
-                organization_id, principal_id, parent_id
-            )
-            if current.snapshot_sha256 != original.snapshot_sha256:
-                raise ValidationExecutionUnavailable("Sources changed before dispatch")
-            with observe_transport_attempts(execution):
-                result = await run_memory_validation(original.prepared, extractor)
-        except (Exception, asyncio.CancelledError) as failure:
-            try:
-                await execution.record_failure(failure)
-            except Exception:
-                if isinstance(failure, asyncio.CancelledError):
-                    raise failure from None
-                raise
-            raise
-        # A cancellation after extraction must still retain its reported usage.
-        recording = asyncio.create_task(execution.record_result(result))
-        try:
-            await asyncio.shield(recording)
-        except asyncio.CancelledError as cancelled:
-            try:
-                await recording
-            except Exception:
-                raise cancelled from None
-            raise
-    try:
+    from sibyl_core.services.validation_stages import run_validation_stage
+
+    async def current():
         await authorize()
-        current = await prepare_stored_procedure_validation(
+        refreshed = await prepare_stored_procedure_validation(
             organization_id, principal_id, parent_id
         )
-        if current.snapshot_sha256 != original.snapshot_sha256:
-            raise ValidationExecutionUnavailable("Sources changed after validation")
-        rows = await _query(
-            "RETURN {"
-            + _SNAPSHOT
-            + "LET $source_states_to_fence=$states;"
-            + SOURCE_STATE_WRITE_WITNESS
-            + """
-            RETURN (UPDATE memory_validation_executions SET state = IF $snapshot_digest = $expected THEN 'returned' ELSE 'fenced' END
-                WHERE uuid = $uuid AND organization_id = $org AND principal_id = $principal
-                    AND state IN ['recorded', 'returned'] AND purged = false RETURN AFTER);
-        };""",
-            **execution.params,
-            parent=parent_id,
-            expected=original.snapshot_sha256,
-        )
-        if len(rows) != 1 or rows[0].get("state") != "returned":
-            raise ValidationExecutionUnavailable("Final validation source fence failed")
-    except (Exception, asyncio.CancelledError) as failure:
-        try:
-            await _query(
-                "UPDATE memory_validation_executions SET state = 'fenced' WHERE uuid = $uuid AND organization_id = $org AND principal_id = $principal AND state = 'recorded';",
-                **execution.params,
-            )
-        except Exception:
-            if isinstance(failure, asyncio.CancelledError):
-                raise failure from None
-            raise
-        raise
-    return await execution.result()
+        if refreshed.snapshot_sha256 != original.snapshot_sha256:
+            raise ValidationExecutionUnavailable("Validation sources changed")
+
+    return await run_validation_stage(
+        execution=execution,
+        parent_id=parent_id,
+        source_ids=original.source_ids,
+        request=request,
+        policy=policy,
+        check_current=current,
+        run=lambda: run_memory_validation(original.prepared, extractor),
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/services/validation_execution.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/validation_execution.py
@@ -15,10 +15,13 @@ from sibyl_core.ai.transport import FailedExtractionUsage, TransportAttempt
 from sibyl_core.services import content_client
 from sibyl_core.tasks._evidence_json import canonical
 from sibyl_core.tasks.memory_validation import MemoryValidationResult
+from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
 from sibyl_core.tasks.procedure_review import review_digest
 from sibyl_core.tasks.reflection_correction import ReflectionCorrectionResult
 
-ValidationStageResult = MemoryValidationResult | ReflectionCorrectionResult
+ValidationStageResult = (
+    MemoryValidationResult | ReflectionCorrectionResult | ProcedureCorrectionResult
+)
 
 
 class ValidationExecutionUnavailable(ValueError):

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -382,6 +382,17 @@ def _extraction_input(group: ConsolidationGroup) -> _ExtractionInput:
     return _ExtractionInput(prompt, EVIDENCE_SYSTEM_PROMPT, EvidenceProposal, citations, receipt)
 
 
+def procedure_review_citations(
+    group: ConsolidationGroup, *, evidence: _ExtractionInput | None = None
+) -> dict[str, EvidenceCitation]:
+    """Use one original-evidence namespace for stored critique and reconsideration."""
+    extracted = evidence if evidence is not None else _extraction_input(group)
+    return extracted.citations or {
+        f"episode:{index}": EvidenceCitation(episode.episode_id, ((0, len(episode.artifact)),))
+        for index, episode in enumerate(group.episodes)
+    }
+
+
 def _review_input(
     group: ConsolidationGroup, evidence: _ExtractionInput, record: dict[str, Any]
 ) -> _ExtractionInput:
@@ -390,10 +401,7 @@ def _review_input(
         raise ValueError("invalid reconsideration record")
     submission = ReviewSubmission.model_validate(record["submission"])
     parent = DraftConditionalProcedure.model_validate(record["parent_procedure"])
-    citations = evidence.citations or {
-        f"episode:{index}": EvidenceCitation(episode.episode_id, ((0, len(episode.artifact)),))
-        for index, episode in enumerate(group.episodes)
-    }
+    citations = procedure_review_citations(group, evidence=evidence)
     resolved = resolve_review_findings(submission, parent, citations)
     retained = {
         "submission": submission.model_dump(mode="json"),

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/procedure_correction_result.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/procedure_correction_result.py
@@ -1,0 +1,17 @@
+"""Lossless durable output of the existing procedure reconsideration owner."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from sibyl_core.ai.llm.extractor import ExtractionUsage
+from sibyl_core.tasks.consolidation import ConsolidationResult
+
+
+@dataclass(frozen=True)
+class ProcedureCorrectionResult:
+    status: Literal["procedure_correction"]
+    parent_operation_id: str
+    parent_candidate_sha256: str
+    review_execution_id: str
+    result: ConsolidationResult
+    usage: ExtractionUsage

--- a/packages/python/sibyl-core/tests/test_automatic_procedure.py
+++ b/packages/python/sibyl-core/tests/test_automatic_procedure.py
@@ -1,0 +1,326 @@
+"""Stored signed critique drives the existing extraction and persistence owners."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from sibyl_core.ai.llm.extractor import Extractor
+from sibyl_core.services import automatic_procedure as automatic
+from sibyl_core.services import eval_publication as publication
+from sibyl_core.services import procedure_validation as validation
+from sibyl_core.tasks.memory_validation import CriticOutput
+from sibyl_core.tasks.procedure_review import ReviewSubmission, review_digest
+from tests.test_eval_publication import admitted_pair as admitted_pair
+from tests.test_eval_publication import content_store as content_store
+from tests.test_eval_publication import evidence as evidence
+from tests.test_eval_publication import proposal as proposal
+from tests.test_eval_publication import rows
+from tests.test_validation_execution import candidate as candidate
+
+
+@pytest.fixture
+async def correction_model(candidate, proposal, monkeypatch):
+    original = await validation.prepare_stored_procedure_validation("org", "owner", candidate.id)
+    payload = json.loads(original.prepared.payload_json)
+    finding = {
+        "claim_path": "/goal",
+        "claim_sha256": review_digest(payload["assertions"]["/goal"]),
+        "evidence_refs": [{"evidence_id": "episode:0"}],
+        "basis": "unsupported_generalization",
+        "disposition": "qualify",
+        "critique": "Keep the goal within the original evidence.",
+    }
+    review = ReviewSubmission(
+        parent_operation_id=payload["parent_operation_id"],
+        parent_candidate_sha256=payload["parent_candidate_sha256"],
+        findings=[finding],
+    )
+    calls = []
+    controls = {"recheck_abstain": False, "correction_abstain": False}
+
+    async def critic():
+        calls.append("critic")
+        output = {"findings": [finding] if len(calls) == 1 else []}
+        if len(calls) > 1 and controls["recheck_abstain"]:
+            output["abstention_reason"] = "Original evidence remains insufficient."
+        return Extractor(
+            CriticOutput,
+            agent=Agent(TestModel(custom_output_args=output), output_type=CriticOutput),
+        ), '{"model":"offline"}'
+
+    async def agent(extractor):
+        calls.append("correction")
+        output = proposal[1].proposal.model_dump(mode="json")
+        if controls["correction_abstain"]:
+            output.update(
+                procedure=None, abstention_reason="Original evidence cannot support a correction."
+            )
+        output["assessments"] = [
+            {
+                "finding_id": review.finding_ids()[0],
+                "disposition": "accepted",
+                "explanation": "The goal remains limited to the observed condition.",
+                "evidence_refs": [{"evidence_id": "episode:0"}],
+            }
+        ]
+        return Agent(TestModel(custom_output_args=output), output_type=extractor.output_type)
+
+    monkeypatch.setattr(validation, "validation_extractor", critic)
+    monkeypatch.setattr(Extractor, "_get_agent", agent)
+    monkeypatch.setattr(
+        automatic,
+        "_extractor_policy",
+        AsyncMock(
+            return_value=publication._ExtractorPolicy(
+                "test",
+                "r",
+                100000,
+                2048,
+                "tool",
+                None,
+            )
+        ),
+    )
+
+    # Critic agents are explicit. Preserve them while substituting the correction factory.
+    async def get_agent(extractor):
+        if extractor.output_type is CriticOutput:
+            return extractor._agent
+        return await agent(extractor)
+
+    monkeypatch.setattr(Extractor, "_get_agent", get_agent)
+    return controls
+
+
+async def test_signed_automatic_no_findings_preserves_pending(candidate):
+    result = await automatic.automatically_reconsider_procedure(
+        organization_id="org",
+        principal_id="owner",
+        parent_id=candidate.id,
+        authorize=AsyncMock(),
+    )
+    assert result.status == "validated" and result.candidate_id == candidate.id
+    assert len(await rows("eval_consolidations")) == 1
+    assert (await rows("raw_captures"))[-1]["review_state"] == "pending"
+
+
+async def test_signed_automatic_correction_rechecks_and_replays(candidate, correction_model):
+    from pydantic import TypeAdapter
+
+    from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
+
+    original_rows = await rows("eval_consolidations")
+    original = await validation.prepare_stored_procedure_validation("org", "owner", candidate.id)
+    args = dict(
+        organization_id="org", principal_id="owner", parent_id=candidate.id, authorize=AsyncMock()
+    )
+    first = await automatic.automatically_reconsider_procedure(**args)
+    assert first.status == "corrected"
+    assert first.candidate_id != candidate.id and len(first.executions) == 3
+    assert first.stored.memory.review_state == "pending"
+    assert (
+        first.stored.build_receipt["reconsideration"]["submission"]["parent_operation_id"]
+        == candidate.metadata["eval_consolidation"]
+    )
+    assert len(await rows("eval_consolidations")) == 2
+    second = await automatic.automatically_reconsider_procedure(**args)
+    assert second == first
+    stages = await rows("memory_validation_executions")
+    assert len(stages) == 3
+    stage = next(row for row in stages if row["uuid"] == first.executions[1])
+    retained = TypeAdapter(ProcedureCorrectionResult).validate_json(stage["result_json"])
+    assert retained.result.group == original.artifact.group
+    assert (
+        retained.parent_candidate_sha256
+        == json.loads(original.prepared.payload_json)["parent_candidate_sha256"]
+    )
+    assert (
+        next(
+            row
+            for row in await rows("eval_consolidations")
+            if row["uuid"] == original_rows[0]["uuid"]
+        )
+        == original_rows[0]
+    )
+
+
+async def test_signed_correction_recorded_cancellation_resumes_without_extraction(
+    candidate, correction_model, monkeypatch
+):
+    import asyncio
+
+    from sibyl_core.services.validation_execution import ValidationExecution
+    from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
+
+    record = ValidationExecution.record_result
+    interrupted = False
+
+    async def cancel_after_record(execution, result):
+        nonlocal interrupted
+        await record(execution, result)
+        if isinstance(result, ProcedureCorrectionResult) and not interrupted:
+            interrupted = True
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(ValidationExecution, "record_result", cancel_after_record)
+    args = dict(
+        organization_id="org", principal_id="owner", parent_id=candidate.id, authorize=AsyncMock()
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await automatic.automatically_reconsider_procedure(**args)
+    stored = await rows("memory_validation_executions")
+    correction = next(row for row in stored if row["state"] == "recorded")
+    assert json.loads(correction["usage_json"])["requests"] == 1
+    monkeypatch.setattr(
+        automatic,
+        "propose_conditional_procedure",
+        AsyncMock(side_effect=AssertionError("duplicate paid extraction")),
+    )
+    result = await automatic.automatically_reconsider_procedure(**args)
+    assert result.status == "corrected" and len(await rows("eval_consolidations")) == 2
+
+
+async def test_signed_correction_identity_alone_cannot_authorize_write(proposal):
+    from dataclasses import replace
+
+    operation, result = proposal
+    corrected = replace(
+        operation,
+        correction_execution_id="a" * 64,
+        parent_operation_id="b" * 64,
+        parent_candidate_sha256="c" * 64,
+    )
+    assert corrected.key != operation.key
+    with pytest.raises(publication.ConsolidationConflict, match="stored correction authority"):
+        await publication.store_consolidation(corrected, result)
+    assert not await rows("eval_consolidations")
+
+
+async def test_signed_correction_late_parent_mutation_keeps_usage_without_child(
+    candidate, correction_model, monkeypatch
+):
+    from sibyl_core.backends.surreal import SurrealContentClient
+
+    execute = SurrealContentClient.execute_query
+    mutated = False
+
+    async def race(client, query, **params):
+        nonlocal mutated
+        if (
+            "CREATE eval_consolidations" in query
+            and "correction_execution" in params
+            and not mutated
+        ):
+            mutated = True
+            await execute(
+                client,
+                "UPDATE raw_captures SET metadata.changed=true WHERE uuid=$id;",
+                id=candidate.id,
+            )
+        return await execute(client, query, **params)
+
+    monkeypatch.setattr(SurrealContentClient, "execute_query", race)
+    with pytest.raises(Exception, match="Correction sources changed"):
+        await automatic.automatically_reconsider_procedure(
+            organization_id="org",
+            principal_id="owner",
+            parent_id=candidate.id,
+            authorize=AsyncMock(),
+        )
+    assert mutated and len(await rows("eval_consolidations")) == 1
+    stages = await rows("memory_validation_executions")
+    correction = next(
+        row for row in stages if json.loads(row["result_json"])["status"] == "procedure_correction"
+    )
+    assert json.loads(correction["usage_json"])["requests"] == 1
+
+
+@pytest.mark.parametrize("mutation", ["revision", "purge"])
+async def test_consolidation_transaction_fences_concurrent_source(proposal, monkeypatch, mutation):
+    import asyncio
+
+    from sibyl_core.services import content_client
+
+    async with content_client.surreal_content_client() as client:
+        if not client._url.startswith(("ws://", "wss://")):
+            pytest.skip("Requires independent native server transactions")
+    operation, result = proposal
+    source_id = result.group.episodes[0].stored_sources[0].source_id
+    entered = asyncio.Event()
+    original = publication._STORE
+    monkeypatch.setattr(
+        publication,
+        "_STORE",
+        original.replace("    LET $source_ids=", "    SLEEP 1s;\n    LET $source_ids="),
+    )
+    from sibyl_core.backends.surreal import SurrealContentClient
+
+    execute = SurrealContentClient.execute_query
+
+    async def observed(client, query, **params):
+        if "SLEEP 1s" in query:
+            entered.set()
+        return await execute(client, query, **params)
+
+    monkeypatch.setattr(SurrealContentClient, "execute_query", observed)
+    storing = asyncio.create_task(publication.store_consolidation(operation, result))
+    await entered.wait()
+    await asyncio.sleep(0.3)
+    async with content_client.surreal_content_client() as client:
+        if mutation == "purge":
+            await client.execute_query("DELETE raw_captures WHERE uuid=$id;", id=source_id)
+        else:
+            await client.execute_query(
+                "UPDATE raw_captures SET metadata.changed=true WHERE uuid=$id;", id=source_id
+            )
+    assert not storing.done(), "Source write must commit inside the dependent transaction window"
+    with pytest.raises(
+        Exception,
+        match=r"original admitted source changed|read or write conflict|transaction.*conflict",
+    ):
+        await storing
+    assert not await rows("eval_consolidations")
+    assert len(await rows("raw_captures")) == (1 if mutation == "purge" else 2)
+
+
+@pytest.mark.parametrize("boundary", ["correction_abstain", "recheck_abstain"])
+async def test_signed_automatic_insufficient_evidence_abstains(
+    candidate, correction_model, boundary
+):
+    correction_model[boundary] = True
+    result = await automatic.automatically_reconsider_procedure(
+        organization_id="org",
+        principal_id="owner",
+        parent_id=candidate.id,
+        authorize=AsyncMock(),
+    )
+    assert result.status == "abstained" and result.candidate_id is None
+    assert result.reason and "evidence" in result.reason.lower()
+    assert all(row.get("promoted_entity_id") is None for row in await rows("eval_consolidations"))
+    assert len(result.executions) == (2 if boundary == "correction_abstain" else 3)
+
+
+async def test_signed_correction_purge_removes_stored_source_bodies(candidate, correction_model):
+    from sibyl_core.services import content_client
+    from sibyl_core.services.validation_execution import validation_archive_guard
+
+    await automatic.automatically_reconsider_procedure(
+        organization_id="org",
+        principal_id="owner",
+        parent_id=candidate.id,
+        authorize=AsyncMock(),
+    )
+    stages = await rows("memory_validation_executions")
+    assert len(stages) == 3
+    for stage in stages:
+        assert validation_archive_guard("memory_validation_executions", stage)
+    original = await validation.prepare_stored_procedure_validation("org", "owner", candidate.id)
+    source = original.artifact.group.episodes[0].stored_sources[0].source_id
+    async with content_client.surreal_content_client() as client:
+        await client.execute_query("DELETE raw_captures WHERE uuid=$id;", id=source)
+    after = await rows("memory_validation_executions")
+    assert all(stage["purged"] and stage.get("result_json") is None for stage in after)
+    assert all(json.loads(stage["usage_json"])["requests"] == 1 for stage in after)

--- a/packages/python/sibyl-core/tests/test_validation_execution.py
+++ b/packages/python/sibyl-core/tests/test_validation_execution.py
@@ -211,14 +211,14 @@ async def test_validation_execution_actual_sdk_durable_attempts(candidate, monke
 
 
 async def test_validation_execution_final_snapshot_cas(candidate, monkeypatch):
-    from sibyl_core.services import content_client
+    from sibyl_core.services import content_client, validation_stages
 
-    query = validation._query
+    query = validation_stages._query
     mutated = False
 
     async def race(sql, **params):
         nonlocal mutated
-        if "SET state = IF" in sql and not mutated:
+        if "SET state='returned'" in sql and not mutated:
             mutated = True
             async with content_client.surreal_content_client() as client:
                 await client.execute_query(
@@ -227,8 +227,8 @@ async def test_validation_execution_final_snapshot_cas(candidate, monkeypatch):
                 )
         return await query(sql, **params)
 
-    monkeypatch.setattr(validation, "_query", race)
-    with pytest.raises(ValidationExecutionUnavailable):
+    monkeypatch.setattr(validation_stages, "_query", race)
+    with pytest.raises(Exception, match="Validation sources changed"):
         await validation.validate_stored_procedure(
             organization_id="org",
             principal_id="owner",


### PR DESCRIPTION
Stored procedure critiques can now drive automatic correction using the original admitted evidence. The adapter reuses the existing extraction and durable validation owners, stores a distinct corrected candidate, and runs a second critic against that stored candidate. Recorded results resume after interruption without repeating extraction.

The correction operation binds its parent, candidate digest and stored execution. The existing consolidation writer verifies the exact persisted result and fences current sources inside its transaction. A shared original-evidence citation map keeps critique and reconsideration aligned. Normal consolidation keys remain unchanged.

## 🧪 Validation

Independent review covered the eight changed files and the shared stage owner. Root repeated 24 native controls, including concurrent source revision and purge, cancellation recovery, and retained negative outcomes. An actual database process restart passed seed and resume checks with correction extraction forbidden. Both owned containers were removed. The affected author suite passed 259 core controls, seven API compatibility controls and four static checks.

The adapter returns validated or corrected candidates; it does not publish them to the graph. The next integration connects the stored validation result to existing promotion and recall checks. These tests establish execution and source-lifecycle behavior, not model usefulness or learning gain.

## 🛠️ Stack

This layer follows #552 and adds the signed procedure adapter. Automatic promotion remains a separate reviewed layer.
