### PR TITLE
fix(graph): bind edge reads to current endpoint ancestry

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/_search_lifecycle.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/_search_lifecycle.py
@@ -3,17 +3,26 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
 
 import structlog
 
 from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
-from sibyl_core.retrieval._search_candidates import _string_value
+from sibyl_core.retrieval._search_candidates import (
+    _candidate_allowed,
+    _candidate_from_edge_record,
+    _string_value,
+)
 from sibyl_core.retrieval._search_database import _execute_query_records
-from sibyl_core.retrieval._search_plan import RetrievalSignal
-from sibyl_core.retrieval.candidates import RetrievalCandidate
+from sibyl_core.retrieval._search_plan import RetrievalPlan, RetrievalSignal
+from sibyl_core.retrieval.candidates import CandidateKind, RetrievalCandidate
 from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+from sibyl_core.services.graph_entities import EntityManager
+from sibyl_core.services.graph_read_availability import available_graph_entities
+from sibyl_core.services.graph_relationships import RelationshipManager
+from sibyl_core.services.graph_runtime import GraphRuntime
 
 _SUPERSEDES_PREDICATE = "SUPERSEDES"
 _SUPERSESSION_LOOKUP_BATCH_SIZE = 512
@@ -201,11 +210,89 @@ def _edge_sort_key(value: object) -> str:
     return _string_value(value) or ""
 
 
+async def _available_edge_endpoints(
+    client: Any, group_id: str, candidates: Sequence[RetrievalCandidate], plan: RetrievalPlan | None
+) -> tuple[dict[str, tuple[str, str]], dict[str, RetrievalCandidate]]:
+    edge_ids = list(
+        dict.fromkeys(
+            candidate.id
+            for candidate in candidates
+            if candidate.kind == CandidateKind.EDGE or candidate.type in {"claim", "relationship"}
+        )
+    )
+    if not edge_ids:
+        return {}, {}
+    rows = []
+    for offset in range(0, len(edge_ids), 512):
+        rows.extend(
+            await _execute_query_records(
+                client,
+                "SELECT *, in.uuid AS source_uuid, out.uuid AS target_uuid, in.uuid AS source_node_uuid, out.uuid AS target_node_uuid FROM relates_to WHERE group_id=$group_id AND uuid IN $ids;",
+                group_id=group_id,
+                ids=edge_ids[offset : offset + 512],
+            )
+        )
+    endpoints = {
+        str(row["uuid"]): (str(row["source_uuid"]), str(row["target_uuid"]))
+        for row in rows
+        if row.get("group_id") == group_id
+        and row.get("uuid") in edge_ids
+        and row.get("source_uuid")
+        and row.get("target_uuid")
+    }
+    entities = await available_graph_entities(
+        group_id,
+        list({endpoint for pair in endpoints.values() for endpoint in pair}),
+        runtime=GraphRuntime(
+            client,
+            EntityManager(client, group_id=group_id),
+            RelationshipManager(client, group_id=group_id),
+        ),
+    )
+    allowed = set()
+    if plan is not None:
+        for identifier, entity in entities.items():
+            candidate = RetrievalCandidate(
+                id=identifier,
+                type=entity.entity_type.value,
+                name=entity.name,
+                content=entity.content,
+                score=0,
+                source=None,
+                metadata=entity.metadata,
+                project_id=identifier
+                if entity.entity_type.value == "project"
+                else entity.metadata.get("project_id"),
+            )
+            if _candidate_allowed(candidate, plan=plan, requested_types=set(), facet=None):
+                allowed.add(identifier)
+    available_edges: dict[str, RetrievalCandidate] = {}
+    if plan is not None:
+        for row in rows:
+            identifier = str(row.get("uuid", ""))
+            if identifier not in endpoints or not set(endpoints[identifier]) <= allowed:
+                continue
+            current = _candidate_from_edge_record(
+                row, signal=RetrievalSignal.EDGE_FULLTEXT, score=0
+            )
+            if graph_metadata_recallable(current.metadata) and _candidate_allowed(
+                current, plan=plan, requested_types=set(), facet=None
+            ):
+                available_edges[identifier] = current
+    unavailable = await unavailable_publication_ids(
+        group_id, {key: candidate.metadata for key, candidate in available_edges.items()}
+    )
+    return endpoints, {
+        key: candidate for key, candidate in available_edges.items() if key not in unavailable
+    }
+
+
 async def _apply_supersession_gate(
     *,
     client: Any,
     group_id: str,
     source_lists: Sequence[tuple[RetrievalSignal, list[RetrievalCandidate]]],
+    plan: RetrievalPlan | None = None,
 ) -> tuple[list[tuple[RetrievalSignal, list[RetrievalCandidate]]], dict[str, Any]]:
     """Drop rows a writer has already retired, before anything is fused.
 
@@ -225,13 +312,35 @@ async def _apply_supersession_gate(
             candidate.id: candidate.metadata
             for _signal, candidates in source_lists
             for candidate in candidates
+            if candidate.kind != CandidateKind.EDGE
+            and candidate.type not in {"claim", "relationship"}
         },
+    )
+    edge_endpoints, available_edges = await _available_edge_endpoints(
+        client,
+        group_id,
+        [candidate for _, candidates in source_lists for candidate in candidates],
+        plan,
     )
     lifecycle_dropped = 0
     surviving: list[tuple[RetrievalSignal, list[RetrievalCandidate]]] = []
     for signal, candidates in source_lists:
         kept: list[RetrievalCandidate] = []
         for candidate in candidates:
+            if candidate.kind == CandidateKind.EDGE or candidate.type in {"claim", "relationship"}:
+                current = available_edges.get(candidate.id)
+                if current is None:
+                    lifecycle_dropped += 1
+                    continue
+                candidate = replace(
+                    current,
+                    score=candidate.score,
+                    retrieval_signals=candidate.retrieval_signals,
+                    metadata={
+                        **current.metadata,
+                        "retrieval_signals": list(candidate.retrieval_signals or (signal.value,)),
+                    },
+                )
             if (
                 graph_metadata_recallable(candidate.metadata)
                 and candidate.id not in unavailable_publications
@@ -247,6 +356,11 @@ async def _apply_supersession_gate(
             for _signal, candidates in surviving
             for candidate in candidates
             if candidate.type not in _NON_ENTITY_CANDIDATE_TYPES
+        )
+    )
+    node_uuids = list(
+        dict.fromkeys(
+            [*node_uuids, *(endpoint for pair in edge_endpoints.values() for endpoint in pair)]
         )
     )
     superseded: set[str] = set()
@@ -272,7 +386,12 @@ async def _apply_supersession_gate(
     if superseded:
         gated: list[tuple[RetrievalSignal, list[RetrievalCandidate]]] = []
         for signal, candidates in surviving:
-            kept = [candidate for candidate in candidates if candidate.id not in superseded]
+            kept = [
+                candidate
+                for candidate in candidates
+                if candidate.id not in superseded
+                and not (set(edge_endpoints.get(candidate.id, ())) & superseded)
+            ]
             edge_dropped += len(candidates) - len(kept)
             gated.append((signal, kept))
         surviving = gated

--- a/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
+++ b/packages/python/sibyl-core/src/sibyl_core/retrieval/search.py
@@ -215,6 +215,7 @@ async def context_search(
     direct_lists, direct_supersession_metadata = await lifecycle_stage._apply_supersession_gate(
         client=client,
         group_id=search_plan.organization_id,
+        plan=search_plan,
         source_lists=direct_lists,
     )
     stage_timings_ms["candidate_filtering"] = _elapsed_ms(stage_started_at)
@@ -257,6 +258,7 @@ async def context_search(
     ) = await lifecycle_stage._apply_supersession_gate(
         client=client,
         group_id=search_plan.organization_id,
+        plan=search_plan,
         source_lists=[
             (
                 RetrievalSignal.GRAPH_EXPANSION,

--- a/packages/python/sibyl-core/src/sibyl_core/services/eval_publication_guards.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/eval_publication_guards.py
@@ -11,6 +11,8 @@ from sibyl_core.services import content_client
 from sibyl_core.services.content_models import RawMemory
 
 if TYPE_CHECKING:
+    from sibyl_core.models.entities import Entity
+    from sibyl_core.services.graph_client import SurrealGraphClient
     from sibyl_core.services.memory_source_validation import SourceReadAuthority
 
 # These hash-only observations live in the server-only consolidation ledger.
@@ -115,6 +117,8 @@ async def unavailable_publication_ids(
     *,
     raw_memories: Sequence[RawMemory] = (),
     source_authority: SourceReadAuthority | None = None,
+    graph_entities: Mapping[str, Entity] | None = None,
+    graph_client: SurrealGraphClient | None = None,
 ) -> set[str]:
     """Resolve stable row IDs against the protected ledger before retrieval.
 
@@ -178,7 +182,11 @@ async def unavailable_publication_ids(
     else:
         from sibyl_core.services.graph_derivations import unavailable_graph_derivation_ids
 
-        unavailable.update(await unavailable_graph_derivation_ids(organization_id, list(rows)))
+        unavailable.update(
+            await unavailable_graph_derivation_ids(
+                organization_id, list(rows), expected_entities=graph_entities, client=graph_client
+            )
+        )
     return unavailable
 
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_derivations.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_derivations.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from sibyl_core.backends.surreal.records import normalize_records
 from sibyl_core.memory_pipeline.observations import SourceIdentity, SourceKind, evidence_hash
+from sibyl_core.models.entities import Entity
 from sibyl_core.runtime_ports import RuntimePortUnavailable, get_source_authority_resolver
+from sibyl_core.services.graph_client import SurrealGraphClient
 from sibyl_core.services.memory_derivations import observation_from_record, validate_observations
 from sibyl_core.services.memory_source_validation import source_authority_ceiling
 from sibyl_core.services.source_observations import SourceUnavailableError, graph_evidence
@@ -94,16 +96,23 @@ async def graph_derivation_current(entity, *, ancestors=frozenset()) -> bool:
     return await graph_association_current(entity, rows[0] if rows else None, ancestors=ancestors)
 
 
-async def unavailable_graph_derivation_ids(organization_id: str, ids: Sequence[str]) -> set[str]:
+async def unavailable_graph_derivation_ids(
+    organization_id: str,
+    ids: Sequence[str],
+    *,
+    expected_entities: Mapping[str, Entity] | None = None,
+    client: SurrealGraphClient | None = None,
+) -> set[str]:
     from sibyl_core.services.graph_records import entity_from_surreal_row
 
     if not ids:
         return set()
     from sibyl_core.services.graph_runtime import get_surreal_graph_runtime
 
-    runtime = await get_surreal_graph_runtime(organization_id)
+    if client is None:
+        client = (await get_surreal_graph_runtime(organization_id)).client
     snapshots = normalize_records(
-        await runtime.client.execute_query(
+        await client.execute_query(
             """RETURN {
             RETURN {
                 associations: (SELECT * FROM memory_derivations WHERE organization_id=$org
@@ -129,6 +138,18 @@ async def unavailable_graph_derivation_ids(organization_id: str, ids: Sequence[s
         association = associations.get(target_id)
         entity = targets.get(target_id)
         identity = SourceIdentity(organization_id, SourceKind.GRAPH_ENTITY, target_id)
+        if expected_entities is not None:
+            expected = expected_entities.get(target_id)
+            if (
+                expected is None
+                or entity is None
+                or (
+                    expected.model_dump(mode="json") != entity.model_dump(mode="json")
+                    or expected.derivation_required != entity.derivation_required
+                    or expected.observed_revision != entity.observed_revision
+                )
+            ):
+                return target_id
         if entity is None or not await graph_association_current(
             entity, association, ancestors=frozenset({identity})
         ):
@@ -138,7 +159,12 @@ async def unavailable_graph_derivation_ids(organization_id: str, ids: Sequence[s
     return {
         value
         for value in await asyncio.gather(
-            *(current(target_id) for target_id in targets.keys() | associations.keys())
+            *(
+                current(target_id)
+                for target_id in targets.keys()
+                | associations.keys()
+                | (expected_entities.keys() if expected_entities is not None else set())
+            )
         )
         if value is not None
     }

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_read_availability.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_read_availability.py
@@ -1,0 +1,48 @@
+"""Current stored graph rows eligible for ancestry-aware public readers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.entities import Entity
+from sibyl_core.services.eval_publication_guards import unavailable_publication_ids
+from sibyl_core.services.graph_runtime import GraphRuntime, get_surreal_graph_runtime
+
+_READ_BATCH_SIZE = 512
+
+
+async def available_graph_entities(
+    organization_id: str,
+    entity_ids: Sequence[str],
+    *,
+    runtime: GraphRuntime | None = None,
+) -> dict[str, Entity]:
+    """Refresh actual rows and reject missing, retired, or unavailable ancestry.
+
+    A supplied runtime must be the existing GraphRuntime for this organization.
+    Callers retain their principal/project scope filters and render these current
+    rows, rather than cached values with the same IDs.
+    """
+    ids = list(dict.fromkeys(entity_ids))
+    if not ids:
+        return {}
+    graph = runtime or await get_surreal_graph_runtime(organization_id, ensure_schema=False)
+    current: dict[str, Entity] = {}
+    for offset in range(0, len(ids), _READ_BATCH_SIZE):
+        batch = ids[offset : offset + _READ_BATCH_SIZE]
+        rows = await graph.entity_manager.get_many(batch)
+        for row in rows:
+            if (
+                row.id in batch
+                and row.organization_id == organization_id
+                and graph_metadata_recallable(row.metadata)
+            ):
+                current[row.id] = row
+    unavailable = await unavailable_publication_ids(
+        organization_id,
+        {key: row.metadata for key, row in current.items()},
+        graph_entities=current,
+        graph_client=graph.client,
+    )
+    return {key: row for key, row in current.items() if key not in unavailable}

--- a/packages/python/sibyl-core/src/sibyl_core/tools/explore.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tools/explore.py
@@ -6,9 +6,7 @@ import structlog
 
 from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
 from sibyl_core.models.entities import Entity, EntityType, RelationshipType
-from sibyl_core.services.eval_publication_guards import (
-    unavailable_publication_ids,
-)
+from sibyl_core.services.graph_read_availability import available_graph_entities
 from sibyl_core.tools.helpers import (
     VALID_ENTITY_TYPES,
     ScopeGuard,
@@ -654,6 +652,16 @@ async def _explore_related(
     runtime = await get_graph_runtime(group_id)
     relationship_manager = runtime.relationship_manager
 
+    def allowed(entity):
+        project = _project_id_for_policy(entity)
+        return (scope_guard is None or scope_guard(entity)) and (
+            accessible_projects is None or project is None or project in accessible_projects
+        )
+
+    seeds = await available_graph_entities(group_id, [entity_id], runtime=runtime)
+    if entity_id not in seeds or not allowed(seeds[entity_id]):
+        return ExploreResponse(mode=mode, entities=[], total=0, filters=filters)
+
     # Convert relationship type strings to enum
     rel_types = None
     if relationship_types:
@@ -672,34 +680,27 @@ async def _explore_related(
         limit=limit,
     )
 
-    unavailable_publications = await unavailable_publication_ids(
-        group_id,
-        {
-            str(entity.id): getattr(entity, "metadata", None)
-            for entity, _relationship in raw_results
-        },
-    )
+    endpoint_ids = {entity_id}
+    for _entity, relationship in raw_results:
+        endpoint_ids.update((relationship.source_id, relationship.target_id))
+    current = await available_graph_entities(group_id, sorted(endpoint_ids), runtime=runtime)
+    current = {key: entity for key, entity in current.items() if allowed(entity)}
+    if entity_id not in current:
+        return ExploreResponse(mode=mode, entities=[], total=0, filters=filters)
     results = []
     for entity, relationship in raw_results:
-        if scope_guard is not None and not scope_guard(entity):
-            continue
-        # Synthesis sources its neighborhood through this lane, so a corrected
-        # or superseded row reached a rendered handbook as a cited source
-        # without ever passing pack admission.
-        if (
-            not graph_metadata_recallable(getattr(entity, "metadata", None))
-            or str(entity.id) in unavailable_publications
+        if not graph_metadata_recallable(getattr(relationship, "metadata", None)) or not allowed(
+            relationship
         ):
             continue
-
-        # RBAC: Filter by accessible projects
-        entity_project = _project_id_for_policy(entity)
+        endpoints = {relationship.source_id, relationship.target_id}
         if (
-            accessible_projects is not None
-            and entity_project is not None
-            and entity_project not in accessible_projects
+            entity_id not in endpoints
+            or entity.id not in endpoints
+            or not endpoints <= current.keys()
         ):
             continue
+        entity = current[entity.id]
 
         direction: Literal["outgoing", "incoming"] = (
             "outgoing" if relationship.source_id == entity_id else "incoming"

--- a/packages/python/sibyl-core/tests/test_graph_edge_ancestry.py
+++ b/packages/python/sibyl-core/tests/test_graph_edge_ancestry.py
@@ -1,0 +1,248 @@
+"""Relationship facts and navigation retain both current endpoint ancestors."""
+
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.retrieval._search_lifecycle import _apply_supersession_gate
+from sibyl_core.retrieval._search_plan import RetrievalSignal, build_context_retrieval_plan
+from sibyl_core.retrieval.candidates import CandidateKind, RetrievalCandidate
+from sibyl_core.tools.helpers import memory_scope_guard
+from tests.test_graph_passage_derivations import published_passages
+from tests.test_synthesis_source_observations import content_store as content_store
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+from tests.test_synthesis_source_observations import runtime as runtime
+
+explore_module = importlib.import_module("sibyl_core.tools.explore")
+
+
+def plan(org, principal="user_a"):
+    return build_context_retrieval_plan(
+        query="approval",
+        organization_id=org,
+        facets=[],
+        facet_types={},
+        principal_id=principal,
+        project=None,
+        accessible_projects=None,
+    )
+
+
+def candidate(edge):
+    return RetrievalCandidate(
+        id=edge.id,
+        type="claim",
+        name="RELATED_TO",
+        content="Stored relationship fact",
+        score=1,
+        source=None,
+        metadata={
+            "stale_annotation": "old candidate bytes",
+            "source_node_uuid": "forged-visible",
+            "target_node_uuid": "forged-visible",
+        },
+        kind=CandidateKind.EDGE,
+    )
+
+
+async def edge_results(runtime, edge, principal="user_a"):
+    lists, _receipt = await _apply_supersession_gate(
+        client=runtime.client,
+        group_id=runtime.client.group_id,
+        source_lists=[(RetrievalSignal.EDGE_FULLTEXT, [candidate(edge)])],
+        plan=plan(runtime.client.group_id, principal),
+    )
+    return lists[0][1]
+
+
+async def related(runtime, seed, monkeypatch, principal="user_a"):
+    monkeypatch.setattr(explore_module, "get_graph_runtime", AsyncMock(return_value=runtime))
+    return await explore_module._explore_related(
+        entity_id=seed,
+        relationship_types=["RELATED_TO"],
+        depth=4,
+        limit=50,
+        filters={},
+        mode="related",
+        group_id=runtime.client.group_id,
+        scope_guard=memory_scope_guard(
+            principal_id=principal, accessible_projects=None, allowed_memory_scope_keys=None
+        ),
+    )
+
+
+async def test_graph_edge_protected_endpoints_and_seed_retire_together(
+    runtime, content_store, monkeypatch
+):
+    source, target, _projection, passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+    edge = Relationship(
+        id="protected-edge",
+        relationship_type=RelationshipType.RELATED_TO,
+        metadata={"fact": "Stored relationship fact"},
+        source_id=target.id,
+        target_id=passage.id,
+    )
+    await runtime.relationship_manager.create(edge)
+    assert await edge_results(runtime, edge)
+    assert (await related(runtime, target.id, monkeypatch)).total == 1
+    assert not await edge_results(runtime, edge, "foreign_reader")
+    assert (await related(runtime, target.id, monkeypatch, "foreign_reader")).total == 0
+    await runtime.entity_manager.update(source.id, {"content": "Original evidence withdrawn"})
+    assert not await edge_results(runtime, edge)
+    assert (await related(runtime, target.id, monkeypatch)).total == 0
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["none", "missing", "retired", "edge_fact", "edge_scope", "edge_retired", "edge_attributes"],
+)
+async def test_graph_edge_ordinary_endpoints_remain_available(
+    runtime, content_store, monkeypatch, mutation
+):
+    for key in ("ordinary-a", "ordinary-b"):
+        await runtime.entity_manager.create_direct(
+            Entity(id=key, name=key, entity_type=EntityType.PATTERN)
+        )
+    edge = Relationship(
+        id="ordinary-edge",
+        relationship_type=RelationshipType.RELATED_TO,
+        metadata={"fact": "Stored relationship fact"},
+        source_id="ordinary-a",
+        target_id="ordinary-b",
+    )
+    await runtime.relationship_manager.create(edge)
+    if mutation == "missing":
+        await runtime.client.execute_query("DELETE entity WHERE uuid='ordinary-b';")
+    elif mutation == "retired":
+        await runtime.entity_manager.update(
+            "ordinary-b", {"metadata": {"excluded_from_recall": True}}
+        )
+    elif mutation == "edge_fact":
+        await runtime.client.execute_query(
+            "UPDATE relates_to SET fact='Changed current fact' WHERE uuid=$id;", id=edge.id
+        )
+    elif mutation == "edge_scope":
+        await runtime.client.execute_query(
+            "UPDATE relates_to SET attributes.memory_scope='private', attributes.principal_id='other' WHERE uuid=$id;",
+            id=edge.id,
+        )
+    elif mutation == "edge_attributes":
+        await runtime.client.execute_query(
+            "UPDATE relates_to SET attributes.source_ids=['current-ref'], attributes.audit_note='current metadata' WHERE uuid=$id;",
+            id=edge.id,
+        )
+    elif mutation == "edge_retired":
+        await runtime.client.execute_query(
+            "UPDATE relates_to SET attributes.excluded_from_recall=true WHERE uuid=$id;", id=edge.id
+        )
+    actual = await edge_results(runtime, edge)
+    assert bool(actual) == (mutation in {"none", "edge_fact", "edge_attributes"})
+    if actual:
+        assert "stale_annotation" not in actual[0].metadata
+    if mutation == "edge_attributes":
+        assert actual[0].metadata["source_ids"] == ["current-ref"]
+        assert actual[0].metadata["audit_note"] == "current metadata"
+    if mutation == "edge_fact":
+        assert actual[0].content == "Changed current fact"
+        assert actual[0].score == 1
+        assert actual[0].metadata["source_node_uuid"] == "ordinary-a"
+    assert bool((await related(runtime, "ordinary-a", monkeypatch)).total) == (
+        mutation in {"none", "edge_fact", "edge_attributes"}
+    )
+
+
+@pytest.mark.parametrize("protected_side", ["source", "target"])
+async def test_graph_edge_checks_each_actual_endpoint_even_with_forged_metadata(
+    runtime, content_store, monkeypatch, protected_side
+):
+    source, target, _projection, _passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+    await runtime.entity_manager.create_direct(
+        Entity(id="ordinary-neighbor", name="Ordinary", entity_type=EntityType.PATTERN)
+    )
+    endpoints = (
+        (target.id, "ordinary-neighbor")
+        if protected_side == "source"
+        else ("ordinary-neighbor", target.id)
+    )
+    edge = Relationship(
+        id="mixed-edge",
+        relationship_type=RelationshipType.RELATED_TO,
+        metadata={"fact": "Stored relationship fact"},
+        source_id=endpoints[0],
+        target_id=endpoints[1],
+    )
+    await runtime.relationship_manager.create(edge)
+    assert await edge_results(runtime, edge)
+    assert (await related(runtime, "ordinary-neighbor", monkeypatch)).total == 1
+    await runtime.entity_manager.update(source.id, {"content": "Retired underlying evidence"})
+    assert not await edge_results(runtime, edge)
+    assert (await related(runtime, "ordinary-neighbor", monkeypatch)).total == 0
+
+
+async def test_graph_edge_query_error_is_not_an_empty_available_set():
+    from sibyl_core.backends.surreal.records import SurrealQueryError
+    from sibyl_core.retrieval._search_lifecycle import _available_edge_endpoints
+
+    class Client:
+        async def execute_query(self, query, **params):
+            return [{"status": "ERR", "result": "owned query denied"}]
+
+    edge = Relationship(
+        id="query-error",
+        relationship_type=RelationshipType.RELATED_TO,
+        source_id="a",
+        target_id="b",
+    )
+    with pytest.raises(SurrealQueryError):
+        await _available_edge_endpoints(Client(), "org", [candidate(edge)], plan("org"))
+
+
+async def test_graph_explore_missing_seed_does_not_expand(runtime, content_store, monkeypatch):
+    expansion = AsyncMock(side_effect=AssertionError("missing seed expanded"))
+    monkeypatch.setattr(runtime.relationship_manager, "get_related_entities", expansion)
+    assert (await related(runtime, "missing-seed", monkeypatch)).total == 0
+    expansion.assert_not_awaited()
+
+
+async def test_graph_edge_actual_context_search_rechecks_endpoint_ancestry(
+    runtime, content_store, monkeypatch
+):
+    from dataclasses import replace
+
+    from sibyl_core.retrieval import _search_database
+    from sibyl_core.retrieval.search import context_search
+
+    source, target, _projection, passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+    edge = Relationship(
+        id="context-edge",
+        relationship_type=RelationshipType.RELATED_TO,
+        source_id=target.id,
+        target_id=passage.id,
+        metadata={"fact": "Deployment approval context fact"},
+    )
+    await runtime.relationship_manager.create(edge)
+    monkeypatch.setattr(
+        _search_database, "_get_read_only_graph_runtime", AsyncMock(return_value=runtime)
+    )
+    request = replace(
+        plan(runtime.client.group_id),
+        signals=(RetrievalSignal.EDGE_FULLTEXT,),
+        graph_expansion_depth=0,
+    )
+    before = await context_search(plan=request, types=["relationship"], embedding_provider=None)
+    assert edge.id in {row.id for row in before.results}
+    await runtime.entity_manager.update(
+        source.id, {"content": "Original approval no longer applies"}
+    )
+    after = await context_search(plan=request, types=["relationship"], embedding_provider=None)
+    assert edge.id not in {row.id for row in after.results}

--- a/packages/python/sibyl-core/tests/test_graph_read_availability.py
+++ b/packages/python/sibyl-core/tests/test_graph_read_availability.py
@@ -1,0 +1,83 @@
+"""Public readers use current stored entities and their protected ancestry."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sibyl_core.models.entities import Entity, EntityType
+from sibyl_core.services import graph_read_availability as availability
+
+
+def entity(identifier, **kwargs):
+    return Entity(
+        id=identifier,
+        name=identifier,
+        entity_type=EntityType.PATTERN,
+        organization_id=kwargs.pop("organization_id", "org"),
+        **kwargs,
+    )
+
+
+async def test_graph_availability_refreshes_actual_rows_and_denies_unavailable(monkeypatch):
+    rows = [
+        entity("ordinary"),
+        entity("protected"),
+        entity("retired", metadata={"excluded_from_recall": True}),
+        entity("foreign", organization_id="other"),
+    ]
+    manager = SimpleNamespace(get_many=AsyncMock(return_value=rows))
+    guard = AsyncMock(return_value={"protected"})
+    monkeypatch.setattr(availability, "unavailable_publication_ids", guard)
+    result = await availability.available_graph_entities(
+        "org",
+        ["ordinary", "protected", "retired", "foreign", "missing"],
+        runtime=SimpleNamespace(entity_manager=manager, client="owned"),
+    )
+    assert result == {"ordinary": rows[0]}
+    guard.assert_awaited_once_with(
+        "org",
+        {"ordinary": {}, "protected": {}},
+        graph_entities={"ordinary": rows[0], "protected": rows[1]},
+        graph_client="owned",
+    )
+    rows[0].name = "current source name"
+    again = await availability.available_graph_entities(
+        "org", ["ordinary"], runtime=SimpleNamespace(entity_manager=manager, client="owned")
+    )
+    assert again["ordinary"].name == "current source name"
+
+
+async def test_graph_availability_batches_deduplicates_and_uses_checked_owner(monkeypatch):
+    ids = [str(index) for index in range(1025)]
+    manager = SimpleNamespace(
+        get_many=AsyncMock(side_effect=lambda batch: [entity(i) for i in batch])
+    )
+    guard = AsyncMock(return_value=set())
+    monkeypatch.setattr(availability, "unavailable_publication_ids", guard)
+    result = await availability.available_graph_entities(
+        "org", ids + ids, runtime=SimpleNamespace(entity_manager=manager, client="owned")
+    )
+    assert list(result) == ids
+    assert [len(call.args[0]) for call in manager.get_many.await_args_list] == [512, 512, 1]
+    assert guard.await_count == 1
+
+
+async def test_graph_availability_empty_does_not_allocate_runtime(monkeypatch):
+    factory = AsyncMock()
+    monkeypatch.setattr(availability, "get_surreal_graph_runtime", factory)
+    assert await availability.available_graph_entities("org", []) == {}
+    factory.assert_not_awaited()
+
+
+async def test_graph_availability_propagates_owner_failure(monkeypatch):
+    manager = SimpleNamespace(get_many=AsyncMock(return_value=[entity("protected")]))
+    monkeypatch.setattr(
+        availability,
+        "unavailable_publication_ids",
+        AsyncMock(side_effect=RuntimeError("unavailable")),
+    )
+    with pytest.raises(RuntimeError, match="unavailable"):
+        await availability.available_graph_entities(
+            "org", ["protected"], runtime=SimpleNamespace(entity_manager=manager, client="owned")
+        )

--- a/packages/python/sibyl-core/tests/test_graph_read_availability_native.py
+++ b/packages/python/sibyl-core/tests/test_graph_read_availability_native.py
@@ -1,0 +1,80 @@
+"""Read-model identity stays bound to the actual protected graph association."""
+
+import pytest
+
+from sibyl_core.services import graph_read_availability as availability
+from sibyl_core.services.graph_derivations import graph_target_digest
+from tests.test_graph_passage_derivations import published_passages
+from tests.test_synthesis_source_observations import content_store as content_store
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+from tests.test_synthesis_source_observations import runtime as runtime
+
+
+@pytest.mark.parametrize("changed", [False, True])
+async def test_graph_availability_binds_the_returned_target_to_its_association(
+    runtime, content_store, monkeypatch, changed
+):
+    _source, target, _projection, _passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+    guard = availability.unavailable_publication_ids
+
+    async def replace_between_reads(org, rows, **kwargs):
+        if changed:
+            await runtime.entity_manager.update(target.id, {"name": "New current publication"})
+            replacement = await runtime.entity_manager.get(target.id)
+            await runtime.client.execute_query(
+                "UPDATE memory_derivations SET body_sha256=$digest WHERE target_id=$id;",
+                id=target.id,
+                digest=graph_target_digest(replacement),
+            )
+            # Both states have valid ancestry. Only returning the old model is wrong.
+            assert not await guard(org, {replacement.id: replacement.metadata})
+        return await guard(org, rows, **kwargs)
+
+    monkeypatch.setattr(availability, "unavailable_publication_ids", replace_between_reads)
+    current = await availability.available_graph_entities(
+        runtime.client.group_id, [target.id], runtime=runtime
+    )
+    assert set(current) == (set() if changed else {target.id})
+    if not changed:
+        assert current[target.id].name == target.name
+
+
+async def test_graph_availability_retired_original_hides_protected_descendants(
+    runtime, content_store, monkeypatch
+):
+    source, target, _projection, passage = await published_passages(
+        runtime, content_store, monkeypatch
+    )
+    assert set(
+        await availability.available_graph_entities(
+            runtime.client.group_id, [target.id, passage.id], runtime=runtime
+        )
+    ) == {target.id, passage.id}
+    await runtime.entity_manager.update(source.id, {"content": "Original evidence withdrawn"})
+    assert not await availability.available_graph_entities(
+        runtime.client.group_id, [target.id, passage.id], runtime=runtime
+    )
+
+
+async def test_graph_availability_supplied_runtime_owns_association_snapshot(
+    runtime, content_store, monkeypatch
+):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.models.entities import Entity, EntityType
+    from sibyl_core.services import graph_runtime
+
+    await runtime.entity_manager.create_direct(
+        Entity(id="explicit-owner", name="Explicit runtime", entity_type=EntityType.PATTERN)
+    )
+    fallback = AsyncMock(side_effect=AssertionError("unrelated runtime lookup"))
+    monkeypatch.setattr(graph_runtime, "get_surreal_graph_runtime", fallback)
+    actual = await availability.available_graph_entities(
+        runtime.client.group_id, ["explicit-owner"], runtime=runtime
+    )
+    assert actual["explicit-owner"].name == "Explicit runtime"
+    fallback.assert_not_awaited()

--- a/packages/python/sibyl-core/tests/test_supersession_enforcement.py
+++ b/packages/python/sibyl-core/tests/test_supersession_enforcement.py
@@ -768,7 +768,10 @@ async def test_the_edge_lookup_is_not_fed_ids_that_cannot_be_edge_endpoints() ->
 
     class RecordingClient:
         async def execute_query(self, _query: str, **params: object) -> list[dict[str, object]]:
-            seen_uuids.append(list(params.get("uuids") or ()))
+            if "uuids" in params:
+                seen_uuids.append(list(params["uuids"]))
+            else:
+                assert params["ids"] == ["rel-1"]
             return []
 
     def candidate(identifier: str, entity_type: str) -> RetrievalCandidate:

--- a/packages/python/sibyl-core/tests/test_tools.py
+++ b/packages/python/sibyl-core/tests/test_tools.py
@@ -3316,12 +3316,26 @@ class TestExploreTool:
             )
         )
 
-        with patch(
-            "sibyl_core.tools.explore.get_graph_runtime",
-            AsyncMock(
-                return_value=make_graph_runtime(
-                    relationship_manager=relationship_manager,
-                )
+        seed = MockEntity(
+            id="task_visible",
+            entity_type=EntityType.TASK,
+            name="Seed",
+            project_id="project_visible",
+        )
+        stored = {row.id: row for row in (seed, visible, hidden, unassigned)}
+
+        async def available(_org, ids, **_kwargs):
+            return {key: stored[key] for key in ids if key in stored}
+
+        with (
+            patch("sibyl_core.tools.explore.available_graph_entities", side_effect=available),
+            patch(
+                "sibyl_core.tools.explore.get_graph_runtime",
+                AsyncMock(
+                    return_value=make_graph_runtime(
+                        relationship_manager=relationship_manager,
+                    )
+                ),
             ),
         ):
             response = await explore(


### PR DESCRIPTION
Relationship search could return a fact after one of its protected endpoints lost valid source ancestry. Related exploration checked its returned neighbors but could still expand an unavailable seed. Both paths now resolve current stored endpoints and apply ancestry, lifecycle, and reader-scope checks before returning graph data.

## 🛠️ Current records govern the read

The shared availability helper loads entity rows in batches and validates their protected associations through the existing publication owner. The supplied graph runtime owns both reads. A comparison against the loaded model prevents a same-ID replacement from authorizing stale content captured before the association changed.

Search resolves actual relationship endpoints with scoped batch queries. Caller metadata cannot substitute different endpoints. Returned relationship fields come from the current row, including its body, source references, scope, and other metadata; ranking scores and retrieval signals are preserved. Missing or retired endpoints, revoked ancestry, and inaccessible scopes exclude the relationship.

Exploration checks its seed before expanding and checks both current endpoints before rendering neighbors. The existing one-hop relationship behavior is preserved.

## 🧪 Validation

Independent review verified all eleven changed files and passed 30 isolated native SurrealDB 3.2.3 controls, including this feature's 21 controls and nine community integration controls. Core lint and typecheck passed. The author also ran 98 existing exploration, supersession, and graph-derivation compatibility controls.

Native cases cover both endpoint orientations, ordinary edges, missing and retired sources, private scope, same-ID replacement, explicit runtime ownership, refreshed facts and metadata, and checked query errors. An actual context-search case verifies fulltext relationship retrieval before and after original-source retirement. Every owned native database fixture was removed after verification.

REST graph and visualization-cache changes are a separate follow-up using the shared helper. This PR does not claim those public surfaces are complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved graph search and relationship exploration filtering to exclude unavailable, retired, superseded, or protected entities and relationships.
  - Ensured graph edges are validated against the current availability of both endpoints.
  - Prevented traversal from unavailable seed entities and filtered results using current graph data.
  - Improved handling of refreshed entity metadata and publication visibility during graph reads.

- **Tests**
  - Added comprehensive coverage for graph availability, ancestry, supersession, batching, visibility, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->