### PR TITLE
feat(memory): learn ordinary cohorts through verified publication

### DIFF
--- a/apps/api/src/sibyl/jobs/ordinary_cohorts.py
+++ b/apps/api/src/sibyl/jobs/ordinary_cohorts.py
@@ -1,0 +1,109 @@
+"""Scheduled ordinary cohorts use current memberships and existing stage owners."""
+
+from collections import defaultdict
+
+from sibyl.jobs.lifecycle_repair import resolve_source_authority
+from sibyl.persistence.auth_runtime import (
+    resolve_accessible_project_graph_ids,
+    resolve_auth_context,
+)
+from sibyl_core.auth import OrganizationRole, ProjectRole
+from sibyl_core.services.content_models import RawMemory
+from sibyl_core.services.ordinary_cohort import partition_stored_cohort, propose_stored_cohort
+from sibyl_core.services.source_observations import SourceUnavailableError
+
+
+async def writable_source_authority(org: str, principal: str):
+    """Resolve read authority plus writable project coverage on every provider send."""
+    context = await resolve_auth_context(claims={"sub": principal, "org": org})
+    if context.org_role not in {
+        OrganizationRole.OWNER,
+        OrganizationRole.ADMIN,
+        OrganizationRole.MEMBER,
+    }:
+        raise SourceUnavailableError
+    authority = await resolve_source_authority(org, principal)
+    if authority is None:
+        raise SourceUnavailableError
+    writable = await resolve_accessible_project_graph_ids(
+        user_id=principal, org_id=org, required_role=ProjectRole.CONTRIBUTOR
+    )
+    # Sources in a project require contributor access. Private sources retain
+    # their principal ceiling and need no unrelated project membership.
+    from dataclasses import replace
+
+    return replace(authority, projects=authority.projects.intersection(writable))
+
+
+async def reflect_cohorts(org: str, sources: list[RawMemory], *, dry_run: bool):
+    groups = defaultdict(list)
+    for source in sources:
+        groups[
+            (source.principal_id, source.memory_scope, source.scope_key, source.project_id)
+        ].append(source)
+    results = []
+    consumed = set()
+    for (principal, _, _, _), members in groups.items():
+        if not principal or len(members) < 2:
+            continue
+        identifiers = sorted(s.id for s in members)
+        if dry_run:
+            results.append(
+                {"source_ids": identifiers, "outcome": "cohort_preview", "dry_run": True}
+            )
+            consumed.update(identifiers)
+            continue
+        try:
+            bins = await partition_stored_cohort(
+                org, principal, identifiers, writable_source_authority
+            )
+        except Exception as exc:
+            consumed.update(identifiers)
+            results.append(
+                {
+                    "source_ids": identifiers,
+                    "outcome": "error",
+                    "reason": str(exc),
+                    "stage_kind": "ordinary_cohort_preparation",
+                }
+            )
+            continue
+        for identifiers in bins:
+            if len(identifiers) < 2:
+                results.append(
+                    {
+                        "source_ids": identifiers,
+                        "outcome": "individual_fallback",
+                        "reason": "no_complete_cohort_fits_input_budget",
+                    }
+                )
+                continue
+            consumed.update(identifiers)
+
+            async def authorize(principal=principal):
+                await writable_source_authority(org, principal)
+
+            try:
+                candidate, execution = await propose_stored_cohort(
+                    org, principal, identifiers, writable_source_authority, authorize=authorize
+                )
+                results.append(
+                    {
+                        "source_ids": identifiers,
+                        "outcome": "reflected",
+                        "operation_id": execution,
+                        "candidate_count": int(candidate is not None),
+                        "candidate_ids": [candidate.id] if candidate else [],
+                        "stage_kind": "ordinary_cohort",
+                    }
+                )
+            except Exception as exc:
+                results.append(
+                    {
+                        "source_ids": identifiers,
+                        "outcome": "error",
+                        "reason": str(exc),
+                        "stage_kind": "ordinary_cohort",
+                    }
+                )
+    return results, consumed

--- a/apps/api/src/sibyl/jobs/reflection.py
+++ b/apps/api/src/sibyl/jobs/reflection.py
@@ -148,7 +148,14 @@ async def run_reflection_dream_cycle(
         "latency_ms": round((perf_counter() - start_time) * 1000, 2),
         "source_limit": source_budget,
         "candidate_limit": candidate_budget,
-        "sources_scanned": len(source_results),
+        "sources_scanned": len(
+            {
+                identifier
+                for item in source_results
+                for identifier in item.get("source_ids", [item.get("source_id")])
+                if identifier is not None
+            }
+        ),
         "sources_reflected": sum(1 for item in source_results if item["outcome"] == "reflected"),
         "candidates_scanned": len(candidate_results),
         "promoted": sum(1 for item in candidate_results if item["outcome"] == "auto_promote"),
@@ -157,8 +164,19 @@ async def run_reflection_dream_cycle(
         "skipped": sum(1 for item in all_results if item["outcome"] == "skip"),
         "failed": sum(1 for item in all_results if item["outcome"] == "error"),
         "model_usage": {
-            "extractor": "sibyl_reflection_extractor",
-            "metered": False,
+            "accounting": "durable_validation_stages",
+            "execution_ids": sorted(
+                {
+                    str(identifier)
+                    for item in all_results
+                    for identifier in (
+                        [item.get("operation_id")]
+                        if item.get("stage_kind") == "ordinary_cohort"
+                        else item.get("validation_executions", [])
+                    )
+                    if identifier is not None
+                }
+            ),
         },
         "sources": source_results,
         "candidates": candidate_results,
@@ -186,9 +204,6 @@ async def _reflect_dream_sources(
             work = await _load_dream_work(group_id, source)
             if work is None:
                 return False
-            stage = await load_dream_stage(work)
-            if stage is not None and stage.get("completion_json") is not None:
-                return False
         except SourceUnavailableError:
             return False
         except Exception as exc:
@@ -203,14 +218,23 @@ async def _reflect_dream_sources(
         is_pending=pending,
         after_source_id=after_source_id,
     )
-    results: list[dict[str, Any]] = []
+    from sibyl.jobs.ordinary_cohorts import reflect_cohorts
+
+    results, consumed = await reflect_cohorts(group_id, sources, dry_run=dry_run)
     for source in sources:
         if cursor_owned:
             cursor_owned = await advance_dream_cursor(group_id, source.id, cursor_revision)
             cursor_revision += int(cursor_owned)
+        if source.id in consumed:
+            continue
         try:
             if source.id in selection_errors:
                 raise selection_errors[source.id]
+            work = selected.get(source.id)
+            if work is not None:
+                stage = await load_dream_stage(work)
+                if stage is not None and stage.get("completion_json") is not None:
+                    continue
             results.append(
                 await _reflect_dream_source(
                     source=source,
@@ -386,12 +410,13 @@ async def _drain_dream_candidate(
     confidence_threshold: float | None,
 ) -> dict[str, Any]:
     automatic_executions: list[str] = []
+    validation_promotion = None
     if not dry_run:
-        from sibyl.jobs.lifecycle_repair import resolve_source_authority
+        from sibyl.jobs.ordinary_cohorts import writable_source_authority
         from sibyl_core.services.automatic_reflection import automatically_review_reflection
 
         automatic = await automatically_review_reflection(
-            group_id, str(candidate.principal_id or ""), candidate.id, resolve_source_authority
+            group_id, str(candidate.principal_id or ""), candidate.id, writable_source_authority
         )
         automatic_executions = list(automatic.executions)
         if automatic.candidate is None:
@@ -412,6 +437,19 @@ async def _drain_dream_candidate(
                 "validation_executions": automatic_executions,
             }
         candidate = automatic.candidate
+        from sibyl_core.services.ordinary_publication import ordinary_promotion_binding
+
+        async def authorize_publication():
+            await writable_source_authority(group_id, str(candidate.principal_id or ""))
+
+        validation_promotion = await ordinary_promotion_binding(
+            group_id,
+            str(candidate.principal_id or ""),
+            candidate.id,
+            automatic_executions[-1],
+            writable_source_authority,
+            authorize_publication,
+        )
     target_scope = _candidate_target_scope(candidate)
     target_scope_key = _candidate_target_scope_key(candidate, target_scope)
     project = _candidate_project(
@@ -436,6 +474,19 @@ async def _drain_dream_candidate(
             required_role=ProjectRole.CONTRIBUTOR,
         ),
     )
+    if validation_promotion is not None:
+        from sibyl_core.services.memory_autonomy import reflection_autonomy_candidate_metadata
+        from sibyl_core.services.reflection_validation import prepare_stored_reflection
+
+        current = await prepare_stored_reflection(
+            group_id, str(candidate.principal_id or ""), candidate.id, writable_source_authority
+        )
+        flags = set((preview.metadata or {}).get("sensitivity_flags", []))
+        for source in current.sources:
+            flags.update(reflection_autonomy_candidate_metadata(source)["sensitivity_flags"])
+        preview = replace(
+            preview, metadata={**(preview.metadata or {}), "sensitivity_flags": sorted(flags)}
+        )
     policy = ReflectionAutonomyPolicy(
         confidence_threshold=confidence_threshold
         if confidence_threshold is not None
@@ -445,10 +496,12 @@ async def _drain_dream_candidate(
         preview,
         policy=policy,
         dry_run=dry_run,
+        validated_source_support=validation_promotion is not None,
     )
     promotion: ReflectionPromotionResult | None = None
     if decision.should_promote:
         promotion = await promote_reflection_candidate_review(
+            validation_promotion=validation_promotion,
             candidate_id=candidate.id,
             expected_candidate_revision=candidate.revision,
             organization_id=group_id,

--- a/apps/api/tests/test_automatic_dream_validation.py
+++ b/apps/api/tests/test_automatic_dream_validation.py
@@ -203,7 +203,7 @@ async def _assert_job_reuses_validation(monkeypatch, resolver, recheck, candidat
         "validation_extractor",
         AsyncMock(return_value=(recheck, '{"model":"offline"}')),
     )
-    monkeypatch.setattr("sibyl.jobs.lifecycle_repair.resolve_source_authority", resolver)
+    monkeypatch.setattr("sibyl.jobs.ordinary_cohorts.writable_source_authority", resolver)
     monkeypatch.setattr(
         reflection,
         "preview_reflection_candidate_promotion",

--- a/apps/api/tests/test_jobs_reflection.py
+++ b/apps/api/tests/test_jobs_reflection.py
@@ -19,6 +19,16 @@ from sibyl_core.services.surreal_content import MemoryScope, RawMemory
 def dispatch_cursor(monkeypatch):
     monkeypatch.setattr("sibyl.jobs.reflection.load_dream_cursor", AsyncMock(return_value=("", 0)))
     monkeypatch.setattr("sibyl.jobs.reflection.advance_dream_cursor", AsyncMock(return_value=True))
+    # These orchestration tests stub the validator; the public cohort tests
+    # exercise the durable binding and real publisher together.
+    monkeypatch.setattr(
+        "sibyl_core.services.ordinary_publication.ordinary_promotion_binding",
+        AsyncMock(return_value=SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.reflection_validation.prepare_stored_reflection",
+        AsyncMock(return_value=SimpleNamespace(sources=[])),
+    )
 
 
 ORG_ID = "00000000-0000-0000-0000-000000000111"

--- a/apps/api/tests/test_ordinary_cohort_learning.py
+++ b/apps/api/tests/test_ordinary_cohort_learning.py
@@ -1,0 +1,487 @@
+"""Default free-form captures flow through the scheduled proposal and publisher."""
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from sibyl.api.routes import memory_raw
+from sibyl.api.schemas import RawMemoryRememberRequest
+from sibyl.jobs import ordinary_cohorts, reflection
+from sibyl_core.ai.llm.extractor import Extractor
+from sibyl_core.auth import OrganizationRole
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.services import procedure_validation
+from sibyl_core.services.graph_client import SurrealGraphClient, prepare_graph_schema
+from sibyl_core.services.graph_entities import EntityManager
+from sibyl_core.services.graph_relationships import RelationshipManager
+from sibyl_core.services.graph_runtime import GraphRuntime
+from sibyl_core.tasks.memory_validation import CriticOutput
+
+
+@pytest.fixture
+async def cohort_runtime(monkeypatch):
+    from sibyl.jobs.lifecycle_repair import resolve_source_authority
+    from sibyl.persistence.surreal.auth import (
+        SurrealOrganizationMembershipRepository,
+        SurrealOrganizationRepository,
+        SurrealUserRepository,
+    )
+    from sibyl_core.backends.surreal import SurrealAuthClient, bootstrap_auth_schema
+
+    auth = SurrealAuthClient(url="memory://")
+    await bootstrap_auth_schema(auth, reset=True)
+    user = await SurrealUserRepository.from_client(auth).create_local_user(
+        email="cohort@example.test", password="fixture-password-123", name="Fixture"
+    )
+    org = await SurrealOrganizationRepository.from_client(auth).create(name="Cohort fixture")
+    await SurrealOrganizationMembershipRepository.from_client(auth).add_member(
+        organization_id=org.id, user_id=user.id, role=OrganizationRole.OWNER
+    )
+
+    @asynccontextmanager
+    async def auth_session():
+        yield auth
+
+    monkeypatch.setattr(
+        "sibyl.persistence.surreal.auth_runtime._common.surreal_auth_client_scope", auth_session
+    )
+    context = await ordinary_cohorts.resolve_auth_context(
+        claims={"sub": str(user.id), "org": str(org.id)}
+    )
+    client = SurrealContentClient(url="memory://")
+    graph = SurrealGraphClient(group_id=str(org.id), url="memory://")
+    await bootstrap_content_schema(client, reset=True)
+    await prepare_graph_schema(graph)
+    runtime = GraphRuntime(
+        client=graph,
+        entity_manager=EntityManager(graph, group_id=str(org.id)),
+        relationship_manager=RelationshipManager(graph, group_id=str(org.id)),
+    )
+
+    @asynccontextmanager
+    async def session():
+        yield client
+
+    monkeypatch.setattr("sibyl_core.services.content_client.surreal_content_client", session)
+    monkeypatch.setattr(
+        "sibyl_core.services.content_models.configured_raw_memory_embedding_provider", lambda: None
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.memory_reflection.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_runtime.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_derivations.get_source_authority_resolver",
+        lambda: resolve_source_authority,
+    )
+    monkeypatch.setattr("sibyl.api.routes.memory_auth.log_memory_audit_event", AsyncMock())
+    monkeypatch.setattr(reflection, "log_memory_audit_event", AsyncMock())
+    monkeypatch.setattr(memory_raw, "publish_raw_capture_changed", AsyncMock())
+    try:
+        yield org, context, client, runtime
+    finally:
+        await graph.close()
+        await client.close()
+        await auth.close()
+
+
+async def capture(cohort_runtime):
+    org, context, client, _runtime = cohort_runtime
+    for body in [
+        "Inspect logs before changing configuration.",
+        "The logs show which configuration value was loaded.",
+    ]:
+        await memory_raw.remember_raw(
+            RawMemoryRememberRequest(raw_content=body),
+            http_request=SimpleNamespace(headers={}, client=None),
+            org=org,
+            ctx=context,
+        )
+    return await client.execute_query("SELECT * FROM raw_captures ORDER BY uuid;")
+
+
+def install_model(monkeypatch, source):
+    output = {
+        "procedure": {
+            "kind": "pattern",
+            "goal": {
+                "statement": "Logs reveal configuration choices",
+                "label": "inferred",
+                "support": [
+                    {
+                        "episode_id": source["uuid"],
+                        "start_byte": 0,
+                        "end_byte": len(source["raw_content"].encode()),
+                    }
+                ],
+            },
+        },
+        "abstention_reason": None,
+    }
+    calls = []
+
+    async def factory():
+        calls.append(True)
+        value = output if len(calls) <= 2 else {"findings": []}
+        return Extractor(
+            CriticOutput, agent=Agent(TestModel(custom_output_args=value), output_type=CriticOutput)
+        ), '{"model":"offline"}'
+
+    monkeypatch.setattr(procedure_validation, "validation_extractor", factory)
+    return calls
+
+
+async def test_ordinary_cohort_public_capture_scheduled_publish_recall(cohort_runtime, monkeypatch):
+    org, context, client, _runtime = cohort_runtime
+    sources = await capture(cohort_runtime)
+    calls = install_model(monkeypatch, sources[0])
+    receipt = await reflection.run_reflection_dream_cycle({}, str(org.id))
+    assert receipt["failed"] == 0, receipt
+    assert receipt["promoted"] == 1, receipt
+    assert len(calls) == 3
+    stages = await client.execute_query("SELECT * FROM memory_validation_executions;")
+    assert len(stages) == 2
+    assert all(s["state"] == "returned" for s in stages)
+    assert sum(json.loads(s["usage_json"])["requests"] for s in stages) == 2
+    assert not await client.execute_query("SELECT * FROM dream_source_checkpoints;")
+    from sibyl_core.services.content_raw_recall import recall_raw_memory
+
+    recalled = await recall_raw_memory(
+        organization_id=str(org.id), principal_id=context.user_id, query="Logs reveal configuration"
+    )
+    candidate = next(m for m in recalled if m.capture_surface == "reflection_candidate")
+    assert candidate.metadata["confidence"] == 0
+    assert candidate.review_state == "promoted"
+    from sibyl_core.services.validation_promotion import validated_graph_current
+
+    assert await validated_graph_current(str(org.id), candidate.metadata["promoted_entity_id"])
+    # Identical cohort work may be selected again, but its durable proposal is reused.
+    before = await client.execute_query(
+        "SELECT uuid, result_json FROM memory_validation_executions ORDER BY uuid;"
+    )
+    monkeypatch.setattr(
+        Extractor, "extract_with_usage", AsyncMock(side_effect=AssertionError("redispatch"))
+    )
+    await reflection.run_reflection_dream_cycle({}, str(org.id))
+    after = await client.execute_query(
+        "SELECT uuid, result_json FROM memory_validation_executions ORDER BY uuid;"
+    )
+    assert before == after
+
+
+@pytest.mark.parametrize("phase", ["proposal", "critic", "publication"])
+async def test_ordinary_cohort_current_role_fences_each_stage(cohort_runtime, monkeypatch, phase):
+
+    from sibyl_core.services import memory_reflection
+
+    org, context, client, _runtime = cohort_runtime
+    sources = await capture(cohort_runtime)
+    install_model(monkeypatch, sources[0])
+    calls = 0
+    extract = Extractor.extract_with_usage
+
+    async def revoke():
+        from sibyl.persistence.surreal.auth_runtime._common import _auth_client_scope
+
+        async with _auth_client_scope() as auth:
+            rows = await auth.execute_query(
+                "UPDATE organization_members SET role='viewer' WHERE organization_id=$org AND user_id=$user RETURN AFTER;",
+                org=str(org.id),
+                user=context.user_id,
+            )
+        assert len(rows) == 1
+
+    async def revoke_after_extract(self, prompt):
+        nonlocal calls
+        value = await extract(self, prompt)
+        calls += 1
+        if (phase == "proposal" and calls == 1) or (phase == "critic" and calls == 2):
+            await revoke()
+        return value
+
+    monkeypatch.setattr(Extractor, "extract_with_usage", revoke_after_extract)
+    if phase == "publication":
+        reserve = memory_reflection._reserve_promotion
+
+        async def revoke_before_reserve(*args, **kwargs):
+            await revoke()
+            return await reserve(*args, **kwargs)
+
+        monkeypatch.setattr(memory_reflection, "_reserve_promotion", revoke_before_reserve)
+    receipt = await reflection.run_reflection_dream_cycle({}, str(org.id))
+    assert receipt["promoted"] == 0
+    assert receipt["failed"] == 1, receipt
+    stages = await client.execute_query("SELECT * FROM memory_validation_executions;")
+    assert sum(json.loads(s["usage_json"])["requests"] for s in stages) == calls
+    assert calls == (1 if phase == "proposal" else 2)
+    assert not await client.execute_query(
+        "SELECT * FROM raw_captures WHERE review_state='promoted';"
+    )
+
+
+async def test_ordinary_cohort_does_not_hide_source_sensitivity(cohort_runtime, monkeypatch):
+    org, _context, client, _runtime = cohort_runtime
+    sources = await capture(cohort_runtime)
+    await client.execute_query(
+        "UPDATE raw_captures SET metadata.contains_sensitive=true WHERE uuid=$id;",
+        id=sources[0]["uuid"],
+    )
+    install_model(monkeypatch, sources[0])
+    receipt = await reflection.run_reflection_dream_cycle({}, str(org.id))
+    assert receipt["failed"] == 0, receipt
+    assert receipt["promoted"] == 0
+    assert receipt["archived"] == 1
+    assert "sensitive_candidate" in receipt["candidates"][0]["exception_reasons"]
+
+
+async def test_ordinary_cohort_correction_recheck_and_publication(cohort_runtime, monkeypatch):
+    from sibyl_core.services.reflection_validation import prepare_stored_reflection
+    from sibyl_core.tasks.ordinary_proposals import QUALIFICATION
+    from sibyl_core.tasks.procedure_review import ReviewSubmission, review_digest
+
+    org, context, client, _runtime = cohort_runtime
+    sources = await capture(cohort_runtime)
+    install_model(monkeypatch, sources[0])
+    proposal_factory = procedure_validation.validation_extractor
+    count = 0
+    submission = None
+    corrected_text = None
+
+    async def factory():
+        nonlocal count, submission, corrected_text
+        count += 1
+        if count <= 2:
+            return await proposal_factory()
+        if count == 3:
+            rows = await client.execute_query(
+                "SELECT uuid FROM raw_captures WHERE capture_surface='reflection_candidate';"
+            )
+            prepared = await prepare_stored_reflection(
+                str(org.id),
+                context.user_id,
+                rows[0]["uuid"],
+                ordinary_cohorts.writable_source_authority,
+            )
+            payload = json.loads(prepared.prepared.payload_json)
+            claim = payload["assertions"]["/content"]
+            submission = ReviewSubmission(
+                parent_operation_id=payload["parent_operation_id"],
+                parent_candidate_sha256=payload["parent_candidate_sha256"],
+                findings=[
+                    {
+                        "claim_path": "/content",
+                        "claim_sha256": review_digest(claim),
+                        "evidence_refs": [{"evidence_id": "s0"}],
+                        "basis": "factual_contradiction",
+                        "disposition": "reconsider",
+                        "critique": "Keep the observation specific to the recorded configuration.",
+                    }
+                ],
+            )
+            corrected_text = (
+                QUALIFICATION
+                + "\nThe recorded logs may identify the loaded configuration; check the actual log contents."
+            )
+            output = {"findings": [f.model_dump(mode="json") for f in submission.findings]}
+        elif count == 4:
+            output = {
+                "content": corrected_text,
+                "abstention_reason": None,
+                "assessments": [
+                    {
+                        "finding_id": submission.finding_ids()[0],
+                        "disposition": "accepted",
+                        "explanation": "Keep the statement conditional and source-specific.",
+                        "evidence_refs": [{"evidence_id": "s0"}],
+                    }
+                ],
+            }
+        else:
+            assert count == 5
+            output = {"findings": []}
+        return Extractor(
+            CriticOutput,
+            agent=Agent(TestModel(custom_output_args=output), output_type=CriticOutput),
+        ), '{"model":"offline"}'
+
+    monkeypatch.setattr(procedure_validation, "validation_extractor", factory)
+    receipt = await reflection.run_reflection_dream_cycle({}, str(org.id))
+    assert receipt["failed"] == 0, receipt
+    assert receipt["promoted"] == 1, receipt
+    assert count == 5
+    stages = await client.execute_query("SELECT * FROM memory_validation_executions;")
+    assert len(stages) == 4
+    assert sum(json.loads(s["usage_json"])["requests"] for s in stages) == 4
+    rows = await client.execute_query(
+        "SELECT * FROM raw_captures WHERE capture_surface='reflection_candidate';"
+    )
+    assert {r["review_state"] for r in rows} == {"promoted", "archived"}
+    child = next(r for r in rows if r["review_state"] == "promoted")
+    assert child["raw_content"] == corrected_text
+    assert QUALIFICATION in child["raw_content"]
+    from sibyl_core.services.validation_promotion import validated_graph_current
+
+    assert await validated_graph_current(str(org.id), child["metadata"]["promoted_entity_id"])
+
+
+async def test_ordinary_cohort_preparation_denial_never_falls_back(cohort_runtime, monkeypatch):
+    org, context, client, _runtime = cohort_runtime
+    await capture(cohort_runtime)
+    from sibyl.persistence.surreal.auth_runtime._common import _auth_client_scope
+
+    async with _auth_client_scope() as auth:
+        await auth.execute_query(
+            "UPDATE organization_members SET role='viewer' WHERE organization_id=$org AND user_id=$user;",
+            org=str(org.id),
+            user=context.user_id,
+        )
+    factory = AsyncMock(side_effect=AssertionError("provider preparation after denied authority"))
+    monkeypatch.setattr(procedure_validation, "validation_extractor", factory)
+    receipt = await reflection.run_reflection_dream_cycle({}, str(org.id))
+    assert receipt["failed"] == 1
+    assert receipt["sources_reflected"] == 0
+    factory.assert_not_awaited()
+    assert not await client.execute_query("SELECT * FROM dream_source_checkpoints;")
+    assert not await client.execute_query("SELECT * FROM memory_validation_executions;")
+    assert not await client.execute_query(
+        "SELECT * FROM raw_captures WHERE capture_surface='reflection_candidate';"
+    )
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "source_sensitive",
+        "source_sensitive_string",
+        "source_sensitive_tag",
+        "candidate_conflict",
+        "candidate_scope",
+    ],
+)
+async def test_ordinary_cohort_late_publication_policy_interpretation(
+    cohort_runtime, monkeypatch, change
+):
+    from sibyl_core.services import memory_reflection
+
+    org, _context, client, _runtime = cohort_runtime
+    sources = await capture(cohort_runtime)
+    install_model(monkeypatch, sources[0])
+    reserve = memory_reflection._reserve_promotion
+
+    async def changed(plan, *args, **kwargs):
+        if change in {"source_sensitive", "source_sensitive_string"}:
+            await client.execute_query(
+                "UPDATE raw_captures SET metadata.contains_sensitive=$value WHERE uuid=$id;",
+                id=sources[0]["uuid"],
+                value="true" if change == "source_sensitive_string" else True,
+            )
+        elif change == "source_sensitive_tag":
+            await client.execute_query(
+                "UPDATE raw_captures SET tags=['secret'] WHERE uuid=$id;", id=sources[0]["uuid"]
+            )
+        elif change == "candidate_conflict":
+            await client.execute_query(
+                "UPDATE raw_captures SET metadata.conflicts_with_source_ids=['conflict'] WHERE uuid=$id;",
+                id=plan.candidate_memory.id,
+            )
+        else:
+            await client.execute_query(
+                "UPDATE raw_captures SET metadata.suggested_memory_scope='organization' WHERE uuid=$id;",
+                id=plan.candidate_memory.id,
+            )
+        return await reserve(plan, *args, **kwargs)
+
+    monkeypatch.setattr(memory_reflection, "_reserve_promotion", changed)
+    receipt = await reflection.run_reflection_dream_cycle({}, str(org.id))
+    # The existing interpreter accepts literal booleans, not string flags.
+    denied = change != "source_sensitive_string"
+    assert receipt["promoted"] == (0 if denied else 1), receipt
+    assert receipt["failed"] == (1 if denied else 0), receipt
+    promoted = await client.execute_query(
+        "SELECT * FROM raw_captures WHERE review_state='promoted';"
+    )
+    assert len(promoted) == (0 if denied else 1)
+    stages = await client.execute_query("SELECT usage_json FROM memory_validation_executions;")
+    assert sum(json.loads(stage["usage_json"])["requests"] for stage in stages) == 2
+
+
+@pytest.mark.parametrize("raced", [False, True])
+async def test_ordinary_cohort_native_final_policy_race(cohort_runtime, monkeypatch, raced):
+    import asyncio
+    import os
+
+    if not os.environ.get("SIBYL_COHORT_NATIVE_URL"):
+        pytest.skip("native multi-connection publication policy race")
+    org, _context, client, _runtime = cohort_runtime
+    sources = await capture(cohort_runtime)
+    install_model(monkeypatch, sources[0])
+    execute = client.execute_query
+    execute_raw = client.execute_query_raw
+    before = await execute(
+        "SELECT generation, revision, incarnation, deleted FROM source_states WHERE source_id=$id;",
+        id=sources[0]["uuid"],
+    )
+    assert len(before) == 1
+    delayed_once = False
+
+    async def delayed(query, **kwargs):
+        nonlocal delayed_once
+        if (
+            delayed_once
+            or not kwargs.get("validation_binding")
+            or kwargs.get("record", {}).get("review_state") != "promoted"
+        ):
+            return await execute_raw(query, **kwargs)
+        assert "IF $snapshot_digest!=$ordinary_snapshot" in query
+        delayed_once = True
+        pending = asyncio.create_task(
+            execute_raw(
+                query.replace(
+                    "IF $snapshot_digest!=$ordinary_snapshot",
+                    "SLEEP 1s; IF $snapshot_digest!=$ordinary_snapshot",
+                    1,
+                ),
+                **kwargs,
+            )
+        )
+        try:
+            if raced:
+                await asyncio.sleep(0.25)
+                changed = await execute(
+                    "UPDATE raw_captures SET metadata.contains_sensitive=true WHERE uuid=$id RETURN AFTER;",
+                    id=sources[0]["uuid"],
+                )
+                assert len(changed) == 1
+            return await pending
+        finally:
+            if not pending.done():
+                await pending
+
+    monkeypatch.setattr(client, "execute_query_raw", delayed)
+    receipt = await reflection.run_reflection_dream_cycle({}, str(org.id))
+    assert delayed_once
+    assert receipt["promoted"] == (0 if raced else 1), receipt
+    if raced:
+        assert not await execute("SELECT * FROM raw_captures WHERE review_state='promoted';")
+        row = await execute(
+            "SELECT metadata FROM raw_captures WHERE uuid=$id;", id=sources[0]["uuid"]
+        )
+        assert row[0]["metadata"]["contains_sensitive"] is True
+
+    after = await execute(
+        "SELECT generation, revision, incarnation, deleted FROM source_states WHERE source_id=$id;",
+        id=sources[0]["uuid"],
+    )
+    assert after == before
+    stages = await execute("SELECT usage_json FROM memory_validation_executions;")
+    assert sum(json.loads(stage["usage_json"])["requests"] for stage in stages) == 2

--- a/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/content_raw_persistence.py
@@ -655,6 +655,7 @@ def reflection_candidate_metadata(
 
 async def remember_reflection_candidate_review(
     *,
+    embedding_provider: EmbeddingProvider | object | None = _RAW_MEMORY_EMBEDDING_AUTO,
     organization_id: str,
     principal_id: str,
     candidate: ReflectionCandidate,
@@ -687,6 +688,7 @@ async def remember_reflection_candidate_review(
         extraction_prompt_metadata=extraction_prompt_metadata,
     )
     return await remember_raw_memory(
+        embedding_provider=embedding_provider,
         organization_id=organization_id,
         principal_id=principal_id,
         source_id=resolved_source_id,

--- a/packages/python/sibyl-core/src/sibyl_core/services/memory_autonomy.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/memory_autonomy.py
@@ -131,6 +131,7 @@ def decide_reflection_candidate_autonomy(
     *,
     policy: ReflectionAutonomyPolicy | None = None,
     dry_run: bool = False,
+    validated_source_support: bool = False,
 ) -> ReflectionAutonomyDecision:
     active_policy = policy or ReflectionAutonomyPolicy()
     metadata = dict(preview.metadata or {})
@@ -139,7 +140,10 @@ def decide_reflection_candidate_autonomy(
         preview=preview,
         metadata=metadata,
         policy=active_policy,
+        validated_source_support=validated_source_support,
     )
+    if validated_source_support:
+        metadata["autonomy_confidence_basis"] = "validated_source_support"
     confidence = _metadata_float(metadata, "confidence")
 
     if preview.reason in {"candidate_already_promoted", "candidate_archived"}:
@@ -228,6 +232,7 @@ def _exception_reasons(
     preview: ReflectionPromotionPreviewLike,
     metadata: Mapping[str, Any],
     policy: ReflectionAutonomyPolicy,
+    validated_source_support: bool = False,
 ) -> list[str]:
     reasons: list[str] = []
     if preview.reason == "candidate_not_found":
@@ -240,10 +245,11 @@ def _exception_reasons(
         reasons.append("missing_source")
 
     confidence = _metadata_float(metadata, "confidence")
-    if confidence is None:
-        reasons.append("missing_confidence")
-    elif confidence < policy.confidence_threshold:
-        reasons.append("low_confidence")
+    if not validated_source_support:
+        if confidence is None:
+            reasons.append("missing_confidence")
+        elif confidence < policy.confidence_threshold:
+            reasons.append("low_confidence")
 
     sensitivity_flags = _str_list(metadata.get("sensitivity_flags"))
     if sensitivity_flags:

--- a/packages/python/sibyl-core/src/sibyl_core/services/ordinary_cohort.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/ordinary_cohort.py
@@ -1,0 +1,368 @@
+"""Propose ordinary memories from one authorized, durable cohort observation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from pydantic import TypeAdapter
+from pydantic_ai import Agent, NativeOutput
+from pydantic_ai.models import Model
+
+from sibyl_core.ai.llm.extractor import Extractor
+from sibyl_core.backends.surreal.schema_source_witness import SOURCE_STATE_WRITE_WITNESS
+from sibyl_core.config import settings
+from sibyl_core.memory_pipeline.observations import SourceIdentity, SourceKind
+from sibyl_core.services.content_models import RawMemory
+from sibyl_core.services.content_raw_persistence import (
+    get_raw_memory,
+    remember_reflection_candidate_review,
+)
+from sibyl_core.services.memory_source_validation import (
+    SourceAuthorityResolver,
+    SourceReadAuthority,
+)
+from sibyl_core.services.observed_sources import load_authorized_source_snapshot
+from sibyl_core.services.source_observations import SourceUnavailableError
+from sibyl_core.services.source_state_store import RawSourceSnapshot
+from sibyl_core.services.validation_candidate import ValidationCandidateWrite
+from sibyl_core.services.validation_execution import ValidationExecution, _query
+from sibyl_core.services.validation_stages import run_validation_stage
+from sibyl_core.tasks._evidence_json import canonical
+from sibyl_core.tasks.consolidation import ConsolidationInputBudgetExceeded
+from sibyl_core.tasks.ordinary_evidence import OrdinarySource
+from sibyl_core.tasks.ordinary_proposal_result import OrdinaryProposalResult
+from sibyl_core.tasks.ordinary_proposals import (
+    VERSION,
+    PartialCohort,
+    PartialEpisode,
+    PartialProposal,
+    PreparedPartialProposal,
+    prepare_partial_proposal,
+)
+from sibyl_core.tasks.procedure_review import review_digest
+
+COHORT_SNAPSHOT = """
+LET $captures=(SELECT * OMIT embedding, retrieval_count, citation_count, misled_count, last_recalled_at, last_used_at, metadata.embedding_metadata FROM raw_captures WHERE organization_id=$org AND uuid IN $source_ids ORDER BY uuid);
+LET $states=(SELECT * OMIT validation_write_witness FROM source_states WHERE organization_id=$org
+    AND source_kind='raw_capture' AND source_id IN $source_ids ORDER BY source_id);
+LET $snapshot={captures:$captures,states:$states};
+LET $snapshot_digest=crypto::sha256(type::string($snapshot));
+"""
+COHORT_GUARD = (
+    COHORT_SNAPSHOT
+    + "IF $snapshot_digest!=$expected { THROW 'Ordinary cohort sources changed'; };"
+    + "LET $source_states_to_fence=$states;"
+    + SOURCE_STATE_WRITE_WITNESS
+)
+
+
+@dataclass(frozen=True)
+class PreparedCohort:
+    prepared: PreparedPartialProposal
+    sources: tuple[RawSourceSnapshot, ...]
+    snapshot_sha256: str
+    authority: SourceReadAuthority
+
+    @property
+    def ids(self) -> list[str]:
+        return [source.memory.id for source in self.sources]
+
+    @property
+    def bindings(self) -> list[dict[str, object]]:
+        return [
+            {
+                "source_id": s.memory.id,
+                "incarnation": s.observation.effective_incarnation,
+                "generation": s.observation.generation,
+            }
+            for s in self.sources
+        ]
+
+
+async def prepare_stored_cohort(
+    org: str,
+    principal: str,
+    source_ids: list[str],
+    resolver: SourceAuthorityResolver,
+) -> PreparedCohort:
+    """Resolve actual retained sources; project grouping never proves environment facts."""
+    ids = sorted(source_ids)
+    if len(ids) < 2 or len(ids) != len(set(ids)):
+        raise ValueError("An ordinary cohort requires distinct retained sources")
+    authority = await resolver(org, principal)
+    if authority is None or authority.principal_id != principal:
+        raise SourceUnavailableError()
+    rows = await _query(
+        "RETURN {" + COHORT_SNAPSHOT + "RETURN {snapshot:$snapshot,token:$snapshot_digest}; };",
+        org=org,
+        source_ids=ids,
+    )
+    if len(rows) != 1:
+        raise SourceUnavailableError()
+    data = rows[0]["snapshot"]
+    captures = {r["uuid"]: r for r in data["captures"]}
+    states = {r["source_id"]: r for r in data["states"]}
+    if set(captures) != set(ids) or set(states) != set(ids):
+        raise SourceUnavailableError()
+    sources = []
+    episodes = []
+    scope = None
+    for identifier in ids:
+        source = await load_authorized_source_snapshot(
+            SourceIdentity(org, SourceKind.RAW_CAPTURE, identifier), authority, organization_id=org
+        )
+        if not isinstance(source, RawSourceSnapshot):
+            raise SourceUnavailableError()
+        memory = source.memory
+        state = states[identifier]
+        identity = (memory.memory_scope, memory.scope_key, memory.project_id)
+        if memory.principal_id != principal or (scope is not None and identity != scope):
+            raise SourceUnavailableError()
+        scope = identity
+        if (
+            memory.raw_content != captures[identifier]["raw_content"]
+            or memory.revision != captures[identifier]["revision"]
+            or source.observation.effective_incarnation != state["incarnation"]
+            or source.observation.generation != state["generation"]
+        ):
+            raise SourceUnavailableError()
+        if memory.capture_surface in {"reflection_candidate", "reflection_source"} or (
+            memory.entity_type in {"procedure", "pattern"} and memory.derivation_required
+        ):
+            raise SourceUnavailableError()
+        artifact = memory.raw_content.encode("utf-8")
+        episodes.append(
+            PartialEpisode(
+                episode_id=identifier,
+                artifact=artifact,
+                source=OrdinarySource(
+                    source_id=identifier,
+                    incarnation=source.observation.effective_incarnation,
+                    generation=source.observation.generation,
+                    observed_revision=memory.revision,
+                    content_sha256=hashlib.sha256(artifact).hexdigest(),
+                ),
+            )
+        )
+        sources.append(source)
+    assert scope is not None
+    group = PartialCohort(
+        group_id=review_digest(ids),
+        mechanism="Compare ordinary retained observations",
+        organization_id=org,
+        owner_principal_id=principal,
+        memory_scope=scope[0],
+        scope_key=scope[1],
+        episodes=tuple(episodes),
+    )
+    return PreparedCohort(
+        prepare_partial_proposal(group), tuple(sources), rows[0]["token"], authority
+    )
+
+
+async def propose_stored_cohort(
+    org: str,
+    principal: str,
+    source_ids: list[str],
+    resolver: SourceAuthorityResolver,
+    *,
+    authorize: Callable[[], Awaitable[None]],
+) -> tuple[RawMemory | None, str]:
+    """Reuse completed results without redispatch, then persist their protected derivation."""
+    from sibyl_core.services.procedure_validation import (
+        _close_resources,
+        _OwnedValidationExtractor,
+        validation_extractor,
+    )
+
+    await authorize()
+    original = await prepare_stored_cohort(org, principal, source_ids, resolver)
+    if len(original.prepared.prompt) > settings.consolidation_max_input_chars:
+        raise ConsolidationInputBudgetExceeded(
+            len(original.prepared.prompt), settings.consolidation_max_input_chars
+        )
+    owned, policy = await validation_extractor()
+    try:
+        extractor = await _proposal_extractor(owned, original.prepared.system)
+        schema = await extractor.output_schema()
+        policy = canonical({**json.loads(policy), "version": VERSION, "schema": schema})
+        actual = (
+            len(original.prepared.system) + len(original.prepared.prompt) + len(canonical(schema))
+        )
+        if actual > settings.consolidation_max_input_chars:
+            raise ConsolidationInputBudgetExceeded(actual, settings.consolidation_max_input_chars)
+        return await _run_cohort(org, principal, original, resolver, extractor, policy, authorize)
+    finally:
+        if isinstance(owned, _OwnedValidationExtractor):
+            await _close_resources(owned.resources)
+
+
+async def _run_cohort(org, principal, original, resolver, extractor, policy, authorize):
+    async def current():
+        await authorize()
+        refreshed = await prepare_stored_cohort(org, principal, original.ids, resolver)
+        if (
+            refreshed.snapshot_sha256 != original.snapshot_sha256
+            or refreshed.prepared != original.prepared
+        ):
+            raise SourceUnavailableError()
+
+    request = {
+        "kind": VERSION,
+        "org": org,
+        "principal": principal,
+        "parent": original.ids[0],
+        "source_bindings": original.bindings,
+        "snapshot": original.snapshot_sha256,
+        "input": original.prepared.input_sha256,
+        "policy": policy,
+    }
+    identity = review_digest(request)
+    params = {
+        "org": org,
+        "principal": principal,
+        "source_ids": original.ids,
+        "expected": original.snapshot_sha256,
+    }
+    execution = ValidationExecution(
+        identity,
+        org,
+        principal,
+        authorize=current,
+        dispatch_guard=COHORT_GUARD,
+        guard_params={k: v for k, v in params.items() if k not in {"org", "principal"}},
+    )
+
+    async def run():
+        result = await extractor.extract_with_usage(original.prepared.prompt)
+        proposal = PartialProposal.model_validate(result.output.model_dump())
+        error = None
+        try:
+            original.prepared.render(proposal)
+        except ValueError as failure:
+            error = str(failure)
+        return OrdinaryProposalResult(
+            "ordinary_cohort_proposal",
+            original.prepared.input_sha256,
+            proposal,
+            result.usage,
+            error,
+        )
+
+    value = await run_validation_stage(
+        execution=execution,
+        parent_id=original.ids[0],
+        source_ids=original.ids,
+        request=request,
+        policy=policy,
+        check_current=current,
+        run=run,
+    )
+    result = TypeAdapter(OrdinaryProposalResult).validate_python(
+        {k: v for k, v in value.items() if k != "execution_id"}
+    )
+    if result.input_sha256 != original.prepared.input_sha256:
+        raise SourceUnavailableError()
+    if result.validation_error is not None:
+        failure = ValueError(result.validation_error)
+        failure.__dict__["extraction_usage"] = result.usage.model_dump(mode="json")
+        raise failure
+    candidate = original.prepared.render(result.proposal)
+    if candidate is None:
+        return None, identity
+    await current()
+    row = await execution.load()
+    if row is None:
+        raise SourceUnavailableError()
+    write = ValidationCandidateWrite(identity, row["result_json"], COHORT_GUARD, params)
+    replay = await get_raw_memory(organization_id=org, memory_id=write.id)
+    embedding = {"embedding_provider": None} if replay is not None else {}
+    memory = await remember_reflection_candidate_review(
+        **embedding,
+        organization_id=org,
+        principal_id=principal,
+        candidate=candidate,
+        raw_source_ids=original.ids,
+        source_id=original.ids[0],
+        memory_scope=original.sources[0].memory.memory_scope,
+        scope_key=original.sources[0].memory.scope_key,
+        suggested_memory_scope=candidate.suggested_memory_scope,
+        suggested_scope_key=candidate.suggested_scope_key,
+        source_observations=[source.observation for source in original.sources],
+        validation_write=write,
+        accessible_projects=original.authority.projects,
+        accessible_teams=original.authority.teams,
+        accessible_delegations=original.authority.delegations,
+        allowed_memory_scope_keys=original.authority.scope_keys,
+    )
+    return memory, identity
+
+
+async def _proposal_extractor(owned, system: str):
+    model = (await owned._get_agent()).model
+    if not isinstance(model, Model):
+        raise ValueError("Cohort proposal needs a resolved model")
+    extractor = Extractor(
+        PartialProposal,
+        agent=Agent(
+            model,
+            system_prompt=system,
+            output_type=NativeOutput(PartialProposal, strict=True)
+            if owned.output_mode == "native_strict"
+            else PartialProposal,
+            retries={"output": 2},
+        ),
+        surface=owned.surface,
+        system_prompt=system,
+        max_tokens=owned.max_tokens,
+        output_retries=2,
+        output_mode=owned.output_mode,
+        openrouter_provider=owned.openrouter_provider,
+        model_override=owned.model_override,
+    )
+    return extractor
+
+
+async def partition_stored_cohort(org, principal, source_ids, resolver):
+    """Pack complete authorized episodes against the actual resolved schema budget."""
+    from sibyl_core.services.procedure_validation import (
+        _close_resources,
+        _OwnedValidationExtractor,
+        validation_extractor,
+    )
+
+    original = await prepare_stored_cohort(org, principal, source_ids, resolver)
+    owned, _policy = await validation_extractor()
+    try:
+        extractor = await _proposal_extractor(owned, original.prepared.system)
+        schema_chars = len(canonical(await extractor.output_schema()))
+    finally:
+        if isinstance(owned, _OwnedValidationExtractor):
+            await _close_resources(owned.resources)
+    group = PartialCohort.model_validate_json(original.prepared.input_json)
+    bins = []
+
+    def fits(episodes):
+        if len(episodes) < 2:
+            return True
+        ids = [e.episode_id for e in episodes]
+        partial = PartialCohort.model_validate(
+            {**group.model_dump(), "episodes": tuple(episodes), "group_id": review_digest(ids)}
+        )
+        prepared = prepare_partial_proposal(partial)
+        return (
+            len(prepared.prompt) + len(prepared.system) + schema_chars
+            <= settings.consolidation_max_input_chars
+        )
+
+    for episode in group.episodes:
+        for bucket in bins:
+            if fits([*bucket, episode]):
+                bucket.append(episode)
+                break
+        else:
+            bins.append([episode])
+    return [[episode.episode_id for episode in bucket] for bucket in bins]

--- a/packages/python/sibyl-core/src/sibyl_core/services/ordinary_publication.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/ordinary_publication.py
@@ -1,0 +1,127 @@
+"""Publish ordinary memories using the actual stored semantic review binding."""
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import TypeAdapter
+
+from sibyl_core.backends.surreal.schema_source_witness import SOURCE_STATE_WRITE_WITNESS
+from sibyl_core.services.content_models import RawMemory
+from sibyl_core.services.memory_autonomy import reflection_autonomy_candidate_metadata
+from sibyl_core.services.memory_source_validation import SourceAuthorityResolver
+from sibyl_core.services.reflection_validation import ORDINARY_SNAPSHOT, prepare_stored_reflection
+from sibyl_core.services.validation_execution import (
+    ValidationExecution,
+    ValidationExecutionUnavailable,
+)
+from sibyl_core.services.validation_promotion import (
+    ValidatedPromotion,
+    ValidationBinding,
+    validated_result,
+)
+from sibyl_core.tasks.memory_validation import MemoryValidationResult, PreparedMemoryValidation
+from sibyl_core.tasks.procedure_review import review_digest
+
+
+def ordinary_semantic_digest(prepared: PreparedMemoryValidation) -> str:
+    """Bind actual claims/evidence while permitting fenced publication bookkeeping."""
+    payload = json.loads(prepared.payload_json)
+    if payload["kind"] != "reflection":
+        raise ValueError("Ordinary publication requires reflection evidence")
+    payload.pop("parent_candidate_sha256")
+    return review_digest(payload)
+
+
+def ordinary_policy_digest(memories: list[RawMemory]) -> str:
+    """Bind the existing policy interpreter's inputs, excluding publication bookkeeping."""
+    return review_digest(
+        [
+            {
+                "source_id": memory.id,
+                "principal_id": memory.principal_id,
+                "memory_scope": memory.memory_scope.value,
+                "scope_key": memory.scope_key,
+                "project_id": memory.project_id,
+                "autonomy": reflection_autonomy_candidate_metadata(memory),
+                "publication_context": {
+                    key: memory.metadata.get(key)
+                    for key in (
+                        "suggested_memory_scope",
+                        "suggested_scope_key",
+                        "project_id",
+                        "domain",
+                        "related_to",
+                    )
+                },
+            }
+            for memory in sorted(memories, key=lambda item: item.id)
+        ]
+    )
+
+
+@dataclass(frozen=True)
+class OrdinaryValidatedPromotion(ValidatedPromotion):
+    resolver: SourceAuthorityResolver
+
+    async def current_guard(self) -> tuple[str, dict[str, Any]]:
+        await self.authorize()
+        current = await prepare_stored_reflection(
+            self.organization_id,
+            self.principal_id,
+            self.candidate_id,
+            self.resolver,
+            publication=True,
+        )
+        row = await ValidationExecution(
+            self.binding.execution_id, self.organization_id, self.principal_id
+        ).load()
+        if row is None:
+            raise ValidationExecutionUnavailable("Ordinary validation disappeared")
+        validated_result(
+            row, self.binding, self.organization_id, self.principal_id, self.candidate_id
+        )
+        request = json.loads(row["request_json"])
+        if request.get("kind") != "ordinary_reflection_validation-v2" or request.get(
+            "ordinary_semantic_input"
+        ) != ordinary_semantic_digest(current.prepared):
+            raise ValidationExecutionUnavailable("Ordinary validated evidence changed")
+        if request.get("ordinary_publication_policy") != current.publication_policy_sha256:
+            raise ValidationExecutionUnavailable("Ordinary publication policy changed")
+        prior = {v["source_id"]: v for v in request["source_bindings"]}
+        present = {v["source_id"]: v for v in current.source_bindings}
+        if set(prior) != set(present) or any(
+            prior[k]["incarnation"] != present[k]["incarnation"]
+            or (k != self.candidate_id and prior[k]["generation"] != present[k]["generation"])
+            for k in prior
+        ):
+            raise ValidationExecutionUnavailable("Ordinary validated source identity changed")
+        return (
+            "LET $org=$organization_id; LET $parent=$uuid; LET $source_ids=$ordinary_source_ids;"
+            + ORDINARY_SNAPSHOT
+            + "IF $snapshot_digest!=$ordinary_snapshot { THROW 'publication_source_observation_changed'; };"
+            + "LET $source_states_to_fence=$snapshot.states;"
+            + SOURCE_STATE_WRITE_WITNESS,
+            {
+                "ordinary_snapshot": current.snapshot_sha256,
+                "ordinary_source_ids": current.source_ids,
+            },
+        )
+
+
+async def ordinary_promotion_binding(org, principal, parent, execution_id, resolver, authorize):
+    row = await ValidationExecution(execution_id, org, principal).load()
+    if row is None or not isinstance(row.get("result_json"), str):
+        raise ValidationExecutionUnavailable("Ordinary promotion validation unavailable")
+    result = TypeAdapter(MemoryValidationResult).validate_json(row["result_json"])
+    from sibyl_core.services.validation_promotion import _sha
+
+    binding = ValidationBinding(
+        execution_id=execution_id,
+        request_sha256=execution_id,
+        result_sha256=_sha(row["result_json"]),
+        input_sha256=result.input_sha256,
+    )
+    promotion = OrdinaryValidatedPromotion(org, principal, parent, binding, authorize, resolver)
+    await promotion.current_guard()
+    return promotion

--- a/packages/python/sibyl-core/src/sibyl_core/services/reflection_validation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/reflection_validation.py
@@ -54,6 +54,7 @@ class AuthorizedReflection:
     snapshot_sha256: str
     source_bindings: list[dict[str, object]]
     observations: list[SourceObservation]
+    publication_policy_sha256: str
 
     @property
     def source_ids(self) -> list[str]:
@@ -61,7 +62,12 @@ class AuthorizedReflection:
 
 
 async def prepare_stored_reflection(
-    organization_id: str, principal_id: str, parent_id: str, resolver: SourceAuthorityResolver
+    organization_id: str,
+    principal_id: str,
+    parent_id: str,
+    resolver: SourceAuthorityResolver,
+    *,
+    publication: bool = False,
 ) -> AuthorizedReflection:
     """Require protected derivation observations and freshly resolved memberships."""
     authority = await resolver(organization_id, principal_id)
@@ -78,7 +84,7 @@ async def prepare_stored_reflection(
     if (
         memory.principal_id != principal_id
         or memory.deleted_at is not None
-        or memory.review_state != "pending"
+        or memory.review_state not in ({"pending", "promoted"} if publication else {"pending"})
         or not raw_memory_currently_recallable(memory)
         or not _authorize_share_source_read(
             memory=memory,
@@ -197,6 +203,11 @@ async def prepare_stored_reflection(
         evidence=evidence,
         citations=citations,
     )
+    from sibyl_core.services.ordinary_publication import ordinary_policy_digest
+
+    publication_policy = ordinary_policy_digest(
+        [raw_memory_from_record(row) for row in snapshot[0]["data"]["captures"]]
+    )
     return AuthorizedReflection(
         memory,
         candidate,
@@ -209,6 +220,7 @@ async def prepare_stored_reflection(
             for state in states
         ],
         observations,
+        publication_policy,
     )
 
 
@@ -294,12 +306,17 @@ async def _validate_prepared_reflection(
     chars = len(prompt) + len(canonical(schema))
     if chars > settings.consolidation_max_input_chars:
         raise ConsolidationInputBudgetExceeded(chars, settings.consolidation_max_input_chars)
+    from sibyl_core.services.ordinary_publication import ordinary_semantic_digest
+
     request = {
-        "kind": "ordinary_reflection_validation",
+        "kind": "ordinary_reflection_validation-v2",
+        "ordinary_semantic_input": ordinary_semantic_digest(original.prepared),
+        "ordinary_publication_policy": original.publication_policy_sha256,
         "org": memory.organization_id,
         "principal": memory.principal_id,
         "parent": memory.id,
-        "input": review_digest(prompt),
+        "input": original.prepared.input_sha256 if review is None else review_digest(prompt),
+        "prompt_sha256": review_digest(prompt),
         "snapshot": original.snapshot_sha256,
         "source_bindings": original.source_bindings,
         "policy": policy,

--- a/packages/python/sibyl-core/src/sibyl_core/services/validation_execution.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/validation_execution.py
@@ -16,12 +16,16 @@ from sibyl_core.ai.transport import FailedExtractionUsage, TransportAttempt
 from sibyl_core.services import content_client, validation_receipts
 from sibyl_core.tasks._evidence_json import canonical
 from sibyl_core.tasks.memory_validation import MemoryValidationResult
+from sibyl_core.tasks.ordinary_proposal_result import OrdinaryProposalResult
 from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
 from sibyl_core.tasks.procedure_review import review_digest
 from sibyl_core.tasks.reflection_correction import ReflectionCorrectionResult
 
 ValidationStageResult = (
-    MemoryValidationResult | ReflectionCorrectionResult | ProcedureCorrectionResult
+    MemoryValidationResult
+    | ReflectionCorrectionResult
+    | ProcedureCorrectionResult
+    | OrdinaryProposalResult
 )
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/ordinary_proposal_result.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/ordinary_proposal_result.py
@@ -1,0 +1,16 @@
+"""Durable output of a source-bound ordinary cohort proposal."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from sibyl_core.ai.llm.extractor import ExtractionUsage
+from sibyl_core.tasks.ordinary_proposals import PartialProposal
+
+
+@dataclass(frozen=True)
+class OrdinaryProposalResult:
+    status: Literal["ordinary_cohort_proposal"]
+    input_sha256: str
+    proposal: PartialProposal
+    usage: ExtractionUsage
+    validation_error: str | None = None

--- a/packages/python/sibyl-core/tests/test_ordinary_cohort.py
+++ b/packages/python/sibyl-core/tests/test_ordinary_cohort.py
@@ -1,0 +1,370 @@
+"""Durable ordinary proposals use real retained sources and existing stage owners."""
+
+import json
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from sibyl_core.ai.llm.extractor import Extractor
+from sibyl_core.backends.surreal import SurrealContentClient
+from sibyl_core.backends.surreal.content_schema import bootstrap_content_schema
+from sibyl_core.services import ordinary_cohort as service
+from sibyl_core.services import procedure_validation
+from sibyl_core.services.content_raw_persistence import remember_raw_memory, save_raw_memory
+from sibyl_core.services.memory_source_validation import SourceReadAuthority
+from sibyl_core.services.reflection_validation import (
+    prepare_stored_reflection,
+    validate_reflection_stage,
+)
+from sibyl_core.services.source_observations import SourceUnavailableError
+from sibyl_core.tasks.memory_validation import CriticOutput
+from tests.test_eval_publication_promotion import runtime as runtime
+
+
+@pytest.fixture
+async def content_store(monkeypatch):
+    client = SurrealContentClient(url="memory://")
+    try:
+        await bootstrap_content_schema(client, reset=True)
+
+        @asynccontextmanager
+        async def session():
+            yield client
+
+        monkeypatch.setattr("sibyl_core.services.content_client.surreal_content_client", session)
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture
+async def cohort_sources(content_store, monkeypatch):
+    from sibyl_core.services import content_models
+
+    monkeypatch.setattr(content_models, "configured_raw_memory_embedding_provider", lambda: None)
+    return [
+        await remember_raw_memory(
+            organization_id="org",
+            principal_id="owner",
+            source_id=f"source-{i}",
+            raw_content=f"Capture {i}: inspect logs before changing configuration.",
+            embedding_provider=None,
+        )
+        for i in range(2)
+    ]
+
+
+def install_proposal(monkeypatch, sources):
+    assertion = {
+        "statement": "Inspect logs before changing configuration",
+        "label": "inferred",
+        "support": [
+            {
+                "episode_id": sources[0].id,
+                "start_byte": 0,
+                "end_byte": len(sources[0].raw_content.encode()),
+            }
+        ],
+    }
+    output = {"procedure": {"kind": "pattern", "goal": assertion}, "abstention_reason": None}
+    owned = Extractor(
+        CriticOutput, agent=Agent(TestModel(custom_output_args=output), output_type=CriticOutput)
+    )
+    monkeypatch.setattr(
+        procedure_validation,
+        "validation_extractor",
+        AsyncMock(return_value=(owned, '{"model":"offline"}')),
+    )
+    return output
+
+
+async def test_ordinary_cohort_actual_stage_replay_and_critic(
+    cohort_sources, monkeypatch, content_store, runtime
+):
+    sources = cohort_sources
+    install_proposal(monkeypatch, sources)
+    resolver = AsyncMock(return_value=SourceReadAuthority("owner"))
+    authorize = AsyncMock()
+    args = ("org", "owner", [s.id for s in sources], resolver)
+    first, execution = await service.propose_stored_cohort(*args, authorize=authorize)
+    second, replayed = await service.propose_stored_cohort(*args, authorize=authorize)
+    assert first and second and first.id == second.id and execution == replayed
+    stages = await content_store.execute_query("SELECT * FROM memory_validation_executions;")
+    assert len(stages) == 1 and stages[0]["state"] == "returned"
+    assert json.loads(stages[0]["result_json"])["usage"]["requests"] == 1
+    assert json.loads(stages[0]["request_json"])["kind"] == "sibyl-ordinary-partial-proposal-v1"
+    assert stages[0]["parent_id"] in [s.id for s in sources]
+    parent = await prepare_stored_reflection("org", "owner", first.id, resolver)
+    assert {s.id for s in parent.sources} == {s.id for s in sources}
+    critic = Extractor(
+        CriticOutput,
+        agent=Agent(TestModel(custom_output_args={"findings": []}), output_type=CriticOutput),
+    )
+    monkeypatch.setattr(
+        procedure_validation,
+        "validation_extractor",
+        AsyncMock(return_value=(critic, '{"model":"offline"}')),
+    )
+    result = await validate_reflection_stage(parent, resolver)
+    assert result["status"] == "no_findings"
+    stage = await service.ValidationExecution(result["execution_id"], "org", "owner").load()
+    request = json.loads(stage["request_json"])
+    assert request["kind"] == "ordinary_reflection_validation-v2"
+    assert request["input"] == result["input_sha256"]
+    from sibyl_core.services.ordinary_publication import ordinary_promotion_binding
+
+    promotion = await ordinary_promotion_binding(
+        "org", "owner", first.id, result["execution_id"], resolver, authorize
+    )
+    guard, params = await promotion.current_guard()
+    assert (
+        "publication_source_observation_changed" in guard
+        and params["ordinary_source_ids"] == parent.source_ids
+    )
+    from sibyl_core.services.memory_reflection import promote_reflection_candidate_review
+
+    promoted = await promote_reflection_candidate_review(
+        organization_id="org",
+        principal_id="owner",
+        candidate_id=first.id,
+        promote_to_scope="private",
+        promote_to_scope_key="owner",
+        validation_promotion=promotion,
+    )
+    assert promoted.success
+    from sibyl_core.services.validation_promotion import validated_graph_current
+
+    assert await validated_graph_current("org", promoted.promoted_id)
+    replay = await promote_reflection_candidate_review(
+        organization_id="org",
+        principal_id="owner",
+        candidate_id=first.id,
+        promote_to_scope="private",
+        promote_to_scope_key="owner",
+        validation_promotion=promotion,
+    )
+    assert replay.success and replay.promoted_id == promoted.promoted_id
+
+
+async def test_ordinary_cohort_source_change_fences_returned_usage(
+    cohort_sources, monkeypatch, content_store
+):
+    sources = cohort_sources
+    install_proposal(monkeypatch, sources)
+    resolver = AsyncMock(return_value=SourceReadAuthority("owner"))
+    authorize = AsyncMock()
+    extract = Extractor.extract_with_usage
+
+    async def change(self, prompt):
+        result = await extract(self, prompt)
+        await save_raw_memory(
+            replace(sources[0], raw_content="new source body"),
+            expected_revision=sources[0].revision,
+            embedding_provider=None,
+        )
+        return result
+
+    monkeypatch.setattr(Extractor, "extract_with_usage", change)
+    with pytest.raises(SourceUnavailableError):
+        await service.propose_stored_cohort(
+            "org", "owner", [s.id for s in sources], resolver, authorize=authorize
+        )
+    stages = await content_store.execute_query("SELECT * FROM memory_validation_executions;")
+    assert len(stages) == 1 and stages[0]["state"] == "fenced"
+    assert json.loads(stages[0]["usage_json"])["requests"] == 1
+    assert not await content_store.execute_query(
+        "SELECT * FROM raw_captures WHERE capture_surface='reflection_candidate';"
+    )
+
+
+async def test_ordinary_cohort_foreign_authority_no_stage(
+    cohort_sources, monkeypatch, content_store
+):
+    install_proposal(monkeypatch, cohort_sources)
+    with pytest.raises(SourceUnavailableError):
+        await service.propose_stored_cohort(
+            "org",
+            "owner",
+            [s.id for s in cohort_sources],
+            AsyncMock(return_value=None),
+            authorize=AsyncMock(),
+        )
+    assert not await content_store.execute_query("SELECT * FROM memory_validation_executions;")
+
+
+async def test_ordinary_cohort_metadata_cannot_grant_confidence_policy():
+    from types import SimpleNamespace
+
+    from sibyl_core.services.content_models import MemoryScope
+    from sibyl_core.services.memory_autonomy import decide_reflection_candidate_autonomy
+
+    preview = SimpleNamespace(
+        allowed=True,
+        candidate_id="candidate",
+        reason="allowed",
+        review_state="pending",
+        memory_scope=MemoryScope.PRIVATE,
+        scope_key="owner",
+        raw_source_ids=["source"],
+        metadata={
+            "confidence": 0,
+            "autonomy_confidence_basis": "validated_source_support",
+            "validated_source_support": True,
+        },
+    )
+    assert not decide_reflection_candidate_autonomy(preview).should_promote
+    assert decide_reflection_candidate_autonomy(
+        preview, validated_source_support=True
+    ).should_promote
+    preview.metadata["sensitivity_flags"] = ["secret"]
+    assert not decide_reflection_candidate_autonomy(
+        preview, validated_source_support=True
+    ).should_promote
+
+
+@pytest.mark.parametrize("raced", [False, True])
+async def test_ordinary_cohort_native_candidate_source_race(
+    cohort_sources, content_store, monkeypatch, raced
+):
+    import asyncio
+    import os
+
+    if not os.environ.get("SIBYL_COHORT_NATIVE_URL"):
+        pytest.skip("native multi-connection transaction control")
+    install_proposal(monkeypatch, cohort_sources)
+    execute = content_store.execute_query
+    mutated = False
+
+    async def delayed(query, **kwargs):
+        nonlocal mutated
+        if "Correction stage changed" not in query or mutated:
+            return await execute(query, **kwargs)
+        mutated = True
+        pending = asyncio.create_task(
+            execute(query.replace("LET $stage=", "SLEEP 1s; LET $stage=", 1), **kwargs)
+        )
+        try:
+            if raced:
+                await asyncio.sleep(0.25)
+                changed = await execute(
+                    "UPDATE raw_captures SET raw_content='concurrent committed source',revision+=1 WHERE uuid=$source RETURN AFTER;",
+                    source=cohort_sources[0].id,
+                )
+                assert len(changed) == 1
+            return await pending
+        finally:
+            if not pending.done():
+                await pending
+
+    monkeypatch.setattr(content_store, "execute_query", delayed)
+
+    async def run():
+        return await service.propose_stored_cohort(
+            "org",
+            "owner",
+            [s.id for s in cohort_sources],
+            AsyncMock(return_value=SourceReadAuthority("owner")),
+            authorize=AsyncMock(),
+        )
+
+    if raced:
+        with pytest.raises(Exception, match="cohort sources changed"):
+            await run()
+        assert not await execute(
+            "SELECT * FROM raw_captures WHERE capture_surface='reflection_candidate';"
+        )
+        assert not await execute("SELECT * FROM memory_derivations;")
+        rows = await execute(
+            "SELECT raw_content FROM raw_captures WHERE uuid=$source;", source=cohort_sources[0].id
+        )
+        assert rows[0]["raw_content"] == "concurrent committed source"
+    else:
+        candidate, _ = await run()
+        assert candidate is not None
+    stages = await execute("SELECT * FROM memory_validation_executions;")
+    assert len(stages) == 1 and stages[0]["state"] == "returned"
+    assert json.loads(stages[0]["usage_json"])["requests"] == 1
+
+
+async def test_ordinary_cohort_completed_receipt_recovers_without_provider(
+    cohort_sources, monkeypatch, content_store
+):
+    from sibyl_core.services.validation_execution import ValidationExecution
+
+    install_proposal(monkeypatch, cohort_sources)
+    original_finish = ValidationExecution._finish
+    original_reconcile = ValidationExecution.reconcile_result
+    monkeypatch.setattr(
+        ValidationExecution, "_finish", AsyncMock(side_effect=OSError("database unavailable"))
+    )
+    monkeypatch.setattr(
+        ValidationExecution,
+        "reconcile_result",
+        AsyncMock(side_effect=OSError("database unavailable")),
+    )
+    args = (
+        "org",
+        "owner",
+        [s.id for s in cohort_sources],
+        AsyncMock(return_value=SourceReadAuthority("owner")),
+    )
+    with pytest.raises(OSError, match="database unavailable"):
+        await service.propose_stored_cohort(*args, authorize=AsyncMock())
+    monkeypatch.setattr(ValidationExecution, "_finish", original_finish)
+    monkeypatch.setattr(ValidationExecution, "reconcile_result", original_reconcile)
+    monkeypatch.setattr(
+        Extractor, "extract_with_usage", AsyncMock(side_effect=AssertionError("redispatch"))
+    )
+    candidate, _ = await service.propose_stored_cohort(*args, authorize=AsyncMock())
+    assert candidate is not None
+    stages = await content_store.execute_query("SELECT * FROM memory_validation_executions;")
+    assert len(stages) == 1 and stages[0]["state"] == "returned"
+    assert json.loads(stages[0]["usage_json"])["requests"] == 1
+
+
+async def test_ordinary_cohort_budget_partition_keeps_all_source_bytes(
+    cohort_sources, content_store, monkeypatch
+):
+    from sibyl_core.config import settings
+    from sibyl_core.tasks._evidence_json import canonical
+    from sibyl_core.tasks.ordinary_proposals import PartialProposal
+
+    sources = [
+        await remember_raw_memory(
+            organization_id="org",
+            principal_id="owner",
+            source_id=f"large-{i}",
+            raw_content=f"capture-{i}:" + "a" * 3000,
+            embedding_provider=None,
+        )
+        for i in range(20)
+    ]
+    install_proposal(monkeypatch, sources)
+    resolver = AsyncMock(return_value=SourceReadAuthority("owner"))
+    monkeypatch.setattr(settings, "consolidation_max_input_chars", 40000)
+    ids = [s.id for s in sources]
+    bins = await service.partition_stored_cohort("org", "owner", ids, resolver)
+    assert len(bins) > 1
+    assert sorted(i for bucket in bins for i in bucket) == sorted(ids)
+    assert bins == await service.partition_stored_cohort(
+        "org", "owner", list(reversed(ids)), resolver
+    )
+    for bucket in bins:
+        if len(bucket) < 2:
+            continue
+        prepared = await service.prepare_stored_cohort("org", "owner", bucket, resolver)
+        from sibyl_core.ai.llm.extractor import extraction_schema
+
+        assert (
+            len(prepared.prepared.system)
+            + len(prepared.prepared.prompt)
+            + len(canonical(extraction_schema(PartialProposal)))
+            <= 40000
+        )
+        for source in sources:
+            if source.id in bucket:
+                assert source.raw_content in prepared.prepared.prompt


### PR DESCRIPTION
Ordinary free-form captures can now produce shared learning during the scheduled dream cycle. Compatible captures form source-bound proposals, pass through the existing critic and correction flow, and reach authorized recall through the validated publisher. Users do not need to write structured procedure JSON or manually approve an inbox.

## 🛠️ How it works

The scheduler groups captures by principal and scope, then partitions each group using the complete rendered input and actual output schema. Every source keeps its full bytes. Sources that cannot form a fitting cohort retain the individual path, and a cohort has its own durable execution identity rather than borrowing a single-capture checkpoint.

Proposal, critic, and correction results use the existing durable validation owner. Completed results replay without another model call; persisted usage survives result-write recovery. Current source and contributor authority are checked before dispatch and publication.

A stored successful critic result permits source-grounded publication without inventing confidence. The publisher retains the other autonomy restrictions and compares the reviewed policy interpretation for every source and candidate. Its final database write uses the existing source-state witness, so a concurrent sensitivity change cannot publish against an obsolete policy snapshot. Recalled proposals retain their explicit applicability qualification.

## 🧪 Validation

Independent review exercised actual route functions, repository-resolved authorization, scheduled proposal and correction, publication, and recall against isolated native SurrealDB. Controls cover role revocation, completed-result replay, missing authority, full-input budget partitioning, and concurrent source or sensitivity changes. Successful and rejected publication both retain completed model usage.

The implementation is integrated onto the merged operational-retention and signed-correction changes. The exact feature patch is unchanged by integration. The integrated core selection passed 55 tests (two native-only skips), the native API selection passed 26 tests, the native core and operational-writer selection passed 25 tests, and core/API lint and typecheck all passed. Native database fixtures were removed after verification.

The route acceptance invokes the production route function rather than a launched HTTP server. Models are controlled test implementations; these checks establish lifecycle behavior, not learned efficacy or held-out performance.
