### PR TITLE
fix(memory): fence legacy operational source adoption

### DIFF
--- a/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/graph_entity_store.py
@@ -1024,6 +1024,11 @@ async def _publish_operational_entities(
     targets = {row["uuid"]: row for row in normalize_records(target_rows)}
     associations = {row["target_id"]: row for row in normalize_records(association_rows)}
     states = {row["source_id"]: row for row in normalize_records(state_rows)}
+    legacy = (
+        await source.legacy_adoption_proof(client)
+        if any(row.get("derivation_required") is not True for row in targets.values())
+        else None
+    )
     entries = []
     for record in records:
         old = targets.get(record["uuid"])
@@ -1033,28 +1038,32 @@ async def _publish_operational_entities(
             if association is not None or states.get(record["uuid"]) is not None:
                 raise SourceUnavailableError()
         else:
-            state = states.get(record["uuid"])
-            observations = association.get("observations") if association is not None else None
-            if (
-                not isinstance(old, dict)
-                or old.get("group_id") != group_id
-                or old.get("created_by") != source.creator_id
-                or old.get("derivation_required") is not True
-                or not isinstance(state, dict)
-                or state.get("deleted") is not False
-                or state.get("revision") != old.get("revision")
-                or not isinstance(association, dict)
-                or association.get("active") is not True
-                or association.get("target_id") != record["uuid"]
-                or association.get("body_sha256")
-                != graph_target_digest(entity_from_surreal_row(old))
-                or not isinstance(observations, list)
-                or len(observations) != 1
-            ):
-                raise SourceUnavailableError()
-            previous = observation_from_record(observations[0])
-            if previous.source != source.observation.source:
-                raise SourceUnavailableError()
+            if legacy is not None and legacy.permits_entity(old):
+                if association is not None:
+                    raise SourceUnavailableError()
+            else:
+                state = states.get(record["uuid"])
+                observations = association.get("observations") if association is not None else None
+                if (
+                    not isinstance(old, dict)
+                    or old.get("group_id") != group_id
+                    or old.get("created_by") != source.creator_id
+                    or old.get("derivation_required") is not True
+                    or not isinstance(state, dict)
+                    or state.get("deleted") is not False
+                    or state.get("revision") != old.get("revision")
+                    or not isinstance(association, dict)
+                    or association.get("active") is not True
+                    or association.get("target_id") != record["uuid"]
+                    or association.get("body_sha256")
+                    != graph_target_digest(entity_from_surreal_row(old))
+                    or not isinstance(observations, list)
+                    or len(observations) != 1
+                ):
+                    raise SourceUnavailableError()
+                previous = observation_from_record(observations[0])
+                if previous.source != source.observation.source:
+                    raise SourceUnavailableError()
             record["created_by"] = old.get("created_by")
             record["created_at"] = old.get("created_at")
         desired = {
@@ -1091,6 +1100,7 @@ async def _publish_operational_entities(
                 "record": {**record, "derivation_required": True},
                 "association": desired,
                 "replay": replay,
+                "adopting": old is not None and association is None,
             }
         )
     # Inspect graph state before this recheck: an older worker must not adopt
@@ -1101,7 +1111,7 @@ async def _publish_operational_entities(
         .strip()
         .rstrip(";")
     )
-    await client.execute_query(
+    written = await client.execute_query(
         """RETURN {
         LET $targets = SELECT * FROM entity WHERE uuid IN $ids ORDER BY uuid;
         LET $associations = SELECT * FROM memory_derivations WHERE organization_id=$org
@@ -1110,6 +1120,17 @@ async def _publish_operational_entities(
             AND source_kind='graph_entity' AND source_id IN $ids ORDER BY source_id;
         IF crypto::sha256(type::string([$targets,$associations,$states])) != $fingerprint {
             THROW 'operational graph target changed during publication';
+        };
+        IF $legacy_fingerprint != NONE {
+            LET $legacy_edges = SELECT *, in.uuid AS source_uuid, out.uuid AS target_uuid
+                FROM relates_to WHERE group_id=$org AND uuid IN $legacy_edge_ids ORDER BY uuid;
+            IF crypto::sha256(type::string($legacy_edges)) != $legacy_fingerprint {
+                RETURN {applied:false};
+            };
+            -- Include supporting edges in the write set so concurrent edits
+            -- conflict with adoption even after the snapshot read succeeds.
+            UPDATE relates_to SET attributes.operational_write_witness = <string>rand::uuid()
+                WHERE group_id=$org AND uuid IN $legacy_edge_ids;
         };
         FOR $entry IN $entries {
             LET $uuid = $entry.uuid;
@@ -1121,7 +1142,13 @@ async def _publish_operational_entities(
         + upsert
         + """;
                 UPDATE entity SET derivation_required=true WHERE uuid=$uuid AND group_id=$org;
-                IF $association = NONE { CREATE memory_derivations CONTENT $entry.association; }
+                IF $association = NONE {
+                    CREATE memory_derivations CONTENT $entry.association;
+                    IF $entry.adopting {
+                        UPDATE source_states SET generation += 1 WHERE organization_id=$org
+                            AND source_kind='graph_entity' AND source_id=$uuid;
+                    };
+                }
                 ELSE {
                     UPDATE $association.id CONTENT $entry.association;
                     UPDATE source_states SET generation += 1 WHERE organization_id=$org
@@ -1129,13 +1156,17 @@ async def _publish_operational_entities(
                 };
             };
         };
-        RETURN true;
+        RETURN {applied:true};
         };""",
         entries=entries,
         ids=ids,
         fingerprint=snapshot["fingerprint"],
         org=group_id,
+        legacy_fingerprint=legacy.relationship_snapshot_sha256 if legacy is not None else None,
+        legacy_edge_ids=[row[0] for row in legacy.relationship_rows] if legacy is not None else [],
     )
+    if normalize_records(written) != [{"applied": True}]:
+        raise SourceUnavailableError()
     await source.current()
     return projection
 

--- a/packages/python/sibyl-core/src/sibyl_core/services/operational_legacy.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/operational_legacy.py
@@ -1,0 +1,209 @@
+"""Prove deterministic legacy inventory before attaching retained source lineage."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sibyl_core.backends.surreal.records import normalize_records
+from sibyl_core.memory_pipeline.observations import evidence_hash
+from sibyl_core.migrate.source_integrity import encode_record
+from sibyl_core.services.graph_derivations import graph_target_digest
+from sibyl_core.services.graph_records import entity_from_surreal_row, relationship_from_surreal_row
+from sibyl_core.services.memory_derivations import observation_from_record
+from sibyl_core.services.source_observations import SourceUnavailableError
+
+if TYPE_CHECKING:
+    from sibyl_core.services.operational_projection import OperationalProjectionSource
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalLegacyProof:
+    """Exact observed row bytes for adoption under each writer's snapshot CAS."""
+
+    entity_rows: tuple[tuple[str, str], ...]
+    relationship_rows: tuple[tuple[str, str], ...]
+    relationship_snapshot_sha256: str
+
+    def permits_entity(self, row: dict) -> bool:
+        return (row.get("uuid"), _row_digest(row)) in self.entity_rows
+
+    def permits_relationship(self, row: dict) -> bool:
+        return (row.get("uuid"), _row_digest(row)) in self.relationship_rows
+
+
+def _row_digest(row: dict) -> str:
+    # Both supported row normalizers discard the physical target id (one
+    # preserves a record_id alias). UUID identity and the native transaction
+    # snapshot bind the target; endpoint references remain part of the proof.
+    encoded = {key: value for key, value in row.items() if key not in {"id", "record_id"}}
+    for key in ("in", "out"):
+        if key in encoded:
+            encoded[key] = str(encoded[key])
+    return evidence_hash(encode_record(encoded))
+
+
+def _body(model) -> dict:
+    payload = model.model_dump(mode="python")
+    for key in ("created_at", "updated_at", "embedding", "revision", "derivation_required"):
+        payload.pop(key, None)
+    metadata = payload.get("metadata", {})
+    for key in (
+        "record_id",
+        "created_at",
+        "updated_at",
+        "embedding_metadata",
+        "operational_write_witness",
+        "fact_embedding",
+        "embedding",
+        "retrieval_count",
+        "citation_count",
+        "last_recalled_at",
+        "last_used_at",
+        "_direct_insert",
+        "misled_count",
+        "revision",
+    ):
+        metadata.pop(key, None)
+    payload["metadata"] = {key: value for key, value in metadata.items() if value is not None}
+    return encode_record(payload)
+
+
+async def legacy_adoption_proof(
+    client, source: OperationalProjectionSource
+) -> OperationalLegacyProof:
+    """Accept complete originals or resumable, source-bound pending entities.
+
+    No historical bytes are recovered here. The candidate bytes are the newly
+    authorized resubmission, compared with the actual retained graph inventory.
+    """
+    from sibyl_core.projection.experience import project_operational_experience
+
+    _, experience = await source.current()
+    original = await asyncio.to_thread(
+        project_operational_experience,
+        experience,
+        organization_id=source.observation.source.organization_id,
+        created_by=source.creator_id,
+    )
+    protected = await source.projection()
+    org = source.observation.source.organization_id
+    ids = sorted(original.manifest.entity_ids)
+    edge_ids = sorted(original.manifest.relationship_ids)
+    snapshots = normalize_records(
+        await client.execute_query(
+            """RETURN {
+        LET $entities = SELECT * FROM entity WHERE group_id=$org AND uuid IN $ids ORDER BY uuid;
+        LET $edges = SELECT *, in.uuid AS source_uuid, out.uuid AS target_uuid FROM relates_to
+            WHERE group_id=$org AND uuid IN $edges ORDER BY uuid;
+        LET $bindings = SELECT * FROM memory_derivations WHERE organization_id=$org
+            AND target_kind='graph_entity' AND target_id IN $ids ORDER BY target_id;
+        LET $states = SELECT * FROM source_states WHERE organization_id=$org
+            AND source_kind='graph_entity' AND source_id IN $ids ORDER BY source_id;
+        RETURN {entities:$entities, edges:$edges, bindings:$bindings, states:$states,
+            edge_fingerprint:crypto::sha256(type::string($edges))};
+        };""",
+            org=org,
+            ids=ids,
+            edges=edge_ids,
+        )
+    )
+    if len(snapshots) != 1:
+        raise SourceUnavailableError()
+    proof = await asyncio.to_thread(_prove_snapshot, snapshots[0], source, original, protected)
+    await source.current()
+    return proof
+
+
+def _row_uuid(row: dict) -> str:
+    value = row.get("uuid")
+    if not isinstance(value, str) or not value:
+        raise SourceUnavailableError()
+    return value
+
+
+def _prove_snapshot(snapshot, source, original, protected) -> OperationalLegacyProof:
+    from sibyl_core.services.graph_entity_store import _entity_record
+    from sibyl_core.services.graph_relationships import _relationship_record
+
+    org = source.observation.source.organization_id
+    ids = set(original.manifest.entity_ids)
+    edge_ids = set(original.manifest.relationship_ids)
+    rows = normalize_records(snapshot.get("entities"))
+    edges = normalize_records(snapshot.get("edges"))
+    if {_row_uuid(row) for row in rows} != set(ids) or {_row_uuid(row) for row in edges} != set(
+        edge_ids
+    ):
+        raise SourceUnavailableError()
+    associations = {row["target_id"]: row for row in normalize_records(snapshot.get("bindings"))}
+    states = {row["source_id"]: row for row in normalize_records(snapshot.get("states"))}
+    by_id = {_row_uuid(row): row for row in rows}
+    manifest = by_id[original.manifest.manifest_entity_id]
+    protected_inventory = all(row.get("derivation_required") is True for row in rows)
+    if protected_inventory:
+        expected = protected
+    else:
+        if associations or any(row.get("derivation_required") is True for row in rows):
+            raise SourceUnavailableError()
+        attributes = manifest.get("attributes")
+        if (
+            not isinstance(attributes, dict)
+            or attributes.get("operational_projection_state") != "complete"
+        ):
+            raise SourceUnavailableError()
+        expected = original
+    for entity in expected.entities:
+        row = by_id[entity.id]
+        actual = entity_from_surreal_row(row)
+        desired = entity_from_surreal_row(_entity_record(entity, group_id=org))
+        if _body(actual) != _body(desired):
+            raise SourceUnavailableError()
+        state = states.get(entity.id)
+        if (
+            not isinstance(state, dict)
+            or state.get("deleted") is not False
+            or state.get("revision") != row.get("revision")
+        ):
+            raise SourceUnavailableError()
+        if protected_inventory:
+            binding = associations.get(entity.id)
+            if (
+                not isinstance(binding, dict)
+                or binding.get("active") is not True
+                or binding.get("body_sha256") != graph_target_digest(actual)
+            ):
+                raise SourceUnavailableError()
+            observations = binding.get("observations")
+            if (
+                not isinstance(observations, list)
+                or len(observations) != 1
+                or not observation_from_record(observations[0]).same_evidence(source.observation)
+            ):
+                raise SourceUnavailableError()
+            if (
+                binding.get("principal_id") != source.authority.principal_id
+                or binding.get("authority_ceiling") != source.authority.ceiling_metadata()
+            ):
+                raise SourceUnavailableError()
+    expected_edges = {edge.id: edge for edge in original.relationships}
+    for row in edges:
+        edge = expected_edges[_row_uuid(row)]
+        if row.get("source_uuid") != edge.source_id or row.get("target_uuid") != edge.target_id:
+            raise SourceUnavailableError()
+        actual = relationship_from_surreal_row(
+            {key: value for key, value in row.items() if key not in {"source_uuid", "target_uuid"}}
+        )
+        desired = relationship_from_surreal_row(
+            {**_relationship_record(edge, group_id=org), "episodes": []}
+        )
+        if _body(actual) != _body(desired):
+            raise SourceUnavailableError()
+    fingerprint = snapshot.get("edge_fingerprint")
+    if not isinstance(fingerprint, str) or len(fingerprint) != 64:
+        raise SourceUnavailableError()
+    return OperationalLegacyProof(
+        entity_rows=tuple((_row_uuid(row), _row_digest(row)) for row in rows),
+        relationship_rows=tuple((_row_uuid(row), _row_digest(row)) for row in edges),
+        relationship_snapshot_sha256=fingerprint,
+    )

--- a/packages/python/sibyl-core/src/sibyl_core/services/operational_projection.py
+++ b/packages/python/sibyl-core/src/sibyl_core/services/operational_projection.py
@@ -56,6 +56,11 @@ class OperationalProjectionSource:
             raise SourceUnavailableError()
         return snapshot, await asyncio.to_thread(_experience, snapshot)
 
+    async def legacy_adoption_proof(self, client):
+        from sibyl_core.services.operational_legacy import legacy_adoption_proof
+
+        return await legacy_adoption_proof(client, self)
+
     async def projection(self) -> OperationalExperienceProjection:
         _, experience = await self.current()
         projection = await asyncio.to_thread(

--- a/packages/python/sibyl-core/tests/test_operational_legacy.py
+++ b/packages/python/sibyl-core/tests/test_operational_legacy.py
@@ -1,0 +1,191 @@
+"""Legacy graph adoption uses actual complete inventory and retained bytes."""
+
+import pytest
+
+from sibyl_core.config import core_config
+from sibyl_core.projection.experience import persist_operational_experience
+from sibyl_core.services.operational_legacy import legacy_adoption_proof
+from sibyl_core.services.operational_projection import OperationalProjectionSource
+from sibyl_core.services.source_observations import SourceUnavailableError
+from tests.test_operational_projection import authority as authority
+from tests.test_operational_projection import capture
+from tests.test_operational_projection import content_store as content_store
+from tests.test_operational_projection import runtime as runtime
+
+
+async def legacy(runtime, source):
+    _, experience = await source.current()
+    return await persist_operational_experience(
+        entity_manager=runtime.entity_manager,
+        relationship_manager=runtime.relationship_manager,
+        experience=experience,
+        organization_id=runtime.client.group_id,
+        created_by=source.creator_id,
+    )
+
+
+async def test_exact_complete_legacy_inventory_is_adoptable(runtime, content_store, authority):
+    _, source = await capture(runtime, authority)
+    result = await legacy(runtime, source)
+    proof = await legacy_adoption_proof(runtime.client, source)
+    assert {key for key, _ in proof.entity_rows} == set(result.projection.manifest.entity_ids)
+    assert {key for key, _ in proof.relationship_rows} == set(
+        result.projection.manifest.relationship_ids
+    )
+
+
+@pytest.mark.parametrize("mutation", ["entity", "edge", "manifest", "missing"])
+async def test_legacy_adoption_rejects_changed_or_partial_inventory(
+    runtime, content_store, authority, mutation
+):
+    _, source = await capture(runtime, authority)
+    result = await legacy(runtime, source)
+    projection = result.projection
+    if mutation == "entity":
+        await runtime.client.execute_query(
+            "UPDATE entity SET content='changed' WHERE uuid=$id;", id=projection.entities[0].id
+        )
+    elif mutation == "edge":
+        await runtime.client.execute_query(
+            "UPDATE relates_to SET fact='changed' WHERE uuid=$id;",
+            id=projection.relationships[0].id,
+        )
+    elif mutation == "manifest":
+        await runtime.client.execute_query(
+            "UPDATE entity SET attributes.operational_projection_state='pending' WHERE uuid=$id;",
+            id=projection.manifest.manifest_entity_id,
+        )
+    else:
+        await runtime.client.execute_query(
+            "DELETE relates_to WHERE uuid=$id;", id=projection.relationships[0].id
+        )
+    with pytest.raises(SourceUnavailableError):
+        await source.legacy_adoption_proof(runtime.client)
+
+
+async def test_entity_adoption_reconstructs_proof_after_pending_checkpoint(
+    runtime, content_store, authority
+):
+    _, source = await capture(runtime, authority)
+    await legacy(runtime, source)
+    await runtime.entity_manager.publish_operational_entities(source)
+    # Re-resolve from durable raw bytes, discarding the original source object.
+    from sibyl_core.services.operational_projection import load_operational_projection_source
+
+    resumed = await load_operational_projection_source(source.observation.source, authority)
+    proof = await resumed.legacy_adoption_proof(runtime.client)
+    assert proof.relationship_rows
+    await runtime.entity_manager.publish_operational_entities(resumed)
+
+
+async def test_new_actor_rebinds_entities_before_resuming_edge_adoption(
+    runtime, content_store, authority, monkeypatch
+):
+    from dataclasses import replace
+    from unittest.mock import AsyncMock
+
+    from sibyl_core.services.operational_projection import load_operational_projection_source
+
+    _, source = await capture(runtime, authority)
+    await legacy(runtime, source)
+    await runtime.entity_manager.publish_operational_entities(source)
+    new_authority = replace(authority, principal_id="user_b")
+    monkeypatch.setattr(
+        "sibyl_core.services.operational_projection.get_source_authority_resolver",
+        lambda: AsyncMock(return_value=new_authority),
+    )
+    resumed = await load_operational_projection_source(source.observation.source, new_authority)
+    with pytest.raises(SourceUnavailableError):
+        await resumed.legacy_adoption_proof(runtime.client)
+    await runtime.entity_manager.publish_operational_entities(resumed)
+    proof = await resumed.legacy_adoption_proof(runtime.client)
+    assert proof.relationship_rows
+
+
+async def test_legacy_adoption_rejects_supporting_edge_changed_after_proof(
+    runtime, content_store, authority, monkeypatch
+):
+    _, source = await capture(runtime, authority)
+    result = await legacy(runtime, source)
+    edge_id = result.projection.relationships[0].id
+    original = OperationalProjectionSource.legacy_adoption_proof
+    entered = False
+
+    async def changed_after_proof(self, client):
+        nonlocal entered
+        proof = await original(self, client)
+        await client.execute_query(
+            "UPDATE relates_to SET fact='concurrent authoritative edit' WHERE uuid=$uuid;",
+            uuid=edge_id,
+        )
+        entered = True
+        return proof
+
+    monkeypatch.setattr(OperationalProjectionSource, "legacy_adoption_proof", changed_after_proof)
+    with pytest.raises(SourceUnavailableError):
+        await runtime.entity_manager.publish_operational_entities(source)
+    assert entered
+    assert not await runtime.client.execute_query("SELECT * FROM memory_derivations;")
+    rows = await runtime.client.execute_query(
+        "SELECT * FROM relates_to WHERE uuid=$uuid;", uuid=edge_id
+    )
+    assert rows[0]["fact"] == "concurrent authoritative edit"
+
+
+async def test_legacy_adoption_conflicts_with_edge_edit_during_transaction(
+    runtime, content_store, authority, monkeypatch
+):
+    import asyncio
+    import os
+
+    if not os.environ.get("SIBYL_COHORT_NATIVE_URL"):
+        pytest.skip("requires independent native pooled transactions")
+    _, source = await capture(runtime, authority)
+    result = await legacy(runtime, source)
+    edge_id = result.projection.relationships[0].id
+    original = runtime.client.execute_query
+    entered = asyncio.Event()
+
+    async def delayed(query, **params):
+        if "legacy_fingerprint" in params:
+            assert "FOR $entry IN $entries" in query
+            query = query.replace("FOR $entry IN $entries", "SLEEP 1s; FOR $entry IN $entries", 1)
+            entered.set()
+        return await original(query, **params)
+
+    monkeypatch.setattr(runtime.client, "execute_query", delayed)
+    pending = asyncio.create_task(runtime.entity_manager.publish_operational_entities(source))
+    await asyncio.wait_for(entered.wait(), timeout=10)
+    await asyncio.sleep(0.3)
+    await original(
+        "UPDATE relates_to SET fact='edit during adoption transaction' WHERE uuid=$uuid;",
+        uuid=edge_id,
+    )
+    assert not pending.done()
+    with pytest.raises(Exception, match=r"(?i)conflict|changed|unavailable|retry"):
+        await pending
+    assert not await original("SELECT * FROM memory_derivations;")
+    rows = await original("SELECT * FROM relates_to WHERE uuid=$uuid;", uuid=edge_id)
+    assert rows[0]["fact"] == "edit during adoption transaction"
+
+
+async def test_legacy_adoption_witness_preserves_edge_body_and_vectors(
+    runtime, content_store, authority
+):
+    _, source = await capture(runtime, authority)
+    result = await legacy(runtime, source)
+    edge_id = result.projection.relationships[0].id
+    await runtime.client.execute_query(
+        "UPDATE relates_to SET fact_embedding=$vector WHERE uuid=$uuid;",
+        uuid=edge_id,
+        vector=[0.25] * core_config.graph_embedding_dimensions,
+    )
+    query = "SELECT * FROM relates_to WHERE uuid=$uuid;"
+    before = await runtime.client.execute_query(query, uuid=edge_id)
+    raw_before, _ = await source.current()
+    await runtime.entity_manager.publish_operational_entities(source)
+    after = await runtime.client.execute_query(query, uuid=edge_id)
+    assert isinstance(after[0]["attributes"].pop("operational_write_witness"), str)
+    assert after == before
+    raw_after, _ = await source.current()
+    assert raw_after == raw_before


### PR DESCRIPTION
Legacy operational captures can have a complete graph projection without retained raw evidence. This foundation lets the existing entity publisher attach source lineage only when an authorized resubmission matches the full stored entity and relationship inventory. A protected pending inventory can reconstruct the same proof after entity publication.

The proof checks creator, project, source observation, deterministic IDs, relationship endpoints, and content. Entity adoption binds the exact supporting edge snapshot in its transaction. A changing bookkeeping witness on those edges creates a write conflict if another transaction edits them during adoption; a read check or unchanged-value write alone does not provide that guarantee. The witness has no authorization meaning, and edge content and vectors remain unchanged.

## 🧪 Validation

Independent review passed 25 native controls, including creator/project/endpoint substitution, mutations before and during adoption, pending reconstruction, and nonempty-vector preservation. Core lint and typecheck passed. Native fixtures were isolated and removed; no provider calls were made.

## 📌 Integration boundary

This change supplies the shared proof and entity adoption foundation. Authenticated capture activation, deferred jobs, and complete entity-to-edge process restart are successor work. The retained bytes are the newly authorized resubmission; this change does not recover unknown historical request bytes or establish learning quality.
