### PR TITLE
feat(memory): bind procedure promotion to durable validation

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/content_schema.py
@@ -30,6 +30,7 @@ from sibyl_core.backends.surreal.schema_source_states import (
 from sibyl_core.backends.surreal.schema_source_witness import SOURCE_STATE_WITNESS_DEFINITION
 from sibyl_core.backends.surreal.schema_validation_execution import (
     VALIDATION_EXECUTION_SCHEMA,
+    VALIDATION_PROMOTION_SCHEMA,
     VALIDATION_PURGE_EVENT,
 )
 from sibyl_core.backends.surreal.schema_version import (
@@ -86,7 +87,7 @@ CONTENT_TABLES = (
     "backup_settings",
     "backups",
 )
-CONTENT_SCHEMA_CURRENT_VERSION = 38
+CONTENT_SCHEMA_CURRENT_VERSION = 39
 CONTENT_SCHEMA_NAME = "content"
 _SCHEMA_CHECK_BATCH_SIZE = 128
 _CONTENT_MEMORY_SCOPE_VALUES = tuple(scope.value for scope in MemoryScope)
@@ -1020,6 +1021,11 @@ def _content_schema_migrations(*, url: str) -> tuple[SchemaMigration, ...]:
             version=38,
             name="content_source_write_witness",
             statements=tuple(split_statements(SOURCE_STATE_WITNESS_DEFINITION)),
+        ),
+        SchemaMigration(
+            version=39,
+            name="content_validation_promotion_binding",
+            statements=tuple(split_statements(VALIDATION_PROMOTION_SCHEMA)),
         ),
     )
 

--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_validation_execution.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/schema_validation_execution.py
@@ -43,3 +43,15 @@ THEN {
             AND (parent_id = $before.uuid OR $before.uuid IN source_ids);
 };
 """
+
+
+VALIDATION_PROMOTION_SCHEMA = """
+DEFINE FIELD IF NOT EXISTS validation_binding_json ON memory_derivations TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS validation_entity_id ON memory_derivations TYPE option<string>;
+DEFINE INDEX IF NOT EXISTS memory_derivation_validation_entity ON memory_derivations FIELDS organization_id, validation_entity_id;
+DEFINE FIELD IF NOT EXISTS promotion_write_witness ON memory_validation_executions TYPE option<int> DEFAULT 0;
+DEFINE EVENT IF NOT EXISTS retain_validation_binding ON memory_derivations WHEN $event='UPDATE'
+    AND $before.validation_binding_json!=NONE
+    AND ($after.validation_binding_json!=$before.validation_binding_json OR $after.validation_entity_id!=$before.validation_entity_id)
+    THEN { THROW 'validation binding is immutable'; };
+"""

--- a/packages/python/sibyl-core/src/sibyl_core/migrate/source_integrity.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/source_integrity.py
@@ -248,6 +248,10 @@ def validate_integrity_archive(
             or not isinstance(association.get("authority_ceiling"), dict)
         ):
             raise ValueError("archive derivation body or authority is malformed")
+        if association.get("validation_binding_json") is not None:
+            from sibyl_core.services.validation_promotion import ValidationBinding
+
+            ValidationBinding.model_validate_json(association["validation_binding_json"])
         from sibyl_core.services.memory_derivations import observation_from_record
 
         for value in association["observations"]:

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from sibyl_core.memory_pipeline.observations import SourceObservation
     from sibyl_core.services.dream_checkpoints import DreamCandidateWrite
     from sibyl_core.services.validation_candidate import ValidationCandidateWrite
+    from sibyl_core.services.validation_promotion import ValidatedPromotion
 
 _RAW_MEMORY_EMBEDDING_AUTO = object()
 
@@ -891,12 +892,28 @@ async def save_raw_memory(
     superseded_by_memory_id: str | None = None,
     source_observations: Sequence[RawMemory] = (),
     publication_operation_id: str | None = None,
+    validation_promotion: ValidatedPromotion | None = None,
+    validation_derivation: dict[str, object] | None = None,
 ) -> RawMemory:
     from sibyl_core.services.procedure_artifact import publication_build_receipt_json
+    from sibyl_core.services.validation_promotion import VALIDATION_PROMOTION_GUARD
+    from sibyl_core.tasks._evidence_json import canonical
+
+    validation_guard, validation_params = "", {}
+    if validation_promotion is not None:
+        if (memory.organization_id, memory.principal_id, memory.id) != (
+            validation_promotion.organization_id,
+            validation_promotion.principal_id,
+            validation_promotion.candidate_id,
+        ):
+            raise ValueError("Validation promotion owner differs")
+        validation_guard, validation_params = await validation_promotion.current_guard()
 
     if expected_revision is not None and expected_revision < 1:
         raise ValueError("expected_revision must be at least 1")
-    if (source_observations or publication_operation_id) and expected_revision is None:
+    if (
+        source_observations or publication_operation_id or validation_promotion
+    ) and expected_revision is None:
         raise ValueError("source-observed publication requires a revision fence")
     if any(source.organization_id != memory.organization_id for source in source_observations):
         raise ValueError("source observations must belong to the publication organization")
@@ -951,6 +968,8 @@ async def save_raw_memory(
                     client,
                     """
                         RETURN {
+                        __VALIDATION_SOURCE_GUARD__
+                        __VALIDATION_PROMOTION_GUARD__
                         __PUBLICATION_ADMISSION_GUARD__
                         FOR $source IN $source_observations {
                             LET $observed = (SELECT * FROM raw_captures
@@ -1031,9 +1050,30 @@ async def save_raw_memory(
                         };
                         RETURN $saved;
                         };
-                    """.replace(
-                        "__PUBLICATION_ADMISSION_GUARD__", PUBLICATION_ADMISSION_GUARD
-                    ).replace("__SOURCE_STATE_WRITE_WITNESS__", SOURCE_STATE_WRITE_WITNESS),
+                    """.replace("__PUBLICATION_ADMISSION_GUARD__", PUBLICATION_ADMISSION_GUARD)
+                    .replace("__SOURCE_STATE_WRITE_WITNESS__", SOURCE_STATE_WRITE_WITNESS)
+                    .replace("__VALIDATION_SOURCE_GUARD__", validation_guard)
+                    .replace("__VALIDATION_PROMOTION_GUARD__", VALIDATION_PROMOTION_GUARD),
+                    **validation_params,
+                    validation_binding=validation_promotion.binding.model_dump()
+                    if validation_promotion
+                    else None,
+                    validation_binding_json=canonical(validation_promotion.binding.model_dump())
+                    if validation_promotion
+                    else None,
+                    validation_principal=memory.principal_id,
+                    validation_entity_id=memory.metadata.get("promoted_entity_id")
+                    if validation_promotion
+                    else None,
+                    validation_derivation={
+                        **validation_derivation,
+                        "validation_entity_id": memory.metadata.get("promoted_entity_id"),
+                        "validation_binding_json": canonical(
+                            validation_promotion.binding.model_dump()
+                        ),
+                    }
+                    if validation_derivation and validation_promotion
+                    else None,
                     organization_id=memory.organization_id,
                     publication_operation_id=publication_operation_id
                     or (

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_derivations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_derivations.py
@@ -66,6 +66,11 @@ async def graph_association_current(entity, association, *, ancestors=frozenset(
         observations = [observation_from_record(value) for value in values]
     except SourceUnavailableError:
         return False
+    if any(o.source.kind is SourceKind.RAW_CAPTURE for o in observations):
+        from sibyl_core.services.validation_promotion import validated_graph_current
+
+        if not await validated_graph_current(entity.organization_id, entity.id):
+            return False
     return await validate_observations(
         observations, authority, organization_id=entity.organization_id, ancestors=ancestors
     )

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_derivations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_derivations.py
@@ -114,6 +114,10 @@ async def _raw_association_current(
         or association.get("body_sha256") != hashlib.sha256(memory.raw_content.encode()).hexdigest()
     ):
         return False
+    from sibyl_core.services.validation_promotion import validation_binding_current
+
+    if not await validation_binding_current(memory, association):
+        return False
     from sibyl_core.services.memory_source_validation import (
         SOURCE_VALIDATION_CONTEXT_KEY,
         _saved_ceiling,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_reflection.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sibyl_core.services.memory_source_validation import SourceReadAuthority
+    from sibyl_core.services.validation_promotion import ValidatedPromotion
 
 import re
 from collections.abc import Iterable, Sequence
@@ -642,6 +643,7 @@ async def promote_reflection_candidate_review(
     *,
     candidate_id: str,
     expected_candidate_revision: int | None = None,
+    validation_promotion: ValidatedPromotion | None = None,
     organization_id: str,
     principal_id: str | None,
     promote_to_scope: MemoryScope | str | None,
@@ -701,6 +703,7 @@ async def promote_reflection_candidate_review(
         native_source_id=plan.raw_source_ids[0] if plan.raw_source_ids else None,
         lifecycle_source_id=plan.candidate_memory.id,
         lifecycle_reason="accepted_reflection_candidate",
+        validation_promotion=validation_promotion,
     )
 
 
@@ -898,6 +901,7 @@ async def _apply_promotion_plan(
     native_source_id: str | None,
     lifecycle_source_id: str,
     lifecycle_reason: str,
+    validation_promotion: ValidatedPromotion | None = None,
 ) -> ReflectionPromotionResult:
     accessible_projects = (
         frozenset(accessible_projects) if accessible_projects is not None else None
@@ -939,6 +943,7 @@ async def _apply_promotion_plan(
     reservation = await _reserve_promotion(
         plan,
         prospective.id,
+        validation_promotion=validation_promotion,
         legacy_entity_id=reflection_entity_id(
             prospective.model_copy(update={"name": plan.promotion_candidate.title}), version=2
         ),
@@ -976,6 +981,7 @@ async def _apply_promotion_plan(
         result=result,
         lifecycle_source_id=lifecycle_source_id,
         lifecycle_reason=lifecycle_reason,
+        validation_promotion=validation_promotion,
     )
 
 
@@ -1035,8 +1041,11 @@ async def _reserve_promotion(
     entity_id: str,
     *,
     legacy_entity_id: str | None = None,
+    validation_promotion: ValidatedPromotion | None = None,
 ) -> _ReflectionPromotionPlan | ReflectionPromotionResult:
     """Reserve correction's existing pointer before publishing any graph row."""
+    if validation_promotion is not None:
+        await validation_promotion.current_guard()
     memory = plan.candidate_memory
     recorded_id = _metadata_str(memory.metadata, "promoted_entity_id")
     if recorded_id or memory.review_state == _PROMOTED_REVIEW_STATE:
@@ -1049,7 +1058,8 @@ async def _reserve_promotion(
                 scope_key=plan.target_scope_key,
                 raw_source_ids=plan.raw_source_ids,
             )
-        return plan
+        if validation_promotion is None:
+            return plan
     try:
         reserved = await save_raw_memory(
             replace(
@@ -1057,10 +1067,14 @@ async def _reserve_promotion(
                 metadata={
                     **memory.metadata,
                     "promoted_entity_id": entity_id,
-                    "promotion_state": "pending",
+                    "promotion_state": memory.metadata.get("promotion_state", "pending")
+                    if recorded_id
+                    else "pending",
                 },
             ),
             expected_revision=memory.revision,
+            validation_promotion=validation_promotion,
+            validation_derivation=_validation_derivation(plan) if validation_promotion else None,
             **(
                 {"publication_operation_id": str(memory.metadata[EVAL_CONSOLIDATION_METADATA_KEY])}
                 if memory.metadata.get(EVAL_CONSOLIDATION_METADATA_KEY)
@@ -1137,7 +1151,10 @@ async def _mark_promotion_plan_promoted(
     result: ReflectionWriteResult,
     lifecycle_source_id: str,
     lifecycle_reason: str,
+    validation_promotion: ValidatedPromotion | None = None,
 ) -> ReflectionPromotionResult:
+    if validation_promotion is not None:
+        await validation_promotion.current_guard()
     if (
         result.metadata.get("publication_outcome") == "replayed"
         and plan.candidate_memory.review_state == _PROMOTED_REVIEW_STATE
@@ -1159,6 +1176,7 @@ async def _mark_promotion_plan_promoted(
                     metadata=metadata,
                 ),
                 expected_revision=plan.candidate_memory.revision,
+                validation_promotion=validation_promotion,
                 **(
                     {"source_observations": plan.input_memories}
                     if plan.candidate_memory.metadata.get(EVAL_CONSOLIDATION_METADATA_KEY)
@@ -1565,3 +1583,14 @@ async def _resolve_raw_memory_promotion_plan(
         input_memories=input_memories,
         source_observations=(snapshot.observation,) if snapshot is not None else (),
     )
+
+
+def _validation_derivation(plan: _ReflectionPromotionPlan) -> dict[str, object]:
+    from sibyl_core.services.memory_derivations import raw_derivation_record
+
+    if plan.source_authority is None:
+        raise ValueError("Validated promotion requires current source authority")
+    observations = tuple(
+        o for o in plan.source_observations if o.source.id != plan.candidate_memory.id
+    )
+    return raw_derivation_record(plan.candidate_memory, observations, plan.source_authority)

--- a/packages/python/sibyl-core/src/sibyl_core/services/validation_promotion.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/validation_promotion.py
@@ -1,0 +1,253 @@
+"""Consume a stored critic result through the existing promotion transaction."""
+
+import hashlib
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+
+from sibyl_core.services.validation_execution import (
+    ValidationExecution,
+    ValidationExecutionUnavailable,
+)
+from sibyl_core.tasks._evidence_json import canonical
+from sibyl_core.tasks.memory_validation import (
+    VALIDATION_VERSION,
+    CriticOutput,
+    MemoryValidationResult,
+)
+from sibyl_core.tasks.procedure_review import review_digest
+
+
+def _sha(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+class ValidationBinding(BaseModel):
+    """Hash-only reverse reference retained with the mandatory source association."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    execution_id: str = Field(pattern=r"^[0-9a-f]{64}$")
+    request_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    result_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    input_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+def validated_result(
+    row: dict[str, Any], binding: ValidationBinding, org: str, principal: str, parent: str
+) -> MemoryValidationResult:
+    if (
+        row.get("uuid") != binding.execution_id
+        or row.get("organization_id") != org
+        or row.get("principal_id") != principal
+        or row.get("parent_id") != parent
+        or row.get("state") != "returned"
+        or row.get("purged") is not False
+        or not isinstance(row.get("request_json"), str)
+        or not isinstance(row.get("result_json"), str)
+        or _sha(row["result_json"]) != binding.result_sha256
+    ):
+        raise ValidationExecutionUnavailable("Promotion validation is unavailable")
+    request = json.loads(row["request_json"])
+    if not isinstance(request, dict):
+        raise ValidationExecutionUnavailable("Promotion validation request is malformed")
+    if (
+        canonical(request) != row["request_json"]
+        or review_digest(request) != binding.execution_id
+        or row.get("request_sha256") != binding.request_sha256
+        or binding.request_sha256 != binding.execution_id
+        or request.get("org") != org
+        or request.get("principal") != principal
+        or request.get("parent") != parent
+        or request.get("policy") != row.get("policy_json")
+        or request.get("input") != binding.input_sha256
+    ):
+        raise ValidationExecutionUnavailable("Promotion validation identity differs")
+    result = TypeAdapter(MemoryValidationResult).validate_json(row["result_json"])
+    if (
+        result.version != VALIDATION_VERSION
+        or result.schema_sha256 != review_digest(CriticOutput.model_json_schema())
+        or result.status != "no_findings"
+        or result.submission is not None
+        or result.reason is not None
+        or result.input_sha256 != binding.input_sha256
+    ):
+        raise ValidationExecutionUnavailable("Critic did not validate this candidate")
+    return result
+
+
+async def validation_binding_current(memory, association) -> bool:
+    value = association.get("validation_binding_json")
+    if value is None:
+        return True
+    try:
+        binding = ValidationBinding.model_validate_json(value)
+        row = await ValidationExecution(
+            binding.execution_id, memory.organization_id, memory.principal_id
+        ).load()
+        if row is None:
+            return False
+        validated_result(row, binding, memory.organization_id, memory.principal_id, memory.id)
+    except (ValueError, TypeError, KeyError):
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class ValidatedPromotion:
+    organization_id: str
+    principal_id: str
+    candidate_id: str
+    binding: ValidationBinding
+    authorize: Callable[[], Awaitable[None]]
+
+    async def current_guard(self) -> tuple[str, dict[str, Any]]:
+        from sibyl_core.services.procedure_validation import (
+            _SNAPSHOT,
+            prepare_stored_procedure_validation,
+        )
+
+        await self.authorize()
+        current = await prepare_stored_procedure_validation(
+            self.organization_id, self.principal_id, self.candidate_id
+        )
+        row = await ValidationExecution(
+            self.binding.execution_id, self.organization_id, self.principal_id
+        ).load()
+        if row is None:
+            raise ValidationExecutionUnavailable("Promotion validation disappeared")
+        validated_result(
+            row, self.binding, self.organization_id, self.principal_id, self.candidate_id
+        )
+        request = json.loads(row["request_json"])
+        prior = {item["source_id"]: item for item in request["source_bindings"]}
+        present = {item["source_id"]: item for item in current.source_bindings}
+        if set(prior) != set(present) or any(
+            prior[key]["incarnation"] != present[key]["incarnation"]
+            or (key != self.candidate_id and prior[key]["generation"] != present[key]["generation"])
+            for key in prior
+        ):
+            raise ValidationExecutionUnavailable("Validated source identity changed")
+        if current.prepared.input_sha256 != self.binding.input_sha256:
+            raise ValidationExecutionUnavailable("Validated source evidence changed")
+        return (
+            "LET $org=$organization_id; LET $parent=$uuid;"
+            + _SNAPSHOT
+            + "IF $snapshot_digest!=$validation_snapshot { THROW 'publication_source_observation_changed'; };",
+            {"validation_snapshot": current.snapshot_sha256},
+        )
+
+
+async def promote_validated_procedure(
+    *,
+    organization_id: str,
+    principal_id: str,
+    candidate_id: str,
+    execution_id: str,
+    authorize: Callable[[], Awaitable[None]],
+):
+    """Promote privately from durable evidence, never a caller's critique text."""
+    from sibyl_core.services.memory_reflection import promote_reflection_candidate_review
+
+    await authorize()
+    row = await ValidationExecution(execution_id, organization_id, principal_id).load()
+    if row is None or not isinstance(row.get("result_json"), str):
+        raise ValidationExecutionUnavailable("Promotion validation unavailable")
+    result = TypeAdapter(MemoryValidationResult).validate_json(row["result_json"])
+    binding = ValidationBinding(
+        execution_id=execution_id,
+        request_sha256=execution_id,
+        result_sha256=_sha(row["result_json"]),
+        input_sha256=result.input_sha256,
+    )
+    promotion = ValidatedPromotion(organization_id, principal_id, candidate_id, binding, authorize)
+    await promotion.current_guard()
+    return await promote_reflection_candidate_review(
+        candidate_id=candidate_id,
+        organization_id=organization_id,
+        principal_id=principal_id,
+        promote_to_scope="private",
+        promote_to_scope_key=principal_id,
+        validation_promotion=promotion,
+    )
+
+
+VALIDATION_PROMOTION_GUARD = """
+IF $validation_binding != NONE {
+    LET $stage=(SELECT * FROM memory_validation_executions WHERE uuid=$validation_binding.execution_id
+        AND organization_id=$organization_id AND principal_id=$validation_principal)[0];
+    IF $stage=NONE OR $stage.state!='returned' OR $stage.purged!=false
+        OR $stage.parent_id!=$uuid OR $stage.request_sha256!=$validation_binding.request_sha256
+        OR crypto::sha256($stage.request_json)!=$validation_binding.request_sha256
+        OR $stage.result_json=NONE OR crypto::sha256($stage.result_json)!=$validation_binding.result_sha256 {
+        THROW 'publication_source_observation_changed';
+    };
+    LET $association=(SELECT * FROM memory_derivations WHERE organization_id=$organization_id
+        AND target_kind='raw_capture' AND target_id=$uuid)[0];
+    IF $association=NONE {
+        IF $validation_derivation=NONE { THROW 'publication_source_observation_changed'; };
+        CREATE memory_derivations CONTENT $validation_derivation;
+    } ELSE {
+        IF $association.active!=true OR ($association.validation_entity_id!=NONE AND $association.validation_entity_id!=$validation_entity_id) OR ($association.validation_binding_json!=NONE
+            AND $association.validation_binding_json!=$validation_binding_json) {
+            THROW 'publication_source_observation_changed';
+        };
+        UPDATE memory_derivations SET validation_binding_json=$validation_binding_json, validation_entity_id=$validation_entity_id
+            WHERE id=$association.id;
+    };
+    UPDATE memory_validation_executions SET promotion_write_witness=(promotion_write_witness ?? 0)+1
+        WHERE id=$stage.id;
+};
+"""
+
+
+async def validated_graph_current(organization_id: str, entity_id: str) -> bool:
+    """Follow protected reverse references, including legacy publication ledgers."""
+    from sibyl_core.services.content_models import raw_memory_from_record
+    from sibyl_core.services.validation_execution import _query
+
+    rows = await _query(
+        """RETURN {
+        LET $direct=(SELECT * FROM memory_derivations WHERE organization_id=$org
+            AND validation_entity_id=$entity);
+        LET $published=(SELECT candidate_id FROM eval_consolidations WHERE organization_id=$org
+            AND promoted_entity_id=$entity);
+        LET $ids=array::distinct(array::concat($direct.map(|$a| $a.target_id),$published.map(|$p| $p.candidate_id)));
+        RETURN {
+            captures:(SELECT * FROM raw_captures WHERE organization_id=$org AND uuid IN $ids),
+            associations:(SELECT * FROM memory_derivations WHERE organization_id=$org
+                AND target_kind='raw_capture' AND target_id IN $ids),
+            ids:$ids
+        };
+    };""",
+        org=organization_id,
+        entity=entity_id,
+    )
+    if len(rows) != 1:
+        raise ValidationExecutionUnavailable("Validation recall snapshot unavailable")
+    captures = {row["uuid"]: row for row in rows[0]["captures"]}
+    associations = {row["target_id"]: row for row in rows[0]["associations"]}
+    for identifier in rows[0]["ids"]:
+        record = captures.get(identifier)
+        if record is None:
+            return False
+        memory = raw_memory_from_record(record)
+        association = associations.get(identifier)
+        if association is None:
+            if memory.derivation_required:
+                return False
+            continue
+        if association.get("validation_binding_json") is None:
+            if association.get("validation_entity_id") is not None:
+                return False
+            continue
+        if (
+            association.get("active") is not True
+            or association.get("validation_entity_id") != entity_id
+            or association.get("body_sha256") != _sha(memory.raw_content)
+            or not await validation_binding_current(memory, association)
+        ):
+            return False
+    return True

--- a/packages/python/sibyl-core/tests/test_validation_promotion.py
+++ b/packages/python/sibyl-core/tests/test_validation_promotion.py
@@ -1,0 +1,248 @@
+"""A durable critic stage must survive every promotion and recall boundary."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.services import content_client, memory_reflection
+from sibyl_core.services.content_raw_recall import recall_raw_memory
+from sibyl_core.services.procedure_validation import validate_stored_procedure
+from sibyl_core.services.validation_promotion import promote_validated_procedure
+from tests.test_eval_publication import admitted_pair as admitted_pair
+from tests.test_eval_publication import content_store as content_store
+from tests.test_eval_publication import evidence as evidence
+from tests.test_eval_publication import proposal as proposal
+from tests.test_eval_publication import rows
+from tests.test_eval_publication_promotion import runtime as runtime
+from tests.test_validation_execution import candidate as candidate
+
+
+async def mutate(query, **params):
+    async with content_client.surreal_content_client() as client:
+        return await client.execute_query(query, **params)
+
+
+@pytest.fixture
+async def approved(candidate):
+    result = await validate_stored_procedure(
+        organization_id="org", principal_id="owner", parent_id=candidate.id, authorize=AsyncMock()
+    )
+    return dict(
+        organization_id="org",
+        principal_id="owner",
+        candidate_id=candidate.id,
+        execution_id=result["execution_id"],
+        authorize=AsyncMock(),
+    )
+
+
+async def test_validated_promotion_replays_and_recalls(approved, candidate, runtime):
+    first = await promote_validated_procedure(**approved)
+    assert first.success, first
+    associations = await rows("memory_derivations")
+    binding = next(x for x in associations if x["target_id"] == candidate.id)[
+        "validation_binding_json"
+    ]
+    assert json.loads(binding)["execution_id"] == approved["execution_id"]
+    assert candidate.id in {
+        m.id
+        for m in await recall_raw_memory(
+            organization_id="org", principal_id="owner", query="Check the actual output"
+        )
+    }
+    replay = await promote_validated_procedure(**approved)
+    assert replay.success and replay.promoted_id == first.promoted_id
+    assert len(await rows("memory_validation_executions")) == 1
+
+
+@pytest.mark.parametrize("mutation", ["purged", "missing", "result", "owner"])
+async def test_invalid_stored_validation_cannot_promote(approved, runtime, mutation):
+    if mutation == "missing":
+        await mutate("DELETE memory_validation_executions;")
+    elif mutation == "purged":
+        await mutate("UPDATE memory_validation_executions SET purged=true;")
+    elif mutation == "result":
+        await mutate("UPDATE memory_validation_executions SET result_json='{}';")
+    else:
+        approved["principal_id"] = "other"
+    with pytest.raises(ValueError):
+        await promote_validated_procedure(**approved)
+    assert not await rows("memory_derivations")
+
+
+@pytest.mark.parametrize("mutation", ["purged", "missing", "result"])
+async def test_promotion_validation_loss_denies_recall(approved, candidate, runtime, mutation):
+    result = await promote_validated_procedure(**approved)
+    assert result.success, result
+    if mutation == "missing":
+        await mutate("DELETE memory_validation_executions;")
+    elif mutation == "purged":
+        await mutate("UPDATE memory_validation_executions SET purged=true;")
+    else:
+        await mutate("UPDATE memory_validation_executions SET result_json='{}';")
+    assert candidate.id not in {
+        m.id
+        for m in await recall_raw_memory(
+            organization_id="org", principal_id="owner", query="Check the actual output"
+        )
+    }
+    from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+
+    entity = await runtime.entity_manager.get(result.promoted_id)
+    assert result.promoted_id in await unavailable_publication_ids(
+        "org", {result.promoted_id: entity.metadata}
+    )
+
+
+async def test_stage_change_at_final_cas_cannot_publish(approved, candidate, runtime, monkeypatch):
+    original = memory_reflection.save_raw_memory
+
+    async def changed(memory, **kwargs):
+        if memory.review_state == "promoted":
+            await mutate("UPDATE memory_validation_executions SET result_json='{}';")
+        return await original(memory, **kwargs)
+
+    monkeypatch.setattr(memory_reflection, "save_raw_memory", changed)
+    try:
+        result = await promote_validated_procedure(**approved)
+    except ValueError:
+        pass
+    else:
+        assert not result.success
+    assert candidate.id not in {
+        m.id
+        for m in await recall_raw_memory(
+            organization_id="org", principal_id="owner", query="Check the actual output"
+        )
+    }
+
+
+async def test_validation_binding_cannot_be_removed(approved, candidate, runtime):
+    assert (await promote_validated_procedure(**approved)).success
+    with pytest.raises(Exception, match="validation binding is immutable"):
+        await mutate(
+            "UPDATE memory_derivations SET validation_binding_json=NONE WHERE target_id=$id;",
+            id=candidate.id,
+        )
+
+
+async def test_validation_stage_changes_inside_final_query(
+    approved, candidate, runtime, monkeypatch
+):
+    original = content_client.select_many_raw
+    injected = []
+
+    async def changed(client, query, **params):
+        if params.get("record", {}).get("review_state") == "promoted" and params.get(
+            "validation_binding"
+        ):
+            await client.execute_query("UPDATE memory_validation_executions SET result_json='{}';")
+            injected.append(True)
+        return await original(client, query, **params)
+
+    monkeypatch.setattr(content_client, "select_many_raw", changed)
+    result = await promote_validated_procedure(**approved)
+    assert injected == [True]
+    assert not result.success
+    assert candidate.id not in {
+        m.id
+        for m in await recall_raw_memory(
+            organization_id="org", principal_id="owner", query="Check the actual output"
+        )
+    }
+    assert (await rows("memory_validation_executions"))[0]["usage_json"]
+
+
+async def test_source_retired_after_graph_write_stays_unrecalled(
+    approved, candidate, runtime, monkeypatch
+):
+    original = runtime.entity_manager.create_direct_if_absent
+
+    async def changed(entity, **kwargs):
+        result = await original(entity, **kwargs)
+        await mutate(
+            "UPDATE raw_captures SET deleted_at=time::now() WHERE uuid!=$candidate;",
+            candidate=candidate.id,
+        )
+        return result
+
+    monkeypatch.setattr(runtime.entity_manager, "create_direct_if_absent", changed)
+    try:
+        result = await promote_validated_procedure(**approved)
+    except ValueError:
+        pass
+    else:
+        assert not result.success
+    assert candidate.id not in {
+        m.id
+        for m in await recall_raw_memory(
+            organization_id="org", principal_id="owner", query="Check the actual output"
+        )
+    }
+
+
+async def test_validation_binding_survives_source_archive_clean(approved, candidate, runtime):
+    from sibyl_core.memory_pipeline.observations import SourceKind
+    from sibyl_core.services.source_archive_store import (
+        export_source_integrity,
+        restore_source_integrity,
+    )
+
+    assert (await promote_validated_procedure(**approved)).success
+    async with content_client.surreal_content_client() as client:
+        payload = await export_source_integrity(
+            client.execute_query, kind=SourceKind.RAW_CAPTURE, organizations=["org"]
+        )
+        before = next(
+            x for x in await rows("memory_derivations") if x["target_id"] == candidate.id
+        )["validation_binding_json"]
+        await client.execute_query(
+            "UPDATE memory_validation_executions SET purged=true,result_json=NONE;"
+        )
+        await restore_source_integrity(
+            client.execute_query,
+            payload,
+            kind=SourceKind.RAW_CAPTURE,
+            organizations=["org"],
+            clean=True,
+        )
+        after = next(x for x in await rows("memory_derivations") if x["target_id"] == candidate.id)[
+            "validation_binding_json"
+        ]
+    assert before == after
+    assert candidate.id not in {
+        m.id
+        for m in await recall_raw_memory(
+            organization_id="org", principal_id="owner", query="Check the actual output"
+        )
+    }
+
+
+async def test_actual_automatic_result_promotes_without_reextracting(candidate, runtime):
+    from sibyl_core.services.automatic_procedure import automatically_reconsider_procedure
+
+    auth = AsyncMock()
+    checked = await automatically_reconsider_procedure(
+        organization_id="org", principal_id="owner", parent_id=candidate.id, authorize=auth
+    )
+    assert checked.status == "validated"
+    before = await rows("memory_validation_executions")
+    promoted = await promote_validated_procedure(
+        organization_id="org",
+        principal_id="owner",
+        candidate_id=checked.candidate_id,
+        execution_id=checked.executions[-1],
+        authorize=auth,
+    )
+    assert promoted.success
+    after = await rows("memory_validation_executions")
+    assert len(after) == len(before) == 1
+    assert after[0]["result_json"] == before[0]["result_json"]
+    assert after[0]["usage_json"] == before[0]["usage_json"]
+    assert candidate.id in {
+        m.id
+        for m in await recall_raw_memory(
+            organization_id="org", principal_id="owner", query="Check the actual output"
+        )
+    }


### PR DESCRIPTION
The automatic procedure workflow can return a validated candidate, but promotion did not consume the durable critic result. This layer adds a promotion owner that reloads the exact stored request/result, verifies the current candidate and original sources, then uses the existing reflection promotion transaction.

Stack: this PR targets #554 (`nova/automatic-procedure-reconsideration`). The preceding layer owns automatic critique and reconsideration; this layer connects its final successful critic execution to promotion and existing recall. No public route or paid transfer experiment is included.

## 🛠️ Persist the validation requirement

Content migration 39 adds an optional immutable validation binding to the existing mandatory derivation association. The binding records hashes of the critic execution, request, result, and input. An indexed graph reference keeps the requirement discoverable without relying on mutable candidate metadata. Existing unbound records retain their current behavior.

Promotion checks source authority and the stored critic during both reservation and final commit. A write witness on the execution row makes a concurrent mutation conflict with the promotion transaction. A missing, purged, malformed, or changed critic denies promotion and subsequent raw or graph recall, including descendant graph records. Recorded critic usage remains intact when publication fails.

Archive decoding validates the binding shape, and restoration retains the association's validation requirement. The focused archive test covers clean restoration against an already purged execution; a fresh full content-and-graph archive acceptance is a separate gate.

## 🧪 Validation

- The native SurrealDB selection passed 55 tests, including actual automatic validation, promotion, and raw recall with unchanged stored result/usage. Container removal succeeded; an outer assertion initially expected a different Docker absence message. A separate read-only inspection confirmed absence, and the original wrapper failure remains retained.
- Independent review and a separate root repeat passed six adversarial native controls, including post-read execution mutation with rollback, missing associations, metadata removal, and descendant recall after critic deletion. Exact reviewed source hashes and owned cleanup were verified.
- The malformed non-object request regression plus 14 promotion controls passed after an explicit mapping check was added. Core lint and typecheck passed.

No providers or original service instances were used. Native transaction conflicts currently propagate as the existing storage error; no successful publication was observed after the conflicting mutation.
