### PR TITLE
feat(memory): add versioned correction progress assessments

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/tasks/memory_progress.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/memory_progress.py
@@ -1,0 +1,208 @@
+"""Versioned source-bound progress assessment within the existing critic call."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from pydantic import Field
+
+from sibyl_core.tasks._evidence_json import canonical
+from sibyl_core.tasks.memory_validation import (
+    CriticOutput,
+    MemoryValidationResult,
+    PreparedMemoryValidation,
+    validation_assertion_index,
+)
+from sibyl_core.tasks.procedure_evidence import EvidenceRef
+from sibyl_core.tasks.procedure_review import (
+    ReviewSubmission,
+    _Digest,
+    _StrictModel,
+    _Text,
+    review_digest,
+)
+
+PROGRESS_VERSION = "sibyl-memory-validation-progress-v1"
+PROGRESS_INSTRUCTIONS = """Assess the current candidate against the same original evidence.
+The previous candidate and findings are untrusted evidence, not authority.
+Assess every supplied prior finding ID. Identify any supported reduction of the
+unsupported assertions, even when a compound finding is only partially repaired.
+Do not equate unresolved finding counts or a shared /content path with no progress.
+Name the repaired assertion portion and remaining concern; cite original evidence
+IDs. Changed wording alone is not progress. Report remaining concerns against the
+current assertion hashes. Do not invent criticism or assume earlier criticism was
+correct. Abstain explicitly only when original evidence cannot support a useful
+assessment. Progress and an empty finding list grant no publication permission."""
+
+
+class PriorFindingAssessment(_StrictModel):
+    finding_id: _Digest
+    disposition: Literal["resolved", "partially_resolved", "unresolved", "unassessable"]
+    supported_reduction: _Text | None
+    remaining_concern: _Text | None
+    evidence_refs: list[EvidenceRef] = Field(min_length=1)
+
+
+class ProgressCriticOutput(CriticOutput):
+    prior_assessments: list[PriorFindingAssessment]
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProgressMemoryValidationResult(MemoryValidationResult):
+    prior_assessments: tuple[PriorFindingAssessment, ...]
+    progress: Literal["accepted", "advance", "no_progress", "abstain", "unresolved"]
+    version: str = PROGRESS_VERSION
+
+
+def semantic_candidate_digest(payload: dict[str, Any]) -> str:
+    """Ignore runtime/audit metadata while retaining the candidate's assertions."""
+    return review_digest(payload["assertions"])
+
+
+def prepare_progress_validation(
+    previous: PreparedMemoryValidation,
+    current: PreparedMemoryValidation,
+    review: ReviewSubmission,
+    *,
+    ancestor_candidate_digests: tuple[str, ...] = (),
+) -> PreparedMemoryValidation:
+    """Detach a previous review and both claim views; callers still own authority."""
+    before = json.loads(previous.payload_json)
+    after = json.loads(current.payload_json)
+    submission = ReviewSubmission.model_validate_json(review.model_dump_json())
+    if (
+        submission.parent_operation_id != before["parent_operation_id"]
+        or submission.parent_candidate_sha256 != before["parent_candidate_sha256"]
+    ):
+        raise ValueError("progress review parent differs")
+    if before["sources"] != after["sources"] or before["citations"] != after["citations"]:
+        raise ValueError("progress original evidence differs")
+    if before["kind"] != after["kind"]:
+        raise ValueError("progress candidate kind differs")
+    for finding in submission.findings:
+        assertion = before["assertions"].get(finding.claim_path)
+        if assertion is None or review_digest(assertion) != finding.claim_sha256:
+            raise ValueError("progress prior assertion differs")
+        if any(ref.evidence_id not in after["citations"] for ref in finding.evidence_refs):
+            raise ValueError("progress prior evidence differs")
+    for digest in ancestor_candidate_digests:
+        if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+            raise ValueError("invalid progress ancestor identity")
+    after["version"] = PROGRESS_VERSION
+    after["prior_progress"] = {
+        "previous_input_sha256": previous.input_sha256,
+        "evidence_sha256": review_digest([before["sources"], before["citations"]]),
+        "previous_parent_operation_id": before["parent_operation_id"],
+        "previous_parent_candidate_sha256": before["parent_candidate_sha256"],
+        "previous_candidate": before["candidate"],
+        "previous_candidate_view_sha256": review_digest(before["candidate"]),
+        "previous_assertions": before["assertions"],
+        "previous_candidate_digest": semantic_candidate_digest(before),
+        "review": submission.model_dump(mode="json"),
+        "finding_ids": submission.finding_ids(),
+        "ancestor_candidate_digests": list(ancestor_candidate_digests),
+    }
+    return PreparedMemoryValidation(canonical(after))
+
+
+ProgressDecision = Literal["accepted", "advance", "no_progress", "abstain", "unresolved"]
+
+
+def validate_progress_context(payload: dict[str, Any]) -> None:
+    """Reject malformed context before any physical model dispatch."""
+    if not isinstance(payload.get("prior_progress"), dict):
+        raise ValueError("missing progress context")
+    context = payload["prior_progress"]
+    required = {
+        "review",
+        "previous_candidate",
+        "previous_input_sha256",
+        "previous_candidate_view_sha256",
+        "previous_parent_operation_id",
+        "previous_parent_candidate_sha256",
+        "finding_ids",
+        "previous_assertions",
+        "previous_candidate_digest",
+        "ancestor_candidate_digests",
+        "evidence_sha256",
+    }
+    if not required <= context.keys():
+        raise ValueError("incomplete progress context")
+    if not isinstance(context["previous_assertions"], dict) or not isinstance(
+        context["ancestor_candidate_digests"], list
+    ):
+        raise ValueError("invalid progress context shape")
+    digest = context["previous_input_sha256"]
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(c not in "0123456789abcdef" for c in digest)
+    ):
+        raise ValueError("invalid previous input identity")
+    if (
+        review_digest(context["previous_candidate"]) != context["previous_candidate_view_sha256"]
+        or validation_assertion_index(payload["kind"], context["previous_candidate"])
+        != context["previous_assertions"]
+    ):
+        raise ValueError("previous candidate view differs from assertions")
+    if context["evidence_sha256"] != review_digest([payload["sources"], payload["citations"]]):
+        raise ValueError("progress context evidence differs")
+    for digest in context["ancestor_candidate_digests"]:
+        if (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(c not in "0123456789abcdef" for c in digest)
+        ):
+            raise ValueError("invalid progress ancestor identity")
+    review = ReviewSubmission.model_validate(context["review"])
+    if (
+        review.parent_operation_id != context["previous_parent_operation_id"]
+        or review.parent_candidate_sha256 != context["previous_parent_candidate_sha256"]
+        or review.finding_ids() != context["finding_ids"]
+        or review_digest(context["previous_assertions"]) != context["previous_candidate_digest"]
+    ):
+        raise ValueError("progress context identity differs")
+    for finding in review.findings:
+        assertion = context["previous_assertions"].get(finding.claim_path)
+        if assertion is None or review_digest(assertion) != finding.claim_sha256:
+            raise ValueError("progress context assertion differs")
+        refs = [ref.evidence_id for ref in finding.evidence_refs]
+        if len(refs) != len(set(refs)) or any(ref not in payload["citations"] for ref in refs):
+            raise ValueError("progress context citation differs")
+
+
+def assess_progress(
+    payload: dict[str, Any], output: ProgressCriticOutput, status: str
+) -> ProgressDecision:
+    """Derive a proposal outcome; mechanical completeness is not factual proof."""
+    validate_progress_context(payload)
+    context = payload["prior_progress"]
+    expected = context["finding_ids"]
+    actual = [item.finding_id for item in output.prior_assessments]
+    if len(actual) != len(set(actual)) or set(actual) != set(expected):
+        raise ValueError("progress assessments incomplete or duplicated")
+    for assessment in output.prior_assessments:
+        refs = [ref.evidence_id for ref in assessment.evidence_refs]
+        if len(refs) != len(set(refs)) or any(ref not in payload["citations"] for ref in refs):
+            raise ValueError("progress assessment evidence differs")
+        improved = assessment.disposition in ("resolved", "partially_resolved")
+        if improved != (assessment.supported_reduction is not None):
+            raise ValueError("progress assessment reduction differs")
+        if (assessment.disposition == "resolved") != (assessment.remaining_concern is None):
+            raise ValueError("progress assessment remaining concern differs")
+    if status == "abstain":
+        return "abstain"
+    if status == "no_findings":
+        if any(item.disposition != "resolved" for item in output.prior_assessments):
+            raise ValueError("accepted critic leaves prior concerns unresolved")
+        return "accepted"
+    current = semantic_candidate_digest(payload)
+    if current in [context["previous_candidate_digest"], *context["ancestor_candidate_digests"]]:
+        return "no_progress"
+    if any(
+        item.disposition in ("resolved", "partially_resolved") for item in output.prior_assessments
+    ):
+        return "advance"
+    return "unresolved"

--- a/packages/python/sibyl-core/src/sibyl_core/tasks/memory_validation.py
+++ b/packages/python/sibyl-core/src/sibyl_core/tasks/memory_validation.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
-from typing import Literal
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from sibyl_core.tasks.memory_progress import ProgressCriticOutput
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -68,7 +71,12 @@ class PreparedMemoryValidation:
 
     @property
     def prompt(self) -> str:
-        return VALIDATION_INSTRUCTIONS + "\n\n" + self.payload_json
+        from sibyl_core.tasks.memory_progress import PROGRESS_INSTRUCTIONS, PROGRESS_VERSION
+
+        instructions = VALIDATION_INSTRUCTIONS
+        if json.loads(self.payload_json)["version"] == PROGRESS_VERSION:
+            instructions += "\n\n" + PROGRESS_INSTRUCTIONS
+        return instructions + "\n\n" + self.payload_json
 
     @property
     def input_sha256(self) -> str:
@@ -194,6 +202,24 @@ def _prepare(
     )
 
 
+def validation_assertion_index(kind: str, candidate: object) -> dict[str, dict[str, object]]:
+    """Index the exact candidate view through the adapter's shared assertion owner."""
+    if kind == "conditional_procedure":
+        return assertion_index(DraftConditionalProcedure.model_validate(candidate))
+    if kind != "reflection" or not isinstance(candidate, dict):
+        raise ValueError("invalid validation candidate view")
+    content = candidate.get("content")
+    claims = candidate.get("claim_records")
+    if not isinstance(content, str) or not isinstance(claims, list):
+        raise ValueError("invalid reflection candidate view")
+    assertions: dict[str, dict[str, object]] = {"/content": {"statement": content}}
+    for index, claim in enumerate(claims):
+        if not isinstance(claim, dict) or not isinstance(claim.get("content"), str):
+            raise ValueError("invalid reflection claim view")
+        assertions[f"/claim_records/{index}/content"] = {"statement": claim["content"]}
+    return assertions
+
+
 def prepare_reflection_validation(
     candidate: ReflectionCandidate,
     *,
@@ -204,9 +230,7 @@ def prepare_reflection_validation(
 ) -> PreparedMemoryValidation:
     """Index ordinary content and claims without inventing signed task outcomes."""
     snapshot = candidate.to_dict()
-    assertions: dict[str, dict[str, object]] = {"/content": {"statement": candidate.content}}
-    for index, claim in enumerate(candidate.claim_records):
-        assertions[f"/claim_records/{index}/content"] = {"statement": claim.content}
+    assertions = validation_assertion_index("reflection", snapshot)
     return _prepare(
         parent_operation_id=parent_operation_id,
         parent_candidate_sha256=parent_candidate_sha256,
@@ -249,21 +273,34 @@ def prepare_procedure_validation(
 
 async def run_memory_validation(
     prepared: PreparedMemoryValidation,
-    extractor: Extractor[CriticOutput],
+    extractor: Extractor[CriticOutput] | Extractor[ProgressCriticOutput],
 ) -> MemoryValidationResult:
     """Return actual usage even for invalid critique; extraction errors retain SDK receipts.
 
     The caller owns model configuration, durable dispatch/outcome recording and
     current-authority fences. Cancellation propagates with extraction_usage.
     """
-    if extractor.output_type is not CriticOutput:
-        raise ValueError("validation requires the shared critic output contract")
+    from sibyl_core.tasks.memory_progress import (
+        PROGRESS_VERSION,
+        ProgressCriticOutput,
+        ProgressDecision,
+        ProgressMemoryValidationResult,
+        assess_progress,
+        validate_progress_context,
+    )
+
     payload = json.loads(prepared.payload_json)
-    if payload["version"] != VALIDATION_VERSION:
+    version = payload["version"]
+    if version not in (VALIDATION_VERSION, PROGRESS_VERSION):
         raise ValueError("unsupported validation version")
+    if version == PROGRESS_VERSION:
+        validate_progress_context(payload)
+    output_type = ProgressCriticOutput if version == PROGRESS_VERSION else CriticOutput
+    if extractor.output_type is not output_type:
+        raise ValueError("validation requires the shared critic output contract")
     policy = canonical(
         {
-            "version": VALIDATION_VERSION,
+            "version": version,
             "surface": extractor.surface.value,
             "model_override": extractor.model_override,
             "output_mode": extractor.output_mode,
@@ -271,15 +308,17 @@ async def run_memory_validation(
             "max_tokens": extractor.max_tokens,
             "openrouter_provider": extractor.openrouter_provider,
             "system_prompt": extractor.system_prompt,
-            "output_schema": CriticOutput.model_json_schema(),
+            "output_schema": output_type.model_json_schema(),
         }
     )
     result = await extractor.extract_with_usage(prepared.prompt)
     submission = None
     reason = None
     status: Literal["no_findings", "reconsider", "abstain"] = "no_findings"
+    progress: ProgressDecision = "abstain"
+    assessments = ()
     try:
-        output = CriticOutput.model_validate(result.output.model_dump())
+        output = output_type.model_validate(result.output.model_dump())
         for finding in output.findings:
             assertion = payload["assertions"].get(finding.claim_path)
             if assertion is None or review_digest(assertion) != finding.claim_sha256:
@@ -299,14 +338,30 @@ async def run_memory_validation(
                 parent_candidate_sha256=payload["parent_candidate_sha256"],
                 findings=output.findings,
             )
+        if isinstance(output, ProgressCriticOutput):
+            progress = assess_progress(payload, output, status)
+            assessments = tuple(output.prior_assessments)
     except ValueError:
         status, reason = "abstain", "critic_output_failed_mechanical_validation"
-    return MemoryValidationResult(
+    except BaseException as error:
+        error.__dict__["extraction_usage"] = result.usage
+        raise
+    validation = MemoryValidationResult(
         status,
         submission,
         reason,
         prepared.input_sha256,
-        review_digest(CriticOutput.model_json_schema()),
+        review_digest(output_type.model_json_schema()),
         result.usage,
         policy,
     )
+
+    if version == PROGRESS_VERSION:
+        values = asdict(validation)
+        values["submission"] = validation.submission
+        values["usage"] = validation.usage
+        values["version"] = PROGRESS_VERSION
+        return ProgressMemoryValidationResult(
+            **values, prior_assessments=assessments, progress=progress
+        )
+    return validation

--- a/packages/python/sibyl-core/tests/test_memory_progress.py
+++ b/packages/python/sibyl-core/tests/test_memory_progress.py
@@ -1,0 +1,421 @@
+"""Progress critiques preserve partial repairs and immutable legacy identities."""
+
+import json
+from dataclasses import asdict
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from sibyl_core.ai.llm.extractor import Extractor
+from sibyl_core.models.reflection import ReflectionCandidate
+from sibyl_core.tasks.memory_progress import (
+    PROGRESS_VERSION,
+    ProgressCriticOutput,
+    prepare_progress_validation,
+)
+from sibyl_core.tasks.memory_validation import (
+    VALIDATION_INSTRUCTIONS,
+    VALIDATION_VERSION,
+    CriticOutput,
+    prepare_reflection_validation,
+    run_memory_validation,
+)
+from sibyl_core.tasks.procedure_review import ReviewSubmission
+from tests.test_memory_validation import candidate as candidate
+from tests.test_memory_validation import citations as citations
+from tests.test_memory_validation import finding
+from tests.test_memory_validation import prepared as prepared
+from tests.test_memory_validation import sources as sources
+from tests.test_tasks_consolidation import group as group
+from tests.test_tasks_consolidation import procedure as procedure
+
+
+@pytest.fixture
+def progress(prepared, sources, citations):
+    prepared = prepare_reflection_validation(
+        ReflectionCandidate(
+            "pattern",
+            "Validation",
+            "All ten cases failed, so retries always work.",
+            "contrast",
+            0.9,
+        ),
+        parent_operation_id="b" * 64,
+        parent_candidate_sha256="c" * 64,
+        evidence=sources,
+        citations=citations,
+    )
+    current = prepare_reflection_validation(
+        ReflectionCandidate(
+            "pattern", "Validation", "Three cases passed, so retries always work.", "contrast", 0.9
+        ),
+        parent_operation_id="d" * 64,
+        parent_candidate_sha256="e" * 64,
+        evidence=sources,
+        citations=citations,
+    )
+    payload = json.loads(prepared.payload_json)
+    concern = finding(prepared)
+    concern["critique"] = "The reported count is three passed, and retry causality is unsupported."
+    review = ReviewSubmission(
+        parent_operation_id=payload["parent_operation_id"],
+        parent_candidate_sha256=payload["parent_candidate_sha256"],
+        findings=[concern],
+    )
+    return prepare_progress_validation(prepared, current, review)
+
+
+def output(prepared, disposition="partially_resolved"):
+    payload = json.loads(prepared.payload_json)
+    return {
+        "findings": [finding(prepared)],
+        "prior_assessments": [
+            {
+                "finding_id": payload["prior_progress"]["finding_ids"][0],
+                "disposition": disposition,
+                "supported_reduction": "The count now matches three passed."
+                if disposition in ("resolved", "partially_resolved")
+                else None,
+                "remaining_concern": None
+                if disposition == "resolved"
+                else "Retry causality remains unsupported.",
+                "evidence_refs": [{"evidence_id": "observed"}],
+            }
+        ],
+    }
+
+
+async def execute(prepared, value):
+    extractor = Extractor(
+        ProgressCriticOutput,
+        agent=Agent(TestModel(custom_output_args=value), output_type=ProgressCriticOutput),
+    )
+    return await run_memory_validation(prepared, extractor)
+
+
+async def test_progress_partial_compound_content_can_advance(progress):
+    result = await execute(progress, output(progress))
+    assert result.status == "reconsider" and result.progress == "advance"
+    assert result.prior_assessments[0].disposition == "partially_resolved"
+    assert result.usage.requests == 1 and result.version == PROGRESS_VERSION
+
+
+async def test_progress_remaining_old_finding_is_not_automatic_no_progress(progress):
+    result = await execute(progress, output(progress, "unresolved"))
+    assert result.progress == "unresolved" and result.status == "reconsider"
+
+
+@pytest.mark.parametrize(
+    "change", ["missing", "duplicate", "finding", "evidence", "reduction", "remaining", "accepted"]
+)
+async def test_progress_mechanical_refusal_preserves_usage(progress, change):
+    value = output(progress)
+    if change == "missing":
+        value["prior_assessments"] = []
+    elif change == "duplicate":
+        value["prior_assessments"] *= 2
+    elif change == "finding":
+        value["prior_assessments"][0]["finding_id"] = "a" * 64
+    elif change == "evidence":
+        value["prior_assessments"][0]["evidence_refs"] = [{"evidence_id": "invented"}]
+    elif change == "reduction":
+        value["prior_assessments"][0]["supported_reduction"] = None
+    elif change == "remaining":
+        value["prior_assessments"][0]["remaining_concern"] = None
+    elif change == "accepted":
+        value["findings"] = []
+    result = await execute(progress, value)
+    assert result.status == "abstain" and result.progress == "abstain"
+    assert (
+        result.reason == "critic_output_failed_mechanical_validation" and result.usage.requests == 1
+    )
+
+
+async def test_progress_no_findings_requires_complete_resolved_assessments(progress):
+    value = output(progress, "resolved")
+    value["findings"] = []
+    result = await execute(progress, value)
+    assert result.status == "no_findings" and result.progress == "accepted"
+
+
+async def test_progress_unchanged_candidate_cannot_advance(prepared):
+    p = json.loads(prepared.payload_json)
+    review = ReviewSubmission(
+        parent_operation_id=p["parent_operation_id"],
+        parent_candidate_sha256=p["parent_candidate_sha256"],
+        findings=[finding(prepared)],
+    )
+    current = prepare_progress_validation(prepared, prepared, review)
+    result = await execute(current, output(current))
+    assert result.progress == "no_progress"
+
+
+async def test_progress_ancestor_oscillation_cannot_advance(progress):
+    from sibyl_core.tasks.memory_progress import semantic_candidate_digest
+    from sibyl_core.tasks.memory_validation import PreparedMemoryValidation
+
+    p = json.loads(progress.payload_json)
+    p["prior_progress"]["ancestor_candidate_digests"] = [semantic_candidate_digest(p)]
+    current = PreparedMemoryValidation(json.dumps(p))
+    assert (await execute(current, output(current))).progress == "no_progress"
+
+
+def test_progress_context_detaches_and_binds_prior_identity(prepared, progress):
+    assert progress.input_sha256 != prepared.input_sha256
+    assert (
+        json.loads(progress.payload_json)["prior_progress"]["previous_parent_candidate_sha256"]
+        == "c" * 64
+    )
+    assert json.loads(progress.payload_json)["parent_candidate_sha256"] == "e" * 64
+    assert "partially repaired" in progress.prompt
+
+
+async def test_progress_legacy_prompt_schema_and_result_remain_v1(prepared):
+    assert prepared.prompt == VALIDATION_INSTRUCTIONS + "\n\n" + prepared.payload_json
+    extractor = Extractor(
+        CriticOutput,
+        agent=Agent(TestModel(custom_output_args={"findings": []}), output_type=CriticOutput),
+    )
+    result = await run_memory_validation(prepared, extractor)
+    assert result.version == VALIDATION_VERSION
+    assert set(asdict(result)) == {
+        "status",
+        "submission",
+        "reason",
+        "input_sha256",
+        "schema_sha256",
+        "usage",
+        "configured_policy_json",
+        "version",
+    }
+    assert "prior_assessments" not in CriticOutput.model_json_schema()["properties"]
+
+
+@pytest.mark.parametrize("change", ["parent", "claim", "source", "observation", "citation"])
+def test_progress_rejects_changed_prior_binding(prepared, progress, change):
+    from sibyl_core.tasks.memory_validation import PreparedMemoryValidation
+
+    before = json.loads(prepared.payload_json)
+    after = json.loads(progress.payload_json)
+    item = finding(prepared)
+    operation = before["parent_operation_id"]
+    if change == "parent":
+        operation = "f" * 64
+    elif change == "claim":
+        item["claim_sha256"] = "f" * 64
+    elif change == "source":
+        after["sources"]["raw"]["sha256"] = "f" * 64
+    elif change == "observation":
+        after["sources"]["raw"]["observation_sha256"] = "f" * 64
+    else:
+        after["citations"]["observed"]["ranges"] = [[0, 1]]
+    review = ReviewSubmission(
+        parent_operation_id=operation,
+        parent_candidate_sha256=before["parent_candidate_sha256"],
+        findings=[item],
+    )
+    with pytest.raises(ValueError):
+        prepare_progress_validation(prepared, PreparedMemoryValidation(json.dumps(after)), review)
+
+
+async def test_progress_actual_extractor_detaches_caller_review(prepared, progress, monkeypatch):
+    before = json.loads(prepared.payload_json)
+    review = ReviewSubmission(
+        parent_operation_id=before["parent_operation_id"],
+        parent_candidate_sha256=before["parent_candidate_sha256"],
+        findings=[finding(prepared)],
+    )
+    current = prepare_progress_validation(prepared, progress, review)
+    digest = current.input_sha256
+    method = Extractor.extract_with_usage
+
+    async def mutate(extractor, *args, **kwargs):
+        review.findings.clear()
+        return await method(extractor, *args, **kwargs)
+
+    monkeypatch.setattr(Extractor, "extract_with_usage", mutate)
+    result = await execute(current, output(current))
+    assert result.progress == "advance" and result.input_sha256 == digest
+    assert len(result.prior_assessments) == 1
+
+
+async def test_progress_post_return_failure_retains_actual_usage(progress, monkeypatch):
+    import sibyl_core.tasks.memory_progress as module
+
+    error = RuntimeError("progress bookkeeping failed")
+
+    def fail(*args):
+        raise error
+
+    monkeypatch.setattr(module, "assess_progress", fail)
+    with pytest.raises(RuntimeError) as caught:
+        await execute(progress, output(progress))
+    assert caught.value is error and error.extraction_usage.requests == 1
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_progress_extraction_failure_keeps_original_exception(progress, monkeypatch, cancel):
+    import asyncio
+
+    error = asyncio.CancelledError() if cancel else RuntimeError("physical outcome unknown")
+    error.extraction_usage = {"requests": 1, "transport_usage_complete": False}
+
+    async def fail(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(Extractor, "extract_with_usage", fail)
+    with pytest.raises(type(error)) as caught:
+        await execute(progress, output(progress))
+    assert caught.value is error and error.extraction_usage["requests"] == 1
+
+
+@pytest.mark.parametrize("change", ["missing", "finding_ids", "parent", "assertion", "evidence"])
+async def test_progress_context_tamper_denied_before_extraction(progress, monkeypatch, change):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.tasks.memory_validation import PreparedMemoryValidation
+
+    payload = json.loads(progress.payload_json)
+    context = payload["prior_progress"]
+    if change == "missing":
+        del payload["prior_progress"]
+    elif change == "finding_ids":
+        context["finding_ids"] = ["f" * 64]
+    elif change == "parent":
+        context["previous_parent_operation_id"] = "f" * 64
+    elif change == "assertion":
+        context["previous_assertions"]["/content"]["statement"] = "changed"
+    else:
+        payload["sources"]["raw"]["observation_sha256"] = "f" * 64
+    call = AsyncMock(side_effect=AssertionError("unexpected physical extraction"))
+    monkeypatch.setattr(Extractor, "extract_with_usage", call)
+    with pytest.raises(ValueError):
+        await execute(PreparedMemoryValidation(json.dumps(payload)), output(progress))
+    call.assert_not_awaited()
+
+
+async def test_progress_signed_adapter_preserves_original_hashes_and_claim_view(procedure, group):
+    from sibyl_core.tasks.episode_evidence import EvidenceCitation
+    from sibyl_core.tasks.memory_validation import (
+        OriginalValidationEvidence,
+        prepare_procedure_validation,
+    )
+    from sibyl_core.tasks.procedure_review import review_digest
+
+    source_group = group
+    parent = procedure
+    sources = [
+        OriginalValidationEvidence(e.episode_id, e.artifact, "a" * 64, "signed")
+        for e in source_group.episodes
+    ]
+    refs = {
+        e.episode_id: EvidenceCitation(e.episode_id, ((0, len(e.artifact)),))
+        for e in source_group.episodes
+    }
+    before = prepare_procedure_validation(
+        parent,
+        parent_operation_id="b" * 64,
+        parent_candidate_sha256="c" * 64,
+        evidence=sources,
+        citations=refs,
+    )
+    child = parent.model_copy(
+        update={"goal": parent.goal.model_copy(update={"statement": "Narrower source-bound goal"})},
+        deep=True,
+    )
+    after = prepare_procedure_validation(
+        child,
+        parent_operation_id="d" * 64,
+        parent_candidate_sha256="e" * 64,
+        evidence=sources,
+        citations=refs,
+    )
+    b = json.loads(before.payload_json)
+    prior = {
+        "claim_path": "/goal",
+        "claim_sha256": b["assertion_hashes"]["/goal"],
+        "evidence_refs": [{"evidence_id": sources[0].source_id}],
+        "basis": "unsupported_generalization",
+        "disposition": "qualify",
+        "critique": "Narrow the goal.",
+    }
+    review = ReviewSubmission(
+        parent_operation_id="b" * 64, parent_candidate_sha256="c" * 64, findings=[prior]
+    )
+    prepared = prepare_progress_validation(before, after, review)
+    payload = json.loads(prepared.payload_json)
+    assert payload["sources"] == b["sources"]
+    assert payload["candidate_view_sha256"] == review_digest(child.model_dump(mode="json"))
+    assert payload["parent_candidate_sha256"] != payload["candidate_view_sha256"]
+    result = await execute(
+        prepared,
+        {
+            "findings": [],
+            "prior_assessments": [
+                {
+                    "finding_id": review.finding_ids()[0],
+                    "disposition": "resolved",
+                    "supported_reduction": "The goal is narrower.",
+                    "remaining_concern": None,
+                    "evidence_refs": [{"evidence_id": sources[0].source_id}],
+                }
+            ],
+        },
+    )
+    assert result.progress == "accepted"
+
+
+@pytest.mark.parametrize(
+    "change",
+    ["missing_view", "missing_input", "invalid_input", "different_view", "different_view_rehashed"],
+)
+async def test_progress_previous_view_integrity_before_dispatch(progress, monkeypatch, change):
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.tasks.memory_validation import PreparedMemoryValidation
+    from sibyl_core.tasks.procedure_review import review_digest
+
+    payload = json.loads(progress.payload_json)
+    context = payload["prior_progress"]
+    if change == "missing_view":
+        del context["previous_candidate"]
+    elif change == "missing_input":
+        del context["previous_input_sha256"]
+    elif change == "invalid_input":
+        context["previous_input_sha256"] = "not-a-digest"
+    else:
+        context["previous_candidate"]["content"] = "An unrelated previous assertion."
+        if change == "different_view_rehashed":
+            context["previous_candidate_view_sha256"] = review_digest(context["previous_candidate"])
+    call = AsyncMock(side_effect=AssertionError("unexpected physical extraction"))
+    monkeypatch.setattr(Extractor, "extract_with_usage", call)
+    with pytest.raises(ValueError):
+        await execute(PreparedMemoryValidation(json.dumps(payload)), output(progress))
+    call.assert_not_awaited()
+
+
+async def test_progress_false_positive_can_resolve_without_candidate_rewrite(sources, citations):
+    prepared = prepare_reflection_validation(
+        ReflectionCandidate(
+            "pattern", "Validation", "The report says three cases passed.", "contrast", 0.9
+        ),
+        parent_operation_id="b" * 64,
+        parent_candidate_sha256="c" * 64,
+        evidence=sources,
+        citations=citations,
+    )
+    before = json.loads(prepared.payload_json)
+    review = ReviewSubmission(
+        parent_operation_id=before["parent_operation_id"],
+        parent_candidate_sha256=before["parent_candidate_sha256"],
+        findings=[finding(prepared)],
+    )
+    unchanged = prepare_progress_validation(prepared, prepared, review)
+    value = output(unchanged, "resolved")
+    value["findings"] = []
+    value["prior_assessments"][0]["supported_reduction"] = (
+        "Original evidence refutes the previous criticism."
+    )
+    result = await execute(unchanged, value)
+    assert result.status == "no_findings" and result.progress == "accepted"


### PR DESCRIPTION
A correction can repair part of a compound unsupported claim while leaving a legitimate concern open. The new opt-in critic contract records that partial progress against the exact prior candidate and findings, so future continuation can preserve useful edits instead of treating every remaining concern as failure.

## 🛠️ Contract and compatibility

The existing Extractor receives the prior candidate, its assertion hashes, and complete finding assessments under a new prompt/schema identity. Preparation rejects missing or inconsistent prior views before dispatch. Completed invalid output retains actual usage. Unchanged or repeated candidates with open concerns report no progress; an evidence-backed resolution of a false-positive criticism can accept unchanged text.

Legacy prompts, policies, schemas, and result identities remain unchanged. The new assessments remain model proposals. This PR does not enable multi-cycle jobs, durable progress decoding, or promotion. The next integration must resolve authenticated prior executions and apply existing source and publication guards.

## 🧪 Validation

- Independent review passed 48 controls, including four reproduced malformed-context failures and an exact baseline comparison of legacy prompt, schema, policy, and result identities.
- Author repeated nine independent binding, usage, and legacy controls: all passed.
- Affected suite passed 106 tests; two unchanged native transaction tests were skipped because they require a server fixture.
- Core lint and typecheck passed. No provider calls were made.
