### PR TITLE
feat(memory): preserve versioned progress receipts through recovery

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/migrate/validation_receipt_archive.py
+++ b/packages/python/sibyl-core/src/sibyl_core/migrate/validation_receipt_archive.py
@@ -6,10 +6,18 @@ import json
 from typing import Any
 
 from cryptography.fernet import InvalidToken
-from pydantic import TypeAdapter
 
 from sibyl_core.services import validation_receipts
-from sibyl_core.services.validation_execution import ValidationStageResult, validation_archive_guard
+from sibyl_core.services.validation_execution import validation_archive_guard
+from sibyl_core.services.validation_progress_history import (
+    ProgressHistoryBinding,
+    validate_history_row,
+    validate_progress_assessments,
+)
+from sibyl_core.services.validation_result_codec import (
+    decode_validation_result,
+    validate_result_request,
+)
 from sibyl_core.tasks._evidence_json import canonical
 
 
@@ -21,10 +29,26 @@ def _rows(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
         if identity in result:
             raise ValueError("Duplicate validation archive execution")
         result[identity] = row
+    for row in result.values():
+        history = json.loads(row["request_json"]).get("progress_history")
+        if history is not None and not row["purged"]:
+            binding = ProgressHistoryBinding.model_validate(history)
+            prior = result.get(binding.execution_id)
+            if prior is None or binding.execution_id == row["uuid"]:
+                raise ValueError("Progress archive prior execution is unavailable")
+            critique = validate_history_row(
+                prior, binding, row["organization_id"], row["principal_id"]
+            )
+            if row.get("result_json") is not None:
+                validate_progress_assessments(
+                    decode_validation_result(json.loads(row["result_json"])), critique
+                )
     return result
 
 
-def _status(row: dict[str, Any], ciphertext: bytes | None) -> str:
+def _status(
+    row: dict[str, Any], ciphertext: bytes | None, records: dict[str, dict[str, Any]]
+) -> str:
     if row["purged"]:
         if row.get("recovery_key") is not None:
             raise ValueError("Purged validation archive retains a recovery key")
@@ -34,7 +58,15 @@ def _status(row: dict[str, Any], ciphertext: bytes | None) -> str:
             value = validation_receipts.decode(row["request_json"], row["recovery_key"], ciphertext)
         except InvalidToken:
             raise ValueError("Validation archive ciphertext authentication failed") from None
-        TypeAdapter(ValidationStageResult).validate_python(value)
+        decoded = decode_validation_result(value)
+        request = json.loads(row["request_json"])
+        validate_result_request(decoded, request)
+        if request.get("progress_history") is not None:
+            binding = ProgressHistoryBinding.model_validate(request["progress_history"])
+            prior = validate_history_row(
+                records[binding.execution_id], binding, row["organization_id"], row["principal_id"]
+            )
+            validate_progress_assessments(decoded, prior)
         if row.get("result_json") is not None and canonical(value) != row["result_json"]:
             raise ValueError("Validation archive receipt and database result differ")
         if row.get("usage_json") is not None and canonical(value["usage"]) != row["usage_json"]:
@@ -51,11 +83,12 @@ def _status(row: dict[str, Any], ciphertext: bytes | None) -> str:
 def capture(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Capture only files named by this authorized execution snapshot."""
     entries = []
-    for identity, row in sorted(_rows(rows).items()):
+    records = _rows(rows)
+    for identity, row in sorted(records.items()):
         ciphertext = None
         if not row["purged"] and row.get("recovery_key") is not None:
             ciphertext = validation_receipts.capture(row["request_json"])
-        entry = {"execution_id": identity, "status": _status(row, ciphertext)}
+        entry = {"execution_id": identity, "status": _status(row, ciphertext, records)}
         if ciphertext is not None:
             entry.update(
                 ciphertext=base64.b64encode(ciphertext).decode("ascii"),
@@ -94,7 +127,7 @@ def prepare(section: Any, rows: list[dict[str, Any]]) -> list[tuple[str, str, by
                 raise ValueError("Validation receipt archive checksum differs")
             if row["purged"] or not isinstance(row.get("recovery_key"), str):
                 raise ValueError("Validation receipt archive key is unavailable")
-        if set(entry) != fields or entry.get("status") != _status(row, ciphertext):
+        if set(entry) != fields or entry.get("status") != _status(row, ciphertext, records):
             raise ValueError("Validation receipt archive status differs")
         if ciphertext is not None:
             pending.append((row["request_json"], row["recovery_key"], ciphertext))

--- a/packages/python/sibyl-core/src/sibyl_core/services/validation_execution.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/validation_execution.py
@@ -9,24 +9,20 @@ from typing import Any
 from uuid import uuid4
 
 from cryptography.fernet import Fernet
-from pydantic import TypeAdapter
 
 from sibyl_core.ai.llm.extractor import ExtractionUsage
 from sibyl_core.ai.transport import FailedExtractionUsage, TransportAttempt
 from sibyl_core.services import content_client, validation_receipts
-from sibyl_core.tasks._evidence_json import canonical
-from sibyl_core.tasks.memory_validation import MemoryValidationResult
-from sibyl_core.tasks.ordinary_proposal_result import OrdinaryProposalResult
-from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
-from sibyl_core.tasks.procedure_review import review_digest
-from sibyl_core.tasks.reflection_correction import ReflectionCorrectionResult
-
-ValidationStageResult = (
-    MemoryValidationResult
-    | ReflectionCorrectionResult
-    | ProcedureCorrectionResult
-    | OrdinaryProposalResult
+from sibyl_core.services.validation_result_codec import (
+    ValidationStageResult,
+    decode_validation_result,
+    encode_validation_result,
+    validate_result_request,
 )
+from sibyl_core.tasks._evidence_json import canonical
+from sibyl_core.tasks.memory_progress import ProgressMemoryValidationResult
+from sibyl_core.tasks.memory_validation import MemoryValidationResult
+from sibyl_core.tasks.procedure_review import review_digest
 
 
 class ValidationExecutionUnavailable(ValueError):
@@ -57,6 +53,7 @@ class ValidationExecution:
         self.authorize = authorize
         self.dispatch_guard = dispatch_guard
         self.guard_params = guard_params or {}
+        self._source_dispatch_guard = dispatch_guard
 
     @property
     def params(self) -> dict[str, str]:
@@ -74,6 +71,7 @@ class ValidationExecution:
         self, *, parent_id: str, source_ids: list[str], policy: str, request: dict[str, Any]
     ) -> bool:
         # The UUID unique index arbitrates only identical operations, not global work.
+        await self._check_progress_history(request)
         await asyncio.to_thread(validation_receipts.ready)
         nonce = uuid4().hex
         recovery_key = Fernet.generate_key().decode()
@@ -113,9 +111,36 @@ class ValidationExecution:
         self._recovery_key = rows[0].get("recovery_key")
         return rows[0].get("claim_id") == nonce
 
+    async def _check_progress_history(
+        self, request: dict[str, Any]
+    ) -> MemoryValidationResult | None:
+        from sibyl_core.services.validation_progress_history import (
+            ProgressHistoryBinding,
+            progress_history_guard,
+            validate_history_row,
+        )
+
+        value = request.get("progress_history")
+        if value is None:
+            return
+        binding = ProgressHistoryBinding.model_validate(value)
+        if binding.execution_id == self.id:
+            raise ValidationExecutionUnavailable("Progress history cannot reference itself")
+        row = await ValidationExecution(binding.execution_id, self.org, self.principal).load()
+        if row is None:
+            raise ValidationExecutionUnavailable("Progress prior execution disappeared")
+        prior = validate_history_row(row, binding, self.org, self.principal)
+        self.dispatch_guard = self._source_dispatch_guard + progress_history_guard(
+            binding, self.org, self.principal
+        )
+        return prior
+
     async def before_dispatch(self) -> str:
         if self.authorize is not None:
             await self.authorize()
+        row = await self.load()
+        if row is not None and self._matches_request(row):
+            await self._check_progress_history(json.loads(row["request_json"]))
         attempt_id = uuid4().hex
         rows = await _query(
             "RETURN {"
@@ -158,10 +183,11 @@ class ValidationExecution:
 
     @staticmethod
     def _result_value(result: ValidationStageResult) -> dict[str, Any]:
-        return TypeAdapter(ValidationStageResult).dump_python(result, mode="json")
+        return encode_validation_result(result)
 
     async def record_result(self, result: ValidationStageResult) -> None:
         value = self._result_value(result)
+        validate_result_request(result, json.loads(self._request_json))
         if self._recovery_key is None:
             raise ValidationExecutionUnavailable("Execution has no durable receipt key")
         await asyncio.to_thread(
@@ -200,7 +226,7 @@ class ValidationExecution:
         )
         if value is None:
             return False
-        result = TypeAdapter(ValidationStageResult).validate_python(value)
+        result = decode_validation_result(value)
         recovered = await self.reconcile_result(result)
         if recovered:
             await asyncio.to_thread(validation_receipts.discard, row["request_json"])
@@ -233,6 +259,7 @@ class ValidationExecution:
             return False
         assert row is not None
         request_json = row["request_json"]
+        validate_result_request(result, json.loads(request_json))
         if row.get("state") == "running":
             await _query(
                 """UPDATE memory_validation_executions SET state = 'recorded',
@@ -310,7 +337,16 @@ class ValidationExecution:
             raise ValidationExecutionUnavailable(
                 f"Validation has no available completed result: {row.get('state') if row else 'missing'}"
             )
-        TypeAdapter(ValidationStageResult).validate_json(row["result_json"])
+        decoded = decode_validation_result(json.loads(row["result_json"]))
+        validate_result_request(decoded, json.loads(row["request_json"]))
+        prior = await self._check_progress_history(json.loads(row["request_json"]))
+        if isinstance(decoded, ProgressMemoryValidationResult):
+            from sibyl_core.services.validation_progress_history import (
+                validate_progress_assessments,
+            )
+
+            assert prior is not None
+            validate_progress_assessments(decoded, prior)
         return {"execution_id": self.id, **json.loads(row["result_json"])}
 
 
@@ -394,7 +430,8 @@ def validation_archive_guard(table: str, record: dict[str, Any]) -> str:
     if sorted(binding["source_id"] for binding in bindings) != sorted(record["source_ids"]):
         raise ValueError("Validation archive source set differs")
     if record.get("result_json") is not None:
-        TypeAdapter(ValidationStageResult).validate_json(record["result_json"])
+        decoded = decode_validation_result(json.loads(record["result_json"]))
+        validate_result_request(decoded, request)
         if record.get("purged"):
             raise ValueError("Purged validation cannot retain readable output")
     clauses = []

--- a/packages/python/sibyl-core/src/sibyl_core/services/validation_progress_history.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/validation_progress_history.py
@@ -1,0 +1,139 @@
+"""Bind progress context to an existing scoped immutable critic receipt."""
+
+import hashlib
+import json
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from sibyl_core.services.validation_result_codec import decode_validation_result
+from sibyl_core.tasks._evidence_json import canonical
+from sibyl_core.tasks.memory_progress import PROGRESS_VERSION, validate_progress_context
+from sibyl_core.tasks.memory_validation import MemoryValidationResult, PreparedMemoryValidation
+from sibyl_core.tasks.procedure_review import review_digest
+
+
+class ProgressHistoryBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    execution_id: str = Field(pattern=r"^[0-9a-f]{64}$")
+    request_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    result_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    input_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    review_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+def validate_history_row(
+    row: dict[str, Any], binding: ProgressHistoryBinding, org: str, principal: str
+) -> MemoryValidationResult:
+    if (
+        row.get("uuid") != binding.execution_id
+        or row.get("request_sha256") != binding.request_sha256
+        or binding.execution_id != binding.request_sha256
+        or row.get("organization_id") != org
+        or row.get("principal_id") != principal
+        or row.get("state") != "returned"
+        or row.get("purged") is not False
+        or not isinstance(row.get("request_json"), str)
+        or not isinstance(row.get("result_json"), str)
+    ):
+        raise ValueError("Progress prior execution is unavailable")
+    request = json.loads(row["request_json"])
+    if (
+        not isinstance(request, dict)
+        or canonical(request) != row["request_json"]
+        or review_digest(request) != binding.execution_id
+        or request.get("org") != org
+        or request.get("principal") != principal
+        or request.get("parent") != row.get("parent_id")
+        or request.get("policy") != row.get("policy_json")
+        or request.get("input") != binding.input_sha256
+        or hashlib.sha256(row["result_json"].encode()).hexdigest() != binding.result_sha256
+    ):
+        raise ValueError("Progress prior request or result identity differs")
+    result = decode_validation_result(json.loads(row["result_json"]))
+    if (
+        not isinstance(result, MemoryValidationResult)
+        or result.status != "reconsider"
+        or result.submission is None
+        or result.input_sha256 != binding.input_sha256
+        or review_digest(result.submission.model_dump(mode="json")) != binding.review_sha256
+    ):
+        raise ValueError("Progress prior critique differs")
+    return result
+
+
+def bind_progress_history(
+    prepared: PreparedMemoryValidation,
+    row: dict[str, Any],
+    org: str,
+    principal: str,
+    *,
+    previous: PreparedMemoryValidation,
+) -> ProgressHistoryBinding:
+    """Compare actual historical input and submission with detached prompt context."""
+    payload = json.loads(prepared.payload_json)
+    if payload.get("version") != PROGRESS_VERSION:
+        raise ValueError("Progress history requires the explicit contract")
+    validate_progress_context(payload)
+    context = payload["prior_progress"]
+    before = json.loads(previous.payload_json)
+    if (
+        previous.input_sha256 != context["previous_input_sha256"]
+        or before["candidate"] != context["previous_candidate"]
+        or before["assertions"] != context["previous_assertions"]
+        or before["parent_operation_id"] != context["previous_parent_operation_id"]
+        or before["parent_candidate_sha256"] != context["previous_parent_candidate_sha256"]
+        or before["sources"] != payload["sources"]
+        or before["citations"] != payload["citations"]
+        or before["kind"] != payload["kind"]
+    ):
+        raise ValueError("Resolved prior prompt differs from progress context")
+    encoded = row.get("result_json")
+    if not isinstance(encoded, str):
+        raise ValueError("Progress prior result is unavailable")
+    binding = ProgressHistoryBinding(
+        execution_id=row["uuid"],
+        request_sha256=row["request_sha256"],
+        result_sha256=hashlib.sha256(encoded.encode()).hexdigest(),
+        input_sha256=context["previous_input_sha256"],
+        review_sha256=review_digest(context["review"]),
+    )
+    validate_history_row(row, binding, org, principal)
+    return binding
+
+
+def progress_history_guard(binding: ProgressHistoryBinding, org: str, principal: str) -> str:
+    """Fence an exact prior receipt on the existing execution witness field."""
+    return f"""
+        LET $progress_prior = (SELECT * FROM memory_validation_executions
+            WHERE uuid = {canonical(binding.execution_id)}
+                AND organization_id = {canonical(org)}
+                AND principal_id = {canonical(principal)} LIMIT 1)[0];
+        IF $progress_prior = NONE OR $progress_prior.state != 'returned'
+            OR $progress_prior.purged != false
+            OR $progress_prior.request_sha256 != {canonical(binding.request_sha256)}
+            OR crypto::sha256($progress_prior.request_json) != {canonical(binding.request_sha256)}
+            OR crypto::sha256($progress_prior.result_json) != {canonical(binding.result_sha256)} {{
+            THROW 'Progress prior receipt changed';
+        }};
+        UPDATE memory_validation_executions
+            SET promotion_write_witness=(promotion_write_witness ?? 0)+1
+            WHERE uuid={canonical(binding.execution_id)}
+                AND organization_id={canonical(org)} AND principal_id={canonical(principal)};
+    """
+
+
+def validate_progress_assessments(result: Any, prior: MemoryValidationResult) -> None:
+    from sibyl_core.tasks.memory_progress import ProgressMemoryValidationResult
+
+    if not isinstance(result, ProgressMemoryValidationResult) or prior.submission is None:
+        raise ValueError("Progress assessment history is unavailable")
+    expected = set(prior.submission.finding_ids())
+    actual = {assessment.finding_id for assessment in result.prior_assessments}
+    mechanical_abstention = (
+        result.status == "abstain"
+        and result.reason == "critic_output_failed_mechanical_validation"
+        and not result.prior_assessments
+    )
+    if actual != expected and not mechanical_abstention:
+        raise ValueError("Progress prior assessment inventory differs")

--- a/packages/python/sibyl-core/src/sibyl_core/services/validation_result_codec.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/validation_result_codec.py
@@ -1,0 +1,92 @@
+"""Version-aware durable validation results without legacy union downgrades."""
+
+import json
+from dataclasses import fields
+from typing import Any
+
+from pydantic import TypeAdapter
+
+from sibyl_core.tasks._evidence_json import canonical
+from sibyl_core.tasks.memory_progress import (
+    PROGRESS_VERSION,
+    ProgressCriticOutput,
+    ProgressMemoryValidationResult,
+)
+from sibyl_core.tasks.memory_validation import VALIDATION_VERSION, MemoryValidationResult
+from sibyl_core.tasks.ordinary_proposal_result import OrdinaryProposalResult
+from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
+from sibyl_core.tasks.procedure_review import review_digest
+from sibyl_core.tasks.reflection_correction import CORRECTION_VERSION, ReflectionCorrectionResult
+
+LegacyValidationStageResult = (
+    MemoryValidationResult
+    | ReflectionCorrectionResult
+    | ProcedureCorrectionResult
+    | OrdinaryProposalResult
+)
+ValidationStageResult = LegacyValidationStageResult | ProgressMemoryValidationResult
+
+
+def decode_validation_result(value: Any) -> ValidationStageResult:
+    """Select explicit progress before the permissive historical dataclass union."""
+    if not isinstance(value, dict):
+        raise ValueError("Validation result must be an object")
+    version = value.get("version")
+    if version == PROGRESS_VERSION:
+        if set(value) != {field.name for field in fields(ProgressMemoryValidationResult)}:
+            raise ValueError("Progress result fields differ")
+        result = TypeAdapter(ProgressMemoryValidationResult).validate_json(canonical(value))
+        policy = json.loads(result.configured_policy_json)
+        expected_status = {
+            "accepted": "no_findings",
+            "advance": "reconsider",
+            "no_progress": "reconsider",
+            "unresolved": "reconsider",
+            "abstain": "abstain",
+        }[result.progress]
+        if (
+            result.status != expected_status
+            or result.schema_sha256 != review_digest(ProgressCriticOutput.model_json_schema())
+            or not isinstance(policy, dict)
+            or policy.get("version") != PROGRESS_VERSION
+            or (
+                result.status == "no_findings"
+                and (result.submission is not None or result.reason is not None)
+            )
+            or (result.status == "reconsider" and result.submission is None)
+        ):
+            raise ValueError("Progress result contract differs")
+        ids = [assessment.finding_id for assessment in result.prior_assessments]
+        if len(ids) != len(set(ids)):
+            raise ValueError("Progress assessment identities are duplicated")
+        for assessment in result.prior_assessments:
+            improved = assessment.disposition in ("resolved", "partially_resolved")
+            if (
+                improved != (assessment.supported_reduction is not None)
+                or (assessment.disposition == "resolved") != (assessment.remaining_concern is None)
+                or (result.status == "no_findings" and assessment.disposition != "resolved")
+            ):
+                raise ValueError("Progress assessment outcome differs")
+        return result
+    if "progress" in value or "prior_assessments" in value:
+        raise ValueError("Progress result cannot downgrade to legacy")
+    if version is not None and version not in (VALIDATION_VERSION, CORRECTION_VERSION):
+        raise ValueError("Unsupported validation result version")
+    return TypeAdapter(LegacyValidationStageResult).validate_json(canonical(value))
+
+
+def encode_validation_result(result: ValidationStageResult) -> dict[str, Any]:
+    if isinstance(result, ProgressMemoryValidationResult):
+        value = TypeAdapter(ProgressMemoryValidationResult).dump_python(result, mode="json")
+    else:
+        value = TypeAdapter(LegacyValidationStageResult).dump_python(result, mode="json")
+    decode_validation_result(value)
+    return value
+
+
+def validate_result_request(result: ValidationStageResult, request: dict[str, Any]) -> None:
+    progress = isinstance(result, ProgressMemoryValidationResult)
+    if progress != ("progress_history" in request):
+        raise ValueError("Progress result/request version differs")
+    if progress and request.get("input") != result.input_sha256:
+        raise ValueError("Progress result input differs")

--- a/packages/python/sibyl-core/tests/test_validation_progress_codec.py
+++ b/packages/python/sibyl-core/tests/test_validation_progress_codec.py
@@ -1,0 +1,370 @@
+"""Progress receipts round-trip without losing assessments or legacy identities."""
+
+import copy
+import json
+
+import pytest
+from pydantic import TypeAdapter
+
+from sibyl_core.services.validation_result_codec import (
+    LegacyValidationStageResult,
+    decode_validation_result,
+    encode_validation_result,
+)
+from sibyl_core.tasks.memory_progress import ProgressMemoryValidationResult
+from tests.test_eval_publication import admitted_pair as admitted_pair
+from tests.test_eval_publication import content_store as content_store
+from tests.test_eval_publication import evidence as evidence
+from tests.test_eval_publication import proposal as proposal
+from tests.test_memory_progress import (
+    citations as citations,
+)
+from tests.test_memory_progress import (
+    execute,
+    output,
+)
+from tests.test_memory_progress import (
+    prepared as prepared,
+)
+from tests.test_memory_progress import (
+    progress as progress,
+)
+from tests.test_memory_progress import (
+    sources as sources,
+)
+from tests.test_memory_validation import candidate as candidate
+from tests.test_validation_receipts import private_journal as private_journal
+
+
+async def test_progress_codec_roundtrip(progress):
+    result = await execute(progress, output(progress))
+    encoded = encode_validation_result(result)
+    decoded = decode_validation_result(json.loads(json.dumps(encoded)))
+    assert isinstance(decoded, ProgressMemoryValidationResult)
+    assert decoded == result
+    assert encode_validation_result(decoded) == encoded
+    assert encoded["prior_assessments"] and encoded["progress"] == "advance"
+
+
+@pytest.mark.parametrize("mutation", ["missing", "downgrade", "unknown", "extra"])
+async def test_progress_codec_refuses_lossy_downgrade(progress, mutation):
+    encoded = encode_validation_result(await execute(progress, output(progress)))
+    changed = copy.deepcopy(encoded)
+    if mutation == "missing":
+        changed.pop("prior_assessments")
+    elif mutation == "downgrade":
+        changed.pop("version")
+    elif mutation == "unknown":
+        changed["version"] = "future-progress"
+    else:
+        changed["unexpected"] = True
+    with pytest.raises(ValueError):
+        decode_validation_result(changed)
+
+
+async def test_progress_codec_preserves_legacy(prepared):
+    from pydantic_ai import Agent
+    from pydantic_ai.models.test import TestModel
+
+    from sibyl_core.ai.llm.extractor import Extractor
+    from sibyl_core.tasks.memory_validation import CriticOutput, run_memory_validation
+
+    result = await run_memory_validation(
+        prepared,
+        Extractor(
+            CriticOutput,
+            agent=Agent(TestModel(custom_output_args={"findings": []}), output_type=CriticOutput),
+        ),
+    )
+    expected = TypeAdapter(LegacyValidationStageResult).dump_python(result, mode="json")
+    assert encode_validation_result(result) == expected
+    assert encode_validation_result(decode_validation_result(expected)) == expected
+
+
+@pytest.fixture
+async def historical(progress):
+    from sibyl_core.services.validation_progress_history import bind_progress_history
+    from sibyl_core.tasks._evidence_json import canonical
+    from sibyl_core.tasks.memory_validation import MemoryValidationResult
+    from sibyl_core.tasks.procedure_review import ReviewSubmission, review_digest
+
+    context = json.loads(progress.payload_json)["prior_progress"]
+    current = await execute(progress, output(progress))
+    prior = MemoryValidationResult(
+        status="reconsider",
+        submission=ReviewSubmission.model_validate(context["review"]),
+        reason=None,
+        input_sha256=context["previous_input_sha256"],
+        schema_sha256="a" * 64,
+        usage=current.usage,
+        configured_policy_json="{}",
+    )
+    request = {
+        "org": "org",
+        "principal": "owner",
+        "parent": "parent",
+        "policy": "{}",
+        "input": prior.input_sha256,
+        "source_bindings": [{"source_id": "parent", "incarnation": "initial", "generation": 1}],
+    }
+    row = {
+        "uuid": review_digest(request),
+        "request_sha256": review_digest(request),
+        "organization_id": "org",
+        "principal_id": "owner",
+        "parent_id": "parent",
+        "policy_json": "{}",
+        "request_json": canonical(request),
+        "result_json": canonical(encode_validation_result(prior)),
+        "state": "returned",
+        "purged": False,
+    }
+    from sibyl_core.tasks.memory_validation import VALIDATION_VERSION, PreparedMemoryValidation
+
+    before = json.loads(progress.payload_json)
+    before.pop("prior_progress")
+    before.update(
+        version=VALIDATION_VERSION,
+        candidate=context["previous_candidate"],
+        assertions=context["previous_assertions"],
+        candidate_view_sha256=context["previous_candidate_view_sha256"],
+        parent_operation_id=context["previous_parent_operation_id"],
+        parent_candidate_sha256=context["previous_parent_candidate_sha256"],
+        assertion_hashes={k: review_digest(v) for k, v in context["previous_assertions"].items()},
+    )
+    previous = PreparedMemoryValidation(canonical(before))
+    return (
+        row,
+        bind_progress_history(progress, row, "org", "owner", previous=previous),
+        current,
+        previous,
+    )
+
+
+@pytest.mark.parametrize("change", ["input", "request", "result", "owner", "purged", "state"])
+async def test_progress_history_exact_prior_binding(historical, progress, change):
+    from sibyl_core.services.validation_progress_history import bind_progress_history
+
+    row, binding, _, previous = historical
+    row = copy.deepcopy(row)
+    if change == "input":
+        payload = json.loads(progress.payload_json)
+        payload["prior_progress"]["previous_input_sha256"] = "1" * 64
+        from sibyl_core.tasks.memory_validation import PreparedMemoryValidation
+
+        progress = PreparedMemoryValidation(json.dumps(payload))
+    elif change in ("request", "result"):
+        row[change + "_json"] += " "
+    elif change == "owner":
+        row["principal_id"] = "other"
+    elif change == "purged":
+        row["purged"] = True
+    else:
+        row["state"] = "recorded"
+    with pytest.raises(ValueError):
+        if change == "input":
+            bind_progress_history(progress, row, "org", "owner", previous=previous)
+        else:
+            from sibyl_core.services.validation_progress_history import validate_history_row
+
+            validate_history_row(row, binding, "org", "owner")
+
+
+@pytest.mark.parametrize("mode", ["recorded", "journal"])
+async def test_progress_durable_recorded_resume(
+    historical, content_store, monkeypatch, private_journal, mode
+):
+    from sibyl_core.services import validation_execution as owner
+    from sibyl_core.services.validation_execution import ValidationExecution
+    from sibyl_core.services.validation_stages import run_validation_stage
+    from sibyl_core.tasks._evidence_json import canonical
+    from sibyl_core.tasks.procedure_review import review_digest
+
+    prior, binding, result, _ = historical
+    await owner._query(
+        "CREATE memory_validation_executions CONTENT $row;",
+        row={
+            **prior,
+            "source_ids": ["parent"],
+            "claim_id": "prior",
+            "usage_json": canonical(json.loads(prior["result_json"])["usage"]),
+        },
+    )
+    request = {
+        "org": "org",
+        "principal": "owner",
+        "parent": "child",
+        "policy": "{}",
+        "input": result.input_sha256,
+        "source_bindings": [{"source_id": "child", "incarnation": "initial", "generation": 1}],
+        "progress_history": binding.model_dump(mode="json"),
+    }
+    execution = ValidationExecution(review_digest(request), "org", "owner")
+    assert await execution.begin(
+        parent_id="child", source_ids=["child"], policy="{}", request=request
+    )
+    if mode == "journal":
+
+        async def unavailable(*args, **kwargs):
+            raise OSError("simulated database outage")
+
+        monkeypatch.setattr(execution, "_finish", unavailable)
+        with pytest.raises(OSError):
+            await execution.record_result(result)
+        assert list(private_journal.glob("*.receipt"))
+        execution = ValidationExecution(review_digest(request), "org", "owner")
+    else:
+        await execution.record_result(result)
+
+    async def current():
+        pass
+
+    async def forbidden():
+        raise AssertionError("completed stage must not dispatch")
+
+    resumed = await run_validation_stage(
+        execution=execution,
+        parent_id="child",
+        source_ids=["child"],
+        request=request,
+        policy="{}",
+        check_current=current,
+        run=forbidden,
+    )
+    assert resumed["prior_assessments"] == encode_validation_result(result)["prior_assessments"]
+    assert resumed["progress"] == "advance"
+    assert not list(private_journal.glob("*.receipt"))
+
+
+async def test_progress_archive_history_and_exact_roundtrip(historical):
+    from sibyl_core.migrate.validation_receipt_archive import capture, prepare
+    from sibyl_core.tasks._evidence_json import canonical
+    from sibyl_core.tasks.procedure_review import review_digest
+
+    prior, binding, result, _ = historical
+    prior = {
+        **prior,
+        "source_ids": ["parent"],
+        "usage_json": canonical(json.loads(prior["result_json"])["usage"]),
+    }
+    request = {
+        "org": "org",
+        "principal": "owner",
+        "parent": "child",
+        "policy": "{}",
+        "input": result.input_sha256,
+        "source_bindings": [{"source_id": "child", "incarnation": "initial", "generation": 1}],
+        "progress_history": binding.model_dump(mode="json"),
+    }
+    child = {
+        "uuid": review_digest(request),
+        "request_sha256": review_digest(request),
+        "organization_id": "org",
+        "principal_id": "owner",
+        "parent_id": "child",
+        "source_ids": ["child"],
+        "policy_json": "{}",
+        "request_json": canonical(request),
+        "result_json": canonical(encode_validation_result(result)),
+        "usage_json": canonical(result.usage.model_dump(mode="json")),
+        "state": "returned",
+        "purged": False,
+    }
+    # Input ordering must not require the prior row to precede the child.
+    section = capture([child, prior])
+    assert prepare(section, [child, prior]) == []
+    for mutation in ("missing", "purged", "changed"):
+        broken = copy.deepcopy(prior)
+        if mutation == "purged":
+            broken.update(purged=True, result_json=None)
+        elif mutation == "changed":
+            broken["result_json"] += " "
+        with pytest.raises(ValueError):
+            prepare(section, [child] if mutation == "missing" else [child, broken])
+
+
+async def test_progress_history_native_conflict(
+    historical, content_store, private_journal, monkeypatch
+):
+    import asyncio
+    import os
+
+    if not os.environ.get("SIBYL_OPERATIONAL_TEST_URL"):
+        pytest.skip("Requires the isolated native SDK database")
+    from sibyl_core.services import validation_execution as owner
+    from sibyl_core.services.validation_execution import ValidationExecution
+    from sibyl_core.tasks.procedure_review import review_digest
+
+    prior, binding, result, _ = historical
+    await owner._query(
+        "CREATE memory_validation_executions CONTENT $row;",
+        row={**prior, "source_ids": ["parent"], "claim_id": "prior", "usage_json": "{}"},
+    )
+    request = {
+        "org": "org",
+        "principal": "owner",
+        "parent": "child",
+        "policy": "{}",
+        "input": result.input_sha256,
+        "source_bindings": [],
+        "progress_history": binding.model_dump(mode="json"),
+    }
+    execution = ValidationExecution(review_digest(request), "org", "owner")
+    assert await execution.begin(
+        parent_id="child", source_ids=["child"], policy="{}", request=request
+    )
+    original_query = owner._query
+    entered = asyncio.Event()
+
+    async def delayed(query, **params):
+        if "CREATE memory_validation_attempts" in query:
+            query = query.replace(
+                "UPDATE memory_validation_executions",
+                "SLEEP 1s; UPDATE memory_validation_executions",
+                1,
+            )
+            entered.set()
+        return await original_query(query, **params)
+
+    monkeypatch.setattr(owner, "_query", delayed)
+    dispatch = asyncio.create_task(execution.before_dispatch())
+    await entered.wait()
+    await asyncio.sleep(0.3)
+    await original_query(
+        "UPDATE memory_validation_executions SET purged=true WHERE uuid=$uuid;", uuid=prior["uuid"]
+    )
+    assert not dispatch.done()
+    with pytest.raises(Exception) as failure:
+        await dispatch
+    assert (
+        "conflict" in str(failure.value).lower()
+        or "prior receipt changed" in str(failure.value).lower()
+    )
+    assert not await original_query("SELECT * FROM memory_validation_attempts;")
+    assert (
+        await original_query(
+            "SELECT * FROM memory_validation_executions WHERE uuid=$uuid;", uuid=prior["uuid"]
+        )
+    )[0]["purged"] is True
+
+
+async def test_progress_codec_legacy_signed_tuple_roundtrip(proposal):
+    from sibyl_core.ai.llm.extractor import ExtractionUsage
+    from sibyl_core.tasks.procedure_correction_result import ProcedureCorrectionResult
+
+    _, consolidation = proposal
+    result = ProcedureCorrectionResult(
+        status="procedure_correction",
+        parent_operation_id="a" * 64,
+        parent_candidate_sha256="b" * 64,
+        review_execution_id="c" * 64,
+        result=consolidation,
+        usage=ExtractionUsage(requests=0, input_tokens=0, output_tokens=0, total_tokens=0),
+    )
+    historical = TypeAdapter(LegacyValidationStageResult).dump_python(result, mode="json")
+    assert isinstance(historical["result"]["group"]["episodes"], list)
+    assert encode_validation_result(result) == historical
+    decoded = decode_validation_result(historical)
+    assert isinstance(decoded, ProcedureCorrectionResult)
+    assert isinstance(decoded.result.group.episodes, tuple)
+    assert encode_validation_result(decoded) == historical


### PR DESCRIPTION
Progress critiques carry assessments that the legacy result union can discard during serialization. The durable codec now selects the explicit progress version, preserves every assessment through database and encrypted receipt recovery, and refuses a malformed progress result being interpreted as legacy output.

## 🛠️ Recovery and prior history

The prior critic binding includes the exact scoped request, result, input and review digests. Preparing the binding also requires the actual resolved prior prompt. Dispatch and finalization use the existing execution write witness to reject concurrent prior-history changes. Completed output and usage remain retained when the final history check fails.

Archive preparation checks prior references against the complete inventory before publishing ciphertext, so input row order cannot change acceptance. Legacy signed results retain JSON validation semantics, including strict tuple fields. The current ordinary proposal result remains supported.

## 🧪 Validation

Independent review passed 17 native controls, a separate post-output prior-purge control, fresh-process encrypted recovery with provider dispatch forbidden, and core lint/typecheck. Author repeated the two independent native controls successfully and verified all five reviewed file hashes after restacking.

Author integration passed 81 automatic, ordinary and progress controls with five native-only skips. A separate native run passed 18 controls, including signed tuple roundtrip and legacy process recovery. API archive regression coverage passed 27 tests with one native-only public restore skip.

The initial codec incorrectly applied Python validation to serialized JSON arrays; actual signed-owner tests caught eight failures. JSON-aware decoding fixes that regression without changing legacy serialized bytes.

## 📌 Activation boundary

This PR builds on #575 but enables no progress producer, job loop or promotion path. Automatic continuation still needs authenticated chain discovery and dependent lifecycle invalidation. Removing prior history must invalidate its progress descendants before activation, so backups cannot be blocked by dangling live history. Progress assessments grant no publication authority.
