### PR TITLE
feat(memory): retain stable operational source write identities

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
@@ -45,6 +45,7 @@ from sibyl_core.services.eval_publication_guards import PUBLICATION_ADMISSION_GU
 if TYPE_CHECKING:
     from sibyl_core.memory_pipeline.observations import SourceObservation
     from sibyl_core.services.dream_checkpoints import DreamCandidateWrite
+    from sibyl_core.services.operational_capture import OperationalSourceWrite
     from sibyl_core.services.validation_candidate import ValidationCandidateWrite
     from sibyl_core.services.validation_promotion import ValidatedPromotion
 
@@ -375,6 +376,7 @@ async def remember_raw_memory(
     source_memories: Sequence[RawMemory] = (),
     dream_write: DreamCandidateWrite | None = None,
     validation_write: ValidationCandidateWrite | None = None,
+    operational_write: OperationalSourceWrite | None = None,
     source_observations: Sequence[SourceObservation] = (),
     accessible_projects: Iterable[str] | None = None,
     accessible_teams: Iterable[str] | None = None,
@@ -409,6 +411,16 @@ async def remember_raw_memory(
         ),
         captured_at=models.utcnow(),
     )
+    if operational_write is not None:
+        if (
+            dream_write is not None
+            or validation_write is not None
+            or source_memories
+            or source_observations
+        ):
+            raise ValueError("Operational source cannot also be a derived candidate")
+        operational_write.validate(memory, incoming=True)
+        memory.id = operational_write.id
     if validation_write is not None:
         if dream_write is not None or not source_observations:
             raise ValueError("Corrected review requires observed original sources")
@@ -442,9 +454,23 @@ async def remember_raw_memory(
         if embedding_provider is _RAW_MEMORY_EMBEDDING_AUTO
         else cast("EmbeddingProvider | None", embedding_provider)
     )
-    memory = await _raw_memory_with_embedding(memory, provider)
+    if operational_write is None:
+        memory = await _raw_memory_with_embedding(memory, provider)
     async with content_client.surreal_content_client() as client:
-        if validation_write is not None:
+        if operational_write is not None:
+            from sibyl_core.services.operational_capture import write_operational_source
+
+            async def prepare_operational_record() -> dict[str, object]:
+                embedded = await _raw_memory_with_embedding(memory, provider)
+                return models.raw_memory_record(embedded)
+
+            record = await write_operational_source(
+                client,
+                models.raw_memory_record(memory),
+                operational_write,
+                prepare_record=prepare_operational_record,
+            )
+        elif validation_write is not None:
             from sibyl_core.services.memory_derivations import raw_derivation_record
             from sibyl_core.services.validation_candidate import insert_validation_candidate
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/operational_capture.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/operational_capture.py
@@ -1,0 +1,167 @@
+"""Internal replay identity for retained operational sources, never caller metadata."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID, uuid5
+
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.errors import RevisionConflictError
+from sibyl_core.models.experience import OperationalExperience
+from sibyl_core.models.memory_scope import MemoryScope
+from sibyl_core.services import content_client, content_models
+
+_NAMESPACE = UUID("0403e7da-5b40-40a8-90bf-7281d817ed77")
+SURFACE = "operational_experience"
+
+
+def canonical_experience(experience: OperationalExperience) -> str:
+    """Server-normalized retained source bytes, not original HTTP transport bytes."""
+    return json.dumps(
+        experience.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+@dataclass(frozen=True)
+class OperationalSourceWrite:
+    """An authorized service's identity intent; an update requires its read revision."""
+
+    organization_id: str
+    source_id: str
+    principal_id: str
+    project_id: str
+    expected_revision: int | None = None
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(value, str) or not value.strip()
+            for value in (self.organization_id, self.source_id, self.principal_id, self.project_id)
+        ):
+            raise ValueError("Operational source needs explicit identity and project")
+        if self.expected_revision is not None and (
+            type(self.expected_revision) is not int or self.expected_revision < 1
+        ):
+            raise ValueError("Operational update requires a positive revision")
+
+    @property
+    def id(self) -> str:
+        return str(
+            uuid5(
+                _NAMESPACE,
+                json.dumps([self.organization_id, self.source_id], separators=(",", ":")),
+            )
+        )
+
+    def validate(self, memory: content_models.RawMemory, *, incoming: bool = False) -> None:
+        if (
+            memory.organization_id != self.organization_id
+            or memory.source_id != self.source_id
+            or memory.principal_id != self.principal_id
+            or memory.project_id != self.project_id
+            or memory.memory_scope != MemoryScope.PROJECT
+            or memory.scope_key != self.project_id
+            or memory.capture_surface != SURFACE
+        ):
+            raise ValueError("Operational source identity or project differs")
+        if incoming and memory.metadata != {"project_id": self.project_id}:
+            raise ValueError("Operational source row metadata is owned by the capture service")
+        experience = OperationalExperience.model_validate_json(memory.raw_content)
+        if experience.source_id != self.source_id or experience.project_id != self.project_id:
+            raise ValueError("Operational payload source identity differs")
+        if memory.raw_content != canonical_experience(experience):
+            raise ValueError("Operational source requires canonical validated JSON")
+
+
+_SNAPSHOT = """RETURN {
+    LET $row = (SELECT * FROM raw_captures WHERE uuid=$uuid LIMIT 1)[0];
+    LET $state = (SELECT * FROM source_states WHERE organization_id=$org
+        AND source_kind='raw_capture' AND source_id=$uuid LIMIT 1)[0];
+    RETURN {row:$row, state:$state, fingerprint:crypto::sha256(type::string([$row,$state]))};
+};"""
+
+
+async def write_operational_source(
+    client: SurrealContentClient,
+    record: dict[str, Any],
+    intent: OperationalSourceWrite,
+    *,
+    prepare_record: Callable[[], Awaitable[dict[str, object]]],
+) -> dict[str, Any]:
+    """Fence an inspected source and atomically create, replay or update its row."""
+    rows = content_client.normalize_records(
+        await client.execute_query(_SNAPSHOT, uuid=intent.id, org=intent.organization_id)
+    )
+    if len(rows) != 1:
+        raise ValueError("Operational source snapshot is not unique")
+    snapshot = rows[0]
+    old, state = snapshot.get("row"), snapshot.get("state")
+    if old is None:
+        if state is not None:
+            raise ValueError("Operational source is retired or missing its retained row")
+        if intent.expected_revision is not None:
+            raise RevisionConflictError(intent.id, intent.expected_revision, 0)
+        mode = "create"
+    else:
+        if not isinstance(old, dict):
+            raise ValueError("Operational source row has invalid shape")
+        existing = content_models.raw_memory_from_record(old)
+        intent.validate(existing)
+        if not content_models.raw_memory_currently_recallable(existing) or (
+            not isinstance(state, dict)
+            or state.get("deleted") is not False
+            or state.get("revision") != existing.revision
+        ):
+            raise ValueError("Operational source is retired or unavailable")
+        if intent.expected_revision is not None and intent.expected_revision != existing.revision:
+            raise RevisionConflictError(intent.id, intent.expected_revision, existing.revision)
+        # Retrieval counters and lifecycle are not reset by a capture replay.
+        keys = ("raw_content", "title", "entity_type", "tags", "provenance")
+        same = all(old.get(key) == record.get(key) for key in keys)
+        if same:
+            mode = "replay"
+        elif intent.expected_revision is None:
+            raise RevisionConflictError(intent.id, 0, existing.revision)
+        else:
+            mode = "update"
+    if mode != "replay":
+        record = await prepare_record()
+    saved = content_client.normalize_records(
+        await client.execute_query(
+            """RETURN {
+            LET $old = (SELECT * FROM raw_captures WHERE uuid=$uuid LIMIT 1)[0];
+            LET $state = (SELECT * FROM source_states WHERE organization_id=$org
+                AND source_kind='raw_capture' AND source_id=$uuid LIMIT 1)[0];
+            IF crypto::sha256(type::string([$old,$state])) != $fingerprint {
+                THROW 'Operational source changed during capture';
+            };
+            IF $mode = 'replay' { RETURN $old; };
+            IF $mode = 'create' {
+                CREATE raw_captures CONTENT $record;
+            } ELSE {
+                UPDATE raw_captures SET raw_content=$record.raw_content,
+                    title=$record.title, entity_type=$record.entity_type,
+                    tags=$record.tags, provenance=$record.provenance,
+                    embedding=$record.embedding,
+                    metadata.embedding_metadata=$record.metadata.embedding_metadata,
+                    revision=$old.revision + 1
+                    WHERE uuid=$uuid AND organization_id=$org;
+            };
+            RETURN (SELECT * FROM raw_captures WHERE uuid=$uuid LIMIT 1)[0];
+        };""",
+            uuid=intent.id,
+            org=intent.organization_id,
+            record=record,
+            fingerprint=snapshot["fingerprint"],
+            mode=mode,
+        )
+    )
+    if len(saved) != 1:
+        raise ValueError("Operational source write returned no unique row")
+    return saved[0]

--- a/packages/python/sibyl-core/tests/test_operational_capture.py
+++ b/packages/python/sibyl-core/tests/test_operational_capture.py
@@ -1,0 +1,356 @@
+"""Exercise the real content store through the shared capture writer."""
+
+from contextlib import asynccontextmanager
+from dataclasses import replace
+
+import pytest
+
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import EMBEDDING_DIM, bootstrap_content_schema
+from sibyl_core.errors import RevisionConflictError
+from sibyl_core.models.experience import OperationalExperience
+from sibyl_core.services.content_raw_persistence import remember_raw_memory, save_raw_memory
+from sibyl_core.services.operational_capture import OperationalSourceWrite, canonical_experience
+
+
+@pytest.fixture
+async def store(monkeypatch):
+    client = SurrealContentClient(url="memory://")
+    await bootstrap_content_schema(client, reset=True)
+
+    @asynccontextmanager
+    async def session():
+        yield client
+
+    monkeypatch.setattr("sibyl_core.services.content_client.surreal_content_client", session)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+def payload(outcome=""):
+    return canonical_experience(
+        OperationalExperience.model_validate(
+            {
+                "source_id": "experience",
+                "project_id": "project",
+                "goal": "inspect",
+                "outcome": outcome,
+                "observations": [
+                    {
+                        "id": "state",
+                        "ordinal": 0,
+                        "evidence": [{"id": "part", "content": 'original "quoted"\ntext'}],
+                    }
+                ],
+            }
+        )
+    )
+
+
+async def capture(
+    *,
+    outcome="",
+    expected=None,
+    principal="owner",
+    project="project",
+    intent=True,
+    metadata=None,
+    provider=None,
+):
+    write = OperationalSourceWrite("org", "experience", principal, project, expected)
+    return await remember_raw_memory(
+        organization_id="org",
+        principal_id=principal,
+        source_id="experience",
+        raw_content=payload(outcome),
+        memory_scope="project",
+        scope_key=project,
+        metadata=metadata or {"project_id": project},
+        capture_surface="operational_experience",
+        embedding_provider=provider,
+        operational_write=write if intent else None,
+    )
+
+
+async def test_operational_create_replay_has_one_source_and_generation(store):
+    first = await capture()
+    before = await store.execute_query(
+        "SELECT * FROM source_states WHERE source_kind='raw_capture';"
+    )
+    second = await capture()
+    assert (
+        first.id == second.id == OperationalSourceWrite("org", "experience", "owner", "project").id
+    )
+    assert first.revision == second.revision == 1
+    assert second.raw_content == payload()
+    assert len(await store.execute_query("SELECT * FROM raw_captures;")) == 1
+    assert (
+        await store.execute_query("SELECT * FROM source_states WHERE source_kind='raw_capture';")
+        == before
+    )
+
+
+async def test_operational_change_requires_expected_revision_and_preserves_creator(store):
+    first = await capture()
+    with pytest.raises(RevisionConflictError):
+        await capture(outcome="failed")
+    changed = await capture(outcome="failed", expected=first.revision)
+    assert changed.id == first.id and changed.revision == first.revision + 1
+    assert changed.created_at == first.created_at and changed.principal_id == first.principal_id
+    with pytest.raises(RevisionConflictError):
+        await capture(outcome="old retry", expected=first.revision)
+
+
+@pytest.mark.parametrize("missing", [False, True])
+async def test_operational_retired_source_cannot_be_recreated(store, missing):
+    first = await capture()
+    if missing:
+        await store.execute_query("DELETE raw_captures WHERE uuid=$id;", id=first.id)
+    else:
+        from sibyl_core.services.content_models import utcnow
+
+        await save_raw_memory(
+            replace(first, deleted_at=utcnow()),
+            embedding_provider=None,
+            expected_revision=first.revision,
+        )
+    with pytest.raises(ValueError, match=r"retired|unavailable"):
+        await capture()
+
+
+async def test_raw_only_creator_survives_without_graph_manifest(store):
+    first = await capture()
+    with pytest.raises(ValueError, match="identity or project"):
+        await capture(principal="other-contributor")
+    assert len(await store.execute_query("SELECT * FROM raw_captures;")) == 1
+    assert (await capture()).id == first.id
+
+
+async def test_generic_metadata_cannot_choose_internal_identity(store):
+    generic = await capture(
+        intent=False, metadata={"project_id": "project", "operational_write": True}
+    )
+    internal = await capture()
+    assert generic.id != internal.id
+    assert len(await store.execute_query("SELECT * FROM raw_captures;")) == 2
+
+
+async def test_source_change_between_inspection_and_write_is_not_overwritten(store, monkeypatch):
+    first = await capture()
+    execute = store.execute_query
+    changed = False
+
+    async def interleave(query, **kwargs):
+        nonlocal changed
+        if "Operational source changed during capture" in query and not changed:
+            changed = True
+            await execute(
+                "UPDATE raw_captures SET raw_content='concurrent correction', revision += 1 WHERE uuid=$id;",
+                id=first.id,
+            )
+        return await execute(query, **kwargs)
+
+    monkeypatch.setattr(store, "execute_query", interleave)
+    with pytest.raises(Exception, match="Operational source changed"):
+        await capture(outcome="late", expected=first.revision)
+    assert changed
+    rows = await execute("SELECT * FROM raw_captures WHERE uuid=$id;", id=first.id)
+    assert rows[0]["raw_content"] == "concurrent correction"
+
+
+async def test_internal_capture_rejects_arbitrary_row_metadata(store):
+    with pytest.raises(ValueError, match="metadata is owned"):
+        await capture(metadata={"project_id": "project", "raw_source_ids": ["fake-source"]})
+    assert not await store.execute_query("SELECT * FROM raw_captures;")
+
+
+async def test_replay_preserves_source_metadata_and_creation_dates(store):
+    first = await capture()
+    await store.execute_query(
+        "UPDATE raw_captures SET metadata.last_recalled_at=time::now(), metadata.retrieval_count=3 WHERE uuid=$id;",
+        id=first.id,
+    )
+    before = await store.execute_query("SELECT * FROM raw_captures WHERE uuid=$id;", id=first.id)
+    await capture()
+    assert (
+        await store.execute_query("SELECT * FROM raw_captures WHERE uuid=$id;", id=first.id)
+        == before
+    )
+
+
+async def test_project_collision_denied_even_without_graph_manifest(store):
+    first = await capture()
+    # The identity intentionally does not change with project, so foreign scope
+    # cannot create a second row under the same operational source name.
+    other = OperationalSourceWrite("org", "experience", "owner", "other")
+    assert other.id == first.id
+    value = OperationalExperience.model_validate_json(payload()).model_copy(
+        update={"project_id": "other"}
+    )
+    with pytest.raises(ValueError, match="identity or project"):
+        await remember_raw_memory(
+            organization_id="org",
+            principal_id="owner",
+            source_id="experience",
+            raw_content=canonical_experience(value),
+            memory_scope="project",
+            scope_key="other",
+            metadata={"project_id": "other"},
+            capture_surface="operational_experience",
+            embedding_provider=None,
+            operational_write=other,
+        )
+    assert len(await store.execute_query("SELECT * FROM raw_captures;")) == 1
+
+
+async def test_payload_format_revision_does_not_mint_a_new_source(store):
+    first = await capture()
+    revised = OperationalExperience.model_validate_json(payload()).model_copy(
+        update={"metadata": {"serialization_revision": 2}}
+    )
+    second = await remember_raw_memory(
+        organization_id="org",
+        principal_id="owner",
+        source_id="experience",
+        raw_content=canonical_experience(revised),
+        memory_scope="project",
+        scope_key="project",
+        metadata={"project_id": "project"},
+        capture_surface="operational_experience",
+        embedding_provider=None,
+        operational_write=OperationalSourceWrite(
+            "org", "experience", "owner", "project", first.revision
+        ),
+    )
+    assert second.id == first.id and second.revision == first.revision + 1
+    assert len(await store.execute_query("SELECT * FROM raw_captures;")) == 1
+
+
+async def test_replayed_or_refused_source_never_embeds(store, monkeypatch):
+    from sibyl_core.services import content_raw_persistence as owner
+
+    calls = []
+    original = owner._raw_memory_with_embedding
+
+    async def spy(memory, provider):
+        calls.append(memory.raw_content)
+        return await original(memory, None)
+
+    monkeypatch.setattr(owner, "_raw_memory_with_embedding", spy)
+    first = await capture()
+    assert len(calls) == 1
+    await capture()
+    with pytest.raises(RevisionConflictError):
+        await capture(outcome="refused without revision")
+    with pytest.raises(RevisionConflictError):
+        await capture(outcome="stale", expected=first.revision + 1)
+    assert len(calls) == 1
+    from sibyl_core.services.content_models import utcnow
+
+    await store.execute_query(
+        "UPDATE raw_captures SET deleted_at=$now WHERE uuid=$id;", id=first.id, now=utcnow()
+    )
+    with pytest.raises(ValueError, match="retired"):
+        await capture()
+    assert len(calls) == 1
+
+
+async def test_source_fence_survives_async_embedding(store, monkeypatch):
+    from sibyl_core.services import content_raw_persistence as owner
+
+    first = await capture()
+
+    async def interleave(memory, provider):
+        await store.execute_query(
+            "UPDATE raw_captures SET raw_content='during embedding', revision += 1 WHERE uuid=$id;",
+            id=first.id,
+        )
+        return memory
+
+    monkeypatch.setattr(owner, "_raw_memory_with_embedding", interleave)
+    with pytest.raises(Exception, match="Operational source changed"):
+        await capture(outcome="late", expected=first.revision)
+    rows = await store.execute_query("SELECT * FROM raw_captures WHERE uuid=$id;", id=first.id)
+    assert rows[0]["raw_content"] == "during embedding"
+
+
+async def test_actual_embedding_provider_is_not_called_for_replay_or_refusal(store):
+    from sibyl_core.embeddings.providers import DeterministicEmbeddingProvider, EmbeddingMetadata
+
+    class Spy(DeterministicEmbeddingProvider):
+        calls = 0
+
+        async def embed_texts(self, texts, *, input_kind="document"):
+            self.calls += 1
+            return await super().embed_texts(texts, input_kind=input_kind)
+
+    provider = Spy(EmbeddingMetadata("test", "one", EMBEDDING_DIM, "test", "bytes"))
+    first = await capture(provider=provider)
+    assert provider.calls == 1 and first.embedding
+    replay = await capture(provider=provider)
+    assert provider.calls == 1 and replay.embedding == first.embedding
+    with pytest.raises(RevisionConflictError):
+        await capture(outcome="changed", provider=provider)
+    assert provider.calls == 1
+    changed = await capture(outcome="changed", expected=first.revision, provider=provider)
+    assert provider.calls == 2 and changed.embedding != first.embedding
+    assert changed.metadata["embedding_metadata"] == first.metadata["embedding_metadata"]
+    await store.execute_query("DELETE raw_captures WHERE uuid=$id;", id=first.id)
+    with pytest.raises(ValueError, match="retired"):
+        await capture(provider=provider)
+    assert provider.calls == 2
+
+
+async def test_lost_write_ack_replays_without_embedding_again(store, monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.embeddings.providers import DeterministicEmbeddingProvider, EmbeddingMetadata
+
+    provider = DeterministicEmbeddingProvider(
+        EmbeddingMetadata("test", "one", EMBEDDING_DIM, "test", "bytes")
+    )
+    embed = AsyncMock(wraps=provider.embed_texts)
+    monkeypatch.setattr(provider, "embed_texts", embed)
+    execute = store.execute_query
+    lost = False
+
+    async def lose_ack(query, **kwargs):
+        nonlocal lost
+        result = await execute(query, **kwargs)
+        if "Operational source changed during capture" in query and not lost:
+            lost = True
+            raise ConnectionError("simulated lost acknowledgment after committed write")
+        return result
+
+    monkeypatch.setattr(store, "execute_query", lose_ack)
+    with pytest.raises(ConnectionError, match="lost acknowledgment"):
+        await capture(provider=provider)
+    assert lost and embed.await_count == 1
+    replay = await capture(provider=provider)
+    assert replay.id == OperationalSourceWrite("org", "experience", "owner", "project").id
+    assert embed.await_count == 1
+    assert len(await execute("SELECT * FROM raw_captures;")) == 1
+
+
+async def test_embedding_metadata_tracks_new_provider_and_null_vector(store):
+    from sibyl_core.embeddings.providers import DeterministicEmbeddingProvider, EmbeddingMetadata
+
+    old = DeterministicEmbeddingProvider(
+        EmbeddingMetadata("test", "v1", EMBEDDING_DIM, "old", "bytes")
+    )
+    new = DeterministicEmbeddingProvider(
+        EmbeddingMetadata("test", "v2", EMBEDDING_DIM, "new", "bytes")
+    )
+    first = await capture(provider=old)
+    before_metadata = dict(first.metadata)
+    second = await capture(outcome="changed", expected=first.revision, provider=new)
+    assert second.embedding != first.embedding
+    assert second.metadata["embedding_metadata"]["model"] == "v2"
+    assert {k: v for k, v in second.metadata.items() if k != "embedding_metadata"} == {
+        k: v for k, v in before_metadata.items() if k != "embedding_metadata"
+    }
+    third = await capture(outcome="no vector", expected=second.revision, provider=None)
+    assert third.embedding is None
+    assert third.metadata.get("embedding_metadata") is None


### PR DESCRIPTION
Operational experience capture needs a stable retained source before its graph projections can share a durable lifecycle. The shared raw writer now accepts an internal operational-source intent that creates one source, replays identical content, and requires the observed revision for changed content.

## 🛠️ Source identity and updates

The source UUID depends on organization and logical source ID, so changing the payload format or content does not create independent evidence. Retained content is canonical validated `OperationalExperience` JSON, not the original HTTP wire bytes. Ordinary capture metadata cannot select the internal write path.

The writer checks identity and lifecycle before preparing embeddings, then fences the complete native row and source-state snapshot when saving. Exact replays preserve revisions and retrieval counters. Deleted or purged source identities are refused. Updates preserve unrelated metadata and replace embedding provenance together with the vector, including clearing stale provenance when no vector is supplied.

This PR supplies the writer foundation only. Public `/memory/experience` retention, authenticated actor checks, graph ancestry and deferred-job integration follow separately. Unkeyed retries across intervening changes do not gain an idempotency guarantee.

## 🧪 Validation

- Affected core tests: 98 passed, covering ordinary raw writes and operational source behavior.
- Policy and schema contracts: 145 passed. Core lint and typecheck passed.
- Fresh native SurrealDB: all 17 authored controls passed, including lost acknowledgments, concurrent source changes, retirement and embedding behavior.
- Independent native review: 22 controls passed, including five additional race and retirement cases. The owned database was removed and absence verified.
- Root review independently checked replay/refusal embedding calls and changed-model provenance. All three controls passed.

No provider calls or existing-instance mutations were used for qualification.
