### PR TITLE
fix(graph): refresh ancestry and visibility before cached views

### DIFF
--- a/apps/api/src/sibyl/api/routes/graph.py
+++ b/apps/api/src/sibyl/api/routes/graph.py
@@ -1,10 +1,11 @@
 """Graph visualization data endpoints."""
 
+from functools import partial
+
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from sibyl.api.decorators import handle_workflow_errors
-from sibyl.api.dependencies import get_knowledge_read_service
 from sibyl.api.schemas import GraphData, GraphEdge, GraphNode, SubgraphRequest
 from sibyl.auth.context import AuthContext
 from sibyl.auth.dependencies import (
@@ -14,14 +15,9 @@ from sibyl.auth.dependencies import (
 )
 from sibyl.persistence.auth_runtime import list_accessible_project_graph_ids
 from sibyl_core.auth import AuthOrganization, OrganizationRole
-from sibyl_core.auth.memory_policy import (
-    memory_metadata_read_allowed,
-    memory_row_project_id,
-    private_scope_granted_for,
-)
-from sibyl_core.errors import EntityNotFoundError
 from sibyl_core.models.entities import Entity, EntityType, RelationshipType
-from sibyl_core.services import KnowledgeReadService
+from sibyl_core.services.graph_read_availability import available_graph_entities
+from sibyl_core.services.graph_visibility import graph_row_read_allowed as _graph_entity_visible
 
 log = structlog.get_logger()
 _READ_ROLES = (
@@ -131,6 +127,7 @@ async def debug_graph(
 
     nodes = await _list_graph_entities(
         runtime.entity_manager,
+        organization_id=group_id,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
         allowed_memory_scope_keys=memory_grants,
@@ -140,19 +137,25 @@ async def debug_graph(
     node_ids = {entity.id for entity in nodes if entity.id}
     relationships = await runtime.relationship_manager.list_all(limit=1000)
 
-    matching = sum(
-        1
+    relationships = [
+        relationship
         for relationship in relationships
-        if relationship.source_id in node_ids and relationship.target_id in node_ids
-    )
-
-    sample_edges = relationships[:3] if relationships else []
+        if relationship.source_id in node_ids
+        and relationship.target_id in node_ids
+        and _graph_entity_visible(
+            relationship,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=memory_grants,
+        )
+    ]
+    sample_edges = relationships[:3]
     sample_nodes = list(node_ids)[:5]
 
     return {
         "node_count": len(node_ids),
         "edge_count": len(relationships),
-        "matching_edges": matching,
+        "matching_edges": len(relationships),
         "sample_nodes": sample_nodes,
         "sample_edges": [{"src": e.source_id, "tgt": e.target_id} for e in sample_edges],
         "first_edge_src_in_nodes": sample_edges[0].source_id in node_ids if sample_edges else None,
@@ -224,36 +227,10 @@ def _authorized_project_focus(
     return allowed or [_UNASSIGNED_PROJECT_FOCUS]
 
 
-def _graph_entity_visible(
-    entity: Entity,
-    *,
-    principal_id: str | None,
-    accessible_projects: set[str],
-    allowed_memory_scope_keys: set[str] | None,
-) -> bool:
-    # A visualization node carries the entity's label and metadata bag, so a
-    # private memory reaches the picture as a readable title unless the same
-    # scope rule that governs search is applied here too. Work items are
-    # deliberately unstamped, so their project is the channel that gates them.
-    return memory_metadata_read_allowed(
-        getattr(entity, "metadata", None),
-        principal_id=principal_id,
-        accessible_projects=accessible_projects,
-        allowed_memory_scope_keys=allowed_memory_scope_keys,
-        private_scope_granted=private_scope_granted_for(
-            allowed_memory_scope_keys, principal_id=principal_id
-        ),
-        row_project_id=memory_row_project_id(
-            getattr(entity, "metadata", None),
-            entity_type=getattr(getattr(entity, "entity_type", None), "value", None),
-            entity_id=getattr(entity, "id", None),
-        ),
-    )
-
-
 async def _list_graph_entities(
     entity_manager: object,
     *,
+    organization_id: str,
     principal_id: str | None,
     accessible_projects: set[str],
     allowed_memory_scope_keys: set[str] | None,
@@ -278,7 +255,11 @@ async def _list_graph_entities(
             break
 
         page_offset += len(batch)
-        for entity in batch:
+        current = await available_graph_entities(organization_id, [entity.id for entity in batch])
+        for listed in batch:
+            entity = current.get(listed.id)
+            if entity is None:
+                continue
             if allowed_types and entity.entity_type not in allowed_types:
                 continue
             if not _graph_entity_visible(
@@ -301,20 +282,16 @@ async def _list_graph_entities(
 
 
 async def _get_graph_entity(
-    entity_manager: object,
+    organization_id: str,
     entity_id: str,
     *,
     principal_id: str | None,
     accessible_projects: set[str],
     allowed_memory_scope_keys: set[str] | None,
 ) -> Entity | None:
-    try:
-        entity = await entity_manager.get(entity_id)
-    except EntityNotFoundError:
-        return None
-    if entity is None:
-        return None
-    if not _graph_entity_visible(
+    current = await available_graph_entities(organization_id, [entity_id])
+    entity = current.get(entity_id)
+    if entity is None or not _graph_entity_visible(
         entity,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
@@ -342,6 +319,7 @@ async def get_all_nodes(
     principal_id, accessible_projects, memory_grants = await _graph_scope_reader(ctx)
     entities = await _list_graph_entities(
         runtime.entity_manager,
+        organization_id=group_id,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
         allowed_memory_scope_keys=memory_grants,
@@ -352,7 +330,15 @@ async def get_all_nodes(
     )
 
     adapter = await get_graph_query_adapter(group_id)
-    connection_counts = await adapter.get_connection_counts([entity.id for entity in entities])
+    connection_counts = await adapter.get_connection_counts(
+        [entity.id for entity in entities],
+        entity_visible=partial(
+            _graph_entity_visible,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=memory_grants,
+        ),
+    )
 
     max_connections = max(connection_counts.values()) if connection_counts else 1
     max_connections = max(max_connections, 1)
@@ -412,10 +398,10 @@ async def get_all_edges(
     endpoint_ids = {rel.source_id for rel in all_relationships} | {
         rel.target_id for rel in all_relationships
     }
-    endpoints = await runtime.entity_manager.get_many(sorted(endpoint_ids))
+    endpoints = await available_graph_entities(group_id, sorted(endpoint_ids))
     visible_ids = {
         entity.id
-        for entity in endpoints
+        for entity in endpoints.values()
         if entity.id
         and _graph_entity_visible(
             entity,
@@ -435,7 +421,14 @@ async def get_all_edges(
             weight=1.0,  # Could be based on strength/confidence
         )
         for rel in all_relationships
-        if rel.source_id in visible_ids and rel.target_id in visible_ids
+        if rel.source_id in visible_ids
+        and rel.target_id in visible_ids
+        and _graph_entity_visible(
+            rel,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=memory_grants,
+        )
     ]
 
 
@@ -456,6 +449,7 @@ async def get_full_graph(
 
     entities = await _list_graph_entities(
         runtime.entity_manager,
+        organization_id=group_id,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
         allowed_memory_scope_keys=memory_grants,
@@ -498,7 +492,16 @@ async def get_full_graph(
 
     edges = []
     for relationship in relationships:
-        if relationship.source_id not in node_ids or relationship.target_id not in node_ids:
+        if (
+            relationship.source_id not in node_ids
+            or relationship.target_id not in node_ids
+            or not _graph_entity_visible(
+                relationship,
+                principal_id=principal_id,
+                accessible_projects=accessible_projects,
+                allowed_memory_scope_keys=memory_grants,
+            )
+        ):
             continue
         edges.append(
             GraphEdge(
@@ -535,7 +538,7 @@ async def get_subgraph(
 
     # Get center entity
     center = await _get_graph_entity(
-        runtime.entity_manager,
+        group_id,
         payload.entity_id,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
@@ -557,7 +560,7 @@ async def get_subgraph(
             return
 
         entity = await _get_graph_entity(
-            runtime.entity_manager,
+            group_id,
             entity_id,
             principal_id=principal_id,
             accessible_projects=accessible_projects,
@@ -587,11 +590,22 @@ async def get_subgraph(
             limit=50,
         )
 
-        for related_entity, relationship in related:
+        current_neighbors = await available_graph_entities(
+            group_id, [entity.id for entity, _relationship in related]
+        )
+        for listed_entity, relationship in related:
+            related_entity = current_neighbors.get(listed_entity.id)
+            if related_entity is None:
+                continue
             # An edge naming a hidden neighbour still discloses that the row
             # exists and its id, so the endpoint drops it before it is built
             # rather than relying on the node check further down the traversal.
             if not _graph_entity_visible(
+                relationship,
+                principal_id=principal_id,
+                accessible_projects=accessible_projects,
+                allowed_memory_scope_keys=memory_grants,
+            ) or not _graph_entity_visible(
                 related_entity,
                 principal_id=principal_id,
                 accessible_projects=accessible_projects,
@@ -843,16 +857,26 @@ async def get_hierarchical_graph_data(
 @router.get("/stats")
 @handle_workflow_errors("get_graph_stats")
 async def get_graph_stats(
-    service: KnowledgeReadService = Depends(get_knowledge_read_service),
+    org: AuthOrganization = Depends(get_current_organization),
+    ctx: AuthContext = Depends(get_auth_context),
 ) -> dict:
-    """Get efficient graph statistics using aggregate queries.
+    """Count current reader-visible graph rows and their visible connections."""
+    from collections import Counter
 
-    Does not load the full graph - uses Cypher aggregation for performance.
-    """
-    stats = await service.stats()
+    from sibyl_core.services.graph_community_snapshot import _get_visible_graph_snapshot
 
+    group_id = str(org.id)
+    runtime = await get_entity_graph_runtime(group_id)
+    principal_id, accessible_projects, memory_grants = await _graph_scope_reader(ctx)
+    snapshot = await _get_visible_graph_snapshot(
+        runtime.client,
+        group_id,
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        allowed_memory_scope_keys=memory_grants,
+    )
     return {
-        "total_nodes": stats.total_entities,
-        "total_edges": stats.total_relationships,
-        "by_type": stats.entities_by_type,
+        "total_nodes": len(snapshot.entities),
+        "total_edges": len(snapshot.relationships),
+        "by_type": dict(Counter(entity.entity_type.value for entity in snapshot.entities)),
     }

--- a/apps/api/src/sibyl/persistence/graph_runtime.py
+++ b/apps/api/src/sibyl/persistence/graph_runtime.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, Self
 
@@ -575,6 +575,7 @@ class GraphQueryAdapter:
     """Thin graph query surface for routes that still need runtime reads."""
 
     def __init__(self, runtime: GraphRuntime, group_id: str) -> None:
+        self._runtime = runtime
         self._client = runtime.client
         self._group_id = group_id
         self._entities = runtime.entity_manager
@@ -718,6 +719,7 @@ class GraphQueryAdapter:
         self,
         entity_ids: Sequence[str],
         *,
+        entity_visible: Callable[[Entity | Relationship], bool],
         relationship_types: list[RelationshipType] | None = None,
     ) -> dict[str, int]:
         scoped_entity_ids = {entity_id for entity_id in entity_ids if entity_id}
@@ -729,7 +731,7 @@ class GraphQueryAdapter:
         rows = _normalize_result(
             await self._client.execute_query(
                 f"""
-                SELECT source_id, target_id
+                SELECT *
                 FROM relates_to
                 WHERE group_id = $group_id
                   AND (source_id IN $entity_ids OR target_id IN $entity_ids)
@@ -740,9 +742,24 @@ class GraphQueryAdapter:
                 relationship_types=[rel.value for rel in relationship_types or []],
             )
         )
+        from sibyl_core.services.graph_read_availability import available_graph_entities
+
+        endpoints = {
+            str(row[key]) for row in rows for key in ("source_id", "target_id") if row.get(key)
+        }
+        current = await available_graph_entities(
+            self._group_id, sorted(endpoints), runtime=self._runtime
+        )
+        visible = {identity for identity, entity in current.items() if entity_visible(entity)}
         for row in rows:
             source_id = str(row.get("source_id") or "")
             target_id = str(row.get("target_id") or "")
+            if (
+                source_id not in visible
+                or target_id not in visible
+                or not entity_visible(relationship_from_surreal_row(row))
+            ):
+                continue
             if source_id in counts:
                 counts[source_id] += 1
             if target_id in counts and target_id != source_id:

--- a/apps/api/tests/test_communities.py
+++ b/apps/api/tests/test_communities.py
@@ -30,6 +30,31 @@ from sibyl_core.services.graph_communities import (
 TEST_ORG_ID = "test-org-communities"
 
 
+@pytest.fixture(autouse=True)
+def current_rendering_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The graph fixtures supply current rows; these tests isolate rendering policy.
+
+    Native source retirement and cached-row replacement are exercised by the
+    graph community ancestry and source-retirement integration suites.
+    """
+
+    async def current(_client, _organization_id, snapshot):
+        return snapshot
+
+    async def current_entities(client, organization_id, ids):
+        from sibyl_core.services.graph_community_snapshot import _get_graph_snapshot
+
+        snapshot = await _get_graph_snapshot(client, organization_id)
+        return {entity.id: entity for entity in snapshot.entities if entity.id in ids}
+
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_community_snapshot._current_graph_snapshot", current
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_community_clusters._current_graph_entities", current_entities
+    )
+
+
 def _make_entity(entity_id: str, name: str, entity_type: EntityType) -> Entity:
     return Entity(
         id=entity_id,

--- a/apps/api/tests/test_routes_graph.py
+++ b/apps/api/tests/test_routes_graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 from uuid import UUID
 
 import pytest
@@ -27,6 +27,28 @@ def _accessible_projects(*project_ids: str):
         "sibyl.api.routes.graph.list_accessible_project_graph_ids",
         AsyncMock(return_value=set(project_ids)),
     )
+
+
+@pytest.fixture(autouse=True)
+def stored_graph_rows(monkeypatch):
+    """Keep route scope controls on their stored-row doubles.
+
+    Protected ancestry and source replacement run against the native runtime
+    in the graph availability and community source-retirement controls.
+    """
+
+    async def available(org, ids):
+        runtime = await graph_routes.get_entity_graph_runtime(org)
+        manager = runtime.entity_manager
+        if hasattr(manager, "get_many"):
+            rows = await manager.get_many(ids)
+        elif hasattr(manager, "get"):
+            rows = [await manager.get(identity) for identity in ids]
+        else:
+            rows = manager.list_all.return_value
+        return {row.id: row for row in rows if row is not None and row.id in ids}
+
+    monkeypatch.setattr(graph_routes, "available_graph_entities", available)
 
 
 class TestGraphRoutes:
@@ -61,7 +83,7 @@ class TestGraphRoutes:
             result = await graph_routes.debug_graph(org=_org(), ctx=_ctx())
 
         assert result["node_count"] == 2
-        assert result["edge_count"] == 2
+        assert result["edge_count"] == 1
         assert result["matching_edges"] == 1
         runtime.entity_manager.list_all.assert_awaited_once_with(
             limit=1000,
@@ -115,7 +137,7 @@ class TestGraphRoutes:
             offset=0,
             include_archived=True,
         )
-        adapter.get_connection_counts.assert_awaited_once_with(["task-1"])
+        adapter.get_connection_counts.assert_awaited_once_with(["task-1"], entity_visible=ANY)
 
     @pytest.mark.asyncio
     async def test_get_all_edges_uses_entity_graph_runtime(self) -> None:

--- a/apps/api/tests/test_wire_scope.py
+++ b/apps/api/tests/test_wire_scope.py
@@ -384,6 +384,10 @@ class TestInaccessibleProjectWire:
                 AsyncMock(return_value=runtime),
             ),
             patch(
+                "sibyl.api.routes.graph.available_graph_entities",
+                AsyncMock(return_value={entity.id: entity for entity in [victim, mine]}),
+            ),
+            patch(
                 "sibyl.api.routes.graph.get_graph_query_adapter",
                 AsyncMock(return_value=adapter),
             ),

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_community_clusters.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_community_clusters.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from typing import Any
 
 import structlog
@@ -13,7 +15,7 @@ from sibyl_core.auth.memory_policy import (
     memory_row_project_id,
     private_scope_granted_for,
 )
-from sibyl_core.models.entities import Entity, RelationshipType
+from sibyl_core.models.entities import Entity, Relationship, RelationshipType
 from sibyl_core.services.graph_community_detection import _detect_communities_from_graph
 from sibyl_core.services.graph_community_managers import _entity_summary
 from sibyl_core.services.graph_community_models import (
@@ -32,17 +34,20 @@ from sibyl_core.services.graph_community_selection import (
 )
 from sibyl_core.services.graph_community_snapshot import (
     _count_int,
+    _current_graph_entities,
     _get_graph_snapshot,
     _get_visible_graph_snapshot,
     _native_rows,
     _reader_cache_key,
+    _snapshot_fingerprint,
 )
+from sibyl_core.services.graph_visibility import graph_row_read_allowed
 
 log = structlog.get_logger()
 
 CLUSTER_CACHE: dict[
     tuple[str, tuple[str, tuple[str, ...], tuple[str, ...] | None]],
-    tuple[datetime, list[ClusterSummary]],
+    tuple[datetime, str, list[ClusterSummary]],
 ] = {}
 CLUSTER_CACHE_TTL = timedelta(minutes=5)
 
@@ -173,6 +178,7 @@ async def _native_relationship_edges_between_ids(
     member_ids: list[str],
     *,
     max_edges: int,
+    relationship_visible: Callable[[Relationship], bool],
 ) -> list[dict[str, Any]] | None:
     if not member_ids:
         return []
@@ -181,7 +187,7 @@ async def _native_relationship_edges_between_ids(
         client,
         organization_id,
         """
-        SELECT source_id, target_id, name
+        SELECT *
         FROM relates_to
         WHERE group_id = $group_id
           AND source_id IN $member_ids
@@ -194,11 +200,17 @@ async def _native_relationship_edges_between_ids(
     if rows is None:
         return None
 
+    from sibyl_core.services.graph_records import relationship_from_surreal_row
+
     edges: list[dict[str, Any]] = []
     for row in rows:
         source_id = str(row.get("source_id") or "")
         target_id = str(row.get("target_id") or "")
-        if not source_id or not target_id:
+        if (
+            not source_id
+            or not target_id
+            or not relationship_visible(relationship_from_surreal_row(row))
+        ):
             continue
         edges.append(
             {
@@ -238,15 +250,6 @@ async def get_clusters_for_visualization(
         _reader_cache_key(principal_id, accessible_projects, allowed_memory_scope_keys),
     )
 
-    # Check cache
-    if not force_refresh and cache_key in CLUSTER_CACHE:
-        cached_at, clusters = CLUSTER_CACHE[cache_key]
-        if datetime.now(UTC) - cached_at < CLUSTER_CACHE_TTL:
-            log.debug("cluster_cache_hit", org_id=organization_id, count=len(clusters))
-            return clusters
-
-    log.info("cluster_cache_miss", org_id=organization_id)
-
     snapshot = await _get_visible_graph_snapshot(
         client,
         organization_id,
@@ -256,6 +259,16 @@ async def get_clusters_for_visualization(
         max_entities=DETECTION_MAX_ENTITIES,
         max_relationships=DETECTION_MAX_RELATIONSHIPS,
     )
+    fingerprint = _snapshot_fingerprint(snapshot)
+
+    # Check cache
+    if not force_refresh and cache_key in CLUSTER_CACHE:
+        cached_at, cached_fingerprint, clusters = CLUSTER_CACHE[cache_key]
+        if cached_fingerprint == fingerprint and datetime.now(UTC) - cached_at < CLUSTER_CACHE_TTL:
+            log.debug("cluster_cache_hit", org_id=organization_id, count=len(clusters))
+            return clusters
+
+    log.info("cluster_cache_miss", org_id=organization_id)
 
     try:
         detected = _detect_communities_from_graph(
@@ -286,7 +299,7 @@ async def get_clusters_for_visualization(
         )
 
     # Cache result
-    CLUSTER_CACHE[cache_key] = (datetime.now(UTC), clusters)
+    CLUSTER_CACHE[cache_key] = (datetime.now(UTC), fingerprint, clusters)
     log.info("cluster_cache_updated", org_id=organization_id, count=len(clusters))
 
     return clusters
@@ -429,24 +442,19 @@ async def get_cluster_nodes(
 
     member_ids = cluster.member_ids[:max_nodes]
     member_id_set = set(member_ids)
-    entity_by_id = await _native_entities_by_ids(client, organization_id, member_ids)
-    if entity_by_id is None:
-        snapshot = await _get_visible_graph_snapshot(
-            client,
-            organization_id,
-            principal_id=principal_id,
-            accessible_projects=accessible_projects,
-            allowed_memory_scope_keys=allowed_memory_scope_keys,
-            max_entities=DETECTION_MAX_ENTITIES,
-            max_relationships=DETECTION_MAX_RELATIONSHIPS,
-        )
-        entity_by_id = snapshot.entity_by_id
+    entity_by_id = await _current_graph_entities(client, organization_id, member_ids)
 
     edges = await _native_relationship_edges_between_ids(
         client,
         organization_id,
         member_ids,
         max_edges=max_edges,
+        relationship_visible=partial(
+            graph_row_read_allowed,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
+        ),
     )
 
     # This is the surface that emits an entity's name and description text, so
@@ -486,9 +494,12 @@ async def get_cluster_nodes(
         ]
 
     if edges is None:
-        snapshot = await _get_graph_snapshot(
+        snapshot = await _get_visible_graph_snapshot(
             client,
             organization_id,
+            principal_id=principal_id,
+            accessible_projects=accessible_projects,
+            allowed_memory_scope_keys=allowed_memory_scope_keys,
             max_entities=DETECTION_MAX_ENTITIES,
             max_relationships=DETECTION_MAX_RELATIONSHIPS,
         )

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_community_hierarchy.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_community_hierarchy.py
@@ -35,16 +35,17 @@ from sibyl_core.services.graph_community_selection import (
 from sibyl_core.services.graph_community_snapshot import (
     _get_visible_graph_snapshot,
     _reader_cache_key,
+    _snapshot_fingerprint,
 )
 
 log = structlog.get_logger()
 
 HIERARCHICAL_CACHE: dict[
     tuple[str, tuple[str, tuple[str, ...], tuple[str, ...] | None]],
-    tuple[datetime, dict[str, str], list[dict[str, Any]]],
+    tuple[datetime, str, dict[str, str], list[dict[str, Any]]],
 ] = {}
 HIERARCHICAL_CACHE_TTL = timedelta(minutes=5)
-GRAPH_LOD_CACHE: dict[tuple[Any, ...], tuple[datetime, HierarchicalGraphData]] = {}
+GRAPH_LOD_CACHE: dict[tuple[Any, ...], tuple[datetime, str, HierarchicalGraphData]] = {}
 GRAPH_LOD_CACHE_TTL = timedelta(minutes=2)
 
 
@@ -183,18 +184,6 @@ async def get_hierarchical_graph(
         accessible_projects=accessible_projects,
         allowed_memory_scope_keys=allowed_memory_scope_keys,
     )
-    cached_lod = GRAPH_LOD_CACHE.get(cache_key)
-    if cached_lod is not None:
-        cached_at, data = cached_lod
-        if datetime.now(UTC) - cached_at < GRAPH_LOD_CACHE_TTL:
-            log.info(
-                "graph_lod_cache_hit",
-                org_id=organization_id,
-                resolution=resolution,
-                cluster_id=cluster_id,
-            )
-            return data
-
     # Load the whole graph (within analytic caps) for detection and selection.
     # max_nodes/max_edges are render budgets applied later, never here — capping
     # the snapshot is what produced the disconnected starfield.
@@ -207,6 +196,22 @@ async def get_hierarchical_graph(
         max_entities=DETECTION_MAX_ENTITIES,
         max_relationships=DETECTION_MAX_RELATIONSHIPS,
     )
+    fingerprint = _snapshot_fingerprint(snapshot)
+    cached_lod = GRAPH_LOD_CACHE.get(cache_key)
+    if cached_lod is not None:
+        cached_at, cached_fingerprint, data = cached_lod
+        if (
+            cached_fingerprint == fingerprint
+            and datetime.now(UTC) - cached_at < GRAPH_LOD_CACHE_TTL
+        ):
+            log.info(
+                "graph_lod_cache_hit",
+                org_id=organization_id,
+                resolution=resolution,
+                cluster_id=cluster_id,
+            )
+            return data
+
     entities = snapshot.entities
     # Build from structural edges only — drop the MENTIONS hairball so projects
     # and their tasks/memory are the visible structure. Totals reflect this
@@ -247,8 +252,13 @@ async def get_hierarchical_graph(
     clusters_meta: list[dict[str, Any]] = []
 
     if community_cache_key in HIERARCHICAL_CACHE:
-        cached_at, cached_clusters, cached_meta = HIERARCHICAL_CACHE[community_cache_key]
-        if datetime.now(UTC) - cached_at < HIERARCHICAL_CACHE_TTL:
+        cached_at, cached_fingerprint, cached_clusters, cached_meta = HIERARCHICAL_CACHE[
+            community_cache_key
+        ]
+        if (
+            cached_fingerprint == fingerprint
+            and datetime.now(UTC) - cached_at < HIERARCHICAL_CACHE_TTL
+        ):
             log.info("hierarchical_cache_hit", org_id=organization_id)
             node_to_cluster = cached_clusters
             clusters_meta = cached_meta
@@ -280,6 +290,7 @@ async def get_hierarchical_graph(
                 # Cache the result
                 HIERARCHICAL_CACHE[community_cache_key] = (
                     datetime.now(UTC),
+                    fingerprint,
                     node_to_cluster,
                     clusters_meta,
                 )
@@ -355,5 +366,5 @@ async def get_hierarchical_graph(
         cluster_id=cluster_id,
     )
 
-    GRAPH_LOD_CACHE[cache_key] = (datetime.now(UTC), data)
+    GRAPH_LOD_CACHE[cache_key] = (datetime.now(UTC), fingerprint, data)
     return data

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_community_snapshot.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_community_snapshot.py
@@ -3,23 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
+import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
 
-from sibyl_core.auth.memory_policy import (
-    memory_metadata_read_allowed,
-    memory_row_project_id,
-    private_scope_granted_for,
-)
 from sibyl_core.models.entities import Entity
 from sibyl_core.services.graph_community_managers import (
     _list_all_entities,
     _list_all_relationships,
 )
 from sibyl_core.services.graph_community_models import GraphSnapshot
+from sibyl_core.services.graph_visibility import graph_row_read_allowed
 
 log = structlog.get_logger()
 
@@ -180,29 +178,23 @@ def _reader_visible_snapshot(
     is the drift this filter exists to prevent, so the snapshot loads whole and
     is narrowed here, once, through the shared rule.
     """
-    entities = [
-        entity
-        for entity in snapshot.entities
-        if memory_metadata_read_allowed(
-            getattr(entity, "metadata", None),
+
+    def allowed(row):
+        return graph_row_read_allowed(
+            row,
             principal_id=principal_id,
             accessible_projects=accessible_projects,
             allowed_memory_scope_keys=allowed_memory_scope_keys,
-            private_scope_granted=private_scope_granted_for(
-                allowed_memory_scope_keys, principal_id=principal_id
-            ),
-            row_project_id=memory_row_project_id(
-                getattr(entity, "metadata", None),
-                entity_type=getattr(getattr(entity, "entity_type", None), "value", None),
-                entity_id=getattr(entity, "id", None),
-            ),
         )
-    ]
+
+    entities = [entity for entity in snapshot.entities if allowed(entity)]
     entity_by_id = _entity_index(entities)
     relationships = [
         relationship
         for relationship in snapshot.relationships
-        if relationship.source_id in entity_by_id and relationship.target_id in entity_by_id
+        if relationship.source_id in entity_by_id
+        and relationship.target_id in entity_by_id
+        and allowed(relationship)
     ]
     return GraphSnapshot(
         entities=entities,
@@ -227,12 +219,86 @@ async def _get_visible_graph_snapshot(
         max_entities=max_entities,
         max_relationships=max_relationships,
     )
+    snapshot = await _current_graph_snapshot(client, organization_id, snapshot)
     return _reader_visible_snapshot(
         snapshot,
         principal_id=principal_id,
         accessible_projects=accessible_projects,
         allowed_memory_scope_keys=allowed_memory_scope_keys,
     )
+
+
+async def _current_graph_entities(
+    client: Any, organization_id: str, ids: list[str]
+) -> dict[str, Entity]:
+    """Keep current-row and ancestry reads on the supplied graph owner."""
+    from sibyl_core.services.graph_community_managers import (
+        _entity_manager_for_client,
+        _relationship_manager_for_client,
+    )
+    from sibyl_core.services.graph_read_availability import available_graph_entities
+    from sibyl_core.services.graph_runtime import GraphRuntime
+
+    runtime = GraphRuntime(
+        client=client,
+        entity_manager=_entity_manager_for_client(client, organization_id),
+        relationship_manager=_relationship_manager_for_client(client, organization_id),
+    )
+    return await available_graph_entities(organization_id, ids, runtime=runtime)
+
+
+async def _current_graph_snapshot(
+    client: Any, organization_id: str, snapshot: GraphSnapshot
+) -> GraphSnapshot:
+    """Refresh cached identities before their content enters a reader cache.
+
+    Enumeration stays cached. Current rows and protected ancestry determine
+    what can be rendered; a replacement using the same ID cannot revive an
+    older cached label or relationship fact.
+    """
+    from sibyl_core.services.graph_common import normalize_graph_records
+    from sibyl_core.services.graph_records import relationship_from_surreal_row
+
+    entities = await _current_graph_entities(client, organization_id, list(snapshot.entity_by_id))
+    edge_ids = [relationship.id for relationship in snapshot.relationships]
+    relationships = []
+    if edge_ids:
+        rows = normalize_graph_records(
+            await client.execute_query(
+                "SELECT * FROM relates_to WHERE group_id=$group_id AND uuid IN $ids;",
+                group_id=organization_id,
+                ids=edge_ids,
+            )
+        )
+        relationships = [relationship_from_surreal_row(row) for row in rows]
+    return GraphSnapshot(
+        entities=list(entities.values()),
+        relationships=[
+            relationship
+            for relationship in relationships
+            if relationship.source_id in entities and relationship.target_id in entities
+        ],
+        entity_by_id=entities,
+    )
+
+
+def _snapshot_fingerprint(snapshot: GraphSnapshot) -> str:
+    """Bind derived cache values to their current, authorized input content."""
+    payload = {
+        "entities": [
+            entity.model_dump(mode="json", exclude={"embedding"})
+            for entity in sorted(snapshot.entities, key=lambda entity: entity.id)
+        ],
+        "relationships": [
+            relationship.model_dump(mode="json", exclude={"embedding"})
+            for relationship in sorted(
+                snapshot.relationships, key=lambda relationship: relationship.id
+            )
+        ],
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
 
 
 def _count_int(value: object) -> int:

--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_visibility.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_visibility.py
@@ -1,0 +1,38 @@
+"""Shared scope and lifecycle predicate for public graph rows."""
+
+from sibyl_core.auth.memory_policy import (
+    memory_metadata_read_allowed,
+    memory_row_project_id,
+    private_scope_granted_for,
+)
+from sibyl_core.memory_pipeline.lifecycle import graph_metadata_recallable
+from sibyl_core.models.entities import Entity, Relationship
+
+
+def graph_row_read_allowed(
+    entity: Entity | Relationship,
+    *,
+    principal_id: str | None,
+    accessible_projects: set[str] | None,
+    allowed_memory_scope_keys: set[str] | None,
+) -> bool:
+    # A visualization node carries the entity's label and metadata bag, so a
+    # private memory reaches the picture as a readable title unless the same
+    # scope rule that governs search is applied here too. Work items are
+    # deliberately unstamped, so their project is the channel that gates them.
+    return graph_metadata_recallable(
+        getattr(entity, "metadata", None)
+    ) and memory_metadata_read_allowed(
+        getattr(entity, "metadata", None),
+        principal_id=principal_id,
+        accessible_projects=accessible_projects,
+        allowed_memory_scope_keys=allowed_memory_scope_keys,
+        private_scope_granted=private_scope_granted_for(
+            allowed_memory_scope_keys, principal_id=principal_id
+        ),
+        row_project_id=memory_row_project_id(
+            getattr(entity, "metadata", None),
+            entity_type=getattr(getattr(entity, "entity_type", None), "value", None),
+            entity_id=getattr(entity, "id", None),
+        ),
+    )

--- a/packages/python/sibyl-core/tests/test_graph_community_ancestry_cache.py
+++ b/packages/python/sibyl-core/tests/test_graph_community_ancestry_cache.py
@@ -1,0 +1,81 @@
+"""Reader caches must track the current authorized graph input."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from sibyl_core.models.entities import Entity, EntityType, Relationship, RelationshipType
+from sibyl_core.services import graph_community_clusters as clusters
+from sibyl_core.services import graph_community_hierarchy as hierarchy
+from sibyl_core.services.graph_community_models import GraphSnapshot
+from sibyl_core.services.graph_community_snapshot import _snapshot_fingerprint
+
+
+def snapshot(name: str = "original") -> GraphSnapshot:
+    entities = [
+        Entity(id="one", name=name, entity_type=EntityType.TASK),
+        Entity(id="two", name="second", entity_type=EntityType.TASK),
+    ]
+    edge = Relationship(
+        id="edge",
+        source_id="one",
+        target_id="two",
+        relationship_type=RelationshipType.RELATED_TO,
+    )
+    return GraphSnapshot(entities, [edge], {entity.id: entity for entity in entities})
+
+
+def test_snapshot_fingerprint_ignores_order_but_tracks_content() -> None:
+    initial = snapshot()
+    reordered = GraphSnapshot(
+        list(reversed(initial.entities)), initial.relationships, initial.entity_by_id
+    )
+    assert _snapshot_fingerprint(initial) == _snapshot_fingerprint(reordered)
+    changed = GraphSnapshot(
+        [initial.entities[0].model_copy(update={"name": "replacement"}), initial.entities[1]],
+        initial.relationships,
+        initial.entity_by_id,
+    )
+    assert _snapshot_fingerprint(initial) != _snapshot_fingerprint(changed)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["clusters", "hierarchy"])
+async def test_derived_cache_reuses_only_current_visible_input(monkeypatch, surface) -> None:
+    clusters.CLUSTER_CACHE.clear()
+    hierarchy.GRAPH_LOD_CACHE.clear()
+    hierarchy.HIERARCHICAL_CACHE.clear()
+    module = clusters if surface == "clusters" else hierarchy
+    initial = snapshot()
+    replacement = GraphSnapshot(
+        [initial.entities[0].model_copy(update={"name": "replacement"}), initial.entities[1]],
+        initial.relationships,
+        initial.entity_by_id,
+    )
+    empty = GraphSnapshot([], [], {})
+    visible = AsyncMock(side_effect=[initial, initial, replacement, empty])
+    detect = Mock(return_value=[])
+    monkeypatch.setattr(module, "_get_visible_graph_snapshot", visible)
+    monkeypatch.setattr(module, "_detect_communities_from_graph", detect)
+    call = (
+        clusters.get_clusters_for_visualization
+        if surface == "clusters"
+        else hierarchy.get_hierarchical_graph
+    )
+    first = await call(object(), "org-cache")
+    assert await call(object(), "org-cache") is first
+    assert detect.call_count == 1
+    updated = await call(object(), "org-cache")
+    assert updated is not first
+    if surface == "hierarchy":
+        assert next(node for node in updated.nodes if node["id"] == "one")["name"] == "replacement"
+    assert detect.call_count == 2
+    retired = await call(object(), "org-cache")
+    assert detect.call_count == 3
+    if surface == "clusters":
+        assert retired == []
+    else:
+        assert not retired.nodes
+        assert not retired.edges
+        assert retired.total_nodes == 0
+    assert visible.await_count == 4

--- a/packages/python/sibyl-core/tests/test_graph_community_ancestry_cache.py
+++ b/packages/python/sibyl-core/tests/test_graph_community_ancestry_cache.py
@@ -41,7 +41,10 @@ def test_snapshot_fingerprint_ignores_order_but_tracks_content() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("surface", ["clusters", "hierarchy"])
-async def test_derived_cache_reuses_only_current_visible_input(monkeypatch, surface) -> None:
+@pytest.mark.parametrize("networkx_available", [True, False])
+async def test_derived_cache_reuses_only_current_visible_input(
+    monkeypatch, surface, networkx_available
+) -> None:
     clusters.CLUSTER_CACHE.clear()
     hierarchy.GRAPH_LOD_CACHE.clear()
     hierarchy.HIERARCHICAL_CACHE.clear()
@@ -55,8 +58,12 @@ async def test_derived_cache_reuses_only_current_visible_input(monkeypatch, surf
     empty = GraphSnapshot([], [], {})
     visible = AsyncMock(side_effect=[initial, initial, replacement, empty])
     detect = Mock(return_value=[])
+    convert = Mock(return_value=object())
+    if not networkx_available:
+        convert.side_effect = ImportError("NetworkX is optional")
     monkeypatch.setattr(module, "_get_visible_graph_snapshot", visible)
     monkeypatch.setattr(module, "_detect_communities_from_graph", detect)
+    monkeypatch.setattr(module, "_snapshot_to_networkx", convert)
     call = (
         clusters.get_clusters_for_visualization
         if surface == "clusters"
@@ -64,14 +71,17 @@ async def test_derived_cache_reuses_only_current_visible_input(monkeypatch, surf
     )
     first = await call(object(), "org-cache")
     assert await call(object(), "org-cache") is first
-    assert detect.call_count == 1
+    assert convert.call_count == 1
+    assert detect.call_count == (1 if networkx_available else 0)
     updated = await call(object(), "org-cache")
     assert updated is not first
     if surface == "hierarchy":
         assert next(node for node in updated.nodes if node["id"] == "one")["name"] == "replacement"
-    assert detect.call_count == 2
+    assert convert.call_count == 2
+    assert detect.call_count == (2 if networkx_available else 0)
     retired = await call(object(), "org-cache")
-    assert detect.call_count == 3
+    assert convert.call_count == 3
+    assert detect.call_count == (3 if networkx_available else 0)
     if surface == "clusters":
         assert retired == []
     else:

--- a/packages/python/sibyl-core/tests/test_graph_community_source_retirement.py
+++ b/packages/python/sibyl-core/tests/test_graph_community_source_retirement.py
@@ -1,0 +1,89 @@
+"""Cached graph views must retire descendants of corrected raw sources."""
+
+from unittest.mock import AsyncMock
+
+from sibyl_core.models.entities import Relationship, RelationshipType
+from sibyl_core.services import graph_community_clusters as clusters
+from sibyl_core.services import graph_community_hierarchy as hierarchy
+from sibyl_core.services import graph_community_snapshot as snapshots
+from sibyl_core.services.memory_correction import apply_memory_correction
+from sibyl_core.services.memory_source_validation import SourceReadAuthority
+from sibyl_core.services.surreal_content import remember_raw_memory
+from tests.test_graph_derivation_publication import publish, share_plan
+from tests.test_synthesis_source_observations import content_store as content_store
+from tests.test_synthesis_source_observations import (
+    disable_embeddings_and_bind_runtime as disable_embeddings_and_bind_runtime,
+)
+from tests.test_synthesis_source_observations import runtime as runtime
+
+
+async def test_warm_community_views_retire_actual_protected_source(
+    runtime, content_store, monkeypatch
+):
+    org = runtime.client.group_id
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_read_availability.get_surreal_graph_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    resolver = AsyncMock(
+        return_value=SourceReadAuthority("user_a", projects=frozenset({"project_a"}))
+    )
+    monkeypatch.setattr(
+        "sibyl_core.services.graph_derivations.get_source_authority_resolver", lambda: resolver
+    )
+    sources, targets = [], []
+    for index in range(2):
+        source = await remember_raw_memory(
+            organization_id=org,
+            principal_id="user_a",
+            source_id=f"view-parent-{index}",
+            raw_content=f"Deployment gate {index} requires approval from blue team.",
+            embedding_provider=None,
+        )
+        result = await publish(runtime, await share_plan(runtime, source.id))
+        assert result.success
+        sources.append(source)
+        targets.append(result.promoted_id)
+    await runtime.relationship_manager.create(
+        Relationship(
+            id="protected-edge",
+            source_id=targets[0],
+            target_id=targets[1],
+            relationship_type=RelationshipType.RELATED_TO,
+        )
+    )
+    await runtime.relationship_manager.create(
+        Relationship(
+            id="private-edge",
+            source_id=targets[0],
+            target_id=targets[1],
+            relationship_type=RelationshipType.DEPENDS_ON,
+            metadata={"memory_scope": "private", "principal_id": "user_a"},
+        )
+    )
+    snapshots.GRAPH_SNAPSHOT_CACHE.clear()
+    clusters.CLUSTER_CACHE.clear()
+    hierarchy.HIERARCHICAL_CACHE.clear()
+    hierarchy.GRAPH_LOD_CACHE.clear()
+    reader = dict(principal_id="user_b", accessible_projects={"project_a"})
+    before = await snapshots._get_visible_graph_snapshot(runtime.client, org, **reader)
+    assert set(targets) <= set(before.entity_by_id)
+    assert any(edge.id == "protected-edge" for edge in before.relationships)
+    assert all(edge.id != "private-edge" for edge in before.relationships)
+    cluster_before = await clusters.get_clusters_for_visualization(runtime.client, org, **reader)
+    assert set(targets) <= {member for cluster in cluster_before for member in cluster.member_ids}
+    hierarchy_before = await hierarchy.get_hierarchical_graph(runtime.client, org, **reader)
+    assert set(targets) <= {node["id"] for node in hierarchy_before.nodes}
+    await apply_memory_correction(
+        organization_id=org, principal_id="user_a", source_id=sources[0].id, action="hide"
+    )
+    after = await snapshots._get_visible_graph_snapshot(runtime.client, org, **reader)
+    assert targets[0] not in after.entity_by_id
+    assert targets[1] in after.entity_by_id
+    assert all(targets[0] not in (edge.source_id, edge.target_id) for edge in after.relationships)
+    cluster_after = await clusters.get_clusters_for_visualization(runtime.client, org, **reader)
+    assert targets[0] not in {member for cluster in cluster_after for member in cluster.member_ids}
+    hierarchy_after = await hierarchy.get_hierarchical_graph(runtime.client, org, **reader)
+    assert targets[0] not in {node["id"] for node in hierarchy_after.nodes}
+    assert all(targets[0] not in (edge["source"], edge["target"]) for edge in hierarchy_after.edges)
+    assert hierarchy_after.total_edges < hierarchy_before.total_edges


### PR DESCRIPTION
Retiring a source or changing a memory's visibility could leave its old nodes, edges and counts visible in cached graph views. Graph routes and community views now refresh current records and apply the same reader policy before returning graph data or reusing cached results.

## 🛠️ Current records before cached views

The graph routes share one visibility predicate for entities and relationships. Both endpoints must remain available, and each relationship must pass its own scope and lifecycle checks. Connection counts, graph statistics and debug samples use the filtered records too.

Community snapshots retain their enumeration cache, then refresh current records and fingerprint the visible input before reusing cluster, hierarchy or level-of-detail results. Unchanged inputs reuse their computed result; retirement, replacement and visibility changes invalidate it. Explicit graph clients remain attached to their original runtime.

## 🧪 Validation

Independent native SurrealDB verification covered current-record replacement, source retirement, relationship scope and matching counts. Three debug-count regressions failed before the fix and passed afterward. The final independent six-control suite passed; package lint and type checks also passed.

The root repeated the six independent controls successfully. An overly broad native test selection also ran unrelated suites and produced four failures; the missing-table failures and transaction-conflict failure class also reproduce on the unchanged parent. Those broader failures remain separate from this change.

The rendering fixtures now supply current records while retaining their real reader-policy checks. All 42 community controls and 21 HTTP wire-scope controls passed independently and in a final author repeat. Eleven core cache and source-retirement controls also passed. The cache tests explicitly exercise both the community-detection path and its optional-NetworkX fallback; both retain unchanged-input reuse and changed-input invalidation checks.

The native checks exercise real persistence and route functions with a supplied reader context. They do not establish full HTTP authentication acceptance or large-graph latency.

## 🌊 Stack

The current ancestry checks from #573 are merged into main. Operational experience publication and automatic correction continuation are separate follow-up slices.
