### PR TITLE
fix(memory): reuse episode evidence in procedure validation

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/procedure_validation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/procedure_validation.py
@@ -160,7 +160,8 @@ async def prepare_stored_procedure_validation(
                 "signed",
             )
         )
-    prepared = prepare_procedure_validation(
+    prepared = await asyncio.to_thread(
+        prepare_procedure_validation,
         procedure,
         parent_operation_id=ledger["uuid"],
         parent_candidate_sha256=review_digest(audit),

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/consolidation.py
@@ -23,10 +23,10 @@ from sibyl_core.models.entities import ProcedureStep
 from sibyl_core.models.memory_scope import MemoryScope
 from sibyl_core.models.reflection import ReflectionCandidate
 from sibyl_core.tasks.episode_evidence import (
-    EPISODE_VERSION,
-    PROJECTION_VERSION,
     EvidenceCitation,
     encode_episode_views,
+    episode_projection_receipt,
+    is_controller_episode,
     project_episode,
 )
 from sibyl_core.tasks.procedure_evidence import (
@@ -320,16 +320,8 @@ class _ExtractionInput:
     reconsideration: dict[str, Any] | None = None
 
 
-def _is_controller_episode(artifact: bytes) -> bool:
-    try:
-        value = json.loads(artifact)
-    except (ValueError, UnicodeError):
-        return False
-    return isinstance(value, dict) and value.get("schema_version") == EPISODE_VERSION
-
-
 def _extraction_input(group: ConsolidationGroup) -> _ExtractionInput:
-    if not all(_is_controller_episode(episode.artifact) for episode in group.episodes):
+    if not all(is_controller_episode(episode.artifact) for episode in group.episodes):
         return _ExtractionInput(_prompt(group), SYSTEM_PROMPT, ProcedureProposal, {})
     projections = [
         project_episode(episode.episode_id, episode.artifact, prefix=f"s{index}")
@@ -355,30 +347,9 @@ def _extraction_input(group: ConsolidationGroup) -> _ExtractionInput:
         + "\n\n"
         + RETROSPECTIVE_REQUEST
     )
-    receipt = {
-        "version": PROJECTION_VERSION,
-        "view_sha256": _digest(_canonical(view)),
-        "citations_sha256": _digest(
-            _canonical(
-                {
-                    key: {"episode_id": value.episode_id, "ranges": value.ranges}
-                    for key, value in citations.items()
-                }
-            )
-        ),
-        "coverage_sha256": _digest(
-            _canonical(
-                [
-                    {
-                        "episode_id": episode.episode_id,
-                        "artifact_sha256": episode.artifact_sha256,
-                        "coverage": projection.coverage,
-                    }
-                    for episode, projection in zip(group.episodes, projections, strict=True)
-                ]
-            )
-        ),
-    }
+    receipt = episode_projection_receipt(
+        [(episode.episode_id, episode.artifact) for episode in group.episodes], projections, view
+    )
     return _ExtractionInput(prompt, EVIDENCE_SYSTEM_PROMPT, EvidenceProposal, citations, receipt)
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/episode_evidence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/episode_evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 from bisect import bisect_right
 from dataclasses import dataclass, field
 from typing import Any
@@ -358,3 +359,45 @@ def _verify_complete_coverage(builder: _EpisodeBuilder) -> None:
 
 def encode_episode_views(projections: list[EpisodeProjection]) -> dict[str, Any]:
     return share_exact_values([projection.view for projection in projections])
+
+
+def is_controller_episode(artifact: bytes) -> bool:
+    """Recognize the controller format without treating malformed projections as legacy."""
+    try:
+        value = json.loads(artifact)
+    except (ValueError, UnicodeError):
+        return False
+    return isinstance(value, dict) and value.get("schema_version") == EPISODE_VERSION
+
+
+def episode_projection_receipt(
+    episodes: list[tuple[str, bytes]],
+    projections: list[EpisodeProjection],
+    view: dict[str, Any],
+) -> dict[str, Any]:
+    """Bind a semantic view and its coverage to immutable original episode bytes."""
+
+    def digest(value: Any) -> str:
+        return hashlib.sha256(canonical(value).encode()).hexdigest()
+
+    return {
+        "version": PROJECTION_VERSION,
+        "view_sha256": digest(view),
+        "citations_sha256": digest(
+            {
+                key: {"episode_id": citation.episode_id, "ranges": citation.ranges}
+                for projection in projections
+                for key, citation in projection.citations.items()
+            }
+        ),
+        "coverage_sha256": digest(
+            [
+                {
+                    "episode_id": episode_id,
+                    "artifact_sha256": hashlib.sha256(artifact).hexdigest(),
+                    "coverage": projection.coverage,
+                }
+                for (episode_id, artifact), projection in zip(episodes, projections, strict=True)
+            ]
+        ),
+    }

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/memory_validation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/memory_validation.py
@@ -17,7 +17,13 @@ from sibyl_core.ai.llm.extractor import ExtractionUsage, Extractor
 from sibyl_core.models.reflection import ReflectionCandidate
 from sibyl_core.tasks._evidence_json import canonical
 from sibyl_core.tasks.consolidation import ConditionalAssertion, DraftConditionalProcedure
-from sibyl_core.tasks.episode_evidence import EvidenceCitation
+from sibyl_core.tasks.episode_evidence import (
+    EvidenceCitation,
+    encode_episode_views,
+    episode_projection_receipt,
+    is_controller_episode,
+    project_episode,
+)
 from sibyl_core.tasks.procedure_review import (
     ReviewFinding,
     ReviewSubmission,
@@ -97,6 +103,29 @@ def _prepare(
 ) -> PreparedMemoryValidation:
     _digest(parent_operation_id)
     _digest(parent_candidate_sha256)
+    projected = (
+        kind == "conditional_procedure"
+        and bool(evidence)
+        and all(is_controller_episode(source.content) for source in evidence)
+    )
+    projections = (
+        [
+            project_episode(source.source_id, source.content, prefix=f"s{index}")
+            for index, source in enumerate(evidence)
+        ]
+        if projected
+        else []
+    )
+    if (
+        projected
+        and {
+            key: citation
+            for projection in projections
+            for key, citation in projection.citations.items()
+        }
+        != citations
+    ):
+        raise ValueError("procedure citations differ from original controller projection")
     sources: dict[str, object] = {}
     for source in evidence:
         _digest(source.observation_sha256)
@@ -105,7 +134,7 @@ def _prepare(
         if source.provenance not in ("reported", "signed"):
             raise ValueError("invalid source provenance")
         sources[source.source_id] = {
-            "text": source.content.decode("utf-8"),
+            **({} if projected else {"text": source.content.decode("utf-8")}),
             "sha256": hashlib.sha256(source.content).hexdigest(),
             "observation_sha256": source.observation_sha256,
             "provenance": source.provenance,
@@ -127,9 +156,26 @@ def _prepare(
         references[identifier] = {"source_id": citation.episode_id, "ranges": citation.ranges}
     if not sources or not references or not assertions:
         raise ValueError("validation requires original evidence and assertions")
+    representation: dict[str, object] = {}
+    if projected:
+        view = encode_episode_views(projections)
+        representation = {
+            "evidence_representation": "controller_episode_projection_v1",
+            "evidence_view_instructions": (
+                "Resolve $ref objects by their index in values; $literal contains literal "
+                "object key/value pairs. Evidence IDs resolve to immutable original byte "
+                "ranges, not offsets into the view. Audit-only transport fields are "
+                "classified in the projection receipt and are not assertion evidence."
+            ),
+            "evidence_view": view,
+            "evidence_projection": episode_projection_receipt(
+                [(source.source_id, source.content) for source in evidence], projections, view
+            ),
+        }
     return PreparedMemoryValidation(
         canonical(
             {
+                **representation,
                 "version": VALIDATION_VERSION,
                 "kind": kind,
                 "parent_operation_id": parent_operation_id,

--- a/packages/python/sibyl-core/tests/test_automatic_procedure.py
+++ b/packages/python/sibyl-core/tests/test_automatic_procedure.py
@@ -1,6 +1,7 @@
 """Stored signed critique drives the existing extraction and persistence owners."""
 
 import json
+import threading
 from unittest.mock import AsyncMock
 
 import pytest
@@ -347,3 +348,19 @@ async def test_signed_correction_result_write_recovery_preserves_replay(
     monkeypatch.setattr(ValidationExecution, "record_result", fail_correction)
     await test_signed_automatic_correction_rechecks_and_replays(candidate, correction_model)
     assert len(corrections) == 1
+
+
+@pytest.mark.asyncio
+async def test_stored_procedure_validation_prepares_evidence_off_event_loop(candidate, monkeypatch):
+    original = validation.prepare_procedure_validation
+    event_loop_thread = threading.get_ident()
+    threads = []
+
+    def observed(*args, **kwargs):
+        threads.append(threading.get_ident())
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(validation, "prepare_procedure_validation", observed)
+    result = await validation.prepare_stored_procedure_validation("org", "owner", candidate.id)
+    assert result.prepared.input_sha256
+    assert len(threads) == 1 and threads[0] != event_loop_thread

--- a/packages/python/sibyl-core/tests/test_validation_evidence_projection.py
+++ b/packages/python/sibyl-core/tests/test_validation_evidence_projection.py
@@ -1,0 +1,145 @@
+"""Procedure critique shares the synthesis view while retaining original authority."""
+
+import hashlib
+import json
+from dataclasses import replace
+
+import pytest
+
+from sibyl_core.tasks.consolidation import DraftConditionalProcedure
+from sibyl_core.tasks.episode_evidence import (
+    EvidenceCitation,
+    encode_episode_views,
+    project_episode,
+)
+from sibyl_core.tasks.memory_validation import (
+    OriginalValidationEvidence,
+    prepare_procedure_validation,
+)
+from tests.test_episode_evidence import _episode
+from tests.test_tasks_consolidation import group as group
+from tests.test_tasks_consolidation import procedure as procedure
+
+
+def prepare(procedure, *, evidence=None, citations=None):
+    if evidence is None:
+        raw = json.dumps(_episode(), ensure_ascii=False).encode()
+        evidence = [
+            OriginalValidationEvidence(k, raw, "a" * 64, "signed") for k in ("success", "failure")
+        ]
+    projections = [
+        project_episode(e.source_id, e.content, prefix=f"s{i}") for i, e in enumerate(evidence)
+    ]
+    if citations is None:
+        citations = {k: v for p in projections for k, v in p.citations.items()}
+    value = procedure.model_dump(mode="json")
+
+    def supports(item):
+        if isinstance(item, dict):
+            for support in item.get("support", []):
+                source = next(e for e in evidence if e.source_id == support["episode_id"])
+                support.update(start_byte=0, end_byte=len(source.content))
+            for child in item.values():
+                supports(child)
+        elif isinstance(item, list):
+            for child in item:
+                supports(child)
+
+    supports(value)
+    prepared = prepare_procedure_validation(
+        DraftConditionalProcedure.model_validate(value),
+        parent_operation_id="b" * 64,
+        parent_candidate_sha256="c" * 64,
+        evidence=evidence,
+        citations=citations,
+    )
+    return prepared, evidence, citations, projections
+
+
+def test_validation_projection_preserves_original_hashes_ranges_and_view(procedure):
+    prepared, evidence, citations, projections = prepare(procedure)
+    payload = json.loads(prepared.payload_json)
+    assert payload["evidence_view"] == encode_episode_views(projections)
+    assert payload["evidence_representation"] == "controller_episode_projection_v1"
+    for source in evidence:
+        row = payload["sources"][source.source_id]
+        assert "text" not in row
+        assert row["sha256"] == hashlib.sha256(source.content).hexdigest()
+        assert row["observation_sha256"] == source.observation_sha256
+        assert row["provenance"] == "signed"
+    for key, citation in citations.items():
+        assert payload["citations"][key] == {
+            "source_id": citation.episode_id,
+            "ranges": [list(r) for r in citation.ranges],
+        }
+
+
+def test_validation_projection_audit_only_change_still_changes_identity(procedure):
+    before, evidence, _, _ = prepare(procedure)
+    value = json.loads(evidence[0].content)
+    value["assurance"] = {"audit": "different retained transport identity"}
+    changed = [
+        replace(evidence[0], content=json.dumps(value, ensure_ascii=False).encode()),
+        evidence[1],
+    ]
+    after, _, _, _ = prepare(procedure, evidence=changed)
+    assert (
+        json.loads(before.payload_json)["evidence_view"]
+        == json.loads(after.payload_json)["evidence_view"]
+    )
+    assert before.input_sha256 != after.input_sha256
+
+
+def test_validation_projection_observation_change_changes_identity(procedure):
+    before, evidence, _, _ = prepare(procedure)
+    after, _, _, _ = prepare(
+        procedure, evidence=[replace(evidence[0], observation_sha256="d" * 64), evidence[1]]
+    )
+    assert before.input_sha256 != after.input_sha256
+
+
+@pytest.mark.parametrize("change", ["range", "alias", "source"])
+def test_validation_projection_rejects_altered_citation_namespace(procedure, change):
+    _, evidence, citations, _ = prepare(procedure)
+    key = next(iter(citations))
+    original = citations[key]
+    if change == "range":
+        citations[key] = EvidenceCitation(original.episode_id, ((0, 1),))
+    elif change == "alias":
+        citations["invented"] = citations.pop(key)
+    else:
+        citations[key] = EvidenceCitation("not-authorized", original.ranges)
+    with pytest.raises(ValueError, match="citations differ"):
+        prepare(procedure, evidence=evidence, citations=citations)
+
+
+def test_validation_projection_noncontroller_fallback_keeps_full_text(procedure, group):
+    evidence = [
+        OriginalValidationEvidence(e.episode_id, e.artifact, "a" * 64, "reported")
+        for e in group.episodes
+    ]
+    citations = {
+        str(i): EvidenceCitation(e.source_id, ((0, len(e.content)),))
+        for i, e in enumerate(evidence)
+    }
+    prepared = prepare_procedure_validation(
+        procedure,
+        parent_operation_id="b" * 64,
+        parent_candidate_sha256="c" * 64,
+        evidence=evidence,
+        citations=citations,
+    )
+    payload = json.loads(prepared.payload_json)
+    assert "evidence_representation" not in payload
+    assert "evidence_view" not in payload
+    for source in evidence:
+        assert payload["sources"][source.source_id]["text"] == source.content.decode()
+
+
+def test_validation_projection_malformed_controller_does_not_fallback(procedure):
+    _, evidence, citations, _ = prepare(procedure)
+    malformed = json.loads(evidence[0].content)
+    malformed["trace"][1]["payload"]["body_sha256"] = "0" * 64
+    evidence[0] = replace(evidence[0], content=json.dumps(malformed).encode())
+    with pytest.raises(ValueError):
+        prepare(procedure, evidence=evidence, citations=citations)


### PR DESCRIPTION
A procedure generated from controller episodes can fit synthesis, then fail validation because the critic serializes every original episode again. The retained routing candidate produced a 2,779,912-character critic prompt, exceeding the 800,000-character input limit before a critic request could run.

Procedure validation now uses the same evidence projection as synthesis. The actual candidate's prompt falls to 493,562 characters without truncation. A shared receipt helper preserves synthesis receipt hashes and binds the critic's representation to its actual input digest. Original source hashes, observation hashes, provenance, and byte citation ranges remain available for verification. Reconstructed citations must match the supplied citation namespace exactly. Reflection and non-controller evidence retain their full-text representation. The existing async service runs preparation in a worker thread so projection does not block the event loop.

## 🧪 Validation

The affected core suite passes 108 tests, with 11 additional collision controls and successful lint/type checks. A provider-free replay of the retained routing candidate confirms the smaller prompt and the same 257 citations and stored projection receipt. The replay establishes input preparation, not critic acceptance or improved learning outcomes.

Independent verification passed 119 affected controls and 12 stored-candidate/routing controls (two existing native-only skips); three final root checks also passed.
