### PR TITLE
fix(storage): reconcile atomic raw transaction conflicts

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/backends/surreal/dedicated_client.py
+++ b/packages/python/sibyl-core/src/sibyl_core/backends/surreal/dedicated_client.py
@@ -420,10 +420,22 @@ class DedicatedSurrealClient:
                                 )
                     client = await connection.connect()
                     response = await self._send_query(client, query, params=params, raw=True)
+                    transaction_retry_allowed = _can_replay_query(query, response)
                     if raw:
+                        # Raw callers retain statement envelopes, but an atomic
+                        # server-declared conflict still belongs to this owner.
+                        if transaction_retry_allowed and isinstance(response, dict):
+                            statements = response.get("result")
+                            if isinstance(statements, list) and any(
+                                isinstance(statement, dict)
+                                and statement.get("status") == "ERR"
+                                and isinstance(statement.get("result"), str)
+                                and _is_retryable_transaction_conflict(statement["result"])
+                                for statement in statements
+                            ):
+                                _checked_query_result(response)
                         result = response
                     else:
-                        transaction_retry_allowed = _can_replay_query(query, response)
                         result = _checked_query_result(response, all_results=all_results)
                     break
                 except Exception as exc:

--- a/packages/python/sibyl-core/tests/test_dedicated_client_pool.py
+++ b/packages/python/sibyl-core/tests/test_dedicated_client_pool.py
@@ -483,3 +483,69 @@ async def test_embedded_schema_renewal_preserves_the_original_store(monkeypatch)
         assert len(clients) == 1 and not clients[0].closed
     finally:
         await client.close()
+
+
+@pytest.mark.parametrize(
+    ("query", "first", "expected_calls"),
+    [
+        ("RETURN { UPDATE item SET value = 1; RETURN true; };", "atomic", 2),
+        ("BEGIN; UPDATE item SET value = 1; COMMIT;", "transaction", 2),
+        ("UPDATE item SET value = 1; UPDATE other SET value = 2;", "mixed", 1),
+        ("RETURN true;", "domain_error", 1),
+        ("RETURN true;", "unmarked", 1),
+        ("RETURN true;", "data", 1),
+    ],
+)
+async def test_raw_query_preserves_envelopes_and_retries_only_atomic_conflicts(
+    monkeypatch, query, first, expected_calls
+):
+    conflict = "Transaction conflict: Write conflict. This transaction can be retried"
+    error = {"status": "ERR", "result": conflict}
+    ok = {"status": "OK", "result": [{"uuid": "retained"}]}
+    envelopes = {
+        "atomic": {"result": [error]},
+        "transaction": {
+            "result": [
+                {
+                    "status": "ERR",
+                    "result": "The query was not executed due to a failed transaction",
+                },
+                error,
+            ]
+        },
+        "mixed": {"result": [ok, error]},
+        "domain_error": {"result": [{"status": "ERR", "result": "source changed"}]},
+        "unmarked": {"result": [{"status": "ERR", "result": "Transaction conflict: unknown"}]},
+        "data": {"result": [{"status": "OK", "result": conflict}]},
+    }
+    original = envelopes[first]
+    success = {"result": [ok], "id": "response-2"}
+    calls = []
+
+    async def send(_client, statement, *, params, raw):
+        if statement == "RETURN true;" and statement != query:
+            return {"result": [{"status": "OK", "result": True}]}
+        calls.append((statement, params))
+        return original if len(calls) == 1 else success
+
+    async def connect(_self):
+        return object()
+
+    async def sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(dedicated_client_module._PooledConnection, "connect", connect)
+    monkeypatch.setattr(dedicated_client_module.asyncio, "sleep", sleep)
+    client = DedicatedSurrealClient(
+        url="ws://localhost:8000/rpc",
+        username="",
+        password="",
+        namespace="raw_conflict",
+        database="content",
+        pool_size=1,
+    )
+    monkeypatch.setattr(client, "_send_query", send)
+    result = await client.execute_query_raw(query, expected_revision=7)
+    assert result is (success if expected_calls == 2 else original)
+    assert len(calls) == expected_calls
+    assert all(params == {"expected_revision": 7} for _, params in calls)


### PR DESCRIPTION
Concurrent promotion of the same source could raise a database write-conflict error instead of resolving the authoritative promotion target. The raw query path returned the server error envelope before the existing transaction conflict handler could inspect it.

## 🛠️ Keep conflict recovery at the query owner

Raw queries now use the existing conflict handler when the server declares a retryable conflict and the whole request is proven atomic. The repeated transaction retains its original revision and source checks, so concurrent promotion resolves against current state. Writer concurrency and the retry budget stay unchanged.

Nontransaction batches retain their original result envelope, including any earlier successful statements. Other raw errors and successful data also retain their exact envelope. An uncertain transport outcome cannot authorize a replay.

## 🧪 Validation

- Independent native SurrealDB 3.2.3 verification passed all four concurrent promotion cases, covering raw and reviewed sources with matching and competing targets.
- Six envelope controls passed, including atomic recovery and refusal to replay a mixed nontransaction batch.
- Two independent controls confirmed that a later source denial remains visible, an uncertain transport failure is not replayed, and the connection returns to its pool.
- The selected core suite passed 225 tests. Core lint and typecheck passed.
- Author spot checks repeated all eight envelope/adversarial controls and all four native cases. Every owned native database was removed and its absence verified.

The change addresses the observed reservation failure. It does not claim progress under unbounded contention or replace source and publication authorization checks.
