### PR TITLE
fix(memory): preserve controller launch arguments in evidence views

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/tasks/episode_evidence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/episode_evidence.py
@@ -16,7 +16,7 @@ from sibyl_core.tasks._evidence_json import (
     share_exact_values,
 )
 
-PROJECTION_VERSION = "sibyl-controller-evidence-view-v1"
+PROJECTION_VERSION = "sibyl-controller-evidence-view-v2"
 EPISODE_VERSION = "sibyl-learning-episode-v1"
 TRACE_VERSION = "sibyl-coding-trace-v1"
 
@@ -272,7 +272,9 @@ class _EpisodeBuilder:
                 base, ("request", "options", "workspace_initial", "image", "interpreter")
             )
         elif kind == "tool_call":
-            view, paths = self.select(base, ("index", "tool_call_id", "name", "command", "call"))
+            view, paths = self.select(
+                base, ("index", "tool_call_id", "name", "command", "call", "argv")
+            )
         elif kind == "tool_result":
             for key in ("stdout", "stderr"):
                 self.encoded_alias((*base, key + "_base64"), (*base, key), json_value=False)

--- a/packages/python/sibyl-core/tests/test_episode_evidence.py
+++ b/packages/python/sibyl-core/tests/test_episode_evidence.py
@@ -274,3 +274,68 @@ def test_projection_receipt_is_stable_across_hash_seeds() -> None:
         )
         results.append(process.stdout)
     assert results[0] == results[1]
+
+
+def test_launch_argv_is_visible_cited_and_changes_native_projection() -> None:
+    argv = [
+        "docker",
+        "run",
+        "--read-only",
+        "--tmpfs",
+        "/tmp:rw,nosuid,nodev,size=16777216",
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges",
+        "image",
+        "-c",
+        "write-result",
+    ]
+    episode = _episode()
+    launch = deepcopy(episode["trace"][-1])
+    launch.update(kind="tool_call", index=3)
+    launch["payload"] = {"name": "command", "command": "write-result", "argv": argv}
+    episode["trace"].insert(3, launch)
+    artifact = json.dumps(episode).encode()
+    projection = project_episode("source", artifact, prefix="s0")
+    assert projection.view["events"][3]["argv"] == argv
+    assert argv in [
+        json.loads(artifact[start:end]) for start, end in projection.citations["s0.e3"].ranges
+    ]
+    assert any(
+        row["path"] == ["trace", 3, "payload", "argv"] and row["disposition"] == "visible"
+        for row in projection.coverage
+    )
+    group = _contrast_group()
+    group = group.model_copy(
+        update={
+            "episodes": tuple(
+                source.model_copy(
+                    update={
+                        "artifact": artifact,
+                        "artifact_sha256": hashlib.sha256(artifact).hexdigest(),
+                    }
+                )
+                for source in group.episodes
+            )
+        }
+    )
+    original = c._extraction_input(group)
+    assert original.projection_receipt["version"] == "sibyl-controller-evidence-view-v2"
+    assert "--read-only" in original.prompt and "--cap-drop=ALL" in original.prompt
+    episode["trace"][3]["payload"]["argv"].remove("--read-only")
+    changed = json.dumps(episode).encode()
+    group = group.model_copy(
+        update={
+            "episodes": tuple(
+                source.model_copy(
+                    update={
+                        "artifact": changed,
+                        "artifact_sha256": hashlib.sha256(changed).hexdigest(),
+                    }
+                )
+                for source in group.episodes
+            )
+        }
+    )
+    altered = c._extraction_input(group)
+    assert original.projection_receipt != altered.projection_receipt
+    assert "--read-only" not in altered.prompt


### PR DESCRIPTION
Controller evidence views kept the command but omitted its launch arguments. Extraction could therefore miss read-only filesystem, tmpfs, capability, or privilege constraints that explain why an action failed. The shared projection now retains the complete ordered argv for each tool launch.

The change uses the existing original-byte citations and exact-value sharing. The projection version advances to v2, giving the changed input and coverage a distinct receipt policy. Historical v1 receipts remain stored; current agreement validation does not reinterpret them as v2, so those candidates need regeneration before validation under the new policy.

## 🧪 Validation

- The regression fails before the fix with missing argv, then verifies native prompt exposure, original-byte citations, and a changed receipt when launch constraints change.
- The focused evidence suites pass 25 tests. Core lint and typecheck pass.
- Retained-corpus and independent controls pass 10 checks, including all 22 episodes, all 375 ordered launch arguments after dictionary decoding, alias validation, and complete leaf classification.

No provider calls were used for verification. The change enables consistent evidence inputs; it does not establish transfer-task performance or complete the separate publication integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tool-call command arguments are now included in episode evidence, making them visible and properly cited.
  - Extraction prompts now retain command arguments for more complete evidence processing.
  - Changes to tool-call arguments are reflected in the resulting projection receipt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->